### PR TITLE
tests: added consumer offsets recovery test

### DIFF
--- a/tests/rptest/clients/offline_log_viewer.py
+++ b/tests/rptest/clients/offline_log_viewer.py
@@ -55,6 +55,9 @@ class OfflineLogViewer:
     def read_consumer_offsets(self, node):
         return self._json_cmd(node, "--type consumer_offsets")
 
+    def consumer_offsets_summary(self, node):
+        return self._json_cmd(node, "--type consumer_offsets_summary")
+
     def read_crash_reports(self, node):
         return self._json_cmd(node, "--type crash_report")
 

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -34,15 +34,17 @@ from rptest.utils.mode_checks import skip_debug_mode
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import ignore, parametrize
-from kafka import KafkaConsumer, TopicPartition
-from kafka import errors as kerr
+
+from kafka import KafkaConsumer, errors as kerr
 from kafka.admin import KafkaAdminClient
 from kafka.protocol.commit import OffsetFetchRequest_v3
 from kafka.protocol.api import Request, Response
 import kafka.protocol.types as types
 from confluent_kafka.admin import AdminClient
-from confluent_kafka import ConsumerGroupState
+from confluent_kafka import ConsumerGroupState, ConsumerGroupTopicPartitions
 from confluent_kafka import Consumer, Producer
+from confluent_kafka import TopicPartition
+from collections import namedtuple
 
 
 class ConsumerGroupTest(RedpandaTest):
@@ -422,9 +424,10 @@ class ConsumerGroupTest(RedpandaTest):
         # Test that the consumer committed what we expected.
         self.logger.info(f"Got offsets: {offsets}")
         assert len(offsets) == 1
-        assert offsets[TopicPartition(self.topic_spec.name, 0)].offset == 1000
-        assert offsets[TopicPartition(self.topic_spec.name,
-                                      0)].leader_epoch > 0
+        assert offsets[TestTopicPartition(self.topic_spec.name,
+                                          0)].offset == 1000
+        assert offsets[TestTopicPartition(self.topic_spec.name,
+                                          0)].leader_epoch > 0
 
         # Remember the old offsets to compare them after the restart.
         prev_offsets = offsets
@@ -1123,6 +1126,9 @@ class OffsetAndMetadata():
     metadata: str
 
 
