### PR TITLE
[CORE-9870] kafka: Support Metadata v11

### DIFF
--- a/src/v/kafka/protocol/schemata/metadata_request.json
+++ b/src/v/kafka/protocol/schemata/metadata_request.json
@@ -16,8 +16,9 @@
 {
   "apiKey": 3,
   "type": "request",
+  "listeners": ["zkBroker", "broker"],
   "name": "MetadataRequest",
-  "validVersions": "0-9",
+  "validVersions": "0-11",
   "flexibleVersions": "9+",
   "fields": [
     // In version 0, an empty array indicates "request metadata for all topics."  In version 1 and
@@ -31,14 +32,21 @@
     // Starting in version 8, authorized operations can be requested for cluster and topic resource.
     //
     // Version 9 is the first flexible version.
+    //
+    // Version 10 adds topicId and allows name field to be null. However, this functionality was not implemented on the server.
+    // Versions 10 and 11 should not use the topicId field or set topic name to null.
+    //
+    // Version 11 deprecates IncludeClusterAuthorizedOperations field. This is now exposed
+    // by the DescribeCluster API (KIP-700).
     { "name": "Topics", "type": "[]MetadataRequestTopic", "versions": "0+", "nullableVersions": "1+",
       "about": "The topics to fetch metadata for.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "TopicId", "type": "uuid", "versions": "10+", "ignorable": true, "about": "The topic id." },
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName", "nullableVersions": "10+",
         "about": "The topic name." }
     ]},
     { "name": "AllowAutoTopicCreation", "type": "bool", "versions": "4+", "default": "true", "ignorable": false,
       "about": "If this is true, the broker may auto-create topics that we requested which do not already exist, if it is configured to do so." },
-    { "name": "IncludeClusterAuthorizedOperations", "type": "bool", "versions": "8+",
+    { "name": "IncludeClusterAuthorizedOperations", "type": "bool", "versions": "8-10",
       "about": "Whether to include cluster authorized operations." },
     { "name": "IncludeTopicAuthorizedOperations", "type": "bool", "versions": "8+",
       "about": "Whether to include topic authorized operations." }

--- a/src/v/kafka/protocol/schemata/metadata_response.json
+++ b/src/v/kafka/protocol/schemata/metadata_response.json
@@ -36,10 +36,15 @@
   // Starting in version 8, brokers can send authorized operations for topic and cluster.
   //
   // Version 9 is the first flexible version.
-  "validVersions": "0-9",
+  //
+  // Version 10 adds topicId.
+  //
+  // Version 11 deprecates ClusterAuthorizedOperations. This is now exposed
+  // by the DescribeCluster API (KIP-700).
+  "validVersions": "0-11",
   "flexibleVersions": "9+",
   "fields": [
-    { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+",
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "Brokers", "type": "[]MetadataResponseBroker", "versions": "0+",
       "about": "Each broker in the response.", "fields": [
@@ -62,6 +67,7 @@
         "about": "The topic error, or 0 if there was no error." },
       { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
         "about": "The topic name." },
+      { "name": "TopicId", "type": "uuid", "versions": "10+", "ignorable": true, "about": "The topic id." },
       { "name": "IsInternal", "type": "bool", "versions": "1+", "default": "false", "ignorable": true,
         "about": "True if the topic is internal." },
       { "name": "Partitions", "type": "[]MetadataResponsePartition", "versions": "0+",
@@ -76,15 +82,15 @@
           "about": "The leader epoch of this partition." },
         { "name": "ReplicaNodes", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
           "about": "The set of all nodes that host this partition." },
-        { "name": "IsrNodes", "type": "[]int32", "versions": "0+",
+        { "name": "IsrNodes", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
           "about": "The set of nodes that are in sync with the leader for this partition." },
-        { "name": "OfflineReplicas", "type": "[]int32", "versions": "5+", "ignorable": true,
+        { "name": "OfflineReplicas", "type": "[]int32", "versions": "5+", "ignorable": true, "entityType": "brokerId",
           "about": "The set of offline replicas of this partition." }
       ]},
       { "name": "TopicAuthorizedOperations", "type": "int32", "versions": "8+", "default": "-2147483648",
         "about": "32-bit bitfield to represent authorized operations for this topic." }
     ]},
-    { "name": "ClusterAuthorizedOperations", "type": "int32", "versions": "8+", "default": "-2147483648",
+    { "name": "ClusterAuthorizedOperations", "type": "int32", "versions": "8-10", "default": "-2147483648",
       "about": "32-bit bitfield to represent authorized operations for this cluster." }
   ]
 }

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -24,6 +24,7 @@
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
 #include "kafka/server/response.h"
