### PR TITLE
`storage`: decompress batch during `batch_timequery()`

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1286,8 +1286,11 @@ remote_partition::timequery(storage::timequery_config cfg) {
     vlog(_ctxlog.debug, "timequery: {} batches", batches.size());
 
     if (batches.size()) {
-        co_return storage::batch_timequery(
-          *(batches.begin()), cfg.min_offset, cfg.time, cfg.max_offset);
+        co_return co_await storage::batch_timequery(
+          std::move(*(batches.begin())),
+          cfg.min_offset,
+          cfg.time,
+          cfg.max_offset);
     } else {
         co_return std::nullopt;
     }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1280,11 +1280,9 @@ remote_partition::timequery(storage::timequery_config cfg) {
     auto translating_reader = co_await make_reader(config);
 
     // Read one batch from the reader to learn the offset
-    model::record_batch_reader::storage_t data
-      = co_await model::consume_reader_to_memory(
-        std::move(translating_reader.reader), model::no_timeout);
+    auto batches = co_await model::consume_reader_to_memory(
+      std::move(translating_reader.reader), model::no_timeout);
 
-    auto& batches = std::get<model::record_batch_reader::data_t>(data);
     vlog(_ctxlog.debug, "timequery: {} batches", batches.size());
 
     if (batches.size()) {

--- a/src/v/kafka/server/tests/list_offsets_test.cc
+++ b/src/v/kafka/server/tests/list_offsets_test.cc
@@ -223,9 +223,7 @@ FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
     auto base_timestamp = 100000;
 
     for (size_t i = 0; i < batch_count; ++i) {
-        // Mixture of compressed and uncompressed, they have distinct offset
-        // lookup behavior when searching by timequery, which will be
-        // validated
+        // Mixture of compressed and uncompressed batches.
         bool compressed = i % 3 == 0;
         batches.push_back(make_random_batch(model::test::record_batch_spec{
           // after queries below.
@@ -279,30 +277,17 @@ FIXTURE_TEST(list_offsets_by_time, redpanda_thread_fixture) {
           }},
         });
 
-        const auto& batch = batches[i];
         auto resp_midbatch
           = client.dispatch(std::move(req2), kafka::api_version(1)).get();
         BOOST_REQUIRE_EQUAL(resp_midbatch.data.topics.size(), 1);
         BOOST_REQUIRE_EQUAL(resp_midbatch.data.topics[0].partitions.size(), 1);
-        if (batch.compressed()) {
-            // Compressed batch: result will point to start of batch, slightly
-            // earlier than the query timestamp
-            BOOST_CHECK(
-              resp_midbatch.data.topics[0].partitions[0].timestamp
-              == model::timestamp(base_timestamp + i * record_count));
-            BOOST_CHECK(
-              resp_midbatch.data.topics[0].partitions[0].offset
-              == model::offset(i * record_count));
-        } else {
-            // Uncompressed batch: result should have seeked to correct record
-            BOOST_CHECK(
-              resp_midbatch.data.topics[0].partitions[0].timestamp
-              == model::timestamp(
-                base_timestamp + i * record_count + record_offset));
-            BOOST_CHECK(
-              resp_midbatch.data.topics[0].partitions[0].offset
-              == model::offset(i * record_count + record_offset));
-        }
+        BOOST_CHECK(
+          resp_midbatch.data.topics[0].partitions[0].timestamp
+          == model::timestamp(
+            base_timestamp + i * record_count + record_offset));
+        BOOST_CHECK(
+          resp_midbatch.data.topics[0].partitions[0].offset
+          == model::offset(i * record_count + record_offset));
     }
 
     client.stop().then([&client] { client.shutdown(); }).get();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2851,8 +2851,8 @@ disk_log_impl::timequery(timequery_config cfg) {
 
     if (
       !batches.empty() && batches.front().header().max_timestamp >= cfg.time) {
-        co_return batch_timequery(
-          batches.front(), cfg.min_offset, cfg.time, cfg.max_offset);
+        co_return co_await batch_timequery(
+          std::move(batches.front()), cfg.min_offset, cfg.time, cfg.max_offset);
     }
 
     co_return std::nullopt;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2842,23 +2842,20 @@ ss::future<std::optional<timequery_result>>
 disk_log_impl::timequery(timequery_config cfg) {
     vassert(!_closed, "timequery on closed log - {}", *this);
     if (_segs.empty()) {
-        return ss::make_ready_future<std::optional<timequery_result>>();
+        co_return std::nullopt;
     }
-    return make_reader(cfg).then([cfg](model::record_batch_reader reader) {
-        return model::consume_reader_to_memory(
-                 std::move(reader), model::no_timeout)
-          .then([cfg](model::record_batch_reader::storage_t st) {
-              using ret_t = std::optional<timequery_result>;
-              auto& batches = std::get<model::record_batch_reader::data_t>(st);
-              if (
-                !batches.empty()
-                && batches.front().header().max_timestamp >= cfg.time) {
-                  return ret_t(batch_timequery(
-                    batches.front(), cfg.min_offset, cfg.time, cfg.max_offset));
-              }
-              return ret_t();
-          });
-    });
+
+    auto reader = co_await make_reader(cfg);
+    auto batches = co_await model::consume_reader_to_memory(
+      std::move(reader), model::no_timeout);
+
+    if (
+      !batches.empty() && batches.front().header().max_timestamp >= cfg.time) {
+        co_return batch_timequery(
+          batches.front(), cfg.min_offset, cfg.time, cfg.max_offset);
+    }
+
+    co_return std::nullopt;
 }
 
 ss::future<> disk_log_impl::remove_segment_permanently(

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -18,6 +18,7 @@
 #include "storage/logger.h"
 #include "storage/offset_translator_state.h"
 #include "storage/parser_errc.h"
+#include "storage/parser_utils.h"
 #include "storage/segment_set.h"
 #include "storage/types.h"
 
@@ -581,8 +582,8 @@ bool log_reader::is_done() {
            || is_finished_offset(_lease->range, _config.start_offset);
 }
 
-timequery_result batch_timequery(
-  const model::record_batch& b,
+ss::future<timequery_result> batch_timequery(
+  model::record_batch b,
   model::offset min_offset,
   model::timestamp t,
   model::offset max_offset) {
@@ -595,23 +596,25 @@ timequery_result batch_timequery(
     // records in the batch have different timestamps.
     model::offset result_o = b.base_offset();
     model::timestamp result_t = b.header().first_timestamp;
-    if (!b.compressed()) {
-        b.for_each_record(
-          [&result_o, &result_t, &b, query_interval, t](
-            const model::record& r) -> ss::stop_iteration {
-              auto record_o = model::offset{r.offset_delta()} + b.base_offset();
-              auto record_t = model::timestamp(
-                b.header().first_timestamp() + r.timestamp_delta());
-              if (record_t >= t && query_interval.contains(record_o)) {
-                  result_o = record_o;
-                  result_t = record_t;
-                  return ss::stop_iteration::yes;
-              } else {
-                  return ss::stop_iteration::no;
-              }
-          });
-    }
-    return {result_o, result_t};
+    auto batch = co_await internal::decompress_batch(std::move(b));
+    co_await batch.for_each_record_async(
+      [&result_o, &result_t, &batch, query_interval, t](
+        const model::record& r) -> ss::future<ss::stop_iteration> {
+          auto record_o = model::offset{r.offset_delta()} + batch.base_offset();
+          auto record_t = model::timestamp(
+            batch.header().first_timestamp() + r.timestamp_delta());
+          if (record_t >= t && query_interval.contains(record_o)) {
+              result_o = record_o;
+              result_t = record_t;
+              return ss::make_ready_future<ss::stop_iteration>(
+                ss::stop_iteration::yes);
+          } else {
+              return ss::make_ready_future<ss::stop_iteration>(
+                ss::stop_iteration::no);
+          }
+      });
+
+    co_return timequery_result{result_o, result_t};
 }
 
 } // namespace storage

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -293,8 +293,8 @@ private:
  * \param t The timestamp to search for
  * \param max_offset The maximum offset to consider
  */
-timequery_result batch_timequery(
-  const model::record_batch& b,
+ss::future<timequery_result> batch_timequery(
+  model::record_batch b,
   model::offset min_offset,
   model::timestamp t,
   model::offset max_offset);


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/25769.

A `ListOffsets` timequery can currently return incorrect results due to the fact that we would not iterate over the records of a compressed batch when constructing the response (this dates back to https://github.com/redpanda-data/redpanda/pull/6658).

We would instead output the same offset for each record in the batch hit by the timequery according to the base offset of the batch itself.


To fix this behavior, decompress the batch and iterate over the records just like we would in the uncompressed case to Do The Right Thing and return correct results.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug in which the broker response to a `ListOffsets` timequery would return incorrect record offsets when considering a compressed record batch. 
