### PR TITLE
[v25.1.x] Introduced `raft::state_machine` initial recovery policy

### DIFF
--- a/src/v/cloud_topics/dl_stm/dl_stm.h
+++ b/src/v/cloud_topics/dl_stm/dl_stm.h
@@ -26,6 +26,11 @@ public:
 
     dl_stm(ss::logger&, raft::consensus*);
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 private:
     ss::future<> do_apply(const model::record_batch& batch) override;
 

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -289,6 +289,11 @@ public:
         return _remote_path_provider;
     }
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 private:
     ss::future<bool>
     do_sync(model::timeout_clock::duration timeout, ss::abort_source* as);

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -351,6 +351,11 @@ public:
         co_return _num_partitions.value();
     }
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 private:
     static constexpr model::partition_id routing_partition{0};
     static constexpr std::chrono::seconds sync_timeout{5};

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -49,6 +49,11 @@ public:
     ss::future<stm_allocation_result>
     reset_next_id(int64_t, model::timeout_clock::duration timeout);
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 private:
     // legacy structs left for backward compatibility with the "old"
     // on-disk log format

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -108,6 +108,11 @@ public:
 
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 protected:
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;

--- a/src/v/cluster/partition_properties_stm.h
+++ b/src/v/cluster/partition_properties_stm.h
@@ -49,6 +49,11 @@ public:
     // Returns a current value of the writes disabled property.
     writes_disabled are_writes_disabled() const;
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::skip_to_end;
+    }
+
 protected:
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -227,6 +227,11 @@ public:
 
     ss::future<tx::errc> abort_all_txes();
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 protected:
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -356,6 +356,11 @@ public:
     checked<tx_metadata, tm_stm::op_status>
     reset_transaction_state(tx_metadata& tx);
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 protected:
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 

--- a/src/v/datalake/coordinator/state_machine.h
+++ b/src/v/datalake/coordinator/state_machine.h
@@ -48,6 +48,11 @@ public:
 
     const topics_state& state() const { return state_; }
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 protected:
     ss::future<> stop() override;
 

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -91,6 +91,11 @@ public:
       model::timeout_clock::duration timeout,
       ss::abort_source&);
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::skip_to_end;
+    }
+
 private:
     struct snapshot
       : serde::envelope<snapshot, serde::version<1>, serde::compat_version<0>> {

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -125,6 +125,11 @@ public:
 
     const all_txs_t& inflight_transactions() const { return _all_txs; }
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
 private:
     static constexpr int8_t supported_local_snapshot_version = 1;
     struct snapshot

--- a/src/v/raft/state_machine_base.cc
+++ b/src/v/raft/state_machine_base.cc
@@ -45,4 +45,14 @@ ss::future<> state_machine_base::wait(
     co_await _waiters.wait(offset, timeout, as);
 }
 
+std::ostream&
+operator<<(std::ostream& o, const stm_initial_recovery_policy& p) {
+    switch (p) {
+    case stm_initial_recovery_policy::read_everything:
+        return o << "read_everything";
+    case stm_initial_recovery_policy::skip_to_end:
+        return o << "skip_to_end";
+    }
+}
+
 } // namespace raft

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -24,6 +24,28 @@ using snapshot_at_offset_supported
 class consensus;
 
 /**
+ * Class defining the state machine behavior when it is created for the first
+ * time for a given partition.
+ *
+ * There are two possible policies:
+ *
+ *  - read_everything - when there is no other state the state machine will
+ *                      starts its existence with next offset set to the
+ *                      beginning of the local log. Be careful as read
+ *                      everything may lead to a large amount of data being
+ *                      read on startup.
+ *
+ *   - skip_to_end    - when there is no other state the state machine will
+ *                      start reading from the first confirmed committed offset
+ *                      (see state machine manager implementation for the
+ *                      detailed description).
+ */
+enum class stm_initial_recovery_policy : uint8_t {
+    read_everything = 0,
+    skip_to_end = 1,
+};
+
+/**
  * State machine interface. The class provides an interface that must be
  * implemented to build state machine that can be registered in
  * state_machine_manager.
@@ -97,6 +119,15 @@ public:
         return snapshot_at_offset_supported::yes;
     }
 
+    /**
+     * Returns state machine configured initial recovery policy. The default
+     * policy is to read everything as this is the basic behavior of the state
+     * machine
+     */
+    virtual stm_initial_recovery_policy get_initial_recovery_policy() const {
+        return stm_initial_recovery_policy::read_everything;
+    }
+
 protected:
     /**
      * Must always be called under apply mutex scope and apply_units argument
@@ -129,7 +160,7 @@ private:
     mutable offset_monitor<model::offset> _waiters;
     model::offset _next{0};
 };
-
+std::ostream& operator<<(std::ostream&, const stm_initial_recovery_policy&);
 /**
  * This flavor of state machine base allows implementer to opt out from taking
  * snapshot at arbitrary offset. This way a partition that the STM is based on

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -120,13 +120,9 @@ public:
     }
 
     /**
-     * Returns state machine configured initial recovery policy. The default
-     * policy is to read everything as this is the basic behavior of the state
-     * machine
+     * Returns state machine configured initial recovery policy.
      */
