### PR TITLE
[CORE-9906] datalake: fix translation double-stop

### DIFF
--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -231,7 +231,7 @@ public:
      * matter what stat it is in (e.g. running, waiting, idle). The translator
      * is free to clear the request after taking action.
      */
-    virtual void set_finish_translation() {}
+    virtual void set_finish_translation() = 0;
 
     /**
      * Return true if the translator is still in the progress of satisfying the

--- a/src/v/datalake/translation/scheduling_policies.cc
+++ b/src/v/datalake/translation/scheduling_policies.cc
@@ -384,19 +384,18 @@ ss::future<> fair_scheduling_policy::on_resource_exhaustion(
                  > b.status().memory_bytes_reserved;
       });
 
-    auto num_running = executor.running.size();
     // pick the earliest scheduled translator and force a flush.
+    auto& executable = *executor.running.begin();
     vlog(
       datalake_log.debug,
       "[{}] stopping translator due to memory exhaustion",
-      *executor.running.begin());
-    executor.stop_translation(
-      *executor.running.begin(), translator::stop_reason::oom);
-
-    while (mem_tracker.memory_exhausted() && !executor.as.abort_requested()
-           && executor.running.size() == num_running) {
-        co_await ss::sleep_abortable(polling_interval, executor.as);
-    }
+      executable);
+    co_await finish_translator(
+      executor,
+      finish_choice_info(
+        executable.translator_ptr()->id(),
+        finish_choice_info::status::running,
+        translator::stop_reason::oom));
 }
 
 enum fair_scheduling_policy::finish_choice_info::status

--- a/src/v/datalake/translation/tests/scheduler_fixture.cc
+++ b/src/v/datalake/translation/tests/scheduler_fixture.cc
@@ -15,6 +15,8 @@
 #include "ssx/future-util.h"
 #include "test_utils/randoms.h"
 
+#include <seastar/util/defer.hh>
+
 using namespace std::chrono_literals;
 
 namespace datalake::translation::scheduling {
@@ -163,6 +165,8 @@ ss::future<> mock_translator::translation_loop() {
         {
             co_await _wait_for_scheduler_cb.wait(
               [this] { return _translation_state.has_value(); });
+            auto clear_finish_request = ss::defer(
+              [this] { _finish_translation_requested = false; });
             auto holder = _translation_state->gate.hold();
             auto deadline = _translation_state->translate_for;
             auto start_time = clock::now();

--- a/src/v/datalake/translation/tests/scheduler_fixture.h
+++ b/src/v/datalake/translation/tests/scheduler_fixture.h
@@ -43,6 +43,12 @@ public:
     std::chrono::milliseconds current_lag_ms() const override {
         return std::chrono::milliseconds{0};
     }
+    void set_finish_translation() final {
+        _finish_translation_requested = true;
+    }
+    bool get_finish_translation() final {
+        return _finish_translation_requested;
+    }
 
 private:
     // Mock of a single parquet file writer.
@@ -91,6 +97,7 @@ private:
     ss::timer<clock> _translation_timer;
     ss::condition_variable _wait_for_scheduler_cb;
     clock::time_point _next_checkpoint;
+    bool _finish_translation_requested{false};
 };
 
 // A translator that overshoots deadline and requires explict force flushing


### PR DESCRIPTION
The assertion

```
assert - Assert failure:
(/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-07975cb829048dc6f-1/redpanda/redpanda/src/v/datalake/translation/scheduling.cc:365)
'!_waiting_hook.is_linked() && _running_hook.is_linked() &&
!_stop_in_progress' Invalid request to stop translation: {translator:
{id: {kafka/test/4}, status: {target_lag: 300000ms, next_checkpoint:
240252ms, memory_reserved: {161253464}}}, time_since_start: 172509ms,
current_wait_time: {nullopt}, total_wait_time: 33032ms,
current_running_time: {3166ms}, total_running_time: 27385ms,
translations_scheduled: 21, stop_in_progress: true, running: true,
waiting: false}
```

was encountered where stop_translator was called twice without waiting for the stop to complete and reset the translator state. the scenario that was occuring was that in when handling oom resource exhaustion the scheduler would stop a translator and then wait for the stop to complete by monitoring the running list size.

```
    while (mem_tracker.memory_exhausted() && !executor.as.abort_requested()
           && executor.running.size() == num_running) {
        co_await ss::sleep_abortable(polling_interval, executor.as);
    }
```

however, tasks may stop for other reasons. what we actually want to do here is wait for _the specific translator that was stopped_ to stop, rather than any translator. in the assertion failure case the translator stop was requested, released from this wait loop before actually stopping, and then at some point stopped again (either oom or because it was requested to be stopped for out of disk).

The fix is to wait on the specific translator to stop.

Fixes https://redpandadata.atlassian.net/browse/CORE-9906

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
