### PR TITLE
bazel: support running benchmarks directly with runfiles

### DIFF
--- a/src/v/test_utils/runfiles.cc
+++ b/src/v/test_utils/runfiles.cc
@@ -1,6 +1,7 @@
 #include "test_utils/runfiles.h"
 
 #include <cstdlib>
+#include <filesystem>
 
 #ifdef BAZEL_TEST
 #include "tools/cpp/runfiles/runfiles.h"
@@ -22,7 +23,9 @@ get_runfile_path([[maybe_unused]] std::string_view path) {
         runfiles.reset(
           Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
     } else {
-        runfiles.reset(Runfiles::Create("", BAZEL_CURRENT_REPOSITORY, &error));
+        static auto argv0 = std::filesystem::canonical("/proc/self/exe");
+        runfiles.reset(
+          Runfiles::Create(argv0, BAZEL_CURRENT_REPOSITORY, &error));
     }
     if (runfiles == nullptr) {
         throw std::runtime_error(error);


### PR DESCRIPTION
Bazel can lookup runfiles using argv0, but we have to pass that in.
Since we don't have that plumbed down to this layer, we'll just resolve
the symlink in the runfiles code. This is test only code anyways (bazel
enforced), so I'm not worried about the IO here for tests/benchmarks as
this should be for setup only.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
