### PR TITLE
CORE-9903 crash_tracker: improve diagnostics on backtrace failure

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -212,7 +212,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "hz3QOymiw+wcbn410QZohmLH4wgvrmZEfGbSKitaxAI=",
+        "bzlTransitiveDigest": "zeVh9jz8NxWJEFV5nxz4uzVBn3nNPb951lh46efMXJ0=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -378,9 +378,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "integrity": "sha256-4gYdTu6AFv6mR1kdXeendKxd6YhNT/DCBCBB/tvn7F4=",
-              "strip_prefix": "seastar-d260e40702d1a95fd6393c652aa44deadfd0b6bc",
-              "url": "https://github.com/redpanda-data/seastar/archive/d260e40702d1a95fd6393c652aa44deadfd0b6bc.tar.gz"
+              "integrity": "sha256-ttlG4lNYD9VNKzUeshYwvUm6LJWlRyryMsDQlZGowQA=",
+              "strip_prefix": "seastar-398be413afad0b6fca48b5d781c9bd9bf10033ff",
+              "url": "https://github.com/redpanda-data/seastar/archive/398be413afad0b6fca48b5d781c9bd9bf10033ff.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -161,9 +161,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        integrity = "sha256-4gYdTu6AFv6mR1kdXeendKxd6YhNT/DCBCBB/tvn7F4=",
-        strip_prefix = "seastar-d260e40702d1a95fd6393c652aa44deadfd0b6bc",
-        url = "https://github.com/redpanda-data/seastar/archive/d260e40702d1a95fd6393c652aa44deadfd0b6bc.tar.gz",
+        integrity = "sha256-ttlG4lNYD9VNKzUeshYwvUm6LJWlRyryMsDQlZGowQA=",
+        strip_prefix = "seastar-398be413afad0b6fca48b5d781c9bd9bf10033ff",
+        url = "https://github.com/redpanda-data/seastar/archive/398be413afad0b6fca48b5d781c9bd9bf10033ff.tar.gz",
     )
 
     http_archive(

--- a/src/v/crash_tracker/signals.cc
+++ b/src/v/crash_tracker/signals.cc
@@ -9,9 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+#include "crash_tracker/logger.h"
 #include "crash_tracker/recorder.h"
 
 #include <seastar/core/smp.hh>
+#include <seastar/util/backtrace.hh>
+#include <seastar/util/log.hh>
 #include <seastar/util/print_safe.hh>
 
 namespace crash_tracker {
@@ -69,15 +72,34 @@ void install_oneshot_signal_handler() {
     }).get();
 }
 
-void sigsegv_action() {
+static void maybe_print_backtrace(std::string_view signal_msg) noexcept {
+    if (ctlog.is_enabled(ss::log_level::debug)) {
+        ss::print_safe(signal_msg.data(), signal_msg.size());
+        ss::print_safe(":\n");
+        ss::backtrace(
+          [](const ss::frame& f) {
+              ss::print_safe("0x");
+              ss::print_zero_padded_hex_safe(f.addr);
+              ss::print_safe(" in ");
+              ss::print_safe(f.so->name.c_str());
+              ss::print_safe("\n");
+          },
+          true);
+    }
+}
+
+static void sigsegv_action() noexcept {
+    maybe_print_backtrace("Segmentation fault");
     constexpr auto signo = crash_tracker::recorder::recorded_signo::sigsegv;
     crash_tracker::get_recorder().record_crash_sighandler(signo);
 }
 void sigabrt_action() {
+    maybe_print_backtrace("Aborting");
     constexpr auto signo = crash_tracker::recorder::recorded_signo::sigabrt;
     crash_tracker::get_recorder().record_crash_sighandler(signo);
 }
 void sigill_action() {
+    maybe_print_backtrace("Illegal instruction");
     constexpr auto signo = crash_tracker::recorder::recorded_signo::sigill;
     crash_tracker::get_recorder().record_crash_sighandler(signo);
 }

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -25,10 +25,11 @@ CRASH_LOOP_LOG = [
 
 SIGNAL_CRASH_LOG = [
     "Aborting on",
+    "Aborting:",
     "Segmentation fault on",
-    "Segmentation fault: resolved ip:",
-    "Segmentation fault: si_code:",
+    "Segmentation fault:",
     "Illegal instruction on",
+    "Illegal instruction:",
 ]
 
 ASSERT_CRASH_LOG = ["assert - "]


### PR DESCRIPTION
If the stack is corrupted by the time the signal handler runs,
a regular (non-incremental) backtrace call may segfault.
This makes it difficult to diagnose the origin of the signal.

This commit adds a functionality to use seastar's incremental backtrace
method to print the backtrace immediately after entering the signal
handler.

This behavior is gated behind the log level of the crash_tracker logger.
By default, this is disabled to avoid printing the backtrace twice—
once here, and again by Seastar's signal handler.

Backporting to 25.1 as this is useful for debugging in the described scenario.

Fixes https://redpandadata.atlassian.net/browse/CORE-9903
Relates to https://github.com/redpanda-data/vtools/pull/3589

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
### Improvements
* Improved signal handling diagnostics with incremental backtrace printing.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
