### PR TITLE
[v24.3.x] datalake: finish writers even on error

### DIFF
--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -208,9 +208,6 @@ record_multiplexer::operator()(model::record_batch batch) {
 
 ss::future<result<record_multiplexer::write_result, writer_error>>
 record_multiplexer::end_of_stream() {
-    if (_error) {
-        co_return *_error;
-    }
     if (!_result) {
         // no batches were processed.
         co_return writer_error::no_data;


### PR DESCRIPTION
Backport [#25215](https://github.com/redpanda-data/redpanda/pull/25215)

CONFLICT:
- finish() in this branch is end_of_stream()

We could previously crash due to improperly closing our writers:

```
WARN  2025-02-28 03:17:08,881 [shard 1:data] datalake - {kafka/structured_tp_4/0} - record_multiplexer.cc:198 - Error ensuring table schema for record 507
WARN  2025-02-28 03:17:08,881 [shard 1:data] datalake - translation_task.cc:233 - Error writing data files - Data Writer Error:1
WARN  2025-02-28 03:17:08,881 [shard 1:data] datalake - {kafka/structured_tp_4/0}-term-1 - partition_translator.cc:339 - Error translating range local file IO error
redpanda: external/_main~non_module_dependencies~seastar/include/seastar/core/iostream.hh:420: seastar::output_stream<char>::~output_stream() [CharType = char]: Assertion `!_end && !_zc_bufs && "Was this stream properly closed?"' failed.
...
seastar::output_stream<char>::~output_stream() at ??:?
serde::parquet::writer::impl::~impl() at ??:?
std::__2::default_delete<serde::parquet::writer::impl>::operator()[abi:ne180100](serde::parquet::writer::impl*) const at writer.cc:?
std::__2::unique_ptr<serde::parquet::writer::impl, std::__2::default_delete<serde::parquet::writer::impl> >::reset[abi:ne180100](serde::parquet::writer::impl*) at writer.cc:?
std::__2::unique_ptr<serde::parquet::writer::impl, std::__2::default_delete<serde::parquet::writer::impl> >::~unique_ptr[abi:ne180100]() at writer.cc:?
serde::parquet::writer::~writer() at ??:?
datalake::serde_parquet_writer::~serde_parquet_writer() at ??:?
datalake::serde_parquet_writer::~serde_parquet_writer() at ??:?
std::__2::default_delete<datalake::parquet_ostream>::operator()[abi:ne180100](datalake::parquet_ostream*) const at local_parquet_file_writer.cc:?
std::__2::unique_ptr<datalake::parquet_ostream, std::__2::default_delete<datalake::parquet_ostream> >::reset[abi:ne180100](datalake::parquet_ostream*) at local_parquet_file_writer.cc:?
std::__2::unique_ptr<datalake::parquet_ostream, std::__2::default_delete<datalake::parquet_ostream> >::~unique_ptr[abi:ne180100]() at local_parquet_file_writer.cc:?
datalake::local_parquet_file_writer::~local_parquet_file_writer() at ??:?
datalake::local_parquet_file_writer::~local_parquet_file_writer() at ??:?
std::__2::default_delete<datalake::parquet_file_writer>::operator()[abi:ne180100](datalake::parquet_file_writer*) const at partition_translator.cc:?
std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> >::reset[abi:ne180100](datalake::parquet_file_writer*) at partition_translator.cc:?
std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> >::~unique_ptr[abi:ne180100]() at partition_translator.cc:?
std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >::~pair() at ??:?
_ZNSt3__212__destroy_atB8ne180100INS_4pairIN7iceberg13partition_keyENS_10unique_ptrIN8datalake19parquet_file_writerENS_14default_deleteIS6_EEEEEETnNS_9enable_ifIXntsr8is_arrayIT_EE5valueEiE4typeELi0EEEvPSC_ at partition_translator.cc:?
void std::__2::allocator_traits<std::__2::allocator<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > > > >::destroy[abi:ne180100]<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_
file_writer> > >, void, void>(std::__2::allocator<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > > >&, std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >*) at ??:
?
std::__2::vector<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >, std::__2::allocator<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > > > >::__base_destruct_at_
end[abi:ne180100](std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >*) at partition_translator.cc:?
std::__2::vector<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >, std::__2::allocator<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > > > >::__clear[abi:ne18010
0]() at partition_translator.cc:?
std::__2::vector<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >, std::__2::allocator<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > > > >::__destroy_vector::o
perator()[abi:ne180100]() at partition_translator.cc:?
std::__2::vector<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > >, std::__2::allocator<std::__2::pair<iceberg::partition_key, std::__2::unique_ptr<datalake::parquet_file_writer, std::__2::default_delete<datalake::parquet_file_writer> > > > >::~vector[abi:ne18010
0]() at partition_translator.cc:?
...
```

The issue appears to be that when there is an error in multiplexing we previously early exited out of the finish() method, which meant that we destructed our writers without finishing them.

(cherry picked from commit 25cc05ba43ae1f616350503e0228eb0cbfc803a4)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a crash that could happen when an error occurred during translation in an Iceberg Topic.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
