### PR TITLE
[v25.1.x] `storage`: minor compaction utility changes, ensure last record is persisted in `do_copy_segment_data()`

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -362,7 +362,6 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":log_manager_probe",
-        ":logger",
         "//src/v/syschecks",
     ],
     include_prefix = "storage",
@@ -373,6 +372,7 @@ redpanda_cc_library(
         ":compaction",
         ":index_state",
         ":key_offset_map",
+        ":logger",
         ":parser_utils",
         ":record_batch_builder",
         ":record_batch_utils",

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -161,7 +161,7 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     int32_t records_seen = 0;
     co_await batch.for_each_record_async(
       [this, &batch, &offset_deltas, &records_seen](const model::record& r) {
-          records_seen++;
+          ++records_seen;
           return maybe_keep_offset(
             batch, r, batch.record_count() == records_seen, offset_deltas);
       });

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -174,7 +174,7 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
         // contiguousness of the offset space.
         auto placeholder = make_placeholder_batch(batch.header());
         vlog(
-          stlog.debug,
+          gclog.debug,
           "installing a placeholder {} for compacted batch: {}",
           placeholder,
           batch);
@@ -438,7 +438,7 @@ ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
           can_discard_tx_data_batch(b)
           || can_discard_consumer_offsets_batch(b)) {
             vlog(
-              stlog.trace, "discarded batch during compaction: {}", b.header());
+              gclog.trace, "discarded batch during compaction: {}", b.header());
             _stats.batches_discarded++;
             co_return ss::stop_iteration::no;
         }

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -166,7 +166,9 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
             batch, r, batch.record_count() == records_seen, offset_deltas);
       });
 
-    if (batch.last_offset() == _segment_last_offset && offset_deltas.empty()) {
+    if (
+      _compaction_placeholder_enabled
+      && batch.last_offset() == _segment_last_offset && offset_deltas.empty()) {
         // last batch in the segment has been compacted away.
         // This is most likely caused by aborted data batches getting compacted
         // away during self compaction of the segment if they are the last batch

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -163,11 +163,13 @@ public:
       bool internal_topic,
       offset_delta_time apply_offset,
       model::offset segment_last_offset,
+      bool compaction_placeholder_enabled,
       compacted_index_writer* cidx = nullptr,
       bool inject_failure = false,
       ss::abort_source* as = nullptr)
       : _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
+      , _compaction_placeholder_enabled(compaction_placeholder_enabled)
       , _appender(a)
       , _compacted_idx(cidx)
       , _idx(index_state::make_empty_index(apply_offset))
@@ -197,6 +199,11 @@ private:
 
     // Offset to keep in case the index is empty as of getting to this offset.
     model::offset _segment_last_offset;
+
+    // Whether feature::compaction_placeholder batch is enabled or not- expected
+    // to be queried from feature table.
+    bool _compaction_placeholder_enabled;
+
     segment_appender* _appender;
 
     // Compacted index writer for the newly written segment. May not be

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -431,6 +431,18 @@ disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
     return _start_offset;
 }
 
