### PR TITLE
iceberg/protobuf: fix uint32 conversion

### DIFF
--- a/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
@@ -667,3 +667,40 @@ TEST_CORO(values_protobuf, TestProto2FieldPresence) {
         Eq(std::nullopt),
         Eq(std::nullopt)));
 }
+
+TEST_CORO(values_protobuf, TestProto2Issue) {
+    proto2::Foo msg;
+    msg.set_a(123);
+    msg.set_b(456);
+    msg.set_c("bar");
+    msg.set_d(789);
+    msg.set_e(123.456);
+    msg.set_f(123);
+    msg.set_g("foo");
+    msg.set_h("baz");
+    msg.set_i("qux");
+    msg.set_j("thud");
+    msg.set_k("zing");
+
+    auto result = co_await serialize_and_convert(msg);
+    ASSERT_TRUE_CORO(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE_CORO(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    EXPECT_THAT(
+      struct_v->fields,
+      ElementsAre(
+        OptionalIcebergPrimitive<string_value>("123"),
+        OptionalIcebergPrimitive<string_value>("456"),
+        OptionalIcebergPrimitive<string_value>("bar"),
+        OptionalIcebergPrimitive<long_value>(789),
+        OptionalIcebergPrimitive<double_value>(123.456),
+        OptionalIcebergPrimitive<long_value>(123),
+        OptionalIcebergPrimitive<string_value>("foo"),
+        OptionalIcebergPrimitive<string_value>("baz"),
+        OptionalIcebergPrimitive<string_value>("qux"),
+        OptionalIcebergPrimitive<string_value>("thud"),
+        OptionalIcebergPrimitive<string_value>("zing")));
+}

--- a/src/v/iceberg/conversion/tests/testdata/proto2.proto
+++ b/src/v/iceberg/conversion/tests/testdata/proto2.proto
@@ -22,3 +22,17 @@ message MessageWithOptionalFields {
         bool oneof_bool = 14;
     }
 }
+
+message Foo {
+    optional uint64 a = 1;
+    optional uint64 b = 2;
+    optional string c = 3;
+    optional uint32 d = 4;
+    optional double e = 5;
+    optional uint32 f = 6;
+    optional string g = 7;
+    optional string h = 8;
+    optional string i = 9;
+    optional string j = 10;
+    optional string k = 11;
+}

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -259,8 +259,12 @@ ss::future<optional_value_outcome> single_field_to_value(
           std::move(field),
           field_descriptor,
           &pb::FieldDescriptor::default_value_float);
-    // casting uint32 to long value to prevent overflow
     case pb::FieldDescriptor::TYPE_UINT32:
+        // casting uint32 to long value to prevent overflow
+        co_return convert<uint32_t, iceberg::long_value>(
+          std::move(field),
+          field_descriptor,
+          &pb::FieldDescriptor::default_value_uint32);
     case pb::FieldDescriptor::TYPE_FIXED32:
     case pb::FieldDescriptor::TYPE_SFIXED64:
     case pb::FieldDescriptor::TYPE_INT64:


### PR DESCRIPTION
The holder type is incorrect, it needs to be uint32, then cast.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes conversion of protobuf uint32 types to iceberg long types.