-    virtual stm_initial_recovery_policy get_initial_recovery_policy() const {
-        return stm_initial_recovery_policy::read_everything;
-    }
+    virtual stm_initial_recovery_policy get_initial_recovery_policy() const = 0;
 
 protected:
     /**

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -162,7 +162,11 @@ state_machine_manager::state_machine_manager(
   consensus* raft, std::vector<named_stm> stms, ss::scheduling_group apply_sg)
   : _raft(raft)
   , _log(ctx_log(_raft->group(), _raft->ntp()))
-  , _apply_sg(apply_sg) {
+  , _apply_sg(apply_sg)
+  , _initial_recovery_snapshot_mgr(
+      std::filesystem::path(_raft->log_config().work_directory()),
+      "stm_manager.snapshot",
+      ss::default_priority_class()) {
     for (auto& n_stm : stms) {
         _supports_snapshot_at_offset
           = _supports_snapshot_at_offset
@@ -219,6 +223,8 @@ ss::future<> state_machine_manager::start() {
       _log.debug,
       "started state machine manager with initial next offset: {}",
       _next);
+    // it safe to update next here as the apply loop didn't start yet.
+    co_await apply_initial_recovery_policy();
     ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _as.abort_requested(); }, [this] { return apply(); });
@@ -237,6 +243,113 @@ ss::future<> state_machine_manager::stop() {
     co_await ss::coroutine::parallel_for_each(
       _machines, [](auto p) { return p.second->stm->stop(); });
     co_await std::move(gate_f);
+}
+
+ss::future<> state_machine_manager::apply_initial_recovery_policy() {
+    auto snapshot = co_await read_initial_recovery_snapshot();
+    if (!snapshot) {
+        /**
+         * If snapshot is not available create one, it will be populated during
+         * initial recovery
+         */
+        vlog(_log.debug, "no initial recovery snapshot found");
+        snapshot.emplace(initial_recovery_snapshot{});
+    }
+    vlog(_log.debug, "Starting with initial recovery snapshot: {}", *snapshot);
+    for (auto& [name, entry] : _machines) {
+        auto it = snapshot->initial_recovery_next_offsets.find(name);
+        if (it != snapshot->initial_recovery_next_offsets.end()) {
+            const auto init_recovery_offset = it->second;
+            vlog(
+              _log.debug,
+              "skipping initial recovery for {} state machine as it was "
+              "recovered from snapshot",
+              name);
+            if (
+              entry->stm->next() > model::offset{0}
+              && entry->stm->next() < init_recovery_offset) {
+                vlog(
+                  _log.error,
+                  "State machine '{}' has next offset set to {} which is "
+                  "less than the snapshot offset {}. Skipping initial "
+                  "recovery.",
+                  name,
+                  entry->stm->next(),
+                  init_recovery_offset);
+                continue;
+            }
+            entry->stm->set_next(
+              std::max(init_recovery_offset, entry->stm->next()));
+            continue;
+        }
+        // Stm needs initial recovery
+        const auto policy = entry->stm->get_initial_recovery_policy();
+        vlog(
+          _log.info,
+          "Applying '{}' initial recovery policy for '{}' state machine",
+          policy,
+          name);
+        switch (policy) {
+        case stm_initial_recovery_policy::read_everything:
+            snapshot->initial_recovery_next_offsets.emplace(
+              name, model::offset{0});
+            continue;
+        case stm_initial_recovery_policy::skip_to_end:
+            /**
+             * special case of a state machine that already existed in the
+             * previous version but the initial policy logic wasn't there yet
+             */
+            if (entry->stm->next() > model::offset{0}) {
+                vlog(
+                  _log.info,
+                  "State machine '{}' already has next offset set to {}",
+                  name,
+                  entry->stm->next());
+                snapshot->initial_recovery_next_offsets.emplace(
+                  name, model::offset{0});
+                continue;
+            }
+            /**
+             * Here we apply the skip to end policy.
+             *
+             * The policy leverages the fact that the _next offset is already
+             * established as all local snapshots from the other state machines
+             * were already applied.
+             *
+             * We must not use the log end offset here as the end offset may
+             * change with the truncation as it haven't yet been committed in
+             * Raft sense.
+             *
+             * The `_next` is safe as it is based on the last applied offset of
+             * the other state machines i.e. the `_next` offset is already
+             * committed.
+             *
+             * This policy comes with the trade off. The newly added state
+             * machines will not actually rewind to the physical end of the log.
+             * But will read a small part of it.
+             */
+            vlog(
+              _log.info,
+              "Setting next offset: {} for: '{}' state machine as a part of "
+              "initial recovery policy.",
+              _next,
+              name);
+            entry->stm->set_next(_next);
+            /**
+             * Initial recovery finished, marked as done in the snapshot.
+             */
+            snapshot->initial_recovery_next_offsets.emplace(
+              name, entry->stm->next());
+        }
+    }
+
+    // clean up offsets from state machines that are not longer present in the
+    // manager but are still in the initial recovery snapshot.
+    absl::erase_if(
+      snapshot->initial_recovery_next_offsets,
+      [this](const auto& pair) { return !_machines.contains(pair.first); });
+
+    co_await write_initial_recovery_snapshot(std::move(*snapshot));
 }
 
 std::vector<state_machine_manager::entry_ptr>
