### PR TITLE
bazel: fix runfiles for benchmarks

### DIFF
--- a/src/v/crypto/tests/crypto_bench.cc
+++ b/src/v/crypto/tests/crypto_bench.cc
@@ -23,6 +23,7 @@
 
 #include <exception>
 #include <filesystem>
+#include <memory>
 
 static constexpr size_t inner_iters = 1000;
 
@@ -63,12 +64,10 @@ public:
         _svc.invoke_on_all(&crypto::ossl_context_service::start).get();
     }
 
-    ss::future<> stop() {
-        co_await _svc.stop();
-        co_await _thread_worker->stop();
-    }
-
-    ~openssl_perf() = default;
+    ~openssl_perf() {
+        _svc.stop().get();
+        _thread_worker->stop().get();
+    };
 
 private:
     std::unique_ptr<ssx::singleton_thread_worker> _thread_worker{nullptr};
@@ -86,19 +85,8 @@ private:
     }
 };
 
-static std::unique_ptr<openssl_perf> global_perf{nullptr};
-
 struct openssl_perf_test {
-    openssl_perf_test() {
-        if (!global_perf) {
-            global_perf = std::make_unique<openssl_perf>();
-            ss::engine().at_exit([]() -> ss::future<> {
-                co_await global_perf->stop();
-                global_perf.reset();
-            });
-        }
-    }
-    ~openssl_perf_test() = default;
+    std::unique_ptr<openssl_perf> perf = std::make_unique<openssl_perf>();
 };
 
 PERF_TEST_F(openssl_perf_test, md5_1k) {

--- a/src/v/test_utils/runfiles.cc
+++ b/src/v/test_utils/runfiles.cc
@@ -17,8 +17,13 @@ get_runfile_path([[maybe_unused]] std::string_view path) {
 #ifdef BAZEL_TEST
     using bazel::tools::cpp::runfiles::Runfiles;
     std::string error;
-    std::unique_ptr<Runfiles> runfiles(
-      Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+    std::unique_ptr<Runfiles> runfiles;
+    if (std::getenv("BAZEL_TEST") != nullptr) {
+        runfiles.reset(
+          Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+    } else {
+        runfiles.reset(Runfiles::Create("", BAZEL_CURRENT_REPOSITORY, &error));
+    }
     if (runfiles == nullptr) {
         throw std::runtime_error(error);
     }


### PR DESCRIPTION
Runfiles::*ForTest only works when invoked by `bazel test`, otherwise it
tries to lookup a environment variable which is `nullptr` which causes
segfaults. Instead look at the BAZEL_TEST[1] envvar to determine if `bazel
test` is running the binary and invoke the correct runfile creation
method.

[1]: https://bazel.build/reference/test-encyclopedia#initial-conditions

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
