### PR TITLE
[CORE-9738] pandaproxy/sr: improve lookup by schema in sr

### DIFF
--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -324,37 +324,46 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
         throw as_exception(invalid_subject_schema(schema.sub()));
     }
 
-    std::optional<stored_schema> sub_schema;
-    for (auto ver : versions) {
-        try {
-            auto res = co_await get_subject_schema(schema.sub(), ver, inc_del);
-            if (schema.def() == res.schema.def()) {
-                sub_schema.emplace(std::move(res));
-                break;
-            }
-        } catch (const exception& e) {
-            if (
-              e.code() == error_code::subject_not_found
-              || e.code() == error_code::subject_version_not_found) {
-            } else if (
-              // Stored schemas might be invalid if imported improperly
-              e.code() == error_code::schema_invalid) {
-                vlog(
-                  plog.warn,
-                  "Failed to parse stored schema, subject '{}', version {}. "
-                  "Error: {}",
-                  schema.sub(),
-                  ver,
-                  e.what());
-            } else {
-                throw;
-            }
-        }
-    };
-    if (!sub_schema.has_value()) {
+    // Determine if the definition already exists
+    auto map = [&schema](store& s) { return s.get_schema_id(schema.def()); };
+    auto reduce = [](
+                    std::optional<schema_id> acc,
+                    std::optional<schema_id> s_id) { return acc ? acc : s_id; };
+    auto s_id = co_await _store.map_reduce0(
+      map, std::optional<schema_id>{}, reduce);
+
+    if (!s_id.has_value()) {
         throw as_exception(schema_not_found());
     }
-    co_return std::move(sub_schema).value();
+
+    // Determine if the subject already has a version that references this
+    // schema, deleted versions may be seen.
+    std::optional<schema_version> v_id;
+    for (const auto& v : versions) {
+        auto sve = co_await _store.invoke_on(
+          shard_for(schema.sub()),
+          _smp_opts,
+          [sub = schema.sub(), v, inc_del](store& s) {
+              return s.get_subject_version_id(sub, v, inc_del);
+          });
+        if (!sve.has_value()) {
+            continue;
+        }
+
+        if (sve.value().id == *s_id) {
+            v_id.emplace(v);
+            break;
+        }
+    }
+    if (!v_id.has_value()) {
+        throw as_exception(schema_not_found());
+    }
+
+    try {
+        co_return co_await get_subject_schema(schema.sub(), *v_id, inc_del);
+    } catch (const exception& e) {
+        throw as_exception(schema_not_found());
+    }
 }
 
 ss::future<std::optional<schema_definition>>

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -106,13 +106,19 @@ public:
 
     ///\brief Return the id of the schema, if it already exists.
     std::optional<schema_id> get_schema_id(const schema_definition& def) const {
-        const auto s_it = std::find_if(
-          _schemas.begin(), _schemas.end(), [&](const auto& s) {
-              const auto& entry = s.second;
-              return def == entry.definition;
-          });
-        return s_it == _schemas.end() ? std::optional<schema_id>{}
-                                      : s_it->first;
+        auto h = absl::Hash<schema_definition>{}(def);
+        const auto h_it = _schemas_hash.find(h);
+        if (h_it == _schemas_hash.end()) {
+            return {};
+        }
+        const auto s_it = _schemas.find(h_it->second);
+        if (s_it == _schemas.end()) {
+            return {};
+        }
+        if (s_it->second.definition != def) {
+            return {};
+        }
+        return h_it->second;
     }
 
     ///\brief Return a list of subject-versions for the shema id.
@@ -635,9 +641,14 @@ public:
             return {s_it->first, false};
         }
 
+        auto h = absl::Hash<schema_definition>{}(def);
+
         const auto id = _schemas.empty() ? schema_id{1}
                                          : std::prev(_schemas.end())->first + 1;
         auto [_, inserted] = _schemas.try_emplace(id, std::move(def));
+
+        _schemas_hash.try_emplace(h, id);
+
         return {id, inserted};
     }
 
@@ -645,11 +656,20 @@ public:
         if (mark_schema) {
             _marked_schemas.push_back(id);
         }
+        auto h = absl::Hash<schema_definition>{}(def);
+        _schemas_hash.try_emplace(h, id);
         return _schemas.insert_or_assign(id, schema_entry(std::move(def)))
           .second;
     }
 
-    void delete_schema(schema_id id) { _schemas.erase(id); }
+    void delete_schema(schema_id id) {
+        const auto it = _schemas.find(id);
+        if (it != _schemas.end()) {
+            auto h = absl::Hash<schema_definition>{}(it->second.definition);
+            _schemas_hash.erase(h);
+        }
+        _schemas.erase(id);
+    }
 
     // This function returns and unmarkes all marked schemas.
     chunked_vector<schema_id> extract_marked_schemas() {
@@ -850,6 +870,7 @@ private:
             }
         }
     };
+    using schema_hash = absl::btree_map<size_t, schema_id>;
     using schema_map = absl::btree_map<schema_id, schema_entry>;
     using subject_map = absl::node_hash_map<subject, subject_entry>;
 
@@ -910,6 +931,7 @@ private:
         return v_it;
     }
 
+    schema_hash _schemas_hash;
     schema_map _schemas;
     subject_map _subjects;
     chunked_vector<schema_id> _marked_schemas;

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -116,6 +116,11 @@ struct schema_reference {
     ss::sstring name;
     subject sub{invalid_subject};
     schema_version version{invalid_schema_version};
+
+    template<typename H>
+    friend H AbslHashValue(H h, const schema_reference& ref) {
+        return H::combine(std::move(h), ref.name, ref.sub, ref.version);
+    }
 };
 
 ///\brief Definition of a schema and its type.
@@ -178,6 +183,16 @@ public:
 
     auto destructure() && {
         return make_tuple(std::move(_def), _type, std::move(_refs));
+    }
+
+    template<typename H>
+    friend H AbslHashValue(H h, const schema_definition& schema) {
+        for (const auto& io_frag : schema.raw()()) {
+            std::string_view sv_frag{io_frag.get(), io_frag.size()};
+            h = H::combine(
+              std::move(h), absl::Hash<std::string_view>()(sv_frag));
+        }
+        return H::combine(std::move(h), schema.type(), schema.refs());
     }
 
 private:


### PR DESCRIPTION
Implements: [CORE-9738](https://redpandadata.atlassian.net/browse/CORE-9738)

Changes:
- Introduce hashing for schema definitions.
- Use this hash to reduce schema lookup from `n` to `log(n)`

Notes:
- This approach doesn't deal with hash collisions on the same shard. Current approach is to keep the first schema in a collision.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-9738]: https://redpandadata.atlassian.net/browse/CORE-9738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