@@ -663,6 +776,92 @@ ss::future<> state_machine_manager::remove_local_state() {
     co_await ss::coroutine::parallel_for_each(_machines, [](auto entry_pair) {
         return entry_pair.second->stm->remove_local_state();
     });
+    co_await _initial_recovery_snapshot_mgr.remove_snapshot();
 }
 
+ss::future<std::optional<state_machine_manager::initial_recovery_snapshot>>
+state_machine_manager::read_initial_recovery_snapshot() {
+    auto reader = co_await _initial_recovery_snapshot_mgr.open_snapshot();
+    if (!reader) {
+        co_return std::nullopt;
+    }
+
+    auto md_buffer_f = co_await ss::coroutine::as_future(
+      reader->read_metadata());
+
+    if (md_buffer_f.failed()) {
+        auto e = md_buffer_f.get_exception();
+        vlog(
+          _log.error,
+          "failed to read initial recovery snapshot metadata: {}",
+          e);
+        co_await reader->close();
+        std::rethrow_exception(e);
+    }
+
+    auto snap_sz_f = co_await ss::coroutine::as_future(
+      reader->get_snapshot_size());
+    if (snap_sz_f.failed()) {
+        auto e = snap_sz_f.get_exception();
+        vlog(
+          _log.error, "failed to read initial recovery snapshot size: {}", e);
+        co_await reader->close();
+        std::rethrow_exception(e);
+    }
+    auto snapshot_content_f = co_await ss::coroutine::as_future(
+      read_iobuf_exactly(reader->input(), snap_sz_f.get()));
+
+    if (snapshot_content_f.failed()) {
+        auto e = snapshot_content_f.get_exception();
+        vlog(_log.error, "failed to read recovery snapshot: {}", e);
+        co_await reader->close();
+        std::rethrow_exception(e);
+    }
+    co_await reader->close();
+
+    co_await _initial_recovery_snapshot_mgr.remove_partial_snapshots();
+    co_return serde::from_iobuf<initial_recovery_snapshot>(
+      std::move(snapshot_content_f.get()));
+}
+
+ss::future<> state_machine_manager::write_initial_recovery_snapshot(
+  initial_recovery_snapshot snap) {
+    vlog(_log.trace, "writing initial recovery snapshot: {}", snap);
+    auto writer = co_await _initial_recovery_snapshot_mgr.start_snapshot();
+
+    auto md_f = co_await ss::coroutine::as_future(
+      writer.write_metadata(iobuf{}));
+    if (md_f.failed()) {
+        auto e = md_f.get_exception();
+        vlog(
+          _log.error,
+          "failed to write initial recovery snapshot metadata: {}",
+          e);
+        co_await writer.close();
+        std::rethrow_exception(e);
+    }
+
+    auto data_f = co_await ss::coroutine::as_future(
+      write_iobuf_to_output_stream(
+        serde::to_iobuf(std::move(snap)), writer.output()));
+    if (data_f.failed()) {
+        auto e = data_f.get_exception();
+        vlog(
+          _log.error, "failed to write initial recovery snapshot data: {}", e);
+        co_await writer.close();
+        std::rethrow_exception(e);
+    }
+
+    co_await writer.close();
+    co_await _initial_recovery_snapshot_mgr.finish_snapshot(writer);
+}
+
+std::ostream& operator<<(
+  std::ostream& o, const state_machine_manager::initial_recovery_snapshot& s) {
+    fmt::print(
+      o,
+      "{{ initial_recovery_next_offsets: {} }}",
+      s.initial_recovery_next_offsets);
+    return o;
+}
 } // namespace raft

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -139,6 +139,31 @@ private:
         ss::sstring name;
         stm_ptr stm;
     };
