### PR TITLE
r/tests: run raft tests in parallel

### DIFF
--- a/src/v/raft/tests/BUILD
+++ b/src/v/raft/tests/BUILD
@@ -144,7 +144,6 @@ redpanda_cc_btest(
     srcs = [
         "bootstrap_configuration_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":simple_record_fixture",
         "//src/v/config",
@@ -188,7 +187,6 @@ redpanda_cc_btest(
     srcs = [
         "consensus_utils_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":simple_record_fixture",
         "//src/v/config",
@@ -214,7 +212,6 @@ redpanda_cc_gtest(
     srcs = [
         "group_configuration_tests.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":simple_record_fixture",
         "//src/v/base",
@@ -243,7 +240,6 @@ redpanda_cc_gtest(
         "snapshot_recovery_test.cc",
     ],
     cpu = 1,
-    tags = ["exclusive"],
     deps = [
         ":raft_fixture",
         ":raft_fixture_retry_policy",
@@ -266,7 +262,6 @@ redpanda_cc_btest(
     srcs = [
         "foreign_entry_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/model",
         "//src/v/model/tests:random",
@@ -354,7 +349,6 @@ redpanda_cc_gtest(
     srcs = [
         "membership_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":raft_fixture",
         ":raft_fixture_retry_policy",
@@ -375,7 +369,6 @@ redpanda_cc_gtest(
     srcs = [
         "leadership_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":raft_fixture",
         "//src/v/finjector",
@@ -393,7 +386,6 @@ redpanda_cc_gtest(
     srcs = [
         "state_removal_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         ":raft_fixture",
         ":raft_fixture_retry_policy",
@@ -413,7 +405,6 @@ redpanda_cc_btest(
     srcs = [
         "offset_monitor_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/base",
         "//src/v/raft",
@@ -430,7 +421,6 @@ redpanda_cc_btest(
     srcs = [
         "mutex_buffer_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/raft",
         "//src/v/ssx:sformat",
@@ -450,7 +440,6 @@ redpanda_cc_btest(
     srcs = [
         "configuration_manager_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/base",
         "//src/v/config",
@@ -514,7 +503,6 @@ redpanda_cc_gtest(
     srcs = [
         "stm_manager_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/raft/tests:raft_fixture_retry_policy",
         "//src/v/raft/tests:stm_raft_fixture",
@@ -558,7 +546,6 @@ redpanda_cc_gtest(
     ],
     cpu = 4,
     memory = "6GiB",
-    tags = ["exclusive"],
     deps = [
         "//src/v/base",
         "//src/v/bytes",
@@ -588,7 +575,6 @@ redpanda_cc_gtest(
     srcs = [
         "persisted_stm_test.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/model",
         "//src/v/raft",
@@ -613,7 +599,6 @@ redpanda_cc_gtest(
     srcs = [
         "replication_monitor_tests.cc",
     ],
-    tags = ["exclusive"],
     deps = [
         "//src/v/model",
         "//src/v/raft/tests:raft_fixture",


### PR DESCRIPTION
Removed `exclusive` attribute from Raft tests to run them in parallel. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none