### PR TITLE
[v25.1.x] tests/write_caching: limit number of messages sent in write caching test

### DIFF
--- a/tests/rptest/tests/write_caching_fi_e2e_test.py
+++ b/tests/rptest/tests/write_caching_fi_e2e_test.py
@@ -70,7 +70,7 @@ class WriteCachingFailureInjectionE2ETest(RedpandaTest):
         consumer.start()
 
         num_restart_rounds = 2
-        num_msg_per_round = 5000
+        num_msg_per_round = 1500
 
         # Transactions are slower, so we reduce the number of messages to
         # produce and consume to keep the test duration reasonable.


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25858
