### PR TITLE
`storage`: replace a `segment`'s `batch_cache_index` after compaction

### DIFF
--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -472,8 +472,7 @@ void batch_cache_index::mark_clean(model::offset up_to_inclusive) {
 
     _dirty_tracker.mark_clean(up_to_inclusive);
 }
-ss::future<> batch_cache_index::clear_async() {
-    lock_guard lk(*this);
+ss::future<> batch_cache_index::clear_async_unlocked() {
     vassert(
       _dirty_tracker.clean(),
       "Destroying batch_cache_index ({}) tracking dirty batches.",
@@ -483,6 +482,11 @@ ss::future<> batch_cache_index::clear_async() {
           _cache->evict(std::move(value.second.range()));
       });
     _index.clear();
+}
+
+ss::future<> batch_cache_index::clear_async() {
+    lock_guard lk(*this);
+    co_await clear_async_unlocked();
 }
 
 void batch_cache::background_reclaimer::start() {

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -532,6 +532,8 @@ public:
     batch_cache_index& operator=(const batch_cache_index&) = delete;
 
     ss::future<> clear_async();
+    // Requires that a `lock_guard` for `this` is held elsewhere.
+    ss::future<> clear_async_unlocked();
     bool empty() const { return _index.empty(); }
 
     void

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -624,6 +624,13 @@ public:
         return _index.find(offset) != _index.end();
     }
 
+    // Leaves the batch_cache_index in a fully clean, re-usable state.
+    ss::future<> reset() {
+        lock_guard lk(*this);
+        co_await clear_async_unlocked();
+        _small_batches_range = nullptr;
+    }
+
 private:
     friend class batch_cache;
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1515,7 +1515,7 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     // Persist the state of our indexes in their new names.
     seg->index().swap_index_state(std::move(new_idx));
     seg->force_set_commit_offset_from_index();
-    seg->release_batch_cache_index();
+    co_await seg->reset_batch_cache_index();
 
     const ssize_t removed_bytes = ssize_t(size_before) - ssize_t(size_after);
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -222,6 +222,10 @@ public:
     bool has_compactible_offsets(const compaction_config& cfg) const;
 
     void release_batch_cache_index() { _cache.reset(); }
+    // Calls `_cache->reset()`, iff the optional `_cache` has a value. This
+    // leaves the object in a re-usable state. If there is no contained object
+    // (i.e `_cache == std::nullopt`), this function is a no-op.
+    ss::future<> reset_batch_cache_index();
     /** Cache methods */
     std::optional<std::reference_wrapper<batch_cache_index>> cache();
     std::optional<std::reference_wrapper<const batch_cache_index>>
@@ -468,6 +472,11 @@ inline bool segment::finished_windowed_compaction() const {
 }
 inline bool segment::has_clean_compact_timestamp() const {
     return index().has_clean_compact_timestamp();
+}
+inline ss::future<> segment::reset_batch_cache_index() {
+    if (_cache.has_value()) {
+        co_await _cache->reset();
+    }
 }
 inline std::optional<std::reference_wrapper<batch_cache_index>>
 segment::cache() {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -221,7 +221,6 @@ public:
     // deletion/eviction, and compaction.
     bool has_compactible_offsets(const compaction_config& cfg) const;
 
-    void release_batch_cache_index() { _cache.reset(); }
     // Calls `_cache->reset()`, iff the optional `_cache` has a value. This
     // leaves the object in a re-usable state. If there is no contained object
     // (i.e `_cache == std::nullopt`), this function is a no-op.

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -603,7 +603,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
 
     s->index().swap_index_state(std::move(idx));
     s->force_set_commit_offset_from_index();
-    s->release_batch_cache_index();
+    co_await s->reset_batch_cache_index();
     co_await s->index().flush();
     s->advance_generation();
     co_return s->size_bytes();


### PR DESCRIPTION
Previously, a `segment` would release its `batch_cache_index` after being compacted (either via self compaction or sliding window compaction) and would never replace it, barring a restart.

This commit changes the behavior to allow segments to reset their `batch_cache_index` instead of releasing it after being compacted.



## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Fixes sub-optimal behavior in which a `segment`'s `batch_cache_index` would be released after compaction and never re-assigned.
