### PR TITLE
Functional tests for Iceberg on cloud AWS + Unity Catalog

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/iceberg_catalogs_test.py
+++ b/tests/rptest/redpanda_cloud_tests/iceberg_catalogs_test.py
@@ -1,0 +1,150 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from typing import Any
+import logging
+import json
+import time
+import requests
+
+from ducktape.mark import matrix
+from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
+from rptest.services.provider_clients.rpcloud_client import RpCloudApiClient
+
+from rptest.clients.installpack import InstallPackClient
+from rptest.clients.rpk import RpkTool, TopicSpec, RpkException
+
+from rptest.services.redpanda import get_cloud_provider
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaServiceCloud
+
+from rptest.services.databricks_workspace import DatabricksWorkspace
+from rptest.context.databricks import DatabricksContext, OauthCredentials
+from rptest.services.catalog_service import CatalogType
+#from rptest.tests.datalake.datalake_services import DatalakeServices
+#from rptest.tests.datalake.query_engine_base import QueryEngineType
+#from rptest.tests.datalake.utils import supported_storage_types
+#from rptest.tests.redpanda_test import RedpandaTest
+#from rptest.utils.mode_checks import cleanup_on_early_exit
+
+
+def supported_catalog_types():
+    return ["aws_glue", "databricks_unity", "snowflake"]
+
+
+def supported_network_types():
+    return ["public", "private"]
+
+
+class IcebergCloudCatalogsTest(RedpandaCloudTest):
+    """
+    Verify that cluster infra/config matches config profile used to launch - only applies to cloudv2
+    """
+    def __init__(self, test_context):
+        super().__init__(test_context=test_context)
+        self._ctx = test_context
+        self._ipClient = InstallPackClient(
+            self.redpanda._cloud_cluster.config.install_pack_url_template,
+            self.redpanda._cloud_cluster.config.install_pack_auth_type,
+            self.redpanda._cloud_cluster.config.install_pack_auth)
+
+    def setUp(self):
+        super().setUp()
+        cloud_cluster = self.redpanda._cloud_cluster
+        self.logger.debug(f"Cloud Cluster Info: {vars(cloud_cluster)}")
+        install_pack_version = cloud_cluster.get_install_pack_version()
+        self._ip = self._ipClient.getInstallPack(install_pack_version)
+        self._clusterId = cloud_cluster.cluster_id
+        self._configProfile = self._ip['config_profiles'][
+            cloud_cluster.config.config_profile_name]
+
+    def test_healthy(self):
+        r = self.redpanda.cluster_unhealthy_reason()
+        assert r is None, r
+        assert self.redpanda.cluster_healthy()
+        self.redpanda.assert_cluster_is_reusable()
+
+    @cluster(num_nodes=1)
+    def test_databricks_basic(self):
+        dbx_ctx = DatabricksContext.from_context(self._ctx)
+
+        cloud_cluster = self.redpanda._cloud_cluster
+        client: RpCloudApiClient = cloud_cluster.public_api
+
+        databricks_client = DatabricksWorkspace(context=self._ctx)
+        bucket = f"redpanda-cloud-storage-{self._clusterId}"
+        catalog_info = databricks_client.create_catalog(bucket=bucket)
+        properties = {"iceberg_enabled": True}
+        enable_resp = cloud_cluster.update_cluster_property_public(
+            self._clusterId, properties)
+        self.logger.debug(f"Enable iceberg response: {enable_resp}")
+
+        # Parameters for creating Redpanda secret
+        secret_id = "UNITY_CLIENT_SECRET"
+        
+        #secret_data = dbx_ctx.client_secret
+        # Access credentials (client_secret, client_id) from dbx_ctx.credentials
+        if isinstance(dbx_ctx.credentials, OauthCredentials):
+            secret_data = dbx_ctx.credentials.client_secret
+            databricks_client_id = dbx_ctx.credentials.client_id
+        else:
+            secret_data = dbx_ctx.credentials.token
+            databricks_client_id = None
+
+        create_resp = cloud_cluster.create_secret(secret_id, secret_data)
+        self.logger.debug(f"Create secret response: {create_resp}")
+
+        iceberg_rest_catalog_endpoint = dbx_ctx.iceberg_rest_url
+        iceberg_rest_catalog_warehouse = dbx_ctx.sql_warehouse_path
+
+        # Construct the payload for the request
+        properties = {
+            "iceberg_rest_catalog_endpoint": iceberg_rest_catalog_endpoint,
+            "iceberg_rest_catalog_authentication_mode": "oauth2" if isinstance(dbx_ctx.credentials, OauthCredentials) else "pat",
+            "iceberg_rest_catalog_client_id": databricks_client_id,
+            "iceberg_rest_catalog_client_secret":
+            "${secrets.UNITY_CLIENT_SECRET}",
+            "iceberg_rest_catalog_warehouse": iceberg_rest_catalog_warehouse,
+            "iceberg_catalog_type": "rest"
+        }
+
+        # Log the constructed payload for debugging
+        self.logger.debug(f"Properties to be sent: {properties}")
+
+        try:
+            # Send the HTTP PATCH request
+            response = client.update_cluster_property_public(
+                cluster_id=cloud_cluster.current.cluster_id,
+                properties=properties)
+
+            if response:
+                self.logger.debug(f"Update successful: {response.json()}")
+            else:
+                self.logger.error("Failed to update cluster properties.")
+
+        except Exception as e:
+            self.logger.error(
+                f"An error occurred while updating cluster properties: {e}")
+
+        self.rpk = RpkTool(self.redpanda)
+        test_topic = 'test_topic'
+        self.rpk.create_topic(test_topic)
+        self.rpk.alter_topic_config(test_topic,
+                                    TopicSpec.PROPERTY_ICEBERG_MODE,
+                                    'key_value')
+
+        MESSAGE_COUNT = 100
+        for i in range(MESSAGE_COUNT):
+            self.rpk.produce(test_topic, f"foo {i} ", f"bar {i}")
+
+        self.logger.debug("Waiting 1 minute...")
+        time.sleep(60)
+        # TODO Marat add verification, more tests and options (separate PR)
+
+        databricks_client.stop()

