### PR TITLE
CORE-9798 PP/SR: request-response trace logging

### DIFF
--- a/src/v/pandaproxy/BUILD
+++ b/src/v/pandaproxy/BUILD
@@ -163,6 +163,7 @@ redpanda_cc_library(
         "//src/v/utils:named_type",
         "//src/v/utils:retry",
         "//src/v/utils:tristate",
+        "//src/v/utils:truncating_logger",
         "@abseil-cpp//absl/algorithm:container",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/seastarx.h"
 #include "bytes/iostream.h"
 #include "json/chunked_buffer.h"
 #include "json/chunked_input_stream.h"
@@ -21,6 +22,7 @@
 #include "json/stringbuffer.h"
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/util.h"
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/sstring.hh>
@@ -140,16 +142,19 @@ typename Handler::rjson_parse_result rjson_parse(iobuf buf, Handler&& handler) {
       std::move(buf), std::forward<Handler>(handler));
 }
 
-///\brief Parse a request body using the handler.
 template<impl::RjsonParseHandler Handler>
 typename ss::future<typename Handler::rjson_parse_result>
-rjson_parse(std::unique_ptr<ss::http::request> req, Handler handler) {
-    if (!req->content.empty()) {
-        co_return impl::rjson_parse(req->content.data(), std::move(handler));
+rjson_parse(ss::http::request& req, Handler handler, truncating_logger& log) {
+    if (!req.content.empty()) {
+        pandaproxy::log_request(req, req.content, log);
+
+        // Consume the content here to reduce memory usage
+        auto content = std::move(req.content);
+        co_return impl::rjson_parse(content.data(), std::move(handler));
     }
 
     iobuf buf;
-    auto is = req->content_stream;
+    auto is = req.content_stream;
     co_await ss::repeat([&buf, &is]() {
         return is->read().then([&buf](ss::temporary_buffer<char> tmp_buf) {
             if (tmp_buf.empty()) {
@@ -162,6 +167,7 @@ rjson_parse(std::unique_ptr<ss::http::request> req, Handler handler) {
         });
     });
 
+    pandaproxy::log_request(req, buf, log);
     co_return rjson_parse(std::move(buf), std::move(handler));
 }
 

--- a/src/v/pandaproxy/logger.cc
+++ b/src/v/pandaproxy/logger.cc
@@ -9,7 +9,16 @@
 
 #include "pandaproxy/logger.h"
 
+#include "utils/truncating_logger.h"
+
 namespace pandaproxy {
 ss::logger plog{"pandaproxy"};
 ss::logger srlog{"schemaregistry"};
+
+ss::logger _preqs{"pandaproxy/requests"};
+truncating_logger preqs(_preqs, max_log_line_bytes);
+
+ss::logger _srreqs{"schemaregistry/requests"};
+truncating_logger srreqs(_srreqs, max_log_line_bytes);
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/logger.h
+++ b/src/v/pandaproxy/logger.h
@@ -12,10 +12,15 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "base/units.h"
+#include "utils/truncating_logger.h"
 
 #include <seastar/util/log.hh>
 
 namespace pandaproxy {
 extern ss::logger plog;
 extern ss::logger srlog;
+static constexpr size_t max_log_line_bytes = 128_KiB;
+extern truncating_logger preqs;
+extern truncating_logger srreqs;
 } // namespace pandaproxy

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -16,17 +16,23 @@
 #include "kafka/protocol/exceptions.h"
 #include "pandaproxy/error.h"
 #include "pandaproxy/json/exceptions.h"
+#include "pandaproxy/json/requests/error_reply.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/exceptions.h"
 #include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/server.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/http/reply.hh>
+#include <seastar/http/request.hh>
 
+#include <fmt/format.h>
+
+#include <memory>
 #include <system_error>
 
 namespace pandaproxy {
@@ -55,54 +61,89 @@ error_code_to_status(std::error_condition ec) {
     return static_cast<ss::http::reply::status_type>(value);
 }
 
-inline ss::http::reply& set_reply_unavailable(ss::http::reply& rep) {
-    return rep.set_status(ss::http::reply::status_type::service_unavailable)
-      .add_header("Retry-After", "0");
-}
+class err_reply_builder {
+public:
+    using body_t = pandaproxy::json::error_body;
 
-inline ss::http::reply& set_reply_too_many_requests(ss::http::reply& rep) {
-    return rep.set_status(ss::http::reply::status_type::too_many_requests)
-      .add_header("Retry-After", "0");
-}
+    err_reply_builder()
+      : _body{std::nullopt}
+      , _rep{std::make_unique<ss::http::reply>()} {}
+    explicit err_reply_builder(std::unique_ptr<ss::http::reply> rep)
+      : _rep(std::move(rep)) {};
 
-inline ss::http::reply& set_reply_payload_too_large(ss::http::reply& rep) {
-    return rep.set_status(ss::http::reply::status_type::payload_too_large);
-}
+    auto& set_status(ss::http::reply::status_type status) {
+        _rep->set_status(status);
+        return *this;
+    }
 
-inline std::unique_ptr<ss::http::reply> reply_unavailable() {
-    auto rep = std::make_unique<ss::http::reply>(ss::http::reply{});
-    set_reply_unavailable(*rep);
+    auto& set_json_body(body_t body) {
+        _body = std::move(body);
+        return *this;
+    }
+
+    auto& add_header(const ss::sstring& h, const ss::sstring& value) {
+        _rep->add_header(h, value);
+        return *this;
+    }
+
+    auto& set_mime_type(const ss::sstring& mime) {
+        _rep->set_mime_type(mime);
+        return *this;
+    }
+
+    auto& set_reply_unavailable() {
+        return set_status(ss::http::reply::status_type::service_unavailable)
+          .add_header("Retry-After", "0");
+    }
+
+    auto& set_reply_too_many_requests() {
+        return set_status(ss::http::reply::status_type::too_many_requests)
+          .add_header("Retry-After", "0");
+    }
+
+    auto& set_reply_payload_too_large() {
+        return set_status(ss::http::reply::status_type::payload_too_large);
+    }
+
+    const std::optional<body_t>& get_json_body() const { return _body; }
+
+    std::unique_ptr<ss::http::reply> build() && {
+        if (_body) {
+            _rep->write_body(
+              "json", pandaproxy::json::rjson_serialize(std::move(*_body)));
+        }
+        return std::move(_rep);
+    }
+
+private:
+    std::optional<body_t> _body{};
+    std::unique_ptr<ss::http::reply> _rep{};
+};
+
+inline auto errored_body(std::error_condition ec, ss::sstring msg) {
+    err_reply_builder rep;
+    rep.set_status(error_code_to_status(ec));
+    rep.set_json_body({.ec = ec, .message = std::move(msg)});
     return rep;
 }
 
-inline std::unique_ptr<ss::http::reply>
-errored_body(std::error_condition ec, ss::sstring msg) {
-    pandaproxy::json::error_body body{.ec = ec, .message = std::move(msg)};
-    auto rep = std::make_unique<ss::http::reply>();
-    rep->set_status(error_code_to_status(ec));
-    rep->write_body("json", json::rjson_serialize(body));
-    return rep;
-}
-
-inline std::unique_ptr<ss::http::reply>
-errored_body(std::error_code ec, ss::sstring msg) {
+inline auto errored_body(std::error_code ec, ss::sstring msg) {
     return errored_body(make_error_condition(ec), std::move(msg));
 }
 
-inline std::unique_ptr<ss::http::reply> unprocessable_entity(ss::sstring msg) {
+inline auto unprocessable_entity(ss::sstring msg) {
     return errored_body(
       make_error_condition(reply_error_code::kafka_bad_request),
       std::move(msg));
 }
 
-inline std::unique_ptr<ss::http::reply>
-exception_reply(ss::logger& log, std::exception_ptr e) {
+inline auto exception_reply(ss::logger& log, std::exception_ptr e) {
     try {
         std::rethrow_exception(e);
     } catch (const ss::gate_closed_exception& e) {
         auto eb = errored_body(
           reply_error_code::kafka_retriable_error, e.what());
-        set_reply_unavailable(*eb);
+        eb.set_reply_unavailable();
         return eb;
     } catch (const json::exception_base& e) {
         return errored_body(e.error, e.what());
@@ -117,10 +158,11 @@ exception_reply(ss::logger& log, std::exception_ptr e) {
     } catch (...) {
         auto ise = reply_error_code::internal_server_error;
         auto eb = errored_body(ise, make_error_condition(ise).message());
+        auto& content = eb.get_json_body();
         vlog(
           log.error,
-          "exception_reply: {}, exception: {}",
-          eb->_content,
+          "exception_reply: {:?}, exception: {}",
+          content ? json::rjson_serialize_str(*content) : ss::sstring{},
           std::current_exception());
         return eb;
     }
@@ -131,8 +173,8 @@ struct exception_replier {
     ss::logger& log;
     std::unique_ptr<ss::http::reply> operator()(const std::exception_ptr& e) {
         auto res = exception_reply(log, e);
-        res->set_mime_type(mime_type);
-        return res;
+        res.set_mime_type(mime_type);
+        return std::move(res).build();
     }
 };
 

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -52,6 +52,12 @@ using server = proxy::server;
 
 } // namespace
 
+template<ppj::impl::RjsonParseHandler Handler>
+typename ss::future<typename Handler::rjson_parse_result>
+rjson_parse(ss::http::request& req, Handler handler) {
+    co_return co_await ppj::rjson_parse(req, std::move(handler), preqs);
+}
+
 ss::future<server::reply_t>
 get_brokers(server::request_t rq, server::reply_t rp) {
     auto res_fmt = parse::accept_header(
@@ -173,8 +179,8 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
 
     vlog(plog.debug, "get_topics_name: topic: {}", topic);
 
-    auto records = co_await ppj::rjson_parse(
-      std::move(rq.req), ppj::produce_request_handler(req_fmt));
+    auto records = co_await rjson_parse(
+      *rq.req, ppj::produce_request_handler(req_fmt));
     co_return co_await rq.dispatch(
       [records{std::move(records)}, topic, res_fmt, rp{std::move(rp)}](
         kafka::client::client& client) mutable {
@@ -212,8 +218,8 @@ create_consumer(server::request_t rq, server::reply_t rp) {
 
     auto base_uri = make_consumer_uri_base(rq, group_id);
 
-    auto req_data = co_await ppj::rjson_parse(
-      std::move(rq.req), ppj::create_consumer_request_handler());
+    auto req_data = co_await rjson_parse(
+      *rq.req, ppj::create_consumer_request_handler());
 
     validate_no_control(req_data.name(), parse::pp_parsing_error{"name"});
 
@@ -322,8 +328,8 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
     auto member_id = parse::request_param<kafka::member_id>(
       *rq.req, "instance");
 
-    auto req_data = co_await ppj::rjson_parse(
-      std::move(rq.req), ppj::subscribe_consumer_request_handler());
+    auto req_data = co_await rjson_parse(
+      *rq.req, ppj::subscribe_consumer_request_handler());
     std::for_each(
       req_data.topics.begin(),
       req_data.topics.end(),
@@ -413,8 +419,7 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};
 
     auto req_data = ppj::partitions_request_to_offset_request(
-      co_await ppj::rjson_parse(
-        std::move(rq.req), ppj::partitions_request_handler()));
+      co_await rjson_parse(*rq.req, ppj::partitions_request_handler()));
 
     std::for_each(req_data.begin(), req_data.end(), [](const auto& r) {
         validate_no_control(r.name(), parse::pp_parsing_error{"topic_name"});
@@ -458,9 +463,8 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto req_data = rq.req->content_length == 0
                       ? std::vector<kafka::offset_commit_request_topic>()
                       : ppj::partition_offsets_request_to_offset_commit_request(
-                          co_await ppj::rjson_parse(
-                            std::move(rq.req),
-                            ppj::partition_offsets_request_handler()));
+                          co_await rjson_parse(
+                            *rq.req, ppj::partition_offsets_request_handler()));
 
     std::for_each(req_data.begin(), req_data.end(), [](const auto& r) {
         validate_no_control(r.name(), parse::pp_parsing_error{"topic_name"});

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -257,7 +257,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
                 auto ec = make_error_condition(
                   reply_error_code::consumer_already_exists);
                 server::reply_t rp;
-                rp.rep = errored_body(ec, ec.message());
+                rp.rep = errored_body(ec, ec.message()).build();
                 return ss::make_ready_future<server::reply_t>(std::move(rp));
             })
             .handle_exception_type(

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -124,7 +124,8 @@ proxy::proxy(
       "/definitions",
       _ctx,
       json::serialization_format::application_json,
-      plog)
+      plog,
+      preqs)
   , _ensure_started{[this]() { return do_start(); }}
   , _controller(controller) {
     _inflight_config_binding.watch([this]() {

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -9,6 +9,7 @@
 
 #include "handlers.h"
 
+#include "bytes/iobuf_parser.h"
 #include "container/json.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
@@ -80,18 +81,33 @@ rjson_parse(ss::http::request& req, Handler handler) {
     co_return co_await ppj::rjson_parse(req, std::move(handler), srreqs);
 }
 
+void log_response(const ss::http::request& req, const iobuf& resp) {
+    if (srreqs.is_enabled(ss::log_level::trace)) {
+        iobuf_const_parser parser{resp};
+        vlog(
+          srreqs.trace,
+          "[{}:{}] sending response {} {}: {:?}",
+          req.get_client_address().addr(),
+          req.get_client_address().port(),
+          req._method,
+          req._url,
+          parser.read_string(
+            std::min(parser.bytes_left(), max_log_line_bytes)));
+    }
+}
+
 ss::future<server::reply_t>
 get_config(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    rq.req.reset();
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
     auto res = co_await rq.service().schema_store().get_compatibility();
 
-    rp.rep->write_body(
-      "json", ppj::rjson_serialize(get_config_req_rep{.compat = res}));
+    auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -103,7 +119,9 @@ put_config(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().write_config(std::nullopt, config.compat);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(config));
+    auto resp = ppj::rjson_serialize_iobuf(config);
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -114,7 +132,6 @@ get_config_subject(server::request_t rq, server::reply_t rp) {
     auto fallback = parse::query_param<std::optional<default_to_global>>(
                       *rq.req, "defaultToGlobal")
                       .value_or(default_to_global::no);
-    rq.req.reset();
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -122,8 +139,9 @@ get_config_subject(server::request_t rq, server::reply_t rp) {
     auto res = co_await rq.service().schema_store().get_compatibility(
       sub, fallback);
 
-    rp.rep->write_body(
-      "json", ppj::rjson_serialize(get_config_req_rep{.compat = res}));
+    auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = res});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -169,7 +187,9 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_config(sub, config.compat);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(config));
+    auto resp = ppj::rjson_serialize_iobuf(std::move(config));
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -177,8 +197,6 @@ ss::future<server::reply_t>
 delete_config_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-
-    rq.req.reset();
 
     // ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -198,21 +216,23 @@ delete_config_subject(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().delete_config(sub);
 
-    rp.rep->write_body(
-      "json", ppj::rjson_serialize(get_config_req_rep{.compat = lvl}));
+    auto resp = ppj::rjson_serialize_iobuf(get_config_req_rep{.compat = lvl});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
 ss::future<server::reply_t> get_mode(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    rq.req.reset();
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
     auto res = co_await rq.service().schema_store().get_mode();
 
-    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = res}));
+    auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = res});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -225,7 +245,9 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(res));
+    auto resp = ppj::rjson_serialize_iobuf(res);
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -236,14 +258,15 @@ get_mode_subject(server::request_t rq, server::reply_t rp) {
     auto fallback = parse::query_param<std::optional<default_to_global>>(
                       *rq.req, "defaultToGlobal")
                       .value_or(default_to_global::no);
-    rq.req.reset();
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
     auto res = co_await rq.service().schema_store().get_mode(sub, fallback);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = res}));
+    auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = res});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -260,7 +283,9 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_mode(sub, res.mode, frc);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(res));
+    auto resp = ppj::rjson_serialize_iobuf(res);
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -268,8 +293,6 @@ ss::future<server::reply_t>
 delete_mode_subject(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-
-    rq.req.reset();
 
     // ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -288,18 +311,20 @@ delete_mode_subject(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().delete_mode(sub);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(mode_req_rep{.mode = m}));
+    auto resp = ppj::rjson_serialize_iobuf(mode_req_rep{.mode = m});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
 ss::future<server::reply_t>
 get_schemas_types(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
-    rq.req.reset();
 
-    static const std::vector<std::string_view> schemas_types{
-      "JSON", "PROTOBUF", "AVRO"};
-    rp.rep->write_body("json", ppj::rjson_serialize(schemas_types));
+    static const iobuf schemas_types{ppj::rjson_serialize_iobuf(
+      std::vector<std::string_view>{"JSON", "PROTOBUF", "AVRO"})};
+    log_response(*rq.req, schemas_types);
+    rp.rep->write_body("json", ppj::as_body_writer(schemas_types.copy()));
     return ss::make_ready_future<server::reply_t>(std::move(rp));
 }
 
@@ -307,7 +332,6 @@ ss::future<server::reply_t>
 get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
-    rq.req.reset();
 
     // With deferred schema validation, there might be a schema that
     // had invalid references. These might have already been posted, so
@@ -318,10 +342,10 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
         return rq.service().schema_store().get_schema_definition(id);
     });
 
-    rp.rep->write_body(
-      "json",
-      ppj::rjson_serialize(
-        get_schemas_ids_id_response{.definition{std::move(def)}}));
+    auto resp = ppj::rjson_serialize_iobuf(
+      get_schemas_ids_id_response{.definition{std::move(def)}});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -329,7 +353,6 @@ ss::future<server::reply_t>
 get_schemas_ids_id_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
-    rq.req.reset();
 
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -340,10 +363,10 @@ get_schemas_ids_id_versions(server::request_t rq, server::reply_t rp) {
     auto svs = co_await rq.service().schema_store().get_schema_subject_versions(
       id);
 
-    rp.rep->write_body(
-      "json",
-      ppj::rjson_serialize(get_schemas_ids_id_versions_response{
-        .subject_versions{std::move(svs)}}));
+    auto resp = ppj::rjson_serialize_iobuf(
+      get_schemas_ids_id_versions_response{.subject_versions{std::move(svs)}});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -354,7 +377,6 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
     auto incl_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
-    rq.req.reset();
 
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -362,11 +384,10 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
     // Force early 40403 if the schema id isn't found
     co_await rq.service().schema_store().get_schema_definition(id);
 
-    rp.rep->write_body(
-      "json",
-      ppj::rjson_serialize(
-        co_await rq.service().schema_store().get_schema_subjects(
-          id, incl_del)));
+    auto resp = ppj::rjson_serialize_iobuf(
+      co_await rq.service().schema_store().get_schema_subjects(id, incl_del));
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -378,15 +399,15 @@ get_subjects(server::request_t rq, server::reply_t rp) {
         .value_or(include_deleted::no)};
     auto subject_prefix{
       parse::query_param<std::optional<ss::sstring>>(*rq.req, "subjectPrefix")};
-    rq.req.reset();
 
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    rp.rep->write_body(
-      "json",
-      json::rjson_serialize(co_await rq.service().schema_store().get_subjects(
-        inc_del, subject_prefix)));
+    auto resp = ppj::rjson_serialize_iobuf(
+      co_await rq.service().schema_store().get_subjects(
+        inc_del, subject_prefix));
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -397,15 +418,15 @@ get_subject_versions(server::request_t rq, server::reply_t rp) {
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
-    rq.req.reset();
 
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto versions = co_await rq.service().schema_store().get_versions(
-      sub, inc_del);
+    auto versions = ppj::rjson_serialize_iobuf(
+      co_await rq.service().schema_store().get_versions(sub, inc_del));
 
-    rp.rep->write_body("json", ppj::rjson_serialize(versions));
+    log_response(*rq.req, versions);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(versions)));
     co_return rp;
 }
 
@@ -449,12 +470,13 @@ post_subject(server::request_t rq, server::reply_t rp) {
     auto sub_schema = co_await rq.service().schema_store().has_schema(
       std::move(schema), inc_del);
 
-    rp.rep->write_body(
-      "json",
-      ppj::rjson_serialize(post_subject_versions_version_response{
+    auto resp = ppj::rjson_serialize_iobuf(
+      post_subject_versions_version_response{
         .schema{std::move(sub_schema.schema)},
         .id{sub_schema.id},
-        .version{sub_schema.version}}));
+        .version{sub_schema.version}});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -507,9 +529,10 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
           std::move(schema));
     }
 
-    rp.rep->write_body(
-      "json",
-      ppj::rjson_serialize(post_subject_versions_response{.id{schema_id}}));
+    auto resp = ppj::rjson_serialize_iobuf(
+      post_subject_versions_response{.id{schema_id}});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -521,7 +544,6 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
-    rq.req.reset();
 
     co_await rq.service().writer().read_sync();
 
@@ -532,12 +554,13 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
           sub, version, inc_del);
     });
 
-    rp.rep->write_body(
-      "json",
-      ppj::rjson_serialize(post_subject_versions_version_response{
+    auto resp = ppj::rjson_serialize_iobuf(
+      post_subject_versions_version_response{
         .schema = std::move(get_res.schema),
         .id = get_res.id,
-        .version = get_res.version}));
+        .version = get_res.version});
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -549,7 +572,6 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
-    rq.req.reset();
 
     co_await rq.service().writer().read_sync();
 
@@ -558,8 +580,9 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
     auto get_res = co_await rq.service().schema_store().get_subject_schema(
       sub, version, inc_del);
 
-    rp.rep->write_body(
-      "json", ppj::as_body_writer(std::move(get_res.schema).def().raw()()));
+    auto resp = std::move(get_res.schema).def().raw();
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)()));
     co_return rp;
 }
 
