### PR TITLE
dl/coordinator: don't crash on missing table

### DIFF
--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -461,34 +461,23 @@ iceberg_file_committer::commit_topic_files_to_catalog(
         auto main_table_id = table_id_provider::table_id(topic);
         auto main_table_res = co_await catalog_.load_table(main_table_id);
         if (main_table_res.has_error()) {
-            switch (main_table_res.error()) {
-            case iceberg::catalog::errc::not_found:
-                vlog(
-                  datalake_log.debug,
-                  "Main table {} not found for committing from topic {}",
-                  main_table_id,
-                  topic);
-                break;
-            default:
-                co_return log_and_convert_catalog_errc(
-                  main_table_res.error(),
-                  fmt::format(
-                    "Error loading table {} for committing from topic {}",
-                    main_table_id,
-                    topic));
-            }
-        } else {
-            auto main_table_commit_builder_res = table_commit_builder::create(
-              cluster,
-              std::move(main_table_id),
-              std::move(main_table_res.value()),
-              !disable_snapshot_tags_());
-            if (main_table_commit_builder_res.has_error()) {
-                co_return main_table_commit_builder_res.error();
-            }
-            main_table_commit_builder = std::move(
-              main_table_commit_builder_res.value());
+            co_return log_and_convert_catalog_errc(
+              main_table_res.error(),
+              fmt::format(
+                "Error loading table {} for committing from topic {}",
+                main_table_id,
+                topic));
         }
+        auto main_table_commit_builder_res = table_commit_builder::create(
+          cluster,
+          std::move(main_table_id),
+          std::move(main_table_res.value()),
+          !disable_snapshot_tags_());
+        if (main_table_commit_builder_res.has_error()) {
+            co_return main_table_commit_builder_res.error();
+        }
+        main_table_commit_builder = std::move(
+          main_table_commit_builder_res.value());
     }
 
     // DLQ table (optional):
@@ -497,39 +486,23 @@ iceberg_file_committer::commit_topic_files_to_catalog(
         auto dlq_table_id = table_id_provider::dlq_table_id(topic);
         auto dlq_table_res = co_await catalog_.load_table(dlq_table_id);
         if (dlq_table_res.has_error()) {
-            switch (dlq_table_res.error()) {
-            case iceberg::catalog::errc::not_found:
-                vlog(
-                  datalake_log.debug,
-                  "DLQ table {} not found for committing from topic {}",
-                  dlq_table_id,
-                  topic);
-                // We ignore the DLQ table not found error and continue under
-                // the assumption that there are will be no DLQ files to commit.
-                // If such a file is found we'll return an error. Ideally we
-                // would load the table conditionally but for now we can't
-                // suspend/co_await here.
-                break;
-            default:
-                co_return log_and_convert_catalog_errc(
-                  dlq_table_res.error(),
-                  fmt::format(
-                    "Error loading table {} for committing from topic {}",
-                    dlq_table_id,
-                    topic));
-            }
-        } else {
-            auto dlq_table_commit_builder_res = table_commit_builder::create(
-              cluster,
-              std::move(dlq_table_id),
-              std::move(dlq_table_res.value()),
-              !disable_snapshot_tags_());
-            if (dlq_table_commit_builder_res.has_error()) {
-                co_return dlq_table_commit_builder_res.error();
-            }
-            dlq_table_commit_builder = std::move(
-              dlq_table_commit_builder_res.value());
+            co_return log_and_convert_catalog_errc(
+              dlq_table_res.error(),
+              fmt::format(
+                "Error loading table {} for committing from topic {}",
+                dlq_table_id,
+                topic));
         }
+        auto dlq_table_commit_builder_res = table_commit_builder::create(
+          cluster,
+          std::move(dlq_table_id),
+          std::move(dlq_table_res.value()),
+          !disable_snapshot_tags_());
+        if (dlq_table_commit_builder_res.has_error()) {
+            co_return dlq_table_commit_builder_res.error();
+        }
+        dlq_table_commit_builder = std::move(
+          dlq_table_commit_builder_res.value());
     }
 
     chunked_hash_map<model::partition_id, kafka::offset> pending_commits;

--- a/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
+++ b/src/v/datalake/coordinator/tests/iceberg_file_committer_test.cc
@@ -204,7 +204,8 @@ TEST_F(FileCommitterTest, TestMissingTable) {
     ASSERT_EQ(0, load_res.value().snapshots->size());
 
     // Now try again with some data.
-    state.topic_to_state[topic] = make_topic_state({{{0, 100}}});
+    state.topic_to_state[topic] = make_topic_state(
+      {{{0, 100}}}, /*added_at=*/model::offset{1000}, /*with_files=*/true);
     res = committer.commit_topic_files_to_catalog(topic, state).get();
     ASSERT_FALSE(res.has_error());
     ASSERT_EQ(1, res.value().size());
@@ -218,6 +219,27 @@ TEST_F(FileCommitterTest, TestMissingTable) {
     ASSERT_EQ(1, table.schemas[0].schema_struct.fields.size());
     ASSERT_EQ(1, table.partition_specs.size());
     ASSERT_EQ(1, table.partition_specs[0].fields.size());
+    ASSERT_TRUE(table.snapshots.has_value());
+    ASSERT_EQ(1, table.snapshots->size());
+
+    // Now drop the table and try to commit. This should fail, but at least
+    // shouldn't crash.
+    catalog.drop_table(table_ident, /*purge=*/true).get();
+    state.topic_to_state[topic] = make_topic_state(
+      {{{101, 200}}}, /*added_at=*/model::offset{1001}, /*with_files=*/true);
+    res = committer.commit_topic_files_to_catalog(topic, state).get();
+    ASSERT_TRUE(res.has_error());
+    ASSERT_EQ(res.error(), file_committer::errc::failed);
+
+    // And the same for the DLQ.
+    state.topic_to_state[topic] = make_topic_state(
+      {{{201, 300}}},
+      /*added_at=*/model::offset{1002},
+      /*with_files=*/true,
+      /*dlq=*/true);
+    res = committer.commit_topic_files_to_catalog(topic, state).get();
+    ASSERT_TRUE(res.has_error());
+    ASSERT_EQ(res.error(), file_committer::errc::failed);
 }
 
 TEST_F(FileCommitterTest, TestMissingTopic) {


### PR DESCRIPTION
There isn't a guarantee that between checkpointing some files and beginning to commit that the table hasn't been dropped. In this case, we could hit an assertion:

```
ERROR 2025-04-05 02:09:15,569 [shard 0:main] assert - Assert failure: (src/v/datalake/coordinator/iceberg_file_committer.cc:543) 'main_table_commit_builder.has_value()' Should have main table builder
```

Fixes this by instead returning an error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a crash that could happen when the underlying Iceberg table of an Iceberg Topic is dropped while the topic is being written to.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
