### PR TITLE
tests/write_caching: use smaller batches in write caching test

### DIFF
--- a/tests/rptest/tests/write_caching_fi_e2e_test.py
+++ b/tests/rptest/tests/write_caching_fi_e2e_test.py
@@ -104,7 +104,8 @@ class WriteCachingFailureInjectionE2ETest(RedpandaTest):
                                         self.topic_name,
                                         self.MSG_SIZE,
                                         num_msg_per_round,
-                                        use_transactions=use_transactions)
+                                        use_transactions=use_transactions,
+                                        batch_max_bytes=2048)
             total_produced += num_msg_per_round
 
             consumer.wait_total_reads(total_produced,


### PR DESCRIPTION
Use smaller batches in order to make the test more prone for the data loss. The reasoning behind this is to make the produce requests more frequent and by that making sure that more individual batches are pending flush.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none