@@ -569,16 +592,16 @@ get_subject_versions_version_referenced_by(
     parse_accept_header(rq, rp);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
     auto ver = parse::request_param<ss::sstring>(*rq.req, "version");
-    rq.req.reset();
 
     co_await rq.service().writer().read_sync();
 
     auto version = parse_schema_version(ver).value();
 
-    auto references = co_await rq.service().schema_store().referenced_by(
-      sub, version);
+    auto references = ppj::rjson_serialize_iobuf(
+      co_await rq.service().schema_store().referenced_by(sub, version));
 
-    rp.rep->write_body("json", ppj::rjson_serialize(std::move(references)));
+    log_response(*rq.req, references);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(references)));
     co_return rp;
 }
 
@@ -589,7 +612,6 @@ delete_subject(server::request_t rq, server::reply_t rp) {
     auto permanent{
       parse::query_param<std::optional<permanent_delete>>(*rq.req, "permanent")
         .value_or(permanent_delete::no)};
-    rq.req.reset();
 
     // Must see latest data to do a valid check of whether the
     // subject is already soft-deleted
@@ -601,7 +623,9 @@ delete_subject(server::request_t rq, server::reply_t rp) {
               sub, std::nullopt)
           : co_await rq.service().writer().delete_subject_impermanent(sub);
 
-    rp.rep->write_body("json", ppj::rjson_serialize(versions));
+    auto resp = ppj::rjson_serialize_iobuf(std::move(versions));
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -613,7 +637,6 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
     auto permanent{
       parse::query_param<std::optional<permanent_delete>>(*rq.req, "permanent")
         .value_or(permanent_delete::no)};
-    rq.req.reset();
 
     // Must see latest data to know whether what we're deleting is the last
     // version
@@ -648,7 +671,9 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
         co_await rq.service().writer().delete_subject_version(sub, version);
     }
 
