### PR TITLE
rpk: prevent security role in cloud

### DIFF
--- a/src/go/rpk/pkg/cli/security/role/assign.go
+++ b/src/go/rpk/pkg/cli/security/role/assign.go
@@ -46,7 +46,7 @@ Assign role "redpanda-admin" to users "red" and "panda"
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitServerlessAdmin(p)
+			config.CheckExitCloudAdmin(p)
 
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)

--- a/src/go/rpk/pkg/cli/security/role/create.go
+++ b/src/go/rpk/pkg/cli/security/role/create.go
@@ -39,7 +39,7 @@ flag in the 'rpk security acl create' command.`,
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitServerlessAdmin(p)
+			config.CheckExitCloudAdmin(p)
 
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)

--- a/src/go/rpk/pkg/cli/security/role/delete.go
+++ b/src/go/rpk/pkg/cli/security/role/delete.go
@@ -39,7 +39,7 @@ The flag '--no-confirm' can be used to avoid the confirmation prompt.
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitServerlessAdmin(p)
+			config.CheckExitCloudAdmin(p)
 
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)

--- a/src/go/rpk/pkg/cli/security/role/describe.go
+++ b/src/go/rpk/pkg/cli/security/role/describe.go
@@ -76,7 +76,7 @@ Print only the ACL associated to the role 'red'
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitServerlessAdmin(p)
+			config.CheckExitCloudAdmin(p)
 
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)

--- a/src/go/rpk/pkg/cli/security/role/list.go
+++ b/src/go/rpk/pkg/cli/security/role/list.go
@@ -49,7 +49,7 @@ List all roles with the prefix "agent-":
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitServerlessAdmin(p)
+			config.CheckExitCloudAdmin(p)
 
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)

--- a/src/go/rpk/pkg/cli/security/role/unassign.go
+++ b/src/go/rpk/pkg/cli/security/role/unassign.go
@@ -46,7 +46,7 @@ Unassign role "redpanda-admin" from users "red" and "panda"
 			}
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitServerlessAdmin(p)
+			config.CheckExitCloudAdmin(p)
 
 			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin api client: %v", err)


### PR DESCRIPTION
This was mistakenly assuming that it was not available in serverless, but available for BYOC and dedicated.

However, this command space uses the admin API and should not be run against Redpanda Cloud atm. This commit adds the check so it exits with a better error message in case you run it from a cloud profile.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x
- [ ] v24.1.x

## Release Notes

* none