### PR TITLE
Initial recovery policy in `raft::state_machine_manger`

### DIFF
--- a/src/v/cluster/partition_properties_stm.h
+++ b/src/v/cluster/partition_properties_stm.h
@@ -49,6 +49,11 @@ public:
     // Returns a current value of the writes disabled property.
     writes_disabled are_writes_disabled() const;
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::skip_to_end;
+    }
+
 protected:
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -90,6 +90,11 @@ public:
       model::timeout_clock::duration timeout,
       ss::abort_source&);
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::skip_to_end;
+    }
+
 private:
     struct snapshot
       : serde::envelope<snapshot, serde::version<1>, serde::compat_version<0>> {

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -367,6 +367,15 @@ ss::future<> persisted_stm_base<BaseT, T>::ensure_local_snapshot_exists(
 }
 
 template<typename BaseT, supported_stm_snapshot T>
+ss::future<> persisted_stm_base<BaseT, T>::finish_initial_recovery() {
+    vlog(
+      _log.debug,
+      "Initial recovery finished with last applied offset: {}",
+      last_applied());
+    return ensure_local_snapshot_exists(last_applied());
+}
+
+template<typename BaseT, supported_stm_snapshot T>
 model::offset persisted_stm_base<BaseT, T>::max_collectible_offset() {
     return model::offset::max();
 }

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -245,6 +245,8 @@ protected:
      */
     ss::future<bool> sync(model::timeout_clock::duration);
 
+    ss::future<> finish_initial_recovery() override;
+
     bool _is_catching_up{false};
     model::term_id _insync_term;
     raft::consensus* _raft;

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -45,4 +45,14 @@ ss::future<> state_machine_base::wait(
     co_await _waiters.wait(offset, timeout, as);
 }
 
+std::ostream&
+operator<<(std::ostream& o, const stm_initial_recovery_policy& p) {
+    switch (p) {
+    case stm_initial_recovery_policy::read_everything:
+        return o << "read_everything";
+    case stm_initial_recovery_policy::skip_to_end:
+        return o << "skip_to_end";
+    }
+}
+
 } // namespace raft

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -24,6 +24,26 @@ using snapshot_at_offset_supported
 class consensus;
 
 /**
+ * Class defining the state machine behavior when it is created for the first
+ * time for a given partition.
+ *
+ * There are two possible policies:
+ *
+ *  - read_everything - when there is no other state the state machine will
+ *                      starts its existence with next offset set to the
+ *                      beginning of the local log. Be careful as read
+ *                      everything may lead to a large amount of data being
+ *                      read on startup.
+ *
+ *   - skip_to_end      - when there is no other state the state machine will
+ *                      start reading from the first confirmed committed offset.
+ */
+enum class stm_initial_recovery_policy : uint8_t {
+    read_everything = 0,
+    skip_to_end = 1,
+};
+
+/**
  * State machine interface. The class provides an interface that must be
  * implemented to build state machine that can be registered in
  * state_machine_manager.
@@ -97,6 +117,28 @@ public:
         return snapshot_at_offset_supported::yes;
     }
 
+    /**
+     * Returns true only if this is the first start of the state machine and it
+     * needs an initial recovery to happen. In this case the state machine
+     * manager will perform the initial recovery according to the returned
+     * policy.
+     *
+     * This method is called after the state machine has been started but before
+     * any apply happened.
+     */
+    virtual bool needs_initial_recovery() const {
+        return last_applied_offset() == model::offset{};
+    }
+
+    /**
+     * Returns state machine configured initial recovery policy. The default
+     * policy is to read everything as this is the basic behavior of the state
+     * machine
+     */
+    virtual stm_initial_recovery_policy get_initial_recovery_policy() const {
+        return stm_initial_recovery_policy::read_everything;
+    }
+
 protected:
     /**
      * Must always be called under apply mutex scope and apply_units argument
@@ -106,6 +148,13 @@ protected:
     virtual ss::future<>
     apply(const model::record_batch&, const ssx::semaphore_units& apply_units)
       = 0;
+
+    /**
+     * This method is called by the state machine manager to notify the state
+     * machine that it should checkpoint its state. The state machine base
+     * provides a noop implementation for this method.
+     */
+    virtual ss::future<> finish_initial_recovery() { return ss::now(); }
 
     /**
      *  Lifecycle is managed by state_machine_manager
@@ -129,7 +178,7 @@ private:
     mutable offset_monitor<model::offset> _waiters;
     model::offset _next{0};
 };
-
+std::ostream& operator<<(std::ostream&, const stm_initial_recovery_policy&);
 /**
  * This flavor of state machine base allows implementer to opt out from taking
  * snapshot at arbitrary offset. This way a partition that the STM is based on

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -185,6 +185,11 @@ ss::future<> state_machine_manager::start() {
     });
     std::vector<model::offset> offsets;
     for (const auto& [name, stm_meta] : _machines) {
+        vlog(
+          _log.trace,
+          "state machine {} last applied offset: {}",
+          name,
+          stm_meta->stm->last_applied_offset());
         offsets.push_back(stm_meta->stm->last_applied_offset());
     }
     std::sort(offsets.begin(), offsets.end());

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -174,6 +174,13 @@ state_machine_manager::state_machine_manager(
     }
 }
 
+model::offset state_machine_manager::max_next_offset() const {
+    auto offsets = _machines | std::views::transform([](const auto& entry) {
+                       return entry.second->stm->last_applied_offset();
+                   });
+    return model::next_offset(*std::ranges::max_element(offsets));
+}
+
 ss::future<> state_machine_manager::start() {
     vlog(_log.debug, "starting state machine manager");
     if (_machines.empty()) {
@@ -218,17 +225,31 @@ ss::future<> state_machine_manager::stop() {
     co_await std::move(gate_f);
 }
 
+std::vector<state_machine_manager::entry_ptr>
+state_machine_manager::all_state_machines() const {
+    std::vector<entry_ptr> all_stms;
+    all_stms.reserve(_machines.size());
+    std::ranges::copy(
+      std::views::values(_machines), std::back_inserter(all_stms));
+    return all_stms;
+}
+
 ss::future<> state_machine_manager::apply_raft_snapshot() {
     auto snapshot = co_await _raft->open_snapshot();
     if (!snapshot) {
         co_return;
     }
-
     auto fut = co_await ss::coroutine::as_future(
       acquire_background_apply_mutexes().then([&, this](auto units) mutable {
           return do_apply_raft_snapshot(
-            std::move(snapshot->metadata), snapshot->reader, std::move(units));
+            all_state_machines(),
+            std::move(snapshot->metadata),
+            snapshot->reader,
+            std::move(units));
       }));
+    // update the _next offset to the max of the state machines applied offset
+    // as some of them might have thrown
+    _next = std::max(max_next_offset(), _next);
     co_await snapshot->reader.close();
     if (fut.failed()) {
         const auto e = fut.get_exception();
@@ -241,6 +262,7 @@ ss::future<> state_machine_manager::apply_raft_snapshot() {
 }
 
 ss::future<> state_machine_manager::do_apply_raft_snapshot(
+  std::vector<entry_ptr> state_machines,
   snapshot_metadata metadata,
   storage::snapshot_reader& reader,
   [[maybe_unused]] std::vector<ssx::semaphore_units> background_apply_units) {
@@ -268,8 +290,8 @@ ss::future<> state_machine_manager::do_apply_raft_snapshot(
           "compatibility",
           last_offset);
         co_await ss::coroutine::parallel_for_each(
-          _machines, [last_offset](auto& pair) {
-              auto stm = pair.second->stm;
+          state_machines, [last_offset](entry_ptr& entry) {
+              auto stm = entry->stm;
               if (stm->last_applied_offset() >= last_offset) {
                   return ss::now();
               }
@@ -284,13 +306,12 @@ ss::future<> state_machine_manager::do_apply_raft_snapshot(
         auto snap = co_await serde::read_async<managed_snapshot>(parser);
 
         co_await ss::coroutine::parallel_for_each(
-          _machines,
+          state_machines,
           [this, snap = std::move(snap), last_offset](
-            state_machines_t::value_type& stm_pair) mutable {
-              return apply_snapshot_to_stm(stm_pair.second, snap, last_offset);
+            entry_ptr& entry) mutable {
+              return apply_snapshot_to_stm(entry, snap, last_offset);
           });
     }
-    _next = model::next_offset(metadata.last_included_index);
 }
 
 ss::future<> state_machine_manager::apply_snapshot_to_stm(
@@ -449,6 +470,40 @@ void state_machine_manager::maybe_start_background_apply(
 ss::future<> state_machine_manager::background_apply_fiber(
   entry_ptr entry, ssx::semaphore_units units) {
     while (!_as.abort_requested() && entry->stm->next() < _next) {
+        if (entry->stm->next() < _raft->start_offset()) {
+            auto snapshot = co_await _raft->open_snapshot();
+            if (!snapshot) {
+                vlog(
+                  _log.warn,
+                  "background apply fiber was not able to open snapshot for "
+                  "'{}' stm",
+                  entry->name);
+                co_await ss::sleep_abortable(100ms, _as);
+                continue;
+            }
+            vlog(
+              _log.info,
+              "background apply fiber applying raft snapshot with offset {} "
+              "for {} state machine",
+              snapshot->metadata.last_included_index,
+              entry->name);
+
+            auto fut = co_await ss::coroutine::as_future(do_apply_raft_snapshot(
+              {entry},
+              std::move(snapshot->metadata),
+              snapshot->reader,
+              std::vector<ssx::semaphore_units>{}));
+            co_await snapshot->reader.close();
+            if (fut.failed()) {
+                const auto e = fut.get_exception();
+                // do not log known shutdown exceptions as errors
+                if (!ssx::is_shutdown_exception(e)) {
+                    vlog(_log.error, "error applying raft snapshot - {}", e);
+                }
+                std::rethrow_exception(e);
+            }
+            continue;
+        }
         storage::log_reader_config config(
           entry->stm->next(),
           model::prev_offset(_next),

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -199,8 +199,7 @@ ss::future<> state_machine_manager::start() {
           stm_meta->stm->last_applied_offset());
         offsets.push_back(stm_meta->stm->last_applied_offset());
     }
-    std::sort(offsets.begin(), offsets.end());
-    _next = model::next_offset(offsets.front());
+    _next = model::next_offset(*std::ranges::max_element(offsets));
     vlog(
       _log.debug,
       "started state machine manager with initial next offset: {}",
@@ -427,7 +426,6 @@ ss::future<> state_machine_manager::try_apply_in_foreground() {
 }
 
 ss::future<> state_machine_manager::apply() {
-    co_await try_apply_in_foreground();
     /**
      * If any of the state machine is behind, dispatch background apply fibers
      */
