### PR TITLE
tests: Add more allowed log line for crash handler test

### DIFF
--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -26,6 +26,8 @@ CRASH_LOOP_LOG = [
 SIGNAL_CRASH_LOG = [
     "Aborting on",
     "Segmentation fault on",
+    "Segmentation fault: resolved ip:",
+    "Segmentation fault: sicode:",
     "Illegal instruction on",
 ]
 


### PR DESCRIPTION
The crash handler test allows segfault log lines as it's part of the test. Our new segv handler in seastar prints additional "segmentation fault" warnings so we need to exclude those too.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none

