### PR TITLE
Wait for a legitimate log data size report in partition balancer

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -247,10 +247,22 @@ void partition_balancer_backend::on_topic_table_update() {
 void partition_balancer_backend::on_health_monitor_update(
   const node_health_report& report,
   std::optional<ss::lw_shared_ptr<const node_health_report>> old_report) {
+    auto has_log_data_size = [](const node_health_report& r) {
+        return r.local_state.log_data_size.has_value();
+    };
+
     if (!old_report) {
         vlog(
           clusterlog.debug,
           "health report for node {} appeared, scheduling tick",
+          report.id);
+
+        maybe_rearm_timer(/*now=*/true);
+    } else if (
+      !has_log_data_size(*old_report.value()) && has_log_data_size(report)) {
+        vlog(
+          clusterlog.debug,
+          "log data size for node {} appeared, scheduling tick",
           report.id);
 
         maybe_rearm_timer(/*now=*/true);
@@ -391,6 +403,8 @@ ss::future<> partition_balancer_backend::do_tick() {
         .min_partition_size_threshold = get_min_partition_size_threshold(),
         .node_responsiveness_timeout = node_responsiveness_timeout,
         .topic_aware = _topic_aware(),
+        .space_management_enabled
+        = config::shard_local_cfg().space_management_enable,
       },
       _state,
       _partition_allocator);

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -356,6 +356,18 @@ void partition_balancer_planner::init_per_node_state(
     }
 
     for (const auto& node_report : health_report.node_reports) {
+        if (
+          ctx.config().space_management_enabled
+          && !node_report->local_state.log_data_size) {
+            // Since space management is enabled, we expect log_data_size to be
+            // present in the health report. If it is not present, probably the
+            // node was recently restarted and hasn't yet had time to calculate
+            // it for the first time. To avoid possible skew caused by using raw
+            // disk usage numbers for some nodes and not the others, we skip
+            // this disk report.
+            continue;
+        }
+
         const auto [total, free] = get_node_bytes_info(
           node_report->local_state);
         auto disk_info = node_disk_space{node_report->id, total, total - free};

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -252,11 +252,6 @@ private:
 std::pair<uint64_t, uint64_t> partition_balancer_planner::get_node_bytes_info(
   const node::local_state& node_state) {
     const auto& state = node_state.log_data_size;
-    vlog(
-      clusterlog.debug,
-      "getting node disk information from node: {}",
-      node_state);
-
     if (likely(state)) {
         // It is okay to account reclaimable space as free space even through
         // the space is not readily available. During the partition move if the
@@ -363,33 +358,34 @@ void partition_balancer_planner::init_per_node_state(
     for (const auto& node_report : health_report.node_reports) {
         const auto [total, free] = get_node_bytes_info(
           node_report->local_state);
-        ctx.node_disk_reports.emplace(
+        auto disk_info = node_disk_space{node_report->id, total, total - free};
+        const bool is_full = disk_info.original_used_ratio()
+                             > _config.soft_max_disk_usage_ratio;
+        vlogl(
+          clusterlog,
+          is_full ? ss::log_level::info : ss::log_level::debug,
+          "node {} disk used: {}, total: {} (ratio: {:.4}, is_full: {}), "
+          "node report: {}",
           node_report->id,
-          node_disk_space(node_report->id, total, total - free));
+          human::bytes(disk_info.used),
+          human::bytes(disk_info.total),
+          disk_info.original_used_ratio(),
+          is_full,
+          node_report->local_state);
+        ctx.node_disk_reports.emplace(node_report->id, disk_info);
+
+        if (
+          is_full
+          && _config.mode == model::partition_autobalancing_mode::continuous) {
+            result.violations.full_nodes.emplace_back(
+              node_report->id,
+              uint32_t(disk_info.original_used_ratio() * 100.0));
+        }
     }
 
     for (model::node_id id : ctx.all_nodes) {
-        auto disk_it = ctx.node_disk_reports.find(id);
-        if (disk_it == ctx.node_disk_reports.end()) {
+        if (!ctx.node_disk_reports.contains(id)) {
             vlog(clusterlog.info, "node {}: no disk report", id);
-            continue;
-        }
-
-        const auto& disk = disk_it->second;
-        double used_space_ratio = disk.original_used_ratio();
-        vlog(
-          clusterlog.debug,
-          "node {}: bytes used: {}, bytes total: {}, used ratio: {:.4}",
-          id,
-          disk.used,
-          disk.total,
-          used_space_ratio);
-
-        if (
-          _config.mode == model::partition_autobalancing_mode::continuous
-          && used_space_ratio > _config.soft_max_disk_usage_ratio) {
-            result.violations.full_nodes.emplace_back(
-              id, uint32_t(used_space_ratio * 100.0));
         }
     }
 }

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -60,6 +60,10 @@ struct planner_config {
     // partitions on each node, as opposed to balancing the total number of
     // partitions.
     bool topic_aware = false;
+
+    // If true, expects nodes to report their space management statistics in the
+    // health report.
+    bool space_management_enabled = false;
 };
 
 class partition_balancer_planner {

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -92,12 +92,34 @@ ss::future<> disk_space_manager::stop() {
         _storage_node->local().unregister_disk_notification(
           node::disk_type::data, _data_disk_nid);
     }
+    _as.request_abort();
     _control_sem.broken();
     co_await _gate.close();
 }
 
 ss::future<> disk_space_manager::run_loop() {
     vassert(ss::this_shard_id() == run_loop_core, "Run on wrong core");
+
+    // Always wait for the trim interval after startup to ensure that
+    // partitions are fully started. Known sources of skew early in the node
+    // startup phase:
+    // 1. controller_backend::start() doesn't wait for the first reconciliation
+    // round, so not all partitions may yet exist in the partition manager.
+    // 2. Even though partition::start() waits for STMs to apply local snapshots
+    // (and therefore have a recent-enough state), some STMs don't return
+    // a sensible max_collectible_offset until later. For example:
+    //   * rm_stm waits until it is replayed up to raft committed index
+    //   * archival_metadata_stm waits until the state is marked "clean"
+    //     (i.e. until the corresponding manifest is uploaded to the cloud).
+    //     Moreover, because the snapshot stores only the boolean "dirty" flag,
+    //     we can't reliably restore the "last clean at" offset just from the
+    //     snapshot.
+    try {
+        co_await ss::sleep_abortable(
+          config::shard_local_cfg().retention_local_trim_interval(), _as);
+    } catch (ss::sleep_aborted&) {
+        co_return;
+    }
 
     while (!_gate.is_closed()) {
         try {

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -384,6 +384,7 @@ private:
 
     eviction_policy _policy;
 
+    ss::abort_source _as;
     ss::gate _gate;
     ss::future<> run_loop();
     ssx::semaphore _control_sem{0, "resource_mgmt::space_manager"};

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -102,7 +102,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
                  .decommission_node(model::node_id(0))
                  .get();
     BOOST_REQUIRE(!err);
-    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+    RPTEST_REQUIRE_EVENTUALLY(60s, [&] {
         auto partition = app->partition_manager.local().get(ntp);
         return partition == nullptr;
     });
@@ -212,7 +212,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
                  .decommission_node(model::node_id(0))
                  .get();
     BOOST_REQUIRE(!err);
-    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+    RPTEST_REQUIRE_EVENTUALLY(60s, [&] {
         auto partition = app->partition_manager.local().get(ntp);
         return partition == nullptr;
     });

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5522,7 +5522,7 @@ class RedpandaService(RedpandaServiceBase):
                                          new_nodes,
                                          admin=None,
                                          min_partitions=5,
-                                         progress_timeout=30,
+                                         progress_timeout=60,
                                          timeout=300,
                                          backoff=2):
         """Waits until the rebalance triggered by adding new nodes is finished."""

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -665,6 +665,10 @@ class NodesDecommissioningTest(PreallocNodesTest):
     @parametrize(shutdown_decommissioned=True)
     @parametrize(shutdown_decommissioned=False)
     def test_decommissioning_rebalancing_node(self, shutdown_decommissioned):
+        # lower space management loop interval to make partition balancing
+        # start faster after node restart.
+        self.redpanda.add_extra_rp_conf(
+            {"retention_local_trim_interval": 5_000})
 
         # start 4 nodes
         self.redpanda.start(nodes=self.redpanda.nodes[0:4])
@@ -697,7 +701,7 @@ class NodesDecommissioningTest(PreallocNodesTest):
         to_decommission_id = self.redpanda.node_id(to_decommission)
         first_node = self.redpanda.nodes[0]
         wait_until(lambda: self._partitions_moving(node=first_node),
-                   timeout_sec=15,
+                   timeout_sec=30,
                    backoff_sec=1)
 
         # request decommission of newly added broker

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -1226,6 +1226,7 @@ class PartitionBalancerTest(PartitionBalancerService):
         self.start_producer(1)
         self.start_consumer(1)
         self.await_startup()
+        self.wait_until_ready()
 
         with self.NodeStopper(self) as ns:
             to_kill = random.choice(self.redpanda.nodes)


### PR DESCRIPTION
1. Delay calculating log data size on startup to allow partitions to fully load
2. Skip a node disk report if no log data size is present, but we expect it (i.e. if space management is enabled)

Fixes https://redpandadata.atlassian.net/browse/CORE-9582

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* Fix a bug that resulted in spurious partition balancer actions during rolling restart