### PR TITLE
CORE-9920 [v25.1.x] CORE-9903 crash_tracker: improve diagnostics on backtrace failure

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -201,7 +201,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "YA64kzfEoBibr8F1Y14l6D2ukhdTl5w7ypC/9VajjyA=",
+        "bzlTransitiveDigest": "+fcNQVnLOI5iivykMgnTGZjuCSYDWvUv2CHmv12MqGc=",
         "usagesDigest": "8eEn6X1e7HKkx2OPWUwQBOEnT9TIkMhEcXbu/wRjGno=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -378,9 +378,9 @@
             "ruleClassName": "http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "cf0ea1788629c8897bcb9cec077c82646f0c2bc3e8bed493428c9ad213bb656c",
-              "strip_prefix": "seastar-a37824fb2a5c47c5d69099d66ea21e1fef7c5550",
-              "url": "https://github.com/redpanda-data/seastar/archive/a37824fb2a5c47c5d69099d66ea21e1fef7c5550.tar.gz"
+              "sha256": "6e1dadc1f005d96fbc5abe886a2a5da5f7794c8390eab02868baf1a567ba475a",
+              "strip_prefix": "seastar-8403fc6200ce8ffd51cc44c74738fd3491ce7296",
+              "url": "https://github.com/redpanda-data/seastar/archive/8403fc6200ce8ffd51cc44c74738fd3491ce7296.tar.gz"
             }
           },
           "unordered_dense": {
@@ -5471,7 +5471,7 @@
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/rustc": "241027b94ad67beb36d0356f7cc05180daaa9966b2958cfba1d4de089d2e521c",
           "@@//bazel/thirdparty/Cargo.lock": "931fa1bc55d0e5d2e5b6d96da399569a4c2254a4bb1d99c98f71bb4b98eead73",
           "@@//bazel/thirdparty/Cargo.toml": "cb23768a6e7edc8f97215921e956f5be06521ad93cc0ecf64a932e3a8caada54",
-          "@@//MODULE.bazel": "2681cdb2e8a77b00541d5ce12f75851eb3dbddc81a91510b5d3969487d8734eb",
+          "@@//MODULE.bazel": "64f2c3e2bd9bcf25a46b9bf23e7ba854d334830bbb99a2ae061e2e35544c2e82",
           "@@//bazel/thirdparty/wasmtime.BUILD": "4b55deaf51f5b8be25fc3592f9bcf3d732f99632cd793c685436ddca9a177534",
           "@@rules_rust~~rust_host_tools~rust_host_tools//bin/cargo": "35099f3b7b9497b3ae95aa00886ac6839343488e5cdb958e69c16c9b58c3afb2"
         },

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -159,9 +159,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "cf0ea1788629c8897bcb9cec077c82646f0c2bc3e8bed493428c9ad213bb656c",
-        strip_prefix = "seastar-a37824fb2a5c47c5d69099d66ea21e1fef7c5550",
-        url = "https://github.com/redpanda-data/seastar/archive/a37824fb2a5c47c5d69099d66ea21e1fef7c5550.tar.gz",
+        sha256 = "6e1dadc1f005d96fbc5abe886a2a5da5f7794c8390eab02868baf1a567ba475a",
+        strip_prefix = "seastar-8403fc6200ce8ffd51cc44c74738fd3491ce7296",
+        url = "https://github.com/redpanda-data/seastar/archive/8403fc6200ce8ffd51cc44c74738fd3491ce7296.tar.gz",
     )
 
     http_archive(

--- a/src/v/crash_tracker/signals.cc
+++ b/src/v/crash_tracker/signals.cc
@@ -9,9 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+#include "crash_tracker/logger.h"
 #include "crash_tracker/recorder.h"
 
 #include <seastar/core/smp.hh>
+#include <seastar/util/backtrace.hh>
+#include <seastar/util/log.hh>
 #include <seastar/util/print_safe.hh>
 
 namespace crash_tracker {
@@ -69,15 +72,34 @@ void install_oneshot_signal_handler() {
     }).get();
 }
 
-void sigsegv_action() {
+static void maybe_print_backtrace(std::string_view signal_msg) noexcept {
+    if (ctlog.is_enabled(ss::log_level::debug)) {
+        ss::print_safe(signal_msg.data(), signal_msg.size());
+        ss::print_safe(":\n");
+        ss::backtrace(
+          [](const ss::frame& f) {
+              ss::print_safe("0x");
+              ss::print_zero_padded_hex_safe(f.addr);
+              ss::print_safe(" in ");
+              ss::print_safe(f.so->name.c_str());
+              ss::print_safe("\n");
+          },
+          true);
+    }
+}
+
+static void sigsegv_action() noexcept {
+    maybe_print_backtrace("Segmentation fault");
     constexpr auto signo = crash_tracker::recorder::recorded_signo::sigsegv;
     crash_tracker::get_recorder().record_crash_sighandler(signo);
 }
 void sigabrt_action() {
+    maybe_print_backtrace("Aborting");
     constexpr auto signo = crash_tracker::recorder::recorded_signo::sigabrt;
     crash_tracker::get_recorder().record_crash_sighandler(signo);
 }
 void sigill_action() {
+    maybe_print_backtrace("Illegal instruction");
     constexpr auto signo = crash_tracker::recorder::recorded_signo::sigill;
     crash_tracker::get_recorder().record_crash_sighandler(signo);
 }

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -25,10 +25,11 @@ CRASH_LOOP_LOG = [
 
 SIGNAL_CRASH_LOG = [
     "Aborting on",
+    "Aborting:",
     "Segmentation fault on",
-    "Segmentation fault: resolved ip:",
-    "Segmentation fault: si_code:",
+    "Segmentation fault:",
     "Illegal instruction on",
+    "Illegal instruction:",
 ]
 
 ASSERT_CRASH_LOG = ["assert - "]


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/25914

Manual due to the difference in the commit we updated seastar to in https://github.com/redpanda-data/redpanda/commit/8c840a133505dec9ee80a434257f2884da06dcb1.

Fixes https://redpandadata.atlassian.net/browse/CORE-9920

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