+    /**
+     * Initial recovery snapshot is used by the state machine manager to store
+     * the information about the State Machines initial recovery. This way a
+     * state machine manager can skip to the end the log for the state machines
+     * that require that.
+     */
+    struct initial_recovery_snapshot
+      : serde::checksum_envelope<
+          initial_recovery_snapshot,
+          serde::version<0>,
+          serde::compat_version<0>> {
+        friend bool operator==(
+          const initial_recovery_snapshot&, const initial_recovery_snapshot&)
+          = default;
+
+        auto serde_fields() { return std::tie(initial_recovery_next_offsets); }
+
+        // The initial recovery offset map contains the initial next offset for
+        // each state machine that has been added to the manager.
+        absl::flat_hash_map<ss::sstring, model::offset>
+          initial_recovery_next_offsets;
+    };
+
+    friend std::ostream&
+    operator<<(std::ostream&, const initial_recovery_snapshot&);
 
     state_machine_manager(
       consensus* raft,
@@ -189,6 +214,17 @@ private:
     std::vector<entry_ptr> all_state_machines() const;
     model::offset max_next_offset() const;
     model::offset last_applied() const { return model::prev_offset(_next); }
+
+    ss::future<> apply_initial_recovery_policy();
+
+    /**
+     * Methods to access/write the local state machine manager snapshot. The
+     * snapshot is currently used to maintain the state of initial recovery for
+     * state machines.
+     */
+    ss::future<std::optional<initial_recovery_snapshot>>
+    read_initial_recovery_snapshot();
+    ss::future<> write_initial_recovery_snapshot(initial_recovery_snapshot);
     /**
      * Simple data structure allowing manager to store independent snapshot
      * for each of the STMs
@@ -220,6 +256,7 @@ private:
     ss::abort_source _as;
     ss::scheduling_group _apply_sg;
     snapshot_at_offset_supported _supports_snapshot_at_offset{true};
+    storage::simple_snapshot_manager _initial_recovery_snapshot_mgr;
 };
 
 /**

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -66,6 +66,7 @@ struct kv_state
             } else {
                 remove(op.key);
             }
+            valid_op_cnt++;
             return true;
         }
     }
@@ -103,6 +104,7 @@ struct kv_state
             } else {
                 kv_map.erase(it);
             }
+            valid_op_cnt++;
             return true;
         }
 
@@ -111,14 +113,16 @@ struct kv_state
 
     state_t kv_map;
 
-    friend bool operator==(const kv_state&, const kv_state&) = default;
+    friend bool operator==(const kv_state& lhs, const kv_state& rhs) {
+        return lhs.kv_map == rhs.kv_map;
+    }
     friend std::ostream& operator<<(std::ostream& o, const kv_state& st) {
         for (auto& [k, v] : st.kv_map) {
             fmt::print(o, "{}={}, ", k, v);
         }
         return o;
     }
-
+    size_t valid_op_cnt{0};
     auto serde_fields() { return std::tie(kv_map); }
 };
 
@@ -988,4 +992,124 @@ TEST_F_CORO(persisted_stm_test_fixture, test_application_on_lagging_replica) {
     auto added_stm = builder.create_stm<other_persisted_kv>(n);
     co_await n.start(std::move(builder));
     co_await wait_for_apply();
+}
+
+class start_from_end_stm : public persisted_kv {
+public:
+    static constexpr std::string_view name = "start_from_end_stm";
+    explicit start_from_end_stm(raft_node_instance& rn)
+      : persisted_kv(rn, false, "start_from_end_stm_kv_stm_snapshot") {}
+
+    ss::future<> apply_raft_snapshot(const iobuf& buffer) override {
+        if (buffer.empty()) {
+            co_return;
+        }
+        state = serde::from_iobuf<kv_state>(buffer.copy());
+        co_return;
+    };
+    stm_initial_recovery_policy get_initial_recovery_policy() const override {
+        return stm_initial_recovery_policy::skip_to_end;
+    }
+    // This STM only counts the number of apply function calls
+    ss::future<> do_apply(const model::record_batch& batch) override {
+        if (batch.header().type != model::record_batch_type::raft_data) {
+            co_return;
+        }
+        apply_count++;
+    }
+};
+
+/**
+ * This test initializes raft group with only one stm applies some data and
+ * takes local snapshot.
+ *
+ * After that all the replicas are stopped and two more state machines are added
+ * to the raft group.
+ *
+ * The two state machines uses different initialization policies. Finally the
+ * test verifies if the state machines were applied with expected batches.
+ */
+TEST_F(persisted_stm_test_fixture, test_persisted_stm_recovery_policy) {
+    initialize_state_machines().get();
+    kv_state expected;
+    auto ops = random_operations(2000);
+    for (auto batch : ops) {
+        apply_operations(expected, std::move(batch)).get();
+    }
+    wait_for_apply().get();
+    for (const auto& [_, stm] : node_stms) {
+        ASSERT_EQ(stm->state, expected);
+    }
+
+    take_local_snapshot_on_every_node().get();
+    auto ops_to_snapshot = expected.valid_op_cnt;
+    auto ops_phase_two = random_operations(2000);
+    for (auto batch : ops) {
+        apply_operations(expected, std::move(batch)).get();
+    }
+    absl::flat_hash_map<model::node_id, ss::sstring> data_directories;
+    for (auto& [id, node] : nodes()) {
+        data_directories[id] = node->raft()->log()->config().base_directory();
+    }
+
+    std::vector<ss::shared_ptr<other_persisted_kv>> full_read_stms;
+    std::vector<ss::shared_ptr<start_from_end_stm>> short_read_stms;
+    auto restart_with_new_state_machines = [&] {
+        full_read_stms.clear();
+        short_read_stms.clear();
+        for (auto& [id, data_dir] : data_directories) {
+            stop_node(id).get();
+            add_node(id, model::revision_id(0), data_dir);
+        }
+
+        /**
+         * Now add the state machines and restart the replicas.
+         */
+        for (auto& [id, node] : nodes()) {
+            node->initialise(all_vnodes()).get();
+            raft::state_machine_manager_builder builder;
+            auto stm = builder.create_stm<persisted_kv>(*node);
+            full_read_stms.push_back(
+              builder.create_stm<other_persisted_kv>(*node));
+            short_read_stms.push_back(
+              builder.create_stm<start_from_end_stm>(*node));
+
+            node->start(std::move(builder)).get();
+            node_stms.insert_or_assign(node->get_vnode(), std::move(stm));
+        }
+    };
+
+    restart_with_new_state_machines();
+    wait_for_apply().get();
+    // the base stm state must not change
+    for (auto& [_, stm] : node_stms) {
+        ASSERT_EQ(stm->state, expected);
+    }
+
+    for (auto& stm : full_read_stms) {
+        ASSERT_EQ(stm->apply_count, expected.valid_op_cnt);
+    }
+
+    for (auto& stm : short_read_stms) {
+        ASSERT_EQ(stm->apply_count, expected.valid_op_cnt - ops_to_snapshot);
+    }
+    /**
+     * Verify that initial recovery policy is respected after local snapshot
+     * removal
+     */
+
+    // remove the state machines local snapshots
+    for (auto& stm : node_stms) {
+        stm.second->remove_local_state().get();
+    }
+    // restart state machines
+    restart_with_new_state_machines();
+    wait_for_apply().get();
+    for (auto& stm : full_read_stms) {
+        ASSERT_EQ(stm->apply_count, expected.valid_op_cnt);
+    }
+
+    for (auto& stm : short_read_stms) {
+        ASSERT_EQ(stm->apply_count, expected.valid_op_cnt - ops_to_snapshot);
+    }
 }

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -289,6 +289,11 @@ public:
         throw_on_apply = should_throw;
     }
 
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const override {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
     bool throw_on_apply = false;
     kv_state state;
     kv_operation last_operation;
@@ -522,6 +527,11 @@ public:
         co_await validate_applied_offsets(applied_offset_before);
         co_return stm_snapshot::create(
           0, last_applied_offset(), serde::to_iobuf(_last_stm_applied));
+    }
+
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
     }
 
 private:

