### PR TITLE
rptest: test consuming from two clusters sharing bucket

### DIFF
--- a/tests/rptest/tests/remote_label_test.py
+++ b/tests/rptest/tests/remote_label_test.py
@@ -7,10 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
 from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin, NamespacedTopic, InboundTopic
 from rptest.services.redpanda import RedpandaService, SISettings, get_cloud_storage_type, make_redpanda_service
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.tests.redpanda_test import RedpandaTest
@@ -26,18 +29,27 @@ class RemoteLabelsTest(RedpandaTest):
     Tests that exercise multiple clusters sharing a single bucket.
     """
     def __init__(self, test_context: TestContext):
-        extra_rp_conf = dict(cloud_storage_spillover_manifest_size=None,
-                             cloud_storage_topic_purge_grace_period_ms=1000)
+        self.extra_rp_conf = dict(
+            cloud_storage_spillover_manifest_size=None,
+            cloud_storage_topic_purge_grace_period_ms=1000,
+            retention_local_target_capacity_bytes=1024,
+            retention_local_trim_interval=1000,
+            log_compaction_interval_ms=100,
+            log_segment_ms_min=1000,
+            log_segment_ms=1000,
+        )
         super(RemoteLabelsTest, self).__init__(
             num_brokers=1,
             test_context=test_context,
-            extra_rp_conf=extra_rp_conf,
+            extra_rp_conf=self.extra_rp_conf,
             si_settings=SISettings(
                 test_context,
                 log_segment_size=1024,
                 fast_uploads=True,
                 cloud_storage_housekeeping_interval_ms=1000,
                 cloud_storage_spillover_manifest_max_segments=10))
+        self.redpanda.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"})
 
         # Set up si_settings so new clusters to reuse the same bucket.
         self.new_cluster_si_settings = SISettings(
@@ -57,14 +69,21 @@ class RemoteLabelsTest(RedpandaTest):
         new_cluster = make_redpanda_service(
             self.test_context,
             num_brokers=1,
-            si_settings=self.new_cluster_si_settings)
+            si_settings=self.new_cluster_si_settings,
+            extra_rp_conf=self.extra_rp_conf)
+        new_cluster.set_environment(
+            {"__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"})
         new_cluster.start()
         self.extra_clusters.append(new_cluster)
         return new_cluster
 
-    def create_topic(self, cluster: RedpandaService, topic_name: str) -> None:
+    def create_topic(self,
+                     cluster: RedpandaService,
+                     topic_name: str,
+                     partitions: int | None = None) -> None:
         spec = TopicSpec(name=topic_name,
-                         partition_count=self.partition_count,
+                         partition_count=self.partition_count
+                         if partitions is None else partitions,
                          replication_factor=1)
         DefaultClient(cluster).create_topic(spec)
 
@@ -92,7 +111,7 @@ class RemoteLabelsTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type())
-    def test_clusters_share_bucket(self, cloud_storage_type) -> None:
+    def test_share_bucket_delete_topic(self, cloud_storage_type) -> None:
         """
         cluster 1 creates topic_a
         cluster 2 creates topic_a
@@ -148,3 +167,115 @@ class RemoteLabelsTest(RedpandaTest):
         assert len(
             out_lines
         ) == num_records, f"output has {len(out_lines)} lines: {out}"
