### PR TITLE
dl/file_writer: disable write_behinds

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -405,6 +405,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/iceberg:datatypes",
         "//src/v/iceberg:values",
+        "//src/v/resource_mgmt:io_priority",
         "@seastar",
     ],
 )

--- a/src/v/datalake/local_parquet_file_writer.cc
+++ b/src/v/datalake/local_parquet_file_writer.cc
@@ -13,6 +13,7 @@
 #include "base/units.h"
 #include "base/vlog.h"
 #include "datalake/logger.h"
+#include "resource_mgmt/io_priority.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
@@ -46,8 +47,18 @@ local_parquet_file_writer::initialize(const iceberg::struct_type& schema) {
         co_return writer_error::file_io_error;
     }
 
+    ss::file_output_stream_options opts;
+    // Minimal buffer size to flush aggressively and avoid buffering in
+    // memory.
+    opts.buffer_size = 4_KiB;
+    // No write behind because
+    // - data is appended to the stream batch wise linearly.
+    // - avoids per writer waiter allocations in the ss stream implementation
+    opts.write_behind = 0;
+    opts.io_priority_class = datalake_priority();
+
     auto fut = co_await ss::coroutine::as_future(
-      ss::make_file_output_stream(std::move(output_file)));
+      ss::make_file_output_stream(std::move(output_file), opts));
 
     if (fut.failed()) {
         vlog(


### PR DESCRIPTION
Avoids unnecessary allocation as described in https://github.com/redpanda-data/seastar/pull/189. Scale test with a lot of writers is accumulating memory from this code path. Since data is appended to the parquet file linearly (batch by batch and then column writer each), we do not really use any write behind semantics fwict.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