+ss::future<compaction_result> disk_log_impl::segment_self_compact(
+  compaction_config cfg, ss::lw_shared_ptr<segment> seg) {
+    co_return co_await storage::internal::self_compact_segment(
+      seg,
+      _stm_manager,
+      cfg,
+      *_probe,
+      *_readers_cache,
+      _manager.resources(),
+      _feature_table);
+}
+
 ss::future<> disk_log_impl::adjacent_merge_compact(
   compaction_config cfg, std::optional<model::offset> new_start_offset) {
     vlog(
@@ -495,14 +507,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
         }
 
         auto segment = *seg_it;
-        auto result = co_await storage::internal::self_compact_segment(
-          segment,
-          _stm_manager,
-          cfg,
-          *_probe,
-          *_readers_cache,
-          _manager.resources(),
-          _feature_table);
+        auto result = co_await segment_self_compact(cfg, segment);
 
         if (segment->is_closed()) {
             // We can race here with a truncation operation that removes the
@@ -610,14 +615,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             cfg.asrc->check();
         }
 
-        auto result = co_await storage::internal::self_compact_segment(
-          seg,
-          _stm_manager,
-          cfg,
-          *_probe,
-          *_readers_cache,
-          _manager.resources(),
-          _feature_table);
+        auto result = co_await segment_self_compact(cfg, seg);
 
         if (result.did_compact() == false) {
             continue;
@@ -958,14 +956,9 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
         replacement->mark_as_finished_windowed_compaction();
     }
     _probe->add_initial_segment(*replacement.get());
-    auto ret = co_await storage::internal::self_compact_segment(
-      replacement,
-      _stm_manager,
-      cfg,
-      *_probe,
-      *_readers_cache,
-      _manager.resources(),
-      _feature_table);
+
+    auto ret = co_await segment_self_compact(cfg, replacement);
+
     _probe->delete_segment(*replacement.get());
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -228,6 +228,10 @@ public:
 
     storage_resources& resources();
 
+    // Self compacts a segment.
+    ss::future<compaction_result>
+    segment_self_compact(compaction_config, ss::lw_shared_ptr<segment> seg);
+
     // Performs self-compaction on the earliest segment possible, and then
     // attempts to perform compaction on adjacent segments.
     ss::future<> adjacent_merge_compact(

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -42,7 +42,7 @@ ss::future<ss::stop_iteration> put_entry(
     co_return ss::stop_iteration::yes;
 }
 
-ss::future<bool> should_keep(
+ss::future<bool> is_latest_record_for_key(
   const key_offset_map& map,
   const model::record_batch& b,
   const model::record& r) {
@@ -184,56 +184,47 @@ ss::future<index_state> deduplicate_segment(
     }
     auto rdr = internal::create_segment_full_reader(
       seg, cfg, probe, std::move(read_holder));
+
+    auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
-
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
+
+    auto is_latest_record = [&map](
+                              const model::record_batch& b,
+                              const model::record& r) -> ss::future<bool> {
+        return is_latest_record_for_key(map, b, r);
+    };
+
+    auto record_filter = [f = std::move(is_latest_record),
+                          &feature_table,
+                          segment_last_offset,
+                          past_tombstone_delete_horizon,
+                          &may_have_tombstone_records,
+                          &probe](
+                           const model::record_batch& b,
+                           const model::record& r,
+                           bool is_last_record_in_batch) {
+        return internal::should_keep(
+          b,
+          r,
+          is_last_record_in_batch,
+          f,
+          probe,
+          feature_table,
+          segment_last_offset,
+          past_tombstone_delete_horizon,
+          may_have_tombstone_records);
+    };
+
     auto copy_reducer = internal::copy_data_segment_reducer(
-      [&map,
-       &may_have_tombstone_records,
-       &probe,
-       segment_last_offset = seg->offsets().get_committed_offset(),
-       past_tombstone_delete_horizon,
-       compaction_placeholder_enabled](
-        const model::record_batch& b,
-        const model::record& r,
-        bool is_last_record_in_batch) {
-          auto is_last_batch = b.last_offset() == segment_last_offset;
-          // once compaction placeholder feature is enabled, we are not
-          // worried about empty batches as the reducer then installs a
-          // placeholder batch if all the records are compacted away.
-          if (
-            !compaction_placeholder_enabled
-            && (is_last_batch && is_last_record_in_batch)) {
-              vlog(
-                gclog.trace,
-                "retaining last record: {} of segment from batch: {}",
-                r,
-                b.header());
-              return ss::make_ready_future<bool>(true);
-          }
-
-          // Deal with tombstone record removal
-          if (r.is_tombstone() && past_tombstone_delete_horizon) {
-              probe.add_removed_tombstone();
-              return ss::make_ready_future<bool>(false);
-          }
-
-          return should_keep(map, b, r).then(
-            [&may_have_tombstone_records,
-             is_tombstone = r.is_tombstone()](bool keep) {
-                if (is_tombstone && keep) {
-                    may_have_tombstone_records = true;
-                }
-                return keep;
-            });
-      },
+      std::move(record_filter),
       &appender,
       seg->path().is_internal_topic(),
       should_offset_delta_times,
-      seg->offsets().get_committed_offset(),
+      segment_last_offset,
       compaction_placeholder_enabled,
       &cmp_idx_writer,
       inject_reader_failure,

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -234,6 +234,7 @@ ss::future<index_state> deduplicate_segment(
       seg->path().is_internal_topic(),
       should_offset_delta_times,
       seg->offsets().get_committed_offset(),
+      compaction_placeholder_enabled,
       &cmp_idx_writer,
       inject_reader_failure,
       cfg.asrc);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -388,6 +388,9 @@ ss::future<storage::index_state> do_copy_segment_data(
       "copying compacted segment data from {} to {}",
       seg->reader().filename(),
       tmpname);
+
+    auto compaction_placeholder_enabled = feature_table.local().is_active(
+      features::feature::compaction_placeholder_batch);
     bool may_have_tombstone_records = false;
     auto should_keep =
       [compacted_list = std::move(compacted_offsets),
@@ -422,6 +425,7 @@ ss::future<storage::index_state> do_copy_segment_data(
       seg->path().is_internal_topic(),
       apply_offset,
       segment_last_offset,
+      compaction_placeholder_enabled,
       /*cidx=*/nullptr,
       /*inject_failure=*/false,
       cfg.asrc);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -354,9 +354,6 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto old_broker_timestamp = seg->index().broker_timestamp();
     auto old_clean_compact_timestamp = seg->index().clean_compact_timestamp();
 
-    const bool past_tombstone_delete_horizon
-      = internal::is_past_tombstone_delete_horizon(seg, cfg);
-
     // find out which offsets will survive compaction
     auto idx_path = seg->reader().path().to_compacted_index();
     auto compacted_reader = make_file_backed_compacted_reader(
@@ -389,38 +386,45 @@ ss::future<storage::index_state> do_copy_segment_data(
       seg->reader().filename(),
       tmpname);
 
+    auto segment_last_offset = seg->offsets().get_committed_offset();
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
+    const bool past_tombstone_delete_horizon
+      = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
-    auto should_keep =
-      [compacted_list = std::move(compacted_offsets),
-       past_tombstone_delete_horizon,
-       &may_have_tombstone_records,
-       &pb](const model::record_batch& b, const model::record& r, bool) {
-          // Deal with tombstone record removal
-          if (r.is_tombstone() && past_tombstone_delete_horizon) {
-              pb.add_removed_tombstone();
-              return ss::make_ready_future<bool>(false);
-          }
 
-          const auto o = b.base_offset()
-                         + model::offset_delta(r.offset_delta());
-          const auto keep = compacted_list.contains(o);
+    auto offset_in_compacted_list =
+      [compacted_offsets = std::move(compacted_offsets)](
+        const model::record_batch& b,
+        const model::record& r) -> ss::future<bool> {
+        const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
+        const auto keep = compacted_offsets.contains(o);
+        return ss::make_ready_future<bool>(keep);
+    };
 
-          if (r.is_tombstone() && keep) {
-              may_have_tombstone_records = true;
-          }
+    auto record_filter = [f = std::move(offset_in_compacted_list),
+                          &feature_table,
+                          segment_last_offset,
+                          past_tombstone_delete_horizon,
+                          &may_have_tombstone_records,
+                          &pb](
+                           const model::record_batch& b,
+                           const model::record& r,
+                           bool is_last_record_in_batch) {
+        return internal::should_keep(
+          b,
+          r,
+          is_last_record_in_batch,
+          f,
+          pb,
+          feature_table,
+          segment_last_offset,
+          past_tombstone_delete_horizon,
+          may_have_tombstone_records);
+    };
 
-          return ss::make_ready_future<bool>(keep);
-      };
-
-    model::offset segment_last_offset{};
-    if (likely(feature_table.local().is_active(
-          features::feature::compaction_placeholder_batch))) {
-        segment_last_offset = seg->offsets().get_committed_offset();
-    }
     auto copy_reducer = copy_data_segment_reducer(
-      std::move(should_keep),
+      std::move(record_filter),
       appender.get(),
       seg->path().is_internal_topic(),
       apply_offset,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -16,6 +16,7 @@
 #include "storage/compacted_index_reader.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compacted_offset_list.h"
+#include "storage/logger.h"
 #include "storage/probe.h"
 #include "storage/readers_cache.h"
 #include "storage/segment.h"
@@ -25,6 +26,7 @@
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/rwlock.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <roaring/roaring.hh>
 
@@ -298,6 +300,53 @@ auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
                 [] { return ss::make_ready_future<>(); });
           });
       });
+}
+
+template<typename Func>
+ss::future<bool> should_keep(
+  const model::record_batch& b,
+  const model::record& r,
+  bool is_last_record_in_batch,
+  Func&& is_latest_key,
+  probe& pb,
+  ss::sharded<features::feature_table>& feature_table,
+  model::offset segment_last_offset,
+  bool past_tombstone_delete_horizon,
+  bool& may_have_tombstone_records) {
+    auto compaction_placeholder_enabled = feature_table.local().is_active(
+      features::feature::compaction_placeholder_batch);
+    auto is_last_batch = b.last_offset() == segment_last_offset;
+    // once compaction placeholder feature is enabled, we are not
+    // worried about empty batches as the reducer then installs a
+    // placeholder batch if all the records are compacted away.
+    if (
+      !compaction_placeholder_enabled
+      && (is_last_batch && is_last_record_in_batch)) {
+        vlog(
+          gclog.trace,
+          "retaining last record: {} of segment from batch: {}",
+          r,
+          b.header());
+        if (r.is_tombstone()) {
+            may_have_tombstone_records = true;
+        }
+
+        co_return true;
+    }
+
+    // Deal with tombstone record removal
+    if (r.is_tombstone() && past_tombstone_delete_horizon) {
+        pb.add_removed_tombstone();
+        co_return false;
+    }
+
+    auto keep = co_await is_latest_key(b, r);
+
+    if (r.is_tombstone() && keep) {
+        may_have_tombstone_records = true;
+    }
+
+    co_return keep;
 }
 
 } // namespace storage::internal

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -836,6 +836,9 @@ redpanda_cc_gtest(
     cpu = 1,
     deps = [
         "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/cluster:features",
+        "//src/v/features",
         "//src/v/kafka/server/tests:kafka_test_utils",
         "//src/v/model",
         "//src/v/random:generators",

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -8,12 +8,20 @@
 // by the Apache License, Version 2.0
 
 #include "base/vlog.h"
+#include "cluster/feature_manager.h"
+#include "cluster/feature_update_action.h"
+#include "features/feature_state.h"
+#include "features/feature_table.h"
 #include "gtest/gtest.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/namespace.h"
+#include "model/record_batch_reader.h"
 #include "model/record_batch_types.h"
+#include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
+#include "storage/segment.h"
+#include "storage/segment_utils.h"
 #include "storage/tests/manual_mixin.h"
 #include "storage/types.h"
 #include "test_utils/async.h"
@@ -28,6 +36,7 @@
 
 #include <chrono>
 #include <numeric>
+#include <ranges>
 
 using namespace std::chrono_literals;
 
@@ -224,7 +233,7 @@ public:
 
     ss::future<bool> do_sliding_window_compact(
       model::offset max_collect_offset,
-      std::optional<std::chrono::milliseconds> tombstone_ret_ms,
+      std::optional<std::chrono::milliseconds> tombstone_ret_ms = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt) {
         // Compact, allowing the map to grow as large as we need.
         ss::abort_source never_abort;
@@ -241,6 +250,25 @@ public:
         // sliding_window_compact takes cfg by const&, so return will be a
         // use-after-free
         co_return co_await disk_log.sliding_window_compact(cfg);
+    }
+
+    ss::future<storage::compaction_result> do_segment_self_compact(
+      ss::lw_shared_ptr<storage::segment> seg,
+      model::offset max_collect_offset,
+      std::optional<std::chrono::milliseconds> tombstone_ret_ms = std::nullopt,
+      std::optional<size_t> max_keys = std::nullopt) {
+        ss::abort_source never_abort;
+        storage::compaction_config cfg(
+          max_collect_offset,
+          tombstone_ret_ms,
+          ss::default_priority_class(),
+          never_abort,
+          std::nullopt,
+          max_keys,
+          nullptr,
+          nullptr);
+        auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+        co_return co_await disk_log.segment_self_compact(cfg, seg);
     }
 
 protected:
@@ -1336,3 +1364,96 @@ INSTANTIATE_TEST_SUITE_P(
   RandomDistributionMultiPass,
   CompactionFixtureTombstonesMultiPassRandomParamTest,
   ::testing::Combine(::testing::Bool(), ::testing::Values(10, 25, 100)));
+
+class CompactionFixturePlaceHolderBatchTest
+  : public CompactionFixtureTest
+  , public ::testing::WithParamInterface<bool> {};
+
+TEST_P(
+  CompactionFixturePlaceHolderBatchTest,
+  TestSelfCompactionWithPlaceholderBatch) {
+    bool placeholder_batch_enabled = GetParam();
+    if (!placeholder_batch_enabled) {
+        cluster::feature_manager& feature_manager
+          = app.controller->get_feature_manager().local();
+        feature_manager
+          .write_action(cluster::feature_update_action{
+            .feature_name = ss::sstring{"compaction_placeholder_batch"},
+            .action = cluster::feature_update_action::action_t::deactivate})
+          .get();
+        auto& feature_table = app.controller->get_feature_table().local();
+        auto feature_state
+          = feature_table
+              .get_state(features::feature::compaction_placeholder_batch)
+              .get_state();
+        ASSERT_TRUE(
+          feature_state == features::feature_state::state::disabled_active);
+    }
+
+    constexpr auto num_segments = 1;
+    constexpr auto cardinality = 1;
+    size_t batches_per_segment = 1;
+    size_t records_per_batch = 1;
+    map_t latest_kv_map;
+    generate_data(
+      num_segments,
+      cardinality,
+      batches_per_segment,
+      records_per_batch,
+      0,
+      true,
+      &latest_kv_map)
+      .get();
+
+    ASSERT_EQ(latest_kv_map.size(), 1);
+
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    auto& segs = disk_log.segments();
+
+    ASSERT_EQ(segs.size(), 2);
+
+    auto check_num_data_batches =
+      [](const auto& batches, int expected_num_data_batches) {
+          int num_data_batches = 0;
+          for (const auto& b : batches) {
+              if (b.header().type == model::record_batch_type::raft_data) {
+                  ++num_data_batches;
+              }
+          }
+          ASSERT_EQ(num_data_batches, expected_num_data_batches);
+      };
+
+    // Mark the segment as having completed window compaction and cleanly
+    // compacted.
+    storage::internal::mark_segment_as_finished_window_compaction(
+      segs[0], true, disk_log.get_probe())
+      .get();
+
+    // Sleep to allow self compaction to _possibly_ remove the tombstone record.
+    ss::sleep(100ms).get();
+
+    // Self compact the segment
+    do_segment_self_compact(segs[0], model::offset::max(), 1ms).get();
+
+    {
+        auto seg_0_reader_cfg = storage::log_reader_config(
+          segs[0]->offsets().get_base_offset(),
+          model::offset::max(),
+          ss::default_priority_class());
+        auto seg_0_batches = model::consume_reader_to_memory(
+                               log->make_reader(seg_0_reader_cfg).get(),
+                               model::no_timeout)
+                               .get();
+
+        // We should expect that even though the tombstone is removable, because
+        // it is the last record in the segment, it is persisted due to
+        // feature::compaction_placeholder_batch being disabled.
+        auto num_expected_data_batches = placeholder_batch_enabled ? 0 : 1;
+        check_num_data_batches(seg_0_batches, num_expected_data_batches);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  PlaceholderBatchEnabled,
+  CompactionFixturePlaceHolderBatchTest,
+  ::testing::Bool());


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25873