@@ -436,6 +434,7 @@ ss::future<> state_machine_manager::apply() {
             maybe_start_background_apply(entry);
         }
     }
+    co_await try_apply_in_foreground();
 }
 
 void state_machine_manager::maybe_start_background_apply(

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -204,6 +204,8 @@ ss::future<> state_machine_manager::start() {
       _log.debug,
       "started state machine manager with initial next offset: {}",
       _next);
+    // it safe to update next here as apply loop didn't started yet.
+    co_await apply_initial_recovery_policy();
     ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _as.abort_requested(); }, [this] { return apply(); });
@@ -222,6 +224,50 @@ ss::future<> state_machine_manager::stop() {
     co_await ss::coroutine::parallel_for_each(
       _machines, [](auto p) { return p.second->stm->stop(); });
     co_await std::move(gate_f);
+}
+
+ss::future<> state_machine_manager::apply_initial_recovery_policy() {
+    for (auto& [name, entry] : _machines) {
+        // state machine has already been applied with updates, the initial
+        // recovery policy doesn't apply
+        if (entry->stm->last_applied_offset() != model::offset{}) {
+            continue;
+        }
+        const auto policy = entry->stm->get_initial_recovery_policy();
+        vlog(
+          _log.info,
+          "Applying '{}' initial recovery policy for '{}' state machine",
+          name,
+          policy);
+        if (policy == stm_initial_recovery_policy::read_everything) {
+            continue;
+        }
+        /**
+         * Here we apply the skip to end policy.
+         *
+         * The policy leverages the fact that the _next offset is already
+         * established as all local snapshots were applied.
+         *
+         * We must not use the log end offset here as the end offset may change
+         * with the truncation as it haven't yet been committed.
+         *
+         * The `_next` is safe as it is based on the last applied offset of the
+         * other state machines i.e. the `_next` offset is already committed.
+         *
+         * This policy comes with the trade off. The newly added state machines
+         * will not actually rewind to the physical end of the log. But will
+         * actually read a small part of it.
+         */
+
+        vlog(
+          _log.info,
+          "Setting next offset: {} for: '{}' state machine as a part of "
+          "initial recovery policy.",
+          _next,
+          name);
+        entry->stm->set_next(_next);
+        co_await entry->stm->finish_initial_recovery();
+    }
 }
 
 std::vector<state_machine_manager::entry_ptr>

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -178,6 +178,7 @@ private:
 
     ss::future<> apply_raft_snapshot();
     ss::future<> do_apply_raft_snapshot(
+      std::vector<entry_ptr> state_machines,
       raft::snapshot_metadata metadata,
       storage::snapshot_reader& reader,
       std::vector<ssx::semaphore_units> background_apply_units);
