### PR TITLE
r/tests/persisted_stm_test: break STM on non-leader only and block lship

### DIFF
--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -834,8 +834,18 @@ TEST_F_CORO(persisted_stm_test_fixture, test_snapshot_in_background_apply) {
     for (const auto& [_, stm] : node_stms) {
         ASSERT_EQ_CORO(stm->state, expected);
     }
-    // force background apply on one of the state machines
-    auto throwing_stm = node_stms.begin()->second;
+
+    // force background apply on one of the non-leader state machines
+    ss::shared_ptr<persisted_kv> throwing_stm;
+    for (auto& [id, stm] : node_stms) {
+        auto raft = stm->raft_node.raft();
+        if (!raft->is_leader()) {
+            raft->block_new_leadership();
+            throwing_stm = stm;
+            break;
+        }
+    }
+    vassert(throwing_stm, "all nodes are leaders");
     throwing_stm->set_throw_on_apply(true);
 
     auto ops_phase_three = random_operations(20);


### PR DESCRIPTION
When nominating an STM to become broken pick one from a non-leader and block it from becoming a leader. Otherwise the test may get stuck on waiting for offset on the state machine that cannot move forward.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