-    rp.rep->write_body("json", ppj::rjson_serialize(version));
+    auto resp = ppj::rjson_serialize_iobuf(version);
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;
 }
 
@@ -696,13 +721,13 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
               errors, [ec](error_code e) { return ec == e; });
         };
         if (is_verbose && reportable(e.code())) {
-            rp.rep->write_body(
-              "json",
-              json::rjson_serialize(post_compatibility_res{
-                .is_compat = false,
-                .messages = {e.message()},
-                .is_verbose = is_verbose,
-              }));
+            auto resp = ppj::rjson_serialize_iobuf(post_compatibility_res{
+              .is_compat = false,
+              .messages = {e.message()},
+              .is_verbose = is_verbose,
+            });
+            log_response(*rq.req, resp);
+            rp.rep->write_body("json", json::as_body_writer(std::move(resp)));
             co_return rp;
         }
         throw;
@@ -714,13 +739,13 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
             version, schema.share(), is_verbose);
       });
 
-    rp.rep->write_body(
-      "json",
-      json::rjson_serialize(post_compatibility_res{
-        .is_compat = get_res.is_compat,
-        .messages = std::move(get_res.messages),
-        .is_verbose = is_verbose,
-      }));
+    auto resp = ppj::rjson_serialize_iobuf(post_compatibility_res{
+      .is_compat = get_res.is_compat,
+      .messages = std::move(get_res.messages),
+      .is_verbose = is_verbose,
+    });
+    log_response(*rq.req, resp);
+    rp.rep->write_body("json", json::as_body_writer(std::move(resp)));
     co_return rp;
 }
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -12,6 +12,7 @@
 #include "container/json.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/httpd.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