@@ -186,6 +187,9 @@ private:
 
     ss::future<std::vector<ssx::semaphore_units>>
     acquire_background_apply_mutexes();
+
+    std::vector<entry_ptr> all_state_machines() const;
+    model::offset max_next_offset() const;
     /**
      * Simple data structure allowing manager to store independent snapshot
      * for each of the STMs

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -100,8 +100,6 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    model::offset last_applied() const { return model::prev_offset(_next); }
-
     snapshot_at_offset_supported supports_snapshot_at_offset() const {
         return _supports_snapshot_at_offset;
     }
@@ -190,6 +188,7 @@ private:
 
     std::vector<entry_ptr> all_state_machines() const;
     model::offset max_next_offset() const;
+    model::offset last_applied() const { return model::prev_offset(_next); }
     /**
      * Simple data structure allowing manager to store independent snapshot
      * for each of the STMs

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -189,6 +189,8 @@ private:
     std::vector<entry_ptr> all_state_machines() const;
     model::offset max_next_offset() const;
     model::offset last_applied() const { return model::prev_offset(_next); }
+
+    ss::future<> apply_initial_recovery_policy();
     /**
      * Simple data structure allowing manager to store independent snapshot
      * for each of the STMs

--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -584,7 +584,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_gtest(
     name = "persisted_stm_test",
-    timeout = "short",
+    timeout = "long",
     srcs = [
         "persisted_stm_test.cc",
     ],

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -66,6 +66,7 @@ struct kv_state
             } else {
                 remove(op.key);
             }
+            valid_op_cnt++;
             return true;
         }
     }
@@ -103,6 +104,7 @@ struct kv_state
             } else {
                 kv_map.erase(it);
             }
+            valid_op_cnt++;
             return true;
         }
 
@@ -111,14 +113,16 @@ struct kv_state
 
     state_t kv_map;
 
-    friend bool operator==(const kv_state&, const kv_state&) = default;
+    friend bool operator==(const kv_state& lhs, const kv_state& rhs) {
+        return lhs.kv_map == rhs.kv_map;
+    }
     friend std::ostream& operator<<(std::ostream& o, const kv_state& st) {
         for (auto& [k, v] : st.kv_map) {
             fmt::print(o, "{}={}, ", k, v);
         }
         return o;
     }
-
+    size_t valid_op_cnt{0};
     auto serde_fields() { return std::tie(kv_map); }
 };
 
@@ -990,4 +994,101 @@ TEST_F_CORO(persisted_stm_test_fixture, test_application_on_lagging_replica) {
     auto added_stm = builder.create_stm<other_persisted_kv>(n);
     co_await n.start(std::move(builder));
     co_await wait_for_apply();
+}
+
+class start_from_end_stm : public persisted_kv {
+public:
+    static constexpr std::string_view name = "start_from_end_stm";
+    explicit start_from_end_stm(raft_node_instance& rn)
+      : persisted_kv(rn, false, "start_from_end_stm_kv_stm_snapshot") {}
+
+    ss::future<> apply_raft_snapshot(const iobuf& buffer) override {
+        if (buffer.empty()) {
+            co_return;
+        }
+        state = serde::from_iobuf<kv_state>(buffer.copy());
+        co_return;
+    };
+    stm_initial_recovery_policy get_initial_recovery_policy() const override {
+        return stm_initial_recovery_policy::skip_to_end;
+    }
+    // This STM only counts the number of apply function calls
+    ss::future<> do_apply(const model::record_batch& batch) override {
+        if (batch.header().type != model::record_batch_type::raft_data) {
+            co_return;
+        }
+        apply_count++;
+    }
+};
+
+/**
+ * This test initializes raft group with only one stm applies some data and
+ * takes local snapshot.
+ *
+ * After that all the replicas are stopped and two more state machines are added
+ * to the raft group.
+ *
+ * The two state machines uses different initialization policies. Finally the
+ * test verifies if the state machines were applied with expected batches.
+ */
+TEST_F_CORO(persisted_stm_test_fixture, test_persisted_stm_recovery_policy) {
+    co_await initialize_state_machines();
+    kv_state expected;
+    auto ops = random_operations(2000);
+    for (auto batch : ops) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+
+    co_await take_local_snapshot_on_every_node();
+    auto ops_to_snapshot = expected.valid_op_cnt;
+    auto ops_phase_two = random_operations(2000);
+    for (auto batch : ops) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+    absl::flat_hash_map<model::node_id, ss::sstring> data_directories;
+    for (auto& [id, node] : nodes()) {
+        data_directories[id] = node->raft()->log()->config().base_directory();
+    }
+
+    std::vector<ss::shared_ptr<other_persisted_kv>> full_read_stms;
+    std::vector<ss::shared_ptr<start_from_end_stm>> short_read_stms;
+
+    for (auto& [id, data_dir] : data_directories) {
+        co_await stop_node(id);
+        add_node(id, model::revision_id(0), data_dir);
+    }
+
+    /**
+     * Now add the state machines and restart the replicas.
+     */
+    for (auto& [id, node] : nodes()) {
+        co_await node->initialise(all_vnodes());
+        raft::state_machine_manager_builder builder;
+        auto stm = builder.create_stm<persisted_kv>(*node);
+        full_read_stms.push_back(builder.create_stm<other_persisted_kv>(*node));
+        short_read_stms.push_back(
+          builder.create_stm<start_from_end_stm>(*node));
+
+        co_await node->start(std::move(builder));
+        node_stms.insert_or_assign(node->get_vnode(), std::move(stm));
+    }
+
+    co_await wait_for_apply();
+    // the base stm state must not change
+    for (auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+
+    for (auto& stm : full_read_stms) {
+        ASSERT_EQ_CORO(stm->apply_count, expected.valid_op_cnt);
+    }
+
+    for (auto& stm : short_read_stms) {
+        ASSERT_EQ_CORO(
+          stm->apply_count, expected.valid_op_cnt - ops_to_snapshot);
+    }
 }

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -220,6 +220,9 @@ public:
     }
 
     ss::future<> do_apply(const model::record_batch& batch) override {
+        if (throw_on_apply) {
+            throw std::runtime_error("Error from apply");
+        }
         auto last_op = apply_to_state(batch, state);
         if (last_op) {
             last_operation = std::move(*last_op);
@@ -275,6 +278,11 @@ public:
         return std::move(builder).build();
     }
 
+    void set_throw_on_apply(bool should_throw) {
+        throw_on_apply = should_throw;
+    }
+
+    bool throw_on_apply = false;
     kv_state state;
     kv_operation last_operation;
     raft_node_instance& raft_node;
@@ -765,4 +773,82 @@ TEST_F_CORO(state_machine_fixture, test_concurrent_apply_and_snapshot) {
     stop = true;
     co_await std::move(write_sleep_f);
     co_await std::move(local_snapshot_f);
+}
+/**
+ * Test the scenario in which a Raft snapshot is applied to the state machine
+ * which is in the background apply.
+ */
+TEST_F_CORO(persisted_stm_test_fixture, test_snapshot_in_background_apply) {
+    for (int i = 0; i < 3; ++i) {
+        add_node(model::node_id(i), model::revision_id(0));
+    }
+    std::vector<ss::shared_ptr<other_persisted_kv>> other_stms;
+    for (auto& [_, node] : nodes()) {
+        co_await node->initialise(all_vnodes());
+        raft::state_machine_manager_builder builder;
+        auto stm = builder.create_stm<persisted_kv>(*node);
+        other_stms.push_back(builder.create_stm<other_persisted_kv>(*node));
+        co_await node->start(std::move(builder));
+        node_stms.emplace(node->get_vnode(), std::move(stm));
+    }
+
+    kv_state expected;
+    auto ops = random_operations(2000);
+    for (auto batch : ops) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+
+    // take local snapshot on every node
+    co_await take_local_snapshot_on_every_node();
+    // update state
+    auto ops_phase_two = random_operations(50);
+    for (auto batch : ops_phase_two) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+    // force background apply on one of the state machines
+    auto throwing_stm = node_stms.begin()->second;
+    throwing_stm->set_throw_on_apply(true);
+
+    auto ops_phase_three = random_operations(200);
+    for (auto batch : ops_phase_three) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+
+    auto leader = co_await wait_for_leader(10s);
+    auto offset = node(leader).raft()->dirty_offset();
+    co_await wait_for_committed_offset(
+      node(leader).raft()->dirty_offset(), 10s);
+
+    // while one of the stms is running in the background we are going to take
+    // raft snapshot
+    std::optional<state_machine_manager::snapshot_result> snapshot;
+    // take snapshot on one of the nodes that state machine is fully up to date.
+    for (auto& [id, stm] : node_stms) {
+        if (stm->last_applied() == offset) {
+            snapshot
+              = co_await node(id.id()).raft()->stm_manager()->take_snapshot();
+            break;
+        }
+    }
+    ASSERT_TRUE_CORO(snapshot.has_value());
+    // trigger snapshot write on all of the nodes
+    co_await parallel_for_each_node([&](raft_node_instance& n) {
+        auto committed = n.raft()->committed_offset();
+
+        return n.raft()->write_snapshot(
+          raft::write_snapshot_cfg(committed, snapshot->data.copy()));
+    });
+    throwing_stm->set_throw_on_apply(false);
+
+    co_await wait_for_apply();
 }

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -124,10 +124,12 @@ struct kv_state
 
 class persisted_kv : public persisted_stm<> {
 public:
-    static constexpr std::string_view name = "persited_kv_stm";
+    static constexpr std::string_view name = "persisted_kv_stm";
     explicit persisted_kv(
-      raft_node_instance& rn, bool reject_local_snapshots = false)
-      : persisted_stm<>("simple-kv", logger, rn.raft().get())
+      raft_node_instance& rn,
+      bool reject_local_snapshots = false,
+      ss::sstring snapshot_name = "persisted_kv_stm_snapshot")
+      : persisted_stm<>(std::move(snapshot_name), logger, rn.raft().get())
       , raft_node(rn)
       , reject_local_snapshots(reject_local_snapshots) {}
 
@@ -225,6 +227,7 @@ public:
         }
         auto last_op = apply_to_state(batch, state);
         if (last_op) {
+            apply_count++;
             last_operation = std::move(*last_op);
         }
         co_return;
