### PR TITLE
c/members_table: don't double-notify if node id was re-added

### DIFF
--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -327,7 +327,13 @@ void members_table::apply_snapshot(
     for (const auto& [id, node] : snap.removed_nodes) {
         vlog(clusterlog.trace, "removed node {} from snapshot", node.broker);
         _removed_nodes.emplace(id, node_metadata{node.broker, node.state});
-        notify_member_updated(id, model::membership_state::removed);
+        if (!_nodes.contains(id)) {
+            // If the node id is present in both maps, it means that the id was
+            // removed and later added (reverse order is impossible, as the
+            // removal command removes the id from _nodes). Therefore we don't
+            // need to notify the same id the second time here.
+            notify_member_updated(id, model::membership_state::removed);
+        }
     }
 
     // notify for changes in broker maintenance state

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -1308,3 +1308,69 @@ class NodeDecommissionSpaceManagementTest(RedpandaTest):
                                         progress_timeout=60)
         waiter.wait_for_removal()
         self.redpanda.stop_node(to_decommission)
+
+
+class NodeIdReuseTest(RedpandaTest):
+    """
+    Test reusing node id after decommissioning a node.
+    This is not recommended but should still work.
+    """
+    def __init__(self, test_context):
+        super(NodeIdReuseTest, self).__init__(test_context=test_context,
+                                              num_brokers=3)
+
+    def setup(self):
+        # defer starting redpanda to test body
+        pass
+
+    @cluster(num_nodes=3)
+    def test_node_status(self):
+        """
+        Reproducer for bug https://redpandadata.atlassian.net/browse/CORE-8625
+        """
+        self.redpanda.add_extra_rp_conf({'controller_snapshot_max_age_sec': 5})
+
+        orig_nodes = self.redpanda.nodes[0:2]
+        self.redpanda.start(nodes=orig_nodes, auto_assign_node_id=False)
+
+        admin = Admin(self.redpanda)
+        controller_id = admin.await_stable_leader("controller",
+                                                  namespace="redpanda",
+                                                  timeout_s=30)
+
+        controller = self.redpanda.get_node_by_id(controller_id)
+        for n in self.redpanda.started_nodes():
+            node_id = self.redpanda.node_id(n)
+            if node_id != controller_id:
+                other_node = n
+                other_node_id = node_id
+
+        self.logger.info(
+            f"decomming node {other_node.name} (id: {other_node_id})...")
+        admin.decommission_broker(other_node_id)
+        waiter = NodeDecommissionWaiter(self.redpanda,
+                                        node_id=other_node_id,
+                                        logger=self.logger)
+        waiter.wait_for_removal()
+
+        self.logger.info("re-adding the node")
+        self.redpanda.stop_node(other_node)
+        self.redpanda.clean_node(other_node, preserve_current_install=True)
+        self.redpanda.start_node(other_node, auto_assign_node_id=False)
+        self.redpanda.wait_for_membership(first_start=False)
+        # verify that the node id is reused
+        assert admin.get_node_config(other_node)["node_id"] == other_node_id
+
+        # wait until all controller commands are snapshotted
+        controller_offset = admin.get_controller_status(
+            controller)["dirty_offset"]
+        self.redpanda.wait_for_controller_snapshot(
+            controller, prev_start_offset=controller_offset)
+
+        self.logger.info("adding the last node")
+        joiner_node = self.redpanda.nodes[2]
+        self.redpanda.start_node(joiner_node, auto_assign_node_id=False)
+        self.redpanda.wait_for_membership(first_start=False)
+
+        brokers = admin.get_brokers(joiner_node)
+        assert all(b["is_alive"] for b in brokers)


### PR DESCRIPTION
If the node id is present both in _nodes and _removed_nodes, it means that the id was removed and later added (reverse order is impossible, as the removal command removes the id from _nodes). Therefore, when restoring from the controller snapshot, we only need to notify such ids with the "added" state.

Fixes https://redpandadata.atlassian.net/browse/CORE-8625

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* Fix a bug that resulted in brokers being reported with `is_alive=false` in the broker list returned by admin API if node ids were reused.