--- a/src/v/raft/tests/stm_manager_test.cc
+++ b/src/v/raft/tests/stm_manager_test.cc
@@ -578,6 +578,10 @@ public:
     ss::future<iobuf> take_snapshot() final {
         co_return serde::to_iobuf(state);
     }
+
+    stm_initial_recovery_policy get_initial_recovery_policy() const override {
+        return stm_initial_recovery_policy::read_everything;
+    }
 };
 
 TEST_F_CORO(state_machine_fixture, test_opt_out_from_snapshot_at_offset) {

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -151,6 +151,10 @@ public:
 
         co_return serde::to_iobuf(std::move(inc_state));
     };
+
+    stm_initial_recovery_policy get_initial_recovery_policy() const override {
+        return stm_initial_recovery_policy::read_everything;
+    }
 };
 using wait_for_each_batch = ss::bool_class<struct wait_for_each_tag>;
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5474,6 +5474,22 @@ class RedpandaService(RedpandaServiceBase):
         else:
             return None
 
+    def estimate_total_disk_bytes_read(self):
+        try:
+            samples = self.metrics_sample(
+                "vectorized_io_queue_total_read_bytes_total",
+                nodes=self.started_nodes())
+        except Exception as e:
+            self.logger.warn(
+                f"Cannot check metrics, did a test finish with all nodes down? ({e})"
+            )
+            return None
+
+        if samples is not None and samples.samples:
+            return sum(s.value for s in samples.samples)
+        else:
+            return None
+
     def wait_node_add_rebalance_finished(self,
                                          new_nodes,
                                          admin=None,

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -10,7 +10,9 @@ import datetime
 import re
 import time
 import random
+from rptest.clients.default import DefaultClient, TopicSpec
 from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from random import randint
 import json
@@ -30,6 +32,8 @@ from rptest.services.metrics_check import MetricCheck
 from rptest.services.catalog_service import CatalogType
 from google import protobuf
 from google.protobuf import text_format as pb_text_format, json_format as pb_json_format
+
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class AvroSchema:
@@ -952,3 +956,100 @@ class DatalakeMetricsTest(RedpandaTest):
                 timeouts_metric, MetricsEndpoint.PUBLIC_METRICS) > 0,
                        timeout_sec=30,
                        backoff_sec=1)