--- a/tests/rptest/redpanda_cloud_tests/iceberg_catalogs_test.py
+++ b/tests/rptest/redpanda_cloud_tests/iceberg_catalogs_test.py
@@ -87,7 +87,7 @@ class IcebergCloudCatalogsTest(RedpandaCloudTest):
 
         # Parameters for creating Redpanda secret
         secret_id = "UNITY_CLIENT_SECRET"
-        
+
         #secret_data = dbx_ctx.client_secret
         # Access credentials (client_secret, client_id) from dbx_ctx.credentials
         if isinstance(dbx_ctx.credentials, OauthCredentials):
@@ -105,13 +105,19 @@ class IcebergCloudCatalogsTest(RedpandaCloudTest):
 
         # Construct the payload for the request
         properties = {
-            "iceberg_rest_catalog_endpoint": iceberg_rest_catalog_endpoint,
-            "iceberg_rest_catalog_authentication_mode": "oauth2" if isinstance(dbx_ctx.credentials, OauthCredentials) else "pat",
-            "iceberg_rest_catalog_client_id": databricks_client_id,
+            "iceberg_rest_catalog_endpoint":
+            iceberg_rest_catalog_endpoint,
+            "iceberg_rest_catalog_authentication_mode":
+            "oauth2"
+            if isinstance(dbx_ctx.credentials, OauthCredentials) else "bearer",
+            "iceberg_rest_catalog_client_id":
+            databricks_client_id,
             "iceberg_rest_catalog_client_secret":
             "${secrets.UNITY_CLIENT_SECRET}",
-            "iceberg_rest_catalog_warehouse": iceberg_rest_catalog_warehouse,
-            "iceberg_catalog_type": "rest"
+            "iceberg_rest_catalog_warehouse":
+            catalog_info.name,
+            "iceberg_catalog_type":
+            "rest"
         }
 
         # Log the constructed payload for debugging

--- a/tests/rptest/services/databricks_workspace.py
+++ b/tests/rptest/services/databricks_workspace.py
@@ -62,13 +62,18 @@ class DatabricksWorkspace(Service):
 
         self._location_names.add(bucket)
 
