### PR TITLE
io: wire up seastar reclaimer to page cache

### DIFF
--- a/src/v/io/interval_map.h
+++ b/src/v/io/interval_map.h
@@ -116,9 +116,11 @@ public:
     /**
      * Erase the interval pointed to by the iterator \it.
      *
+     * Returns an iterator to the next element in the map.
+     *
      * Invalidates iterators.
      */
-    void erase(const_iterator it);
+    const_iterator erase(const_iterator it);
 
 private:
     map_type map_;
@@ -220,8 +222,10 @@ bool interval_map<T, V>::empty() const {
 }
 
 template<std::integral T, typename V>
-void interval_map<T, V>::erase(interval_map<T, V>::const_iterator it) {
-    map_.erase(it);
+interval_map<T, V>::const_iterator
+interval_map<T, V>::erase(interval_map<T, V>::const_iterator it) {
+    return map_.erase(it);
+}
 }
 
 } // namespace experimental::io

--- a/src/v/io/interval_map.h
+++ b/src/v/io/interval_map.h
@@ -122,6 +122,11 @@ public:
      */
     const_iterator erase(const_iterator it);
 
+    /**
+     * Returns the number of elements in the map.
+     */
+    [[nodiscard]] size_t size() const;
+
 private:
     map_type map_;
 };
@@ -226,6 +231,10 @@ interval_map<T, V>::const_iterator
 interval_map<T, V>::erase(interval_map<T, V>::const_iterator it) {
     return map_.erase(it);
 }
+
+template<std::integral T, typename V>
+size_t interval_map<T, V>::size() const {
+    return map_.size();
 }
 
 } // namespace experimental::io

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -74,4 +74,9 @@ void page::signal_waiters() {
       [](page::waiter* waiter) { waiter->ready.set_value(); });
 }
 
+bool page::may_evict() const {
+    return !test_flag(flags::faulting) && !test_flag(flags::dirty)
+           && use_count() == 1;
+}
+
 } // namespace experimental::io

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -24,6 +24,29 @@ namespace experimental::io {
 
 /**
  * A page represents a contiguous region of data in a file.
+ *
+ * Concurrency
+ * -----------
+ *
+ * Pages are subject to synchronous eviction, via the page cache, by the Seastar
+ * memory reclaimer, and thus have specific rules related to concurrency.
+ *
+ * Pages in the page cache (and subject to Seastar reclaim) are contained on an
+ * intrusive list using the page::cache_hook intrusive list hook. The Seastar
+ * reclaimer accesses pages through this list. When a page is chosen for
+ * eviction its may_evict method is called. If the page is allowed to be
+ * evicted, then the page cache is permitted to clear the page's data buffer and
+ * remove the page from the cache's intrusive list, but the page structure
+ * itself otherwise left unmodified.
+ *
+ * The interactions of the reclaimer (free, intrusive_list::erase, may_evict)
+ * should all be allocation-free, problematic interleavings that corrupt data
+ * structures are unexpected. However, there are additional page access rules.
+ *
+ * After obtaining a shared_ptr reference to a page it should be tested for
+ * with page.data().empty() to determine if the page had been evicted. If it has
+ * not been evicted, then as long as the held reference remains alive the page
+ * is not subject to eviction.
  */
 class page : public seastar::enable_lw_shared_from_this<page> {
 public:
@@ -103,21 +126,28 @@ public:
     void clear();
 
     /*
-     * Used by the cache to test if this page may be evicted. If true, the cache
-     * is permitted to release the backing memory for this page and remove the
-     * page from the cache.
+     * Used by the page cache to test if this page may be evicted. If true, the
+     * cache is permitted to release the backing memory for this page. Note that
+     * this will be invoked by Seastar's synchronous relaimer. See the comment
+     * on the page class for additional details.
      *
-     * use_count(): we maintain the invariant that a page in the cache is always
-     * referenced by an index structure. therefore, if its use_count is 1 then
-     * there are no other active references to the page, and the backing memory
-     * can be released. this property is useful because it bounds the set of
-     * locations where a page must be tested to those where new page references
-     * are obtained from an index.
+     * A page is non-evictable when:
+     *
+     * Faulting: when a page is faulting we cannot evict it because inflight I/O
+     * may be writing to the page's data buffer and expect it to be present.
+     *
+     * Dirty: when a page is dirty we cannot evict it because we would lose
+     * updates that have not yet been made persistent.
+     *
+     * References: the container that owns pages (most likely page_set) stores
+     * shared_ptr<page> objects which have an base line use count of 1. When the
+     * use count is 1 the page is considered evictable--it is alive, but not
+     * being actively used. However, when new references to the page
+     * are created (e.g. a reader) then the use count is > 1 and the page is not
+     * subject to eviction. See Scylla's LSA weak pointer for additional
+     * inspiration.
      */
-    [[nodiscard]] bool may_evict() const {
-        return !test_flag(flags::faulting) && !test_flag(flags::dirty)
-               && use_count() == 1;
-    }
+    [[nodiscard]] bool may_evict() const;
 
     /**
      * Page cache entry intrusive list hook.

--- a/src/v/io/page_cache.cc
+++ b/src/v/io/page_cache.cc
@@ -24,6 +24,8 @@ bool page_cache::evict::operator()(page& page) noexcept {
     return false;
 }
 
-size_t page_cache::cost::operator()(const page& /*page*/) noexcept { return 1; }
+size_t page_cache::cost::operator()(const page& page) noexcept {
+    return page.size();
+}
 
 } // namespace experimental::io

