### PR TITLE
`storage`: log on skipping partition compaction due to dirty ratio

### DIFF
--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -318,6 +318,13 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
                 return true;
             }
 
+            vlog(
+              gclog.trace,
+              "{}: dirty ratio ({}) < min.cleanable.dirty.ratio ({}), skipping "
+              "compaction.",
+              l->config().ntp(),
+              dirty_ratio,
+              min_cleanable_dirty_ratio);
             return false;
         };
 


### PR DESCRIPTION
It may be confusing for users/developers who have enabled `TRACE` logging for `storage-gc` to see that certain partitions are not being considered for compaction without any indication as to why (especially if they are `grep`'ing for a specific `ntp`).

Add a `TRACE` level log to indicate when a log is not going to be compacted due to its dirty ratio value being less than `min.cleanable.dirty.ratio`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
