### PR TITLE
[v25.1.x] k/server: Adjust log levels in delete_records

### DIFF
--- a/src/v/kafka/server/handlers/delete_records.cc
+++ b/src/v/kafka/server/handlers/delete_records.cc
@@ -143,7 +143,7 @@ ss::future<result_t> prefix_truncate(
       kafka_truncation_offset, ss::lowres_clock::now() + timeout_ms);
     if (errc != error_code::none) {
         vlog(
-          klog.info,
+          klog.warn,
           "Possible failed attempted to truncate partition: {} error: {}",
           ktp,
           errc);
@@ -154,7 +154,7 @@ ss::future<result_t> prefix_truncate(
     /// until the local start offset was updated
     const auto kafka_start_offset = partition->start_offset();
     vlog(
-      klog.info,
+      klog.debug,
       "Truncated partition: {} to offset: {}",
       ktp,
       kafka_start_offset);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25856
