### PR TITLE
Use m2 cache seed to speed up DT test image generation

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,10 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM public.ecr.aws/docker/library/ubuntu:jammy-20240911.1 AS base
+FROM public.ecr.aws/docker/library/ubuntu:jammy-20240911.1 AS os_base
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive
+
+FROM os_base AS m2_seed
+ARG USE_MAVEN_SEED=1
+# Used to seed the maven cache for the java base image, see script for details
+COPY --chmod=0755 tests/docker/ducktape-deps/seed-maven-cache /
+RUN /seed-maven-cache && rm -rf /seed-maven-cache /var/lib/apt/lists/*
+
+FROM os_base AS base
 
 RUN mkdir -p /opt/redpanda-tests
 COPY --chown=0:0 tests/protobuf /opt/redpanda-tests/protobuf
@@ -35,7 +43,13 @@ RUN /tool-pkgs && \
 
 #################################
 
-FROM base AS kafka-streams-examples
+FROM base AS maven_base
+# maven_base is used for all maven-using java stages below
+COPY --from=m2_seed /root/.m2 /root/.m2
+
+#################################
+
+FROM maven_base AS kafka-streams-examples
 
 # Install kafka streams examples.  This is a very slow step (tens of minutes), doing
 # many maven dependency downloads without any parallelism.  To avoid re-running it
@@ -46,7 +60,7 @@ RUN /kafka-streams-examples && \
 
 #################################
 
-FROM base AS omb
+FROM maven_base AS omb
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/omb /
 RUN /omb && \
@@ -54,7 +68,7 @@ RUN /omb && \
 
 #################################
 
-FROM base AS java-verifiers
+FROM maven_base AS java-verifiers
 
 COPY --chown=0:0 tests/java/e2e-verifiers /opt/redpanda-tests/java/e2e-verifiers
 COPY --chown=0:0 tests/java/verifiers /opt/redpanda-tests/java/verifiers
@@ -65,7 +79,7 @@ RUN /java-verifiers && \
 
 #################################
 
-FROM base AS kafka-tools
+FROM maven_base AS kafka-tools
 
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/kafka-tools /
@@ -261,10 +275,28 @@ RUN /trino && rm /trino
 
 #################################
 
-FROM base AS spark
+FROM maven_base AS spark
 COPY --chown=0:0 tests/java/spark-iceberg-dependencies /opt/redpanda-tests/java/spark-iceberg-dependencies
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/spark /
 RUN /spark && rm /spark
+
+#################################
+# m2-collector creates the final .m2 cache from all images
+# that execute directly out of the cache, so we avoid duplicating
+# the full cache contents N times in the final image
+FROM base AS m2-collector
+COPY --from=kafka-streams-examples /root/.m2 /root/.m2
+COPY --from=java-verifiers /root/.m2 /root/.m2
+COPY --from=omb /root/.m2 /root/.m2
+
+###################################
+# m2-all collects additional m2 caches from images that do not
+# execute directly out of the cache, so they can be included
+# in the seed tarball
+FROM m2-collector AS m2-all
+COPY --from=kafka-tools /root/.m2 /root/.m2
+COPY --from=spark /root/.m2 /root/.m2
+
 
 #################################
 
@@ -333,13 +365,10 @@ RUN echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config && \
 
 # copy from other images
 COPY --from=kafka-streams-examples /opt/kafka-streams-examples /opt/kafka-streams-examples
-COPY --from=kafka-streams-examples /root/.m2 /root/.m2
 COPY --from=omb /opt/openmessaging-benchmark /opt/openmessaging-benchmark
-COPY --from=omb /root/.m2 /root/.m2
 COPY --from=java-verifiers /opt/redpanda-tests/java /opt/redpanda-tests/java
 COPY --from=java-verifiers /opt/verifiers /opt/verifiers
 COPY --from=java-verifiers /opt/kafka-serde /opt/kafka-serde
-COPY --from=java-verifiers /root/.m2 /root/.m2
 COPY --from=kafka-tools /opt /opt
 COPY --from=kcat /usr/local/bin/kcat /usr/local/bin/
 COPY --from=sarama-examples /opt/sarama /opt/sarama
@@ -363,6 +392,7 @@ COPY --from=flink /opt/flink/ /opt/flink/
 COPY --from=iceberg-rest /opt/iceberg-rest-catalog /opt/iceberg-rest-catalog
 COPY --from=trino /opt/trino /opt/trino
 COPY --from=spark /opt/spark /opt/spark
+COPY --from=m2-collector /root/.m2 /root/.m2
 
 RUN ldconfig
 

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -1,0 +1,40 @@
+## tests/docker
+
+This Dockerfile is used to back the ducktape cluster nodes when running ducktape in docker/podman mode. It relies heavily on multi-root builds to build the relatively heavy dependencies (mostly large Java projects) in parallel and to limit layer rebuilds when only a subset change.
+
+### .m2 caching
+
+#### Design
+
+The test image contains several Java projects which use maven, and if not handled specially the download time for all the maven artifacts can be very long.
+
+To solve this, we seed the java maven stages with an ~/.m2 directory (this is
+where maven stores its local repository of downloaded files) downloaded from our
+artifact repository. This happens in the m2_seed and java_base stages in the
+dockerfile. The contents of this seed cache do not need to be exact: the other stages in the file will work fine if it is empty or contain old jars, etc: as maven already separates files by version and will download any additional files.
+
+
+When the seed cache is up-to-date, there will be very little maven activity visible during the build. Over time, however, the seed cache may become out of date as project versions are updated and they pull in newer dependency versions. Furthermore, some projects may have -SNAPSHOT dependencies which mean that the jar version may change even if the project and pom.xml is unchanged. So it is useful to periodically refresh the seed cache as described below.
+
+If you regularly see a lot of maven download activity during the build, it may be time to update the seed tarball. Maven activity looks like this:
+
+```
+ => => # Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.6/plexus-containers-1.6.pom
+ => => # Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.6/plexus-containers-1.6.pom (3.8 kB at 92 kB/s)
+ => => # Downloading from confluent: https://packages.confluent.io/maven/org/codehaus/plexus/plexus/3.3.2/plexus-3.3.2.pom
+ => => # Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.2/plexus-3.3.2.pom
+ => => # Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.2/plexus-3.3.2.pom (22 kB at 525 kB/s)
+```
+
+The next section describes how to do this:
+
+#### Refresh the seed cache
+
+
+To update the tarball run:
+
+```
+task rp:extract-test-docker-image-m2-tarball
+```
+
+and then follow the instructions (prefixed with TODO) emitted to upload the new tarball to our artifact archive.

--- a/tests/docker/ducktape-deps/seed-maven-cache
+++ b/tests/docker/ducktape-deps/seed-maven-cache
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is used to download the maven cache seed for the ducktape docker image.
+# Further documentation at ../docker/README.md.
+
+seed_file="m2-cache-2025-04-25-59e96a8aeb.tgz"
+
+seed_url="https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$seed_file"
+# Use this URL instead for local testing:
+# seed_url="https://perf-team-public.s3.us-west-2.amazonaws.com/deps-staging/$seed_file"
+
+if [[ ${USE_MAVEN_SEED:=unset} != 1 ]]; then
+  echo "Skipping maven cache seeding (USE_MAVEN_SEED=$USE_MAVEN_SEED)"
+  # touch it since later COPY expect it to at least exist
+  mkdir -p /root/.m2
+  exit 0
+fi
+
+# install axel & ssl deps for fast downloads
+apt-get update && apt-get install openssl ca-certificates axel -y
+echo "Downloading the maven cache seed from: $seed_url"
+axel -n 10 -o /tmp/m2.tgz "$seed_url"
+tar xzf /tmp/m2.tgz -C /root
+rm -f /tmp/m2.tgz
+
+


### PR DESCRIPTION
Seed the top of the maven image build with the populated .m2 dir in our docker build. This reduces image the re-build time from 30-60 minutes to ~12 minutes for me. Additional details in the README.md in this change. 

AI's take:

This pull request refactors the `tests/docker/Dockerfile` to optimize Maven cache usage across multiple build stages, reducing redundancy and improving build efficiency. The changes introduce a new multi-stage build structure with `os_base`, `m2_seed`, `maven_base`, and cache collection stages.

### Maven cache optimization:

* Introduced a new `m2_seed` stage to pre-seed the Maven cache, which is reused in subsequent Maven-related stages (`tests/docker/Dockerfile`).
* Added a `maven_base` stage that copies the pre-seeded Maven cache from `m2_seed` and serves as the base for all maven-using stages (`tests/docker/Dockerfile`).
* Replaced `base` with `maven_base` in all Maven-using stages (`kafka-streams-examples`, `omb`, `java-verifiers`, `kafka-tools`, `spark`) to leverage the shared Maven cache (`tests/docker/Dockerfile`) [[1]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL49-R71) [[2]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL68-R82) [[3]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL264-R300).

### Cache collection:

* Introduced `m2-collector` to aggregate Maven caches from all stages that execute directly from the cache (`tests/docker/Dockerfile`).
* Added `m2-all` to collect additional Maven caches from stages not directly using the cache, ensuring completeness for the seed tarball (`tests/docker/Dockerfile`).

### Final image adjustments:

* Updated the final image to copy the aggregated Maven cache from `m2-collector`, removing redundant copies from individual stages (`tests/docker/Dockerfile`) [[1]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL336-L342) [[2]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aR395).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
