### PR TITLE
PP/SR: access-log-like trace logs

### DIFF
--- a/src/v/pandaproxy/logger.cc
+++ b/src/v/pandaproxy/logger.cc
@@ -11,4 +11,5 @@
 
 namespace pandaproxy {
 ss::logger plog{"pandaproxy"};
+ss::logger srlog{"schemaregistry"};
 } // namespace pandaproxy

--- a/src/v/pandaproxy/logger.h
+++ b/src/v/pandaproxy/logger.h
@@ -17,4 +17,5 @@
 
 namespace pandaproxy {
 extern ss::logger plog;
+extern ss::logger srlog;
 } // namespace pandaproxy

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -95,7 +95,8 @@ inline std::unique_ptr<ss::http::reply> unprocessable_entity(ss::sstring msg) {
       std::move(msg));
 }
 
-inline std::unique_ptr<ss::http::reply> exception_reply(std::exception_ptr e) {
+inline std::unique_ptr<ss::http::reply>
+exception_reply(ss::logger& log, std::exception_ptr e) {
     try {
         std::rethrow_exception(e);
     } catch (const ss::gate_closed_exception& e) {
@@ -117,7 +118,7 @@ inline std::unique_ptr<ss::http::reply> exception_reply(std::exception_ptr e) {
         auto ise = reply_error_code::internal_server_error;
         auto eb = errored_body(ise, make_error_condition(ise).message());
         vlog(
-          plog.error,
+          log.error,
           "exception_reply: {}, exception: {}",
           eb->_content,
           std::current_exception());
@@ -127,8 +128,9 @@ inline std::unique_ptr<ss::http::reply> exception_reply(std::exception_ptr e) {
 
 struct exception_replier {
     ss::sstring mime_type;
+    ss::logger& log;
     std::unique_ptr<ss::http::reply> operator()(const std::exception_ptr& e) {
-        auto res = exception_reply(e);
+        auto res = exception_reply(log, e);
         res->set_mime_type(mime_type);
         return res;
     }

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -123,7 +123,8 @@ proxy::proxy(
       "header",
       "/definitions",
       _ctx,
-      json::serialization_format::application_json)
+      json::serialization_format::application_json,
+      plog)
   , _ensure_started{[this]() { return do_start(); }}
   , _controller(controller) {
     _inflight_config_binding.watch([this]() {

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -75,7 +75,7 @@ ss::future<> api::start() {
 }
 
 ss::future<> api::stop() {
-    vlog(plog.debug, "Stopping schema registry API...");
+    vlog(srlog.debug, "Stopping schema registry API...");
     co_await _client.stop();
     co_await _service.stop();
     co_await _sequencer.stop();
@@ -84,11 +84,11 @@ ss::future<> api::stop() {
     if (_store) {
         co_await _store->stop();
     }
-    vlog(plog.debug, "Stopped schema registry API...");
+    vlog(srlog.debug, "Stopped schema registry API...");
 }
 
 ss::future<> api::restart() {
-    vlog(plog.info, "Restarting the schema registry");
+    vlog(srlog.info, "Restarting the schema registry");
     co_await stop();
     co_await start();
 }

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -147,7 +147,7 @@ std::invoke_result_t<F> get_or_load(server::request_t& rq, F f) {
     }
 
     // Load latest writes and retry
-    vlog(plog.debug, "get_or_load: refreshing schema store on missing item");
+    vlog(srlog.debug, "get_or_load: refreshing schema store on missing item");
     co_await rq.service().writer().read_sync();
     co_return co_await f();
 }
@@ -415,7 +415,7 @@ post_subject(server::request_t rq, server::reply_t rp) {
     auto norm{parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
                 .value_or(normalize::no)};
     vlog(
-      plog.debug,
+      srlog.debug,
       "post_subject subject='{}', normalize='{}', deleted='{}'",
       sub,
       norm,
@@ -461,7 +461,7 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     auto norm{parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
                 .value_or(normalize::no)};
     vlog(
-      plog.debug,
+      srlog.debug,
       "post_subject_versions subject='{}', normalize='{}'",
       sub,
       norm);
@@ -663,7 +663,7 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
 
     vlog(
-      plog.info,
+      srlog.info,
       "compatibility_subject_version: subject: {}, version: {}",
       unparsed.def.sub(),
       ver);

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -468,7 +468,7 @@ ss::future<pb::FileDescriptorProto> import_schema(
           dp, store, schema.share(), norm);
     } catch (const exception& e) {
         vlog(
-          plog.warn, "Failed to decode schema {}: {}", schema.sub(), e.what());
+          srlog.warn, "Failed to decode schema {}: {}", schema.sub(), e.what());
         throw as_exception(invalid_schema(schema));
     }
 }

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -61,7 +61,7 @@ struct batch_builder : public storage::record_batch_builder {
 
     void operator()(const seq_marker& s) {
         vlog(
-          plog.debug,
+          srlog.debug,
           "Delete {} tombstoning sub={} at {}",
           to_string_view(s.key_type),
           sub,
@@ -130,12 +130,12 @@ ss::future<> seq_writer::wait_for(model::offset offset) {
     return container().invoke_on(
       reader_shard, _smp_opts, [offset](seq_writer& seq) {
           if (auto waiters = seq._wait_for_sem.waiters(); waiters != 0) {
-              vlog(plog.trace, "wait_for waiting for {} waiters", waiters);
+              vlog(srlog.trace, "wait_for waiting for {} waiters", waiters);
           }
           return ss::with_semaphore(seq._wait_for_sem, 1, [&seq, offset]() {
               if (offset > seq._loaded_offset) {
                   vlog(
-                    plog.debug,
+                    srlog.debug,
                     "wait_for dirty!  Reading {}..{}",
                     seq._loaded_offset,
                     offset);
@@ -148,7 +148,7 @@ ss::future<> seq_writer::wait_for(model::offset offset) {
                     .consume(
                       consume_to_store{seq._store, seq}, model::no_timeout);
               } else {
-                  vlog(plog.trace, "wait_for clean (offset  {})", offset);
+                  vlog(srlog.trace, "wait_for clean (offset  {})", offset);
                   return ss::make_ready_future<>();
               }
           });
@@ -178,12 +178,13 @@ ss::future<bool> seq_writer::produce_and_apply(
 
     auto success = write_at.value_or(res.base_offset) == res.base_offset;
     if (success) {
-        vlog(plog.debug, "seq_writer: Successful write at {}", res.base_offset);
+        vlog(
+          srlog.debug, "seq_writer: Successful write at {}", res.base_offset);
         co_await consume_to_store(_store, *this)(std::move(batch));
         co_await _store.process_marked_schemas();
     } else {
         vlog(
-          plog.debug,
+          srlog.debug,
           "seq_writer: Failed write at {} (wrote at {})",
           write_at,
           res.base_offset);
@@ -200,14 +201,14 @@ ss::future<> seq_writer::advance_offset(model::offset offset) {
 void seq_writer::advance_offset_inner(model::offset offset) {
     if (_loaded_offset < offset) {
         vlog(
-          plog.debug,
+          srlog.debug,
           "seq_writer::advance_offset {}->{}",
           _loaded_offset,
           offset);
         _loaded_offset = offset;
     } else {
         vlog(
-          plog.debug,
+          srlog.debug,
           "seq_writer::advance_offset ignoring {} (have {})",
           offset,
           _loaded_offset);
@@ -224,18 +225,20 @@ ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
       = co_await _store.project_ids(schema.share())
           .handle_exception([](std::exception_ptr e) {
               vlog(
-                plog.debug, "write_subject_version: project_ids failed: {}", e);
+                srlog.debug,
+                "write_subject_version: project_ids failed: {}",
+                e);
               return ss::make_exception_future<sharded_store::insert_result>(e);
           });
 
     if (!projected.inserted) {
-        vlog(plog.debug, "write_subject_version: no-op");
+        vlog(srlog.debug, "write_subject_version: no-op");
         co_return projected.id;
     } else {
         auto canonical = std::move(schema.schema);
         auto sub = canonical.sub();
         vlog(
-          plog.debug,
+          srlog.debug,
           "seq_writer::write_subject_version project offset={} "
           "subject={} "
           "schema={} "
@@ -280,7 +283,7 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
   compatibility_level compat,
   model::offset write_at) {
     vlog(
-      plog.debug,
+      srlog.debug,
       "write_config sub={} compat={} offset={}",
       sub,
       to_string_view(compat),
@@ -326,7 +329,7 @@ ss::future<bool> seq_writer::write_config(
 }
 
 ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
-    vlog(plog.debug, "delete config sub={}", sub);
+    vlog(srlog.debug, "delete config sub={}", sub);
 
     co_await check_mutable(sub);
 
@@ -358,7 +361,7 @@ ss::future<bool> seq_writer::delete_config(subject sub) {
 ss::future<std::optional<bool>> seq_writer::do_write_mode(
   std::optional<subject> sub, mode m, force f, model::offset write_at) {
     vlog(
-      plog.debug,
+      srlog.debug,
       "write_mode sub={} mode={} force={} offset={}",
       sub,
       to_string_view(m),
@@ -404,7 +407,7 @@ seq_writer::write_mode(std::optional<subject> sub, mode mode, force f) {
 
 ss::future<std::optional<bool>>
 seq_writer::do_delete_mode(subject sub, model::offset write_at) {
-    vlog(plog.debug, "delete mode sub={} offset={}", sub, write_at);
+    vlog(srlog.debug, "delete mode sub={} offset={}", sub, write_at);
 
     // Report an error if the mode isn't registered
     co_await _store.get_mode(sub, default_to_global::no);
@@ -441,7 +444,7 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
 
     auto key = schema_key{
       .seq{write_at}, .node{_node_id}, .sub{sub}, .version{version}};
-    vlog(plog.debug, "seq_writer::delete_subject_version {}", key);
+    vlog(srlog.debug, "seq_writer::delete_subject_version {}", key);
     schema_value value{
       .schema{subject_schema{sub, std::move(schema)}},
       .version{version},
@@ -528,7 +531,7 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
 
 ss::future<std::vector<schema_version>>
 seq_writer::delete_subject_impermanent(subject sub) {
-    vlog(plog.debug, "delete_subject_impermanent sub={}", sub);
+    vlog(srlog.debug, "delete_subject_impermanent sub={}", sub);
     return sequenced_write(
       [sub{std::move(sub)}](model::offset write_at, seq_writer& seq) {
           return seq.do_delete_subject_impermanent(sub, write_at);
@@ -555,7 +558,7 @@ seq_writer::delete_subject_permanent_inner(
 
     /// Check for whether our victim is already soft-deleted happens
     /// within these store functions (will throw a 404-equivalent if so)
-    vlog(plog.debug, "delete_subject_permanent sub={}", sub);
+    vlog(srlog.debug, "delete_subject_permanent sub={}", sub);
 
     co_await check_mutable(sub);
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -115,7 +115,7 @@ private:
         auto remote = [base_backoff, f](seq_writer& seq) {
             if (auto waiters = seq._write_sem.waiters(); waiters != 0) {
                 vlog(
-                  plog.trace,
+                  srlog.trace,
                   "sequenced_write waiting for {} waiters",
                   waiters);
             }
@@ -124,7 +124,7 @@ private:
                   if (auto waiters = seq._wait_for_sem.waiters();
                       waiters != 0) {
                       vlog(
-                        plog.debug,
+                        srlog.debug,
                         "sequenced_write acquired write_sem with {} "
                         "wait_for_sem waiters",
                         waiters);

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -208,7 +208,9 @@ private:
       const request_auth_result auth_result,
       ss::sstring reason) const {
         vlog(
-          plog.trace, "Attempting to audit authz for {}", rq.req->format_url());
+          srlog.trace,
+          "Attempting to audit authz for {}",
+          rq.req->format_url());
         auto success = rq.service().audit_mgr().enqueue_api_activity_event(
           security::audit::event_type::schema_registry,
           *rq.req,
@@ -219,7 +221,7 @@ private:
 
         if (!success) {
             vlog(
-              plog.error,
+              srlog.error,
               "Failed to audit authorization request for endpoint: {}",
               rq.req->format_url());
             throw ss::httpd::base_exception(
@@ -232,12 +234,14 @@ private:
       const server::request_t& rq,
       security::audit::authentication_event_options options) const {
         vlog(
-          plog.trace, "Attempting to audit authn for {}", rq.req->format_url());
+          srlog.trace,
+          "Attempting to audit authn for {}",
+          rq.req->format_url());
         auto success = rq.service().audit_mgr().enqueue_authn_event(
           std::move(options));
         if (!success) {
             vlog(
-              plog.error,
+              srlog.error,
               "Failed to audit authentication request for endpoint: {}",
               rq.req->format_url());
             throw ss::httpd::base_exception(
@@ -248,7 +252,9 @@ private:
 
     void do_audit_authz(const server::request_t& rq) const {
         vlog(
-          plog.trace, "Attempting to audit authz for {}", rq.req->format_url());
+          srlog.trace,
+          "Attempting to audit authz for {}",
+          rq.req->format_url());
         auto success = rq.service().audit_mgr().enqueue_api_activity_event(
           security::audit::event_type::schema_registry,
           *rq.req,
@@ -257,7 +263,7 @@ private:
 
         if (!success) {
             vlog(
-              plog.error,
+              srlog.error,
               "Failed to audit authorization request for endpoint: {}",
               rq.req->format_url());
             throw ss::httpd::base_exception(
@@ -402,10 +408,10 @@ ss::future<> service::do_start() {
     auto guard = _gate.hold();
     try {
         co_await create_internal_topic();
-        vlog(plog.info, "Schema registry successfully initialized");
+        vlog(srlog.info, "Schema registry successfully initialized");
     } catch (...) {
         vlog(
-          plog.error,
+          srlog.error,
           "Schema registry failed to initialize: {}",
           std::current_exception());
         throw;
@@ -438,13 +444,13 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
 
     if (it != err_vec.end()) {
         vlog(
-          plog.warn,
+          srlog.warn,
           "Failed to create ACLs for {}, err {} - {}",
           principal,
           *it,
           cluster::make_error_code(*it).message());
     } else {
-        vlog(plog.debug, "Successfully created ACLs for {}", principal);
+        vlog(srlog.debug, "Successfully created ACLs for {}", principal);
     }
 }
 
@@ -469,7 +475,7 @@ ss::future<> service::mitigate_error(std::exception_ptr eptr) {
         // Return so that the client doesn't try to mitigate.
         return ss::now();
     }
-    vlog(plog.warn, "mitigate_error: {}", eptr);
+    vlog(srlog.warn, "mitigate_error: {}", eptr);
     return ss::make_exception_future<>(eptr)
       .handle_exception_type(
         [this, eptr](const kafka::client::broker_error& ex) {
@@ -498,7 +504,7 @@ ss::future<> service::mitigate_error(std::exception_ptr eptr) {
 }
 
 ss::future<> service::inform(model::node_id id) {
-    vlog(plog.trace, "inform: {}", id);
+    vlog(srlog.trace, "inform: {}", id);
 
     // Inform a particular node
     if (id != kafka::client::unknown_node_id) {
@@ -514,7 +520,7 @@ ss::future<> service::inform(model::node_id id) {
 ss::future<> service::do_inform(model::node_id id) {
     auto& fe = _controller->get_ephemeral_credential_frontend().local();
     auto ec = co_await fe.inform(id, principal);
-    vlog(plog.info, "Informed: broker: {}, ec: {}", id, ec);
+    vlog(srlog.info, "Informed: broker: {}, ec: {}", id, ec);
 }
 
 ss::future<> service::create_internal_topic() {
@@ -525,7 +531,7 @@ ss::future<> service::create_internal_topic() {
         _controller->internal_topic_replication());
 
     vlog(
-      plog.debug,
+      srlog.debug,
       "Schema registry: attempting to create internal topic (replication={})",
       replication_factor);
 
@@ -565,11 +571,11 @@ ss::future<> service::create_internal_topic() {
 
     const auto& topic = res.data.topics[0];
     if (topic.error_code == kafka::error_code::none) {
-        vlog(plog.debug, "Schema registry: created internal topic");
+        vlog(srlog.debug, "Schema registry: created internal topic");
     } else if (topic.error_code == kafka::error_code::topic_already_exists) {
-        vlog(plog.debug, "Schema registry: found internal topic");
+        vlog(srlog.debug, "Schema registry: found internal topic");
     } else if (topic.error_code == kafka::error_code::not_controller) {
-        vlog(plog.debug, "Schema registry: not controller");
+        vlog(srlog.debug, "Schema registry: not controller");
     } else {
         throw kafka::exception(
           topic.error_code,
@@ -581,7 +587,7 @@ ss::future<> service::create_internal_topic() {
 }
 
 ss::future<> service::fetch_internal_topic() {
-    vlog(plog.debug, "Schema registry: loading internal topic");
+    vlog(srlog.debug, "Schema registry: loading internal topic");
 
     // TODO: should check the replication_factor of the topic is
     // what our config calls for
@@ -589,7 +595,7 @@ ss::future<> service::fetch_internal_topic() {
     auto offset_res = co_await _client.local().list_offsets(
       model::schema_registry_internal_tp);
     auto max_offset = offset_res.data.topics[0].partitions[0].offset;
-    vlog(plog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
+    vlog(srlog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 
     co_await kafka::client::make_client_fetch_batch_reader(
       _client.local(),
@@ -629,7 +635,8 @@ service::service(
       "schema_registry_header",
       "/schema_registry_definitions",
       _ctx,
-      json::serialization_format::schema_registry_v1_json)
+      json::serialization_format::schema_registry_v1_json,
+      srlog)
   , _store(store)
   , _writer(sequencer)
   , _controller(controller)

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -175,10 +175,11 @@ sharded_store::get_schema_version(stored_schema schema) {
         } else {
             // Use the supplied id
             s_id = schema.id;
-            vlog(plog.debug, "project_ids: using supplied ID {}", s_id.value());
+            vlog(
+              srlog.debug, "project_ids: using supplied ID {}", s_id.value());
         }
     } else if (s_id) {
-        vlog(plog.debug, "project_ids: existing ID {}", s_id.value());
+        vlog(srlog.debug, "project_ids: existing ID {}", s_id.value());
     }
 
     // Determine if the subject already has a version that references this
@@ -231,7 +232,7 @@ sharded_store::project_ids(stored_schema schema) {
     if (s_id == invalid_schema_id) {
         // New schema, project an ID for it.
         s_id = co_await project_schema_id();
-        vlog(plog.debug, "project_ids: projected new ID {}", s_id);
+        vlog(srlog.debug, "project_ids: projected new ID {}", s_id);
     }
 
     auto sub_shard{shard_for(sub)};
@@ -340,7 +341,7 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
               // Stored schemas might be invalid if imported improperly
               e.code() == error_code::schema_invalid) {
                 vlog(
-                  plog.warn,
+                  srlog.warn,
                   "Failed to parse stored schema, subject '{}', version {}. "
                   "Error: {}",
                   schema.sub(),
@@ -747,7 +748,7 @@ ss::future<> sharded_store::maybe_update_max_schema_id(schema_id id) {
         auto old = _next_schema_id;
         _next_schema_id = std::max(_next_schema_id, id + 1);
         vlog(
-          plog.debug,
+          srlog.debug,
           "maybe_update_max_schema_id: {}->{}",
           old,
           _next_schema_id);

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1377,7 +1377,7 @@ struct consume_to_store {
 
         auto key_type = from_string_view<topic_key_type>(key_type_str);
         if (!key_type.has_value()) {
-            vlog(plog.error, "Ignoring keytype: {}", key_type_str);
+            vlog(srlog.error, "Ignoring keytype: {}", key_type_str);
             co_await _sequencer.advance_offset(offset);
             co_return;
         }
@@ -1456,7 +1456,7 @@ struct consume_to_store {
         // compatibility, which can't collide.
         if (val && key.seq.has_value() && offset != key.seq) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "Ignoring out of order {} (at offset {})",
               key,
               offset);
@@ -1465,7 +1465,7 @@ struct consume_to_store {
 
         try {
             vlog(
-              plog.debug,
+              srlog.debug,
               "Applying: {} tombstone={} (at offset {})",
               key,
               !val.has_value(),
@@ -1483,7 +1483,7 @@ struct consume_to_store {
                       e.code() == error_code::subject_not_found
                       || e.code() == error_code::subject_version_not_found) {
                         vlog(
-                          plog.debug,
+                          srlog.debug,
                           "Ignoring tombstone at offset={}, subject or version "
                           "already removed ({})",
                           offset,
@@ -1505,7 +1505,7 @@ struct consume_to_store {
                   val->deleted);
             }
         } catch (const exception& e) {
-            vlog(plog.debug, "Error replaying: {}: {}", key, e.what());
+            vlog(srlog.debug, "Error replaying: {}: {}", key, e.what());
         }
     }
 
@@ -1517,7 +1517,7 @@ struct consume_to_store {
         // compatibility, which can't collide.
         if (val && key.seq.has_value() && offset != key.seq) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "Ignoring out of order {} (at offset {})",
               key,
               offset);
@@ -1530,7 +1530,7 @@ struct consume_to_store {
               fmt::format("Unexpected magic: {}", key));
         }
         try {
-            vlog(plog.debug, "Applying: {}", key);
+            vlog(srlog.debug, "Applying: {}", key);
             if (key.sub.has_value()) {
                 if (!val.has_value()) {
                     co_await _store.clear_compatibility(
@@ -1554,11 +1554,11 @@ struct consume_to_store {
                 co_await _store.set_compatibility(val->compat);
             } else {
                 vlog(
-                  plog.warn,
+                  srlog.warn,
                   "Tried to apply config with neither subject nor value");
             }
         } catch (const exception& e) {
-            vlog(plog.debug, "Error replaying: {}: {}", key, e);
+            vlog(srlog.debug, "Error replaying: {}: {}", key, e);
         }
     }
 
@@ -1570,7 +1570,7 @@ struct consume_to_store {
         // compatibility, which can't collide.
         if (val && key.seq.has_value() && offset != key.seq) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "Ignoring out of order {} (at offset {})",
               key,
               offset);
@@ -1583,7 +1583,7 @@ struct consume_to_store {
               fmt::format("Unexpected magic: {}", key));
         }
         try {
-            vlog(plog.debug, "Applying: {}", key);
+            vlog(srlog.debug, "Applying: {}", key);
             if (key.sub.has_value()) {
                 if (!val.has_value()) {
                     co_await _store.clear_mode(
@@ -1609,11 +1609,11 @@ struct consume_to_store {
                 co_await _store.set_mode(val->mode, force::yes);
             } else {
                 vlog(
-                  plog.warn,
+                  srlog.warn,
                   "Tried to apply mode with neither subject nor value");
             }
         } catch (const exception& e) {
-            vlog(plog.debug, "Error replaying: {}: {}", key, e);
+            vlog(srlog.debug, "Error replaying: {}: {}", key, e);
         }
     }
 
@@ -1629,7 +1629,7 @@ struct consume_to_store {
         // compatibility, which can't collide.
         if (val && key.seq.has_value() && offset != key.seq) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "Ignoring out of order {} (at offset {})",
               key,
               offset);
@@ -1642,7 +1642,8 @@ struct consume_to_store {
             // actual removal of subjects/versions happens on hard delete, i.e.
             // the tombstone for the schema/version itself, not the tombstone
             // for the soft deletion.
-            vlog(plog.debug, "Ignoring delete_subject tombstone at {}", offset);
+            vlog(
+              srlog.debug, "Ignoring delete_subject tombstone at {}", offset);
             co_return;
         }
 
@@ -1652,7 +1653,7 @@ struct consume_to_store {
               fmt::format("Unexpected magic: {}", key));
         }
         try {
-            vlog(plog.debug, "Applying: {}", key);
+            vlog(srlog.debug, "Applying: {}", key);
             co_await _store.delete_subject(
               seq_marker{
                 .seq = key.seq,
@@ -1662,7 +1663,7 @@ struct consume_to_store {
               key.sub,
               permanent_delete::no);
         } catch (const exception& e) {
-            vlog(plog.debug, "Error replaying: {}: {}", key, e);
+            vlog(srlog.debug, "Error replaying: {}: {}", key, e);
         }
     }
 

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -196,7 +196,7 @@ public:
 
         if (parser.bytes_left() < 5) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: topic: {}, field: {}, not enough bytes: {}",
               topic(),
               to_string_view(field),
@@ -207,7 +207,7 @@ public:
         auto magic = parser.consume_type<int8_t>();
         if (magic != 0) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: topic: {}, field: {}, invalid magic: {}",
               topic(),
               to_string_view(field),
@@ -222,7 +222,7 @@ public:
         if (_api->_schema_id_cache.local().has(
               topic, field, sns, id, std::nullopt)) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: topic: {}, field: {}, cache hit",
               topic(),
               to_string_view(field));
@@ -236,7 +236,7 @@ public:
             schema.emplace(co_await _api->_store->get_schema_definition(id));
         } catch (const exception& ex) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: topic: {}, field: {}, schema not found: {}",
               topic(),
               to_string_view(field),
@@ -249,7 +249,7 @@ public:
             auto offsets = get_proto_offsets(parser);
             if (offsets.empty()) {
                 vlog(
-                  plog.debug,
+                  srlog.debug,
                   "validating: topic: {}, field: {}, invalid protobuf offsets",
                   topic(),
                   to_string_view(field));
@@ -259,7 +259,7 @@ public:
             if (_api->_schema_id_cache.local().has(
                   topic, field, sns, id, offsets)) {
                 vlog(
-                  plog.debug,
+                  srlog.debug,
                   "validating: topic: {}, field: {}, cache hit",
                   topic(),
                   to_string_view(field));
@@ -274,7 +274,7 @@ public:
           *_api->_store, sns, *std::move(schema), proto_offsets);
         if (!record_name) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: topic: {}, field: {}, unable to extract record_name",
               topic(),
               to_string_view(field));
@@ -287,7 +287,7 @@ public:
           sub, id, include_deleted::yes);
         if (!has_id) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: sub: {}, id: {}, has_id: {}",
               sub,
               id,
@@ -377,7 +377,7 @@ public:
 
         if (!valid) {
             vlog(
-              plog.debug,
+              srlog.debug,
               "validating: _topic: {}, _record_key_schema_id_validation: {}, "
               "_record_key_subject_name_strategy: {}, "
               "_record_value_schema_id_validation: {}, "
@@ -438,7 +438,7 @@ std::optional<schema_id_validator> maybe_make_schema_id_validator(
     if (should_validate_schema_id(props, mode)) {
         if (!api) {
             vlog(
-              plog.error,
+              srlog.error,
               "{} requires schema_registry to be enabled in redpanda.yaml",
               config::shard_local_cfg().enable_schema_id_validation.name());
         }
@@ -452,7 +452,7 @@ ss::future<kafka::error_code> schema_id_validator::operator()(
     using futurator = ss::futurize<kafka::error_code>;
     return (*_impl)(batch)
       .handle_exception([](std::exception_ptr e) {
-          vlog(plog.warn, "Invalid record due to exception: {}", e);
+          vlog(srlog.warn, "Invalid record due to exception: {}", e);
           return futurator::convert(kafka::error_code::invalid_record);
       })
       .then([probe](futurator::value_type res) {

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -79,12 +79,14 @@ struct handler_adaptor : ss::httpd::handler_base {
       server::function_handler&& handler,
       ss::httpd::path_description& path_desc,
       const ss::sstring& metrics_group_name,
-      json::serialization_format exceptional_mime_type)
+      json::serialization_format exceptional_mime_type,
+      ss::logger& log)
       : _pending_requests(pending_requests)
       , _ctx(ctx)
       , _handler(std::move(handler))
       , _probe(path_desc, metrics_group_name)
-      , _exceptional_mime_type(exceptional_mime_type) {}
+      , _exceptional_mime_type(exceptional_mime_type)
+      , _log(log) {}
 
     ss::future<std::unique_ptr<ss::http::reply>> handle(
       const ss::sstring&,
@@ -121,7 +123,7 @@ struct handler_adaptor : ss::httpd::handler_base {
           rq.req->get_client_address().port());
         auto req_line = ssx::sformat(
           "{} {} HTTP/{}", rq.req->_method, rq.req->_url, rq.req->_version);
-        vlog(plog.trace, "{} handling {}", prefix, req_line);
+        vlog(_log.trace, "{} handling {}", prefix, req_line);
 
         if (_ctx.as.abort_requested()) {
             set_reply_unavailable(*rp.rep);
@@ -136,16 +138,17 @@ struct handler_adaptor : ss::httpd::handler_base {
         } catch (...) {
             auto ex = std::current_exception();
             vlog(
-              plog.warn,
+              _log.warn,
               "Request: {} {} failed: {}",
               method,
               url,
               std::current_exception());
-            rp = server::reply_t{exception_reply(ex), _exceptional_mime_type};
+            rp = server::reply_t{
+              exception_reply(_log, ex), _exceptional_mime_type};
         }
         set_and_measure_response(rp);
         vlog(
-          plog.trace,
+          _log.trace,
           "{} responding to {}: status={} resp_size={}",
           prefix,
           req_line,
@@ -160,6 +163,7 @@ struct handler_adaptor : ss::httpd::handler_base {
     server::function_handler _handler;
     probe _probe;
     json::serialization_format _exceptional_mime_type;
+    ss::logger& _log;
 };
 
 server::server(
@@ -169,7 +173,8 @@ server::server(
   const ss::sstring& header,
   const ss::sstring& definitions,
   context_t& ctx,
-  json::serialization_format exceptional_mime_type)
+  json::serialization_format exceptional_mime_type,
+  ss::logger& log)
   : _server(server_name)
   , _public_metrics_group_name(public_metrics_group_name)
   , _pending_reqs()
@@ -177,7 +182,8 @@ server::server(
   , _has_routes(false)
   , _ctx(ctx)
   , _exceptional_mime_type(exceptional_mime_type)
-  , _probe{} {
+  , _probe{}
+  , _log(log) {
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
@@ -196,7 +202,8 @@ void server::route(server::route_t r) {
       std::move(r.handler),
       r.path_desc,
       _public_metrics_group_name,
-      _exceptional_mime_type);
+      _exceptional_mime_type,
+      _log);
     r.path_desc.set(_server._routes, handler);
 }
 
@@ -221,7 +228,7 @@ ss::future<> server::start(
   const std::vector<config::endpoint_tls_config>& endpoints_tls,
   const std::vector<model::broker_endpoint>& advertised) {
     _server._routes.register_exeption_handler(
-      exception_replier{ss::sstring{name(_exceptional_mime_type)}});
+      exception_replier{ss::sstring{name(_exceptional_mime_type)}, _log});
 
     _probe = std::make_unique<server_probe>(_ctx, _public_metrics_group_name);
 
@@ -255,11 +262,11 @@ ss::future<> server::start(
               it->config,
               _public_metrics_group_name,
               it->name,
-              [](
+              [&log = _log](
                 const std::unordered_set<ss::sstring>& updated,
                 const std::exception_ptr& eptr) {
                   rpc::log_certificate_reload_event(
-                    plog, "API TLS", updated, eptr);
+                    log, "API TLS", updated, eptr);
               });
         }
         co_await _server.listen(addr, cred);

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -114,6 +114,15 @@ struct handler_adaptor : ss::httpd::handler_base {
             co_return std::move(rp.rep);
         }
         auto sem_units = co_await ss::get_units(_ctx.mem_sem, req_size);
+
+        auto prefix = ssx::sformat(
+          "[{}:{}]",
+          rq.req->get_client_address().addr(),
+          rq.req->get_client_address().port());
+        auto req_line = ssx::sformat(
+          "{} {} HTTP/{}", rq.req->_method, rq.req->_url, rq.req->_version);
+        vlog(plog.trace, "{} handling {}", prefix, req_line);
+
         if (_ctx.as.abort_requested()) {
             set_reply_unavailable(*rp.rep);
             rp.mime_type = _exceptional_mime_type;
@@ -135,6 +144,14 @@ struct handler_adaptor : ss::httpd::handler_base {
             rp = server::reply_t{exception_reply(ex), _exceptional_mime_type};
         }
         set_and_measure_response(rp);
+        vlog(
+          plog.trace,
+          "{} responding to {}: status={} resp_size={}",
+          prefix,
+          req_line,
+          static_cast<std::underlying_type_t<ss::http::reply::status_type>>(
+            rp.rep->_status),
+          rp.rep->_content.size());
         co_return std::move(rp.rep);
     }
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -18,6 +18,7 @@
 #include "kafka/client/client.h"
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/kafka_client_cache.h"
+#include "pandaproxy/logger.h"
 #include "pandaproxy/types.h"
 #include "security/request_auth.h"
 #include "utils/adjustable_semaphore.h"
@@ -121,7 +122,8 @@ public:
       const ss::sstring& header,
       const ss::sstring& definitions,
       context_t& ctx,
-      json::serialization_format exceptional_mime_type);
+      json::serialization_format exceptional_mime_type,
+      ss::logger& log = plog);
 
     void route(route_t route);
     void routes(routes_t&& routes);
@@ -141,6 +143,7 @@ private:
     context_t& _ctx;
     json::serialization_format _exceptional_mime_type;
     std::unique_ptr<server_probe> _probe;
+    ss::logger& _log;
 };
 
 template<typename service_t>

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -18,7 +18,6 @@
 #include "kafka/client/client.h"
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/kafka_client_cache.h"
-#include "pandaproxy/logger.h"
 #include "pandaproxy/types.h"
 #include "security/request_auth.h"
 #include "utils/adjustable_semaphore.h"
@@ -123,7 +122,7 @@ public:
       const ss::sstring& definitions,
       context_t& ctx,
       json::serialization_format exceptional_mime_type,
-      ss::logger& log = plog);
+      ss::logger& log);
 
     void route(route_t route);
     void routes(routes_t&& routes);

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2089,7 +2089,7 @@ class AuditLogTestSchemaRegistry(AuditLogTestBase):
             log_config=LoggingConfig('info',
                                      logger_levels={
                                          'auditing': 'trace',
-                                         'pandaproxy': 'trace'
+                                         'schemaregistry': 'trace'
                                      }),
             schema_registry_config=sr_config)
 

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -40,6 +40,7 @@ log_config = LoggingConfig('info',
                            logger_levels={
                                'security': 'trace',
                                'pandaproxy': 'trace',
+                               'schemaregistry': 'trace',
                                'kafka/client': 'trace',
                                'kafka': 'debug',
                                'http': 'trace',

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -717,7 +717,7 @@ dependent_schemas = {
 log_config = LoggingConfig('info',
                            logger_levels={
                                'security': 'trace',
-                               'pandaproxy': 'trace',
+                               'schemaregistry': 'trace',
                                'kafka/client': 'trace'
                            })
 


### PR DESCRIPTION
This PR introduces trace logs intended as a debugging aid, to make it easier to see a trace of all endpoints being used, their responses statuses and the clients that hit these endpoints.

Do not rely on the format of these log lines, as they are subject to change. The format is currently so:
```
TRACE 2025-04-09 15:16:46,405 [shard  0:main] pandaproxy - server.cc:124 - [127.0.0.1:41790] handling POST /subjects/sub-123/versions?deleted=true HTTP/1.1
...
TRACE 2025-04-09 15:16:46,647 [shard  0:main] pandaproxy - server.cc:154 - [127.0.0.1:41790] responding to POST /subjects/sub-123/versions?deleted=true HTTP/1.1: status=422 resp_size=0
```

Furthermore, the PR separates the loggers of pandaproxy and schemaregistry. This is because it is confusing for users to have to enable the pandaproxy logger when debugging schema registry issues.

The change is backported to ensure they can be used for debugging in all recent releases.

Fixes https://redpandadata.atlassian.net/browse/CORE-9796
Fixes https://redpandadata.atlassian.net/browse/CORE-9799

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements
* The Schema Registry service now uses a new logger named `schemaregistry`, separating it from the existing `pandaproxy` logger used for the REST proxy. 

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