-        location: ExternalLocationInfo = self._client.external_locations.create(
-            name=bucket,
-            # TODO: Add support for gcs, azure
-            url=f"s3://{bucket}",
-            credential_name=self._databricks_context.ext_loc_credential_name,
-        )
-        self.logger.debug(f"Created external location: {location}")
+        try:
+            location: ExternalLocationInfo = self._client.external_locations.create(
+                name=bucket,
+                # TODO: Add support for gcs, azure
+                url=f"s3://{bucket}",
+                credential_name=self._databricks_context.
+                ext_loc_credential_name,
+            )
+            self.logger.debug(f"Created external location: {location}")
+        except databricks.sdk.errors.DatabricksError as e:
+            self.logger.error(f"Failed to create external location: {str(e)}")
+            raise
 
         requested_catalog_name = f"panda-catalog-{uuid.uuid1()}"
         self._catalog_names.add(requested_catalog_name)
@@ -83,12 +88,17 @@ class DatabricksWorkspace(Service):
             "We expect to only managed catalogs."
         assert catalog_info.name, "Catalog name must not be empty"
 
-        sql_connection = databricks.sql.connect(
-            server_hostname=self._databricks_context.server_hostname,
-            http_path=self._databricks_context.sql_warehouse_path,
-            catalog=catalog_info.name,
-            credentials_provider=self._databricks_context.credentials_provider,
-        )
+        try:
+            sql_connection = databricks.sql.connect(
+                server_hostname=self._databricks_context.server_hostname,
+                http_path=self._databricks_context.sql_warehouse_path,
+                catalog=catalog_info.name,
+                credentials_provider=self._databricks_context.credentials_provider,
+            )
+            self.logger.debug("SQL connection established successfully.")
+        except Exception as e:
+            self.logger.error(f"Error establishing SQL connection: {e}")
+            return  # Exit if the connection fails
 
         # This is a unity catalog peculiarity. It allows schemas (iceberg
         # namespaces) to be created but tables inside it are not allowed

--- a/tests/rptest/services/databricks_workspace.py
+++ b/tests/rptest/services/databricks_workspace.py
@@ -93,12 +93,13 @@ class DatabricksWorkspace(Service):
                 server_hostname=self._databricks_context.server_hostname,
                 http_path=self._databricks_context.sql_warehouse_path,
                 catalog=catalog_info.name,
-                credentials_provider=self._databricks_context.credentials_provider,
+                credentials_provider=self._databricks_context.
+                credentials_provider,
             )
             self.logger.debug("SQL connection established successfully.")
         except Exception as e:
             self.logger.error(f"Error establishing SQL connection: {e}")
-            return  # Exit if the connection fails
+            raise
 
         # This is a unity catalog peculiarity. It allows schemas (iceberg
         # namespaces) to be created but tables inside it are not allowed

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -95,12 +95,33 @@ class RpCloudApiClient(object):
                    override_headers={},
                    **kwargs):
         token = self._get_token()
+        self._logger.debug(f"http token: '{token}'")
         headers = {
             'Authorization': f'Bearer {token}',
             'Accept': 'application/json'
         } | override_headers
         _base = base_url if base_url else self._config.api_url
         resp = requests.post(f'{_base}{endpoint}', headers=headers, **kwargs)
+        _r = self._handle_error(resp)
+        return _r if _r is None else _r.json()
+
+    def _http_patch(self,
+                    base_url: str | None = None,
+                    endpoint: str = '',
+                    override_headers: dict[str, str] = {},
+                    **kwargs):
+        """
+            Like _http_post but uses PATCH.
+            Injects Bearer token and Accept header the same way.
+        """
+        token = self._get_token()
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/json'
+        } | override_headers
+
+        _base = base_url if base_url else self._config.api_url
+        resp = requests.patch(f'{_base}{endpoint}', headers=headers, **kwargs)
         _r = self._handle_error(resp)
         return _r if _r is None else _r.json()
 

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -10,7 +10,7 @@ import ipaddress
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 from prometheus_client.parser import text_string_to_metric_families
 
 from ducktape.utils.util import wait_until
@@ -1548,6 +1548,7 @@ class CloudCluster():
                                        endpoint='/ScaleCluster',
                                        json=payload)
 
