### PR TITLE
removed conflicting version requirements

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='hi@redpanda.com',
     description='redpanda internal testing',
     packages=find_packages(),
-    setup_requires=['setuptools', 'grpcio-tools==1.53'],
+    setup_requires=['setuptools'],
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Removing conflicting version requirements in setup file. We started seeing pip internal errors during setup:

```
==> redpanda-testing.amazon-ebs.ubuntu:     weights = get_topological_weights(
==> redpanda-testing.amazon-ebs.ubuntu:   File "/opt/.ducktape-venv/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 276, in get_topological_weights
==> redpanda-testing.amazon-ebs.ubuntu:     assert len(weights) == expected_node_count
==> redpanda-testing.amazon-ebs.ubuntu: AssertionError
```

Not yet clear what change affected it, could be internal pip packaging.. Also, we might need to upgrade our pip version since it is a bit outdated and yesterday we started seeing these failures.

In setup.py file I see two requirements with different versions.. 

The theory is that pip’s new resolver merged those conflicting grpcio‑tools pins into one graph node, dropped the duplicate during topological sorting, and then tripped the len(weights) == expected_node_count assertion.

Not 100% sure, but this might fix it. Also would make it more consistent.

JIRA: [DEVPROD-2868]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none


[DEVPROD-2868]: https://redpandadata.atlassian.net/browse/DEVPROD-2868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