### PR TITLE
tests/upgrade: tolerate consumer restart in v22.x

### DIFF
--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -14,6 +14,7 @@ from packaging.version import Version
 
 from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
+from ducktape.errors import TimeoutError
 from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
@@ -223,6 +224,11 @@ class UpgradeBackToBackTest(PreallocNodesTest):
 
         wrote_at_least = 0
 
+        def restart_consumers():
+            for consumer in self._consumers:
+                consumer.stop()
+                consumer.start(clean=False)
+
         for current_version in self.upgrade_through_versions(self.versions):
             if not started:
                 # First version, start up the workload
@@ -247,7 +253,26 @@ class UpgradeBackToBackTest(PreallocNodesTest):
 
             # Wait for consumers to finish work and check invariants.
             for consumer in self._consumers:
-                consumer.wait()
+                max_retries = 5
+                while max_retries > 0:
+                    max_retries -= 1
+                    try:
+                        consumer.wait()
+                        break
+                    except Exception as e:
+                        # consumer status endpoint timeout, in v22 we need to tolerate the offset for leader epoch handler error
+                        if current_version[0] <= 22:
+                            self.logger.info(
+                                f"restarting consumer, Redpanda running {current_version} version"
+                            )
+                            try:
+                                consumer.stop()
+                            except Exception:
+                                self.logger.info(
+                                    f"failed to stop consumer {consumer}")
+                            consumer.start(clean=False)
+                        else:
+                            raise e
 
             # Check consumer invariants after each upgrade.
             assert self._seq_consumer.consumer_status.validator.valid_reads >= wrote_at_least
@@ -255,9 +280,7 @@ class UpgradeBackToBackTest(PreallocNodesTest):
             assert self._cg_consumer.consumer_status.validator.valid_reads >= wrote_at_least
 
             # Restart the consumers for the next upgrade.
-            for consumer in self._consumers:
-                consumer.stop()
-                consumer.start(clean=False)
+            restart_consumers()
 
         # Validate that the data structures written by a mixture of historical
         # versions remain readable by our current debug tools


### PR DESCRIPTION
In versions v22 we had a bug leading to incorrect offset being returned from OffsetForLeaderEpoch request handler. Added code that restarts the consumer in case it failed only during upgrades in version v22

Fixes: CORE-9747
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none