### PR TITLE
update ada-url to v3.2.2

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -222,9 +222,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:ada.BUILD",
-              "sha256": "8e222d536d237269488f7d454544eedf12847f47b3d42651e8c9963c3fb0cf5e",
-              "strip_prefix": "ada-2.7.3",
-              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-2.7.3.tar.gz"
+              "sha256": "caae8ecdb96fd4a50828205a327b62d047a028f08cd370b74178e23903140831",
+              "strip_prefix": "",
+              "url": "https://github.com/ada-url/ada/releases/download/v3.2.2/singleheader.zip"
             }
           },
           "avro": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -212,7 +212,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "kMKjJBdb2IH9kGY4fz+CkTAk8TyOzYqgTRt7Qxs9eRQ=",
+        "bzlTransitiveDigest": "Evb2gveAZy3r9rsXR0rw0hcpkMmt6BjUasSIhLWTY3M=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -222,8 +222,8 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:ada.BUILD",
-              "sha256": "caae8ecdb96fd4a50828205a327b62d047a028f08cd370b74178e23903140831",
-              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-3.2.2.single-header.zip"
+              "sha256": "bd89fcf57c93e965e6e2488448ab9d1cf8005311808c563b288f921d987e4924",
+              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-3.2.4.single-header.zip"
             }
           },
           "avro": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -212,7 +212,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "zeVh9jz8NxWJEFV5nxz4uzVBn3nNPb951lh46efMXJ0=",
+        "bzlTransitiveDigest": "kMKjJBdb2IH9kGY4fz+CkTAk8TyOzYqgTRt7Qxs9eRQ=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -223,8 +223,7 @@
             "attributes": {
               "build_file": "@@//bazel/thirdparty:ada.BUILD",
               "sha256": "caae8ecdb96fd4a50828205a327b62d047a028f08cd370b74178e23903140831",
-              "strip_prefix": "",
-              "url": "https://github.com/ada-url/ada/releases/download/v3.2.2/singleheader.zip"
+              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-3.2.2.single-header.zip"
             }
           },
           "avro": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -15,9 +15,9 @@ def data_dependency():
     http_archive(
         name = "ada",
         build_file = "//bazel/thirdparty:ada.BUILD",
-        sha256 = "8e222d536d237269488f7d454544eedf12847f47b3d42651e8c9963c3fb0cf5e",
-        strip_prefix = "ada-2.7.3",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-2.7.3.tar.gz",
+        sha256 = "caae8ecdb96fd4a50828205a327b62d047a028f08cd370b74178e23903140831",
+        strip_prefix = "",
+        url = "https://github.com/ada-url/ada/releases/download/v3.2.2/singleheader.zip",
     )
 
     http_archive(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -15,8 +15,8 @@ def data_dependency():
     http_archive(
         name = "ada",
         build_file = "//bazel/thirdparty:ada.BUILD",
-        sha256 = "caae8ecdb96fd4a50828205a327b62d047a028f08cd370b74178e23903140831",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-3.2.2.single-header.zip",
+        sha256 = "bd89fcf57c93e965e6e2488448ab9d1cf8005311808c563b288f921d987e4924",
+        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-3.2.4.single-header.zip",
     )
 
     http_archive(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -16,8 +16,7 @@ def data_dependency():
         name = "ada",
         build_file = "//bazel/thirdparty:ada.BUILD",
         sha256 = "caae8ecdb96fd4a50828205a327b62d047a028f08cd370b74178e23903140831",
-        strip_prefix = "",
-        url = "https://github.com/ada-url/ada/releases/download/v3.2.2/singleheader.zip",
+        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/ada-3.2.2.single-header.zip",
     )
 
     http_archive(

--- a/bazel/thirdparty/ada.BUILD
+++ b/bazel/thirdparty/ada.BUILD
@@ -12,6 +12,7 @@ cmake(
         "ADA_TESTING": "OFF",
         "ADA_TOOLS": "OFF",
         "ADA_BENCHMARKS": "OFF",
+        "ADA_INCLUDE_URL_PATTERN": "OFF",
         "CMAKE_INSTALL_LIBDIR": "lib",
     },
     env = {

--- a/bazel/thirdparty/ada.BUILD
+++ b/bazel/thirdparty/ada.BUILD
@@ -5,6 +5,7 @@ cc_library(
         "ada.h",
         "ada_c.h",
     ],
+    defines = ["ADA_INCLUDE_URL_PATTERN=0"],
     includes = ["."],
     visibility = [
         "//visibility:public",

--- a/bazel/thirdparty/ada.BUILD
+++ b/bazel/thirdparty/ada.BUILD
@@ -1,28 +1,11 @@
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-
-filegroup(
-    name = "srcs",
-    srcs = glob(["**"]),
-)
-
-cmake(
+cc_library(
     name = "ada",
-    cache_entries = {
-        "BUILD_SHARED_LIBS": "OFF",
-        "ADA_TESTING": "OFF",
-        "ADA_TOOLS": "OFF",
-        "ADA_BENCHMARKS": "OFF",
-        "ADA_INCLUDE_URL_PATTERN": "OFF",
-        "CMAKE_INSTALL_LIBDIR": "lib",
-    },
-    env = {
-        # prevent cmake from trying to open the ccache read/write directory
-        # which is outside the bazel sandbox.
-        "CCACHE_DISABLE": "1",
-    },
-    generate_args = ["-GNinja"],
-    lib_source = ":srcs",
-    out_static_libs = ["libada.a"],
+    srcs = ["ada.cpp"],
+    hdrs = [
+        "ada.h",
+        "ada_c.h",
+    ],
+    includes = ["."],
     visibility = [
         "//visibility:public",
     ],

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -95,9 +95,10 @@ fetch_dep(GTest
 set(ADA_TESTING OFF)
 set(ADA_TOOLS OFF)
 set(ADA_BENCHMARKS OFF)
+set(ADA_INCLUDE_URL_PATTERN OFF)
 fetch_dep(ada
   REPO https://github.com/ada-url/ada
-  TAG v2.7.3)
+  TAG v3.2.2)
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   set(TINYGO_TARBALL "tinygo-linux-amd64.tar.gz")

--- a/src/v/http/request_builder.h
+++ b/src/v/http/request_builder.h
@@ -78,7 +78,7 @@ public:
 
 private:
     ada::result<ada::url_aggregator> _url{
-      tl::unexpected{ada::errors::generic_error}};
+      tl::unexpected{ada::errors::type_error}};
     std::optional<ss::sstring> _target{std::nullopt};
     boost::beast::http::request_header<> _request;
     absl::flat_hash_map<ss::sstring, ss::sstring> _query_params_kv;

--- a/src/v/thirdparty/ada/BUILD
+++ b/src/v/thirdparty/ada/BUILD
@@ -1,7 +1,9 @@
 cc_library(
     name = "ada",
+    srcs = ["ada.cpp"],
     hdrs = [
         "ada.h",
+        "ada_c.h",
     ],
     include_prefix = "thirdparty/ada",
     visibility = ["//visibility:public"],

--- a/src/v/thirdparty/ada/BUILD
+++ b/src/v/thirdparty/ada/BUILD
@@ -1,9 +1,8 @@
 cc_library(
     name = "ada",
-    srcs = ["ada.cpp"],
+    srcs = [],
     hdrs = [
         "ada.h",
-        "ada_c.h",
     ],
     include_prefix = "thirdparty/ada",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
I'm one of the co-authors of Ada URL parser. I saw that Redpanda still uses an extremely old version of Ada. I recommend upgrading it.