### PR TITLE
rpk: update dataplane proto version

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,8 +9,8 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250320090119-84779f9e5085.1
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250416134411-a63ce18a889a.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.6-20240917150400-3f349e63f44a.1
-	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250319124900-5103d6dd4791.1
-	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.5-20250319124900-5103d6dd4791.1
+	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250404200318-65f29ddd7b29.1
+	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.5-20250404200318-65f29ddd7b29.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20241209180130-05cf059c71c1.1
 	buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.6-20241209180130-05cf059c71c1.1
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250416134411-a6
 buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.6-20250416134411-a63ce18a889a.1/go.mod h1:RUUH9gPqxuRHYeNMFjrU5hboN4lPAz2kNeOi81gjQcI=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.6-20240917150400-3f349e63f44a.1 h1:PZG/e6nKfOkEIp45KoUIzReXRH6JpL9oKPe4tlJqD64=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.6-20240917150400-3f349e63f44a.1/go.mod h1:yA5Jg45dsAoOvAx1XHbDwwcWkkYW568MUeKJsa9bgrY=
-buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250319124900-5103d6dd4791.1 h1:pqDaDfukKNDDd4M8nRacBE29bMHv6V915eitQJBU1mM=
-buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250319124900-5103d6dd4791.1/go.mod h1:8tJZv4V4PP9GeuDCZyNtOaDcMONzcY4zCt/Hj0MRVdU=
-buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.5-20250319124900-5103d6dd4791.1 h1:GnOUOAHR6YqEGuwhZHTFeDnYwpFd3WQCBpF2SQAJtl8=
-buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.5-20250319124900-5103d6dd4791.1/go.mod h1:GX9Ho7surUAto5GGU+jO7zZNU7s/DjJ4Pw6489j0PTU=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250404200318-65f29ddd7b29.1 h1:iIj2C/0IDTFR0JtIgKfFHRtkCIb7YqQEdNylVab2pz0=
+buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250404200318-65f29ddd7b29.1/go.mod h1:72CA7I2EBjkbygOtYfvNpyLwD14RqoMa9vL9SGlWkIk=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.5-20250404200318-65f29ddd7b29.1 h1:/i5xh4Kk3Vvbvcqyunu9NOdxIU7Mu5EuiYzczjckbgE=
+buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.5-20250404200318-65f29ddd7b29.1/go.mod h1:GX9Ho7surUAto5GGU+jO7zZNU7s/DjJ4Pw6489j0PTU=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20241209180130-05cf059c71c1.1 h1:w7eMzWZiwi46baJaGhLyvU7utqMz8HutMdnqVnbscXs=
 buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20241209180130-05cf059c71c1.1/go.mod h1:IFEsRLaNT2AxqEoYPujolN4ecrJXpvwZXIGEHo2tXaw=
 buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.6-20241209180130-05cf059c71c1.1 h1:iuIKINuwFyjOgLyEx/ZLJBGs9VVURiyjsQ2bNVqSk+k=


### PR DESCRIPTION
This version was recently downgraded in
99d9bfa, this commit reverts that.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes



* none
