### PR TITLE
`storage`: adjacent segment compaction over ranges

### DIFF
--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -945,8 +945,7 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
     b | storage::add_segment(*first)
       | storage::add_random_batch(*first, spec.last_segment_num_records);
 
-    // Compaction will rewrite each segment, and merge the first two.
-    // Segment boundaries: [5, 24][25, 34][35, 50]...
+    // Compaction will rewrite each segment, and merge the first few.
     b.gc(model::timestamp::max(), std::nullopt).get();
 
     size_t max_size = b.get_segment(0).size_bytes()
@@ -965,7 +964,7 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
     auto upload_candidate = upload_with_locks.candidate;
     BOOST_REQUIRE(!upload_candidate.sources.empty());
     BOOST_REQUIRE_EQUAL(upload_candidate.starting_offset, model::offset{10});
-    BOOST_REQUIRE_EQUAL(upload_candidate.final_offset, model::offset{29});
+    BOOST_REQUIRE_EQUAL(upload_candidate.final_offset, model::offset{39});
 
     // Start with all the segments collected
     auto expected_content_length = collector.collected_size();
@@ -979,7 +978,7 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
     BOOST_REQUIRE_EQUAL(
       expected_content_length, upload_candidate.content_length);
 
-    BOOST_REQUIRE_EQUAL(upload_with_locks.read_locks.size(), 2);
+    BOOST_REQUIRE_EQUAL(upload_with_locks.read_locks.size(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_same_size_reupload_skipped) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1090,6 +1090,16 @@ configuration::configuration()
       "compaction.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , log_compaction_merge_max_ranges(
+      *this,
+      "log_compaction_merge_max_ranges",
+      "The maximum number of ranges of segments that can be processed in a "
+      "single round of adjacent segment compaction. If `null` (the default "
+      "value), no maximum is imposed on the number of ranges that can be "
+      "processed at once. A value below 1 effectively disables adjacent merge "
+      "compaction.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1080,6 +1080,16 @@ configuration::configuration()
       false)
   , log_compaction_adjacent_merge_self_compaction_count(
       *this, "log_compaction_adjacent_merge_self_compaction_count")
