### PR TITLE
[CORE-9797] schema_registry: Improve diagnostics when references are missing

### DIFF
--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -161,7 +161,7 @@ inline auto exception_reply(ss::logger& log, std::exception_ptr e) {
         auto& content = eb.get_json_body();
         vlog(
           log.error,
-          "exception_reply: {:?}, exception: {}",
+          "exception_reply: {:?}, exception: {:?}",
           content ? json::rjson_serialize_str(*content) : ss::sstring{},
           std::current_exception());
         return eb;

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -560,11 +560,19 @@ ss::future<collected_schema> collect_schema(
   ss::sstring name,
   subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
-        if (!collected.contains(ref.name)) {
-            auto ss = co_await store.get_subject_schema(
-              ref.sub, ref.version, include_deleted::yes);
-            collected = co_await collect_schema(
-              store, std::move(collected), ref.name, std::move(ss.schema));
+        if (name != ref.name && !collected.contains(ref.name)) {
+            try {
+                auto ss = co_await store.get_subject_schema(
+                  ref.sub, ref.version, include_deleted::yes);
+                collected = co_await collect_schema(
+                  store, std::move(collected), ref.name, std::move(ss.schema));
+            } catch (const exception& e) {
+                if (failed_subject_schema_lookup(e.code())) {
+                    throw as_exception(
+                      no_reference_found_for(schema, ref.sub, ref.version));
+                }
+                throw;
+            }
         }
     }
     collected.insert(std::move(name), std::move(schema).def());
@@ -634,6 +642,16 @@ sanitize_avro_schema_definition(schema_definition def) {
       schema_definition::raw_string{std::move(buf).as_iobuf()},
       schema_type::avro,
       def.refs()};
+}
+
+ss::future<subject_schema> make_canonical_avro_schema(
+  schema_getter&, subject_schema unparsed_schema, normalize) {
+    auto [sub, schema] = std::move(unparsed_schema).destructure();
+    // TODO: Check references
+    // co_await collect_schema(store, {}, sub, {sub, schema.share()});
+    co_return subject_schema{
+      std::move(sub),
+      sanitize_avro_schema_definition(std::move(schema)).value()};
 }
 
 compatibility_result check_compatible(

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -645,8 +645,14 @@ sanitize_avro_schema_definition(schema_definition def) {
 }
 
 ss::future<subject_schema> make_canonical_avro_schema(
-  schema_getter&, subject_schema unparsed_schema, normalize) {
-    auto [sub, schema] = std::move(unparsed_schema).destructure();
+  schema_getter&, subject_schema unparsed_schema, normalize norm) {
+    auto [sub, unparsed] = std::move(unparsed_schema).destructure();
+    auto [def, type, refs] = std::move(unparsed).destructure();
+    if (norm) {
+        std::sort(refs.begin(), refs.end());
+        refs.erase(std::unique(refs.begin(), refs.end()), refs.end());
+    }
+    schema_definition schema{std::move(def), type, std::move(refs)};
     // TODO: Check references
     // co_await collect_schema(store, {}, sub, {sub, schema.share()});
     co_return subject_schema{

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -23,6 +23,9 @@ make_avro_schema_definition(schema_getter& store, subject_schema schema);
 result<schema_definition>
 sanitize_avro_schema_definition(schema_definition def);
 
+ss::future<subject_schema> make_canonical_avro_schema(
+  schema_getter& store, subject_schema schema, normalize norm = normalize::no);
+
 compatibility_result check_compatible(
   const avro_schema_definition& reader,
   const avro_schema_definition& writer,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -11,6 +11,7 @@
 
 #include "error.h"
 
+#include "bytes/iobuf_parser.h"
 #include "pandaproxy/error.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
@@ -156,6 +157,7 @@ error_info no_reference_found_for(
                     | std::views::transform([](const auto& ref) {
                           return fmt::format("{{{:e}}}", ref);
                       });
+    iobuf_const_parser parser{schema.def().raw()};
     return {
       error_code::schema_missing_reference,
       fmt::format(
@@ -166,7 +168,7 @@ error_info no_reference_found_for(
         schema.sub()(),
         to_string_view(schema.def().type()),
         fmt::join(fmt_refs, ", "),
-        schema.def().raw()(),
+        parser.read_string(parser.bytes_left()),
         fmt::join(fmt_refs, ", "),
         to_string_view(schema.type()),
         sub(),

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -34,6 +34,8 @@ struct error_category final : std::error_category {
             return "Invalid schema";
         case error_code::schema_empty:
             return "Empty schema";
+        case error_code::schema_missing_reference:
+            return "Schema references a schema that doesn't exist";
         case error_code::schema_incompatible:
             return "Schema being registered is incompatible with an earlier "
                    "schema for subject";
@@ -112,6 +114,7 @@ struct error_category final : std::error_category {
         case error_code::schema_invalid:
             return reply_error_code::unprocessable_entity;
         case error_code::schema_empty:
+        case error_code::schema_missing_reference:
             return reply_error_code::schema_empty; // 42201
         case error_code::schema_version_invalid:
             return reply_error_code::schema_version_invalid; // 42202
@@ -154,7 +157,7 @@ error_info no_reference_found_for(
                           return fmt::format("{{{:e}}}", ref);
                       });
     return {
-      error_code::schema_empty,
+      error_code::schema_missing_reference,
       fmt::format(
         "Invalid schema "
         "{{subject={},version=0,id=-1,schemaType={},references=[{}],metadata="

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -20,6 +20,7 @@ enum class error_code {
     schema_id_not_found = 1,
     schema_invalid,
     schema_empty,
+    schema_missing_reference,
     schema_incompatible,
     schema_version_invalid,
     subject_not_found,

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -201,4 +201,9 @@ inline error_info versions_exhausted(const subject& sub) {
       fmt::format("Versions exhausted for subject {}", sub())};
 }
 
+inline bool failed_subject_schema_lookup(std::error_code ec) {
+    return ec == error_code::subject_not_found
+           || ec == error_code::subject_version_not_found;
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -716,7 +716,9 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     } catch (exception& e) {
         constexpr auto reportable = [](std::error_code ec) {
             constexpr std::array errors{
-              error_code::schema_invalid, error_code::schema_empty};
+              error_code::schema_invalid,
+              error_code::schema_empty,
+              error_code::schema_missing_reference};
             return absl::c_any_of(
               errors, [ec](error_code e) { return ec == e; });
         };

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -233,9 +233,7 @@ ss::future<> check_references(sharded_store& store, subject_schema schema) {
     for (const auto& ref : schema.def().refs()) {
         co_await store.get_id(ref.sub, ref.version)
           .handle_exception_type([&](const exception& e) -> schema_id {
-              if (
-                e.code() == error_code::subject_not_found
-                || e.code() == error_code::schema_id_not_found) {
+              if (failed_subject_schema_lookup(e.code())) {
                   throw as_exception(
                     no_reference_found_for(schema, ref.sub, ref.version));
               }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -437,13 +437,21 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
         if (dp.FindFileByName(ref.name)) {
             continue;
         }
-        auto dep = co_await store.get_subject_schema(
-          ref.sub, ref.version, include_deleted::yes);
-        co_await build_file_with_refs(
-          dp,
-          store,
-          subject_schema{subject{ref.name}, std::move(dep.schema).def()},
-          normalize::no);
+        try {
+            auto dep = co_await store.get_subject_schema(
+              ref.sub, ref.version, include_deleted::yes);
+            co_await build_file_with_refs(
+              dp,
+              store,
+              subject_schema{subject{ref.name}, std::move(dep.schema).def()},
+              normalize::no);
+        } catch (const exception& e) {
+            if (failed_subject_schema_lookup(e.code())) {
+                throw as_exception(
+                  no_reference_found_for(schema, ref.sub, ref.version));
+            }
+            throw;
+        }
     }
 
     parser p;
@@ -467,6 +475,12 @@ ss::future<pb::FileDescriptorProto> import_schema(
         co_return co_await build_file_with_refs(
           dp, store, schema.share(), norm);
     } catch (const exception& e) {
+        // Rethrow if the schema is missing references
+        if (e.code() == error_code::schema_missing_reference) {
+            throw;
+        }
+        // Otherwise log the error details and throw an appropriate error for
+        // the response
         vlog(
           srlog.warn, "Failed to decode schema {}: {}", schema.sub(), e.what());
         throw as_exception(invalid_schema(schema));

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -482,7 +482,10 @@ ss::future<pb::FileDescriptorProto> import_schema(
         // Otherwise log the error details and throw an appropriate error for
         // the response
         vlog(
-          srlog.warn, "Failed to decode schema {}: {}", schema.sub(), e.what());
+          srlog.warn,
+          "Failed to decode schema {}: {:?}",
+          schema.sub(),
+          e.what());
         throw as_exception(invalid_schema(schema));
     }
 }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -89,12 +89,9 @@ ss::future<subject_schema> sharded_store::make_canonical_schema(
                  config::shard_local_cfg().schema_registry_always_normalize()};
     }
     switch (schema.type()) {
-    case schema_type::avro: {
-        auto [sub, unparsed] = std::move(schema).destructure();
-        co_return subject_schema{
-          std::move(sub),
-          sanitize_avro_schema_definition(std::move(unparsed)).value()};
-    }
+    case schema_type::avro:
+        co_return co_await make_canonical_avro_schema(
+          *this, std::move(schema), norm);
     case schema_type::protobuf:
         co_return co_await make_canonical_protobuf_schema(
           *this, std::move(schema), norm);

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -334,9 +334,7 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
                 break;
             }
         } catch (const exception& e) {
-            if (
-              e.code() == error_code::subject_not_found
-              || e.code() == error_code::subject_version_not_found) {
+            if (failed_subject_schema_lookup(e.code())) {
             } else if (
               // Stored schemas might be invalid if imported improperly
               e.code() == error_code::schema_invalid) {

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -22,6 +22,7 @@
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
@@ -1479,9 +1480,7 @@ struct consume_to_store {
                     // tombstone all the records referring to a particular
                     // version, we will see more than one get applied, and
                     // after the first one, the rest will not find it.
-                    if (
-                      e.code() == error_code::subject_not_found
-                      || e.code() == error_code::subject_version_not_found) {
+                    if (failed_subject_schema_lookup(e.code())) {
                         vlog(
                           srlog.debug,
                           "Ignoring tombstone at offset={}, subject or version "

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -135,7 +135,9 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
       pps::make_protobuf_schema_definition(store.store, schema1.share()).get(),
       pps::exception,
       [](const pps::exception& ex) {
-          return ex.code() == pps::error_code::schema_invalid;
+          return ex.code() == pps::error_code::schema_missing_reference
+                 && std::string_view(ex.message())
+                      .contains("No schema reference found for subject");
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -360,7 +360,7 @@ const std::array test_reference_cases = {
   test_references_data{
     {{{referenced.share(), {}},
       {referencer_wrong_sub.share(),
-       {pps::error_code::schema_empty,
+       {pps::error_code::schema_missing_reference,
         R"(Invalid schema {subject=referencer,version=0,id=-1,schemaType=JSON,references=[{name='example.com/referenced.json', subject='wrong_sub', version=1}],metadata=null,ruleSet=null,schema={
   "description": "A schema that references the base schema",
   "type": "object",

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -148,7 +148,7 @@ struct handler_adaptor : ss::httpd::handler_base {
             auto ex = std::current_exception();
             vlog(
               _log.warn,
-              "Request: {} {} failed: {}",
+              "Request: {} {} failed: {:?}",
               method,
               url,
               std::current_exception());

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -666,6 +666,22 @@ soft_deleted_schemas = {
         "type": "AVRO",
     }
 }
+
+not_dependent_schemas = {
+    "proto": {
+        "schema": schema_proto_def,
+        "type": "PROTOBUF",
+    },
+    "json": {
+        "schema": json_number_schema_def,
+        "type": "JSON",
+    },
+    "avro": {
+        "schema": schema_avro_def,
+        "type": "AVRO",
+    },
+}
+
 dependent_schemas = {
     "proto": {
         "subject":
@@ -3450,6 +3466,50 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         #Sanity check on normalized input
         test_subjects_subject(normalized, expected_version=2)
         test_subjects_subject(normalized, expected_version=2, norm=True)
+
+    @cluster(num_nodes=3)
+    @matrix(stype=["json"])
+    def test_missing_references(self, stype):
+        """
+        Missing references should return an error message with details of the missing reference
+        """
+
+        self._set_config(data=json.dumps({"compatibility": "NONE"}))
+
+        base_schema = not_dependent_schemas[stype]
+        schema = dependent_schemas[stype]
+        subject = schema["subject"]
+        ref_subject = schema["references"][0]["subject"]
+        ref_version = schema["references"][0]["version"]
+
+        result_raw = self._post_subjects_subject_versions(
+            subject=subject,
+            data=json.dumps({
+                "schema": base_schema["schema"],
+                "schemaType": base_schema["type"],
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                f"Request content: {result_raw.content}. Processing {stype}."
+
+        for endpoint in [
+                self._post_subjects_subject_versions,
+                self._post_subjects_subject
+        ]:
+            result_raw = endpoint(subject=subject,
+                                  data=json.dumps({
+                                      "schema":
+                                      schema["schema"],
+                                      "schemaType":
+                                      schema["type"],
+                                      "references":
+                                      schema["references"],
+                                  }))
+            assert result_raw.status_code == requests.codes.unprocessable_entity, \
+                    f"Expected {requests.codes.unprocessable_entity} but got {result_raw.status_code}. "\
+                    f"Request content: {result_raw.content}. Processing {type}."
+            assert f"No schema reference found for subject \"{ref_subject}\" and version {ref_version}" in result_raw.json()["message"], \
+                f"Expected result to contain missing references, but got {result_raw.json()}."
 
     @cluster(num_nodes=3)
     def test_soft_deleted_references(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3468,7 +3468,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         test_subjects_subject(normalized, expected_version=2, norm=True)
 
     @cluster(num_nodes=3)
-    @matrix(stype=["json"])
+    @matrix(stype=["json", "proto"])
     def test_missing_references(self, stype):
         """
         Missing references should return an error message with details of the missing reference


### PR DESCRIPTION
Improve diagnostics when references are missing during:
* `POST /subjects/{subject}/`
* `POST /subjects/{subject}/versions`
* `POST /compatibility/subjects/{subject}/versions`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Schema Registry: Improve diagnostics when POST a schema with missing references