+
+    @cluster(num_nodes=2,
+             log_allow_list=[
+                 re.compile("No such file or directory.*cloud_storage_cache")
+             ])
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_share_bucket_concurrent_consume(self, cloud_storage_type) -> None:
+        """
+        - cluster 1 creates topic_a
+        - cluster 2 creates topic_a
+        - cluster 1 produces to topic_a with pattern X
+        - cluster 2 produces to topic_a with pattern Y
+        - both clusters continue producing until there are many segments in
+          cloud, and wait for local data to be reclaimed
+        - both clusters verify their workloads independently
+        - both clusters unmount and then mount the other clusters' topic
+        - verify the swapped workloads
+        """
+        topic_name = "topic-a"
+        c1 = self.redpanda
+        c2 = self.start_new_cluster()
+        self.create_topic(c1, topic_name, partitions=1)
+        self.create_topic(c2, topic_name, partitions=1)
+
+        # Produce different data to each topic.
+        rpk_c1 = RpkTool(c1)
+        rpk_c2 = RpkTool(c2)
+        num_msgs_per_round = 100
+        msg_len = 1024
+
+        def local_storage_trimmed(cluster: RedpandaService):
+            admin = Admin(cluster)
+            status = admin.get_partition_cloud_storage_status(topic_name, 0)
+            return status["local_log_start_offset"] > 0
+
+        def local_trimmed_or_produce():
+            # Once we trim local storage from both clusters, we're done.
+            if local_storage_trimmed(c1) and local_storage_trimmed(c2):
+                return True
+            for _ in range(num_msgs_per_round):
+                rpk_c1.produce(topic_name, key="1", msg="1" * msg_len)
+                rpk_c2.produce(topic_name, key="2", msg="2" * msg_len)
+            return False
+
+        # Keep producing until space management kicks out the local data.
+        wait_until(local_trimmed_or_produce, timeout_sec=30, backoff_sec=1)
+
+        def wipe_cloud_cache(cluster: RedpandaService):
+            cache_dir = cluster.cache_dir
+            cluster.for_nodes(cluster.nodes,
+                              lambda n: n.account.ssh(f"rm -rf {cache_dir}/*"))
+
+        # Wipe both clusters' cloud caches to ensure reads will go from S3.
+        wipe_cloud_cache(c1)
+        wipe_cloud_cache(c2)
+
+        def consume_topic(cluster: RedpandaService, missing_char):
+            rpk = RpkTool(cluster)
+
+            def partition_hwms():
+                return [
+                    p.high_watermark for p in rpk.describe_topic(topic_name)
+                ]
+
+            wait_until(lambda: len(partition_hwms()) == 1,
+                       timeout_sec=10,
+                       backoff_sec=1)
+
+            hwm = partition_hwms()[0]
+            assert hwm > 0, f"Expected non-zero hwm: {hwm}"
+            out = rpk.consume(topic_name, format="%k,%v\n", offset=0, n=hwm)
+            assert missing_char not in out, f"Expected missing '{missing_char}': {out}"
+
+            # Filter out empty lines and check we have as many records as the
+            # HWM claims.
+            rows = list(filter(None, out.split('\n')))
+            assert len(
+                rows) == hwm, f"Expected {hwm} rows: {len(rows)}, {rows}"
+
+        consume_topic(c1, missing_char="2")
+        consume_topic(c2, missing_char="1")
+
+        # Unmount the topics.
+        admin_c1 = Admin(c1)
+        admin_c2 = Admin(c2)
+        ns_topic = NamespacedTopic(topic_name)
+        admin_c1.unmount_topics([ns_topic])
+        admin_c2.unmount_topics([ns_topic])
+        c1_uuid = admin_c1.get_cluster_uuid()
+        c2_uuid = admin_c2.get_cluster_uuid()
+
+        wait_until(lambda: len(list(rpk_c1.list_topics())) == 0,
+                   timeout_sec=10,
+                   backoff_sec=1)
+        wait_until(lambda: len(list(rpk_c2.list_topics())) == 0,
+                   timeout_sec=10,
+                   backoff_sec=1)
+
+        # Remount them swapped.
+        admin_c1.mount_topics(
+            [InboundTopic(NamespacedTopic(f"{topic_name}/{c2_uuid}"))])
+        admin_c2.mount_topics(
+            [InboundTopic(NamespacedTopic(f"{topic_name}/{c1_uuid}"))])
+
+        wait_until(lambda: len(list(rpk_c1.list_topics())) == 1,
+                   timeout_sec=10,
+                   backoff_sec=1)
+        wait_until(lambda: len(list(rpk_c2.list_topics())) == 1,
+                   timeout_sec=10,
+                   backoff_sec=1)
+        consume_topic(c1, missing_char="1")
+        consume_topic(c2, missing_char="2")


### PR DESCRIPTION
Adds a test that sets up two clusters pointing at the same bucket, produces to both clusters, and then consumes from tiered storage from each.

This is a smoke test for shared clusters, which is useful to validate as more functionality is built out for multitenant clusters.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