+
+
+class DatalakeDelayedEnablementTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        super(DatalakeDelayedEnablementTest, self).__init__(
+            test_ctx,
+            num_brokers=3,
+            si_settings=SISettings(test_context=test_ctx),
+            extra_rp_conf={
+                "iceberg_catalog_commit_interval_ms": 5000,
+                "log_compaction_interval_ms": 2000,
+                "storage_target_replay_bytes": 5 * 1024 * 1024
+            },
+            schema_registry_config=SchemaRegistryConfig(),
+            pandaproxy_config=PandaproxyConfig(),
+            environment={
+                "__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"
+            },
+            *args,
+            **kwargs)
+        self.test_ctx = test_ctx
+
+    def setUp(self):
+        pass
+
+    def is_topic_fully_caught_up(self, topic_name: str):
+        admin = Admin(self.redpanda)
+        partitions = admin.get_partitions(topic=topic_name)
+
+        for p in partitions:
+            p_id = p['partition_id']
+            status = admin.get_partition_state("kafka",
+                                               topic=topic_name,
+                                               partition=p['partition_id'])
+            for replica in status['replicas']:
+                c_index = replica['raft_state']['commit_index']
+                for stm in replica['raft_state']['stms']:
+                    self.logger.debug(
+                        f"{topic_name}/{p_id} state machine: {stm['name']} on: {replica['raft_state']['node_id']} last_applied_offset: {stm['last_applied_offset']}"
+                    )
+                    if stm['last_applied_offset'] < c_index:
+                        return False
+
+        return True
+
+    @cluster(num_nodes=6)
+    # this test doesn't have to run with different catalog types
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=[CatalogType.REST_JDBC])
+    @skip_debug_mode
+    def test_enabling_iceberg_in_existing_cluster(self, cloud_storage_type,
+                                                  catalog_type):
+        count = 100
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=catalog_type) as dl:
+
+            topic = TopicSpec(name="delayed-iceberg-topic",
+                              partition_count=3,
+                              replication_factor=3,
+                              segment_bytes=1024 * 1024,
+                              redpanda_remote_read=False,
+                              redpanda_remote_write=False)
+
+            DefaultClient(dl.redpanda).create_topic(topic)
+
+            # produce ~120 MiB to the topic
+            dl.produce_to_topic(topic.name, 1024, 120 * 1024)
+            # wait for a while for the local snapshot to be taken
+            time.sleep(5)
+            dl.redpanda.restart_nodes(dl.redpanda.nodes)
+
+            def wait_for_topic(topic_name: str):
+                wait_until(lambda: self.is_topic_fully_caught_up(topic_name),
+                           timeout_sec=30,
+                           backoff_sec=1,
+                           err_msg=f"Error waiting for topic {topic_name} \
+                        state machines to catch up")
+
+            wait_for_topic(topic.name)
+            bytes_read_before = self.redpanda.estimate_total_disk_bytes_read()
+
+            # enable iceberg, this will restart the cluster
+            dl.redpanda.set_cluster_config({"iceberg_enabled": True},
+                                           expect_restart=True)
+
+            wait_for_topic(topic.name)
+            bytes_read_after = self.redpanda.estimate_total_disk_bytes_read()
+
+            self.logger.info(
+                f"Bytes read before: {bytes_read_before}, bytes read after: {bytes_read_after}"
+            )
+            # we introduce a small tolerance here, since the read bytes may
+            # increase slightly due to term changes and leader elections.
+            assert bytes_read_after <= bytes_read_before * 1.01,\
+            f"Enabling Iceberg in the cluster should not cause a major read increase"

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -14,6 +14,7 @@ from packaging.version import Version
 
 from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
