### PR TITLE
`storage`: check if segments need rewrite in sliding window compaction

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -783,7 +783,10 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         const bool is_clean_compacted = seg->offsets().get_base_offset()
                                         >= idx_start_offset;
 
-        if (!co_await segment_needs_rewrite_with_offset_map(cfg, seg, map)) {
+        const bool segment_needs_rewrite
+          = internal::may_have_removable_tombstones(seg, cfg)
+            || co_await segment_needs_rewrite_with_offset_map(cfg, seg, map);
+        if (!segment_needs_rewrite) {
             vlog(
               gclog.trace,
               "[{}] segment does not require rewrite with provided offset map: "
@@ -1398,8 +1401,11 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
                 continue;
             }
 
-            if (!co_await segment_needs_rewrite_with_offset_map(
-                  compact_cfg, s, map)) {
+            const bool segment_needs_rewrite
+              = internal::may_have_removable_tombstones(s, compact_cfg)
+                || co_await segment_needs_rewrite_with_offset_map(
+                  compact_cfg, s, map);
+            if (!segment_needs_rewrite) {
                 vlog(
                   gclog.trace,
                   "[{}] segment does not require rewrite with provided offset "

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -783,6 +783,23 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         const bool is_clean_compacted = seg->offsets().get_base_offset()
                                         >= idx_start_offset;
 
+        if (!co_await segment_needs_rewrite_with_offset_map(cfg, seg, map)) {
+            vlog(
+              gclog.trace,
+              "[{}] segment does not require rewrite with provided offset map: "
+              "{}",
+              config().ntp(),
+              seg->filename());
+            bool marked_as_cleanly_compacted
+              = co_await internal::mark_segment_as_finished_window_compaction(
+                seg, is_clean_compacted, *_probe);
+            if (marked_as_cleanly_compacted) {
+                subtract_dirty_segment_bytes(seg->size_bytes());
+            }
+
+            continue;
+        }
+
         co_await rewrite_segment_with_offset_map(
           cfg, seg, map, is_finished_window_compaction, is_clean_compacted);
     }
@@ -1378,6 +1395,17 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
                 // the _segment_rewrite_lock, meaning some segments in the
                 // window may have been closed. It is safe to `continue` and
                 // rewrite the other, non-closed segments in the window.
+                continue;
+            }
+
+            if (!co_await segment_needs_rewrite_with_offset_map(
+                  compact_cfg, s, map)) {
+                vlog(
+                  gclog.trace,
+                  "[{}] segment does not require rewrite with provided offset "
+                  "map: {}",
+                  config().ntp(),
+                  seg->filename());
                 continue;
             }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -9,6 +9,8 @@
 
 #include "storage/segment_deduplication_utils.h"
 
+#include "model/fundamental.h"
+#include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
@@ -22,9 +24,13 @@
 #include "storage/segment_utils.h"
 #include "storage/types.h"
 
+#include <seastar/core/loop.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/coroutine/as_future.hh>
 
 #include <exception>
+#include <optional>
 
 namespace storage {
 
@@ -300,6 +306,52 @@ ss::future<bool> index_chunk_of_segment_for_map(
     }
 
     co_return fully_indexed_segment;
+}
+
+ss::future<bool> segment_needs_rewrite_with_offset_map(
+  const compaction_config& cfg,
+  ss::lw_shared_ptr<segment> seg,
+  const key_offset_map& map) {
+    auto compaction_idx_path = seg->path().to_compacted_index();
+    // If the file doesn't exist for whatever reason, return true.
+    // This could, for example, race with a truncation which removes the
+    // .compaction_index.
+    if (!co_await ss::file_exists(compaction_idx_path.string())) {
+        co_return true;
+    }
+    auto compaction_idx_file = co_await internal::make_reader_handle(
+      compaction_idx_path, cfg.sanitizer_config);
+    auto rdr = make_file_backed_compacted_reader(
+      compaction_idx_path, compaction_idx_file, cfg.iopc, 64_KiB, cfg.asrc);
+
+    auto fut = co_await ss::coroutine::as_future(rdr.verify_integrity());
+    if (fut.failed()) {
+        // If we were unable to read the .compaction_index file, proceed with
+        // compaction.
+        fut.ignore_ready_future();
+        co_await rdr.close();
+        co_return true;
+    }
+
+    bool segment_needs_rewrite = false;
+    // The segment in question needs rewriting _only_ iff it contains at least
+    // one key found in the key_offset_map which is not the latest offset for
+    // that key.
+    co_await rdr.for_each_async(
+      [&map, &segment_needs_rewrite](
+        const compacted_index::entry& e) -> ss::future<ss::stop_iteration> {
+          model::offset o = e.offset + model::offset_delta(e.delta);
+          return map.get(e.key).then([o, &segment_needs_rewrite](
+                                       std::optional<model::offset> map_entry) {
+              if (map_entry.has_value() && map_entry.value() > o) {
+                  segment_needs_rewrite = true;
+                  return ss::stop_iteration::yes;
+              }
+              return ss::stop_iteration::no;
+          });
+      },
+      model::no_timeout);
+    co_return segment_needs_rewrite;
 }
 
 } // namespace storage

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -72,4 +72,12 @@ ss::future<bool> index_chunk_of_segment_for_map(
   probe& pb,
   model::offset& last_indexed_offset);
 
+// Returns true iff the segment's .compacted_index file contains ANY key present
+// in the key_offset_map that is not the latest offset for that key. Otherwise,
+// there would be no point to rewriting the segment and its index files.
+ss::future<bool> segment_needs_rewrite_with_offset_map(
+  const compaction_config& cfg,
+  ss::lw_shared_ptr<segment> seg,
+  const key_offset_map& map);
+
 } // namespace storage

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -860,7 +860,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_btest(
     name = "compaction_fuzz_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "compaction_fuzz_test.cc",
     ],

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -632,21 +632,16 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     disk_log.sliding_window_compact(new_cfg).get();
 
     // Most segments have already compacted their segments away entirely,
-    // except their last record. Such segments shouldn't be compacted. Three
+    // except their last record. Such segments shouldn't be compacted. Two
     // segments should be compacted:
-    // - the new segment is compacted twice (self + windowed)
+    // - the new segment is self compacted
     // - the segment that previously had the latest keys should be compacted
     auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
     auto compaction_ratio_3 = disk_log.compaction_ratio().get();
-    ASSERT_EQ(segments_compacted + 3, segments_compacted_3);
+    ASSERT_EQ(segments_compacted + 2, segments_compacted_3);
 
     // Check for a reasonable compaction ratio.
     ASSERT_LT(compaction_ratio_3, 0.65);
-
-    // Compared to our first compaction ratio that windowed compacted many
-    // segments in a row, one self-compaction + windowed compaction will have a
-    // worse compaction ratio.
-    ASSERT_LT(compaction_ratio, compaction_ratio_3);
 }
 INSTANTIATE_TEST_SUITE_P(
   RecordsPerBatch,
@@ -1543,4 +1538,88 @@ TEST_F(CompactionFixtureTest, TestSegmentIndexReconstructed) {
     ASSERT_EQ(
       pre_sliding_window_index_relative_offsets,
       post_sliding_window_index_relative_offsets);
+}
+
+TEST_F(CompactionFixtureTest, TestSlidingWindowNoUnecessaryRewrites) {
+    constexpr auto cardinality = 100;
+    constexpr auto num_segments = 2;
+    constexpr auto batches_per_segment = 1;
+    constexpr auto records_per_batch = 10;
+    generate_data(
+      num_segments, cardinality, batches_per_segment, records_per_batch)
+      .get();
+
+    ss::abort_source never_abort;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    auto& segments = disk_log.segments();
+
+    storage::compaction_config cfg(
+      model::offset::max(),
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
+
+    for (auto& seg : segments) {
+        if (!seg->has_appender()) {
+            disk_log.segment_self_compact(cfg, seg).get();
+        }
+    }
+
+    // Check that the segment .log file and the .compaction_index file are not
+    // re-written if they don't need to be during a round of sliding window
+    // compaction. The same check cannot be applied to the .base_index file, as
+    // segments may be marked cleanly compacted and the file would be reflushed
+    // to disk to reflect the updated state.
+    using time_point = std::chrono::system_clock::time_point;
+    std::vector<std::vector<time_point>>
+      segments_file_mtimes_pre_sliding_window;
+    for (auto& seg : segments) {
+        if (seg->has_appender()) {
+            continue;
+        }
+        std::vector<time_point> segment_file_mtimes{
+          ss::file_stat(seg->path().string()).get().time_modified,
+          ss::file_stat(seg->path().to_compacted_index().string())
+            .get()
+            .time_modified,
+        };
+        segments_file_mtimes_pre_sliding_window.push_back(segment_file_mtimes);
+    }
+
+    disk_log.sliding_window_compact(cfg).get();
+
+    std::vector<std::vector<time_point>>
+      segments_file_mtimes_post_sliding_window;
+    for (auto& seg : segments) {
+        if (seg->has_appender()) {
+            continue;
+        }
+        std::vector<time_point> segment_file_mtimes{
+          ss::file_stat(seg->path().string()).get().time_modified,
+          ss::file_stat(seg->path().to_compacted_index().string())
+            .get()
+            .time_modified,
+        };
+        segments_file_mtimes_post_sliding_window.push_back(segment_file_mtimes);
+    }
+
+    ASSERT_EQ(
+      segments_file_mtimes_pre_sliding_window,
+      segments_file_mtimes_post_sliding_window);
+
+    // We should see 2 compacted segments (from self-compaction)
+    auto segments_compacted = log->get_probe().get_segments_compacted();
+    ASSERT_EQ(segments_compacted, 2);
+
+    // Generate more data (of the same profile), and expect to see the original
+    // 2 segments now window compacted, and the additional 2 segments
+    // self-compacted.
+    generate_data(
+      num_segments, cardinality, batches_per_segment, records_per_batch)
+      .get();
+
+    disk_log.sliding_window_compact(cfg).get();
+
+    segments_compacted = log->get_probe().get_segments_compacted();
+    ASSERT_EQ(segments_compacted, 6);
 }

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -519,3 +519,39 @@ TEST(DeduplicateSegmentsTest, TestBadReader) {
         .get(),
       std::runtime_error);
 }
+
+TEST(DeduplicateSegmentsTest, SegmentNeedsRewriteNoCompactedIndex) {
+    storage::disk_log_builder b;
+    build_segments(
+      b,
+      /*num_segs=*/1,
+      /*records_per_seg=*/10,
+      /*start_offset=*/0,
+      /*mark_compacted=*/false);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+
+    auto& segs = disk_log.segments();
+    auto& seg = segs[0];
+    compaction_config cfg(
+      model::offset{0},
+      std::nullopt,
+      ss::default_priority_class(),
+      never_abort);
+    simple_key_offset_map map(50);
+
+    // When the .compaction_index file doesn't exist, the segment should assume
+    // it needs rewriting.
+    ASSERT_FALSE(
+      ss::file_exists(seg->path().to_compacted_index().string()).get());
+
+    bool needs_rewrite
+      = segment_needs_rewrite_with_offset_map(cfg, seg, map).get();
+
+    // Make sure we didn't create a new .compaction_index file by just
+    // attempting to read it.
+    ASSERT_FALSE(
+      ss::file_exists(seg->path().to_compacted_index().string()).get());
+
+    ASSERT_EQ(needs_rewrite, true);
+}


### PR DESCRIPTION
Segments considered during sliding window compaction need rewriting _only_ iff they contain at least one key found in the `key_offset_map` which is _not_ the latest offset for that key.

In an attempt to reduce unnecessary CPU and IO work effectively copying the segment along with the compacted index and segment index to new files, we can use a compacted index reader to determine whether the segment actually requires a rewrite or not before doing so.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Reduce unnecessary CPU & IO work during compaction by avoiding rewrites of `segment` files that would remove no data (effectively be copies).
