### PR TITLE
Restore libpciaccess as dep of hwloc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,9 +77,7 @@ use_repo(non_module_dependencies, "hdrhistogram")
 use_repo(non_module_dependencies, "hwloc")
 use_repo(non_module_dependencies, "jsoncons")
 use_repo(non_module_dependencies, "krb5")
-
-# workaround for CORE-9546
-# use_repo(non_module_dependencies, "libpciaccess")
+use_repo(non_module_dependencies, "libpciaccess")
 use_repo(non_module_dependencies, "libprotobuf_mutator")
 use_repo(non_module_dependencies, "libxml2")
 use_repo(non_module_dependencies, "lksctp")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -5777,7 +5777,7 @@
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
           "@@//bazel/thirdparty/Cargo.lock": "931fa1bc55d0e5d2e5b6d96da399569a4c2254a4bb1d99c98f71bb4b98eead73",
           "@@//bazel/thirdparty/Cargo.toml": "cb23768a6e7edc8f97215921e956f5be06521ad93cc0ecf64a932e3a8caada54",
-          "@@//MODULE.bazel": "2b57c34de42ea6176f2cdac8a68353691eb68608f5e43249308be323b7896a44",
+          "@@//MODULE.bazel": "95197662702f84ae3836bf17657faf8ae3c473f988968e0a470d5cbe541dd7fd",
           "@@//bazel/thirdparty/wasmtime.BUILD": "4b55deaf51f5b8be25fc3592f9bcf3d732f99632cd793c685436ddca9a177534",
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
         },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -201,7 +201,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "ZGaKqwECNyUDduSXFKqG/ehB6Bql/WaXimCv69fuksU=",
+        "bzlTransitiveDigest": "SIRWQ+radZuG0xin6bW2+kQwnBPkC1XE+o1F046iwIA=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -306,7 +306,7 @@
               "build_file": "@@//bazel/thirdparty:libpciaccess.BUILD",
               "sha256": "d0d0d53c2085d21ab37ae5989e55a3de13d4d80dc2c0a8d5c77154ea70f4783c",
               "strip_prefix": "libpciaccess-2ec2576cabefef1eaa5dd9307c97de2e887fc347",
-              "url": "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/2ec2576cabefef1eaa5dd9307c97de2e887fc347/libpciaccess-2ec2576cabefef1eaa5dd9307c97de2e887fc347.tar.gz"
+              "url": "https://vectorized-public.s3.amazonaws.com/dependencies/libpciaccess-2ec2576cabefef1eaa5dd9307c97de2e887fc347.tar.gz"
             }
           },
           "libprotobuf_mutator": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -85,7 +85,7 @@ def data_dependency():
         build_file = "//bazel/thirdparty:libpciaccess.BUILD",
         sha256 = "d0d0d53c2085d21ab37ae5989e55a3de13d4d80dc2c0a8d5c77154ea70f4783c",
         strip_prefix = "libpciaccess-2ec2576cabefef1eaa5dd9307c97de2e887fc347",
-        url = "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/2ec2576cabefef1eaa5dd9307c97de2e887fc347/libpciaccess-2ec2576cabefef1eaa5dd9307c97de2e887fc347.tar.gz",
+        url = "https://vectorized-public.s3.amazonaws.com/dependencies/libpciaccess-2ec2576cabefef1eaa5dd9307c97de2e887fc347.tar.gz",
     )
 
     http_archive(

--- a/bazel/thirdparty/hwloc.BUILD
+++ b/bazel/thirdparty/hwloc.BUILD
@@ -48,8 +48,7 @@ configure_make(
         "//visibility:public",
     ],
     deps = [
-        # workaround for CORE-9546
-        # "@libpciaccess",
+        "@libpciaccess",
     ],
 )
 


### PR DESCRIPTION
Start using libpciaccess again. See commits for details.

AI's idea... dependency re-enabling:

* [`MODULE.bazel`](diffhunk://#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdcL80-R80): Re-enabled the use of `libpciaccess` by removing the workaround comments and uncommenting the related line.
* [`bazel/thirdparty/hwloc.BUILD`](diffhunk://#diff-0942ac17ae1eecb2c7921c9750dccbde98eafb5bc7cdb5e3d1b2c464c3ecca70L51-R51): Added `@libpciaccess` back to the dependencies list by removing the workaround comments.

URL source update:

* [`bazel/repositories.bzl`](diffhunk://#diff-8e1b8edd0dd49f5a7468a7071405b488c7ffb93fd46c68de99df0a8d7d25b0d4L88-R88): Updated the URL for `libpciaccess` to point to a new location on `vectorized-public.s3.amazonaws.com`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
