### PR TITLE
compaction: compact stale tx_fence from consumer_offsets topic 

### DIFF
--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -96,4 +96,9 @@ inline bool is_user_topic(const ntp& ntp) {
     return is_user_topic(topic_namespace_view{ntp});
 }
 
+inline bool is_consumer_offsets_topic(const ntp& ntp) {
+    return ntp.ns == kafka_namespace
+           && ntp.tp.topic == kafka_consumer_offsets_topic;
+}
+
 } // namespace model

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -150,7 +150,7 @@ ss::future<std::optional<model::record_batch>>
 copy_data_segment_reducer::filter(model::record_batch batch) {
     // do not compact raft configuration and archival metadata as they shift
     // offset translation
-    if (!is_compactible(batch)) {
+    if (!is_compactible(_ntp, batch)) {
         co_return std::move(batch);
     }
 
@@ -293,7 +293,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
     const auto records_to_remove = record_count_before
                                    - to_copy->record_count();
     _stats.records_discarded += records_to_remove;
-    bool compactible_batch = is_compactible(to_copy.value());
+    bool compactible_batch = is_compactible(_ntp, to_copy.value());
     if (!compactible_batch) {
         ++_stats.non_compactible_batches;
     }
@@ -429,7 +429,7 @@ bool tx_reducer::can_discard_consumer_offsets_batch(
     // committed data has already been rewritten as separate raft_data batches,
     // so no need to retain originally written group_prepare_tx batches while
     // the transaction is in progress.
-    return is_compactible_control_batch(b.header().type);
+    return is_compactible_control_batch(_ntp, b.header().type);
 }
 
 ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
@@ -477,7 +477,7 @@ map_building_reducer::operator()(model::record_batch batch) {
     // There is no point to indexing records in uncompactible batches, since
     // their inclusion in the segment post compaction is irrespective of the map
     // state (see copy_data_segment_reducer::filter()).
-    if (!is_compactible(batch)) {
+    if (!is_compactible(_ntp, batch)) {
         co_return ss::stop_iteration::no;
     }
     auto b = co_await decompress_batch(std::move(batch));

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -158,6 +158,7 @@ public:
     };
 
     copy_data_segment_reducer(
+      model::ntp ntp,
       filter_t f,
       segment_appender* a,
       bool internal_topic,
@@ -168,7 +169,8 @@ public:
       compacted_index_writer* cidx = nullptr,
       bool inject_failure = false,
       ss::abort_source* as = nullptr)
-      : _should_keep_fn(std::move(f))
+      : _ntp(std::move(ntp))
+      , _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
       , _compaction_placeholder_enabled(compaction_placeholder_enabled)
       , _appender(a)
@@ -196,6 +198,7 @@ private:
     // Creates a placeholder batch with same offset range as the input header.
     model::record_batch make_placeholder_batch(model::record_batch_header&);
 
+    model::ntp _ntp;
     filter_t _should_keep_fn;
 
     // Offset to keep in case the index is empty as of getting to this offset.
@@ -263,10 +266,12 @@ private:
 class tx_reducer : public compaction_reducer {
 public:
     explicit tx_reducer(
+      model::ntp ntp,
       ss::lw_shared_ptr<storage::stm_manager> stm_mgr,
       fragmented_vector<model::tx_range>&& txs,
       compacted_index_writer* w) noexcept
-      : _delegate(index_rebuilder_reducer(w))
+      : _ntp(std::move(ntp))
+      , _delegate(index_rebuilder_reducer(w))
       , _aborted_txs(model::tx_range_cmp(), std::move(txs))
       , _stm_mgr(stm_mgr)
       , _transactional_stm_type(stm_mgr->transactional_stm_type()) {
@@ -301,7 +306,9 @@ private:
     // transaction (if any) may be added and finished aborted
     // transactions are removed if an abort batch is encountered.
     void refresh_ongoing_aborted_txs(const model::record_batch&);
+    bool has_transactional_data() const;
 
+    model::ntp _ntp;
     index_rebuilder_reducer _delegate;
     // A min heap of aborted transactions based on begin offset.
     using underlying_t = std::priority_queue<
@@ -332,8 +339,9 @@ private:
 class map_building_reducer : public compaction_reducer {
 public:
     explicit map_building_reducer(
-      key_offset_map* map, model::offset start_offset_inclusive)
-      : _map(map)
+      model::ntp ntp, key_offset_map* map, model::offset start_offset_inclusive)
+      : _ntp(std::move(ntp))
+      , _map(map)
       , _start_offset(start_offset_inclusive) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
@@ -347,6 +355,7 @@ private:
       bool is_control,
       bool& fully_indexed_batch);
 
+    model::ntp _ntp;
     key_offset_map* _map;
     model::offset _start_offset;
     bool _fully_indexed_segment = true;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -484,7 +484,7 @@ ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
         co_return;
     }
     // do not index not compactible batches
-    if (!internal::is_compactible(b)) {
+    if (!internal::is_compactible(path().get_ntp(), b)) {
         co_return;
     }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -220,6 +220,7 @@ ss::future<index_state> deduplicate_segment(
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
+      seg->path().get_ntp(),
       std::move(record_filter),
       &appender,
       seg->path().is_internal_topic(),
@@ -279,7 +280,8 @@ ss::future<bool> index_chunk_of_segment_for_map(
     auto start_offset_inclusive = model::next_offset(last_indexed_offset);
     auto rdr = internal::create_segment_full_reader(
       seg, compact_cfg, pb, std::move(read_holder), start_offset_inclusive);
-    internal::map_building_reducer reducer(&map, start_offset_inclusive);
+    internal::map_building_reducer reducer(
+      seg->path().get_ntp(), &map, start_offset_inclusive);
 
     bool fully_indexed_segment = co_await std::move(rdr).consume(
       reducer, model::no_timeout);

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -132,7 +132,8 @@ void segment_index::maybe_track(
           to_optional_model_timestamp(new_broker_ts),
           path().is_internal_topic()
             || hdr.type == model::record_batch_type::raft_data,
-          internal::is_compactible(hdr) ? hdr.record_count : 0)) {
+          internal::is_compactible(_path.get_ntp(), hdr) ? hdr.record_count
+                                                         : 0)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -425,6 +425,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     };
 
     auto copy_reducer = copy_data_segment_reducer(
+      seg->path().get_ntp(),
       std::move(record_filter),
       appender.get(),
       seg->path().is_internal_topic(),
@@ -620,7 +621,8 @@ ss::future<> build_compaction_index(
   storage_resources& resources) {
     auto w = storage::make_file_backed_compacted_index(
       p, cfg.iopc, false, resources, cfg.sanitizer_config);
-    auto reducer = tx_reducer(stm_manager, std::move(aborted_txs), w.get());
+    auto reducer = tx_reducer(
+      p.get_ntp(), stm_manager, std::move(aborted_txs), w.get());
     auto index_builder = co_await ss::coroutine::as_future<tx_reducer::stats>(
       std::move(rdr)
         .consume(std::move(reducer), model::no_timeout)

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -225,22 +225,36 @@ struct clean_segment_value
     auto serde_fields() { return std::tie(segment_name); }
 };
 
-inline bool
-is_compactible_control_batch(const model::record_batch_type batch_type) {
+inline bool is_compactible_control_batch(
+  const model::ntp& ntp, const model::record_batch_type batch_type) {
     // Control batches in consumer offsets are special compared to
     // the ones in data partitions can be safely compacted away.
-    return batch_type == model::record_batch_type::group_fence_tx
+    //
+    // tx_fence batches  in consumer offsets are special and should be
+    // compacted. They were used historically to mark the begin of a transaction
+    // but later switched to group_fence_tx.
+
+    // Note: This ugly hack of propagating the consumer offsets flag is
+    // temporary until we fix the compaction to compact away all the control
+    // batches (including the ones in data partitions), at which point we solely
+    // can make this decision on whether the batch is a control batch or not and
+    // avoid propagating the flag everywhere.
+    return unlikely(
+             batch_type == model::record_batch_type::tx_fence
+             && model::is_consumer_offsets_topic(ntp))
+           || batch_type == model::record_batch_type::group_fence_tx
            || batch_type == model::record_batch_type::group_prepare_tx
            || batch_type == model::record_batch_type::group_abort_tx
            || batch_type == model::record_batch_type::group_commit_tx;
 }
 
-inline bool is_compactible(const model::record_batch_header& h) {
+inline bool
+is_compactible(const model::ntp& ntp, const model::record_batch_header& h) {
     if (
-      (h.attrs.is_control() && !is_compactible_control_batch(h.type))
+      (h.attrs.is_control() && !is_compactible_control_batch(ntp, h.type))
       || h.type == model::record_batch_type::compaction_placeholder) {
-        // Keep control batches to ensure we maintain transaction boundaries.
-        // They should be rare.
+        // Keep control batches to ensure we maintain transaction boundaries
+        // (unless it is CO topic). They should be rare.
         return false;
     }
     static const auto filtered_types = model::offset_translator_batch_types();
@@ -248,8 +262,9 @@ inline bool is_compactible(const model::record_batch_header& h) {
     return n == 0;
 }
 
-inline bool is_compactible(const model::record_batch& b) {
-    return is_compactible(b.header());
+inline bool
+is_compactible(const model::ntp& ntp, const model::record_batch& b) {
+    return is_compactible(ntp, b.header());
 }
 
 offset_delta_time should_apply_delta_time_offset(


### PR DESCRIPTION
tx_fence was once used as the fence batch in consumer offsets
topic, the same batch type used as fence batches in user topic
partitions. At a later point the batch type got changed to
group_tx_fence so CO has a dedidacted batch type. Due to a bug in the
original implementations of CO topic with transactions tx_fence was not
compacted away. This led to certain deployments retaining this batch in
the log. This commit  ensures that `tx_fence` from CO is also compacted
away.

Do note that currently we donot compact control batches from user
topics, so the function to determine whether tx_fence is compactible
depends on the ntp being compacted which is plumbed all the way into
utilities. Its a bit ugly but can be undone once we support compacting
away control batches from user topics.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes
### Bug Fixes
* removes stale uncompacted tx_fence batches from consumer offsets topic.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
