### PR TITLE
bazel: Patch krb5-1.21.3 to address CVEs

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -201,7 +201,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "2Uw5QX6md8K97DisPU1L329rJLygrdBDdu7e4guJMMI=",
+        "bzlTransitiveDigest": "ZGaKqwECNyUDduSXFKqG/ehB6Bql/WaXimCv69fuksU=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -290,7 +290,13 @@
               "build_file": "@@//bazel/thirdparty:krb5.BUILD",
               "sha256": "2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861",
               "strip_prefix": "krb5-krb5-1.21.3-final",
-              "url": "https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz"
+              "url": "https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz",
+              "patches": [
+                "@@//bazel/thirdparty:0001-Fix-two-unlikely-memory-leaks.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
             }
           },
           "libpciaccess": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -76,6 +76,8 @@ def data_dependency():
         sha256 = "2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861",
         strip_prefix = "krb5-krb5-1.21.3-final",
         url = "https://github.com/krb5/krb5/archive/refs/tags/krb5-1.21.3-final.tar.gz",
+        patches = ["//bazel/thirdparty:0001-Fix-two-unlikely-memory-leaks.patch"],
+        patch_args = ["-p1"],
     )
 
     http_archive(

--- a/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
+++ b/bazel/thirdparty/0001-Fix-two-unlikely-memory-leaks.patch
@@ -1,0 +1,205 @@
+From 8161936fa0188709585ddcd0f6ea0ebdaa3e0b17 Mon Sep 17 00:00:00 2001
+From: Greg Hudson <ghudson@mit.edu>
+Date: Tue, 5 Mar 2024 19:53:07 -0500
+Subject: [PATCH] Fix two unlikely memory leaks
+
+In gss_krb5int_make_seal_token_v3(), one of the bounds checks (which
+could probably never be triggered) leaks plain.data.  Fix this leak
+and use current practices for cleanup throughout the function.
+
+In xmt_rmtcallres() (unused within the tree and likely elsewhere),
+store port_ptr into crp->port_ptr as soon as it is allocated;
+otherwise it could leak if the subsequent xdr_u_int32() operation
+fails.
+
+(cherry picked from commit c5f9c816107f70139de11b38aa02db2f1774ee0d)
+---
+ src/lib/gssapi/krb5/k5sealv3.c | 56 +++++++++++++++-------------------
+ src/lib/rpc/pmap_rmt.c         |  9 +++---
+ 2 files changed, 29 insertions(+), 36 deletions(-)
+
+diff --git a/src/lib/gssapi/krb5/k5sealv3.c b/src/lib/gssapi/krb5/k5sealv3.c
+index 1fcbdfbb8..d3210c110 100644
+--- a/src/lib/gssapi/krb5/k5sealv3.c
++++ b/src/lib/gssapi/krb5/k5sealv3.c
+@@ -65,7 +65,7 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+                                 int conf_req_flag, int toktype)
+ {
+     size_t bufsize = 16;
+-    unsigned char *outbuf = 0;
++    unsigned char *outbuf = NULL;
+     krb5_error_code err;
+     int key_usage;
+     unsigned char acceptor_flag;
+@@ -75,9 +75,13 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ #endif
+     size_t ec;
+     unsigned short tok_id;
+-    krb5_checksum sum;
++    krb5_checksum sum = { 0 };
+     krb5_key key;
+     krb5_cksumtype cksumtype;
++    krb5_data plain = empty_data();
++
++    token->value = NULL;
++    token->length = 0;
+ 
+     acceptor_flag = ctx->initiate ? 0 : FLAG_SENDER_IS_ACCEPTOR;
+     key_usage = (toktype == KG_TOK_WRAP_MSG
+@@ -107,14 +111,15 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ #endif
+ 
+     if (toktype == KG_TOK_WRAP_MSG && conf_req_flag) {
+-        krb5_data plain;
+         krb5_enc_data cipher;
+         size_t ec_max;
+         size_t encrypt_size;
+ 
+         /* 300: Adds some slop.  */
+-        if (SIZE_MAX - 300 < message->length)
+-            return ENOMEM;
++        if (SIZE_MAX - 300 < message->length) {
++            err = ENOMEM;
++            goto cleanup;
++        }
+         ec_max = SIZE_MAX - message->length - 300;
+         if (ec_max > 0xffff)
+             ec_max = 0xffff;
+@@ -126,20 +131,20 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ #endif
+         err = alloc_data(&plain, message->length + 16 + ec);
+         if (err)
+-            return err;
++            goto cleanup;
+ 
+         /* Get size of ciphertext.  */
+         encrypt_size = krb5_encrypt_size(plain.length, key->keyblock.enctype);
+         if (encrypt_size > SIZE_MAX / 2) {
+             err = ENOMEM;
+-            goto error;
++            goto cleanup;
+         }
+         bufsize = 16 + encrypt_size;
+         /* Allocate space for header plus encrypted data.  */
+         outbuf = gssalloc_malloc(bufsize);
+         if (outbuf == NULL) {
+-            free(plain.data);
+-            return ENOMEM;
++            err = ENOMEM;
++            goto cleanup;
+         }
+ 
+         /* TOK_ID */
+@@ -164,11 +169,8 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+         cipher.ciphertext.length = bufsize - 16;
+         cipher.enctype = key->keyblock.enctype;
+         err = krb5_k_encrypt(context, key, key_usage, 0, &plain, &cipher);
+-        zap(plain.data, plain.length);
+-        free(plain.data);
+-        plain.data = 0;
+         if (err)
+-            goto error;
++            goto cleanup;
+ 
+         /* Now that we know we're returning a valid token....  */
+         ctx->seq_send++;
+@@ -181,7 +183,6 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+         /* If the rotate fails, don't worry about it.  */
+ #endif
+     } else if (toktype == KG_TOK_WRAP_MSG && !conf_req_flag) {
+-        krb5_data plain;
+         size_t cksumsize;
+ 
+         /* Here, message is the application-supplied data; message2 is
+@@ -193,21 +194,19 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+     wrap_with_checksum:
+         err = alloc_data(&plain, message->length + 16);
+         if (err)
+-            return err;
++            goto cleanup;
+ 
+         err = krb5_c_checksum_length(context, cksumtype, &cksumsize);
+         if (err)
+-            goto error;
++            goto cleanup;
+ 
+         assert(cksumsize <= 0xffff);
+ 
+         bufsize = 16 + message2->length + cksumsize;
+         outbuf = gssalloc_malloc(bufsize);
+         if (outbuf == NULL) {
+-            free(plain.data);
+-            plain.data = 0;
+             err = ENOMEM;
+-            goto error;
++            goto cleanup;
+         }
+ 
+         /* TOK_ID */
+@@ -239,23 +238,15 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+         if (message2->length)
+             memcpy(outbuf + 16, message2->value, message2->length);
+ 
+-        sum.contents = outbuf + 16 + message2->length;
+-        sum.length = cksumsize;
+-
+         err = krb5_k_make_checksum(context, cksumtype, key,
+                                    key_usage, &plain, &sum);
+-        zap(plain.data, plain.length);
+-        free(plain.data);
+-        plain.data = 0;
+         if (err) {
+             zap(outbuf,bufsize);
+-            goto error;
++            goto cleanup;
+         }
+         if (sum.length != cksumsize)
+             abort();
+         memcpy(outbuf + 16 + message2->length, sum.contents, cksumsize);
+-        krb5_free_checksum_contents(context, &sum);
+-        sum.contents = 0;
+         /* Now that we know we're actually generating the token...  */
+         ctx->seq_send++;
+ 
+@@ -285,12 +276,13 @@ gss_krb5int_make_seal_token_v3 (krb5_context context,
+ 
+     token->value = outbuf;
+     token->length = bufsize;
+-    return 0;
++    outbuf = NULL;
++    err = 0;
+ 
+-error:
++cleanup:
++    krb5_free_checksum_contents(context, &sum);
++    zapfree(plain.data, plain.length);
+     gssalloc_free(outbuf);
+-    token->value = NULL;
+-    token->length = 0;
+     return err;
+ }
+ 
+diff --git a/src/lib/rpc/pmap_rmt.c b/src/lib/rpc/pmap_rmt.c
+index 8c7e30c21..149de98b0 100644
+--- a/src/lib/rpc/pmap_rmt.c
++++ b/src/lib/rpc/pmap_rmt.c
+@@ -160,11 +160,12 @@ xdr_rmtcallres(
+ 	caddr_t port_ptr;
+ 
+ 	port_ptr = (caddr_t)(void *)crp->port_ptr;
+-	if (xdr_reference(xdrs, &port_ptr, sizeof (uint32_t),
+-	    xdr_u_int32) && xdr_u_int32(xdrs, &crp->resultslen)) {
+-		crp->port_ptr = (uint32_t *)(void *)port_ptr;
++	if (!xdr_reference(xdrs, &port_ptr, sizeof (uint32_t),
++		xdr_u_int32))
++		return (FALSE);
++	crp->port_ptr = (uint32_t *)(void *)port_ptr;
++	if (xdr_u_int32(xdrs, &crp->resultslen))
+ 		return ((*(crp->xdr_results))(xdrs, crp->results_ptr));
+-	}
+ 	return (FALSE);
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Addresses the following CVEs:

* CVE-2024-26458
* CVE-2024-26461

Cherry-picked
https://github.com/krb5/krb5/commit/c5f9c816107f70139de11b38aa02db2f1774ee0d#diff-ef41df3e0d3c1aa8b2c9a8d1da5c3538fbb78fa29fedb0f83695256977ca3488 onto the krb5-1.21 branch and created a patch from the resulting commit.

Fixes: CORE-9786

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