+TestTopicPartition = namedtuple('TestTopicPartition', ['topic', 'partition'])
+
+
 class KafkaTestAdminClient():
     """
     A wrapper around KafkaAdminClient with support for newer Kafka versions.
@@ -1136,7 +1142,7 @@ class KafkaTestAdminClient():
 
     def list_offsets(
         self, group_id: str, partitions: List[TopicPartition]
-    ) -> Dict[TopicPartition, OffsetAndMetadata]:
+    ) -> Dict[TestTopicPartition, OffsetAndMetadata]:
         coordinator = self._admin._find_coordinator_ids([group_id])[group_id]
         future = self._list_offsets_send_request(group_id, coordinator,
                                                  partitions)
@@ -1505,3 +1511,192 @@ class ConsumerGroupStaticMembersRebalance(RedpandaTest):
             restart_then_stop_consumer,
             verify_all_consumers_are_present,
             consumer_session_timeout=10000)
+
+
+class OffsetCommitter:
+    def __init__(self, bootstrap_servers, group, topic, id, logger,
+                 partition_id: int):
+        self.bootstrap_servers = bootstrap_servers
+        self.id = id
+        self.group = group
+        self.topic = topic
+        self.consumer_thread = threading.Thread(
+            name=f'consumer-{id}',
+            target=lambda this: this.loop(),
+            args=[self])
+        self.stopped = threading.Event()
+
+        self.logger = logger
+        self.consumer_thread.daemon = True
+        self.last_committed = -1
+        self.lock = threading.Lock()
+        self.restarted = threading.Event()
+        self.partition_id = partition_id
+        self.next = 0
+        self.consumer_thread.start()
+
+    def stop(self):
+        self.logger.info(f"stopping consumer with id: {self.id}")
+        self.stopped.set()
+        self.consumer_thread.join()
+
+    def is_stopped(self):
+        return self.stopped.is_set()
+
+    def create_consumer_client(self):
+        self.consumer = Consumer(
+            {
+                "group.id": self.group,
+                "client.id": f"consumer-{self.id}",
+                'bootstrap.servers': self.bootstrap_servers,
+                'auto.offset.reset': 'earliest',
+                'enable.auto.offset.store': True,
+                'enable.auto.commit': False,
+            },
+            logger=self.logger)
+
+        self.consumer.assign([TopicPartition(self.topic, self.partition_id)])
+
+    def loop(self):
+        self.create_consumer_client()
+        self.logger.info(f"starting consumer with id: {self.id}")
+        while not self.stopped.is_set():
+            try:
+                to_commit = self.next
+                self.next += 1
+                ret = self.consumer.commit(offsets=[
+                    TopicPartition(self.topic,
+                                   self.partition_id,
+                                   offset=to_commit)
+                ],
+                                           asynchronous=False)
+                with self.lock:
+                    self.last_committed = ret[0].offset
+            except Exception as e:
+                self.logger.error(f"consumer {self.id} error - {e}")
+        self.logger.info(f"closing consumer with id: {self.id}")
+        self.consumer.close()
+
+    def get_last_committed(self):
+        with self.lock:
+            return self.last_committed
+
+
+class ConsumerGroupOffsetResetTest(RedpandaTest):
+    """
+    This tests simulates a large number of consumers trying to commit consumer 
+    group offsets. The test doesn't produce or fetch any messages, 
+    it just stress tests OffsetCommit requests and validates the final 
+    state of the consumer group.
+    """
+    def __init__(self, test_context):
+        super(ConsumerGroupOffsetResetTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf={
+                                 "group_topic_partitions": 1,
+                                 "compacted_log_segment_size": 1024 * 1024,
+                                 "log_compaction_interval_ms": 1000,
+                                 "group_offset_retention_sec": 20,
+                             })
+
+    def get_group_description(self):
+        description = self.admin_client.describe_consumer_groups(
+            group_ids=[self.group_id])[self.group_id].result()
+        return description
+
+    def list_consumer_group_offsets(self, topic):
+        topic_partitions = [
+            TopicPartition(topic, p) for p in range(self.consumer_count)
+        ]
+        cg_tp = ConsumerGroupTopicPartitions(self.group_id,
+                                             topic_partitions=topic_partitions)
+        offsets = self.admin_client.list_consumer_group_offsets([cg_tp])
+
+        return offsets[self.group_id].result()
+
+    def total_committed(self):
+        return sum([c.get_last_committed() for c in self.consumers])
+
+    def wait_for_total_commits(self, total_commits):
+        last_total = 0
+        while self.total_committed() < total_commits:
+            wait_until(
+                lambda: self.total_committed() > last_total, 60, 2,
+                "Timeout waiting for consumers to make progress committing offsets"
+            )
+            last_total = self.total_committed()
+            self.logger.debug(f"Total offsets committed: {last_total}")
+            time.sleep(5)
+
+    @cluster(num_nodes=3)
+    @skip_debug_mode
+    def test_stress_consumer_group_commits(self):
+        self.consumer_count = 200
+
+        topic = TopicSpec(name="cg-test-topic-1",
+                          partition_count=self.consumer_count)
+        DefaultClient(self.redpanda).create_topic(topic)
+        self.group_id = "test-group-1"
+
+        self.consumers: list[OffsetCommitter] = []
+
+        for c_id in range(self.consumer_count):
+            self.consumers.append(
+                OffsetCommitter(
+                    bootstrap_servers=self.redpanda.brokers(),
+                    group=self.group_id,
+                    topic=topic.name,
+                    id=c_id,
+                    logger=self.logger,
+                    partition_id=c_id,
+                ))
+
+        self.admin_client = AdminClient(
+            {"bootstrap.servers": self.redpanda.brokers()})
+        total_commits = 2_000_000
+        self.wait_for_total_commits(total_commits)
+
+        rp_admin = Admin(self.redpanda)
+        for i in range(3):
+            # transfer leadership of __consumer_offsets to a different node
+            rp_admin.partition_transfer_leadership("kafka",
+                                                   "__consumer_offsets", 0)
+            time.sleep(2)
+
+        wait_until(
+            lambda: self.get_group_description().state == ConsumerGroupState.
+            EMPTY,
+            timeout_sec=60,
+            backoff_sec=1,
+            retry_on_exc=True,
+        )
+
+        for c in self.consumers:
+            c.stop()
+
+        # list committed offsets
+        gd = self.list_consumer_group_offsets(topic.name)
+
+        for tp in gd.topic_partitions:
+            expected = self.consumers[tp.partition].get_last_committed()
+            self.logger.info(
+                f"Partition {tp.topic}/{tp.partition} committed offset={tp.offset}"
+            )
+            assert tp.offset == expected, f"Offset mismatch for partition {tp.topic}{tp.partition}, expected: {expected} got: {tp.offset}"
+
+        olv = OfflineLogViewer(self.redpanda)
+        for n in self.redpanda.nodes:
+            summary = olv.consumer_offsets_summary(n)
+            for _, cg_partition_summary in summary.items():
+                assert len(
+                    cg_partition_summary['raft_configurations']
+                ) >= 2, "There must have been at least 1 leadership change"
+                offsets = cg_partition_summary['groups'][
+                    self.group_id]['offsets']
+                for p in range(self.consumer_count):
+                    expected = self.consumers[p].get_last_committed()
+                    committed = offsets[f'{topic.name}/{p}'][
+                        'committed_offset']
+                    assert committed == self.consumers[p].get_last_committed(
+                    ), f"On disk state mismatch, expected: {expected}, got: {expected}"


### PR DESCRIPTION
Added test that stresses the `__consumer_offsets` topic and performs high frequency offset commits in the single consumer group. The test doesn't produce any data to end user topics but just uses `Consumer` interface to execute offset commits.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none