--- a/src/v/io/page_cache.cc
+++ b/src/v/io/page_cache.cc
@@ -10,10 +10,15 @@
  */
 #include "io/page_cache.h"
 
+using reclaim_scope = seastar::memory::reclaimer_scope;
+
 namespace experimental::io {
 
 page_cache::page_cache(config cfg)
-  : cache_(cfg, evict(this)) {}
+  : cache_(cfg, evict(this))
+  , reclaimer_(
+      [this](reclaimer::request request) { return reclaim(request); },
+      reclaim_scope::sync) {}
 
 void page_cache::insert(page& page) noexcept { cache_.insert(page); }
 
@@ -34,6 +39,36 @@ bool page_cache::evict::operator()(page& page) noexcept {
 
 size_t page_cache::cost::operator()(const page& page) noexcept {
     return page.size();
+}
+
+page_cache::reclaim_result
+page_cache::reclaim(reclaimer::request request) noexcept {
+    if (is_memory_reclaiming()) {
+        return reclaim_result::reclaimed_nothing;
+    }
+    batch_reclaiming_lock lock(*this);
+
+    const auto cache_size = [this] {
+        const auto stat = cache_.stat();
+        return stat.small_queue_size + stat.main_queue_size;
+    };
+
+    const auto evicted_size = [init = cache_size(), cache_size] {
+        return init - cache_size();
+    };
+
+    while (true) {
+        const auto evicted = cache_.evict();
+        if (!evicted) {
+            break;
+        }
+        if (evicted_size() >= request.bytes_to_reclaim) {
+            break;
+        }
+    }
+
+    return evicted_size() == 0 ? reclaim_result::reclaimed_nothing
+                               : reclaim_result::reclaimed_something;
 }
 
 uint64_t page_cache::stats::evictions_requested() const {

--- a/src/v/io/page_cache.cc
+++ b/src/v/io/page_cache.cc
@@ -12,12 +12,20 @@
 
 namespace experimental::io {
 
+page_cache::page_cache(config cfg)
+  : cache_(cfg, evict(this)) {}
+
 void page_cache::insert(page& page) noexcept { cache_.insert(page); }
 
 void page_cache::remove(const page& page) noexcept { cache_.remove(page); }
 
+page_cache::evict::evict(page_cache* cache)
+  : cache_(cache) {}
+
 bool page_cache::evict::operator()(page& page) noexcept {
+    cache_->evict_stats_.total++;
     if (page.may_evict()) {
+        cache_->evict_stats_.granted++;
         page.clear();
         return true;
     }
@@ -26,6 +34,22 @@ bool page_cache::evict::operator()(page& page) noexcept {
 
 size_t page_cache::cost::operator()(const page& page) noexcept {
     return page.size();
+}
+
+uint64_t page_cache::stats::evictions_requested() const {
+    return evictions_requested_;
+}
+
+uint64_t page_cache::stats::evictions_granted() const {
+    return evictions_granted_;
+}
+
+uint64_t page_cache::stats::evictions_rejected() const {
+    return evictions_requested_ - evictions_granted_;
+}
+
+struct page_cache::stats page_cache::stats() const noexcept {
+    return {evict_stats_.total, evict_stats_.granted};
 }
 
 } // namespace experimental::io

--- a/src/v/io/page_cache.h
+++ b/src/v/io/page_cache.h
@@ -12,14 +12,26 @@
 #include "io/page.h"
 #include "utils/s3_fifo.h"
 
+#include <seastar/core/memory.hh>
+
 namespace experimental::io {
 
 /**
  * The page cache tracks pages and controls cache eviction.
  */
 class page_cache {
-    struct evict {
+    class evict {
+    public:
+        struct stats {
+            uint64_t total{0};
+            uint64_t granted{0};
+        };
+
+        explicit evict(page_cache*);
         bool operator()(page&) noexcept;
+
+    private:
+        page_cache* cache_;
     };
 
     struct cost {
@@ -35,8 +47,7 @@ public:
     /**
      * Initialize with the given configuration.
      */
-    explicit page_cache(config cfg)
-      : cache_(cfg) {}
+    explicit page_cache(config cfg);
 
     /**
      * Insert @page into the cache.
@@ -52,7 +63,28 @@ public:
      */
     void remove(const page&) noexcept;
 
+    struct stats {
+    public:
+        [[nodiscard]] uint64_t evictions_requested() const;
+        [[nodiscard]] uint64_t evictions_granted() const;
+        [[nodiscard]] uint64_t evictions_rejected() const;
+
+    private:
+        friend page_cache;
+
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+        stats(uint64_t evictions_requested, uint64_t evictions_granted)
+          : evictions_requested_(evictions_requested)
+          , evictions_granted_(evictions_granted) {}
+
+        uint64_t evictions_requested_;
+        uint64_t evictions_granted_;
+    };
+
+    [[nodiscard]] stats stats() const noexcept;
+
 private:
+    evict::stats evict_stats_;
     cache_type cache_;
 };
 

--- a/src/v/io/page_cache.h
+++ b/src/v/io/page_cache.h
@@ -50,6 +50,15 @@ public:
     explicit page_cache(config cfg);
 
     /**
+     * The seastar reclaimer callback captures `this`.
+     */
+    page_cache(const page_cache&) = delete;
+    page_cache& operator=(const page_cache&) = delete;
+    page_cache(page_cache&&) noexcept = delete;
+    page_cache& operator=(page_cache&&) noexcept = delete;
+    ~page_cache() = default;
+
+    /**
      * Insert @page into the cache.
      *
      * The page must not already be stored in the cache.
@@ -84,8 +93,32 @@ public:
     [[nodiscard]] stats stats() const noexcept;
 
 private:
+    using reclaimer = seastar::memory::reclaimer;
+    using reclaim_result = seastar::memory::reclaiming_result;
+
+    bool _is_reclaiming{false};
+    struct batch_reclaiming_lock {
+        explicit batch_reclaiming_lock(page_cache& cache) noexcept
+          : ref(cache)
+          , prev(ref._is_reclaiming) {
+            ref._is_reclaiming = true;
+        }
+        ~batch_reclaiming_lock() noexcept { ref._is_reclaiming = prev; }
+        batch_reclaiming_lock(const batch_reclaiming_lock&) = delete;
+        batch_reclaiming_lock(batch_reclaiming_lock&&) = delete;
+        batch_reclaiming_lock& operator=(const batch_reclaiming_lock&) = delete;
+        batch_reclaiming_lock& operator=(batch_reclaiming_lock&&) = delete;
+
+    private:
+        page_cache& ref;
+        bool prev;
+    };
+    [[nodiscard]] bool is_memory_reclaiming() const { return _is_reclaiming; }
+    reclaim_result reclaim(reclaimer::request) noexcept;
+
     evict::stats evict_stats_;
     cache_type cache_;
+    reclaimer reclaimer_;
 };
 
 } // namespace experimental::io

--- a/src/v/io/page_set.cc
+++ b/src/v/io/page_set.cc
@@ -24,8 +24,8 @@ page_set::const_iterator page_set::find(uint64_t offset) const {
     return const_iterator(pages_.find(offset));
 }
 
-void page_set::erase(page_set::const_iterator it) {
-    pages_.erase(it.base_reference());
+page_set::const_iterator page_set::erase(page_set::const_iterator it) {
+    return const_iterator{pages_.erase(it.base_reference())};
 }
 
 page_set::const_iterator page_set::begin() const {

--- a/src/v/io/page_set.cc
+++ b/src/v/io/page_set.cc
@@ -45,4 +45,6 @@ page_set::insert(seastar::lw_shared_ptr<page> page) {
     return {const_iterator(res.first), res.second};
 }
 
+size_t page_set::size() const { return pages_.size(); }
+
 } // namespace experimental::io

--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -76,8 +76,10 @@ public:
 
     /**
      * Remove the page pointed to be \p it.
+     *
+     * Returns an iterator to the next page in the set.
      */
-    void erase(const_iterator it);
+    const_iterator erase(const_iterator it);
 
     /**
      * Return an iterator to the first page in the set.

--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -91,6 +91,11 @@ public:
      */
     [[nodiscard]] const_iterator end() const;
 
+    /**
+     * Returns the number of pages in the set.
+     */
+    [[nodiscard]] size_t size() const;
+
 private:
     map_type pages_;
 };

--- a/src/v/io/tests/BUILD
+++ b/src/v/io/tests/BUILD
@@ -108,3 +108,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "page_cache_test",
+    timeout = "short",
+    srcs = ["page_cache_test.cc"],
+    deps = [
+        ":testing",
+        "//src/v/base",
+        "//src/v/io",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/io/tests/BUILD
+++ b/src/v/io/tests/BUILD
@@ -110,14 +110,20 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
-    name = "page_cache_test",
+    name = "page_cache_reclaim_test",
     timeout = "short",
-    srcs = ["page_cache_test.cc"],
+    srcs = ["page_cache_reclaim_test.cc"],
+    memory = "500M",
     deps = [
         ":testing",
         "//src/v/base",
+        "//src/v/container:fragmented_vector",
         "//src/v/io",
+        "//src/v/ssx:async_algorithm",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "//src/v/utils:memory_data_source",
+        "@boost//:range",
         "@googletest//:gtest",
         "@seastar",
     ],

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -216,8 +216,9 @@ TEST(IntervalMap, Erase) {
         imap map;
         auto res = map.insert({0, 10}, 0);
         EXPECT_FALSE(map.empty());
-        map.erase(res.first);
+        auto next = map.erase(res.first);
         EXPECT_TRUE(map.empty());
+        EXPECT_EQ(next, map.end());
     }
 
     // erase 2 becomes empty
@@ -225,13 +226,36 @@ TEST(IntervalMap, Erase) {
         imap map;
         EXPECT_TRUE(map.insert({0, 10}, 0).second);
         EXPECT_TRUE(map.insert({10, 10}, 0).second);
-        const auto it0 = map.find(0);
+        EXPECT_FALSE(map.empty());
+
         const auto it1 = map.find(10);
+        auto next = map.erase(it1);
         EXPECT_FALSE(map.empty());
-        map.erase(it1);
-        EXPECT_FALSE(map.empty());
-        map.erase(it0);
+        EXPECT_EQ(next, map.end());
+
+        const auto it0 = map.find(0);
+        next = map.erase(it0);
         EXPECT_TRUE(map.empty());
+        EXPECT_EQ(next, map.end());
+    }
+
+    // erase returns non-end next
+    {
+        imap map;
+        EXPECT_TRUE(map.insert({0, 10}, 0).second);
+        EXPECT_TRUE(map.insert({10, 10}, 0).second);
+        EXPECT_FALSE(map.empty());
+
+        const auto it0 = map.find(0);
+        auto next = map.erase(it0);
+        EXPECT_FALSE(map.empty());
+        EXPECT_EQ(next, map.begin());
+        EXPECT_NE(next, map.end());
+
+        const auto it1 = map.find(10);
+        next = map.erase(it1);
+        EXPECT_TRUE(map.empty());
+        EXPECT_EQ(next, map.end());
     }
 }
 

--- a/src/v/io/tests/interval_map_test.cc
+++ b/src/v/io/tests/interval_map_test.cc
@@ -41,6 +41,23 @@ TEST(IntervalMap, InsertIntoEmptyMap) {
     }
 }
 
+TEST(IntervalMap, Size) {
+    imap map;
+    EXPECT_EQ(map.size(), 0);
+
+    EXPECT_TRUE(map.insert({0, 10}, 0).second);
+    EXPECT_EQ(map.size(), 1);
+
+    EXPECT_TRUE(map.insert({10, 10}, 0).second);
+    EXPECT_EQ(map.size(), 2);
+
+    map.erase(map.begin());
+    EXPECT_EQ(map.size(), 1);
+
+    map.erase(map.begin());
+    EXPECT_EQ(map.size(), 0);
+}
+
 TEST(IntervalMap, InsertOverlapRejected) {
     imap map;
     EXPECT_TRUE(map.insert({0, 10}, 0).second);

--- a/src/v/io/tests/page_cache_reclaim_test.cc
+++ b/src/v/io/tests/page_cache_reclaim_test.cc
@@ -1,0 +1,312 @@
+
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page.h"
+#include "io/page_cache.h"
+#include "io/page_set.h"
+#include "ssx/async_algorithm.h"
+#include "test_utils/randoms.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/align.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/util/log.hh>
+
+using namespace std::chrono_literals;
+
+namespace io = experimental::io;
+
+static ss::logger lg{"test"};
+
+struct reclaim_test {
+    static constexpr size_t page_size = 4096;
+    static constexpr double ghost_queue_ratio_limit = 0.05;
+
+    seastar::gate gate;
+    const io::page_cache::config cache_config;
+    io::page_cache cache;
+    io::page_set pages;
+    io::page_set pages_referenced;
+    uint64_t next_offset{0};
+    struct io::page_cache::stats prev_stats;
+    uint64_t ghost_queue_size{0};
+    uint64_t evictable{0};
+    double evictable_ratio{0.0};
+    double ghost_queue_ratio{0.0};
+
+    explicit reclaim_test(size_t cache_size)
+      : cache_config{cache_size - 1, cache_size - 2}
+      , cache(cache_config)
+      , prev_stats(cache.stats()) {}
+
+    void start() {
+        std::ignore = ghost_queue_vaccum();
+        std::ignore = page_churner();
+    }
+
+    seastar::future<> stop() {
+        co_await gate.close();
+        for (auto& page : pages) {
+            cache.remove(*page);
+        }
+    }
+
+    void add_new_page(
+      std::optional<uint64_t> offset = std::nullopt,
+      std::optional<io::page::flags> flag = std::nullopt,
+      const std::optional<utils::s3_fifo::cache_hook>& hook
+      = std::nullopt) noexcept {
+        auto page = alloc_page(offset.value_or(next_offset), hook);
+        if (!offset.has_value()) {
+            next_offset += page->size();
+        }
+        if (flag.has_value()) {
+            page->set_flag(flag.value());
+        } else {
+            ++evictable;
+        }
+        auto res = pages.insert(page);
+        vassert(res.second, "could not insert page");
+        cache.insert(*page);
+    }
+
+    void update_stats() {
+        auto curr_stats = cache.stats();
+        auto evictions_granted = curr_stats.evictions_granted()
+                                 - prev_stats.evictions_granted();
+        ghost_queue_size += evictions_granted;
+        evictable -= evictions_granted;
+        const auto live_pages = pages.size() - ghost_queue_size;
+        evictable_ratio = static_cast<double>(live_pages)
+                          / static_cast<double>(evictable);
+        ghost_queue_ratio = static_cast<double>(ghost_queue_size)
+                            / static_cast<double>(pages.size());
+        prev_stats = curr_stats;
+    }
+
+    /*
+     * eviction move a page into the ghost queue, but it page structure remains.
+     * these needs to be vaccumed up in practice. here we just use a brute force
+     * approach. in real world this work should handled more intelligently.
+     */
+    seastar::future<> ghost_queue_vaccum() {
+        auto gh = gate.hold();
+        while (!gate.is_closed()) {
+            co_await seastar::yield();
+            update_stats();
+            if (ghost_queue_ratio <= ghost_queue_ratio_limit) {
+                continue;
+            }
+            auto offset = random_generators::get_int<size_t>(0, pages.size());
+            auto it = pages.begin();
+            std::advance(it, offset);
+            for (int i = 0; i < 50 && it != pages.end();) {
+                if ((*it)->data().empty()) {
+                    it = pages.erase(it);
+                    --ghost_queue_size;
+                } else {
+                    ++it;
+                }
+            }
+        }
+    }
+
+    [[nodiscard]] bool is_referenced(uint64_t offset) const {
+        return pages_referenced.find(offset) != pages_referenced.end();
+    }
+
+    [[nodiscard]] static bool
+    is_clean(const ss::lw_shared_ptr<io::page>& page) {
+        return !page->test_flag(io::page::flags::dirty)
+               && !page->test_flag(io::page::flags::faulting);
+    }
+
+    /*
+     * random churn the state of pages
+     */
+    seastar::future<> page_churner() {
+        auto gh = gate.hold();
+        while (!gate.is_closed()) {
+            co_await seastar::yield();
+            auto offset = random_generators::get_int<size_t>(0, next_offset);
+            auto it = pages.find(offset);
+            if (it == pages.end()) {
+                /*
+                 * page was removed by ghost queue vaccum. a read to this
+                 * location would allocate a new page in the faulting state.
+                 */
+                add_new_page(
+                  seastar::align_down(offset, page_size),
+                  io::page::flags::faulting);
+                continue;
+            }
+
+            auto page = *it;
+
+            /*
+             * remove page from the ghost queue, and maybe fault it back
+             */
+            if (page->data().empty()) {
+                pages.erase(it);
+                --ghost_queue_size;
+                if (tests::random_bool()) {
+                    add_new_page(
+                      page->offset(),
+                      io::page::flags::faulting,
+                      page->cache_hook);
+                }
+                continue;
+            }
+
+            bool was_dirty_or_faulting = false;
+
+            // if faulting, then can make clean
+            if (page->test_flag(io::page::flags::faulting)) {
+                was_dirty_or_faulting = true;
+                page->clear_flag(io::page::flags::faulting);
+                if (!is_referenced(page->offset())) {
+                    evictable++;
+                }
+            }
+
+            // if dirty, then can read or make clean
+            if (page->test_flag(io::page::flags::dirty)) {
+                was_dirty_or_faulting = true;
+                page->clear_flag(io::page::flags::dirty);
+                if (!is_referenced(page->offset())) {
+                    evictable++;
+                }
+            }
+
+            // if clean, then can make dirty or read
+            if (!was_dirty_or_faulting) {
+                page->set_flag(io::page::flags::faulting);
+                if (!is_referenced(page->offset())) {
+                    evictable--;
+                }
+            }
+
+            // churn the set of extra references
+            if (tests::random_bool()) {
+                if (!is_referenced(page->offset())) {
+                    auto res = pages_referenced.insert(page);
+                    vassert(res.second, "failed to insert page");
+                    if (is_clean(page)) {
+                        evictable--;
+                    }
+                }
+                if (pages_referenced.size() > 10) {
+                    auto offset = random_generators::get_int<size_t>(
+                      0, pages_referenced.size());
+                    auto it = pages_referenced.begin();
+                    std::advance(it, offset);
+                    if (it != pages_referenced.end()) {
+                        if (is_clean(*it)) {
+                            evictable++;
+                        }
+                        pages_referenced.erase(it);
+                    }
+                }
+            }
+        }
+    }
+
+    static seastar::lw_shared_ptr<io::page> alloc_page(
+      uint64_t offset,
+      std::optional<utils::s3_fifo::cache_hook> hook = std::nullopt) noexcept {
+        auto buf = seastar::temporary_buffer<char>::aligned(
+          page_size, page_size);
+        if (hook.has_value()) {
+            return seastar::make_lw_shared<io::page>(
+              offset, std::move(buf), hook.value());
+        }
+        return seastar::make_lw_shared<io::page>(offset, std::move(buf));
+    }
+};
+
+class ReclaimTest : public testing::TestWithParam<bool> {};
+
+TEST_P(ReclaimTest, RandomOps) {
+    /*
+     * When seastar_reclaim is true, set the cache limit near the limit where
+     * seastar will also start issuing reclaim requests. Otherwise, set the
+     * cache size limit below the this limit so that it is never reached.
+     */
+    const auto seastar_reclaim = GetParam();
+    const auto cache_size = [seastar_reclaim] {
+        const auto total = seastar::memory::stats().total_memory();
+        const auto min_free = seastar::memory::min_free_memory();
+        if (seastar_reclaim) {
+            // +2 to accomodate the adjustment made in reclaim_test constructor
+            // to satisfy the s3 requirement that the main fifo queue is larger
+            // than the small fifo queue
+            return total - min_free + 2;
+        }
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+        return static_cast<size_t>(200) << 20;
+#else
+        return (total - min_free) / 2;
+#endif
+    }();
+
+    reclaim_test rt(cache_size);
+    rt.start();
+
+    const auto iters = 100 * 1000;
+    for (int i = 0; i < iters; ++i) {
+        rt.add_new_page();
+
+        rt.update_stats();
+        thread_local static ss::logger::rate_limit rate(250ms);
+        lg.log(
+          ss::log_level::warn,
+          rate,
+          "ss reclaims {} evictions requested {} granted {} rejected {} "
+          "num_pages {} ghost queue size/ratio {}/{} evictable size/ratio "
+          "{}/{}",
+          ss::memory::stats().reclaims(),
+          rt.cache.stats().evictions_requested(),
+          rt.cache.stats().evictions_granted(),
+          rt.cache.stats().evictions_rejected(),
+          rt.pages.size(),
+          rt.ghost_queue_size,
+          rt.ghost_queue_ratio,
+          rt.evictable,
+          rt.evictable_ratio);
+
+        if (i % ssx::async_algo_traits::interval == 0) {
+            seastar::yield().get();
+        }
+    }
+
+    rt.stop().get();
+
+    if (seastar_reclaim) {
+        EXPECT_GT(seastar::memory::stats().reclaims(), 1000);
+    } else {
+        EXPECT_EQ(seastar::memory::stats().reclaims(), 0);
+    }
+
+    EXPECT_GT(rt.cache.stats().evictions_requested(), 1000);
+    EXPECT_GT(rt.cache.stats().evictions_granted(), 1000);
+    EXPECT_GT(rt.cache.stats().evictions_rejected(), 1000);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  CacheSizeLimit,
+  ReclaimTest,
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+  ::testing::Values(false)
+#else
+  ::testing::Bool()
+#endif
+);

--- a/src/v/io/tests/page_cache_test.cc
+++ b/src/v/io/tests/page_cache_test.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page_cache.h"
+
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+#include <gtest/gtest.h>
+
+namespace io = experimental::io;
+
+namespace {
+auto make_page(uint64_t offset, uint64_t size) {
+    return seastar::make_lw_shared<io::page>(
+      offset, seastar::temporary_buffer<char>(size));
+}
+} // namespace
+
+TEST(PageCache, Stats) {
+    constexpr size_t page_size = 4096;
+
+    // evictions happens _after_ size is exceeded. so, set the limit to be less
+    // than the size of 2 pages so evictions start after the second page. sizes
+    // are slightly different because s3 fifo expects the main fifo queue size
+    // to be larger than the small fifo queue size.
+    io::page_cache cache({(2 * page_size) - 1, (2 * page_size) - 2});
+
+    EXPECT_EQ(cache.stats().evictions_requested(), 0);
+    EXPECT_EQ(cache.stats().evictions_granted(), 0);
+    EXPECT_EQ(cache.stats().evictions_rejected(), 0);
+
+    std::vector<seastar::lw_shared_ptr<io::page>> pages;
+
+    // 1 page in cache
+    pages.push_back(make_page(0, page_size));
+    cache.insert(*pages.back());
+    EXPECT_EQ(cache.stats().evictions_requested(), 0);
+    EXPECT_EQ(cache.stats().evictions_granted(), 0);
+    EXPECT_EQ(cache.stats().evictions_rejected(), 0);
+
+    // 2 page in cache
+    pages.push_back(make_page(0, page_size));
+    cache.insert(*pages.back());
+    EXPECT_EQ(cache.stats().evictions_requested(), 0);
+    EXPECT_EQ(cache.stats().evictions_granted(), 0);
+    EXPECT_EQ(cache.stats().evictions_rejected(), 0);
+
+    // 3rd page triggers a reclaim
+    pages.push_back(make_page(0, page_size));
+    cache.insert(*pages.back());
+    EXPECT_EQ(cache.stats().evictions_requested(), 1);
+    EXPECT_EQ(cache.stats().evictions_granted(), 1);
+    EXPECT_EQ(cache.stats().evictions_rejected(), 0);
+
+    // holding references to pages make them non-evictable
+    auto references = pages;
+
+    // eviction will fail on all pages
+    pages.push_back(make_page(0, page_size));
+    cache.insert(*pages.back());
+    EXPECT_EQ(cache.stats().evictions_requested(), 3);
+    EXPECT_EQ(cache.stats().evictions_granted(), 1);
+    EXPECT_EQ(cache.stats().evictions_rejected(), 2);
+
+    // the last page insertion still succeeds, and isn't contained in the
+    // references, so it should be the one page that is now evictable
+    auto prev_requested = cache.stats().evictions_requested();
+    pages.push_back(make_page(0, page_size));
+    cache.insert(*pages.back());
+    auto new_requests = cache.stats().evictions_requested() - prev_requested;
+    EXPECT_GE(new_requests, 1);
+    EXPECT_EQ(cache.stats().evictions_granted(), 2);
+    EXPECT_EQ(cache.stats().evictions_rejected(), 2 + (new_requests - 1));
+
+    references.clear();
+    for (auto& page : pages) {
+        cache.remove(*page);
+    }
+}

--- a/src/v/io/tests/page_set_test.cc
+++ b/src/v/io/tests/page_set_test.cc
@@ -99,12 +99,14 @@ TEST(PageSet, Erase) {
     EXPECT_NE(set.begin(), set.end());
 
     // remove the first page. set is not empty
-    set.erase(set.find(5));
+    auto next = set.erase(set.find(5));
     EXPECT_NE(set.begin(), set.end());
+    EXPECT_EQ(next, set.begin());
 
     // remove the second
-    set.erase(set.find(25));
+    next = set.erase(set.find(25));
 
     // now the set is empty
     EXPECT_EQ(set.begin(), set.end());
+    EXPECT_EQ(next, set.end());
 }

--- a/src/v/io/tests/page_set_test.cc
+++ b/src/v/io/tests/page_set_test.cc
@@ -34,6 +34,19 @@ TEST(PageSet, FindReturnsEndWhenEmpty) {
     EXPECT_EQ(set.find(0), set.end());
 }
 
+TEST(PageSet, Size) {
+    io::page_set set;
+    EXPECT_EQ(set.size(), 0);
+    (void)set.insert(make_page(0, 10));
+    EXPECT_EQ(set.size(), 1);
+    (void)set.insert(make_page(10, 10));
+    EXPECT_EQ(set.size(), 2);
+    set.erase(set.begin());
+    EXPECT_EQ(set.size(), 1);
+    set.erase(set.begin());
+    EXPECT_EQ(set.size(), 0);
+}
+
 TEST(PageSet, InsertOne) {
     io::page_set set;
 


### PR DESCRIPTION
io: wire up seastar reclaimer to page cache

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