+#include "model/errc.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
@@ -326,8 +327,12 @@ get_topic_metadata(
         if (
           !config::shard_local_cfg().auto_create_topics_enabled
           || !request.data.allow_auto_topic_creation) {
+            bool valid = validate_kafka_topic_name(topic.name)
+                         == model::errc::success;
             res.push_back(make_error_topic_response(
-              std::move(topic.name), error_code::unknown_topic_or_partition));
+              std::move(topic.name),
+              valid ? error_code::unknown_topic_or_partition
+                    : error_code::invalid_topic_exception));
             continue;
         }
         /**

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -305,32 +305,42 @@ get_topic_metadata(
     std::vector<ss::future<metadata_response::topic>> new_topics;
 
     for (auto& topic : *request.data.topics) {
+        const auto move_topic_name = [&topic]() {
+            return std::move(topic.name).value_or(model::topic{});
+        };
+
         /**
          * Authorize source topic in case if we deal with materialized one
          */
-        if (!ctx.authorized(security::acl_operation::describe, topic.name)) {
+        if (!ctx.authorized(
+              security::acl_operation::describe,
+              topic.name.value_or(model::topic{}))) {
             // not authorized, return authorization error
             res.push_back(make_error_topic_response(
-              std::move(topic.name), error_code::topic_authorization_failed));
+              move_topic_name(), error_code::topic_authorization_failed));
             continue;
         }