@@ -287,13 +290,14 @@ public:
     kv_operation last_operation;
     raft_node_instance& raft_node;
     bool reject_local_snapshots = false;
+    size_t apply_count = 0;
 };
 
 class other_persisted_kv : public persisted_kv {
 public:
-    static constexpr std::string_view name = "other_persited_kv_stm";
+    static constexpr std::string_view name = "other_persisted_kv_stm";
     explicit other_persisted_kv(raft_node_instance& rn)
-      : persisted_kv(rn) {}
+      : persisted_kv(rn, false, "other_persisted_kv_stm_snapshot") {}
     ss::future<> apply_raft_snapshot(const iobuf& buffer) override {
         if (buffer.empty()) {
             co_return;
@@ -310,6 +314,7 @@ public:
         if (batch.header().type != model::record_batch_type::raft_data) {
             co_return;
         }
+        apply_count++;
         batch.for_each_record([this](model::record r) {
             last_operation = serde::from_iobuf<kv_operation>(r.value().copy());
         });
@@ -732,7 +737,7 @@ TEST_F_CORO(persisted_stm_test_fixture, test_adding_state_machine) {
         auto stm = builder.create_stm<persisted_kv>(*node);
         other_stm = builder.create_stm<other_persisted_kv>(*node);
         co_await node->start(std::move(builder));
-        node_stms.emplace(node->get_vnode(), std::move(stm));
+        node_stms.insert_or_assign(node->get_vnode(), std::move(stm));
     }
 
     co_await wait_for_committed_offset(committed, 30s);
@@ -782,12 +787,12 @@ TEST_F_CORO(persisted_stm_test_fixture, test_snapshot_in_background_apply) {
     for (int i = 0; i < 3; ++i) {
         add_node(model::node_id(i), model::revision_id(0));
     }
-    std::vector<ss::shared_ptr<other_persisted_kv>> other_stms;
+
     for (auto& [_, node] : nodes()) {
         co_await node->initialise(all_vnodes());
         raft::state_machine_manager_builder builder;
         auto stm = builder.create_stm<persisted_kv>(*node);
-        other_stms.push_back(builder.create_stm<other_persisted_kv>(*node));
+        builder.create_stm<other_persisted_kv>(*node);
         co_await node->start(std::move(builder));
         node_stms.emplace(node->get_vnode(), std::move(stm));
     }
@@ -850,5 +855,139 @@ TEST_F_CORO(persisted_stm_test_fixture, test_snapshot_in_background_apply) {
     });
     throwing_stm->set_throw_on_apply(false);
 
+    co_await wait_for_apply();
+}
+
+TEST_F_CORO(
+  persisted_stm_test_fixture, test_adding_state_machine_no_raft_snapshot) {
+    co_await initialize_state_machines();
+    kv_state expected;
+    auto ops = random_operations(2000);
+    for (auto batch : ops) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+
+    // take local snapshot on every node
+    co_await take_local_snapshot_on_every_node();
+    // update state
+    auto ops_phase_two = random_operations(50);
+    for (auto batch : ops_phase_two) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+
+    auto committed = node(model::node_id(0)).raft()->committed_offset();
+
+    absl::flat_hash_map<model::node_id, ss::sstring> data_directories;
+    for (auto& [id, node] : nodes()) {
+        data_directories[id] = node->raft()->log()->config().base_directory();
+    }
+
+    for (auto& [id, data_dir] : data_directories) {
+        co_await stop_node(id);
+        add_node(id, model::revision_id(0), std::move(data_dir));
+    }
+    ss::shared_ptr<other_persisted_kv> other_stm;
+    for (auto& [_, node] : nodes()) {
+        co_await node->initialise(all_vnodes());
+        raft::state_machine_manager_builder builder;
+        auto stm = builder.create_stm<persisted_kv>(*node);
+        other_stm = builder.create_stm<other_persisted_kv>(*node);
+        co_await node->start(std::move(builder));
+        node_stms.insert_or_assign(node->get_vnode(), std::move(stm));
+    }
+
+    co_await wait_for_committed_offset(committed, 30s);
+    co_await wait_for_apply();
+    auto leader_id = co_await wait_for_leader(10s);
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+        ASSERT_EQ_CORO(stm->last_operation, other_stm->last_operation);
+        ASSERT_LE_CORO(
+          stm->apply_count, node(leader_id).raft()->committed_offset()());
+    }
+}
+
+/**
+ * This test verifies if stm apply continues when the state machine is added to
+ * the replica that has no new batches in the log to apply.
+ */
+TEST_F_CORO(persisted_stm_test_fixture, test_application_on_lagging_replica) {
+    co_await initialize_state_machines();
+    kv_state expected;
+    auto ops = random_operations(2000);
+    for (auto batch : ops) {
+        co_await apply_operations(expected, std::move(batch));
+    }
+    co_await wait_for_apply();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+
+    // take local snapshot on every node
+    co_await take_local_snapshot_on_every_node();
+
+    absl::flat_hash_map<model::node_id, ss::sstring> data_directories;
+    for (auto& [id, node] : nodes()) {
+        data_directories[id] = node->raft()->log()->config().base_directory();
+    }
+    auto committed = node(model::node_id(0)).raft()->committed_offset();
+    for (auto& [id, data_dir] : data_directories) {
+        co_await stop_node(id);
+        add_node(id, model::revision_id(0), data_dir);
+    }
+    auto all_nodes = all_vnodes();
+    std::sort(all_nodes.begin(), all_nodes.end(), [](auto lhs, auto& rhs) {
+        return lhs.id() < rhs.id();
+    });
+    model::node_id node_without_other_stm(all_nodes.back().id());
+    std::vector<ss::shared_ptr<other_persisted_kv>> other_stms;
+    for (auto& [id, node] : nodes()) {
+        co_await node->initialise(all_nodes);
+        raft::state_machine_manager_builder builder;
+        auto stm = builder.create_stm<persisted_kv>(*node);
+        if (id != node_without_other_stm) {
+            other_stms.push_back(builder.create_stm<other_persisted_kv>(*node));
+        }
+        co_await node->start(std::move(builder));
+        node_stms.insert_or_assign(node->get_vnode(), std::move(stm));
+    }
+
+    co_await wait_for_committed_offset(committed, 30s);
+    co_await wait_for_apply();
+    auto leader_id = co_await wait_for_leader(10s);
+
+    for (const auto& [id, stm] : node_stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+        // snapshot was applied, not further applies should happen
+        ASSERT_EQ_CORO(stm->apply_count, 0);
+    }
+    for (auto& stm : other_stms) {
+        ASSERT_GT_CORO(stm->apply_count, 0);
+        ASSERT_LE_CORO(
+          stm->apply_count, node(leader_id).raft()->committed_offset()());
+    }
+
+    co_await take_local_snapshot_on_every_node();
+    co_await stop_node(node_without_other_stm);
+    add_node(
+      node_without_other_stm,
+      model::revision_id(0),
+      std::move(data_directories[node_without_other_stm]));
+    auto& n = node(node_without_other_stm);
+    co_await n.initialise(all_nodes);
+    raft::state_machine_manager_builder builder;
+
+    auto stm = builder.create_stm<persisted_kv>(n);
+    auto added_stm = builder.create_stm<other_persisted_kv>(n);
+    co_await n.start(std::move(builder));
     co_await wait_for_apply();
 }


### PR DESCRIPTION
TBD
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- adds an explicit policy for the state machine semantics during initial recovery.