### PR TITLE
iceberg/protobuf: fix fixed32 conversions

### DIFF
--- a/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
@@ -668,19 +668,20 @@ TEST_CORO(values_protobuf, TestProto2FieldPresence) {
         Eq(std::nullopt)));
 }
 
-TEST_CORO(values_protobuf, TestProto2Issue) {
-    proto2::Foo msg;
-    msg.set_a(123);
-    msg.set_b(456);
-    msg.set_c("bar");
-    msg.set_d(789);
-    msg.set_e(123.456);
-    msg.set_f(123);
-    msg.set_g("foo");
-    msg.set_h("baz");
-    msg.set_i("qux");
-    msg.set_j("thud");
-    msg.set_k("zing");
+TEST_CORO(values_protobuf, TestProtoNumbers) {
+    proto2::NumericScalars msg;
+    msg.set_a(3.14);
+    msg.set_b(53.4f);
+    msg.set_c(5234);
+    msg.set_d(12342542);
+    msg.set_e(52345235);
+    msg.set_f(45353453435);
+    msg.set_g(-234234);
+    msg.set_h(-2342352435);
+    msg.set_i(23453245);
+    msg.set_j(4234234);
+    msg.set_k(-234234);
+    msg.set_l(-234234342);
 
     auto result = co_await serialize_and_convert(msg);
     ASSERT_TRUE_CORO(result.has_value());
@@ -692,15 +693,16 @@ TEST_CORO(values_protobuf, TestProto2Issue) {
     EXPECT_THAT(
       struct_v->fields,
       ElementsAre(
-        OptionalIcebergPrimitive<string_value>("123"),
-        OptionalIcebergPrimitive<string_value>("456"),
-        OptionalIcebergPrimitive<string_value>("bar"),
-        OptionalIcebergPrimitive<long_value>(789),
-        OptionalIcebergPrimitive<double_value>(123.456),
-        OptionalIcebergPrimitive<long_value>(123),
-        OptionalIcebergPrimitive<string_value>("foo"),
-        OptionalIcebergPrimitive<string_value>("baz"),
-        OptionalIcebergPrimitive<string_value>("qux"),
-        OptionalIcebergPrimitive<string_value>("thud"),
-        OptionalIcebergPrimitive<string_value>("zing")));
+        OptionalIcebergPrimitive<double_value>(3.14),
+        OptionalIcebergPrimitive<float_value>(53.4f),
+        OptionalIcebergPrimitive<int_value>(5234),
+        OptionalIcebergPrimitive<long_value>(12342542),
+        OptionalIcebergPrimitive<long_value>(52345235),
+        OptionalIcebergPrimitive<string_value>("45353453435"),
+        OptionalIcebergPrimitive<int_value>(-234234),
+        OptionalIcebergPrimitive<long_value>(-2342352435),
+        OptionalIcebergPrimitive<long_value>(23453245),
+        OptionalIcebergPrimitive<string_value>("4234234"),
+        OptionalIcebergPrimitive<int_value>(-234234),
+        OptionalIcebergPrimitive<long_value>(-234234342)));
 }

--- a/src/v/iceberg/conversion/tests/testdata/proto2.proto
+++ b/src/v/iceberg/conversion/tests/testdata/proto2.proto
@@ -23,16 +23,17 @@ message MessageWithOptionalFields {
     }
 }
 
-message Foo {
-    optional uint64 a = 1;
-    optional uint64 b = 2;
-    optional string c = 3;
-    optional uint32 d = 4;
-    optional double e = 5;
-    optional uint32 f = 6;
-    optional string g = 7;
-    optional string h = 8;
-    optional string i = 9;
-    optional string j = 10;
-    optional string k = 11;
+message NumericScalars {
+    optional double a = 1;
+    optional float b = 2;
+    optional int32 c = 3;
+    optional int64 d = 4;
+    optional uint32 e = 5;
+    optional uint64 f = 6;
+    optional sint32 g = 7;
+    optional sint64 h = 8;
+    optional fixed32 i = 9;
+    optional fixed64 j = 10;
+    optional sfixed32 k = 11;
+    optional sfixed64 l = 12;
 }

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -260,12 +260,12 @@ ss::future<optional_value_outcome> single_field_to_value(
           field_descriptor,
           &pb::FieldDescriptor::default_value_float);
     case pb::FieldDescriptor::TYPE_UINT32:
+    case pb::FieldDescriptor::TYPE_FIXED32:
         // casting uint32 to long value to prevent overflow
         co_return convert<uint32_t, iceberg::long_value>(
           std::move(field),
           field_descriptor,
           &pb::FieldDescriptor::default_value_uint32);
-    case pb::FieldDescriptor::TYPE_FIXED32:
     case pb::FieldDescriptor::TYPE_SFIXED64:
     case pb::FieldDescriptor::TYPE_INT64:
     case pb::FieldDescriptor::TYPE_SINT64:


### PR DESCRIPTION
And add tests to exhaustively test all the options here

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
