### PR TITLE
[v25.1.x] storage: make_ghost_batches off by one

### DIFF
--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -57,28 +57,6 @@ model::record_batch make_ghost_batch(
     return batch;
 }
 
-/**
- * makes multiple ghost batches required to fill the gap in a way that max batch
- * size (max of int32_t) is not exceeded
- */
-std::vector<model::record_batch> make_ghost_batches(
-  model::offset start_offset, model::offset end_offset, model::term_id term) {
-    std::vector<model::record_batch> batches;
-    while (start_offset <= end_offset) {
-        static constexpr model::offset max_batch_size{
-          std::numeric_limits<int32_t>::max()};
-        // limit max batch size
-        const model::offset delta = std::min<model::offset>(
-          max_batch_size, end_offset - start_offset);
-
-        batches.push_back(
-          make_ghost_batch(start_offset, delta + start_offset, term));
-        start_offset = next_offset(batches.back().last_offset());
-    }
-
-    return batches;
-}
-
 } // anonymous namespace
 
 template<>
@@ -97,6 +75,28 @@ struct fmt::formatter<storage::log_reader> : fmt::formatter<std::string_view> {
 
 namespace storage {
 using records_t = ss::circular_buffer<model::record_batch>;
+
+/**
+ * makes multiple ghost batches required to fill the gap in a way that max batch
+ * size (max of int32_t) is not exceeded
+ */
+std::vector<model::record_batch> log_reader::make_ghost_batches(
+  model::offset start_offset, model::offset end_offset, model::term_id term) {
+    std::vector<model::record_batch> batches;
+    while (start_offset <= end_offset) {
+        static constexpr model::offset max_batch_size{
+          std::numeric_limits<int32_t>::max() - 1};
+        // limit max batch size
+        const model::offset delta = std::min<model::offset>(
+          max_batch_size, end_offset - start_offset);
+
+        batches.push_back(
+          make_ghost_batch(start_offset, delta + start_offset, term));
+        start_offset = next_offset(batches.back().last_offset());
+    }
+
+    return batches;
+}
 
 batch_consumer::consume_result skipping_consumer::accept_batch_start(
   const model::record_batch_header& header) const {

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -135,6 +135,10 @@ public:
     using data_t = model::record_batch_reader::data_t;
     using foreign_data_t = model::record_batch_reader::foreign_data_t;
     using storage_t = model::record_batch_reader::storage_t;
+    static std::vector<model::record_batch> make_ghost_batches(
+      model::offset start_offset,
+      model::offset end_offset,
+      model::term_id term);
 
     log_reader(
       std::unique_ptr<lock_manager::lease>,

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -318,3 +318,17 @@ SEASTAR_THREAD_TEST_CASE(iobuf_is_zero_test) {
     zero.append(zeros.data(), zeros.size());
     BOOST_REQUIRE_EQUAL(storage::internal::is_zero(zero), true);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_ghosts_gap) {
+    long twice_i32max = static_cast<long>(std::numeric_limits<int32_t>::max())
+                        * 2;
+    auto ghost_batches = log_reader::make_ghost_batches(
+      model::offset{0}, model::offset{twice_i32max}, model::term_id{0});
+    BOOST_REQUIRE_EQUAL(3, ghost_batches.size());
+    size_t num_records = 0;
+    for (const auto& b : ghost_batches) {
+        BOOST_REQUIRE_GT(b.record_count(), 0);
+        num_records += b.record_count();
+    }
+    BOOST_REQUIRE_EQUAL(twice_i32max + 1, num_records);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25913
