### PR TITLE
Use client with static client_id in datalake throttling test

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -577,7 +577,8 @@ class KgoVerifierProducer(KgoVerifierService):
                  tolerate_data_loss=False,
                  tolerate_failed_produce=False,
                  tombstone_probability=0.0,
-                 validate_latest_values=False):
+                 validate_latest_values=False,
+                 client_name=None):
         super(KgoVerifierProducer,
               self).__init__(context, redpanda, topic, msg_size, custom_node,
                              debug_logs, trace_logs, username, password,
@@ -598,6 +599,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._tolerate_failed_produce = tolerate_failed_produce
         self._tombstone_probability = tombstone_probability
         self._validate_latest_values = validate_latest_values
+        self._client_name = client_name
 
     @property
     def produce_status(self):
@@ -665,11 +667,14 @@ class KgoVerifierProducer(KgoVerifierService):
     def is_complete(self):
         return self._status.acked >= self._msg_count
 
+    def client_name(self):
+        return self._client_name if self._client_name else self.who_am_i()
+
     def start_node(self, node, clean=False):
         if clean:
             self.clean_node(node)
 
-        cmd = f"{TESTS_DIR}/kgo-verifier --brokers {self._redpanda.brokers()} --topic {self._topic} --msg_size {self._msg_size} --produce_msgs {self._msg_count} --rand_read_msgs 0 --seq_read=0 --client-name {self.who_am_i()}"
+        cmd = f"{TESTS_DIR}/kgo-verifier --brokers {self._redpanda.brokers()} --topic {self._topic} --msg_size {self._msg_size} --produce_msgs {self._msg_count} --rand_read_msgs 0 --seq_read=0 --client-name {self.client_name()}"
 
         if self._username is not None:
             cmd = cmd + f' --username {self._username}'

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -17,6 +17,7 @@ from random import randint
 
 from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings, MetricsEndpoint
 from rptest.services.redpanda import CloudStorageType, SISettings
 from rptest.tests.redpanda_test import RedpandaTest
@@ -73,7 +74,15 @@ class DatalakeThrottlingTest(RedpandaTest):
         return total
 
     def producer_throttled(self, dl: DatalakeServices):
-        dl.produce_to_topic(self.topic_name, 128, 10240)
+        KgoVerifierProducer.oneshot(
+            self.test_ctx,
+            self.redpanda,
+            self.topic_name,
+            msg_size=1024,
+            msg_count=3 * 10240,
+            client_name="iceberg_producer",
+        )
+
         throttle = self._total_throttle()
         throttled_requests = self._throttled_requests()
         return throttle > 0 and throttled_requests > 0


### PR DESCRIPTION
Datalake throttling uses the client_id to verify if ProduceRequest may
contain topics which are iceberg enabled. If the producer previously
produced to the iceberg enabled throttling it may be doing it again and
it will be throttled. Using static client id makes the test robust.

Fixes: CORE-9671
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none