### PR TITLE
DEVPROD-1918 updates (remove deprecated test, update RedpandaInstaller)

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -700,7 +700,7 @@ class RedpandaInstaller:
 
         tgz = "redpanda.tar.gz"
         cmds = [
-            f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-connrefused --retry-delay 2 --create-dir -o {version_root}/{tgz}",
+            f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-all-errors --retry-delay 2 --create-dir -o {version_root}/{tgz}",
             f"gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root}",
             f"rm {version_root}/{tgz}"
         ]
@@ -713,8 +713,8 @@ class RedpandaInstaller:
                 self._redpanda.logger.error(
                     f"Exception while downloading to {version_root} on {node.account.hostname}, cleaning up: {str(ssh_exc)}"
                 )
-                # Debug log to avoid printing too much to the console.
-                self._redpanda.logger.debug(
+                # Let's see the details
+                self._redpanda.logger.error(
                     f"Captured output for {str(ssh_exc)} on {node.account.hostname}: {captured_output}"
                 )
                 # Be permissive so we can clean everything.

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -2168,43 +2168,6 @@ class BasicAuthUpgradeTest(PandaProxyEndpoints):
         result = result_raw.json()
         assert result[0] == self.topic
 
-    @cluster(num_nodes=3)
-    @parametrize(base_release=(22, 2), next_release=(22, 3))
-    @parametrize(base_release=(22, 3), next_release=(23, 1))
-    def test_upgrade_and_enable_basic_auth(self, base_release: tuple[int, int],
-                                           next_release: tuple[int, int]):
-        old_version, old_version_str = self.installer.install(
-            self.redpanda.nodes, base_release)
-        security = SecurityConfig()
-        security.enable_sasl = True
-        security.endpoint_authn_method = 'sasl'
-        self.redpanda.set_security_settings(security)
-
-        pandaproxy_config = PandaproxyConfig()
-        if base_release == (22, 2):
-            # v22.2.x or earlier do not support Basic Auth
-            # so there is no kafka client cache
-            pandaproxy_config.cache_keep_alive_ms = None
-            pandaproxy_config.cache_max_size = None
-
-        self.redpanda.set_pandaproxy_settings(pandaproxy_config)
-        self.redpanda.start()
-        self._create_initial_topics()
-        self.check_usage()
-
-        # Upgrade to cluster with basic auth support
-        # and test with basic auth enabled
-        self.installer.install(self.redpanda.nodes, next_release)
-        pandaproxy_config.authn_method = 'http_basic'
-        pandaproxy_config.cache_keep_alive_ms = 300000
-        pandaproxy_config.cache_max_size = 10
-        self.redpanda.set_pandaproxy_settings(pandaproxy_config)
-        self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
-        # self.redpanda.rolling_restart_nodes(self.redpanda.nodes)
-        unique_versions = wait_for_num_versions(self.redpanda, 1)
-        assert old_version_str not in unique_versions
-        self.check_usage()
-
 
 class PandaProxyConsumerGroupTest(PandaProxyEndpoints):
     topics = [


### PR DESCRIPTION
If this doesn't fix [DEVPROD-1918] it'll provide more debugging info to make that easier in the future.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

 * none

[DEVPROD-1918]: https://redpandadata.atlassian.net/browse/DEVPROD-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