### PR TITLE
[v25.1.x] archival: Rate-limit `segments_pending_deletion` metric recomputation

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -710,6 +710,7 @@ redpanda_cc_library(
         "//src/v/ssx:async_clear",
         "//src/v/ssx:event",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:rate_limited_function",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/ssx:single_sharded",

--- a/src/v/cluster/archival/probe.cc
+++ b/src/v/cluster/archival/probe.cc
@@ -13,11 +13,14 @@
 #include "cluster/archival/archival_metadata_stm.h"
 #include "config/configuration.h"
 #include "metrics/prometheus_sanitize.h"
+#include "ssx/rate_limited_function.h"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/smp.hh>
 
 namespace archival {
+
+static constexpr auto segments_pending_deletion_refresh_rate = 60s;
 
 ntp_level_probe::ntp_level_probe(
   per_ntp_metrics_disabled disabled,
@@ -129,17 +132,23 @@ void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {
          .aggregate(aggregate_labels),
        sm::make_gauge(
          "segments_pending_deletion",
-         [this] {
-             const auto first_addressable
-               = _stm->manifest().first_addressable_segment();
-             const auto truncated_seg_count = first_addressable
-                                                  == _stm->manifest().end()
-                                                ? 0
-                                                : first_addressable.index();
+         // We want to avoid calling this function too often because it's
+         // relatively expensive to compute.
+         // The produced value changes rarely so it's safe to cache it for a
+         // while.
+         ssx::rate_limited_function<size_t()>(
+           [this] {
+               const auto first_addressable
+                 = _stm->manifest().first_addressable_segment();
+               const auto truncated_seg_count = first_addressable
+                                                    == _stm->manifest().end()
+                                                  ? 0
+                                                  : first_addressable.index();
 
-             return truncated_seg_count
-                    + _stm->manifest().replaced_segments_count();
-         },
+               return truncated_seg_count
+                      + _stm->manifest().replaced_segments_count();
+           },
+           segments_pending_deletion_refresh_rate),
          sm::description("Total number of segments pending deletion from the "
                          "cloud for the topic"),
          labels)

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -227,3 +227,15 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "rate_limited_function",
+    hdrs = [
+        "rate_limited_function.h",
+    ],
+    include_prefix = "ssx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/rate_limited_function.h
+++ b/src/v/ssx/rate_limited_function.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <functional>
+#include <optional>
+
+namespace ssx {
+
+/// A rate-limited function that caches the result of the function call
+/// for a specified duration.
+template<typename Signature, typename Clock = seastar::lowres_clock>
+class rate_limited_function;
+
+template<typename Ret, bool Noexcept, typename Clock>
+class rate_limited_function<Ret() noexcept(Noexcept), Clock> {
+public:
+    template<class Fn>
+    rate_limited_function(Fn&& func, Clock::duration rate)
+      : _func(std::forward<Fn>(func))
+      , _result(std::nullopt)
+      , _rate(rate)
+      , _last_call(Clock::now()) {}
+
+    Ret operator()() const noexcept(Noexcept) {
+        auto now = Clock::now();
+        if (!is_ready(now)) {
+            // Recompute if there is no cached value or the cached value
+            // has expired.
+            _last_call = now;
+            _result = _func();
+        }
+        return *_result;
+    }
+
+private:
+    // Returns true if the cached value is ready to be used.
+    bool is_ready(Clock::time_point now = Clock::now()) const {
+        return _result.has_value() && now <= (_last_call + _rate);
+    }
+
+    std::function<Ret() noexcept(Noexcept)> _func;
+    mutable std::optional<Ret> _result;
+    Clock::duration _rate;
+    mutable Clock::time_point _last_call;
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -228,3 +228,17 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "rate_limited_function_test",
+    timeout = "short",
+    srcs = [
+        "rate_limited_function_test.cc",
+    ],
+    deps = [
+        "//src/v/ssx:rate_limited_function",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ rp_test(
     event_test.cc
     work_queue_test.cc
     when_all_test.cc
+    rate_limited_function_test.cc
   LIBRARIES v::gtest_main v::ssx
   LABELS ssx
 )

--- a/src/v/ssx/tests/rate_limited_function_test.cc
+++ b/src/v/ssx/tests/rate_limited_function_test.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/rate_limited_function.h"
+
+#include <seastar/core/manual_clock.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+TEST(Event, BasicUsage) {
+    rate_limited_function<size_t(), seastar::manual_clock> fn(
+      [] { return 1; }, 1s);
+    EXPECT_EQ(fn(), 1);
+}
+
+TEST(Event, Expire) {
+    rate_limited_function<
+      seastar::manual_clock::time_point(),
+      seastar::manual_clock>
+      fn([] { return seastar::manual_clock::now(); }, 1s);
+
+    auto baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+
+    seastar::manual_clock::advance(100ms);
+    EXPECT_FALSE(seastar::manual_clock::now() == baseline);
+    EXPECT_TRUE(fn() == baseline);
+
+    // Should expire
+    seastar::manual_clock::advance(1s);
+    baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+}
+
+} // namespace ssx


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25801