@@ -73,6 +74,12 @@ parse_schema_version(const ss::sstring& ver) {
              : parse_numerical_schema_version(ver).value();
 }
 
+template<ppj::impl::RjsonParseHandler Handler>
+typename ss::future<typename Handler::rjson_parse_result>
+rjson_parse(ss::http::request& req, Handler handler) {
+    co_return co_await ppj::rjson_parse(req, std::move(handler), srreqs);
+}
+
 ss::future<server::reply_t>
 get_config(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
@@ -92,8 +99,7 @@ ss::future<server::reply_t>
 put_config(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
-    auto config = co_await ppj::rjson_parse(
-      std::move(rq.req), put_config_handler<>{});
+    auto config = co_await rjson_parse(*rq.req, put_config_handler<>{});
 
     co_await rq.service().writer().write_config(std::nullopt, config.compat);
 
@@ -157,8 +163,7 @@ put_config_subject(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-    auto config = co_await ppj::rjson_parse(
-      std::move(rq.req), put_config_handler<>{});
+    auto config = co_await rjson_parse(*rq.req, put_config_handler<>{});
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -216,7 +221,7 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto frc = parse::query_param<std::optional<force>>(*rq.req, "force")
                  .value_or(force::no);
-    auto res = co_await ppj::rjson_parse(std::move(rq.req), mode_handler<>{});
+    auto res = co_await rjson_parse(*rq.req, mode_handler<>{});
 
     co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
 
@@ -249,7 +254,7 @@ put_mode_subject(server::request_t rq, server::reply_t rp) {
     auto frc = parse::query_param<std::optional<force>>(*rq.req, "force")
                  .value_or(force::no);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
-    auto res = co_await ppj::rjson_parse(std::move(rq.req), mode_handler<>{});
+    auto res = co_await rjson_parse(*rq.req, mode_handler<>{});
 
     // Ensure we see latest writes
     co_await rq.service().writer().read_sync();
@@ -428,8 +433,8 @@ post_subject(server::request_t rq, server::reply_t rp) {
 
     subject_schema schema;
     try {
-        auto unparsed = co_await ppj::rjson_parse(
-          std::move(rq.req), post_subject_versions_request_handler<>{sub});
+        auto unparsed = co_await rjson_parse(
+          *rq.req, post_subject_versions_request_handler<>{sub});
         schema = co_await rq.service().schema_store().make_canonical_schema(
           std::move(unparsed.def), norm);
     } catch (const exception& e) {
@@ -468,8 +473,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 
     co_await rq.service().writer().read_sync();
 
-    auto unparsed = co_await ppj::rjson_parse(
-      std::move(rq.req), post_subject_versions_request_handler<>{sub});
+    auto unparsed = co_await rjson_parse(
+      *rq.req, post_subject_versions_request_handler<>{sub});
 
     // If presented with a non-positive integer for version, set it to
     // invalid_schema_version so that the version number can be projected
@@ -656,8 +661,8 @@ compatibility_subject_version(server::request_t rq, server::reply_t rp) {
     auto is_verbose{
       parse::query_param<std::optional<verbose>>(*rq.req, "verbose")
         .value_or(verbose::no)};
-    auto unparsed = co_await ppj::rjson_parse(
-      std::move(rq.req), post_subject_versions_request_handler<>{sub});
+    auto unparsed = co_await rjson_parse(
+      *rq.req, post_subject_versions_request_handler<>{sub});
 
     // Must read, in case we have the subject in cache with an outdated config
     co_await rq.service().writer().read_sync();

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -42,6 +42,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/http/api_docs.hh>
 #include <seastar/http/exception.hh>
+#include <seastar/util/log.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -636,7 +637,8 @@ service::service(
       "/schema_registry_definitions",
       _ctx,
       json::serialization_format::schema_registry_v1_json,
-      srlog)
+      srlog,
+      srreqs)
   , _store(store)
   , _writer(sequencer)
   , _controller(controller)

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -103,14 +103,18 @@ struct handler_adaptor : ss::httpd::handler_base {
           };
         auto inflight_units = _ctx.inflight_sem.try_get_units(1);
         if (!inflight_units) {
-            set_reply_too_many_requests(*rp.rep);
+            auto er = err_reply_builder{std::move(rp.rep)};
+            er.set_reply_too_many_requests();
+            rp.rep = std::move(er).build();
             rp.mime_type = _exceptional_mime_type;
             set_and_measure_response(rp);
             co_return std::move(rp.rep);
         }
         auto req_size = get_request_size(*rq.req);
         if (req_size > _ctx.max_memory) {
-            set_reply_payload_too_large(*rp.rep);
+            auto er = err_reply_builder{std::move(rp.rep)};
+            er.set_reply_payload_too_large();
+            rp.rep = std::move(er).build();
             rp.mime_type = _exceptional_mime_type;
             set_and_measure_response(rp);
             co_return std::move(rp.rep);
@@ -126,7 +130,9 @@ struct handler_adaptor : ss::httpd::handler_base {
         vlog(_log.trace, "{} handling {}", prefix, req_line);
 
         if (_ctx.as.abort_requested()) {
-            set_reply_unavailable(*rp.rep);
+            auto er = err_reply_builder{std::move(rp.rep)};
+            er.set_reply_unavailable();
+            rp.rep = std::move(er).build();
             rp.mime_type = _exceptional_mime_type;
             set_and_measure_response(rp);
             co_return std::move(rp.rep);
@@ -143,8 +149,8 @@ struct handler_adaptor : ss::httpd::handler_base {
               method,
               url,
               std::current_exception());
-            rp = server::reply_t{
-              exception_reply(_log, ex), _exceptional_mime_type};
+            auto er = exception_reply(_log, ex);
+            rp = server::reply_t{std::move(er).build(), _exceptional_mime_type};
         }
         set_and_measure_response(rp);
         vlog(

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -17,6 +17,7 @@
 #include "pandaproxy/probe.h"
 #include "pandaproxy/reply.h"
 #include "rpc/rpc_utils.h"
+#include "utils/truncating_logger.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/http/function_handlers.hh>
@@ -80,13 +81,15 @@ struct handler_adaptor : ss::httpd::handler_base {
       ss::httpd::path_description& path_desc,
       const ss::sstring& metrics_group_name,
       json::serialization_format exceptional_mime_type,
-      ss::logger& log)
+      ss::logger& log,
+      truncating_logger& req_log)
       : _pending_requests(pending_requests)
       , _ctx(ctx)
       , _handler(std::move(handler))
       , _probe(path_desc, metrics_group_name)
       , _exceptional_mime_type(exceptional_mime_type)
-      , _log(log) {}
+      , _log(log)
+      , _req_log(req_log) {}
 
     ss::future<std::unique_ptr<ss::http::reply>> handle(
       const ss::sstring&,
@@ -150,6 +153,18 @@ struct handler_adaptor : ss::httpd::handler_base {
               url,
               std::current_exception());
             auto er = exception_reply(_log, ex);
+            auto& erb = er.get_json_body();
+            if (_req_log.is_enabled(ss::log_level::trace) && erb.has_value()) {
+                iobuf_parser parser{rjson_serialize_iobuf(*erb)};
+                vlog(
+                  _req_log.trace,
+                  "{} sending response {} {}: {:?}",
+                  prefix,
+                  method,
+                  url,
+                  parser.read_string(
+                    std::min(parser.bytes_left(), max_log_line_bytes)));
+            }
             rp = server::reply_t{std::move(er).build(), _exceptional_mime_type};
         }
         set_and_measure_response(rp);
@@ -170,6 +185,7 @@ struct handler_adaptor : ss::httpd::handler_base {
     probe _probe;
     json::serialization_format _exceptional_mime_type;
     ss::logger& _log;
+    truncating_logger& _req_log;
 };
 
 server::server(
@@ -180,7 +196,8 @@ server::server(
   const ss::sstring& definitions,
   context_t& ctx,
   json::serialization_format exceptional_mime_type,
-  ss::logger& log)
+  ss::logger& log,
+  truncating_logger& req_log)
   : _server(server_name)
   , _public_metrics_group_name(public_metrics_group_name)
   , _pending_reqs()
@@ -189,7 +206,8 @@ server::server(
   , _ctx(ctx)
   , _exceptional_mime_type(exceptional_mime_type)
   , _probe{}
-  , _log(log) {
+  , _log(log)
+  , _req_log(req_log) {
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
@@ -209,7 +227,8 @@ void server::route(server::route_t r) {
       r.path_desc,
       _public_metrics_group_name,
       _exceptional_mime_type,
-      _log);
+      _log,
+      _req_log);
     r.path_desc.set(_server._routes, handler);
 }
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -21,6 +21,7 @@
 #include "pandaproxy/types.h"
 #include "security/request_auth.h"
 #include "utils/adjustable_semaphore.h"
+#include "utils/truncating_logger.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
@@ -122,7 +123,8 @@ public:
       const ss::sstring& definitions,
       context_t& ctx,
       json::serialization_format exceptional_mime_type,
-      ss::logger& log);
+      ss::logger& log,
+      truncating_logger& req_log);
 
     void route(route_t route);
     void routes(routes_t&& routes);
@@ -143,6 +145,7 @@ private:
     json::serialization_format _exceptional_mime_type;
     std::unique_ptr<server_probe> _probe;
     ss::logger& _log;
+    truncating_logger& _req_log;
 };
 
 template<typename service_t>

--- a/src/v/pandaproxy/util.h
+++ b/src/v/pandaproxy/util.h
@@ -13,10 +13,18 @@
 
 #include "base/likely.h"
 #include "base/seastarx.h"
+#include "base/vlog.h"
+#include "bytes/iobuf_parser.h"
+#include "pandaproxy/logger.h"
 #include "ssx/semaphore.h"
+#include "utils/truncating_logger.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/http/request.hh>
+#include <seastar/net/inet_address.hh>
 #include <seastar/util/noncopyable_function.hh>
+
+#include <string_view>
 
 namespace pandaproxy {
 
@@ -58,5 +66,30 @@ private:
     ss::noncopyable_function<ss::future<>()> _func;
     ssx::semaphore _started_sem{0, "pproxy/oneshot"};
 };
+
+inline void log_request(
+  const ss::http::request& req, std::string_view body, truncating_logger& log) {
+    if (log.is_enabled(ss::log_level::trace)) {
+        vlog(
+          log.trace,
+          "[{}:{}] handling {} {}: body={:?}",
+          req.get_client_address().addr(),
+          req.get_client_address().port(),
+          req._method,
+          req._url,
+          body);
+    }
+}
+
+inline void log_request(
+  const ss::http::request& req, const iobuf& body, truncating_logger& log) {
+    if (log.is_enabled(ss::log_level::trace)) {
+        iobuf_const_parser parser{body};
+        log_request(
+          req,
+          parser.read_string(std::min(parser.bytes_left(), max_log_line_bytes)),
+          log);
+    }
+}
 
 } // namespace pandaproxy

--- a/src/v/utils/truncating_logger.h
+++ b/src/v/utils/truncating_logger.h
@@ -89,6 +89,10 @@ public:
         log(ss::log_level::trace, format, std::forward<Args>(args)...);
     }
 
+    bool is_enabled(ss::log_level level) const noexcept {
+        return _logger.is_enabled(level);
+    }
+
 private:
     ss::logger& _logger;
     size_t _max_line_bytes;


### PR DESCRIPTION
This PR introduces two new loggers, `pandaproxy/requests` and `schemaregistry/requests` for the printing of full request and response bodies of Rest Proxy (Pandaproxy) and Schema Registry requests when enabled at the trace level.

We now log at trace level in the new separate loggers:
* For Schema Registry:
	* All request bodies of POST requests for which we attempt to parse the request body
	* Response bodies of error and success responses
* For Rest proxy:
	* All request bodies of POST requests for which we attempt to parse the request body
	* Response bodies of error responses

Note that some requests and responses are not yet logged (but could be added as a follow up):
* Responses sent on uncaught exceptions (see `exception_replier`)
* Requests and responses that are rejected early on in `pandaproxy/server.cc` (eg. too many inflight, too large)
* Response bodies of successful Rest Proxy requests

### Examples

```
TRACE 2025-04-16 10:24:07,869 [shard  0:main] schemaregistry/requests - rjson_util.h:212 - [127.0.0.1:51536] sending response GET /subjects/baz/versions/1: "{\"subject\":\"baz\",\"version\":1,\"id\":0,\"schema\":\"{\\\"type\\\":\\\"record\\\",\\\"name\\\":\\\"Foo\\\",\\\"fields\\\":[{\\\"name\\\":\\\"data\\\",\\\"type\\\":\\\"float\\\"}]}\"}"

TRACE 2025-04-16 10:24:38,332 [shard  0:main] schemaregistry/requests - rjson_util.h:157 - [127.0.0.1:41056] handling POST /subjects/baz/versions: body="{\"id\": 0, \"version\": 1, \"schema\": \"{\\\"name\\\": \\\"Foo\\\", \\\"type\\\": \\\"record\\\", \\\"fields\\\": [{\\\"name\\\": \\\"data\\\", \\\"type\\\": \\\"float\\\"}]}\"}"
TRACE 2025-04-16 10:24:38,344 [shard  0:main] schemaregistry/requests - server.cc:167 - [127.0.0.1:41056] sending response POST /subjects/baz/versions: "{\"error_code\":42207,\"message\":\"Overwrite new schema with id 0 is not permitted.\"}"
```

Fixes https://redpandadata.atlassian.net/browse/CORE-9798

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements
* Introduces two new loggers, `pandaproxy/requests` and `schemaregistry/requests` for the printing of full request and response bodies of Rest Proxy (Pandaproxy) and Schema Registry requests when enabled at the trace level.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
