### PR TITLE
[v24.3.x] [CORE-9764] pandaproxy/sr: Revert to an eager evaluation model on sr startup

### DIFF
--- a/src/v/datalake/tests/record_generator.cc
+++ b/src/v/datalake/tests/record_generator.cc
@@ -27,9 +27,8 @@ record_generator::register_avro_schema(
   std::string_view name, std::string_view schema) {
     using namespace pandaproxy::schema_registry;
     auto id = co_await ss::coroutine::as_future(
-      _sr->create_schema(unparsed_schema{
-        subject{"foo"},
-        unparsed_schema_definition{schema, schema_type::avro}}));
+      _sr->create_schema(subject_schema{
+        subject{"foo"}, schema_definition{schema, schema_type::avro}}));
     if (id.failed()) {
         co_return error{fmt::format(
           "Error creating schema {}: {}", name, id.get_exception())};

--- a/src/v/datalake/tests/record_schema_resolver_test.cc
+++ b/src/v/datalake/tests/record_schema_resolver_test.cc
@@ -79,16 +79,16 @@ public:
 
     void SetUp() override {
         auto avro_schema_id = sr
-                                ->create_schema(unparsed_schema{
+                                ->create_schema(subject_schema{
                                   subject{"foo"},
-                                  unparsed_schema_definition{
+                                  schema_definition{
                                     avro_record_schema, schema_type::avro}})
                                 .get();
         ASSERT_EQ(1, avro_schema_id());
         auto pb_schema_id = sr
-                              ->create_schema(unparsed_schema{
+                              ->create_schema(subject_schema{
                                 subject{"foo"},
-                                unparsed_schema_definition{
+                                schema_definition{
                                   pb_record_schema, schema_type::protobuf}})
                               .get();
         ASSERT_EQ(2, pb_schema_id());

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -652,7 +652,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {
@@ -875,7 +875,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/subject_schema"
+              "$ref": "#/definitions/stored_schema"
             }
           },
           "404": {

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -38,7 +38,7 @@
         }
       }
     },
-    "subject_schema": {
+    "stored_schema": {
       "type": "object",
       "properties": {
         "subject": {

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -496,7 +496,7 @@ result<void> sanitize(json::Value::Array& a, sanitize_context& ctx) {
 } // namespace
 
 avro_schema_definition::avro_schema_definition(
-  avro::ValidSchema vs, canonical_schema_definition::references refs)
+  avro::ValidSchema vs, schema_definition::references refs)
   : _impl(std::move(vs))
   , _refs(std::move(refs)) {}
 
@@ -518,11 +518,10 @@ std::ostream& operator<<(std::ostream& os, const avro_schema_definition& def) {
     return os;
 }
 
-canonical_schema_definition::raw_string avro_schema_definition::raw() const {
+schema_definition::raw_string avro_schema_definition::raw() const {
     iobuf_ostream os;
     _impl.toJson(os.ostream());
-    return canonical_schema_definition::raw_string{
-      json::minify(std::move(os).buf())};
+    return schema_definition::raw_string{json::minify(std::move(os).buf())};
 }
 
 ss::sstring avro_schema_definition::name() const {
@@ -534,32 +533,32 @@ public:
     bool contains(const ss::sstring& name) const {
         return _names.contains(name);
     }
-    bool insert(ss::sstring name, canonical_schema_definition def) {
+    bool insert(ss::sstring name, schema_definition def) {
         bool inserted = _names.insert(std::move(name)).second;
         if (inserted) {
             _schemas.push_back(std::move(def).raw());
         }
         return inserted;
     }
-    canonical_schema_definition::raw_string flatten() && {
+    schema_definition::raw_string flatten() && {
         iobuf out;
         for (auto& s : _schemas) {
             out.append(std::move(s));
             out.append("\n", 1);
         }
-        return canonical_schema_definition::raw_string{std::move(out)};
+        return schema_definition::raw_string{std::move(out)};
     }
 
 private:
     absl::flat_hash_set<ss::sstring> _names;
-    std::vector<canonical_schema_definition::raw_string> _schemas;
+    std::vector<schema_definition::raw_string> _schemas;
 };
 
 ss::future<collected_schema> collect_schema(
   schema_getter& store,
   collected_schema collected,
   ss::sstring name,
-  canonical_schema schema) {
+  subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         if (!collected.contains(ref.name)) {
             auto ss = co_await store.get_subject_schema(
@@ -573,7 +572,7 @@ ss::future<collected_schema> collect_schema(
 }
 
 ss::future<avro_schema_definition>
-make_avro_schema_definition(schema_getter& store, canonical_schema schema) {
+make_avro_schema_definition(schema_getter& store, subject_schema schema) {
     std::optional<avro::Exception> ex;
     try {
         auto name = schema.sub()();
@@ -592,8 +591,8 @@ make_avro_schema_definition(schema_getter& store, canonical_schema schema) {
         fmt::format("Invalid schema {}", ex->what())})));
 }
 
-result<canonical_schema_definition>
-sanitize_avro_schema_definition(unparsed_schema_definition def) {
+result<schema_definition>
+sanitize_avro_schema_definition(schema_definition def) {
     json::Document doc;
     constexpr auto flags = rapidjson::kParseDefaultFlags
                            | rapidjson::kParseStopWhenDoneFlag;
@@ -631,8 +630,8 @@ sanitize_avro_schema_definition(unparsed_schema_definition def) {
         return error_info{error_code::schema_invalid, "Invalid schema"};
     }
 
-    return canonical_schema_definition{
-      canonical_schema_definition::raw_string{std::move(buf).as_iobuf()},
+    return schema_definition{
+      schema_definition::raw_string{std::move(buf).as_iobuf()},
       schema_type::avro,
       def.refs()};
 }

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -18,10 +18,10 @@
 namespace pandaproxy::schema_registry {
 
 ss::future<avro_schema_definition>
-make_avro_schema_definition(schema_getter& store, canonical_schema schema);
+make_avro_schema_definition(schema_getter& store, subject_schema schema);
 
-result<canonical_schema_definition>
-sanitize_avro_schema_definition(unparsed_schema_definition def);
+result<schema_definition>
+sanitize_avro_schema_definition(schema_definition def);
 
 compatibility_result check_compatible(
   const avro_schema_definition& reader,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -14,6 +14,7 @@
 #include "pandaproxy/error.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/types.h"
 
 #include <ranges>
 
@@ -146,7 +147,7 @@ std::error_code make_error_code(error_code e) {
 }
 
 error_info no_reference_found_for(
-  const canonical_schema& schema, const subject& sub, schema_version ver) {
+  const subject_schema& schema, const subject& sub, schema_version ver) {
     // fmt v8 doesn't support formatting for elements in a range
     auto fmt_refs = schema.def().refs()
                     | std::views::transform([](const auto& ref) {

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -145,7 +145,7 @@ inline error_info invalid_subject_schema(const subject& sub) {
       fmt::format("Error while looking up schema under subject {}", sub())};
 }
 
-inline error_info invalid_schema(const canonical_schema& schema) {
+inline error_info invalid_schema(const subject_schema& schema) {
     return {
       error_code::schema_invalid, fmt::format("Invalid schema {}", schema)};
 }
@@ -165,7 +165,7 @@ inline error_info has_references(const subject& sub, schema_version ver) {
 }
 
 error_info no_reference_found_for(
-  const canonical_schema& schema, const subject& sub, schema_version ver);
+  const subject_schema& schema, const subject& sub, schema_version ver);
 
 inline error_info compatibility_not_found(const subject& sub) {
     return error_info{

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -428,7 +428,7 @@ post_subject(server::request_t rq, server::reply_t rp) {
     // Force 40401 if no subject
     co_await rq.service().schema_store().get_versions(sub, inc_del);
 
-    canonical_schema schema;
+    subject_schema schema;
     try {
         auto unparsed = co_await ppj::rjson_parse(
           std::move(rq.req), post_subject_versions_request_handler<>{sub});
@@ -690,7 +690,7 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
         version = parse_numerical_schema_version(ver).value();
     }
 
-    canonical_schema schema;
+    subject_schema schema;
     try {
         schema = co_await rq.service().schema_store().make_canonical_schema(
           std::move(unparsed.def));

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -494,7 +494,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
       is_deleted::no};
 
     auto ids = co_await rq.service().schema_store().get_schema_version(
-      schema.share(), norm);
+      schema.share());
 
     schema_id schema_id{ids.id.value_or(invalid_schema_id)};
     if (!ids.version.has_value()) {

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -486,7 +486,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
         unparsed.id = invalid_schema_id;
     }
 
-    subject_schema schema{
+    stored_schema schema{
       co_await rq.service().schema_store().make_canonical_schema(
         std::move(unparsed.def), norm),
       unparsed.version.value_or(invalid_schema_version),

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -445,7 +445,7 @@ post_subject(server::request_t rq, server::reply_t rp) {
     }
 
     auto sub_schema = co_await rq.service().schema_store().has_schema(
-      std::move(schema), inc_del, norm);
+      std::move(schema), inc_del);
 
     rp.rep->write_body(
       "json",

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -178,14 +178,14 @@ struct json_schema_definition::impl {
     impl(
       document_context ctx,
       std::string_view name,
-      canonical_schema_definition::references refs)
+      schema_definition::references refs)
       : ctx{std::move(ctx)}
       , name{name}
       , refs(std::move(refs)) {}
 
     document_context ctx;
     ss::sstring name;
-    canonical_schema_definition::references refs;
+    schema_definition::references refs;
 };
 
 bool operator==(
@@ -202,12 +202,11 @@ std::ostream& operator<<(std::ostream& os, const json_schema_definition& def) {
     return os;
 }
 
-canonical_schema_definition::raw_string json_schema_definition::raw() const {
-    return canonical_schema_definition::raw_string{_impl->to_json()};
+schema_definition::raw_string json_schema_definition::raw() const {
+    return schema_definition::raw_string{_impl->to_json()};
 }
 
-const canonical_schema_definition::references&
-json_schema_definition::refs() const {
+const schema_definition::references& json_schema_definition::refs() const {
     return _impl->refs;
 }
 
@@ -230,7 +229,7 @@ std::string_view as_string_view(const json::Value& v) {
     return {v.GetString(), v.GetStringLength()};
 }
 
-ss::future<> check_references(sharded_store& store, canonical_schema schema) {
+ss::future<> check_references(sharded_store& store, subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         co_await store.get_id(ref.sub, ref.version)
           .handle_exception_type([&](const exception& e) -> schema_id {
@@ -2359,7 +2358,7 @@ result<id_to_schema_pointer> collect_bundled_schema_and_fix_refs(
 } // namespace
 
 ss::future<json_schema_definition>
-make_json_schema_definition(schema_getter&, canonical_schema schema) {
+make_json_schema_definition(schema_getter&, subject_schema schema) {
     auto doc
       = parse_json(schema.def().shared_raw()()).value(); // throws on error
     std::string_view name = schema.sub()();
@@ -2369,8 +2368,8 @@ make_json_schema_definition(schema_getter&, canonical_schema schema) {
         std::move(doc), name, std::move(refs))};
 }
 
-ss::future<canonical_schema> make_canonical_json_schema(
-  sharded_store& store, unparsed_schema unparsed_schema, normalize norm) {
+ss::future<subject_schema> make_canonical_json_schema(
+  sharded_store& store, subject_schema unparsed_schema, normalize norm) {
     auto [sub, unparsed] = std::move(unparsed_schema).destructure();
     auto [def, type, refs] = std::move(unparsed).destructure();
 
@@ -2384,10 +2383,10 @@ ss::future<canonical_schema> make_canonical_json_schema(
     json::Writer<json::chunked_buffer> w{out};
     ctx.doc.Accept(w);
 
-    canonical_schema schema{
+    subject_schema schema{
       std::move(sub),
-      canonical_schema_definition{
-        canonical_schema_definition::raw_string{std::move(out).as_iobuf()},
+      schema_definition{
+        schema_definition::raw_string{std::move(out).as_iobuf()},
         type,
         std::move(refs)}};
 

--- a/src/v/pandaproxy/schema_registry/json.h
+++ b/src/v/pandaproxy/schema_registry/json.h
@@ -17,10 +17,10 @@
 namespace pandaproxy::schema_registry {
 
 ss::future<json_schema_definition>
-make_json_schema_definition(schema_getter& store, canonical_schema schema);
+make_json_schema_definition(schema_getter& store, subject_schema schema);
 
-ss::future<canonical_schema> make_canonical_json_schema(
-  sharded_store& store, unparsed_schema def, normalize norm = normalize::no);
+ss::future<subject_schema> make_canonical_json_schema(
+  sharded_store& store, subject_schema def, normalize norm = normalize::no);
 
 compatibility_result check_compatible(
   const json_schema_definition& reader,

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -234,7 +234,7 @@ private:
 ///\brief Implements ZeroCopyInputStream with a copy of the definition
 class schema_def_input_stream : public pb::io::ZeroCopyInputStream {
 public:
-    explicit schema_def_input_stream(const canonical_schema_definition& def)
+    explicit schema_def_input_stream(const schema_definition& def)
       : _is{def.shared_raw()}
       , _impl{&_is.istream()} {}
 
@@ -256,7 +256,7 @@ public:
       : _parser{}
       , _fdp{} {}
 
-    const pb::FileDescriptorProto& parse(const canonical_schema& schema) {
+    const pb::FileDescriptorProto& parse(const subject_schema& schema) {
         schema_def_input_stream is{schema.def()};
         io_error_collector error_collector;
         pb::io::Tokenizer t{&is, &error_collector};
@@ -432,7 +432,7 @@ build_file(pb::DescriptorPool& dp, const pb::FileDescriptorProto& fdp) {
 ss::future<pb::FileDescriptorProto> build_file_with_refs(
   pb::DescriptorPool& dp,
   schema_getter& store,
-  canonical_schema schema,
+  subject_schema schema,
   normalize norm) {
     for (const auto& ref : schema.def().refs()) {
         if (dp.FindFileByName(ref.name)) {
@@ -443,7 +443,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
         co_await build_file_with_refs(
           dp,
           store,
-          canonical_schema{subject{ref.name}, std::move(dep.schema).def()},
+          subject_schema{subject{ref.name}, std::move(dep.schema).def()},
           normalize::no);
     }
 
@@ -462,7 +462,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
 ss::future<pb::FileDescriptorProto> import_schema(
   pb::DescriptorPool& dp,
   schema_getter& store,
-  canonical_schema schema,
+  subject_schema schema,
   normalize norm) {
     try {
         co_return co_await build_file_with_refs(
@@ -530,13 +530,12 @@ struct protobuf_schema_definition::impl {
           "{}\n{}\n\n{}\n\n{}\n", header, package, imports, footer);
     }
 
-    canonical_schema_definition::raw_string raw() const {
-        return canonical_schema_definition::raw_string{debug_string()};
+    schema_definition::raw_string raw() const {
+        return schema_definition::raw_string{debug_string()};
     }
 };
 
-canonical_schema_definition::raw_string
-protobuf_schema_definition::raw() const {
+schema_definition::raw_string protobuf_schema_definition::raw() const {
     return _impl->raw();
 }
 
@@ -588,7 +587,7 @@ operator<<(std::ostream& os, const protobuf_schema_definition& def) {
 }
 
 ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
-  schema_getter& store, canonical_schema schema, normalize norm) {
+  schema_getter& store, subject_schema schema, normalize norm) {
     auto refs = schema.def().refs();
     auto impl = ss::make_shared<protobuf_schema_definition::impl>();
     auto v2_renderer = protobuf_renderer_v2::no;
@@ -608,26 +607,19 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
     co_return protobuf_schema_definition{std::move(impl), std::move(refs)};
 }
 
-ss::future<canonical_schema_definition> validate_protobuf_schema(
-  sharded_store& store, canonical_schema schema, normalize norm) {
+ss::future<schema_definition> validate_protobuf_schema(
+  sharded_store& store, subject_schema schema, normalize norm) {
     auto res = co_await make_protobuf_schema_definition(
       store, std::move(schema), norm);
-    co_return canonical_schema_definition{std::move(res)};
+    co_return schema_definition{std::move(res)};
 }
 
-ss::future<canonical_schema> make_canonical_protobuf_schema(
-  sharded_store& store, unparsed_schema schema, normalize norm) {
-    auto [sub, unparsed] = std::move(schema).destructure();
-    auto [def, type, refs] = std::move(unparsed).destructure();
-    canonical_schema temp{
-      sub,
-      {canonical_schema_definition::raw_string{std::move(def)()},
-       type,
-       std::move(refs)}};
-
-    co_return canonical_schema{
+ss::future<subject_schema> make_canonical_protobuf_schema(
+  sharded_store& store, subject_schema schema, normalize norm) {
+    subject sub = schema.sub();
+    co_return subject_schema{
       std::move(sub),
-      co_await validate_protobuf_schema(store, std::move(temp), norm)};
+      co_await validate_protobuf_schema(store, std::move(schema), norm)};
 }
 
 namespace {

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -21,17 +21,13 @@ class Descriptor;
 namespace pandaproxy::schema_registry {
 
 ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
-  schema_getter& store,
-  canonical_schema schema,
-  normalize norm = normalize::no);
+  schema_getter& store, subject_schema schema, normalize norm = normalize::no);
 
-ss::future<canonical_schema_definition> validate_protobuf_schema(
-  sharded_store& store,
-  canonical_schema schema,
-  normalize norm = normalize::no);
+ss::future<schema_definition> validate_protobuf_schema(
+  sharded_store& store, subject_schema schema, normalize norm = normalize::no);
 
-ss::future<canonical_schema> make_canonical_protobuf_schema(
-  sharded_store& store, unparsed_schema schema, normalize norm = normalize::no);
+ss::future<subject_schema> make_canonical_protobuf_schema(
+  sharded_store& store, subject_schema schema, normalize norm = normalize::no);
 
 compatibility_result check_compatible(
   const protobuf_schema_definition& reader,

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -18,7 +18,7 @@
 namespace pandaproxy::schema_registry {
 
 struct get_schemas_ids_id_response {
-    canonical_schema_definition definition;
+    schema_definition definition;
 };
 
 template<typename Buffer>

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -18,7 +18,7 @@
 namespace pandaproxy::schema_registry {
 
 struct post_subject_versions_version_response {
-    canonical_schema schema;
+    subject_schema schema;
     schema_id id;
     schema_version version;
 };

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -24,7 +24,7 @@
 namespace pandaproxy::schema_registry {
 
 struct post_subject_versions_request {
-    canonical_schema schema;
+    subject_schema schema;
 };
 
 template<typename Encoding = ::json::UTF8<>>
@@ -49,16 +49,16 @@ class post_subject_versions_request_handler
 
     struct mutable_schema {
         subject sub{invalid_subject};
-        unparsed_schema_definition::raw_string def;
+        schema_definition::raw_string def;
         schema_type type{schema_type::avro};
-        unparsed_schema_definition::references refs;
+        schema_definition::references refs;
     };
     mutable_schema _schema;
 
 public:
     using Ch = typename json::base_handler<Encoding>::Ch;
     struct rjson_parse_result {
-        unparsed_schema def;
+        subject_schema def;
         std::optional<schema_id> id;
         std::optional<schema_version> version;
     };
@@ -150,8 +150,7 @@ public:
         case state::schema: {
             iobuf buf;
             buf.append(sv.data(), sv.size());
-            _schema.def = unparsed_schema_definition::raw_string{
-              std::move(buf)};
+            _schema.def = schema_definition::raw_string{std::move(buf)};
             _state = state::record;
             return true;
         }

--- a/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/get_subject_versions_version.cc
@@ -20,7 +20,7 @@ namespace pps = pandaproxy::schema_registry;
 SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_version_response) {
     const ss::sstring escaped_schema_def{
       R"({\"type\":\"record\",\"name\":\"test\",\"fields\":[{\"type\":\"string\",\"name\":\"field1\"},{\"type\":\"com.acme.Referenced\",\"name\":\"int\"}]})"};
-    const pps::canonical_schema_definition schema_def{
+    const pps::schema_definition schema_def{
       R"({"type":"record","name":"test","fields":[{"type":"string","name":"field1"},{"type":"com.acme.Referenced","name":"int"}]})",
       pps::schema_type::avro,
       {{{"com.acme.Referenced"},

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -27,7 +27,7 @@ using parse_result
 SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
     const ss::sstring escaped_schema_def{
       R"({\"type\":\"record\",\"name\":\"test\",\"fields\":[{\"type\":\"string\",\"name\":\"field1\"},{\"type\":\"com.acme.Referenced\",\"name\":\"int\"}]})"};
-    const pps::unparsed_schema_definition expected_schema_def{
+    const pps::schema_definition expected_schema_def{
       R"({"type":"record","name":"test","fields":[{"type":"string","name":"field1"},{"type":"com.acme.Referenced","name":"int"}]})",
       pps::schema_type::avro,
       {{.name{"com.acme.Referenced"},
@@ -61,9 +61,8 @@ SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
 
     result.def = {
       std::move(rsub),
-      pps::unparsed_schema_definition{
-        pps::unparsed_schema_definition::raw_string{
-          ::json::minify(std::move(def)())},
+      pps::schema_definition{
+        pps::schema_definition::raw_string{::json::minify(std::move(def)())},
         pps::schema_type::avro,
         std::move(refs)}};
 

--- a/src/v/pandaproxy/schema_registry/schema_getter.h
+++ b/src/v/pandaproxy/schema_registry/schema_getter.h
@@ -25,9 +25,9 @@ public:
       std::optional<schema_version> version,
       include_deleted inc_dec)
       = 0;
-    virtual ss::future<canonical_schema_definition>
+    virtual ss::future<schema_definition>
     get_schema_definition(schema_id id) = 0;
-    virtual ss::future<std::optional<canonical_schema_definition>>
+    virtual ss::future<std::optional<schema_definition>>
     maybe_get_schema_definition(schema_id id) = 0;
     virtual ~schema_getter() = default;
 };

--- a/src/v/pandaproxy/schema_registry/schema_getter.h
+++ b/src/v/pandaproxy/schema_registry/schema_getter.h
@@ -20,7 +20,7 @@ namespace pandaproxy::schema_registry {
 
 class schema_getter {
 public:
-    virtual ss::future<subject_schema> get_subject_schema(
+    virtual ss::future<stored_schema> get_subject_schema(
       subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec)

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -213,7 +213,7 @@ void seq_writer::advance_offset_inner(model::offset offset) {
 }
 
 ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
-  subject_schema schema, model::offset write_at) {
+  stored_schema schema, model::offset write_at) {
     co_await check_mutable(schema.schema.sub());
 
     // Check if store already contains this data: if
@@ -266,7 +266,7 @@ ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
     }
 }
 
-ss::future<schema_id> seq_writer::write_subject_version(subject_schema schema) {
+ss::future<schema_id> seq_writer::write_subject_version(stored_schema schema) {
     co_return co_await sequenced_write(
       [&schema](model::offset write_at, seq_writer& seq) {
           return seq.do_write_subject_version(schema.share(), write_at);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -248,7 +248,7 @@ ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
           .node{_node_id},
           .sub{sub},
           .version{projected.version}};
-        auto value = canonical_schema_value{
+        auto value = schema_value{
           .schema{std::move(canonical)},
           .version{projected.version},
           .id{projected.id},
@@ -435,14 +435,14 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
     }
 
     schema_id s_id = co_await _store.get_id(sub, version);
-    unparsed_schema_definition schema
-      = co_await _store.get_unparsed_schema_definition(s_id);
+    schema_definition schema = co_await _store.get_unparsed_schema_definition(
+      s_id);
 
     auto key = schema_key{
       .seq{write_at}, .node{_node_id}, .sub{sub}, .version{version}};
     vlog(plog.debug, "seq_writer::delete_subject_version {}", key);
-    unparsed_schema_value value{
-      .schema{unparsed_schema{sub, std::move(schema)}},
+    schema_value value{
+      .schema{subject_schema{sub, std::move(schema)}},
       .version{version},
       .id{s_id},
       .deleted{is_deleted::yes}};

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -435,8 +435,7 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
     }
 
     schema_id s_id = co_await _store.get_id(sub, version);
-    schema_definition schema = co_await _store.get_unparsed_schema_definition(
-      s_id);
+    schema_definition schema = co_await _store.get_schema_definition(s_id);
 
     auto key = schema_key{
       .seq{write_at}, .node{_node_id}, .sub{sub}, .version{version}};

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -49,7 +49,7 @@ public:
     // API for readers: notify us when they have read and applied an offset
     ss::future<> advance_offset(model::offset offset);
 
-    ss::future<schema_id> write_subject_version(subject_schema schema);
+    ss::future<schema_id> write_subject_version(stored_schema schema);
 
     ss::future<bool>
     write_config(std::optional<subject> sub, compatibility_level compat);
@@ -80,7 +80,7 @@ private:
     void advance_offset_inner(model::offset offset);
 
     ss::future<std::optional<schema_id>>
-    do_write_subject_version(subject_schema schema, model::offset write_at);
+    do_write_subject_version(stored_schema schema, model::offset write_at);
 
     ss::future<std::optional<bool>> do_write_config(
       std::optional<subject> sub,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -13,7 +13,6 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
-#include "container/fragmented_vector.h"
 #include "hashing/jump_consistent_hash.h"
 #include "hashing/xx.h"
 #include "pandaproxy/logger.h"
@@ -28,16 +27,13 @@
 #include "pandaproxy/schema_registry/util.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/loop.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/exception.hh>
 
 #include <absl/algorithm/container.h>
 #include <fmt/core.h>
 
-#include <exception>
 #include <functional>
 #include <iterator>
 
@@ -144,59 +140,10 @@ sharded_store::make_valid_schema(subject_schema schema) {
 }
 
 ss::future<sharded_store::has_schema_result>
-sharded_store::get_schema_version(stored_schema schema, normalize norm) {
-    // Validate the schema (may throw)
-    co_await validate_schema(schema.schema.share());
-
+sharded_store::get_schema_version(stored_schema schema) {
     // Determine if the definition already exists
-    auto map = [this, norm, &schema](
-                 const store& s) -> ss::future<std::optional<schema_id>> {
-        const auto& schemas = s.get_schemas();
-        auto keys = schemas | std::views::keys;
-        chunked_vector<schema_id> stored_ids{keys.begin(), keys.end()};
-
-        return ss::do_with(
-          std::optional<schema_id>{},
-          std::move(stored_ids),
-          [this, norm, &s, &schema](
-            std::optional<schema_id>& ret_id, chunked_vector<schema_id>& ids) {
-              auto loop_condition = [&ret_id, &ids]() {
-                  return ret_id.has_value() || ids.empty();
-              };
-
-              auto loop_body =
-                [this, norm, &s, &ids, &ret_id, &schema]() -> ss::future<> {
-                  auto id = ids.back();
-                  ids.pop_back();
-
-                  auto s_res = s.get_schema_definition(id);
-                  if (s_res.has_error()) {
-                      return ss::make_ready_future();
-                  }
-
-                  return this
-                    ->make_canonical_schema(
-                      subject_schema{subject{}, std::move(s_res.value())}, norm)
-                    .then([id, &ret_id, &schema](subject_schema processed) {
-                        if (processed.def() == schema.schema.def()) {
-                            ret_id = id;
-                        }
-                        return ss::make_ready_future();
-                    })
-                    .handle_exception([id](std::exception_ptr e) {
-                        vlog(
-                          plog.warn,
-                          "Failed to parse stored schema with "
-                          "id {}. Error: {}",
-                          id,
-                          e);
-                    });
-              };
-
-              return ss::do_until(
-                       std::move(loop_condition), std::move(loop_body))
-                .then([&ret_id] { return ret_id; });
-          });
+    auto map = [&schema](store& s) {
+        return s.get_schema_id(schema.schema.def());
     };
     auto reduce = [](
                     std::optional<schema_id> acc,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -81,11 +81,15 @@ ss::future<> sharded_store::start(is_mutable mut, ss::smp_service_group sg) {
 
 ss::future<> sharded_store::stop() { return _store.stop(); }
 
-ss::future<subject_schema>
-sharded_store::make_canonical_schema(subject_schema schema, normalize norm) {
-    norm = norm
-           || normalize{
-             config::shard_local_cfg().schema_registry_always_normalize()};
+ss::future<subject_schema> sharded_store::make_canonical_schema(
+  subject_schema schema,
+  normalize norm,
+  bool consider_always_normalize_config) {
+    if (consider_always_normalize_config) {
+        norm = norm
+               || normalize{
+                 config::shard_local_cfg().schema_registry_always_normalize()};
+    }
     switch (schema.type()) {
     case schema_type::avro: {
         auto [sub, unparsed] = std::move(schema).destructure();
@@ -299,6 +303,14 @@ ss::future<bool> sharded_store::upsert(
   schema_id id,
   schema_version version,
   is_deleted deleted) {
+    try {
+        subject_schema canonical = co_await make_canonical_schema(
+          schema.share(), normalize::no, false);
+        schema = std::move(canonical);
+    } catch (...) {
+        // do nothing. In case make_canonical_schema fails, continue with the
+        // schema as-is in the topic
+    }
     auto [sub, def] = std::move(schema).destructure();
     co_await upsert_schema(id, std::move(def));
     co_return co_await upsert_subject(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -254,9 +254,8 @@ ss::future<bool> sharded_store::upsert(
   schema_version version,
   is_deleted deleted) {
     try {
-        subject_schema canonical = co_await make_canonical_schema(
+        schema = co_await make_canonical_schema(
           schema.share(), normalize::no, false);
-        schema = std::move(canonical);
     } catch (...) {
         // do nothing. In case make_canonical_schema fails, continue with the
         // schema as-is in the topic

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -140,7 +140,7 @@ sharded_store::make_valid_schema(canonical_schema schema) {
 }
 
 ss::future<sharded_store::has_schema_result>
-sharded_store::get_schema_version(subject_schema schema, normalize norm) {
+sharded_store::get_schema_version(stored_schema schema, normalize norm) {
     // Validate the schema (may throw)
     co_await validate_schema(schema.schema.share());
 
@@ -275,7 +275,7 @@ sharded_store::get_schema_version(subject_schema schema, normalize norm) {
 }
 
 ss::future<sharded_store::insert_result>
-sharded_store::project_ids(subject_schema schema) {
+sharded_store::project_ids(stored_schema schema) {
     const auto& sub = schema.schema.sub();
     auto s_id = schema.id;
     if (s_id == invalid_schema_id) {
@@ -323,7 +323,7 @@ ss::future<> sharded_store::delete_schema(schema_id id) {
       shard_for(id), _smp_opts, [id](store& s) { s.delete_schema(id); });
 }
 
-ss::future<subject_schema> sharded_store::has_schema(
+ss::future<stored_schema> sharded_store::has_schema(
   canonical_schema schema, include_deleted inc_del, normalize norm) {
     auto versions = co_await get_versions(schema.sub(), inc_del);
 
@@ -333,7 +333,7 @@ ss::future<subject_schema> sharded_store::has_schema(
         throw as_exception(invalid_subject_schema(schema.sub()));
     }
 
-    std::optional<subject_schema> sub_schema;
+    std::optional<stored_schema> sub_schema;
     for (auto ver : versions) {
         try {
             auto res = co_await get_subject_schema(
@@ -469,12 +469,12 @@ sharded_store::get_id(subject sub, std::optional<schema_version> version) {
     co_return v_id.id;
 }
 
-ss::future<subject_schema> sharded_store::get_subject_schema(
+ss::future<stored_schema> sharded_store::get_subject_schema(
   subject sub, std::optional<schema_version> version, include_deleted inc_del) {
     return get_subject_schema(sub, version, inc_del, normalize::no);
 }
 
-ss::future<subject_schema> sharded_store::get_subject_schema(
+ss::future<stored_schema> sharded_store::get_subject_schema(
   subject sub,
   std::optional<schema_version> version,
   include_deleted inc_del,
@@ -494,7 +494,7 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
         auto canonical = co_await make_canonical_schema(
           {sub, std::move(def)}, norm);
 
-        co_return subject_schema{
+        co_return stored_schema{
           .schema = std::move(canonical),
           .version = v_id.version,
           .id = v_id.id,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -141,6 +141,9 @@ sharded_store::make_valid_schema(subject_schema schema) {
 
 ss::future<sharded_store::has_schema_result>
 sharded_store::get_schema_version(stored_schema schema) {
+    // Validate the schema (may throw)
+    co_await validate_schema(schema.schema.share());
+
     // Determine if the definition already exists
     auto map = [&schema](store& s) {
         return s.get_schema_id(schema.schema.def());
@@ -276,8 +279,8 @@ ss::future<> sharded_store::delete_schema(schema_id id) {
       shard_for(id), _smp_opts, [id](store& s) { s.delete_schema(id); });
 }
 
-ss::future<stored_schema> sharded_store::has_schema(
-  subject_schema schema, include_deleted inc_del, normalize norm) {
+ss::future<stored_schema>
+sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
     auto versions = co_await get_versions(schema.sub(), inc_del);
 
     try {
@@ -289,8 +292,7 @@ ss::future<stored_schema> sharded_store::has_schema(
     std::optional<stored_schema> sub_schema;
     for (auto ver : versions) {
         try {
-            auto res = co_await get_subject_schema(
-              schema.sub(), ver, inc_del, norm);
+            auto res = co_await get_subject_schema(schema.sub(), ver, inc_del);
             if (schema.def() == res.schema.def()) {
                 sub_schema.emplace(std::move(res));
                 break;
@@ -322,7 +324,7 @@ ss::future<stored_schema> sharded_store::has_schema(
 
 ss::future<std::optional<schema_definition>>
 sharded_store::maybe_get_schema_definition(schema_id id) {
-    auto unparsed = co_await _store.invoke_on(
+    co_return co_await _store.invoke_on(
       shard_for(id),
       _smp_opts,
       [id](store& s) -> std::optional<schema_definition> {
@@ -334,49 +336,10 @@ sharded_store::maybe_get_schema_definition(schema_id id) {
           }
           return std::move(s_res.value());
       });
-    if (!unparsed.has_value()) {
-        co_return std::nullopt;
-    }
-
-    try {
-        auto canonical = co_await make_canonical_schema(
-          {{}, std::move(unparsed.value())});
-
-        co_return std::move(canonical).def();
-    } catch (const exception& e) {
-        vlog(
-          plog.warn,
-          "Failed to parse stored schema with id {}: Error {}",
-          id,
-          e.what());
-        throw;
-    }
 }
 
 ss::future<schema_definition>
 sharded_store::get_schema_definition(schema_id id) {
-    auto unparsed = co_await _store.invoke_on(
-      shard_for(id), _smp_opts, [id](store& s) {
-          return s.get_schema_definition(id).value();
-      });
-
-    try {
-        auto canonical = co_await make_canonical_schema(
-          {{}, std::move(unparsed)});
-
-        co_return std::move(canonical).def();
-    } catch (const exception& e) {
-        vlog(
-          plog.warn,
-          "Failed to parse stored schema with id {}: Error {}",
-          id,
-          e.what());
-        throw;
-    }
-}
-
-ss::future<schema_definition>
-sharded_store::get_unparsed_schema_definition(schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();
@@ -424,14 +387,6 @@ sharded_store::get_id(subject sub, std::optional<schema_version> version) {
 
 ss::future<stored_schema> sharded_store::get_subject_schema(
   subject sub, std::optional<schema_version> version, include_deleted inc_del) {
-    return get_subject_schema(sub, version, inc_del, normalize::no);
-}
-
-ss::future<stored_schema> sharded_store::get_subject_schema(
-  subject sub,
-  std::optional<schema_version> version,
-  include_deleted inc_del,
-  normalize norm) {
     auto sub_shard{shard_for(sub)};
     auto v_id = co_await _store.invoke_on(
       sub_shard, _smp_opts, [sub, version, inc_del](store& s) {
@@ -443,24 +398,11 @@ ss::future<stored_schema> sharded_store::get_subject_schema(
           return s.get_schema_definition(id).value();
       });
 
-    try {
-        auto canonical = co_await make_canonical_schema(
-          {sub, std::move(def)}, norm);
-
-        co_return stored_schema{
-          .schema = std::move(canonical),
-          .version = v_id.version,
-          .id = v_id.id,
-          .deleted = v_id.deleted};
-    } catch (const exception& e) {
-        vlog(
-          plog.warn,
-          "Failed to parse stored schema, subject {}, version {}: {}",
-          sub,
-          v_id.version,
-          e.what());
-        throw;
-    }
+    co_return stored_schema{
+      .schema = {sub, std::move(def)},
+      .version = v_id.version,
+      .id = v_id.id,
+      .deleted = v_id.deleted};
 }
 
 ss::future<chunked_vector<subject>> sharded_store::get_subjects(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -81,15 +81,15 @@ ss::future<> sharded_store::start(is_mutable mut, ss::smp_service_group sg) {
 
 ss::future<> sharded_store::stop() { return _store.stop(); }
 
-ss::future<canonical_schema>
-sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
+ss::future<subject_schema>
+sharded_store::make_canonical_schema(subject_schema schema, normalize norm) {
     norm = norm
            || normalize{
              config::shard_local_cfg().schema_registry_always_normalize()};
     switch (schema.type()) {
     case schema_type::avro: {
         auto [sub, unparsed] = std::move(schema).destructure();
-        co_return canonical_schema{
+        co_return subject_schema{
           std::move(sub),
           sanitize_avro_schema_definition(std::move(unparsed)).value()};
     }
@@ -103,7 +103,7 @@ sharded_store::make_canonical_schema(unparsed_schema schema, normalize norm) {
     __builtin_unreachable();
 }
 
-ss::future<> sharded_store::validate_schema(canonical_schema schema) {
+ss::future<> sharded_store::validate_schema(subject_schema schema) {
     switch (schema.type()) {
     case schema_type::avro: {
         co_await make_avro_schema_definition(*this, std::move(schema));
@@ -120,7 +120,7 @@ ss::future<> sharded_store::validate_schema(canonical_schema schema) {
 }
 
 ss::future<valid_schema>
-sharded_store::make_valid_schema(canonical_schema schema) {
+sharded_store::make_valid_schema(subject_schema schema) {
     // This method seems to confuse clang 12.0.1
     // See #3596 for details, especially if modifying it.
     switch (schema.type()) {
@@ -170,16 +170,10 @@ sharded_store::get_schema_version(stored_schema schema, normalize norm) {
                       return ss::make_ready_future();
                   }
 
-                  auto [raw, type, refs]
-                    = std::move(s_res.value()).destructure();
                   return this
                     ->make_canonical_schema(
-                      unparsed_schema{
-                        subject{},
-                        unparsed_schema_definition{
-                          std::move(raw), type, std::move(refs)}},
-                      norm)
-                    .then([id, &ret_id, &schema](canonical_schema processed) {
+                      subject_schema{subject{}, std::move(s_res.value())}, norm)
+                    .then([id, &ret_id, &schema](subject_schema processed) {
                         if (processed.def() == schema.schema.def()) {
                             ret_id = id;
                         }
@@ -301,7 +295,7 @@ sharded_store::project_ids(stored_schema schema) {
 
 ss::future<bool> sharded_store::upsert(
   seq_marker marker,
-  unparsed_schema schema,
+  subject_schema schema,
   schema_id id,
   schema_version version,
   is_deleted deleted) {
@@ -324,7 +318,7 @@ ss::future<> sharded_store::delete_schema(schema_id id) {
 }
 
 ss::future<stored_schema> sharded_store::has_schema(
-  canonical_schema schema, include_deleted inc_del, normalize norm) {
+  subject_schema schema, include_deleted inc_del, normalize norm) {
     auto versions = co_await get_versions(schema.sub(), inc_del);
 
     try {
@@ -367,12 +361,12 @@ ss::future<stored_schema> sharded_store::has_schema(
     co_return std::move(sub_schema).value();
 }
 
-ss::future<std::optional<canonical_schema_definition>>
+ss::future<std::optional<schema_definition>>
 sharded_store::maybe_get_schema_definition(schema_id id) {
     auto unparsed = co_await _store.invoke_on(
       shard_for(id),
       _smp_opts,
-      [id](store& s) -> std::optional<unparsed_schema_definition> {
+      [id](store& s) -> std::optional<schema_definition> {
           auto s_res = s.get_schema_definition(id);
           if (
             s_res.has_error()
@@ -400,7 +394,7 @@ sharded_store::maybe_get_schema_definition(schema_id id) {
     }
 }
 
-ss::future<canonical_schema_definition>
+ss::future<schema_definition>
 sharded_store::get_schema_definition(schema_id id) {
     auto unparsed = co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
@@ -422,7 +416,7 @@ sharded_store::get_schema_definition(schema_id id) {
     }
 }
 
-ss::future<unparsed_schema_definition>
+ss::future<schema_definition>
 sharded_store::get_unparsed_schema_definition(schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
@@ -765,7 +759,7 @@ sharded_store::clear_compatibility(seq_marker marker, subject sub) {
 }
 
 ss::future<bool>
-sharded_store::upsert_schema(schema_id id, unparsed_schema_definition def) {
+sharded_store::upsert_schema(schema_id id, schema_definition def) {
     co_await maybe_update_max_schema_id(id);
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id, def{std::move(def)}](store& s) mutable {
@@ -825,19 +819,19 @@ ss::future<> sharded_store::maybe_update_max_schema_id(schema_id id) {
 }
 
 ss::future<bool> sharded_store::is_compatible(
-  schema_version version, canonical_schema new_schema) {
+  schema_version version, subject_schema new_schema) {
     auto rslt = co_await do_is_compatible(
       version, std::move(new_schema), verbose::no);
     co_return rslt.is_compat;
 }
 
 ss::future<compatibility_result> sharded_store::is_compatible(
-  schema_version version, canonical_schema new_schema, verbose is_verbose) {
+  schema_version version, subject_schema new_schema, verbose is_verbose) {
     return do_is_compatible(version, std::move(new_schema), is_verbose);
 }
 
 ss::future<compatibility_result> sharded_store::do_is_compatible(
-  schema_version version, canonical_schema new_schema, verbose is_verbose) {
+  schema_version version, subject_schema new_schema, verbose is_verbose) {
     // Lookup the version_ids
     const auto sub = new_schema.sub();
     const auto versions = co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -66,15 +66,10 @@ public:
 
     ss::future<bool> has_schema(schema_id id);
     ss::future<stored_schema> has_schema(
-      subject_schema schema,
-      include_deleted inc_del = include_deleted::no,
-      normalize norm = normalize::no);
+      subject_schema schema, include_deleted inc_del = include_deleted::no);
 
     ///\brief Return a schema definition by id.
     ss::future<schema_definition> get_schema_definition(schema_id id) override;
-
-    ///\brief Return a schema definition by id, without any processing.
-    ss::future<schema_definition> get_unparsed_schema_definition(schema_id id);
 
     ss::future<std::optional<schema_definition>>
     maybe_get_schema_definition(schema_id id) override;
@@ -92,12 +87,6 @@ public:
       subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec) final;
-
-    ss::future<stored_schema> get_subject_schema(
-      subject sub,
-      std::optional<schema_version> version,
-      include_deleted inc_dec,
-      normalize norm);
 
     ///\brief Return the id of a schema by subject and version (or latest).
     ss::future<schema_id>

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -33,14 +33,14 @@ public:
     ss::future<> stop();
 
     ///\brief Make the canonical form of the schema
-    ss::future<canonical_schema> make_canonical_schema(
-      unparsed_schema schema, normalize norm = normalize::no);
+    ss::future<subject_schema> make_canonical_schema(
+      subject_schema schema, normalize norm = normalize::no);
 
     ///\brief Check the schema parses with the native format
-    ss::future<void> validate_schema(canonical_schema schema);
+    ss::future<void> validate_schema(subject_schema schema);
 
     ///\brief Construct a schema in the native format
-    ss::future<valid_schema> make_valid_schema(canonical_schema schema);
+    ss::future<valid_schema> make_valid_schema(subject_schema schema);
 
     struct has_schema_result {
         std::optional<schema_id> id;
@@ -58,26 +58,24 @@ public:
 
     ss::future<bool> upsert(
       seq_marker marker,
-      unparsed_schema schema,
+      subject_schema schema,
       schema_id id,
       schema_version version,
       is_deleted deleted);
 
     ss::future<bool> has_schema(schema_id id);
     ss::future<stored_schema> has_schema(
-      canonical_schema schema,
+      subject_schema schema,
       include_deleted inc_del = include_deleted::no,
       normalize norm = normalize::no);
 
     ///\brief Return a schema definition by id.
-    ss::future<canonical_schema_definition>
-    get_schema_definition(schema_id id) override;
+    ss::future<schema_definition> get_schema_definition(schema_id id) override;
 
     ///\brief Return a schema definition by id, without any processing.
-    ss::future<unparsed_schema_definition>
-    get_unparsed_schema_definition(schema_id id);
+    ss::future<schema_definition> get_unparsed_schema_definition(schema_id id);
 
-    ss::future<std::optional<canonical_schema_definition>>
+    ss::future<std::optional<schema_definition>>
     maybe_get_schema_definition(schema_id id) override;
 
     ///\brief Return a list of subject-versions for the shema id.
@@ -195,7 +193,7 @@ public:
     /// If the compatibility level is transitive, then all versions are checked,
     /// otherwise checks are against the version provided and newer.
     ss::future<bool>
-    is_compatible(schema_version version, canonical_schema new_schema);
+    is_compatible(schema_version version, subject_schema new_schema);
 
     ///\brief Check if the provided schema is compatible with the subject and
     /// version, according the the current compatibility, with the result
@@ -204,7 +202,7 @@ public:
     /// If the compatibility level is transitive, then all versions are checked,
     /// otherwise checks are against the version provided and newer.
     ss::future<compatibility_result> is_compatible(
-      schema_version version, canonical_schema new_schema, verbose is_verbose);
+      schema_version version, subject_schema new_schema, verbose is_verbose);
 
     ss::future<bool> has_version(const subject&, schema_id, include_deleted);
 
@@ -217,10 +215,9 @@ public:
 
 private:
     ss::future<compatibility_result> do_is_compatible(
-      schema_version version, canonical_schema new_schema, verbose is_verbose);
+      schema_version version, subject_schema new_schema, verbose is_verbose);
 
-    ss::future<bool>
-    upsert_schema(schema_id id, unparsed_schema_definition def);
+    ss::future<bool> upsert_schema(schema_id id, schema_definition def);
     ss::future<> delete_schema(schema_id id);
 
     struct insert_subject_result {

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -34,7 +34,9 @@ public:
 
     ///\brief Make the canonical form of the schema
     ss::future<subject_schema> make_canonical_schema(
-      subject_schema schema, normalize norm = normalize::no);
+      subject_schema schema,
+      normalize norm = normalize::no,
+      bool consider_always_normalize_config = true);
 
     ///\brief Check the schema parses with the native format
     ss::future<void> validate_schema(subject_schema schema);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -47,14 +47,14 @@ public:
         std::optional<schema_version> version;
     };
     ss::future<has_schema_result>
-    get_schema_version(subject_schema schema, normalize norm = normalize::no);
+    get_schema_version(stored_schema schema, normalize norm = normalize::no);
 
     struct insert_result {
         schema_version version;
         schema_id id;
         bool inserted;
     };
-    ss::future<insert_result> project_ids(subject_schema schema);
+    ss::future<insert_result> project_ids(stored_schema schema);
 
     ss::future<bool> upsert(
       seq_marker marker,
@@ -64,7 +64,7 @@ public:
       is_deleted deleted);
 
     ss::future<bool> has_schema(schema_id id);
-    ss::future<subject_schema> has_schema(
+    ss::future<stored_schema> has_schema(
       canonical_schema schema,
       include_deleted inc_del = include_deleted::no,
       normalize norm = normalize::no);
@@ -89,12 +89,12 @@ public:
     get_schema_subjects(schema_id id, include_deleted inc_del);
 
     ///\brief Return a schema by subject and version (or latest).
-    ss::future<subject_schema> get_subject_schema(
+    ss::future<stored_schema> get_subject_schema(
       subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec) final;
 
-    ss::future<subject_schema> get_subject_schema(
+    ss::future<stored_schema> get_subject_schema(
       subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec,

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -48,8 +48,7 @@ public:
         std::optional<schema_id> id;
         std::optional<schema_version> version;
     };
-    ss::future<has_schema_result>
-    get_schema_version(stored_schema schema, normalize norm = normalize::no);
+    ss::future<has_schema_result> get_schema_version(stored_schema schema);
 
     struct insert_result {
         schema_version version;

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -299,9 +299,8 @@ public:
     }
 };
 
-template<typename Tag>
 struct schema_value {
-    typed_schema<Tag> schema;
+    subject_schema schema;
     schema_version version;
     schema_id id;
     is_deleted deleted{false};
@@ -320,12 +319,8 @@ struct schema_value {
     }
 };
 
-using unparsed_schema_value = schema_value<unparsed_schema_defnition_tag>;
-using canonical_schema_value = schema_value<canonical_schema_definition_tag>;
-
-template<typename Buffer, typename Tag>
-void rjson_serialize(
-  ::json::iobuf_writer<Buffer>& w, const schema_value<Tag>& val) {
+template<typename Buffer>
+void rjson_serialize(::json::iobuf_writer<Buffer>& w, const schema_value& val) {
     w.StartObject();
     w.Key("subject");
     ::json::rjson_serialize(w, val.schema.sub());
@@ -360,7 +355,7 @@ void rjson_serialize(
     w.EndObject();
 }
 
-template<typename Tag, typename Encoding = ::json::UTF8<>>
+template<typename Encoding = ::json::UTF8<>>
 class schema_value_handler final : public json::base_handler<Encoding> {
     enum class state {
         empty = 0,
@@ -381,15 +376,15 @@ class schema_value_handler final : public json::base_handler<Encoding> {
 
     struct mutable_schema {
         subject sub{invalid_subject};
-        typename typed_schema_definition<Tag>::raw_string def;
+        typename schema_definition::raw_string def;
         schema_type type{schema_type::avro};
-        typename typed_schema_definition<Tag>::references refs;
+        typename schema_definition::references refs;
     };
     mutable_schema _schema;
 
 public:
     using Ch = typename json::base_handler<Encoding>::Ch;
-    using rjson_parse_result = schema_value<Tag>;
+    using rjson_parse_result = schema_value;
     rjson_parse_result result;
 
     schema_value_handler()
@@ -505,8 +500,7 @@ public:
             return true;
         }
         case state::definition: {
-            _schema.def = typename typed_schema_definition<Tag>::raw_string{
-              ss::sstring{sv}};
+            _schema.def = schema_definition::raw_string{ss::sstring{sv}};
             _state = state::object;
             return true;
         }
@@ -605,13 +599,6 @@ public:
         return std::exchange(_state, state::object) == state::references;
     }
 };
-
-template<typename Encoding = ::json::UTF8<>>
-using unparsed_schema_value_handler
-  = schema_value_handler<unparsed_schema_defnition_tag, Encoding>;
-template<typename Encoding = ::json::UTF8<>>
-using canonical_schema_value_handler
-  = schema_value_handler<canonical_schema_definition_tag, Encoding>;
 
 struct config_key {
     static constexpr topic_key_type keytype{topic_key_type::config};
@@ -1399,9 +1386,9 @@ struct consume_to_store {
         case topic_key_type::noop:
             break;
         case topic_key_type::schema: {
-            std::optional<unparsed_schema_value> val;
+            std::optional<schema_value> val;
             if (!record.value().empty()) {
-                val.emplace(from_json_iobuf<unparsed_schema_value_handler<>>(
+                val.emplace(from_json_iobuf<schema_value_handler<>>(
                   record.release_value()));
             }
             co_await apply(
@@ -1452,11 +1439,8 @@ struct consume_to_store {
         co_await _sequencer.advance_offset(offset);
     }
 
-    template<typename Tag>
     ss::future<> apply(
-      model::offset offset,
-      schema_key key,
-      std::optional<schema_value<Tag>> val) {
+      model::offset offset, schema_key key, std::optional<schema_value> val) {
         if (key.magic != 0 && key.magic != 1) {
             throw exception(
               error_code::topic_parse_error,

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -500,7 +500,7 @@ public:
             return true;
         }
         case state::definition: {
-            _schema.def = schema_definition::raw_string{ss::sstring{sv}};
+            _schema.def = schema_definition::raw_string{sv};
             _state = state::object;
             return true;
         }

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -157,7 +157,7 @@ public:
     }
 
     ///\brief Return a schema by subject and version.
-    result<unparsed_subject_schema> get_subject_schema(
+    result<unparsed_stored_schema> get_subject_schema(
       const subject& sub,
       std::optional<schema_version> version,
       include_deleted inc_del) const {
@@ -166,7 +166,7 @@ public:
 
         auto def = BOOST_OUTCOME_TRYX(get_schema_definition(v_id.id));
 
-        return unparsed_subject_schema{
+        return unparsed_stored_schema{
           .schema = {sub, std::move(def)},
           .version = v_id.version,
           .id = v_id.id,

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -103,6 +103,17 @@ public:
         return {it->second.definition.share()};
     }
 
+    ///\brief Return the id of the schema, if it already exists.
+    std::optional<schema_id> get_schema_id(const schema_definition& def) const {
+        const auto s_it = std::find_if(
+          _schemas.begin(), _schemas.end(), [&](const auto& s) {
+              const auto& entry = s.second;
+              return def == entry.definition;
+          });
+        return s_it == _schemas.end() ? std::optional<schema_id>{}
+                                      : s_it->first;
+    }
+
     ///\brief Return a list of subject-versions for the shema id.
     chunked_vector<subject_version> get_schema_subject_versions(schema_id id) {
         chunked_vector<subject_version> svs;
@@ -769,9 +780,6 @@ public:
               });
         }
     };
-
-    ///\brief _schemas const getter
-    const auto& get_schemas() const { return _schemas; }
 
 private:
     struct schema_entry {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -87,7 +87,7 @@ public:
     /// version.
     ///
     /// return the schema_version and schema_id, and whether it's new.
-    insert_result insert(unparsed_schema schema) {
+    insert_result insert(subject_schema schema) {
         auto [sub, def] = std::move(schema).destructure();
         auto id = insert_schema(std::move(def)).id;
         auto [version, inserted] = insert_subject(std::move(sub), id);
@@ -95,8 +95,7 @@ public:
     }
 
     ///\brief Return a schema definition by id.
-    result<unparsed_schema_definition>
-    get_schema_definition(const schema_id& id) const {
+    result<schema_definition> get_schema_definition(const schema_id& id) const {
         auto it = _schemas.find(id);
         if (it == _schemas.end()) {
             return not_found(id);
@@ -157,7 +156,7 @@ public:
     }
 
     ///\brief Return a schema by subject and version.
-    result<unparsed_stored_schema> get_subject_schema(
+    result<stored_schema> get_subject_schema(
       const subject& sub,
       std::optional<schema_version> version,
       include_deleted inc_del) const {
@@ -166,7 +165,7 @@ public:
 
         auto def = BOOST_OUTCOME_TRYX(get_schema_definition(v_id.id));
 
-        return unparsed_stored_schema{
+        return stored_schema{
           .schema = {sub, std::move(def)},
           .version = v_id.version,
           .id = v_id.id,
@@ -614,7 +613,7 @@ public:
         schema_id id;
         bool inserted;
     };
-    insert_schema_result insert_schema(unparsed_schema_definition def) {
+    insert_schema_result insert_schema(schema_definition def) {
         const auto s_it = std::find_if(
           _schemas.begin(), _schemas.end(), [&](const auto& s) {
               const auto& entry = s.second;
@@ -630,7 +629,7 @@ public:
         return {id, inserted};
     }
 
-    bool upsert_schema(schema_id id, unparsed_schema_definition def) {
+    bool upsert_schema(schema_id id, schema_definition def) {
         return _schemas.insert_or_assign(id, schema_entry(std::move(def)))
           .second;
     }
@@ -776,10 +775,10 @@ public:
 
 private:
     struct schema_entry {
-        explicit schema_entry(unparsed_schema_definition definition)
+        explicit schema_entry(schema_definition definition)
           : definition{std::move(definition)} {}
 
-        unparsed_schema_definition definition;
+        schema_definition definition;
     };
 
     class subject_entry {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -28,8 +28,7 @@ namespace pps = pp::schema_registry;
 namespace {
 
 bool check_compatible(
-  const pps::canonical_schema_definition& r,
-  const pps::canonical_schema_definition& w) {
+  const pps::schema_definition& r, const pps::schema_definition& w) {
     pps::sharded_store s;
     return check_compatible(
              pps::make_avro_schema_definition(
@@ -42,8 +41,7 @@ bool check_compatible(
 }
 
 pps::compatibility_result check_compatible_verbose(
-  const pps::canonical_schema_definition& r,
-  const pps::canonical_schema_definition& w) {
+  const pps::schema_definition& r, const pps::schema_definition& w) {
     pps::sharded_store s;
     return check_compatible(
       pps::make_avro_schema_definition(
@@ -261,7 +259,7 @@ SEASTAR_THREAD_TEST_CASE(test_basic_full_transitive_compatibility) {
 SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition) {
     // Parsing Canonical Form requires fields to be ordered:
     // name, type, fields, symbols, items, values, size
-    pps::canonical_schema_definition expected{
+    pps::schema_definition expected{
       R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string","default":"foo"}]})",
       pps::schema_type::avro};
     pps::sharded_store s;
@@ -274,7 +272,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition) {
       std::
         is_same_v<std::decay_t<decltype(valid)>, pps::avro_schema_definition>,
       "schema2 is an avro_schema_definition");
-    pps::canonical_schema_definition avro_conversion{valid};
+    pps::schema_definition avro_conversion{valid};
     BOOST_CHECK_EQUAL(expected, avro_conversion);
     BOOST_CHECK_EQUAL(valid.name(), "myrecord");
 }
@@ -287,7 +285,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition_custom_attributes) {
           {R"({"type":"record","name":"foo","ignored_attr":true,"fields":[{"name":"bar","type":"float","extra_attr":true}]})",
            pps::schema_type::avro})
           .value();
-    pps::canonical_schema_definition expected{
+    pps::schema_definition expected{
       R"({"type":"record","name":"foo","fields":[{"name":"bar","type":"float","extra_attr":true}]})",
       pps::schema_type::avro};
     pps::sharded_store s;
@@ -301,7 +299,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_schema_definition_custom_attributes) {
       std::
         is_same_v<std::decay_t<decltype(valid)>, pps::avro_schema_definition>,
       "schema2 is an avro_schema_definition");
-    pps::canonical_schema_definition avro_conversion{valid};
+    pps::schema_definition avro_conversion{valid};
     BOOST_CHECK_EQUAL(expected, avro_conversion);
 }
 

--- a/src/v/pandaproxy/schema_registry/test/compatibility_common.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_common.h
@@ -17,8 +17,8 @@ namespace pps = pandaproxy::schema_registry;
 template<typename incompatibility>
 struct compat_test_data {
     compat_test_data(
-      pps::canonical_schema_definition reader,
-      pps::canonical_schema_definition writer,
+      pps::schema_definition reader,
+      pps::schema_definition writer,
       absl::flat_hash_set<incompatibility> exp)
       : reader(std::move(reader))
       , writer(std::move(writer))
@@ -30,7 +30,7 @@ struct compat_test_data {
           return std::move(raw)(pps::verbose::yes);
       }()) {}
 
-    pps::canonical_schema_definition reader;
-    pps::canonical_schema_definition writer;
+    pps::schema_definition reader;
+    pps::schema_definition writer;
     pps::compatibility_result expected;
 };

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -45,7 +45,7 @@ struct simple_sharded_store {
     simple_sharded_store& operator=(simple_sharded_store&&) = delete;
 
     pps::schema_id
-    insert(const pps::unparsed_schema& schema, pps::schema_version version) {
+    insert(const pps::subject_schema& schema, pps::schema_version version) {
         const auto id = next_id++;
         store
           .upsert(
@@ -73,22 +73,21 @@ bool check_compatible(
     simple_sharded_store store;
     store.store.set_compatibility(lvl).get();
     store.insert(
-      pandaproxy::schema_registry::unparsed_schema{
+      pandaproxy::schema_registry::subject_schema{
         pps::subject{"sub"},
-        pps::unparsed_schema_definition{writer, pps::schema_type::protobuf}},
+        pps::schema_definition{writer, pps::schema_type::protobuf}},
       pps::schema_version{1});
     return store.store
       .is_compatible(
         pps::schema_version{1},
-        pps::canonical_schema{
+        pps::subject_schema{
           pps::subject{"sub"},
-          pps::canonical_schema_definition{reader, pps::schema_type::protobuf}})
+          pps::schema_definition{reader, pps::schema_type::protobuf}})
       .get();
 }
 
 pps::compatibility_result check_compatible_verbose(
-  const pps::canonical_schema_definition& r,
-  const pps::canonical_schema_definition& w) {
+  const pps::schema_definition& r, const pps::schema_definition& w) {
     pps::sharded_store s;
     return check_compatible(
       pps::make_protobuf_schema_definition(
@@ -105,9 +104,8 @@ pps::compatibility_result check_compatible_verbose(
 SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
     simple_sharded_store store;
 
-    auto schema1 = pps::canonical_schema{
-      pps::subject{"simple"}, simple.share()};
-    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
+    auto schema1 = pps::subject_schema{pps::subject{"simple"}, simple.share()};
+    store.insert(schema1.share(), pps::schema_version{1});
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
                           .get();
@@ -117,9 +115,8 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_nested) {
     simple_sharded_store store;
 
-    auto schema1 = pps::canonical_schema{
-      pps::subject{"nested"}, nested.share()};
-    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
+    auto schema1 = pps::subject_schema{pps::subject{"nested"}, nested.share()};
+    store.insert(schema1.share(), pps::schema_version{1});
     auto valid_nested = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
                           .get();
@@ -132,9 +129,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
     simple_sharded_store store;
 
     // imported depends on simple, which han't been inserted
-    auto schema1 = pps::canonical_schema{
+    auto schema1 = pps::subject_schema{
       pps::subject{"imported"}, imported.share()};
-    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
+    store.insert(schema1.share(), pps::schema_version{1});
     BOOST_REQUIRE_EXCEPTION(
       pps::make_protobuf_schema_definition(store.store, schema1.share()).get(),
       pps::exception,
@@ -146,12 +143,11 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     simple_sharded_store store;
 
-    auto schema1 = pps::canonical_schema{
-      pps::subject{"simple"}, simple.share()};
-    auto schema2 = pps::canonical_schema{
+    auto schema1 = pps::subject_schema{pps::subject{"simple"}, simple.share()};
+    auto schema2 = pps::subject_schema{
       pps::subject{"imported"}, imported_no_ref.share()};
 
-    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
+    store.insert(schema1.share(), pps::schema_version{1});
 
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
@@ -167,16 +163,16 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
     simple_sharded_store store;
 
-    auto schema1 = pps::canonical_schema{
+    auto schema1 = pps::subject_schema{
       pps::subject{"simple.proto"}, simple.share()};
-    auto schema2 = pps::canonical_schema{
+    auto schema2 = pps::subject_schema{
       pps::subject{"imported.proto"}, imported.share()};
-    auto schema3 = pps::canonical_schema{
+    auto schema3 = pps::subject_schema{
       pps::subject{"imported-again.proto"}, imported_again.share()};
 
-    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
-    store.insert(pps::to_unparsed(schema2.share()), pps::schema_version{1});
-    store.insert(pps::to_unparsed(schema3.share()), pps::schema_version{1});
+    store.insert(schema1.share(), pps::schema_version{1});
+    store.insert(schema2.share(), pps::schema_version{1});
+    store.insert(schema3.share(), pps::schema_version{1});
 
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
@@ -192,16 +188,16 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
     simple_sharded_store store;
 
-    auto schema1 = pps::canonical_schema{
+    auto schema1 = pps::subject_schema{
       pps::subject{"simple.proto"}, simple.share()};
-    auto schema2 = pps::canonical_schema{
+    auto schema2 = pps::subject_schema{
       pps::subject{"imported.proto"}, imported.share()};
-    auto schema3 = pps::canonical_schema{
+    auto schema3 = pps::subject_schema{
       pps::subject{"imported-twice.proto"}, imported_twice.share()};
 
-    store.insert(pps::to_unparsed(schema1.share()), pps::schema_version{1});
-    store.insert(pps::to_unparsed(schema2.share()), pps::schema_version{1});
-    store.insert(pps::to_unparsed(schema3.share()), pps::schema_version{1});
+    store.insert(schema1.share(), pps::schema_version{1});
+    store.insert(schema2.share(), pps::schema_version{1});
+    store.insert(schema3.share(), pps::schema_version{1});
 
     auto valid_simple = pps::make_protobuf_schema_definition(
                           store.store, schema1.share())
@@ -217,12 +213,12 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
 SEASTAR_THREAD_TEST_CASE(test_binary_protobuf) {
     simple_sharded_store store;
 
-    BOOST_REQUIRE_NO_THROW(store.store
-                             .make_valid_schema(pps::canonical_schema{
-                               pps::subject{"com.redpanda.Payload.proto"},
-                               pps::canonical_schema_definition{
-                                 base64_raw_proto, pps::schema_type::protobuf}})
-                             .get());
+    BOOST_REQUIRE_NO_THROW(
+      store.store
+        .make_valid_schema(pps::subject_schema{
+          pps::subject{"com.redpanda.Payload.proto"},
+          pps::schema_definition{base64_raw_proto, pps::schema_type::protobuf}})
+        .get());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
@@ -230,16 +226,16 @@ SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
 
     auto broken_base64_raw_proto = base64_raw_proto.substr(1);
 
-    auto schema = pps::canonical_schema{
+    auto schema = pps::subject_schema{
       pps::subject{"com.redpanda.Payload.proto"},
-      pps::canonical_schema_definition{
+      pps::schema_definition{
         broken_base64_raw_proto, pps::schema_type::protobuf}};
 
     BOOST_REQUIRE_EXCEPTION(
       store.store
-        .make_valid_schema(pps::canonical_schema{
+        .make_valid_schema(pps::subject_schema{
           pps::subject{"com.redpanda.Payload.proto"},
-          pps::canonical_schema_definition{
+          pps::schema_definition{
             broken_base64_raw_proto, pps::schema_type::protobuf}})
         .get(),
       pps::exception,
@@ -252,9 +248,9 @@ SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
 SEASTAR_THREAD_TEST_CASE(test_protobuf_well_known) {
     simple_sharded_store store;
 
-    auto schema = pps::canonical_schema{
+    auto schema = pps::subject_schema{
       pps::subject{"test_auto_well_known"},
-      pps::canonical_schema_definition{
+      pps::schema_definition{
         R"(
 syntax =  "proto3";
 package test;
@@ -338,7 +334,7 @@ message well_known_types {
   confluent.type.Decimal c_decimal = 48;
 })",
         pps::schema_type::protobuf}};
-    store.insert(pps::to_unparsed(schema.share()), pps::schema_version{1});
+    store.insert(schema.share(), pps::schema_version{1});
 
     auto valid_empty
       = pps::make_protobuf_schema_definition(store.store, schema.share()).get();
@@ -508,9 +504,9 @@ auto sanitize(
     simple_sharded_store s{proto_v2};
     iobuf buf = pps::make_canonical_protobuf_schema(
                   s.store,
-                  pps::unparsed_schema{
+                  pps::subject_schema{
                     pps::subject{"foo"},
-                    pps::unparsed_schema_definition{
+                    pps::schema_definition{
                       raw_proto, pps::schema_type::protobuf}},
                   norm)
                   .get()
@@ -1944,7 +1940,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_oneof_fully_removed) {
 
 namespace {
 
-const pps::canonical_schema_definition proto2_old{
+const pps::schema_definition proto2_old{
   R"(syntax = "proto2";
 
 message someMessage {
@@ -1977,7 +1973,7 @@ message myrecord {
 })",
   pps::schema_type::protobuf};
 
-const pps::canonical_schema_definition proto2_new{
+const pps::schema_definition proto2_new{
   R"(syntax = "proto2";
 
 message myrecord {
@@ -2008,7 +2004,7 @@ message myrecord {
 })",
   pps::schema_type::protobuf};
 
-const pps::canonical_schema_definition proto3_old{
+const pps::schema_definition proto3_old{
   R"(syntax = "proto3";
 
 message someMessage {
@@ -2042,7 +2038,7 @@ message myrecord {
 )",
   pps::schema_type::protobuf};
 
-const pps::canonical_schema_definition proto3_new{
+const pps::schema_definition proto3_new{
   R"(syntax = "proto3";
 
 message myrecord {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -14,7 +14,7 @@
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
 
-const auto simple = pps::canonical_schema_definition{
+const auto simple = pps::schema_definition{
   R"(
 syntax = "proto3";
 
@@ -23,7 +23,7 @@ message Simple {
 })",
   pps::schema_type::protobuf};
 
-const auto imported_no_ref = pps::canonical_schema_definition{
+const auto imported_no_ref = pps::schema_definition{
   R"(
 syntax = "proto3";
 
@@ -34,7 +34,7 @@ message Test2 {
 })",
   pps::schema_type::protobuf};
 
-const auto imported = pps::canonical_schema_definition{
+const auto imported = pps::schema_definition{
   R"(
 syntax = "proto3";
 
@@ -46,7 +46,7 @@ message Test2 {
   pps::schema_type::protobuf,
   {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}}}};
 
-const auto imported_again = pps::canonical_schema_definition{
+const auto imported_again = pps::schema_definition{
   R"(
 syntax = "proto3";
 
@@ -58,7 +58,7 @@ message Test3 {
   pps::schema_type::protobuf,
   {{"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
 
-const auto imported_twice = pps::canonical_schema_definition{
+const auto imported_twice = pps::schema_definition{
   R"(
 syntax = "proto3";
 
@@ -72,7 +72,7 @@ message Test3 {
   {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}},
    {"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
 
-const auto nested = pps::canonical_schema_definition{
+const auto nested = pps::schema_definition{
   R"(
 syntax = "proto3";
 
@@ -152,6 +152,5 @@ constexpr std::string_view base64_raw_proto{
   "CXRpbWVzdGFtcBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASDwoHbWVzc2FnZRgD"
   "IAEoCUILUAFaBy4vO21haW5iBnByb3RvMw=="};
 
-const pps::canonical_schema_definition base64_proto{
-  pps::canonical_schema_definition{
-    base64_raw_proto, pps::schema_type::protobuf}};
+const pps::schema_definition base64_proto{
+  base64_raw_proto, pps::schema_type::protobuf};

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -33,7 +33,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     auto sub = pps::subject{"sub"};
     s.upsert(
        dummy_marker,
-       pps::to_unparsed({sub, schema1.share()}),
+       pps::subject_schema{sub, schema1.share()},
        pps::schema_id{1},
        pps::schema_version{1},
        pps::is_deleted::no)
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
       s.is_compatible(pps::schema_version{1}, {sub, schema2.share()}).get());
     s.upsert(
        dummy_marker,
-       pps::to_unparsed({sub, schema2.share()}),
+       pps::subject_schema{sub, schema2.share()},
        pps::schema_id{2},
        pps::schema_version{2},
        pps::is_deleted::no)
@@ -56,7 +56,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     // Insert schema with non-defaulted field
     s.upsert(
        dummy_marker,
-       pps::to_unparsed({sub, schema2.share()}),
+       pps::subject_schema{sub, schema2.share()},
        pps::schema_id{2},
        pps::schema_version{2},
        pps::is_deleted::no)

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -42,13 +42,13 @@ constexpr pps::schema_version version1{1};
 constexpr pps::schema_id id0{0};
 constexpr pps::schema_id id1{1};
 
-const pps::canonical_schema_definition string_def0{
+const pps::schema_definition string_def0{
   pps::sanitize_avro_schema_definition(
     {R"({"type":"string"})",
      pps::schema_type::avro,
      {{.name{"ref"}, .sub{subject0}, .version{version0}}}})
     .value()};
-const pps::canonical_schema_definition int_def0{
+const pps::schema_definition int_def0{
   pps::sanitize_avro_schema_definition(
     {R"({"type": "int"})", pps::schema_type::avro})
     .value()};
@@ -114,8 +114,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     auto good_schema_1 = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version0, magic1},
-      pps::canonical_schema_value{
-        {subject0, string_def0.share()}, version0, id0});
+      pps::schema_value{{subject0, string_def0.share()}, version0, id0});
     BOOST_REQUIRE_NO_THROW(c(good_schema_1.copy()).get());
 
     auto s_res = s.get_subject_schema(
@@ -125,8 +124,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     auto good_schema_ref_1 = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version1, magic1},
-      pps::canonical_schema_value{
-        {subject0, string_def0.share()}, version1, id1});
+      pps::schema_value{{subject0, string_def0.share()}, version1, id1});
     BOOST_REQUIRE_NO_THROW(c(good_schema_ref_1.copy()).get());
 
     auto s_ref_res = s.get_subject_schema(
@@ -143,8 +141,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     auto bad_schema_magic = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version0, magic2},
-      pps::canonical_schema_value{
-        {subject0, string_def0.share()}, version0, id0});
+      pps::schema_value{{subject0, string_def0.share()}, version0, id0});
     BOOST_REQUIRE_THROW(c(bad_schema_magic.copy()).get(), pps::exception);
 
     BOOST_REQUIRE(
@@ -237,8 +234,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store_after_compaction) {
     // Insert the schema at seq 0
     auto good_schema_1 = pps::as_record_batch(
       pps::schema_key{sequence, node_id, subject0, version0, magic1},
-      pps::canonical_schema_value{
-        {subject0, string_def0.share()}, version0, id0});
+      pps::schema_value{{subject0, string_def0.share()}, version0, id0});
     BOOST_REQUIRE_NO_THROW(c(good_schema_1.copy()).get());
     // Roll the segment
     // Soft delete the version (at seq 1)

--- a/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/mt_sharded_store.cc
@@ -35,8 +35,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_cross_shard_def) {
     // Upsert a large(ish) number of schemas to the store, all with different
     // subject names and IDs, so they should hash to different shards.
     for (int i = 1; i <= id_n; ++i) {
-        auto referenced_schema = pps::to_unparsed(
-          {pps::subject{fmt::format("simple_{}.proto", i)}, simple.share()});
+        auto referenced_schema = pps::subject_schema{
+          pps::subject{fmt::format("simple_{}.proto", i)}, simple.share()};
         store
           .upsert(
             pps::seq_marker{

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -27,7 +27,7 @@ namespace pps = pp::schema_registry;
 using make_values_unsigned = ss::bool_class<struct make_values_unsigned_tag>;
 
 struct request {
-    pps::canonical_schema schema;
+    pps::subject_schema schema;
     std::optional<pps::schema_id> id = std::nullopt;
     std::optional<pps::schema_version> version = std::nullopt;
     // If the below is set to true, then cast id and version to an unsigned int
@@ -539,9 +539,9 @@ FIXTURE_TEST(
 FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
 
-    const auto company_req = request{pps::canonical_schema{
+    const auto company_req = request{pps::subject_schema{
       pps::subject{"company-value"},
-      pps::canonical_schema_definition(
+      pps::schema_definition(
         R"({
   "namespace": "com.redpanda",
   "type": "record",
@@ -563,9 +563,9 @@ FIXTURE_TEST(schema_registry_post_avro_references, pandaproxy_test_fixture) {
 })",
         pps::schema_type::avro)}};
 
-    const auto employee_req = request{pps::canonical_schema{
+    const auto employee_req = request{pps::subject_schema{
       pps::subject{"employee-value"},
-      pps::canonical_schema_definition{
+      pps::schema_definition{
         R"({
   "namespace": "com.redpanda",
   "type": "record",
@@ -618,9 +618,9 @@ FIXTURE_TEST(
     using namespace std::chrono_literals;
 
     const auto simple_req_id_0 = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",
@@ -636,9 +636,9 @@ FIXTURE_TEST(
       pps::schema_id{0}};
 
     const auto simple_req_id_minus_1 = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",
@@ -686,9 +686,9 @@ FIXTURE_TEST(
     using namespace std::chrono_literals;
 
     const auto simple_req_id_invalid = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",
@@ -721,9 +721,9 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   schema_registry_post_subjects_version_zero, pandaproxy_test_fixture) {
     const auto simple_req_first = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",
@@ -740,9 +740,9 @@ FIXTURE_TEST(
       pps::schema_version{0}};
 
     const auto simple_req_second = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",
@@ -796,9 +796,9 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   schema_registry_post_subjects_version_exhausted, pandaproxy_test_fixture) {
     const auto simple_req_first = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",
@@ -815,9 +815,9 @@ FIXTURE_TEST(
       pps::schema_version{std::numeric_limits<int>::max()}};
 
     const auto simple_req_second = request{
-      pps::canonical_schema{
+      pps::subject_schema{
         pps::subject{"simple-value"},
-        pps::canonical_schema_definition(
+        pps::schema_definition(
           R"({
 "namespace": "com.redpanda",
   "type": "record",

--- a/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
@@ -40,7 +40,7 @@ struct simple_sharded_store {
     simple_sharded_store& operator=(simple_sharded_store&&) = delete;
 
     pps::schema_id
-    insert(const pps::unparsed_schema& schema, pps::schema_version version) {
+    insert(const pps::subject_schema& schema, pps::schema_version version) {
         const auto id = next_id++;
         store
           .upsert(
@@ -70,9 +70,9 @@ std::string sanitize(
     simple_sharded_store s{proto_v2};
     iobuf buf = pps::make_canonical_protobuf_schema(
                   s.store,
-                  pps::unparsed_schema{
+                  pps::subject_schema{
                     pps::subject{"foo"},
-                    pps::unparsed_schema_definition{
+                    pps::schema_definition{
                       raw_proto, pps::schema_type::protobuf, {}}},
                   norm)
                   .get()

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -17,7 +17,7 @@
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
 
-const pps::unparsed_schema_definition not_minimal{
+const pps::schema_definition not_minimal{
   R"({
    "type": "record",
    "name": "myrecord",
@@ -25,73 +25,73 @@ const pps::unparsed_schema_definition not_minimal{
 })",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition not_minimal_sanitized{
+const pps::schema_definition not_minimal_sanitized{
   R"({"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition leading_dot{
+const pps::schema_definition leading_dot{
   R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":".r1","type":"record"}]},{"name":"two","type":["null",".r1"]}]})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition leading_dot_sanitized{
+const pps::schema_definition leading_dot_sanitized{
   R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"type":"record","name":"r1","fields":[{"name":"f1","type":["null","string"]}]}]},{"name":"two","type":["null","r1"]}]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition leading_dot_ns{
+const pps::schema_definition leading_dot_ns{
   R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":".ns.r1","type":"record"}]},{"name":"two","type":["null",".ns.r1"]}]})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition leading_dot_ns_sanitized{
+const pps::schema_definition leading_dot_ns_sanitized{
   R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"type":"record","name":"r1","namespace":".ns","fields":[{"name":"f1","type":["null","string"]}]}]},{"name":"two","type":["null",".ns.r1"]}]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition record_not_sorted{
+const pps::schema_definition record_not_sorted{
   R"({"name":"sort_record","type":"record","aliases":["alias"],"fields":[{"type":"string","name":"one"}],"namespace":"ns","doc":"doc"})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition record_sorted_sanitized{
+const pps::schema_definition record_sorted_sanitized{
   R"({"type":"record","name":"sort_record","namespace":"ns","doc":"doc","fields":[{"name":"one","type":"string"}],"aliases":["alias"]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition enum_not_sorted{
+const pps::schema_definition enum_not_sorted{
   R"({"name":"ns.sort_enum","type":"enum","aliases":["alias"],"symbols":["one", "two", "three"],"default":"two","doc":"doc"})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition enum_sorted_sanitized{
+const pps::schema_definition enum_sorted_sanitized{
   R"({"type":"enum","name":"sort_enum","namespace":"ns","doc":"doc","symbols":["one","two","three"],"default":"two","aliases":["alias"]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition array_not_sorted{
+const pps::schema_definition array_not_sorted{
   R"({"type": "array", "default": [], "items" : "string"})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition array_sorted_sanitized{
+const pps::schema_definition array_sorted_sanitized{
   R"({"type":"array","items":"string","default":[]})", pps::schema_type::avro};
 
-const pps::unparsed_schema_definition map_not_sorted{
+const pps::schema_definition map_not_sorted{
   R"({"type": "map", "default": {}, "values" : "string"})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition map_sorted_sanitized{
+const pps::schema_definition map_sorted_sanitized{
   R"({"type":"map","values":"string","default":{}})", pps::schema_type::avro};
 
-const pps::unparsed_schema_definition fixed_not_sorted{
+const pps::schema_definition fixed_not_sorted{
   R"({"size":16, "type": "fixed", "aliases":["fixed"], "name":"ns.sorted_fixed"})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition fixed_sorted_sanitized{
+const pps::schema_definition fixed_sorted_sanitized{
   R"({"type":"fixed","name":"sorted_fixed","namespace":"ns","size":16,"aliases":["fixed"]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition record_of_obj_unsanitized{
+const pps::schema_definition record_of_obj_unsanitized{
   R"({"name":"sort_record_of_obj","type":"record","fields":[{"type":{"type":"string","connect.parameters":{"tidb_type":"TEXT"}},"default":"","name":"field"}]})",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition record_of_obj_sanitized{
+const pps::schema_definition record_of_obj_sanitized{
   R"({"type":"record","name":"sort_record_of_obj","fields":[{"name":"field","type":{"type":"string","connect.parameters":{"tidb_type":"TEXT"}},"default":""}]})",
   pps::schema_type::avro};
 
-const pps::unparsed_schema_definition namespace_nested_same_unsanitized{
+const pps::schema_definition namespace_nested_same_unsanitized{
   R"({
   "type": "record",
   "name": "Example",
@@ -184,7 +184,7 @@ const pps::unparsed_schema_definition namespace_nested_same_unsanitized{
 })",
   pps::schema_type::avro};
 
-const pps::canonical_schema_definition namespace_nested_same_sanitized{
+const pps::schema_definition namespace_nested_same_sanitized{
   ::json::minify(
     R"({
   "type": "record",
@@ -341,17 +341,12 @@ BOOST_AUTO_TEST_CASE(test_namespace_nested_same) {
       namespace_nested_same_sanitized);
 }
 
-pps::canonical_schema_definition debezium_schema{
+pps::schema_definition debezium_schema{
   R"({"type":"record","name":"SchemaChangeKey","namespace":"io.debezium.connector.mysql","fields":[{"name":"databaseName","type":"string"}],"connect.name":"io.debezium.connector.mysql.SchemaChangeKey"})",
   pps::schema_type::avro};
 
 BOOST_AUTO_TEST_CASE(test_sanitize_avro_debzium) {
-    auto unparsed = pps::unparsed_schema_definition{
-      pps::unparsed_schema_definition::raw_string{
-        debezium_schema.shared_raw()()},
-      debezium_schema.type()};
-
     BOOST_REQUIRE_EQUAL(
-      pps::sanitize_avro_schema_definition(unparsed.share()).value(),
+      pps::sanitize_avro_schema_definition(debezium_schema.share()).value(),
       debezium_schema);
 }

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -31,8 +31,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
     const pps::schema_version ver1{1};
 
     // Insert simple
-    auto referenced_schema = pps::to_unparsed(
-      {pps::subject{"simple.proto"}, simple.share()});
+    auto referenced_schema = pps::subject_schema{
+      pps::subject{"simple.proto"}, simple.share()};
     store
       .upsert(
         pps::seq_marker{
@@ -44,8 +44,8 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
       .get();
 
     // Insert referenced
-    auto importing_schema = pps::to_unparsed(
-      {pps::subject{"imported.proto"}, imported.share()});
+    auto importing_schema = pps::subject_schema{
+      pps::subject{"imported.proto"}, imported.share()};
 
     store
       .upsert(
@@ -100,22 +100,22 @@ SEASTAR_THREAD_TEST_CASE(test_sharded_store_find_unordered) {
     store.start(pps::is_mutable::no, ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&store]() { store.stop().get(); });
 
-    pps::unparsed_schema array_unsanitized{
+    pps::subject_schema array_unsanitized{
       pps::subject{"array"},
-      pps::unparsed_schema_definition{
+      pps::schema_definition{
         R"({"type": "array", "default": [], "items" : "string"})",
         pps::schema_type::avro}};
 
-    pps::canonical_schema array_sanitized{
+    pps::subject_schema array_sanitized{
       pps::subject{"array"},
-      pps::canonical_schema_definition{
+      pps::schema_definition{
         R"({"type":"array","items":"string","default":[]})",
         pps::schema_type::avro}};
 
     const pps::schema_version ver1{1};
 
     // Insert an unsorted schema "onto the topic".
-    auto referenced_schema = pps::canonical_schema{
+    auto referenced_schema = pps::subject_schema{
       pps::subject{"simple.proto"}, simple.share()};
     store
       .upsert(

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -48,10 +48,10 @@ constexpr std::string_view avro_schema_value_sv{
   "schema": "{\"type\":\"string\"}",
   "deleted": true
 })"};
-const pps::canonical_schema_value avro_schema_value{
+const pps::schema_value avro_schema_value{
   .schema{
     pps::subject{"my-kafka-value"},
-    pps::canonical_schema_definition{
+    pps::schema_definition{
       R"({"type":"string"})",
       pps::schema_type::avro,
       {{{"name"}, pps::subject{"subject"}, pps::schema_version{1}}}}},
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
 
     {
         auto val = ppj::impl::rjson_parse(
-          avro_schema_value_sv.data(), pps::canonical_schema_value_handler<>{});
+          avro_schema_value_sv.data(), pps::schema_value_handler{});
         BOOST_CHECK_EQUAL(avro_schema_value, val);
 
         auto str = ppj::rjson_serialize_str(avro_schema_value);

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -22,13 +22,13 @@ namespace pps = pandaproxy::schema_registry;
 constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
 constexpr std::string_view sv_string_def1{R"({"type": "string"})"};
 constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
-const pps::unparsed_schema_definition string_def0{
+const pps::schema_definition string_def0{
   pps::make_schema_definition<json::UTF8<>>(sv_string_def0).value(),
   pps::schema_type::avro};
-const pps::unparsed_schema_definition string_def1{
+const pps::schema_definition string_def1{
   pps::make_schema_definition<json::UTF8<>>(sv_string_def1).value(),
   pps::schema_type::avro};
-const pps::unparsed_schema_definition int_def0{
+const pps::schema_definition int_def0{
   pps::make_schema_definition<json::UTF8<>>(sv_int_def0).value(),
   pps::schema_type::avro};
 const pps::subject subject0{"subject0"};
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_store_insert) {
 bool upsert(
   pps::store& store,
   pps::subject sub,
-  pps::unparsed_schema_definition def,
+  pps::schema_definition def,
   pps::schema_type,
   pps::schema_id id,
   pps::schema_version version,
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     pps::seq_marker dummy_marker;
 
     // First insert, expect id{1}
-    auto ins_res = s.insert(pps::to_unparsed({subject0, schema1.share()}));
+    auto ins_res = s.insert({subject0, schema1.share()});
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subject_versions) {
     BOOST_REQUIRE(versions.empty());
 
     // Second insert, expect id{2}
-    ins_res = s.insert(pps::to_unparsed({subject0, schema2.share()}));
+    ins_res = s.insert({subject0, schema2.share()});
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{2});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{2});
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
     pps::seq_marker dummy_marker;
 
     // First insert, expect id{1}
-    auto ins_res = s.insert(pps::to_unparsed({subject0, schema1.share()}));
+    auto ins_res = s.insert({subject0, schema1.share()});
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
@@ -269,13 +269,13 @@ BOOST_AUTO_TEST_CASE(test_store_get_schema_subjects) {
     BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject0)), 1);
 
     // Second insert, same schema, expect id{1}
-    ins_res = s.insert(pps::to_unparsed({subject1, schema1.share()}));
+    ins_res = s.insert({subject1, schema1.share()});
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
 
     // Insert yet another schema associated with a different subject
-    ins_res = s.insert(pps::to_unparsed({subject2, schema2.share()}));
+    ins_res = s.insert({subject2, schema2.share()});
     BOOST_REQUIRE(ins_res.inserted);
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{2});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -40,8 +40,7 @@ bool check_compatible(
 }
 
 pps::compatibility_result check_compatible_verbose(
-  const pps::canonical_schema_definition& r,
-  const pps::canonical_schema_definition& w) {
+  const pps::schema_definition& r, const pps::schema_definition& w) {
     pps::sharded_store s;
     return check_compatible(
       pps::make_json_schema_definition(
@@ -305,15 +304,15 @@ SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
 
 struct test_references_data {
     struct data {
-        pps::unparsed_schema schema;
+        pps::subject_schema schema;
         pps::error_info result;
     };
     std::array<data, 2> _schemas;
 };
 
-const auto referenced = pps::unparsed_schema{
+const auto referenced = pps::subject_schema{
   pps::subject{"referenced"},
-  pps::unparsed_schema_definition{
+  pps::schema_definition{
     R"({
   "description": "A base schema that defines a number",
   "type": "object",
@@ -326,9 +325,9 @@ const auto referenced = pps::unparsed_schema{
     pps::schema_type::json,
     {}}};
 
-const auto referencer = pps::unparsed_schema{
+const auto referencer = pps::subject_schema{
   pps::subject{"referencer"},
-  pps::unparsed_schema_definition{
+  pps::schema_definition{
     R"({
   "description": "A schema that references the base schema",
   "type": "object",
@@ -344,9 +343,9 @@ const auto referencer = pps::unparsed_schema{
       .sub{referenced.sub()},
       .version = pps::schema_version{1}}}}};
 
-const auto referencer_wrong_sub = pps::unparsed_schema{
+const auto referencer_wrong_sub = pps::subject_schema{
   referencer.sub(),
-  pps::unparsed_schema_definition{
+  pps::schema_definition{
     referencer.def().shared_raw(),
     referencer.def().type(),
     {pps::schema_reference{
@@ -379,7 +378,7 @@ SEASTAR_THREAD_TEST_CASE(test_json_schema_references) {
 
         for (const auto& [schema, result] : test._schemas) {
             pps::schema_version ver{0};
-            pps::canonical_schema canonical{};
+            pps::subject_schema canonical{};
             auto make_canonical = [&]() {
                 canonical = f.store.make_canonical_schema(schema.share()).get();
             };
@@ -397,7 +396,7 @@ SEASTAR_THREAD_TEST_CASE(test_json_schema_references) {
             f.store
               .upsert(
                 pps::seq_marker{},
-                pps::to_unparsed(canonical.share()),
+                canonical.share(),
                 ++id,
                 ++ver,
                 pps::is_deleted::no)
@@ -2250,7 +2249,7 @@ SEASTAR_THREAD_TEST_CASE(test_compatibility_check) {
 
 namespace {
 
-const auto schema_old = pps::canonical_schema_definition({
+const auto schema_old = pps::schema_definition({
   R"(
 {
   "type": "object",
@@ -2270,7 +2269,7 @@ const auto schema_old = pps::canonical_schema_definition({
 })",
   pps::schema_type::json});
 
-const auto schema_new = pps::canonical_schema_definition({
+const auto schema_new = pps::schema_definition({
   R"(
 {
   "type": "object",

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -42,22 +42,7 @@ std::ostream& operator<<(std::ostream& os, const seq_marker& v) {
     return os;
 }
 
-std::ostream& operator<<(
-  std::ostream& os,
-  const typed_schema_definition<unparsed_schema_definition::tag>& def) {
-    fmt::print(
-      os,
-      "type: {}, definition: {}, references: {}",
-      to_string_view(def.type()),
-      // TODO BP: Prevent this linearization
-      to_string(def.shared_raw()),
-      def.refs());
-    return os;
-}
-
-std::ostream& operator<<(
-  std::ostream& os,
-  const typed_schema_definition<canonical_schema_definition::tag>& def) {
+std::ostream& operator<<(std::ostream& os, const schema_definition& def) {
     fmt::print(
       os,
       "type: {}, definition: {}, references: {}",
@@ -78,30 +63,14 @@ bool operator<(const schema_reference& lhs, const schema_reference& rhs) {
            < std::tie(rhs.name, rhs.sub, rhs.version);
 }
 
-std::ostream& operator<<(std::ostream& os, const unparsed_schema& ref) {
-    fmt::print(os, "subject: {}, {}", ref.sub(), ref.def());
-    return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const canonical_schema& ref) {
-    fmt::print(os, "subject: {}, {}", ref.sub(), ref.def());
+std::ostream& operator<<(std::ostream& os, const subject_schema& schema) {
+    fmt::print(os, "subject: {}, {}", schema.sub(), schema.def());
     return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const compatibility_result& res) {
     fmt::print(os, "is_compat: {}, messages: {}", res.is_compat, res.messages);
     return os;
-}
-
-unparsed_schema_definition
-to_unparsed(canonical_schema_definition&& canonical) {
-    auto [raw, type, refs] = std::move(canonical).destructure();
-    return {std::move(raw), type, std::move(refs)};
-}
-
-unparsed_schema to_unparsed(canonical_schema&& canonical) {
-    auto [sub, def] = std::move(canonical).destructure();
-    return {std::move(sub), to_unparsed(std::move(def))};
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -120,46 +120,44 @@ struct schema_reference {
 };
 
 ///\brief Definition of a schema and its type.
-template<typename Tag>
-class typed_schema_definition {
+class schema_definition {
+    using schema_definition_iobuf
+      = named_type<iobuf, struct schema_definition_tag>;
+
 public:
-    using tag = Tag;
-    struct raw_string : named_type<iobuf, tag> {
+    struct raw_string : schema_definition_iobuf {
         raw_string() = default;
         explicit raw_string(iobuf&& buf) noexcept
-          : named_type<iobuf, tag>{std::move(buf)} {}
+          : schema_definition_iobuf{std::move(buf)} {}
         explicit raw_string(std::string_view sv)
-          : named_type<iobuf, tag>{iobuf::from(sv)} {}
+          : schema_definition_iobuf{iobuf::from(sv)} {}
     };
     using references = std::vector<schema_reference>;
 
-    typed_schema_definition() = default;
-    typed_schema_definition(typed_schema_definition&&) noexcept = default;
-    typed_schema_definition(const typed_schema_definition&) = delete;
-    typed_schema_definition& operator=(typed_schema_definition&&) noexcept
-      = default;
-    typed_schema_definition& operator=(const typed_schema_definition& other)
-      = delete;
-    ~typed_schema_definition() noexcept = default;
+    schema_definition() = default;
+    schema_definition(schema_definition&&) noexcept = default;
+    schema_definition(const schema_definition&) = delete;
+    schema_definition& operator=(schema_definition&&) noexcept = default;
+    schema_definition& operator=(const schema_definition& other) = delete;
+    ~schema_definition() noexcept = default;
 
     template<typename T>
-    typed_schema_definition(T&& def, schema_type type)
+    schema_definition(T&& def, schema_type type)
       : _def{std::forward<T>(def)}
       , _type{type}
       , _refs{} {}
 
     template<typename T>
-    typed_schema_definition(T&& def, schema_type type, references refs)
+    schema_definition(T&& def, schema_type type, references refs)
       : _def{std::forward<T>(def)}
       , _type{type}
       , _refs{std::move(refs)} {}
 
-    friend bool operator==(
-      const typed_schema_definition& lhs, const typed_schema_definition& rhs)
+    friend bool
+    operator==(const schema_definition& lhs, const schema_definition& rhs)
       = default;
 
-    friend std::ostream&
-    operator<<(std::ostream& os, const typed_schema_definition&);
+    friend std::ostream& operator<<(std::ostream& os, const schema_definition&);
 
     schema_type type() const { return _type; }
 
@@ -173,11 +171,9 @@ public:
     const references& refs() const& { return _refs; }
     references refs() && { return std::move(_refs); }
 
-    typed_schema_definition share() const {
-        return {shared_raw(), type(), refs()};
-    }
+    schema_definition share() const { return {shared_raw(), type(), refs()}; }
 
-    typed_schema_definition copy() const {
+    schema_definition copy() const {
         return {raw_string{_def().copy()}, type(), refs()};
     }
 
@@ -191,35 +187,14 @@ private:
     references _refs;
 };
 
-///\brief An unvalidated definition of the schema and its type.
-///
-/// This comes from the user and should be considered as potentially
-/// ill-formed.
-using unparsed_schema_definition
-  = typed_schema_definition<struct unparsed_schema_defnition_tag>;
-
-///\brief A canonical definition of the schema and its type.
-///
-/// This form is stored on the topic and returned to the user.
-using canonical_schema_definition
-  = typed_schema_definition<struct canonical_schema_definition_tag>;
-
-///\brief Util function for when a canonical schema need to be re-ingested
-unparsed_schema_definition to_unparsed(canonical_schema_definition&&);
-
-static const unparsed_schema_definition invalid_schema_definition{
-  "", schema_type::avro};
-
 ///\brief The definition of an avro schema.
 class avro_schema_definition {
 public:
     explicit avro_schema_definition(
-      avro::ValidSchema vs, canonical_schema_definition::references refs);
+      avro::ValidSchema vs, schema_definition::references refs);
 
-    canonical_schema_definition::raw_string raw() const;
-    const canonical_schema_definition::references& refs() const {
-        return _refs;
-    };
+    schema_definition::raw_string raw() const;
+    const schema_definition::references& refs() const { return _refs; };
 
     const avro::ValidSchema& operator()() const;
 
@@ -231,15 +206,13 @@ public:
 
     constexpr schema_type type() const { return schema_type::avro; }
 
-    explicit operator canonical_schema_definition() const {
-        return {raw(), type()};
-    }
+    explicit operator schema_definition() const { return {raw(), type()}; }
 
     ss::sstring name() const;
 
 private:
     avro::ValidSchema _impl;
-    canonical_schema_definition::references _refs;
+    schema_definition::references _refs;
 };
 
 class protobuf_schema_definition {
@@ -248,14 +221,12 @@ public:
     using pimpl = ss::shared_ptr<const impl>;
 
     explicit protobuf_schema_definition(
-      pimpl p, canonical_schema_definition::references refs)
+      pimpl p, schema_definition::references refs)
       : _impl{std::move(p)}
       , _refs(std::move(refs)) {}
 
-    canonical_schema_definition::raw_string raw() const;
-    const canonical_schema_definition::references& refs() const {
-        return _refs;
-    };
+    schema_definition::raw_string raw() const;
+    const schema_definition::references& refs() const { return _refs; };
 
     const impl& operator()() const { return *_impl; }
 
@@ -268,7 +239,7 @@ public:
 
     constexpr schema_type type() const { return schema_type::protobuf; }
 
-    explicit operator canonical_schema_definition() const {
+    explicit operator schema_definition() const {
         return {raw(), type(), refs()};
     }
 
@@ -277,7 +248,7 @@ public:
 
 private:
     pimpl _impl;
-    canonical_schema_definition::references _refs;
+    schema_definition::references _refs;
 };
 
 class json_schema_definition {
@@ -288,8 +259,8 @@ public:
     explicit json_schema_definition(pimpl p)
       : _impl{std::move(p)} {}
 
-    canonical_schema_definition::raw_string raw() const;
-    const canonical_schema_definition::references& refs() const;
+    schema_definition::raw_string raw() const;
+    const schema_definition::references& refs() const;
 
     const impl& operator()() const { return *_impl; }
 
@@ -301,7 +272,7 @@ public:
 
     constexpr schema_type type() const { return schema_type::json; }
 
-    explicit operator canonical_schema_definition() const {
+    explicit operator schema_definition() const {
         return {raw(), type(), refs()};
     }
 
@@ -354,16 +325,15 @@ public:
         return visit([](const auto& def) { return def.type(); });
     }
 
-    unparsed_schema_definition::raw_string raw() const& {
+    schema_definition::raw_string raw() const& {
         return visit([](auto&& def) {
-            return unparsed_schema_definition::raw_string{def.raw()()};
+            return schema_definition::raw_string{def.raw()()};
         });
     }
 
-    unparsed_schema_definition::raw_string raw() && {
+    schema_definition::raw_string raw() && {
         return visit([](auto def) {
-            return unparsed_schema_definition::raw_string{
-              std::move(def).raw()()};
+            return schema_definition::raw_string{std::move(def).raw()()};
         });
     }
 
@@ -431,22 +401,19 @@ struct seq_marker {
 };
 
 ///\brief A schema with its subject
-template<typename Tag>
-class typed_schema {
+class subject_schema {
 public:
-    using tag = Tag;
-    using schema_definition = typed_schema_definition<tag>;
+    subject_schema() = default;
 
-    typed_schema() = default;
-
-    typed_schema(subject sub, schema_definition def)
+    subject_schema(subject sub, schema_definition def)
       : _sub{std::move(sub)}
       , _def{std::move(def)} {}
 
-    friend bool operator==(const typed_schema& lhs, const typed_schema& rhs)
+    friend bool operator==(const subject_schema& lhs, const subject_schema& rhs)
       = default;
 
-    friend std::ostream& operator<<(std::ostream& os, const typed_schema& ref);
+    friend std::ostream&
+    operator<<(std::ostream& os, const subject_schema& schema);
 
     const subject& sub() const& { return _sub; }
     subject sub() && { return std::move(_sub); }
@@ -456,8 +423,8 @@ public:
     const schema_definition& def() const& { return _def; }
     schema_definition def() && { return std::move(_def); }
 
-    typed_schema share() const { return {sub(), def().share()}; }
-    typed_schema copy() const { return {sub(), def().copy()}; }
+    subject_schema share() const { return {sub(), def().share()}; }
+    subject_schema copy() const { return {sub(), def().copy()}; }
 
     auto destructure() && {
         return make_tuple(std::move(_sub), std::move(_def));
@@ -468,28 +435,17 @@ private:
     schema_definition _def{"", schema_type::avro};
 };
 
-using unparsed_schema = typed_schema<unparsed_schema_definition::tag>;
-using canonical_schema = typed_schema<canonical_schema_definition::tag>;
-
-///\brief Util function for when a canonical schema need to be re-ingested
-unparsed_schema to_unparsed(canonical_schema&&);
-
-template<typename tag>
-struct typed_stored_schema {
-    typed_schema<tag> schema;
+///\brief Complete description of a subject and schema for a version, as stored
+/// in store
+struct stored_schema {
+    subject_schema schema;
     schema_version version{invalid_schema_version};
     schema_id id{invalid_schema_id};
     is_deleted deleted{false};
-    typed_stored_schema share() const {
+    stored_schema share() const {
         return {schema.share(), version, id, deleted};
     }
 };
-///\brief Complete description of a subject and schema for a version, as stored
-/// in store
-using unparsed_stored_schema
-  = typed_stored_schema<unparsed_schema_definition::tag>;
-///\brief Complete description of a subject and schema for a version.
-using stored_schema = typed_stored_schema<canonical_schema_definition::tag>;
 
 enum class compatibility_level {
     none = 0,
@@ -604,16 +560,7 @@ namespace json {
 template<typename Buffer>
 void rjson_serialize(
   json::iobuf_writer<Buffer>& w,
-  const pandaproxy::schema_registry::canonical_schema_definition::raw_string&
-    def) {
-    w.String(def());
-}
-
-template<typename Buffer>
-void rjson_serialize(
-  json::iobuf_writer<Buffer>& w,
-  const pandaproxy::schema_registry::unparsed_schema_definition::raw_string&
-    def) {
+  const pandaproxy::schema_registry::schema_definition::raw_string& def) {
     w.String(def());
 }
 

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -475,21 +475,21 @@ using canonical_schema = typed_schema<canonical_schema_definition::tag>;
 unparsed_schema to_unparsed(canonical_schema&&);
 
 template<typename tag>
-struct typed_subject_schema {
+struct typed_stored_schema {
     typed_schema<tag> schema;
     schema_version version{invalid_schema_version};
     schema_id id{invalid_schema_id};
     is_deleted deleted{false};
-    typed_subject_schema share() const {
+    typed_stored_schema share() const {
         return {schema.share(), version, id, deleted};
     }
 };
 ///\brief Complete description of a subject and schema for a version, as stored
 /// in store
-using unparsed_subject_schema
-  = typed_subject_schema<unparsed_schema_definition::tag>;
+using unparsed_stored_schema
+  = typed_stored_schema<unparsed_schema_definition::tag>;
 ///\brief Complete description of a subject and schema for a version.
-using subject_schema = typed_subject_schema<canonical_schema_definition::tag>;
+using stored_schema = typed_stored_schema<canonical_schema_definition::tag>;
 
 enum class compatibility_level {
     none = 0,

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -206,7 +206,9 @@ public:
 
     constexpr schema_type type() const { return schema_type::avro; }
 
-    explicit operator schema_definition() const { return {raw(), type()}; }
+    explicit operator schema_definition() const {
+        return {raw(), type(), refs()};
+    }
 
     ss::sstring name() const;
 

--- a/src/v/pandaproxy/schema_registry/util.h
+++ b/src/v/pandaproxy/schema_registry/util.h
@@ -32,7 +32,7 @@ namespace pandaproxy::schema_registry {
 ///
 /// Returns error_code::schema_invalid on failure
 template<typename Encoding>
-result<canonical_schema_definition::raw_string>
+result<schema_definition::raw_string>
 make_schema_definition(std::string_view sv) {
     // Validate and minify
     // TODO (Ben): Minify. e.g.:
@@ -50,7 +50,7 @@ make_schema_definition(std::string_view sv) {
     ::json::chunked_buffer buf;
     ::json::Writer<::json::chunked_buffer> w{buf};
     doc.Accept(w);
-    return canonical_schema_definition::raw_string{std::move(buf).as_iobuf()};
+    return schema_definition::raw_string{std::move(buf).as_iobuf()};
 }
 
 template<typename Tag>

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -104,7 +104,7 @@ std::vector<int32_t> get_proto_offsets(iobuf_parser& p) {
 ss::future<std::optional<ss::sstring>> get_record_name(
   pandaproxy::schema_registry::sharded_store& store,
   subject_name_strategy sns,
-  canonical_schema_definition schema,
+  schema_definition schema,
   std::optional<std::vector<int32_t>>& offsets) {
     if (sns == subject_name_strategy::topic_name) {
         // Result is successfully nothing
@@ -235,7 +235,7 @@ public:
         }
 
         // Determine the schema type
-        std::optional<canonical_schema_definition> schema;
+        std::optional<schema_definition> schema;
         try {
             schema.emplace(co_await _api->_store->get_schema_definition(id));
         } catch (const exception& ex) {

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -48,7 +48,7 @@ public:
         auto [reader, _] = co_await service();
         co_return co_await reader->get_schema_definition(id);
     }
-    ss::future<ppsr::subject_schema> get_subject_schema(
+    ss::future<ppsr::stored_schema> get_subject_schema(
       ppsr::subject sub,
       std::optional<ppsr::schema_version> version) const override {
         auto [reader, _] = co_await service();
@@ -88,7 +88,7 @@ public:
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<ppsr::subject_schema> get_subject_schema(
+    ss::future<ppsr::stored_schema> get_subject_schema(
       ppsr::subject, std::optional<ppsr::schema_version>) const override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");

--- a/src/v/schema/registry.cc
+++ b/src/v/schema/registry.cc
@@ -43,7 +43,7 @@ public:
         co_return reader;
     }
 
-    ss::future<ppsr::canonical_schema_definition>
+    ss::future<ppsr::schema_definition>
     get_schema_definition(ppsr::schema_id id) const override {
         auto [reader, _] = co_await service();
         co_return co_await reader->get_schema_definition(id);
@@ -56,7 +56,7 @@ public:
           sub, version, ppsr::include_deleted::no);
     }
     ss::future<ppsr::schema_id>
-    create_schema(ppsr::unparsed_schema schema) override {
+    create_schema(ppsr::subject_schema schema) override {
         auto [reader, writer] = co_await service();
         co_await writer->read_sync();
         auto parsed = co_await reader->make_canonical_schema(std::move(schema));
@@ -83,7 +83,7 @@ public:
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<ppsr::canonical_schema_definition>
+    ss::future<ppsr::schema_definition>
     get_schema_definition(ppsr::schema_id) const override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
@@ -93,7 +93,7 @@ public:
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }
-    ss::future<ppsr::schema_id> create_schema(ppsr::unparsed_schema) override {
+    ss::future<ppsr::schema_id> create_schema(ppsr::subject_schema) override {
         throw std::logic_error(
           "invalid attempted usage of a disabled schema registry");
     }

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -48,7 +48,7 @@ public:
 
     virtual ss::future<pandaproxy::schema_registry::canonical_schema_definition>
       get_schema_definition(pandaproxy::schema_registry::schema_id) const = 0;
-    virtual ss::future<pandaproxy::schema_registry::subject_schema>
+    virtual ss::future<pandaproxy::schema_registry::stored_schema>
       get_subject_schema(
         pandaproxy::schema_registry::subject,
         std::optional<pandaproxy::schema_registry::schema_version>) const

--- a/src/v/schema/registry.h
+++ b/src/v/schema/registry.h
@@ -46,7 +46,7 @@ public:
     ss::future<std::optional<pandaproxy::schema_registry::valid_schema>>
     get_valid_schema(pandaproxy::schema_registry::schema_id schema_id) const;
 
-    virtual ss::future<pandaproxy::schema_registry::canonical_schema_definition>
+    virtual ss::future<pandaproxy::schema_registry::schema_definition>
       get_schema_definition(pandaproxy::schema_registry::schema_id) const = 0;
     virtual ss::future<pandaproxy::schema_registry::stored_schema>
       get_subject_schema(
@@ -54,6 +54,6 @@ public:
         std::optional<pandaproxy::schema_registry::schema_version>) const
       = 0;
     virtual ss::future<pandaproxy::schema_registry::schema_id>
-      create_schema(pandaproxy::schema_registry::unparsed_schema) = 0;
+      create_schema(pandaproxy::schema_registry::subject_schema) = 0;
 };
 } // namespace schema

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -42,7 +42,7 @@ ss::future<ppsr::stored_schema> schema::fake_store::get_subject_schema(
     co_return std::move(found).value();
 }
 
-ss::future<ppsr::canonical_schema_definition>
+ss::future<ppsr::schema_definition>
 schema::fake_store::get_schema_definition(ppsr::schema_id id) {
     for (const auto& s : schemas) {
         if (s.id == id) {
@@ -52,7 +52,7 @@ schema::fake_store::get_schema_definition(ppsr::schema_id id) {
     throw std::runtime_error("unknown schema id");
 }
 
-ss::future<std::optional<ppsr::canonical_schema_definition>>
+ss::future<std::optional<ppsr::schema_definition>>
 schema::fake_store::maybe_get_schema_definition(ppsr::schema_id id) {
     for (const auto& s : schemas) {
         if (s.id == id) {
@@ -68,7 +68,7 @@ void schema::fake_registry::maybe_throw_injected_failure() const {
     }
 }
 
-ss::future<ppsr::canonical_schema_definition>
+ss::future<ppsr::schema_definition>
 schema::fake_registry::get_schema_definition(ppsr::schema_id id) const {
     maybe_throw_injected_failure();
     return _store.get_schema_definition(id);
@@ -83,7 +83,7 @@ ss::future<ppsr::schema_getter*> schema::fake_registry::getter() const {
     co_return &_store;
 }
 ss::future<ppsr::schema_id>
-schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
+schema::fake_registry::create_schema(ppsr::subject_schema unparsed) {
     maybe_throw_injected_failure();
     // This is wrong, but simple for our testing.
     for (const auto& s : _store.schemas) {
@@ -98,15 +98,8 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
         }
     }
     // TODO: validate references too
-    auto [sub, unparsed_def] = std::move(unparsed).destructure();
-    auto [def, type, refs] = std::move(unparsed_def).destructure();
     _store.schemas.push_back({
-      .schema = ppsr::canonical_schema(
-        std::move(sub),
-        ppsr::canonical_schema_definition(
-          ppsr::canonical_schema_definition::raw_string{std::move(def)()},
-          type,
-          std::move(refs))),
+      .schema = std::move(unparsed),
       .version = version + 1,
       .id = ppsr::schema_id(int32_t(_store.schemas.size() + 1)),
       .deleted = ppsr::is_deleted::no,

--- a/src/v/schema/tests/fake_registry.cc
+++ b/src/v/schema/tests/fake_registry.cc
@@ -22,11 +22,11 @@ namespace ppsr = pandaproxy::schema_registry;
 
 } // namespace
 
-ss::future<ppsr::subject_schema> schema::fake_store::get_subject_schema(
+ss::future<ppsr::stored_schema> schema::fake_store::get_subject_schema(
   ppsr::subject sub,
   std::optional<ppsr::schema_version> version,
   ppsr::include_deleted) {
-    std::optional<ppsr::subject_schema> found;
+    std::optional<ppsr::stored_schema> found;
     for (const auto& s : schemas) {
         if (s.schema.sub() != sub) {
             continue;
@@ -73,7 +73,7 @@ schema::fake_registry::get_schema_definition(ppsr::schema_id id) const {
     maybe_throw_injected_failure();
     return _store.get_schema_definition(id);
 }
-ss::future<ppsr::subject_schema> schema::fake_registry::get_subject_schema(
+ss::future<ppsr::stored_schema> schema::fake_registry::get_subject_schema(
   ppsr::subject sub, std::optional<ppsr::schema_version> version) const {
     maybe_throw_injected_failure();
     return _store.get_subject_schema(sub, version, ppsr::include_deleted::no);
@@ -113,7 +113,7 @@ schema::fake_registry::create_schema(ppsr::unparsed_schema unparsed) {
     });
     co_return _store.schemas.back().id;
 }
-const std::vector<ppsr::subject_schema>& schema::fake_registry::get_all() {
+const std::vector<ppsr::stored_schema>& schema::fake_registry::get_all() {
     maybe_throw_injected_failure();
     return _store.schemas;
 }

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -19,7 +19,7 @@ namespace schema {
 
 struct fake_store : public pandaproxy::schema_registry::schema_getter {
 public:
-    ss::future<pandaproxy::schema_registry::subject_schema> get_subject_schema(
+    ss::future<pandaproxy::schema_registry::stored_schema> get_subject_schema(
       pandaproxy::schema_registry::subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version,
       pandaproxy::schema_registry::include_deleted inc_dec) final;
@@ -30,7 +30,7 @@ public:
     maybe_get_schema_definition(
       pandaproxy::schema_registry::schema_id id) final;
 
-    std::vector<pandaproxy::schema_registry::subject_schema> schemas;
+    std::vector<pandaproxy::schema_registry::stored_schema> schemas;
 };
 
 // This is a fake schema registry for testing. Schemas are maintained in local
@@ -45,7 +45,7 @@ public:
     get_schema_definition(
       pandaproxy::schema_registry::schema_id id) const override;
 
-    ss::future<pandaproxy::schema_registry::subject_schema> get_subject_schema(
+    ss::future<pandaproxy::schema_registry::stored_schema> get_subject_schema(
       pandaproxy::schema_registry::subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version)
       const override;
@@ -53,7 +53,7 @@ public:
     ss::future<pandaproxy::schema_registry::schema_id> create_schema(
       pandaproxy::schema_registry::unparsed_schema unparsed) override;
 
-    const std::vector<pandaproxy::schema_registry::subject_schema>& get_all();
+    const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();
 
     void set_inject_failures(const std::exception_ptr& injected) {
         _injected_failure = injected;

--- a/src/v/schema/tests/fake_registry.h
+++ b/src/v/schema/tests/fake_registry.h
@@ -23,10 +23,9 @@ public:
       pandaproxy::schema_registry::subject sub,
       std::optional<pandaproxy::schema_registry::schema_version> version,
       pandaproxy::schema_registry::include_deleted inc_dec) final;
-    ss::future<pandaproxy::schema_registry::canonical_schema_definition>
+    ss::future<pandaproxy::schema_registry::schema_definition>
     get_schema_definition(pandaproxy::schema_registry::schema_id id) final;
-    ss::future<
-      std::optional<pandaproxy::schema_registry::canonical_schema_definition>>
+    ss::future<std::optional<pandaproxy::schema_registry::schema_definition>>
     maybe_get_schema_definition(
       pandaproxy::schema_registry::schema_id id) final;
 
@@ -41,7 +40,7 @@ public:
 
     ss::future<pandaproxy::schema_registry::schema_getter*>
     getter() const override;
-    ss::future<pandaproxy::schema_registry::canonical_schema_definition>
+    ss::future<pandaproxy::schema_registry::schema_definition>
     get_schema_definition(
       pandaproxy::schema_registry::schema_id id) const override;
 
@@ -51,7 +50,7 @@ public:
       const override;
 
     ss::future<pandaproxy::schema_registry::schema_id> create_schema(
-      pandaproxy::schema_registry::unparsed_schema unparsed) override;
+      pandaproxy::schema_registry::subject_schema unparsed) override;
 
     const std::vector<pandaproxy::schema_registry::stored_schema>& get_all();
 

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -89,7 +89,7 @@ read_encoded_schema_def(ffi::reader* r) {
 
 template<typename T>
 void write_encoded_schema_subject(
-  const pandaproxy::schema_registry::subject_schema& schema, T* w) {
+  const pandaproxy::schema_registry::stored_schema& schema, T* w) {
     w->append(schema.id());
     w->append(schema.version());
     // not writing the subject because the client should already have it.

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -54,7 +54,7 @@ deserialize_schema_type(serialized_schema_type st) {
 
 template<typename T>
 void write_encoded_schema_def(
-  const pandaproxy::schema_registry::canonical_schema_definition& def, T* w) {
+  const pandaproxy::schema_registry::schema_definition& def, T* w) {
     w->append(serialize_schema_type(def.type()));
     w->append_with_length(def.raw()());
     w->append(def.refs().size());
@@ -65,7 +65,7 @@ void write_encoded_schema_def(
     }
 }
 
-pandaproxy::schema_registry::unparsed_schema_definition
+pandaproxy::schema_registry::schema_definition
 read_encoded_schema_def(ffi::reader* r) {
     using namespace pandaproxy::schema_registry;
     auto serialized_type = serialized_schema_type(r->read_varint());
@@ -76,7 +76,7 @@ read_encoded_schema_def(ffi::reader* r) {
     }
     auto def = r->read_sized_string();
     auto rc = r->read_varint();
-    unparsed_schema_definition::references refs;
+    schema_definition::references refs;
     refs.reserve(rc);
     for (int i = 0; i < rc; ++i) {
         auto name = r->read_sized_string();
@@ -199,7 +199,7 @@ ss::future<int32_t> schema_registry_module::create_subject_schema(
     using namespace pandaproxy::schema_registry;
     try {
         *out_schema_id = co_await _sr->create_schema(
-          unparsed_schema(sub, read_encoded_schema_def(&r)));
+          subject_schema(sub, read_encoded_schema_def(&r)));
     } catch (const std::exception& ex) {
         vlog(wasm_log.warn, "error registering subject schema: {}", ex);
         co_return SCHEMA_REGISTRY_ERROR;

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -168,7 +168,7 @@ model::record_batch WasmTestFixture::make_tiny_batch(iobuf record_value) {
     b.add_raw_kv(model::test::make_iobuf(), std::move(record_value));
     return std::move(b).build();
 }
-const std::vector<pandaproxy::schema_registry::subject_schema>&
+const std::vector<pandaproxy::schema_registry::stored_schema>&
 WasmTestFixture::registered_schemas() const {
     return _sr->get_all();
 }

--- a/src/v/wasm/tests/wasm_fixture.h
+++ b/src/v/wasm/tests/wasm_fixture.h
@@ -62,7 +62,7 @@ public:
 
     wasm::engine* engine() { return _engine.get(); }
 
-    const std::vector<pandaproxy::schema_registry::subject_schema>&
+    const std::vector<pandaproxy::schema_registry::stored_schema>&
     registered_schemas() const;
 
     std::vector<ss::sstring> log_lines() const { return _log_lines; }

--- a/src/v/wasm/tests/wasm_sr_test.cc
+++ b/src/v/wasm/tests/wasm_sr_test.cc
@@ -30,7 +30,7 @@ using namespace std::chrono_literals;
 
 namespace {
 std::string generate_example_avro_record(
-  const pandaproxy::schema_registry::canonical_schema_definition& def) {
+  const pandaproxy::schema_registry::schema_definition& def) {
     // Generate a simple avro record that looks like this (as json):
     // {"a":5,"b":"foo"}
     iobuf_istream bis{def.shared_raw()};

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -426,8 +426,10 @@ import_schemas = {
         }],
         "schema":
         schema_c_proto_def,
+        #schema c will be invalid during startup in the test it is used.
+        #that's why the 'sanitized' form is not the actual sanitized form but the input form.
         "sanitized":
-        schema_c_proto_sanitized_def,
+        schema_c_proto_def,
     },
     "schema_d": {
         "subject":
@@ -441,8 +443,10 @@ import_schemas = {
         }],
         "schema":
         schema_d_proto_def,
+        #schema d will be invalid during startup in the test it is used.
+        #that's why the 'sanitized' form is not the actual sanitized form but the input form.
         "sanitized":
-        schema_d_proto_sanitized_def,
+        schema_d_proto_def,
     },
     "schema_e": {
         "subject": "schema_e",
@@ -2646,13 +2650,9 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        #These schemas are valid. We should be able to retrieve them.
-        for id, _ in valid_entries + forward_references_entries:
+        #All schemas should be retrievable by id.
+        for id, _ in valid_entries + forward_references_entries + invalid_entries:
             test_schemas_ids_id(id, expected_successful=True)
-
-        #These schemas are invalid. Tryint to retrieve them should return an error.
-        for id, _ in invalid_entries:
-            test_schemas_ids_id(id, expected_successful=False)
 
         #Test /schemas/ids/{id}/versions
         def test_schemas_ids_id_versions(id, expected_successful):
@@ -2665,10 +2665,9 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        for id, _ in valid_entries + forward_references_entries:
+        #Versions should be retrievable for all ids.
+        for id, _ in valid_entries + forward_references_entries + invalid_entries:
             test_schemas_ids_id_versions(id, expected_successful=True)
-        for id, _ in invalid_entries:
-            test_schemas_ids_id_versions(id, expected_successful=False)
 
         #Test /schemas/ids/{id}/subjects
         def test_schemas_ids_id_subjects(id, expected_successful):
@@ -2681,10 +2680,9 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        for id, _ in valid_entries + forward_references_entries:
+        #Subjects should be retrievable for all ids.
+        for id, _ in valid_entries + forward_references_entries + invalid_entries:
             test_schemas_ids_id_subjects(id, expected_successful=True)
-        for id, _ in invalid_entries:
-            test_schemas_ids_id_subjects(id, expected_successful=False)
 
         #Test /subjects
         result_raw = self._request("GET",
@@ -2702,7 +2700,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             f"Expected {expected_subjects} but got {subjects}, "\
             "for request 'GET subjects'"
 
-        def test_subjects_subject(entry, expected_successful):
+        def test_subjects_subject(entry, expected_code):
             lookup_schema = import_schemas[entry]
             subject = lookup_schema["subject"]
             schema_def = lookup_schema["schema"]
@@ -2719,23 +2717,107 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                                                          references
                                                      }))
             endpoint = f"POST subjects/{subject}",
-            if expected_successful:
-                assert_request_code(result_raw, requests.codes.ok, endpoint)
+            assert_request_code(result_raw, expected_code, endpoint)
+            if expected_code == requests.codes.ok:
                 result = result_raw.json()
                 assert result["version"] == version, \
                         f"Expected version {version} but got {result['version']}, "\
                         f"for request 'POST subjects/{subject}'"
-            else:
-                assert_request_code(result_raw, 422, endpoint)
 
         #Test /subjects/{subject}
-        for _, s in valid_entries + forward_references_entries:
-            test_subjects_subject(s, expected_successful=True)
+        for _, s in valid_entries:
+            test_subjects_subject(s, expected_code=requests.codes.ok)
 
         #These schemas should fail, as the *input* schema has an unsatisfied dependency
         for _, s in invalid_entries:
-            test_subjects_subject(s, expected_successful=False)
+            test_subjects_subject(s, expected_code=422)
 
+        #At this point, all references from these schemas are satisfied. So the input
+        #schema is valid. However, the stored schema could not be processed during startup
+        #so its stored form has not been canonicallized and the request fails
+        for _, s in forward_references_entries:
+            test_subjects_subject(s, expected_code=404)
+
+        #Test /subjects/{subject}/versions/{version}
+        def test_subjects_subject_versions_version(entry, expected_successful):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            version = lookup_schema["version"]
+            expected_schema = lookup_schema["sanitized"].strip()
+            #references = lookup_schema["references"] if "references" in lookup_schema else []
+            result_raw = self._get_subjects_subject_versions_version(
+                subject=subject, version=version)
+            endpoint = f"GET subjects/{subject}/versions/{version}"
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+
+                result = result_raw.json()["schema"].strip()
+                assert result == expected_schema, \
+                        f"Expected:\n{expected_schema}\nGot:\n{result}\nfor request "\
+                        f"'GET subjects/{subject}/versions/{version}'"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        #All schemas should be retrievable through subject/version.
+        for _, s in valid_entries + forward_references_entries + invalid_entries:
+            test_subjects_subject_versions_version(s, expected_successful=True)
+
+        #Test /subjects/{subject}/versions/{version}/schema
+        def test_subjects_subject_versions_version_schema(
+                entry, expected_successful):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            version = lookup_schema["version"]
+            schema_def = lookup_schema["sanitized"].strip()
+            result_raw = self._request(
+                "GET",
+                f"subjects/{subject}/versions/{version}/schema",
+                headers=HTTP_GET_HEADERS)
+
+            endpoint = f"GET subjects/{subject}/versions/{version}/schema"
+            if expected_successful:
+                assert_request_code(result_raw, requests.codes.ok, endpoint)
+
+                result = result_raw.content.decode().strip()
+                assert result == schema_def, \
+                        f"Expected:\n{schema_def}\nGot:\n{result}\n"\
+                        f"for request 'GET subjects/{subject}/versions/{version}/schema'"
+            else:
+                assert_request_code(result_raw, 422, endpoint)
+
+        #All schemas should be retrievable through subject/version.
+        for _, s in valid_entries + forward_references_entries + invalid_entries:
+            test_subjects_subject_versions_version_schema(
+                s, expected_successful=True)
+
+        #Test /subjects/{subject}/versions/{version}/referencedby
+        def test_referenced_by(entry, expected_result):
+            lookup_schema = import_schemas[entry]
+            subject = lookup_schema["subject"]
+            version = lookup_schema["version"]
+            result_raw = self._get_subjects_subject_versions_version_referenced_by(
+                subject, version)
+
+            endpoint = f"GET subjects/{subject}/versions/{version}/referencedby"
+            assert_request_code(result_raw, requests.codes.ok, endpoint)
+            result = result_raw.json()
+            assert result == expected_result, \
+                f"Expected {expected_result} but got {result}, " \
+                f"for request 'GET subjects/{subject}/versions/{version}/referencedby'"
+
+        test_referenced_by("schema_a", [3])
+        test_referenced_by("schema_b", [2])
+        test_referenced_by("schema_c", [])
+        test_referenced_by("schema_d", [])
+        test_referenced_by("schema_f_v1", [8])
+        test_referenced_by("schema_f_v3", [10])
+        test_referenced_by("schema_f_v5", [])
+        test_referenced_by("schema_g_v1", [])
+        test_referenced_by("schema_g_v2", [])
+        test_referenced_by("schema_g_v3", [])
+        test_referenced_by("schema_g_v4", [])
+
+        #This is the last of the endpoint to be checked, as it will change the state
         #Test /subjects/{subject}/versions
         def test_subjects_subject_versions(entry,
                                            expected_successful,
@@ -2769,7 +2851,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                                            expected_successful=True)
 
         #forward_references will fail the lookup, as they didn't get canonicallized.
-        #Each will create a new entree.
+        #Each will create a new entry.
         for id, s in forward_references_entries_new_ids:
             test_subjects_subject_versions(s,
                                            expected_id=id,
@@ -2780,89 +2862,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             test_subjects_subject_versions(s,
                                            expected_id=id,
                                            expected_successful=False)
-
-        #Test /subjects/{subject}/versions/{version}
-        def test_subjects_subject_versions_version(entry, expected_successful):
-            lookup_schema = import_schemas[entry]
-            subject = lookup_schema["subject"]
-            version = lookup_schema["version"]
-            expected_schema = lookup_schema["sanitized"].strip()
-            #references = lookup_schema["references"] if "references" in lookup_schema else []
-            result_raw = self._get_subjects_subject_versions_version(
-                subject=subject, version=version)
-            endpoint = f"GET subjects/{subject}/versions/{version}"
-            if expected_successful:
-                assert_request_code(result_raw, requests.codes.ok, endpoint)
-
-                result = result_raw.json()["schema"].strip()
-                assert result == expected_schema, \
-                        f"Expected:\n{expected_schema}\nGot:\n{result}\nfor request "\
-                        f"'GET subjects/{subject}/versions/{version}'"
-            else:
-                assert_request_code(result_raw, 422, endpoint)
-
-        for _, s in valid_entries + forward_references_entries:
-            test_subjects_subject_versions_version(s, expected_successful=True)
-        for _, s in invalid_entries:
-            test_subjects_subject_versions_version(s,
-                                                   expected_successful=False)
-
-        #Test /subjects/{subject}/versions/{version}/schema
-        def test_subjects_subject_versions_version_schema(
-                entry, expected_successful):
-            lookup_schema = import_schemas[entry]
-            subject = lookup_schema["subject"]
-            version = lookup_schema["version"]
-            schema_def = lookup_schema["sanitized"].strip()
-            result_raw = self._request(
-                "GET",
-                f"subjects/{subject}/versions/{version}/schema",
-                headers=HTTP_GET_HEADERS)
-
-            endpoint = f"GET subjects/{subject}/versions/{version}/schema"
-            if expected_successful:
-                assert_request_code(result_raw, requests.codes.ok, endpoint)
-
-                result = result_raw.content.decode().strip()
-                assert result == schema_def, \
-                        f"Expected:\n{schema_def}\nGot:\n{result}\n"\
-                        f"for request 'GET subjects/{subject}/versions/{version}/schema'"
-            else:
-                assert_request_code(result_raw, 422, endpoint)
-
-        for _, s in valid_entries + forward_references_entries:
-            test_subjects_subject_versions_version_schema(
-                s, expected_successful=True)
-        for _, s in invalid_entries:
-            test_subjects_subject_versions_version_schema(
-                s, expected_successful=False)
-
-        #Test /subjects/{subject}/versions/{version}/referencedby
-        def test_referenced_by(entry, expected_result):
-            lookup_schema = import_schemas[entry]
-            subject = lookup_schema["subject"]
-            version = lookup_schema["version"]
-            result_raw = self._get_subjects_subject_versions_version_referenced_by(
-                subject, version)
-
-            endpoint = f"GET subjects/{subject}/versions/{version}/referencedby"
-            assert_request_code(result_raw, requests.codes.ok, endpoint)
-            result = result_raw.json()
-            assert result == expected_result, \
-                f"Expected {expected_result} but got {result}, " \
-                f"for request 'GET subjects/{subject}/versions/{version}/referencedby'"
-
-        test_referenced_by("schema_a", [3])
-        test_referenced_by("schema_b", [15])
-        test_referenced_by("schema_c", [])
-        test_referenced_by("schema_d", [])
-        test_referenced_by("schema_f_v1", [8])
-        test_referenced_by("schema_f_v3", [10])
-        test_referenced_by("schema_f_v5", [])
-        test_referenced_by("schema_g_v1", [])
-        test_referenced_by("schema_g_v2", [])
-        test_referenced_by("schema_g_v3", [])
-        test_referenced_by("schema_g_v4", [])
 
         #Insert missing dependency, schema_e, and retry the failed schema_d requests
         result_raw = self._post_subjects_subject_versions(
@@ -2880,7 +2879,8 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         test_schemas_ids_id(4, expected_successful=True)
         test_schemas_ids_id_versions(4, expected_successful=True)
         test_schemas_ids_id_subjects(4, expected_successful=True)
-        test_subjects_subject("schema_d", expected_successful=True)
+        #Lookup still fails cause schema_d is stored not in it's canonical form
+        test_subjects_subject("schema_d", expected_code=404)
         #Validate that schema_d can now be posted anew.
         #Note that a new version will be created, as the old one was invalid at
         #startup and it was not in canonical form. Thus it cannot be found and a
@@ -2888,6 +2888,8 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         test_subjects_subject_versions("schema_d",
                                        expected_id=17,
                                        expected_successful=True)
+        #After pushing, schema_d is not stored by its canonical form
+        import_schemas["schema_d"]["sanitized"] = schema_d_proto_sanitized_def
         test_subjects_subject_versions_version("schema_d",
                                                expected_successful=True)
         test_subjects_subject_versions_version_schema("schema_d",
@@ -2956,7 +2958,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
     @cluster(num_nodes=3)
     def test_unsanitized_import(self):
         """
-        Verify that all endpoints sanitize the retrieved schema
+        Verify sanitization during startup
         """
 
         #Test setup: Simulate import of a schema by writting directly into the _schemas topic.
@@ -2986,6 +2988,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             "for request 'POST subjects/imported'"
 
         #Normalization:on - /subjects/{subject}
+        #This should fail to find it, as the schema was not normalized when stored.
         result_raw = self._post_subjects_subject(subject="imported",
                                                  data=json.dumps({
                                                      "schema":
@@ -2994,14 +2997,9 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                                                      "PROTOBUF"
                                                  }),
                                                  normalize=True)
-        assert result_raw.status_code == requests.codes.ok, \
-            f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
+        assert result_raw.status_code == 404, \
+            f"Expected 404 but got {result_raw.status_code}, "\
             f"for request 'POST subjects/imported?normalize=true'"
-        result = result_raw.json()["schema"].strip()
-        expected_result = imported_schema["normalized"].strip()
-        assert result == expected_result, \
-            f"Expected:\n{expected_result}\nGot:\n{result}\n"\
-            "for request 'POST subjects/imported?normalize=true'"
 
         #Normalization:off - /subjects/{subject}/versions
         result_raw = self._post_subjects_subject_versions(subject="imported",
@@ -3387,8 +3385,9 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             {'schema_registry_protobuf_renderer_v2': True},
             expect_restart=True)
 
-        # Post a schema with normalization set to off
+        # Post a schema with and without normalization
         result_raw = self._post_subjects_subject_versions(
+            normalize=False,
             subject="test_subject",
             data=json.dumps({
                 "schema": imported_schema_proto_def,
@@ -3396,10 +3395,26 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             }))
         assert result_raw.status_code == requests.codes.ok, \
             f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup"
+        result_id = result_raw.json()["id"]
+        assert result_id == 1, \
+            f"Expected id 1 but got {result_id} during test setup"
 
-        def test_schemas_ids_id(expected_schema):
+        result_raw = self._post_subjects_subject_versions(
+            normalize=True,
+            subject="test_subject",
+            data=json.dumps({
+                "schema": imported_schema_proto_def,
+                "schemaType": "PROTOBUF"
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+            f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup"
+        result_id = result_raw.json()["id"]
+        assert result_id == 2, \
+            f"Expected id 2 but got {result_id} during test setup"
+
+        def test_schemas_ids_id(id, expected_schema):
             result_raw = self._request("GET",
-                                       f"schemas/ids/1",
+                                       f"schemas/ids/{id}",
                                        headers=HTTP_GET_HEADERS)
             result = result_raw.json()["schema"].strip()
             assert result_raw.status_code == requests.codes.ok, \
@@ -3432,21 +3447,26 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         sanitized = imported_schema_sanitized_proto_def.strip()
         normalized = imported_schema_normalized_proto_def.strip()
 
-        test_schemas_ids_id(sanitized)
+        test_schemas_ids_id(1, sanitized)
+        test_schemas_ids_id(2, normalized)
         test_subjects_subject(sanitized, expected_version=1)
-        test_subjects_subject(sanitized, expected_version=1, norm=True)
-        test_subjects_subject(normalized, expected_version=None)
-        test_subjects_subject(normalized, expected_version=1, norm=True)
+        test_subjects_subject(sanitized, expected_version=2, norm=True)
+        test_subjects_subject(normalized, expected_version=2)
+        test_subjects_subject(normalized, expected_version=2, norm=True)
 
         #Update always_normalize and re-run all tests
         self.redpanda.set_cluster_config(
             {'schema_registry_always_normalize': True})
 
-        test_schemas_ids_id(imported_schema_normalized_proto_def.strip())
-        test_subjects_subject(sanitized, expected_version=1)
-        test_subjects_subject(sanitized, expected_version=1, norm=True)
-        test_subjects_subject(normalized, expected_version=1)
-        test_subjects_subject(normalized, expected_version=1, norm=True)
+        #Verify that always_normalize doesn't affect lookup by id
+        test_schemas_ids_id(1, sanitized)
+        test_schemas_ids_id(2, normalized)
+        #Verify that always_normalize always treats normalization set to on
+        test_subjects_subject(sanitized, expected_version=2)
+        test_subjects_subject(sanitized, expected_version=2, norm=True)
+        #Sanity check on normalized input
+        test_subjects_subject(normalized, expected_version=2)
+        test_subjects_subject(normalized, expected_version=2, norm=True)
 
     @cluster(num_nodes=3)
     def test_soft_deleted_references(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -2604,7 +2604,6 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         valid_entries = [
             (1, "schema_a"),
-            (2, "schema_c"),
             (3, "schema_b"),
             (5, "schema_f_v1"),
             (6, "schema_f_v3"),
@@ -2612,6 +2611,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             (8, "schema_g_v1"),
             (10, "schema_g_v3"),
         ]
+        #These are schemas that having missing dependencies at startup
         invalid_entries = [
             (4, "schema_d"),
             (9, "schema_g_v2"),
@@ -2619,6 +2619,13 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             (12, "schema_i"),
             (13, "schema_j"),
             (14, "schema_k"),
+        ]
+        #These are schemas whose references are loaded after them during startup
+        forward_references_entries = [
+            (2, "schema_c"),
+        ]
+        forward_references_entries_new_ids = [
+            (15, "schema_c"),
         ]
 
         #Test /schemas/ids/{id}
@@ -2640,7 +2647,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #These schemas are valid. We should be able to retrieve them.
-        for id, _ in valid_entries:
+        for id, _ in valid_entries + forward_references_entries:
             test_schemas_ids_id(id, expected_successful=True)
 
         #These schemas are invalid. Tryint to retrieve them should return an error.
@@ -2658,7 +2665,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        for id, _ in valid_entries:
+        for id, _ in valid_entries + forward_references_entries:
             test_schemas_ids_id_versions(id, expected_successful=True)
         for id, _ in invalid_entries:
             test_schemas_ids_id_versions(id, expected_successful=False)
@@ -2674,7 +2681,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        for id, _ in valid_entries:
+        for id, _ in valid_entries + forward_references_entries:
             test_schemas_ids_id_subjects(id, expected_successful=True)
         for id, _ in invalid_entries:
             test_schemas_ids_id_subjects(id, expected_successful=False)
@@ -2722,7 +2729,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 assert_request_code(result_raw, 422, endpoint)
 
         #Test /subjects/{subject}
-        for _, s in valid_entries:
+        for _, s in valid_entries + forward_references_entries:
             test_subjects_subject(s, expected_successful=True)
 
         #These schemas should fail, as the *input* schema has an unsatisfied dependency
@@ -2761,6 +2768,13 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                                            expected_id=id,
                                            expected_successful=True)
 
+        #forward_references will fail the lookup, as they didn't get canonicallized.
+        #Each will create a new entree.
+        for id, s in forward_references_entries_new_ids:
+            test_subjects_subject_versions(s,
+                                           expected_id=id,
+                                           expected_successful=True)
+
         #These schemas should fail, as the *input* schema has an unsatisfied dependencies
         for id, s in invalid_entries:
             test_subjects_subject_versions(s,
@@ -2787,7 +2801,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        for _, s in valid_entries:
+        for _, s in valid_entries + forward_references_entries:
             test_subjects_subject_versions_version(s, expected_successful=True)
         for _, s in invalid_entries:
             test_subjects_subject_versions_version(s,
@@ -2816,7 +2830,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             else:
                 assert_request_code(result_raw, 422, endpoint)
 
-        for _, s in valid_entries:
+        for _, s in valid_entries + forward_references_entries:
             test_subjects_subject_versions_version_schema(
                 s, expected_successful=True)
         for _, s in invalid_entries:
@@ -2839,7 +2853,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 f"for request 'GET subjects/{subject}/versions/{version}/referencedby'"
 
         test_referenced_by("schema_a", [3])
-        test_referenced_by("schema_b", [2])
+        test_referenced_by("schema_b", [15])
         test_referenced_by("schema_c", [])
         test_referenced_by("schema_d", [])
         test_referenced_by("schema_f_v1", [8])
@@ -2860,15 +2874,19 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         assert_request_code(result_raw, requests.codes.ok,
                             "POST subjects/schema_e/versions")
 
-        #Validate that schema_d is recognized as a referee
+        #Validate that schema_d is now accepted as a referee
         test_referenced_by("schema_e", [4])
 
         test_schemas_ids_id(4, expected_successful=True)
         test_schemas_ids_id_versions(4, expected_successful=True)
         test_schemas_ids_id_subjects(4, expected_successful=True)
         test_subjects_subject("schema_d", expected_successful=True)
+        #Validate that schema_d can now be posted anew.
+        #Note that a new version will be created, as the old one was invalid at
+        #startup and it was not in canonical form. Thus it cannot be found and a
+        #new version is created.
         test_subjects_subject_versions("schema_d",
-                                       expected_id=4,
+                                       expected_id=17,
                                        expected_successful=True)
         test_subjects_subject_versions_version("schema_d",
                                                expected_successful=True)
@@ -2882,7 +2900,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
 
         #Fix problematic schemas by adding missing dependency for g_v2 and deleting g_v4.
         test_subjects_subject_versions("schema_f_v2",
-                                       expected_id=16,
+                                       expected_id=18,
                                        expected_successful=True)
 
         result_raw = self._delete_subject_version("schema_g", version=4)
@@ -2890,12 +2908,12 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                             "DELETE subjects/schema_g/versions/4")
 
         test_subjects_subject_versions("schema_g_v5",
-                                       expected_id=17,
+                                       expected_id=19,
                                        expected_successful=True)
 
         #Fix problematic dependency chain by adding base schema.
         test_subjects_subject_versions("schema_h",
-                                       expected_id=18,
+                                       expected_id=20,
                                        expected_successful=True)
         test_schemas_ids_id(12, expected_successful=True)
         test_schemas_ids_id(13, expected_successful=True)
@@ -2940,6 +2958,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         """
         Verify that all endpoints sanitize the retrieved schema
         """
+
         #Test setup: Simulate import of a schema by writting directly into the _schemas topic.
         #This schema is neither sanitized nor normalized
         self._push_to_schemas_topic([imported_schema])
@@ -3001,6 +3020,8 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             "for request 'POST subjects/imported/versions'"
 
         #Normalization:on - /subjects/{subject}/versions
+        #This should fail to find it and create a new one, as the schema was
+        #not normalized when stored.
         result_raw = self._post_subjects_subject_versions(subject="imported",
                                                           data=json.dumps({
                                                               "schema":
@@ -3013,8 +3034,8 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             f"Expected {requests.codes.ok} but got {result_raw.status_code}, "\
             "for request 'POST subjects/imported/versions?normalize=true'"
         result_id = result_raw.json()["id"]
-        assert result_id == 1, \
-            f"Expected id 1 but got {result_id}, "\
+        assert result_id == 2, \
+            f"Expected id 2 but got {result_id}, "\
             "for request 'POST subjects/imported/versions?normalize=true'"
 
     @cluster(num_nodes=4)


### PR DESCRIPTION
Backport of #25764

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
