### PR TITLE
[v24.3.x] r/tests/persisted_stm_test: break STM on non-leader only and block lship

### DIFF
--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -839,8 +839,18 @@ TEST_F_CORO(persisted_stm_test_fixture, test_snapshot_in_background_apply) {
     for (const auto& [_, stm] : node_stms) {
         ASSERT_EQ_CORO(stm->state, expected);
     }
-    // force background apply on one of the state machines
-    auto throwing_stm = node_stms.begin()->second;
+
+    // force background apply on one of the non-leader state machines
+    ss::shared_ptr<persisted_kv> throwing_stm;
+    for (auto& [id, stm] : node_stms) {
+        auto raft = stm->raft_node.raft();
+        if (!raft->is_leader()) {
+            raft->block_new_leadership();
+            throwing_stm = stm;
+            break;
+        }
+    }
+    vassert(throwing_stm, "all nodes are leaders");
     throwing_stm->set_throw_on_apply(true);
 
     auto ops_phase_three = random_operations(20);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25916
