### PR TITLE
[rptest] revert RedpandaInstaller curl retry change

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -700,7 +700,7 @@ class RedpandaInstaller:
 
         tgz = "redpanda.tar.gz"
         cmds = [
-            f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-all-errors --retry-delay 2 --create-dir -o {version_root}/{tgz}",
+            f"curl -vfsSL {self._version_package_url(version)} --retry 3 --retry-connrefused --retry-delay 2 --create-dir -o {version_root}/{tgz}",
             f"gunzip -c {version_root}/{tgz} | tar -xf - -C {version_root}",
             f"rm {version_root}/{tgz}"
         ]


### PR DESCRIPTION
Turns out the version of `curl` we install on our ducktape nodes is too old for `--retry-all-errors`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

