### PR TITLE
archival: Fix archival_stm_snapshot installation

### DIFF
--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -656,7 +656,7 @@ ss::future<> archival_metadata_stm::make_snapshot(
       .start_kafka_offset = m.get_start_kafka_offset_override(),
       .spillover_manifests = std::move(spillover),
       .highest_producer_id = m.highest_producer_id(),
-      .applied_offset = m.get_applied_offset(),
+      .applied_offset = insync_offset,
     });
 
     auto snapshot = raft::stm_snapshot::create(

--- a/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_test.cc
@@ -348,6 +348,9 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
         .sname_format = cloud_storage::segment_name_format::v2,
       });
     m.advance_insync_offset(model::offset{42});
+    // When the snapshot is restored the applied offset is set to be
+    // equal to the insync offset of the snapshot.
+    m.advance_applied_offset(model::offset{42});
 
     BOOST_REQUIRE(m.advance_highest_producer_id(model::producer_id{1000}));
     BOOST_REQUIRE_EQUAL(m.highest_producer_id(), model::producer_id{1000});
@@ -376,7 +379,16 @@ FIXTURE_TEST(test_snapshot_loading, archival_metadata_stm_base_fixture) {
         m.serialize_json(s1);
         archival_stm->manifest().serialize_json(s2);
         vlog(logger.info, "original manifest: {}", s1.str());
+        vlog(
+          logger.info,
+          "original manifest applied offset: {}",
+          m.get_applied_offset());
         vlog(logger.info, "restored manifest: {}", s2.str());
+        vlog(logger.info, "restored manifest: {}", s2.str());
+        vlog(
+          logger.info,
+          "restored manifest applied offset: {}",
+          archival_stm->manifest().get_applied_offset());
     }
 
     BOOST_REQUIRE_EQUAL(archival_stm->get_start_offset(), model::offset{100});

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -245,8 +245,27 @@ ss::future<consensus_ptr> partition_manager::manage(
               dl_result.ot_state);
 
             // Initialize archival snapshot
-            co_await archival_metadata_stm::make_snapshot(
-              ntp_cfg, manifest, max_offset);
+            /*
+             [segment 1] [segment 2] [segment 3]
+                       ^                 ^
+                       |                 |
+                   last_offset      in-sync offset
+
+            Here the ISO is no longer correct because
+            it belongs to the old cluster. We're using last uploaded
+            offset to set up the snapshot.
+            */
+            if (max_offset != model::offset(0)) {
+                vlog(
+                  clusterlog.info,
+                  "Creating snapshot for {} partition, "
+                  "min_offset: {}, max_offset: {}",
+                  ntp_cfg.ntp(),
+                  min_offset,
+                  max_offset);
+                co_await archival_metadata_stm::make_snapshot(
+                  ntp_cfg, manifest, model::prev_offset(max_offset));
+            }
         }
     }
     auto translator_batch_types = raft::offset_translator_batch_types(

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -670,6 +670,8 @@ class ScalingUpTest(PreallocNodesTest):
         total_replicas = 3 * partition_count
         rpk.delete_topic(topic.name)
 
+        time.sleep(10)
+
         rpk.create_topic(topic.name,
                          partition_count,
                          3,


### PR DESCRIPTION
The code that installs the archival STM snapshot during the recovery uses the wrong offset to seed the in-sync offset of the STM (off by one). Because of that the STM may skip the first record batch (which is usually a raft_configuration batch which doesn't affect the archival STM).

Also, the last applied offset of the snapshot is seeded incorrectly using the last applied offset of the manifest. The commit fixes this by using last uploaded offset.

Finally, the commit fixes the ducktape test by adding a short sleep between the deletion of the topic and recovery of the topic. When this two operations are performed back to back it's possible for the recover to pick up different version of the manifest on different replicas. One of the replicas might be uploading the manifest concurrently while the topic is deleted and created which will lead to divergence. This is not a problem during the actual disaster recovery.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none