### PR TITLE
[UX-104] rpk: differentiate fips connect package download

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,7 @@ common --@rules_python//python/config_settings:bootstrap_impl=script
 # By default build without CGO
 build --@rules_go//go/config:pure
 
-build:gofips --@rules_go//go/toolchain:sdk_name=go_sdk_with_systemcrypto
+build:gofips --//bazel:gofips=True --@rules_go//go/toolchain:sdk_name=go_sdk_with_systemcrypto
 build:gofips --@rules_go//go/config:pure=false
 
 # Improve caching and readability of filepaths that the compiler uses by not using

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,6 +1,18 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 bool_flag(
+    name = "gofips",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "gofips_enabled",
+    flag_values = {
+        ":gofips": "true",
+    },
+)
+
+bool_flag(
     name = "has_sanitizers",
     build_setting_default = False,
 )

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -29,6 +29,8 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
       - 'CGO_ENABLED={{ if index .Env "CGO_ENABLED" }}{{ .Env.CGO_ENABLED }}{{ else }}0{{ end }}'
+    tags:
+      - fips
     goos:
       - linux
     goarch:

--- a/src/go/rpk/cmd/rpk/BUILD
+++ b/src/go/rpk/cmd/rpk/BUILD
@@ -11,6 +11,10 @@ go_library(
 go_binary(
     name = "rpk",
     embed = [":rpk_lib"],
+    gotags = select({
+        "//bazel:gofips_enabled": ["fips"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     x_defs = {
         "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version": "{STABLE_GIT_LATEST_TAG}",

--- a/src/go/rpk/pkg/cli/connect/BUILD
+++ b/src/go/rpk/pkg/cli/connect/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//src/go/rpk/pkg/cobraext",
         "//src/go/rpk/pkg/config",
+        "//src/go/rpk/pkg/fips",
         "//src/go/rpk/pkg/httpapi",
         "//src/go/rpk/pkg/os",
         "//src/go/rpk/pkg/out",

--- a/src/go/rpk/pkg/cli/connect/client.go
+++ b/src/go/rpk/pkg/cli/connect/client.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/fips"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
 )
@@ -92,7 +93,11 @@ func newRepoClient() (*connectRepoClient, error) {
 
 func (c *connectRepoClient) Manifest(ctx context.Context) (*connectManifest, error) {
 	var manifest connectManifest
-	err := c.cl.Get(ctx, fmt.Sprintf("%v/connect/manifest.json", getPluginURL()), nil, &manifest)
+	path := fmt.Sprintf("%v/connect/manifest.json", getPluginURL())
+	if fips.IsEnabled() {
+		path = fmt.Sprintf("%v/connect-fips/manifest.json", getPluginURL())
+	}
+	err := c.cl.Get(ctx, path, nil, &manifest)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Redpanda Connect manifest: %v", err)
 	}

--- a/src/go/rpk/pkg/fips/BUILD
+++ b/src/go/rpk/pkg/fips/BUILD
@@ -1,0 +1,13 @@
+# gazelle:ignore
+# This file depends on a build tag and gazelle tries to edit this file.
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fips",
+    srcs = [
+        "disabled.go",
+        "enabled.go",
+    ],
+    importpath = "github.com/redpanda-data/redpanda/src/go/rpk/pkg/fips",
+    visibility = ["//visibility:public"],
+)

--- a/src/go/rpk/pkg/fips/disabled.go
+++ b/src/go/rpk/pkg/fips/disabled.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build !fips
+
+package fips
+
+func IsEnabled() bool {
+	return false
+}

--- a/src/go/rpk/pkg/fips/enabled.go
+++ b/src/go/rpk/pkg/fips/enabled.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+//go:build fips
+
+package fips
+
+func IsEnabled() bool {
+	return true
+}


### PR DESCRIPTION
This PR introduces a new package to detect whether the `fips` build tag is present, allowing us to identify FIPS builds of rpk.

It also updates the plugin download logic to support a separate namespace for FIPS-compatible connect binaries. These are now retrieved from:

```
https://rpk-plugins.redpanda.com/connect-fips/manifest.json
```

As a result, when running rpk-fips, the appropriate connect-fips plugin version will be downloaded automatically.

Fixes UX-104

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* rpk: FIPS versions of rpk will download the FIPS-compatible binaries of Redpanda Connect.
