### PR TITLE
test_macros: add fallback macros for non-g/btest

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -265,6 +265,7 @@ def redpanda_cc_btest(
         env = env,
         target_compatible_with = target_compatible_with,
         data = data,
+        local_defines = ["IS_BTEST"],
         tags = tags,
     )
 

--- a/src/v/test_utils/test_macros.h
+++ b/src/v/test_utils/test_macros.h
@@ -10,7 +10,24 @@
  */
 #pragma once
 
-#ifndef IS_GTEST
+// Here we define test assertion macros which are "portable" across gtest
+// and boot test frameworks. In a boost test or gtest test itself, you are
+// probably better of using the "native" macros directly, but in header files
+// which may be included from both test frameworks, these macros are useful.
+// They are also useful in the .cc files for fixtures which are used by
+// both frameworks.
+//
+// The decision to use the gtest macros or the boost test macros is made
+// based on the IS_GTEST or IS_BTEST macros. These are defined only for
+// the compilation of the test.cc file (and any headers included in that
+// TU), but not for other files, e.g., test helper or fixture code in another
+// .cc file. If neither macro is defined, we use a fallback implementation
+// based on vassert.
+//
+// The emulation is not exact, for example concepts like "add fail" do not
+// exist in boost or fallback vassert, so those fail immediately.
+
+#if defined(IS_BTEST)
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -24,7 +41,9 @@
 #define RPTEST_REQUIRE_NE(m, n) BOOST_REQUIRE_NE(m, n)
 #define RPTEST_REQUIRE_NE_CORO(m, n) BOOST_REQUIRE_NE(m, n)
 #define RPTEST_EXPECT_EQ(m, n) BOOST_REQUIRE_EQUAL(m, n)
-#else
+
+#elif defined(IS_GTEST)
+
 #include "test_utils/test.h"
 
 #define RPTEST_FAIL(m) FAIL() << (m)
@@ -37,4 +56,24 @@
 #define RPTEST_REQUIRE_NE(m, n) ASSERT_NE(m, n)
 #define RPTEST_REQUIRE_NE_CORO(m, n) ASSERT_NE_CORO(m, n)
 #define RPTEST_EXPECT_EQ(m, n) EXPECT_EQ(m, n)
+
+#else
+#include "base/vassert.h"
+
+// fallback macros using vassert
+
+// The fallback macros which accept messages only 1 object which can be
+// formatted via fmt::format, unlike the other macros which can accept <<
+// operator delimited strings.
+#define RPTEST_FAIL(m) vassert(false, "{}", m)
+#define RPTEST_ADD_FAIL(m) RPTEST_FAIL(m)
+#define RPTEST_FAIL_CORO(m) RPTEST_FAIL(m)
+#define RPTEST_REQUIRE(m) vassert(m, "RPTEST_REQUIRE assertion failed")
+#define RPTEST_REQUIRE_CORO(m) RPTEST_REQUIRE(m)
+#define RPTEST_REQUIRE_EQ(m, n) RPTEST_REQUIRE(m == n)
+#define RPTEST_REQUIRE_EQ_CORO(m, n) RPTEST_REQUIRE_EQ(m, n)
+#define RPTEST_REQUIRE_NE(m, n) RPTEST_REQUIRE(m != n)
+#define RPTEST_REQUIRE_NE_CORO(m, n) RPTEST_REQUIRE_NE(m, n)
+#define RPTEST_EXPECT_EQ(m, n) RPTEST_REQUIRE_EQ(m, n)
+
 #endif