-        if (auto md = ctx.metadata_cache().get_topic_metadata(
-              model::topic_namespace_view(model::kafka_namespace, topic.name));
-            md) {
-            auto src_topic_response = make_topic_response(
-              ctx, request, *md, is_node_isolated);
-            src_topic_response.name = std::move(topic.name);
-            res.push_back(std::move(src_topic_response));
-            continue;
+        if (topic.name.has_value()) {
+            if (auto md = ctx.metadata_cache().get_topic_metadata(
+                  model::topic_namespace_view(
+                    model::kafka_namespace, *topic.name));
+                md) {
+                auto src_topic_response = make_topic_response(
+                  ctx, request, *md, is_node_isolated);
+                src_topic_response.name = move_topic_name();
+                res.push_back(std::move(src_topic_response));
+                continue;
+            }
         }
 
         if (
           !config::shard_local_cfg().auto_create_topics_enabled
           || !request.data.allow_auto_topic_creation) {
-            bool valid = validate_kafka_topic_name(topic.name)
-                         == model::errc::success;
+            bool valid = topic.name.has_value()
+                         && validate_kafka_topic_name(*topic.name)
+                              == model::errc::success;
             res.push_back(make_error_topic_response(
-              std::move(topic.name),
+              move_topic_name(),
               valid ? error_code::unknown_topic_or_partition
                     : error_code::invalid_topic_exception));
             continue;
@@ -338,12 +348,12 @@ get_topic_metadata(
         /**
          * check if authorized to create
          */
-        if (!ctx.authorized(security::acl_operation::create, topic.name)) {
+        if (!ctx.authorized(security::acl_operation::create, *topic.name)) {
             res.push_back(make_error_topic_response(
-              std::move(topic.name), error_code::topic_authorization_failed));
+              move_topic_name(), error_code::topic_authorization_failed));
             continue;
         }
-        topics_to_be_created.emplace_back(std::move(topic.name));
+        topics_to_be_created.emplace_back(move_topic_name());
     }
 
     if (!ctx.audit()) {
@@ -543,6 +553,41 @@ ss::future<typename T::api::response_type> handle_metadata(
     T::log_request(ctx.header(), request);
 
     if constexpr (std::same_as<T, metadata_handler>) {
+        auto version = ctx.header().version;
+        if (
+          !request.list_all_topics && version > api_version{9}
+          && version < api_version{12}) {
+            auto err = kafka::error_code::none;
+            for (auto& topic : *request.data.topics) {
+                // Check request validity
+                if (!topic.name.has_value()) {
+                    err = kafka::error_code::invalid_request;
+                    vlog(
+                      klog.info,
+                      "Topic name can not be null for version {}",
+                      version);
+                    break;
+                } else if (topic.topic_id != uuid{}) {
+                    err = kafka::error_code::invalid_request;
+                    vlog(
+                      klog.info,
+                      "Topic IDs are not supported in requests for version {}",
+                      version);
+                    break;
+                }
+            }
+            if (err != kafka::error_code::none) {
+                // Don't include any other information in the response
+                metadata_response reply;
+                for (auto& topic : *request.data.topics) {
+                    reply.data.topics.push_back(metadata_response::topic{
+                      .error_code = err,
+                      .name = std::move(topic.name).value_or(model::topic{}),
+                      .topic_id = topic.topic_id});
+                }
+                co_return reply;
+            }
+        }
         reply.data.topics = co_await get_topic_metadata(
           ctx, request, isolated_or_decommissioned);
     }

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -24,10 +24,7 @@ namespace kafka {
  */
 memory_estimate_fn metadata_memory_estimator;
 
-// IMPORTANT: Do not bump support to v11 (or beyond) unless DescribeCluster v0
-// has been implemented.  v11 drops support for the authorized operations list
-// and moves those lists to DCv0
 using metadata_handler
-  = single_stage_handler<metadata_api, 0, 9, metadata_memory_estimator>;
+  = single_stage_handler<metadata_api, 0, 11, metadata_memory_estimator>;
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -640,6 +640,7 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/redpanda/tests:fixture",
         "//src/v/security",
+        "//src/v/test_utils:random_bytes",
         "//src/v/test_utils:seastar_boost",
         "@abseil-cpp//absl/algorithm:container",
         "@boost//:test",

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -175,7 +175,7 @@ public:
         metadata_req.data.topics
           = std::make_optional<chunked_vector<kafka::metadata_request_topic>>();
         metadata_req.data.topics->push_back(
-          kafka::metadata_request_topic{request_topic.name});
+          kafka::metadata_request_topic{.name{request_topic.name}});
         auto metadata_resp
           = client.dispatch(std::move(metadata_req), kafka::api_version(1))
               .get();

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -79,7 +79,7 @@ public:
         auto client = make_kafka_client().get();
         client.connect().get();
         chunked_vector<kafka::metadata_request_topic> topics;
-        topics.push_back(kafka::metadata_request_topic{tp});
+        topics.push_back(kafka::metadata_request_topic{.name{tp}});
         kafka::metadata_request md_req{
           .data
           = {.topics = std::move(topics), .allow_auto_topic_creation = false},

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -95,6 +95,15 @@ protected:
         BOOST_REQUIRE(!res.errc);
     }
 
+    void disable_sasl() {
+        cluster::config_update_request r{.upsert = {{"enable_sasl", "false"}}};
+        auto res = app.controller->get_config_frontend()
+                     .local()
+                     .patch(r, model::timeout_clock::now() + 1s)
+                     .get();
+        BOOST_REQUIRE(!res.errc);
+    }
+
     security::server_first_message send_scram_client_first(
       kafka::client::transport& client,
       const security::client_first_message& client_first) {
@@ -198,7 +207,7 @@ FIXTURE_TEST(metadata_v9_no_topics, metadata_fixture) {
 }
 
 FIXTURE_TEST(metadata_v9_topics, metadata_fixture) {
-    ss::sstring test_topic_name = "test";
+    ss::sstring test_topic_name = "metadata_v9_topics";
 
     create_topic(test_topic_name, 1, 1);
 
@@ -240,13 +249,14 @@ FIXTURE_TEST(metadata_v9_topics, metadata_fixture) {
 
 FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
     wait_for_controller_leadership().get();
-    ss::sstring test_topic_name = "test";
+    ss::sstring test_topic_name = "metadata_v9_authz_acl";
 
     create_topic(test_topic_name, 1, 1);
     create_user(test_username, test_password);
 
     // Enable SASL to enable authentication
     enable_sasl();
+    auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
     // Start by creating just describe ACLs for the cluster for the user
     std::vector<security::acl_binding> cluster_bindings{security::acl_binding(
@@ -331,4 +341,28 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
     BOOST_CHECK_EQUAL(
       resp.data.topics[0].topic_authorized_operations,
       kafka::details::to_bit_field(expected_cluster_ops));
+}
+
+FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
+    using kafka::api_version;
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    constexpr auto make_request = []() {
+        return kafka::metadata_request{.data{
+          .topics = {{{.name{}}}},
+          .allow_auto_topic_creation = false,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+    };
+    const kafka::metadata_response_data default_response;
+    for (api_version ver{8}; ver < api_version{10}; ++ver) {
+        auto resp = client.dispatch(make_request(), ver).get();
+        BOOST_REQUIRE(resp.data.errored());
+        BOOST_REQUIRE(!resp.data.topics.empty());
+        BOOST_REQUIRE_EQUAL(
+          resp.data.topics.front().error_code,
+          kafka::error_code::invalid_topic_exception);
+    }
 }

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -24,6 +24,7 @@
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
 #include "security/types.h"
+#include "test_utils/random_bytes.h"
 
 #include <absl/algorithm/container.h>
 #include <boost/test/tools/old/interface.hpp>
@@ -357,12 +358,89 @@ FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
           .include_topic_authorized_operations = false}};
     };
     const kafka::metadata_response_data default_response;
-    for (api_version ver{8}; ver < api_version{10}; ++ver) {
+    for (api_version ver{8}; ver < api_version{12}; ++ver) {
         auto resp = client.dispatch(make_request(), ver).get();
         BOOST_REQUIRE(resp.data.errored());
         BOOST_REQUIRE(!resp.data.topics.empty());
+        if (ver <= api_version{9}) {
+            BOOST_REQUIRE_EQUAL(
+              resp.data.topics.front().error_code,
+              kafka::error_code::invalid_topic_exception);
+        } else {
+            BOOST_REQUIRE_EQUAL(
+              resp.data.topics.front().error_code,
+              kafka::error_code::invalid_request);
+            BOOST_REQUIRE(resp.data.brokers.empty());
+            BOOST_REQUIRE_EQUAL(
+              resp.data.cluster_id, default_response.cluster_id);
+            BOOST_REQUIRE_EQUAL(
+              resp.data.controller_id, default_response.controller_id);
+        }
+    }
+}
+
+FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
+    using kafka::api_version;
+    ss::sstring test_topic_name = "metadata_non_empty_topic_id";
+
+    create_topic(test_topic_name, 1, 1);
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    const auto make_request = [&]() {
+        auto uuid = kafka::uuid::from_string(
+          bytes_to_base64(tests::random_bytes(16)));
+        return kafka::metadata_request{.data{
+          .topics = {{{
+            .topic_id{uuid},
+            .name{test_topic_name},
+          }}},
+          .allow_auto_topic_creation = false,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+    };
+    const kafka::metadata_response_data default_response;
+    for (api_version ver{10}; ver < api_version{12}; ++ver) {
+        auto resp = client.dispatch(make_request(), ver).get();
+        BOOST_REQUIRE(resp.data.errored());
+        BOOST_REQUIRE(!resp.data.topics.empty());
+        const auto expected = kafka::error_code::invalid_request;
+        BOOST_REQUIRE_EQUAL(resp.data.topics.front().error_code, expected);
+        BOOST_REQUIRE(resp.data.brokers.empty());
+        BOOST_REQUIRE_EQUAL(resp.data.cluster_id, default_response.cluster_id);
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics.front().error_code,
-          kafka::error_code::invalid_topic_exception);
+          resp.data.controller_id, default_response.controller_id);
+    }
+}
+
+FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
+    // Cluster authorized operations are returned only from v8 to v10
+    using namespace kafka;
+    using api = kafka::metadata_api;
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    const auto make_request = [&]() {
+        return metadata_request{.data{
+          .topics = {},
+          .allow_auto_topic_creation = false,
+          .include_cluster_authorized_operations = true,
+          .include_topic_authorized_operations = false}};
+    };
+
+    const metadata_response_data default_response;
+    const auto cluster_ops = kafka::details::to_bit_field(
+      kafka::details::get_allowed_operations<security::acl_cluster_name>());
+
+    for (api_version ver{1}; ver < api::max_valid; ++ver) {
+        auto resp = client.dispatch(make_request(), ver).get();
+        BOOST_REQUIRE(!resp.data.errored());
+        const auto expected
+          = (ver >= api_version{8} && ver <= api_version{10})
+              ? cluster_ops
+              : default_response.cluster_authorized_operations;
+        BOOST_REQUIRE_EQUAL(resp.data.cluster_authorized_operations, expected);
     }
 }

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -101,7 +101,7 @@ public:
     get_topic_metadata(const model::topic& tp) {
         return do_with_client([tp](kafka::client::transport& client) {
             chunked_vector<kafka::metadata_request_topic> topics;
-            topics.push_back(kafka::metadata_request_topic{tp});
+            topics.push_back(kafka::metadata_request_topic{.name{tp}});
             kafka::metadata_request md_req{
               .data
               = {.topics = std::make_optional(std::move(topics)), .allow_auto_topic_creation = false},


### PR DESCRIPTION
kafka: Support Metadata v11

Also Improve error message when topic name is invalid.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
