### PR TITLE
Fix and enable fetch bench in nonrelease

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -353,7 +353,6 @@ def redpanda_cc_bench(
         duration = None,
         data = [],
         tags = [],
-        target_compatible_with = [],
         redirect_stderr = False):
     """
     Create a seastar benchmark target
@@ -372,7 +371,6 @@ def redpanda_cc_bench(
       data: any data files available to the benchmark as runfiles
       tags: custom tags for the test
       timeout: the timeout for smoke testing the benchmark
-      target_compatible_with: constraints for the test target
       redirect_stderr: if True, redirects stdout (seastar logging, mostly) to a file
                        so that it does not overwhelm the result output
     """
@@ -458,5 +456,4 @@ def redpanda_cc_bench(
         env = env | test_env,
         args = args + ["--iterations=1 --runs=1 --duration=0 --no-stdout --overprovisioned"],
         data = [":" + binary_name] + data + test_data,
-        target_compatible_with = target_compatible_with,
     )

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -814,10 +814,6 @@ redpanda_cc_bench(
     memory = "4GiB",
     runs = 1,
     tags = ["exclusive"],
-    target_compatible_with = select({
-        "//bazel:optimized_build": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
     deps = [
         ":kafka_test_utils",
         "//src/v/base",

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -805,14 +805,11 @@ redpanda_cc_gtest(
 
 redpanda_cc_bench(
     name = "kafka_fetch_rpbench",
-    timeout = "moderate",
     srcs = [
         "fetch_bench.cc",
     ],
     cpu = 2,
-    duration = 1,
     memory = "4GiB",
-    runs = 1,
     tags = ["exclusive"],
     deps = [
         ":kafka_test_utils",

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -222,7 +222,7 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
         // reconfigurations. Therefore waiting until there is no on-going
         // updates will let us know if the previous partition movements have
         // finished.
-        RPTEST_REQUIRE_EVENTUALLY_CORO(30s, [&topic_table] {
+        co_await tests::cooperative_spin_wait_with_timeout(30s, [&topic_table] {
             return !topic_table.has_updates_in_progress();
         });
 
@@ -260,8 +260,7 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
 
     // Creates a topic with a single partition that is on shard 0.
     ss::future<model::topic> initialize_single_partition_topic() {
-        auto t = co_await create_topic(
-          {model::broker_shard{model::node_id{0}, 0}});
+        auto t = co_await create_topic({model::broker_shard{this_node(), 0}});
         co_await produce_to_topic(t, 1, 1);
         co_return t;
     }
@@ -272,12 +271,14 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
         vassert(ss::smp::count >= 2, "requires at least 2 shards");
 
         auto t = co_await create_topic({
-          model::broker_shard{model::node_id{0}, 0},
-          model::broker_shard{model::node_id{0}, 1},
+          model::broker_shard{this_node(), 0},
+          model::broker_shard{this_node(), 1},
         });
         co_await produce_to_topic(t, 2, 1);
         co_return t;
     }
+
+    auto this_node() { return config::node().node_id().value(); }
 
     scoped_config test_local_cfg;
 };


### PR DESCRIPTION
Summary:

 - Make fetch_bench_fixture run in 4 seconds instead of 2 minutes.
 - Remove target_compatible_with support from rp_bench bazel build

### Simplification of `redpanda_cc_bench`:

* Removed the unused `target_compatible_with` parameter from the `redpanda_cc_bench` function in `bazel/test.bzl` and its associated documentation and usage. This parameter was no longer needed and has been cleaned up to simplify the function. [[1]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7L356) [[2]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7L375) [[3]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7L461)
* Removed `target_compatible_with` constraints from the `redpanda_cc_bench` invocation in `src/v/kafka/server/tests/BUILD`. This cleanup aligns with the removal of the parameter in the function definition.

### Improvements to `fetch_bench_fixture`:

* Replaced `RPTEST_REQUIRE_EVENTUALLY_CORO` with `cooperative_spin_wait_with_timeout` in `fetch_bench_fixture` to ensure the bench fails if the condition does not become true.
* Refactored topic creation logic in `fetch_bench_fixture` to use a new helper method `this_node()`, which uses the correct broker id (1) instead of the wrong one (0). [[1]](diffhunk://#diff-9012300a97cae46290b2d5b722fd7b741ffcbeabcb70f5a894735fbfefebaea5L263-R263) [[2]](diffhunk://#diff-9012300a97cae46290b2d5b722fd7b741ffcbeabcb70f5a894735fbfefebaea5L275-R282)


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