--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -25,3 +25,15 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "test_utils_test",
+    timeout = "short",
+    srcs = [
+        "test_utils_test.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/test_utils/tests/test_utils_test.cc
+++ b/src/v/test_utils/tests/test_utils_test.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#ifndef IS_GTEST
+#error expected IS_GEST to be defined
+#endif
+
+// unset this so we test the fallback macros
+#undef IS_GTEST
+
+#include "test_utils/test_macros.h"
+
+#include <gtest/gtest.h>
+
+TEST(test_utils_test, test_macros_pass) {
+    RPTEST_REQUIRE(true);
+    RPTEST_REQUIRE_EQ(1, 1);
+    RPTEST_REQUIRE_NE(1, 2);
+    RPTEST_REQUIRE_EQ_CORO(1, 1);
+    RPTEST_REQUIRE_NE_CORO(1, 2);
+    RPTEST_EXPECT_EQ(1, 1);
+}
+
+TEST(test_utils_test, test_macros_fail) {
+    ASSERT_DEATH(RPTEST_FAIL("fail message"), "fail message");
+    ASSERT_DEATH(RPTEST_ADD_FAIL("fail message"), "fail message");
+    ASSERT_DEATH(RPTEST_FAIL_CORO("fail message"), "fail message");
+    ASSERT_DEATH(RPTEST_REQUIRE(false), "false");
+    ASSERT_DEATH(RPTEST_REQUIRE_EQ(1, 2), "1 == 2");
+    ASSERT_DEATH(RPTEST_REQUIRE_EQ_CORO(1, 2), "1 == 2");
+    ASSERT_DEATH(RPTEST_REQUIRE_NE(1, 1), "1 != 1");
+    ASSERT_DEATH(RPTEST_REQUIRE_NE_CORO(1, 1), "1 != 1");
+    ASSERT_DEATH(RPTEST_EXPECT_EQ(1, 2), "1 == 2");
+}


### PR DESCRIPTION
Test macros are used in the test framework to provide a consistent interface for test cases. The macros are used to define test assertions in a framework-neutral way. However, they currently always fall back to the boost macros if IS_GTEST is not defined, which means they are also compiled the "boost way" - but when not running in a boost test this silently does nothing.

This is pretty likely to occur in practice since IS_GTEST is only defined for the TU itself, but fixture and test utilility code is not compiled with this macro, so when used from a gtest the asserts do not fire. This also happens for benchmarks which use neither boost nor gtest.

In this change, we explicitly identify boost tests with IS_BTEST in a similar way to gtests, and add a fallback to the macros for non-gtest-non-boost case which uses vassert. This ensures that the test macros behave "correctly" more or less correctly regardless of the test framework being used or when no framework is being used.

This pull request introduces enhancements to the testing framework by adding support for Boost Test (`btest`) alongside the existing Google Test (`gtest`). It also includes fallback macros for scenarios where neither framework is available, ensuring broader compatibility and robustness in test utilities. Additionally, a new test suite is added to validate the macros' behavior.

### Enhancements to testing framework:

* **Support for Boost Test (`btest`)**:
  - Added the `IS_BTEST` macro to enable compatibility with Boost Test. This allows the use of Boost Test assertion macros, such as `BOOST_REQUIRE_NE` and `BOOST_REQUIRE_EQUAL`, when `IS_BTEST` is defined (`src/v/test_utils/test_macros.h`). [[1]](diffhunk://#diff-4487e13cb49b7d9550600aacbfcdf8965b30c2260c3fca526a1beceb2251d343L13-R30) [[2]](diffhunk://#diff-4487e13cb49b7d9550600aacbfcdf8965b30c2260c3fca526a1beceb2251d343L27-R46)
  - Updated `redpanda_cc_btest` to include the `IS_BTEST` macro in the `local_defines` parameter (`bazel/test.bzl`).

* **Fallback macros for environments without `gtest` or `btest`**:
  - Introduced fallback macros based on `vassert` for environments where neither `IS_GTEST` nor `IS_BTEST` is defined. These macros ensure basic assertion functionality, such as `RPTEST_REQUIRE_EQ` and `RPTEST_FAIL` (`src/v/test_utils/test_macros.h`).

### New test suite:

* **Validation of test macros**:
  - Added a new test file, `test_utils_test.cc`, to verify the behavior of the test macros in fallback configuration. The tests include both passing and failing assertions to ensure correctness (`src/v/test_utils/tests/test_utils_test.cc`).
  - Registered the new test suite in the build system using `redpanda_cc_gtest` (`src/v/test_utils/tests/BUILD`).


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