+  , log_compaction_merge_max_segments_per_range(
+      *this,
+      "log_compaction_merge_max_segments_per_range",
+      "The maximum number of segments that can be combined into a single "
+      "segment during an adjacent merge operation. If `null` (the default "
+      "value), no maximum is imposed on the number of segments that can be "
+      "combined at once. A value below 2 effectively disables adjacent merge "
+      "compaction.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1079,14 +1079,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , log_compaction_adjacent_merge_self_compaction_count(
-      *this,
-      "log_compaction_adjacent_merge_self_compaction_count",
-      "The number of self compactions that must occur before an adjacent "
-      "compaction is attempted in the log. If set to `std::nullopt`, every "
-      "segment in the log must be self-compacted before an adjacent compaction "
-      "is attempted.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      10)
+      *this, "log_compaction_adjacent_merge_self_compaction_count")
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -264,6 +264,7 @@ struct configuration final : public config_store {
     deprecated_property log_compaction_adjacent_merge_self_compaction_count;
     property<std::optional<uint32_t>>
       log_compaction_merge_max_segments_per_range;
+    property<std::optional<uint32_t>> log_compaction_merge_max_ranges;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -261,8 +261,7 @@ struct configuration final : public config_store {
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
     property<bool> log_compaction_pause_use_sliding_window;
-    property<std::optional<size_t>>
-      log_compaction_adjacent_merge_self_compaction_count;
+    deprecated_property log_compaction_adjacent_merge_self_compaction_count;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -262,6 +262,8 @@ struct configuration final : public config_store {
     property<bool> log_compaction_use_sliding_window;
     property<bool> log_compaction_pause_use_sliding_window;
     deprecated_property log_compaction_adjacent_merge_self_compaction_count;
+    property<std::optional<uint32_t>>
+      log_compaction_merge_max_segments_per_range;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -42,14 +42,15 @@ struct kv_t {
       size_t num_records,
       std::optional<size_t> val_start = std::nullopt,
       size_t key_cardinality = 0,
-      bool produce_tombstones = false) {
+      bool produce_tombstones = false,
+      size_t base = 0) {
         size_t vstart = val_start.value_or(start);
         std::vector<kv_t> records;
         records.reserve(num_records);
         for (size_t i = 0; i < num_records; i++) {
             auto key = start + i;
             if (key_cardinality > 0) {
-                key = key % key_cardinality;
+                key = (key % key_cardinality) + base;
             }
             auto key_str = ssx::sformat("key{}", key);
             if (produce_tombstones) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -861,8 +861,14 @@ std::optional<
 disk_log_impl::find_adjacent_compaction_ranges(
   const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
     {
-        // Early return if cluster configured value effectively disables
+        // Early return if cluster configured values effectively disables
         // adjacent merge compaction.
+        auto max_ranges_size
+          = config::shard_local_cfg().log_compaction_merge_max_ranges();
+        if (max_ranges_size.has_value() && max_ranges_size < 1) {
+            return std::nullopt;
+        }
+
         auto max_segments_in_range
           = config::shard_local_cfg()
               .log_compaction_merge_max_segments_per_range();
@@ -950,6 +956,13 @@ disk_log_impl::find_adjacent_compaction_ranges(
           || is_unstable || !is_valid_offset_range) {
             if (num_segments_in_range > 1) {
                 ranges.push_back(current_range);
+                auto max_ranges_size
+                  = config::shard_local_cfg().log_compaction_merge_max_ranges();
+                if (
+                  max_ranges_size.has_value()
+                  && ranges.size() >= max_ranges_size.value()) {
+                    return ranges;
+                }
             }
 
             auto next_it = is_unstable ? std::next(it) : it;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -857,7 +857,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
 }
 
 std::optional<
-  std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
+  chunked_vector<std::pair<segment_set::iterator, segment_set::iterator>>>
 disk_log_impl::find_adjacent_compaction_ranges(
   const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
     {
@@ -920,7 +920,8 @@ disk_log_impl::find_adjacent_compaction_ranges(
         return offset_delta <= u32_max;
     };
 
-    std::vector<std::pair<segment_set::iterator, segment_set::iterator>> ranges;
+    chunked_vector<std::pair<segment_set::iterator, segment_set::iterator>>
+      ranges;
 
     auto it = _segs.begin();
     size_t current_size{0};
@@ -995,11 +996,11 @@ disk_log_impl::find_adjacent_compaction_ranges(
     return ranges;
 }
 
-ss::future<std::optional<std::vector<compaction_result>>>
+ss::future<std::optional<chunked_vector<compaction_result>>>
 disk_log_impl::compact_adjacent_segment_ranges(
   storage::compaction_config cfg,
   std::optional<model::offset> new_start_offset) {
-    std::vector<compaction_result> rs;
+    chunked_vector<compaction_result> rs;
     if (auto ranges = find_adjacent_compaction_ranges(cfg, new_start_offset);
         ranges) {
         // lightweight copy of segments in all of the found ranges. once a
@@ -1008,8 +1009,8 @@ disk_log_impl::compact_adjacent_segment_ranges(
         // erase an element from the range. The act of compacting adjacent
         // segments will also invalidate iterators pointing to the original
         // _segs vector.
-        using vec_t = std::vector<ss::lw_shared_ptr<segment>>;
-        std::vector<vec_t> seg_ranges;
+        using vec_t = chunked_vector<ss::lw_shared_ptr<segment>>;
+        chunked_vector<vec_t> seg_ranges;
         seg_ranges.reserve(ranges->size());
         for (auto& range : *ranges) {
             seg_ranges.emplace_back(range.first, range.second);
@@ -1040,7 +1041,7 @@ disk_log_impl::compact_adjacent_segment_ranges(
 }
 
 ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   storage::compaction_config cfg) {
     // This shouldn't be the case for any ranges returned from
     // find_adjacent_compaction_ranges(), but it is checked regardless.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1364,22 +1364,38 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
 ss::future<> disk_log_impl::do_compact(
   compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
+    compact_cfg.asrc = &_compaction_as;
+
+    auto compact_fut = ss::now();
+
     auto use_adjacent_merge
       = !config::shard_local_cfg().log_compaction_use_sliding_window()
         || config::shard_local_cfg().log_compaction_pause_use_sliding_window()
         || (compact_cfg.hash_key_map && compact_cfg.hash_key_map->capacity() == 0);
 
     if (use_adjacent_merge) {
-        co_return co_await adjacent_merge_compact(
+        compact_fut = adjacent_merge_compact(
           _segs, compact_cfg, new_start_offset);
+    } else {
+        compact_fut = sliding_window_compact(compact_cfg, new_start_offset)
+                        .then([&](bool compacted) {
+                            vlog(
+                              gclog.debug,
+                              "Sliding compaction of {} did {}compact "
+                              "data, proceeding to adjacent "
+                              "segment compaction",
+                              config().ntp(),
+                              compacted ? "" : "not ");
+                            return compact_adjacent_segment_ranges(
+                                     compact_cfg, new_start_offset)
+                              .discard_result();
+                        });
     }
 
-    // TODO: unify error handling.
-    compact_cfg.asrc = &_compaction_as;
-    auto did_compact_fut = co_await ss::coroutine::as_future(
-      sliding_window_compact(compact_cfg, new_start_offset));
-    if (did_compact_fut.failed()) {
-        auto eptr = did_compact_fut.get_exception();
+    auto compact_result = co_await ss::coroutine::as_future(
+      std::move(compact_fut));
+    if (compact_result.failed()) {
+        auto eptr = compact_result.get_exception();
         if (ssx::is_shutdown_exception(eptr)) {
             vlog(
               gclog.debug,
@@ -1389,14 +1405,6 @@ ss::future<> disk_log_impl::do_compact(
         }
         std::rethrow_exception(eptr);
     }
-    bool compacted = did_compact_fut.get();
-    vlog(
-      gclog.debug,
-      "Sliding compaction of {} did {}compact data, proceeding to adjacent "
-      "segment compaction",
-      config().ntp(),
-      compacted ? "" : "not ");
-    co_await compact_adjacent_segment_ranges(compact_cfg, new_start_offset);
 }
 
 ss::future<bool> disk_log_impl::chunked_sliding_window_compact(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -860,6 +860,17 @@ std::optional<
   std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
 disk_log_impl::find_adjacent_compaction_ranges(
   const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
+    {
+        // Early return if cluster configured value effectively disables
+        // adjacent merge compaction.
+        auto max_segments_in_range
+          = config::shard_local_cfg()
+              .log_compaction_merge_max_segments_per_range();
+        if (max_segments_in_range.has_value() && max_segments_in_range < 2) {
+            return std::nullopt;
+        }
+    }
+
     if (_segs.size() < 2) {
         return std::nullopt;
     }
@@ -925,12 +936,18 @@ disk_log_impl::find_adjacent_compaction_ranges(
         bool size_boundary = current_size
                              > _manager.config().max_compacted_segment_size();
         bool is_unstable = unstable(seg);
+        auto max_segments_in_range
+          = config::shard_local_cfg()
+              .log_compaction_merge_max_segments_per_range();
+        bool reached_max_range_size = max_segments_in_range.has_value()
+                                      && num_segments_in_range
+                                           >= max_segments_in_range.value();
         bool is_valid_offset_range = valid_offset_range(
           *current_range.first, seg);
 
         if (
-          term_boundary || size_boundary || is_unstable
-          || !is_valid_offset_range) {
+          term_boundary || size_boundary || reached_max_range_size
+          || is_unstable || !is_valid_offset_range) {
             if (num_segments_in_range > 1) {
                 ranges.push_back(current_range);
             }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -508,7 +508,9 @@ ss::future<compaction_result> disk_log_impl::segment_self_compact(
 }
 
 ss::future<> disk_log_impl::adjacent_merge_compact(
-  compaction_config cfg, std::optional<model::offset> new_start_offset) {
+  segment_set& segments,
+  compaction_config cfg,
+  std::optional<model::offset> new_start_offset) {
     vlog(
       gclog.trace,
       "[{}] applying 'compaction' log cleanup policy with config: {}",
@@ -554,62 +556,40 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
         }
     };
 
-    // loop until we compact segment or reached end of segments set
-    while (!_segs.empty()) {
-        const auto end_it = std::prev(_segs.end());
-        auto seg_it = std::find_if(
-          _segs.begin(),
-          end_it,
-          [offsets_compactible](ss::lw_shared_ptr<segment>& s) {
-              return !s->has_appender() && s->is_compacted_segment()
-                     && !s->finished_self_compaction()
-                     && offsets_compactible(*s);
-          });
-        // nothing to compact
-        if (seg_it == end_it) {
-            break;
+    for (auto& seg : segments) {
+        if (cfg.asrc) {
+            cfg.asrc->check();
         }
 
-        auto segment = *seg_it;
-        auto result = co_await segment_self_compact(cfg, segment);
+        auto is_compactible_segment = !seg->has_appender()
+                                      && seg->is_compacted_segment()
+                                      && offsets_compactible(*seg);
+        // Skip over segments that that being truncated, or are uncompactible.
+        if (is_compactible_segment) {
+            auto result = co_await segment_self_compact(cfg, seg);
 
-        if (segment->is_closed()) {
-            // We can race here with a truncation operation that removes the
-            // full segment, since we are not under a rewrite lock.
-            continue;
-        }
-
-        vlog(
-          gclog.debug,
-          "[{}] segment {} compaction result: {}",
-          config().ntp(),
-          segment->reader().filename(),
-          result);
-        if (result.did_compact()) {
-            segment->clear_cached_disk_usage();
-            _compaction_ratio.update(result.compaction_ratio());
-            const ssize_t removed_bytes = ssize_t(result.size_before)
-                                          - ssize_t(result.size_after);
-            subtract_segment_bytes(segment, removed_bytes);
-
-            auto config_adjacent_merge_count
-              = config::shard_local_cfg()
-                  .log_compaction_adjacent_merge_self_compaction_count();
-            // >= to ensure proper behavior if the config value were to be
-            // changed to be lower than the active counter.
-            if (
-              config_adjacent_merge_count.has_value()
-              && ++_adjacent_merge_counter
-                   >= config_adjacent_merge_count.value()) {
-                _adjacent_merge_counter = 0;
-                break;
-            } else {
-                co_return;
+            if (seg->is_closed()) {
+                // We can race here with a truncation operation that removes the
+                // full segment, since we are not under a rewrite lock.
+                continue;
+            }
+            vlog(
+              gclog.debug,
+              "[{}] segment {} compaction result: {}",
+              config().ntp(),
+              seg->reader().filename(),
+              result);
+            if (result.did_compact()) {
+                seg->clear_cached_disk_usage();
+                _compaction_ratio.update(result.compaction_ratio());
+                const ssize_t removed_bytes = ssize_t(result.size_before)
+                                              - ssize_t(result.size_after);
+                subtract_segment_bytes(seg, removed_bytes);
             }
         }
     }
 
-    co_await compact_adjacent_segments(cfg);
+    co_await compact_adjacent_segment_ranges(cfg, new_start_offset);
 }
 
 segment_set disk_log_impl::find_sliding_range(
@@ -876,102 +856,6 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     co_return true;
 }
 
-std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
-disk_log_impl::find_adjacent_compaction_range(const compaction_config& cfg) {
-    /*
-     * adjacent segment compaction.
-     *
-     * the strategy is to choose a pair of adjacent segments and first combine
-     * them into a single segment that replaces the pair, and then perform
-     * self-compaction on the replacement segment.
-     */
-    if (_segs.size() < 2) {
-        return std::nullopt;
-    }
-
-    // sliding window over segments. currently restricted to two segments
-    auto range = std::make_pair(_segs.begin(), std::next(_segs.begin(), 2));
-
-    // Ensure that the adjacent segments do not span an offset space greater
-    // than the maximum value that can be represented by a uint32_t. This must
-    // be enforced due to use of roaring::bitmap in the compacted_offset_list,
-    // which is used to deduplicate records during self compaction and sliding
-    // window compaction. Overflows in this area could lead to incorrect
-    // compaction.
-    auto valid_offset_range = [](
-                                ss::lw_shared_ptr<segment>& first,
-                                ss::lw_shared_ptr<segment>& last) -> bool {
-        auto base_offset_first_seg = first->offsets().get_base_offset();
-        auto dirty_offset_last_seg = last->offsets().get_dirty_offset();
-        int64_t offset_delta = dirty_offset_last_seg()
-                               - base_offset_first_seg();
-        static constexpr int64_t u32_max = static_cast<int64_t>(
-          std::numeric_limits<uint32_t>::max());
-        return offset_delta <= u32_max;
-    };
-
-    while (true) {
-        // the simple compaction process in use right now builds a concatenation
-        // of segments so we avoid processing a group that is too large.
-        const auto total_size = std::accumulate(
-          range.first,
-          range.second,
-          size_t(0),
-          [](size_t acc, ss::lw_shared_ptr<segment>& seg) {
-              return acc + seg->size_bytes();
-          });
-
-        // batches in a segment have a term that is implicitly defined by the
-        // name of the file they are contained in. since we need to retain the
-        // term information for reach batch we'll avoid combining segments with
-        // different terms. this can be addressed in a later optimization.
-        const auto same_term = std::all_of(
-          range.first,
-          range.second,
-          [term = (*range.first)->offsets().get_term()](
-            ss::lw_shared_ptr<segment>& seg) {
-              return seg->offsets().get_term() == term;
-          });
-
-        // found a good range if all the tests pass
-        if (
-          same_term
-          && total_size < _manager.config().max_compacted_segment_size()
-          && valid_offset_range(*range.first, *std::prev(range.second))) {
-            break;
-        }
-
-        // no candidate range found, yet. advance the window if we aren't
-        // already at the end of the set. one option would also be to shrink the
-        // range from the lower end if the range is large enough. advanced
-        // scheduling is future work.
-        if (range.second == _segs.end()) {
-            return std::nullopt;
-        }
-        ++range.first;
-        ++range.second;
-    }
-
-    // the chosen segments all need to be stable.
-    // Each participating segment should individually pass the compactible
-    // offset check for the compacted segment to be stable.
-    // Additionally each segment should have finished self compaction. This
-    // is needed by transactions because the compaction index of segments
-    // with transactional batches is only populated during self compaction.
-    // Not having this check would result in concatenating with an empty
-    // compaction index and a data loss.
-    const auto unstable = std::any_of(
-      range.first, range.second, [&cfg](ss::lw_shared_ptr<segment>& seg) {
-          return !seg->finished_self_compaction() || seg->has_appender()
-                 || !seg->is_compactible(cfg);
-      });
-    if (unstable) {
-        return std::nullopt;
-    }
-
-    return range;
-}
-
 std::optional<
   std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
 disk_log_impl::find_adjacent_compaction_ranges(
@@ -998,7 +882,7 @@ disk_log_impl::find_adjacent_compaction_ranges(
             return true;
         }
         return !seg->finished_self_compaction() || seg->has_appender()
-               || !seg->has_compactible_offsets(cfg);
+               || !seg->is_compactible(cfg);
     };
 
     // Ensure that the adjacent segments do not span an offset space greater
@@ -1081,36 +965,65 @@ disk_log_impl::find_adjacent_compaction_ranges(
     return ranges;
 }
 
-ss::future<std::optional<compaction_result>>
-disk_log_impl::compact_adjacent_segments(storage::compaction_config cfg) {
-    std::optional<compaction_result> r;
-    if (auto range = find_adjacent_compaction_range(cfg); range) {
-        r = co_await do_compact_adjacent_segments(std::move(*range), cfg);
-        vlog(
-          gclog.debug,
-          "Adjacent segments of {}, compaction result: {}",
-          config().ntp(),
-          r);
-        if (r->did_compact()) {
-            _compaction_ratio.update(r->compaction_ratio());
+ss::future<std::optional<std::vector<compaction_result>>>
+disk_log_impl::compact_adjacent_segment_ranges(
+  storage::compaction_config cfg,
+  std::optional<model::offset> new_start_offset) {
+    std::vector<compaction_result> rs;
+    if (auto ranges = find_adjacent_compaction_ranges(cfg, new_start_offset);
+        ranges) {
+        // lightweight copy of segments in all of the found ranges. once a
+        // scheduling event occurs in this method we can't rely on the iterators
+        // in the range remaining valid. for example, a concurrent truncate may
+        // erase an element from the range. The act of compacting adjacent
+        // segments will also invalidate iterators pointing to the original
+        // _segs vector.
+        using vec_t = std::vector<ss::lw_shared_ptr<segment>>;
+        std::vector<vec_t> seg_ranges;
+        seg_ranges.reserve(ranges->size());
+        for (auto& range : *ranges) {
+            seg_ranges.emplace_back(range.first, range.second);
+        }
+        for (auto& range : seg_ranges) {
+            if (cfg.asrc) {
+                cfg.asrc->check();
+            }
+
+            auto r = co_await do_compact_adjacent_segments(range, cfg);
+            vlog(
+              gclog.debug,
+              "Adjacent segments of {}, compaction result: {}",
+              config().ntp(),
+              r);
+            if (r.did_compact()) {
+                _compaction_ratio.update(r.compaction_ratio());
+            }
+            rs.push_back(r);
         }
     } else {
         vlog(
           gclog.debug,
-          "Adjacent segments of {}, no adjacent pair",
+          "Adjacent segments of {}, no adjacent ranges",
           config().ntp());
     }
-    co_return r;
+    co_return rs;
 }
 
 ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
-  std::pair<segment_set::iterator, segment_set::iterator> range,
+  std::vector<ss::lw_shared_ptr<segment>>& segments,
   storage::compaction_config cfg) {
-    // lightweight copy of segments in range. once a scheduling event occurs in
-    // this method we can't rely on the iterators in the range remaining valid.
-    // for example, a concurrent truncate may erase an element from the range.
-    auto segments = std::vector<ss::lw_shared_ptr<segment>>(
-      range.first, range.second);
+    // This shouldn't be the case for any ranges returned from
+    // find_adjacent_compaction_ranges(), but it is checked regardless.
+    if (segments.size() < 2) {
+        const auto total_size = std::accumulate(
+          segments.begin(),
+          segments.end(),
+          size_t(0),
+          [](size_t acc, ss::lw_shared_ptr<segment>& seg) {
+              return acc + seg->size_bytes();
+          });
+        co_return compaction_result{total_size};
+    }
 
     const bool all_segments_self_compacted = std::ranges::all_of(
       segments, &segment::finished_self_compaction);
@@ -1142,17 +1055,12 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
         co_return compaction_result{total_size};
     }
 
-    if (gclog.is_enabled(ss::log_level::debug)) {
-        std::stringstream segments_str;
-        for (size_t i = 0; i < segments.size(); i++) {
-            fmt::print(segments_str, "Segment {}: {}, ", i + 1, *segments[i]);
-        }
-        vlog(
-          gclog.debug,
-          "Compacting {} adjacent segments: [{}]",
-          segments.size(),
-          segments_str.str());
-    }
+    vlog(
+      gclog.debug,
+      "Compacting {} adjacent segments over range: [{}:{}]",
+      segments.size(),
+      segments.front()->filename(),
+      segments.back()->filename());
 
     // Important that we take this lock _before_ any segment locks.
     auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();
@@ -1189,28 +1097,29 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     // This is guaranteed to have a value.
     auto ret = *opt_ret;
 
-    auto segment_to_remove = segments.back();
-    // We are going to remove one of the segments, but its bytes have not
-    // technically been removed- just moved to the new segment, `target`.
-    // remove_segment_permanently() will remove bytes, so to make sure the
-    // book-keeping stays correct, we must first add them here to ensure a
-    // net zero change post adjacent merge.
-    add_segment_bytes(segment_to_remove, segment_to_remove->size_bytes());
-
     // remove the now redundant segments, if they haven't already been removed.
     // this could occur if racing with functions like truncate which manipulate
     // the segment set before acquiring segment locks. this also means that the
     // input iterator range may not longer be valid so we must manually search
-    // the segment set.  the current adjacent segment compaction limits
-    // compaction to two segments, and we check that assumption here and use
-    // simplified clean-up routine.
+    // the segment set.
+    for (auto seg_it = std::next(segments.begin()); seg_it != segments.end();
+         ++seg_it) {
+        auto segment_to_remove = *seg_it;
 
-    vassert(segments.size() == 2, "Cannot compact more than two segments");
-    auto it = std::find(_segs.begin(), _segs.end(), segment_to_remove);
-    if (it != _segs.end()) {
-        _segs.erase(it, std::next(it));
-        co_await remove_segment_permanently(
-          segment_to_remove, "compact_adjacent_segments");
+        auto it = std::find(_segs.begin(), _segs.end(), segment_to_remove);
+        if (it != _segs.end()) {
+            // We are going to remove one of the segments, but its bytes have
+            // not technically been removed- just moved to the new segment,
+            // `target`. remove_segment_permanently() will remove bytes, so to
+            // make sure the book-keeping stays correct, we must first add them
+            // here to ensure a net zero change post adjacent merge.
+            add_segment_bytes(
+              segment_to_remove, segment_to_remove->size_bytes());
+
+            _segs.erase(it, std::next(it));
+            co_await remove_segment_permanently(
+              segment_to_remove, "compact_adjacent_segments");
+        }
     }
 
     _probe->add_adjacent_segments_compacted(segments.size() - 1);
@@ -1431,7 +1340,7 @@ ss::future<> disk_log_impl::do_compact(
 
     if (use_adjacent_merge) {
         co_return co_await adjacent_merge_compact(
-          compact_cfg, new_start_offset);
+          _segs, compact_cfg, new_start_offset);
     }
 
     // TODO: unify error handling.
@@ -1456,7 +1365,7 @@ ss::future<> disk_log_impl::do_compact(
       "segment compaction",
       config().ntp(),
       compacted ? "" : "not ");
-    co_await compact_adjacent_segments(compact_cfg);
+    co_await compact_adjacent_segment_ranges(compact_cfg, new_start_offset);
 }
 
 ss::future<bool> disk_log_impl::chunked_sliding_window_compact(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -64,6 +64,7 @@
 #include <chrono>
 #include <exception>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -969,6 +970,115 @@ disk_log_impl::find_adjacent_compaction_range(const compaction_config& cfg) {
     }
 
     return range;
+}
+
+std::optional<
+  std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
+disk_log_impl::find_adjacent_compaction_ranges(
+  const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
+    if (_segs.size() < 2) {
+        return std::nullopt;
+    }
+
+    // the chosen segments all need to be stable.
+    // Each participating segment should individually pass the
+    // compactible offset check for the compacted segment to be stable.
+    // Additionally each segment should have finished self compaction.
+    // This is needed by transactions because the compaction index of
+    // segments with transactional batches is only populated during self
+    // compaction. Not having this check would result in concatenating
+    // with an empty compaction index and a data loss.
+    auto unstable =
+      [&cfg, new_start_offset](ss::lw_shared_ptr<segment>& seg) -> bool {
+        // Don't bother considering segments below the new start offset for
+        // adjacent compaction.
+        if (
+          new_start_offset.has_value()
+          && seg->offsets().get_base_offset() < new_start_offset.value()) {
+            return true;
+        }
+        return !seg->finished_self_compaction() || seg->has_appender()
+               || !seg->has_compactible_offsets(cfg);
+    };
+
+    // Ensure that the adjacent segments do not span an offset space greater
+    // than the maximum value that can be represented by a uint32_t. This must
+    // be enforced due to use of roaring::bitmap in the compacted_offset_list,
+    // which is used to deduplicate records during self compaction and sliding
+    // window compaction. Overflows in this area could lead to incorrect
+    // compaction.
+    auto valid_offset_range = [](
+                                ss::lw_shared_ptr<segment>& first,
+                                ss::lw_shared_ptr<segment>& last) -> bool {
+        auto base_offset_first_seg = first->offsets().get_base_offset();
+        auto dirty_offset_last_seg = last->offsets().get_dirty_offset();
+        int64_t offset_delta = dirty_offset_last_seg()
+                               - base_offset_first_seg();
+        static constexpr int64_t u32_max = static_cast<int64_t>(
+          std::numeric_limits<uint32_t>::max());
+        return offset_delta <= u32_max;
+    };
+
+    std::vector<std::pair<segment_set::iterator, segment_set::iterator>> ranges;
+
+    auto it = _segs.begin();
+    size_t current_size{0};
+    model::term_id current_term{(*it)->offsets().get_term()};
+
+    std::pair<segment_set::iterator, segment_set::iterator> current_range = {
+      it, it};
+    while (it != _segs.end()) {
+        auto& seg = *it;
+        auto seg_size = seg->size_bytes();
+        auto seg_term = seg->offsets().get_term();
+
+        current_size += seg_size;
+
+        auto num_segments_in_range = std::distance(
+          current_range.first, current_range.second);
+
+        bool term_boundary = seg_term != current_term;
+        bool size_boundary = current_size
+                             > _manager.config().max_compacted_segment_size();
+        bool is_unstable = unstable(seg);
+        bool is_valid_offset_range = valid_offset_range(
+          *current_range.first, seg);
+
+        if (
+          term_boundary || size_boundary || is_unstable
+          || !is_valid_offset_range) {
+            if (num_segments_in_range > 1) {
+                ranges.push_back(current_range);
+            }
+
+            auto next_it = is_unstable ? std::next(it) : it;
+            auto next_size = is_unstable ? 0 : seg_size;
+            auto next_term = next_it != _segs.end()
+                               ? (*next_it)->offsets().get_term()
+                               : model::term_id{};
+            current_range = {next_it, next_it};
+            current_size = next_size;
+            current_term = next_term;
+
+            if (!is_unstable) {
+                ++current_range.second;
+            }
+
+        } else {
+            ++current_range.second;
+        }
+        ++it;
+    }
+
+    if (std::distance(current_range.first, current_range.second) > 1) {
+        ranges.push_back(current_range);
+    }
+
+    if (ranges.empty()) {
+        return std::nullopt;
+    }
+
+    return ranges;
 }
 
 ss::future<std::optional<compaction_result>>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -281,12 +281,12 @@ public:
     // Otherwise, a vector containing pairs of iterators representing the
     // [start, end) of segment ranges (e.g inclusive start, exclusive end).
     std::optional<
-      std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
+      chunked_vector<std::pair<segment_set::iterator, segment_set::iterator>>>
     find_adjacent_compaction_ranges(
       const compaction_config& cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
 
-    ss::future<std::optional<std::vector<compaction_result>>>
+    ss::future<std::optional<chunked_vector<compaction_result>>>
     compact_adjacent_segment_ranges(
       storage::compaction_config cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
@@ -326,7 +326,7 @@ private:
     // executed, and the total size of the segments before and after the
     // operation.
     ss::future<compaction_result> do_compact_adjacent_segments(
-      std::vector<ss::lw_shared_ptr<segment>>& segments,
+      chunked_vector<ss::lw_shared_ptr<segment>>& segments,
       storage::compaction_config cfg);
 
     ss::future<std::optional<model::offset>> do_gc(gc_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -282,6 +282,20 @@ public:
 
     std::optional<model::timestamp> earliest_dirty_segment_ts() const final;
 
+    // Finds every sub-range of adjacent segments that can be compacted
+    // together. A valid segment range consists of segments with the same raft
+    // term, and a combined size less than max_compacted_segment_size.
+    // This function guarantees that segments in returned ranges can be
+    // combined. The ranges are guaranteed to contain one or more segments.
+    //
+    // Returns std::nullopt if no valid ranges of segments could be found.
+    // Otherwise, a vector containing pairs of iterators to the segments.
+    std::optional<
+      std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
+    find_adjacent_compaction_ranges(
+      const compaction_config& cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -226,19 +226,8 @@ public:
     ss::future<compaction_result>
     segment_self_compact(compaction_config, ss::lw_shared_ptr<segment> seg);
 
-    // Finds a range of adjacent segments that can be compacted together.
-    // A valid segment range consists of segments with the same raft term, a
-    // combined size less than max_compacted_segment_size, and spanning
-    // a range of offsets that fits in a uint32_t.
-    //
-    // Returns std::nullopt if a valid range of two segments could not be found.
-    // Otherwise, a pair of iterators to the segments.
-    std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
-    find_adjacent_compaction_range(const compaction_config& cfg);
-
-    // Performs self-compaction on the earliest segment possible, and then
-    // attempts to perform compaction on adjacent segments.
     ss::future<> adjacent_merge_compact(
+      segment_set& segments,
       compaction_config,
       std::optional<model::offset> new_start_offset = std::nullopt);
 
@@ -286,14 +275,20 @@ public:
     // together. A valid segment range consists of segments with the same raft
     // term, and a combined size less than max_compacted_segment_size.
     // This function guarantees that segments in returned ranges can be
-    // combined. The ranges are guaranteed to contain one or more segments.
+    // combined. The ranges are guaranteed to contain two or more segments.
     //
     // Returns std::nullopt if no valid ranges of segments could be found.
-    // Otherwise, a vector containing pairs of iterators to the segments.
+    // Otherwise, a vector containing pairs of iterators representing the
+    // [start, end) of segment ranges (e.g inclusive start, exclusive end).
     std::optional<
       std::vector<std::pair<segment_set::iterator, segment_set::iterator>>>
     find_adjacent_compaction_ranges(
       const compaction_config& cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+
+    ss::future<std::optional<std::vector<compaction_result>>>
+    compact_adjacent_segment_ranges(
+      storage::compaction_config cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
 
 private:
@@ -322,28 +317,16 @@ private:
     // Returns if the update actually took place.
     ss::future<bool> update_start_offset(model::offset o);
 
-    // Requests compaction of adjacent segments per the
-    // max_removable_local_log_offset in the compaction_config.
-    //
-    // Returns std::nullopt if an adjacent pair could not be found for adjacent
-    // compaction, or a compaction_result. This result should also have its
-    // did_compact() function checked to verify whether adjacent segment
-    // compaction actually occurred.
-    ss::future<std::optional<compaction_result>>
-    compact_adjacent_segments(storage::compaction_config cfg);
-
-    // Performs compaction of adjacent segments. This pair of segments is
+    // Performs compaction of adjacent segments. The sub-array of segments is
     // physically combined to replace the first segment. The resulting combined
-    // segment is then self-compacted, and the redundant second segment is
+    // segment is then self-compacted, and the redundant segments are
     // permanently removed.
-    // Currently, only two adjacent segments can be compacted at a time (i.e,
-    // there must be, and are only, two segments in the range).
     //
     // Returns a compaction_result indicating whether or not compaction was
     // executed, and the total size of the segments before and after the
     // operation.
     ss::future<compaction_result> do_compact_adjacent_segments(
-      std::pair<segment_set::iterator, segment_set::iterator>,
+      std::vector<ss::lw_shared_ptr<segment>>& segments,
       storage::compaction_config cfg);
 
     ss::future<std::optional<model::offset>> do_gc(gc_config);
@@ -535,14 +518,6 @@ private:
     void reset_dirty_and_closed_bytes();
 
     bool _compaction_enabled;
-
-    // The counter for the number of self compactions that have occured in
-    // adjacent_merge_compact() since the last adjacent merge operation was
-    // triggered. Used in combination with the cluster tunable
-    // `log_compaction_adjacent_merge_self_compaction_count`, which sets the
-    // number of self compactions that must occur before attempting to
-    // compaction adjacent segments.
-    size_t _adjacent_merge_counter{0};
 };
 
 } // namespace storage

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -36,6 +36,9 @@ struct segment_closed_exception final : std::exception {
         return "segment_closed exception";
     }
 };
+namespace testing_details {
+class offset_tracker_accessor;
+};
 
 class segment {
 public:
@@ -110,6 +113,7 @@ public:
         model::offset _dirty_offset;
 
         friend std::ostream& operator<<(std::ostream&, const offset_tracker&);
+        friend class testing_details::offset_tracker_accessor;
     };
     enum class bitflags : uint32_t {
         none = 0,

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -282,6 +282,10 @@ public:
     /// appear to be invalid (e.g. too far in the future)
     ss::future<model::timestamp> get_file_timestamp() const;
 
+    // For use in testing. _gate.close() is called during segment::close()
+    // and is used to ensure release_appender_in_background() safely completes.
+    ss::gate& gate() { return _gate; }
+
 private:
     void set_close();
     void cache_truncate(model::offset offset);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -15,12 +15,14 @@
 #include "base/vlog.h"
 #include "bytes/iobuf_parser.h"
 #include "config/configuration.h"
+#include "container/fragmented_vector.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "ssx/future-util.h"
+#include "ssx/when_all.h"
 #include "storage/chunk_cache.h"
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
@@ -797,18 +799,19 @@ ss::future<compaction_result> self_compact_segment(
     co_return compaction_result(sz_before, *sz_after);
 }
 
-ss::future<
-  std::tuple<ss::lw_shared_ptr<segment>, std::vector<segment::generation_id>>>
+ss::future<std::tuple<
+  ss::lw_shared_ptr<segment>,
+  chunked_vector<segment::generation_id>>>
 make_concatenated_segment(
   segment_full_path path,
-  std::vector<ss::lw_shared_ptr<segment>> segments,
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   compaction_config cfg,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table) {
     // read locks on source segments
-    std::vector<ss::rwlock::holder> locks;
+    chunked_vector<ss::rwlock::holder> locks;
     locks.reserve(segments.size());
-    std::vector<segment::generation_id> generations;
+    chunked_vector<segment::generation_id> generations;
     generations.reserve(segments.size());
     for (auto& segment : segments) {
         locks.push_back(co_await segment->read_lock());
@@ -943,11 +946,11 @@ make_concatenated_segment(
       std::move(generations));
 }
 
-ss::future<std::vector<compacted_index_reader>> make_indices_readers(
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+ss::future<chunked_vector<compacted_index_reader>> make_indices_readers(
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
   ss::abort_source* as) {
-    return ssx::async_transform<std::vector<compacted_index_reader>>(
+    return ssx::async_transform<chunked_vector<compacted_index_reader>>(
       segments.begin(),
       segments.end(),
       [san_cfg = ntp_sanitizer_config, as](ss::lw_shared_ptr<segment>& seg) {
@@ -968,7 +971,7 @@ ss::future<std::vector<compacted_index_reader>> make_indices_readers(
 
 ss::future<> rewrite_concatenated_indicies(
   std::unique_ptr<compacted_index_writer> writer,
-  std::vector<compacted_index_reader>& readers) {
+  chunked_vector<compacted_index_reader>& readers) {
     return ss::do_with(
       std::move(writer),
       [&readers](std::unique_ptr<compacted_index_writer>& writer) {
@@ -992,20 +995,19 @@ ss::future<> rewrite_concatenated_indicies(
 
 ss::future<> do_write_concatenated_compacted_index(
   std::filesystem::path target_path,
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   compaction_config cfg,
   storage_resources& resources) {
     return make_indices_readers(segments, cfg.sanitizer_config, cfg.asrc)
       .then([cfg, target_path = std::move(target_path), &resources](
-              std::vector<compacted_index_reader> readers) mutable {
+              chunked_vector<compacted_index_reader> readers) mutable {
           vlog(gclog.debug, "concatenating {} indicies", readers.size());
           return ss::do_with(
             std::move(readers),
             [cfg, target_path = std::move(target_path), &resources](
-              std::vector<compacted_index_reader>& readers) mutable {
+              chunked_vector<compacted_index_reader>& readers) mutable {
                 return ss::parallel_for_each(
-                         readers.begin(),
-                         readers.end(),
+                         readers,
                          [](compacted_index_reader& reader) {
                              return reader.verify_integrity();
                          })
@@ -1046,27 +1048,22 @@ ss::future<> do_write_concatenated_compacted_index(
 
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path target_path,
-  std::vector<ss::lw_shared_ptr<segment>> segments,
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   compaction_config cfg,
   storage_resources& resources) {
     if (segments.empty()) {
         return ss::now();
     }
-    return ss::do_with(
-      std::move(segments),
-      [cfg, target_path = std::move(target_path), &resources](
-        std::vector<ss::lw_shared_ptr<segment>>& segments) mutable {
-          return do_write_concatenated_compacted_index(
-            std::move(target_path), segments, cfg, resources);
-      });
+    return do_write_concatenated_compacted_index(
+      std::move(target_path), segments, cfg, resources);
 }
 
-ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
+ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> to,
   ss::lw_shared_ptr<segment> from,
   compaction_config cfg,
   probe& probe,
-  std::vector<ss::rwlock::holder> locks) {
+  chunked_vector<ss::rwlock::holder> locks) {
     co_await from->close();
 
     co_await to->index().drop_all_data();
@@ -1094,7 +1091,7 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
 
 ss::future<compaction_result> concatenate_and_rebuild_target_segment(
   ss::lw_shared_ptr<segment> target,
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   ss::lw_shared_ptr<storage::stm_manager> stm_manager,
   compaction_config cfg,
   storage::probe& pb,
@@ -1153,7 +1150,7 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
       maybe_remove_file(target->reader().path().to_compacted_index().string()));
 
     // Evict segment readers and prevent new ones from being added to the cache.
-    std::vector<ss::future<readers_cache::range_lock_holder>> holder_futs;
+    chunked_vector<ss::future<readers_cache::range_lock_holder>> holder_futs;
     holder_futs.reserve(segments.size());
     for (auto& segment : segments) {
         holder_futs.push_back(readers_cache.evict_segment_readers(segment));
@@ -1202,22 +1199,23 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
     co_return ret;
 }
 
-ss::future<std::vector<ss::rwlock::holder>> write_lock_segments(
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+ss::future<chunked_vector<ss::rwlock::holder>> write_lock_segments(
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   ss::semaphore::clock::duration timeout,
   int retries) {
+    using vec_t = chunked_vector<ss::rwlock::holder>;
     vassert(retries >= 0, "Invalid retries value");
-    std::vector<ss::rwlock::holder> held;
+    vec_t held;
     held.reserve(segments.size());
     while (true) {
         try {
-            std::vector<ss::future<ss::rwlock::holder>> held_f;
+            chunked_vector<ss::future<ss::rwlock::holder>> held_f;
             held_f.reserve(segments.size());
             for (auto& segment : segments) {
                 held_f.push_back(
                   segment->write_lock(ss::semaphore::clock::now() + timeout));
             }
-            held = co_await ss::when_all_succeed(held_f.begin(), held_f.end());
+            held = co_await ssx::when_all_succeed<vec_t>(std::move(held_f));
             break;
         } catch (const ss::semaphore_timed_out&) {
             held.clear();

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -85,11 +85,12 @@ ss::future<> rebuild_compaction_index(
  * segment, and upper range offsets (e.g. stable_offset) taken from the last
  * segment in the input range.
  */
-ss::future<
-  std::tuple<ss::lw_shared_ptr<segment>, std::vector<segment::generation_id>>>
+ss::future<std::tuple<
+  ss::lw_shared_ptr<segment>,
+  chunked_vector<segment::generation_id>>>
 make_concatenated_segment(
   segment_full_path,
-  std::vector<ss::lw_shared_ptr<segment>>,
+  chunked_vector<ss::lw_shared_ptr<segment>>&,
   compaction_config,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table);
@@ -103,7 +104,7 @@ make_concatenated_segment(
 // concatenation.
 ss::future<compaction_result> concatenate_and_rebuild_target_segment(
   ss::lw_shared_ptr<segment> target,
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   ss::lw_shared_ptr<storage::stm_manager> stm_manager,
   compaction_config cfg,
   storage::probe& pb,
@@ -114,16 +115,16 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
 
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path,
-  std::vector<ss::lw_shared_ptr<segment>>,
+  chunked_vector<ss::lw_shared_ptr<segment>>&,
   compaction_config,
   storage_resources& resources);
 
-ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
+ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> to,
   ss::lw_shared_ptr<segment> from,
   compaction_config cfg,
   probe& probe,
-  std::vector<ss::rwlock::holder>);
+  chunked_vector<ss::rwlock::holder>);
 
 /*
  * Acquire write locks on multiple segments. The process will proceed until
@@ -132,8 +133,8 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
  * fairness. If a lock cannot be acquired all held locks are released and the
  * process is retried. Favor more retries over longer timeouts.
  */
-ss::future<std::vector<ss::rwlock::holder>> write_lock_segments(
-  std::vector<ss::lw_shared_ptr<segment>>& segments,
+ss::future<chunked_vector<ss::rwlock::holder>> write_lock_segments(
+  chunked_vector<ss::lw_shared_ptr<segment>>& segments,
   ss::semaphore::clock::duration timeout,
   int retries);
 

--- a/src/v/storage/storage_resources.h
+++ b/src/v/storage/storage_resources.h
@@ -22,6 +22,10 @@ namespace storage {
 
 class node_api;
 
+namespace testing_details {
+class storage_resources_accessor;
+}
+
 /**
  * This class is used by various storage components to control consumption
  * of shared system resources.  It broadly does this in two ways:
@@ -153,6 +157,18 @@ private:
     // memory footprint compared with the batch's original size, we must
     // limit how many of these we do in parallel.
     adjustable_semaphore _inflight_compaction_compression{1};
+
+    friend class testing_details::storage_resources_accessor;
 };
+
+namespace testing_details {
+class storage_resources_accessor {
+public:
+    static adjustable_semaphore&
+    inflight_close_flush_sem(storage_resources& resources) {
+        return resources._inflight_close_flush;
+    }
+};
+} // namespace testing_details
 
 } // namespace storage

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -938,6 +938,7 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:scoped_config",
         "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:adjustable_semaphore",
         "//src/v/utils:directory_walker",
         "@abseil-cpp//absl/container:btree",
         "@googletest//:gtest",

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -634,6 +634,7 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:random",
         "//src/v/test_utils:random_bytes",
+        "//src/v/test_utils:scoped_config",
         "//src/v/utils:directory_walker",
         "//src/v/utils:to_string",
         "//src/v/utils:tristate",

--- a/src/v/storage/tests/common.h
+++ b/src/v/storage/tests/common.h
@@ -10,8 +10,10 @@
  */
 #pragma once
 
+#include "model/fundamental.h"
 #include "storage/batch_cache.h"
 #include "storage/log_manager.h"
+#include "storage/segment.h"
 
 namespace storage::testing_details {
 class log_manager_accessor {
@@ -29,4 +31,12 @@ public:
         return m._logs_list;
     }
 };
+
+class offset_tracker_accessor {
+public:
+    static model::offset& base_offset(storage::segment::offset_tracker& ot) {
+        return ot._base_offset;
+    }
+};
+
 } // namespace storage::testing_details

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -22,6 +22,7 @@
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/segment.h"
+#include "storage/segment_set.h"
 #include "storage/segment_utils.h"
 #include "storage/tests/manual_mixin.h"
 #include "storage/types.h"
@@ -129,7 +130,8 @@ public:
       size_t records_per_batch = 1,
       size_t starting_value = 0,
       bool produce_tombstones = false,
-      map_t* latest_kv = nullptr) {
+      map_t* latest_kv = nullptr,
+      size_t base = 0) {
         tests::kafka_produce_transport producer(co_await make_kafka_client());
         co_await producer.start();
 
@@ -142,7 +144,8 @@ public:
                   records_per_batch,
                   val_count,
                   cardinality,
-                  produce_tombstones);
+                  produce_tombstones,
+                  base);
                 if (latest_kv) {
                     for (const auto& kv : kvs) {
                         latest_kv->insert_or_assign(kv.key, kv.val);
@@ -1600,4 +1603,218 @@ TEST_F(CompactionFixtureTest, TestSlidingWindowNoUnecessaryRewrites) {
 
     segments_compacted = log->get_probe().get_segments_compacted();
     ASSERT_EQ(segments_compacted, 6);
+}
+
+TEST_F(CompactionFixtureParamTest, TestSegmentConcatenation) {
+    auto num_segments = 10;
+    auto cardinality = 1000000; // High enough to ensure no duplicates/removable
+                                // records- we want to first ensure
+                                // concatenation works on its own without
+                                // considering compaction.
+    auto batches_per_segment = 100;
+    auto records_per_batch = 100;
+    generate_data(
+      num_segments, cardinality, batches_per_segment, records_per_batch)
+      .get();
+
+    auto reader_cfg = storage::log_reader_config(
+      model::offset{0}, model::offset::max());
+    auto pre_compact_batches = model::consume_reader_to_chunked_vector(
+                                 log->make_reader(reader_cfg).get(),
+                                 model::no_timeout)
+                                 .get();
+
+    // Sanity check we created the right number of segments.
+    // NOTE: ignore the active segment.
+    auto segment_count_before = log->segment_count() - 1;
+    ASSERT_EQ(segment_count_before, num_segments);
+
+    const auto closed_segment_filter = [](const auto& s) -> bool {
+        return !s->has_appender();
+    };
+
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    storage::segment_set::underlying_t filtered_segs;
+    for (const auto& segment :
+         disk_log.segments() | std::views::filter(closed_segment_filter)) {
+        filtered_segs.push_back(segment);
+    }
+
+    storage::segment_set filtered_seg_set(std::move(filtered_segs));
+
+    ss::abort_source never_abort;
+    storage::compaction_config cfg(
+      model::offset::max(),
+      std::nullopt,
+
+      never_abort,
+      std::nullopt,
+      cardinality);
+
+    disk_log.adjacent_merge_compact(filtered_seg_set, cfg).get();
+    auto post_compact_batches = model::consume_reader_to_chunked_vector(
+                                  log->make_reader(reader_cfg).get(),
+                                  model::no_timeout)
+                                  .get();
+
+    ASSERT_EQ(disk_log.segment_count(), 2);
+    ASSERT_EQ(pre_compact_batches, post_compact_batches);
+}
+
+TEST_F(CompactionFixtureTest, TestAdjacentCompaction) {
+    auto num_segments = 10;
+    auto cardinality = 1000;
+    auto batches_per_segment = 100;
+    auto records_per_batch = 100;
+    map_t latest_kv_map;
+    generate_data(
+      num_segments,
+      cardinality,
+      batches_per_segment,
+      records_per_batch,
+      0,
+      false,
+      &latest_kv_map)
+      .get();
+
+    // Sanity check we created the right number of segments.
+    // NOTE: ignore the active segment.
+    auto segment_count_before = log->segment_count() - 1;
+    ASSERT_EQ(segment_count_before, num_segments);
+
+    ss::abort_source never_abort;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    storage::compaction_config cfg(
+      model::offset::max(),
+      std::nullopt,
+
+      never_abort,
+      std::nullopt,
+      cardinality);
+
+    const auto closed_segment_filter = [](const auto& s) -> bool {
+        return !s->has_appender();
+    };
+
+    storage::segment_set::underlying_t filtered_segs;
+    for (const auto& segment :
+         disk_log.segments() | std::views::filter(closed_segment_filter)) {
+        filtered_segs.push_back(segment);
+    }
+
+    storage::segment_set filtered_seg_set(std::move(filtered_segs));
+
+    // All but the active segment
+    ASSERT_EQ(filtered_seg_set.size(), segment_count_before);
+
+    disk_log.adjacent_merge_compact(filtered_seg_set, cfg).get();
+
+    // Another sanity check after compaction.
+    ASSERT_EQ(disk_log.segment_count(), 2);
+
+    {
+        tests::kafka_consume_transport consumer(make_kafka_client().get());
+        consumer.start().get();
+        auto consumed_kvs = consumer
+                              .consume_from_partition(
+                                topic_name,
+                                model::partition_id(0),
+                                model::offset(0))
+                              .get();
+        ASSERT_NO_FATAL_FAILURE();
+
+        // Assert the key consumed is in the latest_kv_map.
+        for (const auto& kv : consumed_kvs) {
+            ASSERT_TRUE(latest_kv_map.contains(kv.key));
+            ASSERT_EQ(kv.val, latest_kv_map[kv.key]);
+        }
+        ASSERT_EQ(consumed_kvs.size(), latest_kv_map.size());
+    }
+}
+
+TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
+    auto num_segments = 10;
+    auto cardinality = 10;
+    auto batches_per_segment = 100;
+    auto records_per_batch = 100;
+    map_t latest_kv_map;
+
+    // Write some data in different terms. Adjacent compaction should be able to
+    // compact several ranges all in one run without fear of dereferencing
+    // invalid iterators or running into other issues.
+    auto raft = partition->raft();
+    auto orig_term = raft->term();
+    auto num_raft_terms = 5;
+
+    int term_idx = 0;
+    while (raft->term()() < orig_term() + num_raft_terms) {
+        // Produced records in segments should look like
+        // [0, 1, 2, ..., 9] | [10, 11, 12, ..., 19] | [...]
+        // where | marks a demarcation point in raft term. This ensures that
+        // the latest key-values can still be verified by the Kafka consumer
+        // below, as we won't compact across raft terms.
+        auto term_base = term_idx * cardinality;
+        generate_data(
+          num_segments,
+          cardinality,
+          batches_per_segment,
+          records_per_batch,
+          term_base,
+          false,
+          &latest_kv_map,
+          term_base)
+          .get();
+        raft->step_down("test").get();
+        RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return raft->is_leader(); });
+        ++term_idx;
+    }
+
+    ss::abort_source never_abort;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    storage::compaction_config cfg(
+      model::offset::max(),
+      std::nullopt,
+
+      never_abort,
+      std::nullopt,
+      cardinality);
+
+    const auto closed_segment_filter = [](const auto& s) -> bool {
+        return !s->has_appender();
+    };
+
+    storage::segment_set::underlying_t filtered_segs;
+    for (const auto& segment :
+         disk_log.segments() | std::views::filter(closed_segment_filter)) {
+        filtered_segs.push_back(segment);
+    }
+
+    storage::segment_set filtered_seg_set(std::move(filtered_segs));
+
+    // All but the active segment.
+    ASSERT_EQ(filtered_seg_set.size(), disk_log.segment_count() - 1);
+
+    disk_log.adjacent_merge_compact(filtered_seg_set, cfg).get();
+
+    // Another sanity check after compaction.
+    ASSERT_EQ(disk_log.segment_count(), num_raft_terms + 1);
+
+    {
+        tests::kafka_consume_transport consumer(make_kafka_client().get());
+        consumer.start().get();
+        auto consumed_kvs = consumer
+                              .consume_from_partition(
+                                topic_name,
+                                model::partition_id(0),
+                                model::offset(0))
+                              .get();
+        ASSERT_NO_FATAL_FAILURE();
+
+        // Assert the key consumed is in the latest_kv_map.
+        for (const auto& kv : consumed_kvs) {
+            ASSERT_TRUE(latest_kv_map.contains(kv.key));
+            ASSERT_EQ(kv.val, latest_kv_map[kv.key]);
+        }
+        ASSERT_EQ(consumed_kvs.size(), latest_kv_map.size());
+    }
 }

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -21,6 +21,7 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "redpanda/tests/fixture.h"
+#include "storage/log_reader.h"
 #include "storage/segment.h"
 #include "storage/segment_set.h"
 #include "storage/segment_utils.h"
@@ -29,6 +30,7 @@
 #include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
 #include "test_utils/test.h"
+#include "utils/adjustable_semaphore.h"
 #include "utils/directory_walker.h"
 
 #include <seastar/core/sleep.hh>
@@ -1817,4 +1819,195 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
         }
         ASSERT_EQ(consumed_kvs.size(), latest_kv_map.size());
     }
+}
+
+TEST_F(
+  CompactionFixtureTest, TestAdjacentCompactionSimulateCrashDuringFileRemoval) {
+    auto num_segments = 5;
+    auto cardinality = 10;
+    auto batches_per_segment = 100;
+    auto records_per_batch = 100;
+
+    generate_data(
+      num_segments, cardinality, batches_per_segment, records_per_batch)
+      .get();
+
+    auto* disk_log = dynamic_cast<storage::disk_log_impl*>(log);
+
+    // All but the active segment.
+    auto segment_count_before = disk_log->segment_count() - 1;
+
+    auto do_adjacent_compact = [](const auto& l) {
+        ss::abort_source never_abort;
+        storage::compaction_config cfg(
+          model::offset::max(), std::nullopt, never_abort);
+
+        const auto closed_segment_filter = [](const auto& s) -> bool {
+            return !s->has_appender();
+        };
+
+        storage::segment_set::underlying_t filtered_segs;
+        for (const auto& segment :
+             l->segments() | std::views::filter(closed_segment_filter)) {
+            filtered_segs.push_back(segment);
+        }
+
+        storage::segment_set filtered_seg_set(std::move(filtered_segs));
+        l->adjacent_merge_compact(filtered_seg_set, cfg).get();
+        // Including the active segment
+        ASSERT_EQ(l->segment_count(), 2);
+    };
+
+    // This test uses 5 (+1 active) segments, which will be adjacently compacted
+    // like so: [0][1][2][3][4][A] -> [0`][A]
+    // We are going to simulate a "crash" during segment removal, in which some
+    // of the segments which were concatenated are left on disk after a restart
+    // like so: [0`][2][3][4][A].
+    // Then, using various consumers/readers of segment data, we will see the
+    // effects of what happens when segments with redundant data are left on
+    // disk.
+    {
+        // Hold the gate for one of the segments in order to block
+        // segment::close().
+        auto& seg = disk_log->segments()[2];
+        auto holder = seg->gate().hold();
+        auto adjacent_compact_fut = [&]() {
+            try {
+                do_adjacent_compact(disk_log);
+            } catch (...) {
+            }
+        };
+
+        // A future which breaks the inflight close semaphore and then releases
+        // the held gate, causing segment::close() to throw exceptions while
+        // attempting to close segments [2][3][4] as seen above.
+        auto break_close_fut
+          = ss::sleep(2s)
+              .then([&disk_log]() {
+                  auto& resources = disk_log->resources();
+                  storage::testing_details::storage_resources_accessor::
+                    inflight_close_flush_sem(resources)
+                      .broken();
+              })
+              .finally([h = std::move(holder)]() {});
+
+        ss::when_all(
+          std::move(adjacent_compact_fut), std::move(break_close_fut))
+          .get();
+
+        // Reset close semaphore.
+        auto& resources = disk_log->resources();
+        storage::testing_details::storage_resources_accessor::
+          inflight_close_flush_sem(resources)
+          = adjustable_semaphore(1);
+    }
+
+    restart(should_wipe::no);
+    wait_for_leader(ntp).get();
+    partition = app.partition_manager.local().get(ntp).get();
+    log = partition->log().get();
+    disk_log = dynamic_cast<storage::disk_log_impl*>(log);
+
+    // Some of the concatenated segments will have been left on disk.
+    auto segment_count_after = disk_log->segment_count();
+    ASSERT_EQ(segment_count_before, segment_count_after);
+
+    // Read log with a Kafka consumer.
+    auto make_kafka_consumer = [&]() {
+        tests::kafka_consume_transport consumer(make_kafka_client().get());
+        consumer.start().get();
+        auto kvs = consumer
+                     .consume_from_partition(
+                       topic_name, model::partition_id(0), model::offset(0))
+                     .get();
+        return kvs;
+    };
+
+    // Read log with a log reader.
+    auto make_log_reader = [&]() {
+        auto reader_cfg = storage::log_reader_config(
+          model::offset{0}, model::offset::max());
+
+        reader_cfg.skip_readers_cache = true;
+        reader_cfg.skip_batch_cache = true;
+
+        auto batches = model::consume_reader_to_chunked_vector(
+                         log->make_reader(reader_cfg).get(), model::no_timeout)
+                         .get();
+
+        return batches;
+    };
+
+    // Read raw log data on disk using a log_segment_batch_reader.
+    auto make_log_segment_batch_reader = [&]() {
+        chunked_vector<model::record_batch> all_batches;
+        for (auto& seg : log->segments()) {
+            if (seg->has_appender()) {
+                break;
+            }
+            auto reader_cfg = storage::log_reader_config(
+              model::offset{0}, model::offset::max());
+
+            reader_cfg.skip_readers_cache = true;
+            reader_cfg.skip_batch_cache = true;
+
+            auto rdr = storage::log_segment_batch_reader(
+              *seg, reader_cfg, log->get_probe());
+            auto recs = rdr.read_some(model::no_timeout).get();
+            while (recs.has_value() && !recs.value().empty()) {
+                auto& batches = recs.value();
+                for (auto& batch : batches) {
+                    all_batches.push_back(std::move(batch));
+                }
+                recs = rdr.read_some(model::no_timeout).get();
+            }
+            rdr.close().get();
+        }
+        return all_batches;
+    };
+
+    // Get total number of data records from a collection of batches.
+    auto num_data_records = [](const auto& batches) {
+        int record_count = 0;
+        for (const auto& batch : batches) {
+            record_count += (batch.header().type
+                             == model::record_batch_type::raft_data)
+                              ? batch.record_count()
+                              : 0;
+        }
+        return record_count;
+    };
+
+    // Kafka consumer
+    auto consumed_kvs_before = make_kafka_consumer();
+    ASSERT_EQ(consumed_kvs_before.size(), cardinality);
+
+    // Log reader
+    auto log_reader_batches_before = make_log_reader();
+    ASSERT_EQ(num_data_records(log_reader_batches_before), cardinality);
+
+    // Raw batches on disk in segment files
+    // We will see that the old data is actually still around.
+    auto on_disk_batches_before = make_log_segment_batch_reader();
+    ASSERT_EQ(
+      num_data_records(on_disk_batches_before),
+      cardinality * (segment_count_after - 1));
+
+    // One more adjacent compact. There should be no differences in batches
+    // processed by the log reader or kafka consumer after this compaction.
+    // However, expect the redundant data on disk to be removed.
+    do_adjacent_compact(disk_log);
+
+    // Kafka consumer
+    auto consumed_kvs_after = make_kafka_consumer();
+    ASSERT_EQ(consumed_kvs_before.size(), consumed_kvs_after.size());
+
+    // Log reader
+    auto log_reader_batches_after = make_log_reader();
+    ASSERT_EQ(log_reader_batches_before, log_reader_batches_after);
+
+    // Raw batches on disk in segment files.
+    auto on_disk_batches_after = make_log_segment_batch_reader();
+    ASSERT_EQ(num_data_records(on_disk_batches_after), cardinality);
+    ASSERT_NE(on_disk_batches_before, on_disk_batches_after);
 }

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -557,8 +557,8 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
     ss::abort_source as;
     compaction_config compaction_cfg(model::offset::max(), std::nullopt, as);
     auto& disk_log = *dynamic_cast<disk_log_impl*>(log.get());
-    disk_log.adjacent_merge_compact(compaction_cfg).get();
-    disk_log.adjacent_merge_compact(compaction_cfg).get();
+    disk_log.adjacent_merge_compact(disk_log.segments(), compaction_cfg).get();
+    disk_log.adjacent_merge_compact(disk_log.segments(), compaction_cfg).get();
     for (const auto& s : log->segments()) {
         if (s->has_appender()) {
             continue;

--- a/src/v/storage/tests/segment_concatenation_test.cc
+++ b/src/v/storage/tests/segment_concatenation_test.cc
@@ -165,10 +165,12 @@ void concatenate_segments_from_log(
     // the segment which will be expanded to replace
     auto target = segments.front();
 
+    chunked_vector<ss::lw_shared_ptr<storage::segment>> chunked_segments(
+      segments.begin(), segments.end());
     [[maybe_unused]] auto ret
       = storage::internal::concatenate_and_rebuild_target_segment(
           target,
-          segments,
+          chunked_segments,
           log.stm_manager(),
           cfg,
           log.get_probe(),

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -9,6 +9,7 @@
 
 #include "config/configuration.h"
 #include "gmock/gmock.h"
+#include "model/fundamental.h"
 #include "model/record_batch_types.h"
 #include "model/tests/random_batch.h"
 #include "model/timestamp.h"

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2033,7 +2033,7 @@ TEST_F(storage_test_fixture, many_segment_locking) {
 
     ASSERT_EQ(disk_log->segment_count(), 4);
 
-    std::vector<ss::lw_shared_ptr<storage::segment>> segments;
+    chunked_vector<ss::lw_shared_ptr<storage::segment>> segments;
     std::copy(
       disk_log->segments().begin(),
       disk_log->segments().end(),

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5883,6 +5883,7 @@ struct sliding_ranges_test_case {
     std::vector<segment_fields> segment_fields;
     std::optional<model::offset> new_start_offset{std::nullopt};
     std::optional<uint32_t> max_segment_count{std::nullopt};
+    std::optional<uint32_t> max_range_count{std::nullopt};
     // These ranges have the same inclusivity as the iterator
     // constructor for std::vector, i.e [first, last).
     std::vector<std::pair<size_t, size_t>> expected_ranges;
@@ -6091,6 +6092,87 @@ TEST_F(storage_test_fixture, find_sliding_ranges) {
 	                                       // 6    - (Active)
 	  .max_segment_count = 2,
 	  .expected_ranges = {{0, 2}, {2, 4}, {4, 6}}},
+      sliding_ranges_test_case{
+	  .desc="Mergeable pairs of segments with ascending raft terms, but number of max ranges is limited to 0 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 -
+	    {1_KiB, model::term_id{0}, true},  // 1 -
+	    {1_KiB, model::term_id{1}, true},  // 2 -
+	    {1_KiB, model::term_id{1}, true},  // 3 -
+	    {1_KiB, model::term_id{2}, true},  // 4 -
+	    {1_KiB, model::term_id{2}, true}}, // 5 -
+	                                       // 6 - (Active)
+	  .max_range_count = 0,
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="Mergeable pairs of segments with ascending raft terms, but number of max ranges is limited to 1 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 A
+	    {1_KiB, model::term_id{0}, true},  // 1 A
+	    {1_KiB, model::term_id{1}, true},  // 2  -
+	    {1_KiB, model::term_id{1}, true},  // 3  -
+	    {1_KiB, model::term_id{2}, true},  // 4  -
+	    {1_KiB, model::term_id{2}, true}}, // 5  -
+	                                       // 6  - (Active)
+	  .max_range_count = 1,
+	  .expected_ranges = {{0, 2}}},
+      sliding_ranges_test_case{
+	  .desc="Mergeable pairs of segments with ascending raft terms, but number of max ranges is limited to 2 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 A
+	    {1_KiB, model::term_id{0}, true},  // 1 A
+	    {1_KiB, model::term_id{1}, true},  // 2  B
+	    {1_KiB, model::term_id{1}, true},  // 3  B
+	    {1_KiB, model::term_id{2}, true},  // 4  -
+	    {1_KiB, model::term_id{2}, true}}, // 5  -
+	                                       // 6  - (Active)
+	  .max_range_count = 2,
+	  .expected_ranges = {{0, 2}, {2, 4}}},
+      sliding_ranges_test_case{
+	  .desc="Mergeable pairs of segments with ascending raft terms, but number of max ranges is limited to 3 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 A
+	    {1_KiB, model::term_id{0}, true},  // 1 A
+	    {1_KiB, model::term_id{1}, true},  // 2  B
+	    {1_KiB, model::term_id{1}, true},  // 3  B
+	    {1_KiB, model::term_id{2}, true},  // 4   C
+	    {1_KiB, model::term_id{2}, true}}, // 5   C
+	                                       // 6    - (Active)
+	  .max_range_count = 3,
+	  .expected_ranges = {{0, 2}, {2, 4}, {4, 6}}},
+      sliding_ranges_test_case{
+	  .desc="segment_count=2, range_count = 1 means only one pair of segments merged at a time.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 A
+	    {1_KiB, model::term_id{0}, true},  // 1 A
+	    {1_KiB, model::term_id{0}, true},  // 2  -
+	    {1_KiB, model::term_id{1}, true},  // 3  -
+	    {1_KiB, model::term_id{1}, true},  // 4  -
+	    {1_KiB, model::term_id{1}, true}}, // 5  -
+	                                       // 6   - (Active)
+	  .max_segment_count = 2,
+	  .max_range_count = 1,
+	  .expected_ranges = {{0, 2}}},
+      sliding_ranges_test_case{
+	  .desc="Mixture of max range and segment count restricting range space.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 A
+	    {1_KiB, model::term_id{0}, true},  // 1 A
+	    {1_KiB, model::term_id{0}, true},  // 2 A
+	    {1_KiB, model::term_id{0}, true},  // 3  B
+	    {1_KiB, model::term_id{0}, true},  // 4  B
+	    {2_MiB, model::term_id{1}, true},  // 5   -
+	    {1_KiB, model::term_id{1}, true},  // 6   -
+	    {1_KiB, model::term_id{2}, true},  // 7    C
+	    {1_KiB, model::term_id{2}, true},  // 8    C
+	    {1_KiB, model::term_id{2}, true},  // 9    C
+	    {1_KiB, model::term_id{2}, true},  // 10    -
+	    {1_KiB, model::term_id{3}, true},  // 11    -
+	    {1_KiB, model::term_id{3}, true}}, // 12    -
+	                                       // 13     - (Active)
+	  .max_segment_count = 3,
+	  .max_range_count = 3,
+	  .expected_ranges = {{0, 3}, {3, 5}, {7, 10}}},
     };
     // clang-format on
 
@@ -6100,6 +6182,8 @@ TEST_F(storage_test_fixture, find_sliding_ranges) {
         const auto& expected_ranges = test_case.expected_ranges;
         test_local_cfg.get("log_compaction_merge_max_segments_per_range")
           .set_value(test_case.max_segment_count);
+        test_local_cfg.get("log_compaction_merge_max_ranges")
+          .set_value(test_case.max_range_count);
         auto ntp = model::ntp(
           "default", fmt::format("test-{}", test_case_index++), 0);
         auto log = mgr

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -42,6 +42,7 @@
 #include "test_utils/async.h"
 #include "test_utils/random_bytes.h"
 #include "test_utils/randoms.h"
+#include "test_utils/scoped_config.h"
 #include "test_utils/test_macros.h"
 #include "utils/directory_walker.h"
 #include "utils/tristate.h"
@@ -5881,12 +5882,14 @@ struct sliding_ranges_test_case {
     ss::sstring desc;
     std::vector<segment_fields> segment_fields;
     std::optional<model::offset> new_start_offset{std::nullopt};
+    std::optional<uint32_t> max_segment_count{std::nullopt};
     // These ranges have the same inclusivity as the iterator
     // constructor for std::vector, i.e [first, last).
     std::vector<std::pair<size_t, size_t>> expected_ranges;
 };
 
 TEST_F(storage_test_fixture, find_sliding_ranges) {
+    scoped_config test_local_cfg;
     auto log_cfg = default_log_config(test_dir);
     log_cfg.max_compacted_segment_size = config::mock_binding<size_t>(1_MiB);
     storage::ntp_config::default_overrides overrides;
@@ -6052,6 +6055,42 @@ TEST_F(storage_test_fixture, find_sliding_ranges) {
 	                                                             // 6   - (Active)
 	  .new_start_offset=model::offset{100},
 	  .expected_ranges = {{3, 6}}},
+      sliding_ranges_test_case{
+	  .desc="All mergeable segments, but number of max segments is limited to 0 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 -
+	    {1_KiB, model::term_id{0}, true},  // 1 -
+	    {1_KiB, model::term_id{0}, true},  // 2 -
+	    {1_KiB, model::term_id{0}, true},  // 3 -
+	    {1_KiB, model::term_id{0}, true},  // 4 -
+	    {1_KiB, model::term_id{0}, true}}, // 5 -
+	                                       // 6 - (Active)
+	  .max_segment_count = 0,
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="All mergeable segments, but number of max segments is limited to 1 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 -
+	    {1_KiB, model::term_id{0}, true},  // 1 -
+	    {1_KiB, model::term_id{0}, true},  // 2 -
+	    {1_KiB, model::term_id{0}, true},  // 3 -
+	    {1_KiB, model::term_id{0}, true},  // 4 -
+	    {1_KiB, model::term_id{0}, true}}, // 5 -
+	                                       // 6 - (Active)
+	  .max_segment_count = 1,
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="All mergeable segments, but number of max segments is limited to 2 via cluster config.",
+	  .segment_fields={
+	    {1_KiB, model::term_id{0}, true},  // 0 A
+	    {1_KiB, model::term_id{0}, true},  // 1 A
+	    {1_KiB, model::term_id{0}, true},  // 2  B
+	    {1_KiB, model::term_id{0}, true},  // 3  B
+	    {1_KiB, model::term_id{0}, true},  // 4   C
+	    {1_KiB, model::term_id{0}, true}}, // 5   C
+	                                       // 6    - (Active)
+	  .max_segment_count = 2,
+	  .expected_ranges = {{0, 2}, {2, 4}, {4, 6}}},
     };
     // clang-format on
 
@@ -6059,6 +6098,8 @@ TEST_F(storage_test_fixture, find_sliding_ranges) {
         vlog(e2e_test_log.info, "Running test case: {}", test_case.desc);
         const auto& segment_fields = test_case.segment_fields;
         const auto& expected_ranges = test_case.expected_ranges;
+        test_local_cfg.get("log_compaction_merge_max_segments_per_range")
+          .set_value(test_case.max_segment_count);
         auto ntp = model::ntp(
           "default", fmt::format("test-{}", test_case_index++), 0);
         auto log = mgr

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1786,23 +1786,20 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction) {
       0ms,
       as);
 
-    // There are 4 segments, and the last is the active segments. The first two
-    // will merge, and the third will be compacted but not merged.
+    // There are 4 segments, and the last is the active segments.
 
-    log->housekeeping(c_cfg).get();
-    ASSERT_EQ(log->segment_count(), 3);
-
-    // Check if it honors max_compactible offset by resetting it to the base
+    // Check if it honors max_compactible offset by setting it to the base
     // offset of first segment. Nothing should be compacted.
     const auto first_segment_offsets = log->segments().front()->offsets();
     c_cfg.compact.max_removable_local_log_offset
       = first_segment_offsets.get_base_offset();
     log->housekeeping(c_cfg).get();
-    ASSERT_EQ(log->segment_count(), 3);
+    ASSERT_EQ(log->segment_count(), 4);
 
-    // Now compact without restricting removable offset. The segment count
-    // will be reduced again.
+    // Now compact without restricting removable offset.
     c_cfg.compact.max_removable_local_log_offset = model::offset::max();
+
+    // The first three will merge.
     log->housekeeping(c_cfg).get();
     ASSERT_EQ(log->segment_count(), 2);
 
@@ -1927,14 +1924,9 @@ TEST_F(storage_test_fixture, max_adjacent_segment_compaction) {
 
     // self compaction steps
     // the first two segments are combined 2+2=4 < 6 MB
+    // the fourth, fifth and sixth can be combined 5 + 16KB + 16KB < 6 MB
     log->housekeeping(c_cfg).get();
-    ASSERT_EQ(disk_log->segment_count(), 5);
-
-    // the new first and second are too big 4+5 > 6 MB but the second and third
-    // can be combined 5 + 15KB < 6 MB
-    // then the next 16 KB can be folded in
-    log->housekeeping(c_cfg).get();
-    ASSERT_EQ(disk_log->segment_count(), 4);
+    ASSERT_EQ(disk_log->segment_count(), 3);
 
     // that's all that can be done. the next seg is an appender
     log->housekeeping(c_cfg).get();
@@ -1985,8 +1977,8 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction_range_u32_bounds) {
 
     ss::abort_source as;
     storage::compaction_config cfg(model::offset::max(), std::nullopt, as);
-    auto range = disk_log->find_adjacent_compaction_range(cfg);
-    ASSERT_TRUE(!range.has_value());
+    auto ranges = disk_log->find_adjacent_compaction_ranges(cfg);
+    ASSERT_TRUE(!ranges.has_value());
 
     // Set the last non-active segment's dirty offset to the uint32_t
     // max- this should make the segment eligible for adjacent compaction
@@ -1994,11 +1986,13 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction_range_u32_bounds) {
     // uint32_t max.
     back_offset_tracker.set_offset(
       storage::segment::offset_tracker::dirty_offset_t{u32_max});
-    range = disk_log->find_adjacent_compaction_range(cfg);
-    ASSERT_TRUE(range.has_value());
+    ranges = disk_log->find_adjacent_compaction_ranges(cfg);
+    ASSERT_TRUE(ranges.has_value());
+    ASSERT_EQ(ranges->size(), 1);
+    auto& range = ranges->front();
 
     auto range_segments = std::vector<ss::lw_shared_ptr<storage::segment>>(
-      range->first, range->second);
+      range.first, range.second);
 
     // Compare filenames for equality
     ASSERT_EQ(range_segments[0]->filename(), segs[0]->filename());
@@ -2198,7 +2192,7 @@ TEST_F(storage_test_fixture, compaction_backlog_calculation) {
     // self compaction steps
     log->housekeeping(c_cfg).get();
 
-    ASSERT_EQ(disk_log->segment_count(), 4);
+    ASSERT_EQ(disk_log->segment_count(), 2);
     auto new_backlog_size = log->compaction_backlog();
     /**
      * after all self segments are compacted they shouldn't be included into the
@@ -2207,7 +2201,7 @@ TEST_F(storage_test_fixture, compaction_backlog_calculation) {
      */
     ASSERT_LT(
       new_backlog_size,
-      backlog_size - self_seg_compaction_sz + segments[3]->size_bytes());
+      backlog_size - self_seg_compaction_sz + segments[1]->size_bytes());
 }
 
 TEST_F(storage_test_fixture, not_compacted_log_backlog) {
@@ -5315,7 +5309,8 @@ TEST_F(storage_test_fixture, dirty_and_closed_bytes_bookkeeping) {
     };
 
     auto adjacent_merge_func = [&]() {
-        disk_log->adjacent_merge_compact(cfg.compact).get();
+        disk_log->adjacent_merge_compact(disk_log->segments(), cfg.compact)
+          .get();
     };
 
     auto sliding_window_func = [&]() {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5873,3 +5873,263 @@ TEST_F(storage_test_fixture, log_compaction_enable_sliding_window) {
     storage::testing_details::log_manager_accessor::housekeeping_scan(mgr)
       .get();
 }
+
+struct segment_fields {
+    ssize_t size;
+    model::term_id term;
+    bool mark_as_stable;
+    std::optional<model::offset> base_offset_override{std::nullopt};
+    std::optional<model::offset> dirty_offset_override{std::nullopt};
+};
+
+struct sliding_ranges_test_case {
+    ss::sstring desc;
+    std::vector<segment_fields> segment_fields;
+    std::optional<model::offset> new_start_offset{std::nullopt};
+    // These ranges have the same inclusivity as the iterator
+    // constructor for std::vector, i.e [first, last).
+    std::vector<std::pair<size_t, size_t>> expected_ranges;
+};
+
+TEST_F(storage_test_fixture, find_sliding_ranges) {
+    auto log_cfg = default_log_config(test_dir);
+    log_cfg.max_compacted_segment_size = config::mock_binding<size_t>(1_MiB);
+    storage::ntp_config::default_overrides overrides;
+    overrides.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(log_cfg);
+
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+
+    // add a segment with random keys until a certain size
+    auto add_segment = [](auto& log, size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 1, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    static constexpr int64_t u32_max = std::numeric_limits<uint32_t>::max();
+    // Don't forget that the active segment will occupy the last index
+    // beyond the segment fields detailed below.
+    // clang-format off
+    std::vector<sliding_ranges_test_case> test_cases = {
+      sliding_ranges_test_case{
+	  .desc="Mix of ranges due to raft terms and max size",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},     // 0 A
+	    {100_KiB, model::term_id{0}, true},   // 1 A
+	    {500_KiB, model::term_id{0}, true},   // 2 A
+	    {1024_KiB, model::term_id{0}, true},  // 3  -
+	    {1_KiB, model::term_id{1}, true},     // 4   B
+	    {2_KiB, model::term_id{1}, true},     // 5   B
+	    {3_KiB, model::term_id{1}, true},     // 6   B
+	    {100_KiB, model::term_id{1}, true},   // 7   B
+	    {50_KiB, model::term_id{2}, true},    // 8    -
+	    {50_KiB, model::term_id{3}, true},    // 9    -
+	    {50_KiB, model::term_id{4}, true},    // 10   -
+	    {50_KiB, model::term_id{5}, true},    // 11   -
+	    {1024_KiB, model::term_id{5}, true}}, // 12   -
+	                                          // 13   - (Active)
+	  .expected_ranges = {
+	    {0, 3}, {4, 8}}},
+      sliding_ranges_test_case{
+	  .desc="Some unstable segments creating gap in ranges",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},    // 0 -
+	    {100_KiB, model::term_id{0}, false}, // 1 -
+	    {500_KiB, model::term_id{0}, false}, // 2 -
+	    {1024_KiB, model::term_id{0}, true}, // 3 -
+	    {1_KiB, model::term_id{1}, true},    // 4  A
+	    {2_KiB, model::term_id{1}, true},    // 5  A
+	    {3_KiB, model::term_id{1}, true},    // 6  A
+	    {100_KiB, model::term_id{1}, true}}, // 7  A
+	                                         // 8   - (Active)
+	  .expected_ranges = {{4, 8}}},
+      sliding_ranges_test_case{
+	  .desc="One unstable segment",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, false}}, // 0 -
+	                                        // 1 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="One stable segment",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true}}, // 0 -
+	                                       // 1 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="All stable segments of the same term with total size less than max compacted segment size",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},    // 0 A
+	    {100_KiB, model::term_id{0}, true},  // 1 A
+	    {100_KiB, model::term_id{0}, true}}, // 2 A
+	                                         // 3  - (Active)
+	  .expected_ranges = {{0, 3}}},
+      sliding_ranges_test_case{
+	  .desc="Alternating stable and unstable segments",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},     // 0 -
+	    {100_KiB, model::term_id{0}, false},  // 1 -
+	    {100_KiB, model::term_id{0}, true},   // 2 -
+	    {100_KiB, model::term_id{0}, false},  // 3 -
+	    {100_KiB, model::term_id{0}, true},   // 4 -
+	    {100_KiB, model::term_id{0}, false}}, // 5 -
+	                                          // 6 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="All unstable segments",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, false},    // 0 -
+	    {100_KiB, model::term_id{0}, false},  // 1 -
+	    {100_KiB, model::term_id{0}, false},  // 2 -
+	    {100_KiB, model::term_id{0}, false},  // 3 -
+	    {100_KiB, model::term_id{0}, false},  // 4 -
+	    {100_KiB, model::term_id{0}, false}}, // 5 -
+	                                          // 6 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="All unique segment terms",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},    // 0 -
+	    {100_KiB, model::term_id{1}, true},  // 1 -
+	    {100_KiB, model::term_id{2}, true},  // 2 -
+	    {100_KiB, model::term_id{3}, true},  // 3 -
+	    {100_KiB, model::term_id{4}, true},  // 4 -
+	    {100_KiB, model::term_id{5}, true}}, // 5 -
+	                                         // 6 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="All stable segments with boundaries set by max compacted segment size",
+	  .segment_fields={
+	    {500_KiB, model::term_id{0}, true},        // 0 A
+	    {500_KiB, model::term_id{0}, true},        // 1 A
+	    {100_KiB, model::term_id{0}, true},        // 2  -
+	    {1_MiB - 10_KiB, model::term_id{0}, true}, // 3   B
+	    {5_KiB, model::term_id{0}, true},          // 4   B
+	    {100_KiB, model::term_id{0}, true}},       // 5    -
+	                                               // 6    - (Active)
+	  .expected_ranges = {{0, 2}, {3, 5}}},
+      sliding_ranges_test_case{
+	  .desc="Just one valid segment at the end",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, false},   // 0 -
+	    {100_KiB, model::term_id{0}, false}, // 1 -
+	    {100_KiB, model::term_id{0}, false}, // 2 -
+	    {100_KiB, model::term_id{0}, false}, // 3 -
+	    {100_KiB, model::term_id{0}, false}, // 4 -
+	    {100_KiB, model::term_id{0}, true}}, // 5 -
+	                                         // 6 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="uint32_t max boundary allowing segment merging",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},                                          // 0 A
+	    {100_KiB, model::term_id{0}, true, std::nullopt, model::offset{u32_max}}}, // 1 A
+	                                                                               // 2 - (Active)
+	  .expected_ranges = {{0, 2}}},
+      sliding_ranges_test_case{
+	  .desc="one past uint32_t max boundary preventing segment merging",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},                                            // 0 -
+	    {100_KiB, model::term_id{0}, true, std::nullopt, model::offset{u32_max+1}}}, // 1 -
+	                                                                                 // 2 - (Active)
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="Mergable segments below new_start_offset should be ignored",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true},     // 0 -
+	    {100_KiB, model::term_id{0}, true},   // 1 -
+	    {500_KiB, model::term_id{0}, true}},  // 2 -
+	                                          // 3 - (Active)
+	  .new_start_offset=model::offset::max(),
+	  .expected_ranges = {}},
+      sliding_ranges_test_case{
+	  .desc="Some mergable segment ranges above and below new_start_offset.",
+	  .segment_fields={
+	    {5_KiB, model::term_id{0}, true, model::offset{0}},      // 0 -
+	    {100_KiB, model::term_id{0}, true, model::offset{1}},    // 1 -
+	    {500_KiB, model::term_id{0}, true, model::offset{2}},    // 2 -
+	    {5_KiB, model::term_id{0}, true, model::offset{101}},    // 3  A
+	    {100_KiB, model::term_id{0}, true, model::offset{102}},  // 4  A
+	    {500_KiB, model::term_id{0}, true, model::offset{103}}}, // 5  A
+	                                                             // 6   - (Active)
+	  .new_start_offset=model::offset{100},
+	  .expected_ranges = {{3, 6}}},
+    };
+    // clang-format on
+
+    for (int test_case_index = 0; const auto& test_case : test_cases) {
+        vlog(e2e_test_log.info, "Running test case: {}", test_case.desc);
+        const auto& segment_fields = test_case.segment_fields;
+        const auto& expected_ranges = test_case.expected_ranges;
+        auto ntp = model::ntp(
+          "default", fmt::format("test-{}", test_case_index++), 0);
+        auto log = mgr
+                     .manage(storage::ntp_config(
+                       ntp,
+                       mgr.config().base_dir,
+                       std::make_unique<storage::ntp_config::default_overrides>(
+                         overrides)))
+                     .get();
+
+        auto* disk_log = static_cast<storage::disk_log_impl*>(log.get());
+
+        for (const auto& segment_field : segment_fields) {
+            add_segment(log, segment_field.size, segment_field.term);
+            disk_log->force_roll().get();
+        }
+
+        storage::compaction_config cfg(model::offset::max(), std::nullopt, as);
+
+        for (size_t i = 0; i < segment_fields.size(); ++i) {
+            auto& seg = disk_log->segments()[i];
+            if (segment_fields[i].mark_as_stable) {
+                // We need to self compact segments before they are
+                // considered in the adjacent compaction ranges
+                seg->mark_as_finished_self_compaction();
+            }
+
+            auto& ot = const_cast<storage::segment::offset_tracker&>(
+              seg->offsets());
+            if (segment_fields[i].dirty_offset_override.has_value()) {
+                // Override the dirty offset of the segment, if specified
+                ot.set_offset(storage::segment::offset_tracker::dirty_offset_t{
+                  *segment_fields[i].dirty_offset_override});
+            }
+            if (segment_fields[i].base_offset_override.has_value()) {
+                // Override the base offset of the segment, if specified
+                storage::testing_details::offset_tracker_accessor::base_offset(
+                  ot)
+                  = *segment_fields[i].base_offset_override;
+            }
+        }
+
+        std::unordered_map<ss::sstring, size_t> segment_filename_index_map;
+        for (size_t i = 0; const auto& segment : disk_log->segments()) {
+            segment_filename_index_map[segment->filename()] = i++;
+        }
+
+        auto adjacent_ranges = disk_log->find_adjacent_compaction_ranges(
+          cfg, test_case.new_start_offset);
+        if (!expected_ranges.empty()) {
+            ASSERT_TRUE(adjacent_ranges.has_value());
+            ASSERT_EQ(adjacent_ranges->size(), expected_ranges.size());
+            for (size_t expected_ranges_index = 0;
+                 const auto& seg_it : *adjacent_ranges) {
+                auto first_index = segment_filename_index_map.at(
+                  (*seg_it.first)->filename());
+                ASSERT_EQ(
+                  first_index, expected_ranges[expected_ranges_index].first);
+                auto second_index = segment_filename_index_map.at(
+                  (*seg_it.second)->filename());
+                ASSERT_EQ(
+                  second_index, expected_ranges[expected_ranges_index].second);
+                ++expected_ranges_index;
+            }
+        } else {
+            ASSERT_TRUE(!adjacent_ranges.has_value());
+        }
+    }
+}

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -159,7 +159,8 @@ disk_log_builder::apply_retention(gc_config cfg) {
 
 ss::future<> disk_log_builder::apply_adjacent_merge_compaction(
   compaction_config cfg, std::optional<model::offset> new_start_offset) {
-    return get_disk_log_impl().adjacent_merge_compact(cfg, new_start_offset);
+    return get_disk_log_impl().adjacent_merge_compact(
+      get_disk_log_impl().segments(), cfg, new_start_offset);
 }
 
 ss::future<bool> disk_log_builder::apply_sliding_window_compaction(

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -11,6 +11,8 @@ import math
 import random
 import re
 import threading
+from enum import Enum
+
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.apache_iceberg_catalog import IcebergRESTCatalog
@@ -48,6 +50,12 @@ TS_LOG_ALLOW_LIST = [
         """.*state_machine_manager.* error applying raft snapshot - std::runtime_error \\(couldn't download manifest: cloud_storage::error_outcome:2\\).*"""
     )
 ]
+
+
+class CompactionMode(str, Enum):
+    SLIDING_WINDOW = "sliding_window"
+    CHUNKED_SLIDING_WINDOW = "chunked_sliding_window"
+    ADJACENT_MERGE = "adjacent_merge"
 
 
 class RandomNodeOperationsTest(PreallocNodesTest):
@@ -161,9 +169,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             f"running test with: [message_size {self.msg_size},  total_bytes: {self.total_data}, message_count: {self.msg_count}, rate_limit: {self.rate_limit}, cluster_operations: {self.node_operations}]"
         )
 
-    def _start_redpanda(self, mixed_versions, with_iceberg,
-                        with_chunked_compaction):
-
+    def _start_redpanda(self, mixed_versions, with_iceberg, compaction_mode):
         # since this test is deleting topics we must tolerate missing manifests
         self._si_settings.set_expected_damage(
             {"ntr_no_topic_manifest", "ntpr_no_manifest"})
@@ -183,7 +189,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
                 "panda-secret",
             })
 
-        if with_chunked_compaction:
+        if compaction_mode == CompactionMode.CHUNKED_SLIDING_WINDOW:
             # This may not be recognized on certain nodes in mixed-version run.
             environment = {
                 "__REDPANDA_TEST_DISABLE_BOUNDED_PROPERTY_CHECKS": "ON"
@@ -192,6 +198,9 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             # Use 3 KiB of memory for compaction map, which should force chunked compaction.
             self.redpanda.add_extra_rp_conf(
                 {"storage_compaction_key_map_memory": 3 * 1024})
+        elif compaction_mode == CompactionMode.ADJACENT_MERGE:
+            self.redpanda.add_extra_rp_conf(
+                {"log_compaction_use_sliding_window": False})
 
         self.redpanda.set_seed_servers(self.redpanda.nodes)
         if mixed_versions:
@@ -343,10 +352,14 @@ class RandomNodeOperationsTest(PreallocNodesTest):
     @matrix(enable_failures=[True, False],
             mixed_versions=[True, False],
             with_iceberg=[True, False],
-            with_chunked_compaction=[True, False],
+            compaction_mode=[
+                CompactionMode.SLIDING_WINDOW,
+                CompactionMode.CHUNKED_SLIDING_WINDOW,
+                CompactionMode.ADJACENT_MERGE
+            ],
             cloud_storage_type=get_cloud_storage_type())
     def test_node_operations(self, enable_failures, mixed_versions,
-                             with_iceberg, with_chunked_compaction,
+                             with_iceberg, compaction_mode,
                              cloud_storage_type):
         # In order to reduce the number of parameters and at the same time cover
         # as many use cases as possible this test uses 3 topics which 3 separate
@@ -389,7 +402,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         # start redpanda process
         self._start_redpanda(mixed_versions,
                              with_iceberg=with_iceberg,
-                             with_chunked_compaction=with_chunked_compaction)
+                             compaction_mode=compaction_mode)
 
         self.redpanda.set_cluster_config(
             {"controller_snapshot_max_age_sec": 1})


### PR DESCRIPTION
Adjacent segment compaction is currently highly limited, as only two segments can be selected for concatenation at a time. Furthermore, when sliding window compaction is enabled, which is the default behavior (and status quo) for every `redpanda` cluster, this process is only kicked off once per sliding window round. For massive compacted topics/partitions whose sliding window round can take orders of minutes or tens of minutes, this means that any attempt to reduce segment count with adjacent compaction can easily be dwarfed by pure ingress and segment creation rate.

The current work improves adjacent segment compaction to work over sub-arrays of `segments`, combining `N` `segment`s into `1` concatenated `segment`.

The high level approach is:
1. Make adjacent segment compaction closer to sliding window compaction in that all `segment`s in the log are iterated over and self compacted first.
2. Instead of only finding two valid `segment`s to combine, entire sub-arrays of `segment`s that can be combined with the current limitations of same raft term, spanning less than the `uint32_t` offset space and conforming to `max_compacted_segment_size` are selected. Every possible sub-array in the log is determined in a single round of adjacent compaction.
3. Each of those sub-arrays are iterated over and concatenated into 1 `segment`.

This is, effectively, hyper aggressive adjacent compaction, which is required for huge `compact` only topics with high ingress rates in order to keep the `segment` count bounded.

The tunable cluster property `log_compaction_adjacent_merge_segment_max` is also added, which allows users to configure one of the following behaviors: 

1. The old behavior of pair wise adjacent compaction (`log_compaction_adjacent_merge_segment_max = 2`)
2. The new behavior of N-wise adjacent compaction (`log_compaction_adjacent_merge_segment_max > 2` or `std::nullopt`)
3. The ability to disable adjacent compaction (`log_compaction_adjacent_merge_segment_max < 2`)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

### Improvements

* Make adjacent segment compaction work over sub-arrays of `segment`s in the log, allowing for a much more effective reduction in `segment` count of `compact`-enabled topics.
