### PR TITLE
archival_stm snapshot: init _last_clean_at as -inf when applying a dirty snapshot

### DIFF
--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -227,7 +227,7 @@ struct archival_metadata_stm::read_write_fence_cmd
 //
 struct archival_metadata_stm::snapshot
   : public serde::
-      envelope<snapshot, serde::version<5>, serde::compat_version<0>> {
+      envelope<snapshot, serde::version<6>, serde::compat_version<0>> {
     /// List of segments
     fragmented_vector<segment> segments;
     /// List of replaced segments
@@ -272,6 +272,12 @@ struct archival_metadata_stm::snapshot
     model::producer_id highest_producer_id;
     // Offset of the last applied command
     model::offset applied_offset;
+    // The offset of the last mark_clean_cmd applied;
+    // default (-inf) in v5 and earlier
+    model::offset last_clean_at;
+    // The offset of the last record that modified the stm;
+    // default (-inf) in v5 and earlier
+    model::offset last_dirty_at;
 
     auto serde_fields() {
         return std::tie(
@@ -291,7 +297,9 @@ struct archival_metadata_stm::snapshot
           last_scrubbed_offset,
           detected_anomalies,
           highest_producer_id,
-          applied_offset);
+          applied_offset,
+          last_clean_at,
+          last_dirty_at);
     }
 };
 
@@ -1263,11 +1271,20 @@ archival_metadata_stm::apply_local_snapshot(
     // reset counter, the value depended on the previous _manifest
     _compacted_replaced_bytes = 0;
 
-    if (snap.dirty == state_dirty::dirty) {
-        _last_clean_at = model::offset{};
+    if (snap.last_clean_at == model::offset{}) {
+        // Handle legacy snapshots which don't have the 'last_clean_at'
+        // field.
+        if (snap.dirty == state_dirty::dirty) {
+            _last_clean_at = model::offset{};
+        } else {
+            _last_clean_at = header.offset;
+        }
     } else {
-        _last_clean_at = header.offset;
+        _last_clean_at = snap.last_clean_at;
     }
+
+    _last_dirty_at = snap.last_dirty_at;
+
     co_return raft::local_snapshot_applied::yes;
 }
 
@@ -1294,7 +1311,9 @@ archival_metadata_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
       .last_scrubbed_offset = _manifest->last_scrubbed_offset(),
       .detected_anomalies = _manifest->detected_anomalies(),
       .highest_producer_id = _manifest->highest_producer_id(),
-      .applied_offset = _manifest->get_applied_offset()});
+      .applied_offset = _manifest->get_applied_offset(),
+      .last_clean_at = _last_clean_at,
+      .last_dirty_at = _last_dirty_at});
     auto snapshot_offset = last_applied_offset();
     apply_units.return_all();
 

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1264,7 +1264,7 @@ archival_metadata_stm::apply_local_snapshot(
     _compacted_replaced_bytes = 0;
 
     if (snap.dirty == state_dirty::dirty) {
-        _last_clean_at = model::offset{0};
+        _last_clean_at = model::offset{};
     } else {
         _last_clean_at = header.offset;
     }

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -11,7 +11,7 @@
 import random
 import string
 import itertools
-import json
+import time
 from time import sleep
 from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
@@ -28,12 +28,68 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.util import wait_for_local_storage_truncate, expect_exception
 from rptest.clients.kcl import KCL
 from rptest.tests.cluster_config_test import wait_for_version_sync
+from rptest.tests.e2e_finjector import Finjector
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.offline_log_viewer import OfflineLogViewer
+
+
+def topic_name():
+    return "test-topic-" + "".join(
+        random.choice(string.ascii_lowercase) for _ in range(16))
+
+
+class RapidTopicRecreateTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(RapidTopicRecreateTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=SISettings(test_context=test_context,
+                                   skip_end_of_test_scrubbing=True),
+            extra_rp_conf={
+                "iceberg_enabled": True,  # to create relevant STMs
+            })
+        self.rpk = RpkTool(self.redpanda)
+        self.topic_name = topic_name()
+
+    def create(self):
+        self._current_partitions = random.randint(1, 4)
+        replication_factor = random.choice([1, 3])
+        self.logger.info(
+            "Creating topic with {self._current_partitions} partitions "
+            "and {replication_factor=}")
+        self.client().create_topic(
+            TopicSpec(name=self.topic_name,
+                      partition_count=self._current_partitions,
+                      replication_factor=replication_factor))
+
+    def delete(self):
+        self.logger.info("Deleting topic")
+        self.client().delete_topic(self.topic_name)
+
+    def add_partitions(self):
+        partitions_to_add = random.randint(1, 4)
+        self.logger.info(f"Adding {partitions_to_add} partitions "
+                         f"to {self._current_partitions} existing")
+        self.rpk.add_partitions(self.topic_name, partitions_to_add)
+        self._current_partitions += partitions_to_add
+
+    @cluster(num_nodes=3)
+    def test_topic_rapid_recreation(self):
+        with Finjector(self.redpanda, self.scale,
+                       max_concurrent_failures=1).finj_thread():
+            for _ in range(100):
+                try:
+                    random.choice(
+                        [self.create, self.delete, self.add_partitions])()
+                    sleep_time = 2**random.uniform(-15, 2)
+                    self.logger.info(f"Sleeping for {sleep_time} seconds")
+                    time.sleep(sleep_time)
+                except Exception as e:
+                    self.logger.debug(f"Error: {e}")
 
 
 class Workload():
@@ -203,11 +259,6 @@ class TopicAutocreateTest(RedpandaTest):
         assert len(auto_topic_cfg_unique) == 0 and \
             len(manual_topic_cfg_unique) == 0, \
                   f"topics {auto_topic=} and {manual_topic=} have these different configs (should be empty) {auto_topic_cfg_unique=} {manual_topic_cfg_unique=}"
-
-
-def topic_name():
-    return "test-topic-" + "".join(
-        random.choice(string.ascii_lowercase) for _ in range(16))
 
 
 class CreateTopicsTest(RedpandaTest):


### PR DESCRIPTION
~This PR includes changes from https://github.com/redpanda-data/redpanda/pull/25728 for the test to pass, only two last commits are relevant.~

I made this change when debugging https://redpandadata.atlassian.net/browse/CORE-9506. The issue is when a topic is deleted quickly after creation the broker sometimes errors with `Failed to fetch manifest during finalize())` as it expects to download partition manifest that has never been uploaded.

Questions to Storage team:
1) Does [the change](https://github.com/redpanda-data/redpanda/commit/49d33cc11ad1b6242a89230396e46ab090ff78d2) make sense? I'm not familiar with the logic of this STM, e.g. `_last_dirty_offset` is not changed on snapshot application at all, is that right?
2) The test (last commit) passes but only if scrubbing is turned off. Should we aim for scrubbing to pass as well or is it expected to have some anomalies if we're recreating topics so wildly?

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none