### PR TITLE
wasm_transform_test: don't rely on operator<<

### DIFF
--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -53,6 +53,6 @@ TEST_F(WasmTestFixture, WorksWithCpuProfiler) {
     std::vector<ss::cpu_profiler_trace> traces;
     ss::engine().profiler_results(traces);
     for (const auto& t : traces) {
-        std::cout << t.user_backtrace << "\n";
+        fmt::print("{}\n", t.user_backtrace);
     }
 }


### PR DESCRIPTION
Don't rely on << for ss::simple_backtrace, instead use fmt, as upstream has removed the << for backtrace.

(cherry picked from commit 18343cf9190af7e9fa12ef444cfe4357b741d801)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none


