### PR TITLE
[v24.3.x] tests/dl: fixed incorrectly used CatalogType

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -14,6 +14,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from random import randint
+import time
 
 from rptest.services.redpanda import PandaproxyConfig, SchemaRegistryConfig, SISettings
 from rptest.services.serde_client import SerdeClient
@@ -337,17 +338,14 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
         return True
 
     @cluster(num_nodes=6)
-    # this test doesn't have to run with different catalog types
-    @matrix(cloud_storage_type=supported_storage_types(),
-            catalog_type=[CatalogType.REST_JDBC])
+    @matrix(cloud_storage_type=supported_storage_types())
     @skip_debug_mode
-    def test_enabling_iceberg_in_existing_cluster(self, cloud_storage_type,
-                                                  catalog_type):
+    def test_enabling_iceberg_in_existing_cluster(self, cloud_storage_type):
         count = 100
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
-                              include_query_engines=[QueryEngineType.SPARK],
-                              catalog_type=catalog_type) as dl:
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
 
             topic = TopicSpec(name="delayed-iceberg-topic",
                               partition_count=3,


### PR DESCRIPTION
CatalogType was introduced in v25.1.x. We can not use it in this version.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none