### PR TITLE
[v25.1.x] `storage`: check for exceptions in `log_manager::disk_usage()`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3841,13 +3841,49 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
      * compute the amount of current disk usage as well as the amount available
      * for being reclaimed.
      */
-    auto [usage, reclaim] = co_await disk_usage_and_reclaimable_space(cfg);
+    usage use;
+    reclaim_size_limits reclaim;
+
+    auto usage_and_reclaim_fut = co_await ss::coroutine::as_future(
+      disk_usage_and_reclaimable_space(cfg));
+
+    if (usage_and_reclaim_fut.failed()) {
+        // The disk usage/reclaimable space could not be computed for some
+        // reason. Return the used size, but with 0 bytes indicated as
+        // reclaimable.
+        auto e = usage_and_reclaim_fut.get_exception();
+        ss::semaphore limit(std::max<size_t>(
+          1,
+          config::shard_local_cfg()
+            .space_management_max_segment_concurrency()));
+
+        use = co_await ss::map_reduce(
+          _segs,
+          [&limit](const segment_set::type& seg) {
+              return ss::with_semaphore(
+                limit, 1, [&seg] { return seg->persistent_size(); });
+          },
+          usage{},
+          [](usage acc, usage u) { return acc + u; });
+
+        vlog(
+          gclog.warn,
+          "Unable to collect disk usage for ntp {}: {}, reporting usage of {} "
+          "with no reclaimable bytes",
+          config().ntp(),
+          e,
+          use.total());
+    } else {
+        auto usage_and_reclaim = usage_and_reclaim_fut.get();
+        use = usage_and_reclaim.first;
+        reclaim = usage_and_reclaim.second;
+    }
 
     /*
      * compute target capacities such as minimum required capacity as well as
      * capacities needed to meet goals such as local retention.
      */
-    auto target = co_await disk_usage_target(cfg, usage);
+    auto target = co_await disk_usage_target(cfg, use);
 
     /*
      * the intention here is to establish a needed <= wanted relationship which
@@ -3856,7 +3892,7 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
     target.min_capacity_wanted = std::max(
       target.min_capacity_wanted, target.min_capacity);
 
-    co_return usage_report(usage, reclaim, target);
+    co_return usage_report(use, reclaim, target);
 }
 
 fragmented_vector<ss::lw_shared_ptr<segment>>

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -1019,7 +1019,20 @@ ss::future<usage_report> log_manager::disk_usage() {
       logs.end(),
       [&limit, cfg](ss::shared_ptr<log> log) {
           return ss::with_semaphore(
-            limit, 1, [cfg, log] { return log->disk_usage(cfg); });
+                   limit, 1, [cfg, log] { return log->disk_usage(cfg); })
+            .then_wrapped([log](ss::future<usage_report> f) {
+                if (f.failed()) {
+                    auto e = f.get_exception();
+                    vlog(
+                      gclog.warn,
+                      "Unable to collect disk usage from ntp {}: {}",
+                      log->config().ntp(),
+                      e);
+                    return ss::make_ready_future<usage_report>();
+                } else {
+                    return f;
+                }
+            });
       },
       usage_report{},
       [](usage_report acc, usage_report update) { return acc + update; });

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5781,3 +5781,27 @@ FIXTURE_TEST(
       std::move(remove_ntp_fut))
       .get();
 }
+
+FIXTURE_TEST(disk_usage_with_log_throwing_exception, storage_test_fixture) {
+    storage::log_manager mgr = make_log_manager();
+    info("Configuration: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp_a = model::ntp("kafka", "a", 0);
+    auto log_a
+      = mgr.manage(storage::ntp_config(ntp_a, mgr.config().base_dir)).get();
+    auto ntp_b = model::ntp("kafka", "b", 0);
+    auto log_b
+      = mgr.manage(storage::ntp_config(ntp_b, mgr.config().base_dir)).get();
+
+    // Closing the housekeeping gate will cause log->disk_usage() to throw an
+    // exception.
+    auto* disk_log = static_cast<storage::disk_log_impl*>(log_b.get());
+    disk_log->gate().close().get();
+
+    // Check that the disk usage is still collected, even if one of the logs
+    // throws an exception for some reason.
+    BOOST_REQUIRE_NO_THROW(mgr.disk_usage().get());
+
+    // Reassign the gate so there is no double close().
+    disk_log->gate() = ss::gate{};
+};


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25833