+from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -27,7 +28,7 @@ from rptest.util import (
     produce_until_segments,
     wait_until_segments,
 )
-from rptest.utils.mode_checks import skip_fips_mode
+from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
 from rptest.utils.si_utils import BucketView
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SISettings, CloudStorageType, get_cloud_storage_type
@@ -658,3 +659,92 @@ class RedpandaInstallerTest(RedpandaTest):
             version = self.redpanda._installer.highest_from_prior_feature_version(
                 version)
             limit = limit - 1
+
+
+class UpgradeAndCheckRecoveryReads(RedpandaTest):
+    """
+    Tests that validates the amount of bytes read after the upgrade
+    """
+    def __init__(self, test_context):
+        super(UpgradeAndCheckRecoveryReads, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            extra_rp_conf={
+                # setup Redpanda to take the local snapshots eagerly
+                "log_compaction_interval_ms": 2000,
+                "storage_target_replay_bytes": 130 * 1024 * 1024
+            },
+            environment={
+                "__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"
+            })
+        self.installer = self.redpanda._installer
+
+    def setUp(self):
+        self.prev_version = \
+            self.installer.highest_from_prior_feature_version(RedpandaInstaller.HEAD)
+
+        self.installer.install(self.redpanda.nodes, self.prev_version)
+        super(UpgradeAndCheckRecoveryReads, self).setUp()
+
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @skip_debug_mode
+    def test_basic_upgrade(self):
+        topic = TopicSpec(partition_count=3,
+                          replication_factor=3,
+                          segment_bytes=1024 * 1024)
+
+        DefaultClient(self.redpanda).create_topic(topic)
+        msg_size = 64 * 1024
+        total_bytes = 135 * 1024 * 1024
+        msg_cnt = int(total_bytes / msg_size)
+
+        KgoVerifierProducer.oneshot(self.test_context,
+                                    self.redpanda,
+                                    topic.name,
+                                    msg_size,
+                                    msg_cnt,
+                                    batch_max_bytes=msg_size * 8,
+                                    timeout_sec=120)
+        # wait for a while to give redpanda time to create a local snapshot for
+        # the state machines
+        time.sleep(5)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        read_before_upgrade = self.redpanda.estimate_total_disk_bytes_read(
+        ) / len(self.redpanda.nodes)
+        node = self.redpanda.nodes[0]
+        initial_version = Version(self.redpanda.get_version(node))
+
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        # wait for the cluster to stabilize, and any necessary recovery to finish
+        time.sleep(5)
+        read_after_upgrade = self.redpanda.estimate_total_disk_bytes_read(
+        ) / len(self.redpanda.nodes)
+
+        def to_mib_str(bytes):
+            return f"{bytes / (1024 * 1024):.2f} MiB"
+
+        head_version_str = self.redpanda.get_version(node)
+        head_version = Version(head_version_str)
+        assert initial_version < head_version, f"{initial_version} vs {head_version}"
+
+        unique_versions = wait_for_num_versions(self.redpanda, 1)
+        assert head_version_str in unique_versions, unique_versions
+        # With the upgrade we are adding new features so the amount of recovery
+        # reads may increase slightly. Now we allow it to be up to 10 % larger post upgrade.
+        after_upgrade_read_increase_ratio = 1.10
+        self.logger.info(
+            f"Recovery bytes read: [before upgrade: {to_mib_str(read_before_upgrade)} MiB, after upgrade: {to_mib_str(read_after_upgrade)} MiB] "
+        )
+        assert read_after_upgrade <= read_before_upgrade * after_upgrade_read_increase_ratio, \
+            f"Bytes read for recovery after upgrade {to_mib_str(read_after_upgrade)} is exceeding the allowed {to_mib_str(after_upgrade_read_increase_ratio * read_before_upgrade)}"
+
+        # restart once
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        read_after_restart = self.redpanda.estimate_total_disk_bytes_read(
+        ) / len(self.redpanda.nodes)
+        # wait for the cluster to stabilize, and any necessary recovery to finish
+        time.sleep(5)
+        assert read_after_restart <= 1.01*read_after_upgrade, \
+            f"Bytes read for recovery after restart {to_mib_str(read_after_restart)} is exceeding the initial read after upgrade {to_mib_str(1.01*read_after_upgrade)}"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25840