+    # Update cluster properties using Admin API
     def set_cluster_config_overrides(self, cluster_id, config_values):
         """
         Set configuration overrides for a specific Redpanda cloud cluster using Admin API
@@ -1562,3 +1563,46 @@ class CloudCluster():
         return self.cloudv2._http_post(base_url=self.config.admin_api_url,
                                        endpoint='/SetClusterConfigOverrides',
                                        json=payload)
+
+    # Update cluster properties using Public API
+    def update_cluster_property_public(self, cluster_id: str,
+                                       properties: Dict[str, str]) -> dict:
+        """
+        Update a specific cluster property via the public API
+
+        :param cluster_id: Redpanda cluster ID
+        :param properties: A dictionary where each key is a property key and the value is the property value
+        :return: response from the API request
+        """
+        # Prepare the payload dynamically based on the key and value
+        update_resp = self.public_api._http_patch(
+            base_url=self.config.public_api_url,
+            endpoint=f"/v1/clusters/{cluster_id}",
+            json={"cluster_configuration": {
+                "custom_properties": properties
+            }})
+        return update_resp
+
+    def create_secret(self, secret_id, secret_data, scopes=None):
+        """
+        Create a new secret on dataplane and return the response.
+        :param secret_id: ID of the secret to create
+        :param secret_data: Data for the secret
+        :param scopes: List of scopes for the secret (default is ["SCOPE_REDPANDA_CLUSTER"])
+        :return: response from the API request
+        """
+        dataplane_url = self._get_dataplane_api_url()
+        if scopes is None:
+            scopes = ["SCOPE_REDPANDA_CLUSTER"]
+        response = self.public_api._http_post(base_url=dataplane_url,
+                                              endpoint=f"/v1/secrets",
+                                              json={
+                                                  "id": secret_id,
+                                                  "scopes": scopes,
+                                                  "secret_data": secret_data,
+                                              })
+        return response
+
+    def _get_dataplane_api_url(self):
+        cluster = self.rpcloud.get_cluster(self.current.cluster_id)
+        return cluster['dataplane_api']['url']

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -1574,14 +1574,26 @@ class CloudCluster():
         :param properties: A dictionary where each key is a property key and the value is the property value
         :return: response from the API request
         """
-        # Prepare the payload dynamically based on the key and value
-        update_resp = self.public_api._http_patch(
-            base_url=self.config.public_api_url,
-            endpoint=f"/v1/clusters/{cluster_id}",
-            json={"cluster_configuration": {
-                "custom_properties": properties
-            }})
-        return update_resp
+        self._logger.debug(
+            f"Updating cluster {cluster_id} with properties: {properties}")
+
+        payload = {"cluster_configuration": {"custom_properties": properties}}
+
+        self._logger.debug(f"Payload to be sent: {payload}")
+
+        try:
+            update_resp = self.public_api._http_patch(
+                base_url=self.config.public_api_url,
+                endpoint=f"/v1/clusters/{cluster_id}",
+                json=payload)
+
+            self._logger.debug(f"Response from API: {update_resp}")
+
+            return update_resp
+        except Exception as e:
+            self._logger.error(
+                f"Error during request to update cluster {cluster_id}: {e}")
+            raise
 
     def create_secret(self, secret_id, secret_data, scopes=None):
         """


### PR DESCRIPTION
Functional tests for Iceberg on cloud AWS + Unity Catalog

- Reads Iceberg specific params and secrets from globals.json (new params were added by DEVPROD-2888) those would be used for local setups and by Buildkite schedules

- Uses public APIs that would be used by customers

- APIs for secret management on dataplane (new feature) @alenkacz FYI

@nvartolomei
- Includes a light-weight Databricks client to work with hosted setup I see that you merged your CDT PR several hours ago.. In your PR it is CDT specific (storage and a few other things not cloud ready), but some items are overlapping as we discussed, so we could consolidate those later to work for CDT and cloud. I would like to merge this client as it was already tested many times for cloud setups

- Uses S3 bucket object storage (AWS provider)
- Sets everything up and produces data to topics
 
DRAFT since
Need to add verification of object storage and queries and cleanups

Testing was done many times, these functions work and including error handling

## Backports Required

- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none

