### PR TITLE
[INC-774] Add the ability to "force" a node ID override in situations where the node already has an ID assigned.

### DIFF
--- a/src/v/config/node_overrides.cc
+++ b/src/v/config/node_overrides.cc
@@ -19,6 +19,10 @@
 namespace config {
 
 std::ostream& operator<<(std::ostream& os, const config::node_id_override& v) {
+    if (v.ignore_existing_node_id) {
+        return os << ssx::sformat(
+                 "{}:{}:{}/ignore_existing_node_id", v.key, v.uuid, v.id);
+    }
     return os << ssx::sformat("{}:{}:{}", v.key, v.uuid, v.id);
 }
 
@@ -26,20 +30,25 @@ std::istream& operator>>(std::istream& is, config::node_id_override& v) {
     std::string s;
     is >> s;
 
-    static const re2::RE2 pattern{R"(^([^:]+):([^:]+):([^:]+)$)"};
+    static const re2::RE2 pattern{
+      R"(^([^:]+):([^:]+):([^:^/]+)(/ignore_existing_node_id)?$)"};
     vassert(pattern.ok(), "Regex compilation failed");
 
-    std::string curr, uuid, id;
+    std::string curr, uuid, id, ignore_existing_node_id;
 
-    if (!re2::RE2::FullMatch(s, pattern, &curr, &uuid, &id)) {
+    if (!re2::RE2::FullMatch(
+          s, pattern, &curr, &uuid, &id, &ignore_existing_node_id)) {
         throw std::runtime_error(fmt::format(
-          R"(Formatting error: '{}', must be of form '<uuid>:<uuid>:<id>')",
+          R"(Formatting error: '{}', must be of form '<uuid>:<uuid>:<id>[/ignore_existing_node_id]?')",
           s));
     }
 
     v.key = boost::lexical_cast<model::node_uuid>(curr);
     v.uuid = boost::lexical_cast<model::node_uuid>(uuid);
     v.id = boost::lexical_cast<model::node_id>(id);
+    if (!ignore_existing_node_id.empty()) {
+        v.ignore_existing_node_id = true;
+    }
 
     return is;
 }
@@ -57,6 +66,7 @@ void node_override_store::maybe_set_overrides(
             }
             _uuid_override.emplace(o.uuid);
             _id_override.emplace(o.id);
+            _ignore_existing_node_id = o.ignore_existing_node_id;
         }
     }
 }
@@ -71,6 +81,11 @@ const std::optional<model::node_id>&
 node_override_store::node_id() const noexcept {
     vassert(ss::this_shard_id() == 0, "Only get overrides on shard 0");
     return _id_override;
+}
+
+bool node_override_store::ignore_existing_node_id() const noexcept {
+    vassert(ss::this_shard_id() == 0, "Only get overrides on shard 0");
+    return _ignore_existing_node_id;
 }
 
 } // namespace config

--- a/src/v/config/node_overrides.h
+++ b/src/v/config/node_overrides.h
@@ -34,13 +34,25 @@ struct node_id_override {
     node_id_override(
       model::node_uuid key,
       model::node_uuid uuid_value,
-      model::node_id id_value)
+      model::node_id id_value,
+      bool ignore_existing_node_id = false)
       : key(key)
       , uuid(uuid_value)
-      , id(id_value) {}
+      , id(id_value)
+      , ignore_existing_node_id(ignore_existing_node_id) {}
     model::node_uuid key{};
     model::node_uuid uuid{};
     model::node_id id{};
+    /**
+     * ignore_existing_node_id - Flag controlling whether the override should be
+     * forced onto the node, possibly overwriting a node ID already store in its
+     * local kvstore.
+     *
+     * - if unset: Ignore the override if the node already has an ID persisted
+     *             to the configuration invariants in its local kvstore.
+     * - if set:   Apply the override irrespective of local kvstore contents.
+     */
+    bool ignore_existing_node_id{false};
 
 private:
     friend std::ostream&
@@ -75,10 +87,12 @@ struct node_override_store {
 
     const std::optional<model::node_uuid>& node_uuid() const noexcept;
     const std::optional<model::node_id>& node_id() const noexcept;
+    bool ignore_existing_node_id() const noexcept;
 
 private:
     std::optional<model::node_uuid> _uuid_override;
     std::optional<model::node_id> _id_override;
+    bool _ignore_existing_node_id{false};
 };
 
 } // namespace config
@@ -93,6 +107,8 @@ struct convert<config::node_id_override> {
         node["current_uuid"] = ssx::sformat("{}", rhs.key);
         node["new_uuid"] = ssx::sformat("{}", rhs.uuid);
         node["new_id"] = ssx::sformat("{}", rhs.id);
+        node["ignore_existing_node_id"] = ssx::sformat(
+          "{}", rhs.ignore_existing_node_id);
 
         return node;
     }
@@ -104,6 +120,11 @@ struct convert<config::node_id_override> {
         rhs.key = node["current_uuid"].as<model::node_uuid>();
         rhs.uuid = node["new_uuid"].as<model::node_uuid>();
         rhs.id = node["new_id"].as<model::node_id>();
+        if (const auto& f = node["ignore_existing_node_id"]; f) {
+            rhs.ignore_existing_node_id = f.as<bool>();
+        } else {
+            rhs.ignore_existing_node_id = false;
+        }
         return true;
     }
 };

--- a/src/v/config/tests/node_override_test.cc
+++ b/src/v/config/tests/node_override_test.cc
@@ -57,6 +57,38 @@ SEASTAR_THREAD_TEST_CASE(test_overrides_decode) {
         BOOST_CHECK_EQUAL(u.key, node_uuid);
         BOOST_CHECK_EQUAL(u.uuid, other_uuid);
         BOOST_CHECK_EQUAL(u.id, node_id);
+        // 'ignore_existing_node_id' defaults to false
+        BOOST_CHECK(!u.ignore_existing_node_id);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_overrides_decode_ignore_existing_node_id) {
+    static model::node_uuid node_uuid{uuid_t::create()};
+    static model::node_uuid other_uuid{uuid_t::create()};
+    auto node_id = model::node_id{0};
+    static auto some_override = ssx::sformat(
+      "node_id_overrides:\n"
+      "  - current_uuid: {}\n"
+      "    new_uuid: {}\n"
+      "    new_id: {}\n"
+      "    ignore_existing_node_id: true\n"
+      "  - current_uuid: {}\n"
+      "    new_uuid: {}\n"
+      "    new_id: {}\n"
+      "    ignore_existing_node_id: true\n",
+      node_uuid,
+      other_uuid,
+      node_id,
+      node_uuid,
+      other_uuid,
+      node_id);
+    auto some_override_cfg = read_from_yaml(some_override);
+    BOOST_CHECK_EQUAL(some_override_cfg.size(), 2);
+    for (const auto& u : some_override_cfg) {
+        BOOST_CHECK_EQUAL(u.key, node_uuid);
+        BOOST_CHECK_EQUAL(u.uuid, other_uuid);
+        BOOST_CHECK_EQUAL(u.id, node_id);
+        BOOST_CHECK(u.ignore_existing_node_id);
     }
 }
 
@@ -81,6 +113,22 @@ SEASTAR_THREAD_TEST_CASE(test_overrides_decode_errors) {
         model::node_uuid{uuid_t::create()},
         model::node_uuid{uuid_t::create()} /* does not parse to node ID */)),
       YAML::TypedBadConversion<model::node_id::type>);
+
+    static constexpr std::string_view entry_fmt_ignore_existing_node_id
+      = "node_id_overrides:\n"
+        "  - current_uuid: {}\n"
+        "    new_uuid: {}\n"
+        "    new_id: {}\n"
+        "    ignore_existing_node_id: {}\n";
+
+    BOOST_CHECK_THROW(
+      read_from_yaml(fmt::format(
+        entry_fmt_ignore_existing_node_id,
+        model::node_uuid{uuid_t::create()},
+        model::node_uuid{uuid_t::create()},
+        model::node_id{0},
+        "eslaf" /* that's not a bool */)),
+      YAML::TypedBadConversion<bool>);
 
     BOOST_CHECK_THROW(
       read_from_yaml(fmt::format(
@@ -113,13 +161,30 @@ SEASTAR_THREAD_TEST_CASE(test_overrides_lexical_cast) {
         ovr = boost::lexical_cast<config::node_id_override>(s);
     };
 
-    BOOST_REQUIRE_NO_THROW(std::invoke(convert, option));
-    BOOST_CHECK_EQUAL(ovr.key, uuid_a);
-    BOOST_CHECK_EQUAL(ovr.uuid, uuid_b);
-    BOOST_CHECK_EQUAL(ovr.id, id);
-    std::stringstream ss;
-    ss << ovr;
-    BOOST_CHECK_EQUAL(ss.str(), option);
+    {
+        BOOST_REQUIRE_NO_THROW(std::invoke(convert, option));
+        BOOST_CHECK_EQUAL(ovr.key, uuid_a);
+        BOOST_CHECK_EQUAL(ovr.uuid, uuid_b);
+        BOOST_CHECK_EQUAL(ovr.id, id);
+        BOOST_CHECK(!ovr.ignore_existing_node_id);
+        std::stringstream ss;
+        ss << ovr;
+        BOOST_CHECK_EQUAL(ss.str(), option);
+    }
+
+    option = ssx::sformat(
+      "{}:{}:{}/ignore_existing_node_id", uuid_a, uuid_b, id);
+
+    {
+        BOOST_REQUIRE_NO_THROW(std::invoke(convert, option));
+        BOOST_CHECK_EQUAL(ovr.key, uuid_a);
+        BOOST_CHECK_EQUAL(ovr.uuid, uuid_b);
+        BOOST_CHECK_EQUAL(ovr.id, id);
+        BOOST_CHECK(ovr.ignore_existing_node_id);
+        std::stringstream ss;
+        ss << ovr;
+        BOOST_CHECK_EQUAL(ss.str(), option);
+    }
 
     option = ssx::sformat("{}", uuid_a);
     BOOST_CHECK_THROW(std::invoke(convert, option), std::runtime_error);
@@ -133,6 +198,11 @@ SEASTAR_THREAD_TEST_CASE(test_overrides_lexical_cast) {
     BOOST_CHECK_THROW(std::invoke(convert, option), boost::bad_lexical_cast);
     option = ssx::sformat("{}:{}:{}", uuid_a, uuid_b, "not-an-id");
     BOOST_CHECK_THROW(std::invoke(convert, option), boost::bad_lexical_cast);
+
+    // 'ignore_existing_node_id' component is not lexically cast, so errors
+    // appear as formatting runtime_errors (rather than bad_lexical_cast).
+    option = ssx::sformat("{}:{}:{}/plzforceplz", uuid_a, uuid_b, id);
+    BOOST_CHECK_THROW(std::invoke(convert, option), std::runtime_error);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_overrides_store) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -454,7 +454,7 @@ int application::run(int ac, char** av) {
       "node-id-overrides",
       po::value<std::vector<config::node_id_override>>()->multitoken(),
       "Override node UUID and ID iff current UUID matches "
-      "- usage: <current UUID>:<new UUID>:<new ID>");
+      "- usage: <current UUID>:<new UUID>:<new ID>[/ignore_existing_node_id]?");
 
     // Validate command line args using options registered by the app and
     // seastar. Keep the resulting variables in a temporary map so they don't
@@ -2726,15 +2726,19 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     cluster::cluster_discovery cd(
       node_uuid, storage.local(), app_signal.abort_source());
 
-    bool ever_ran_controller = storage.local()
-                                 .kvs()
-                                 .get(
-                                   storage::kvstore::key_space::controller,
-                                   cluster::controller::invariants_key())
-                                 .has_value();
+    auto invariants_buf = storage.local().kvs().get(
+      storage::kvstore::key_space::controller,
+      cluster::controller::invariants_key());
+
+    bool ever_ran_controller = invariants_buf.has_value();
+
+    bool has_id = config::node().node_id().has_value() && ever_ran_controller;
+
+    bool force_override = _node_overrides.node_id().has_value()
+                          && _node_overrides.ignore_existing_node_id();
 
     model::node_id node_id;
-    if (config::node().node_id().has_value() && ever_ran_controller) {
+    if (has_id && !force_override) {
         vlog(
           _log.info,
           "Running with already-established node ID {}",
@@ -2743,15 +2747,31 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     } else if (auto id = _node_overrides.node_id(); id.has_value()) {
         vlog(
           _log.warn,
-          "Overriding node ID: {} -> {}",
+          "Overriding node ID: {} -> {} [ignore_existing_node_id? {}]",
           config::node().node_id(),
-          id);
+          id,
+          has_id && force_override);
         node_id = id.value();
         // null out the config'ed ID indiscriminately; it will be set outside
         // the conditional
         ss::smp::invoke_on_all([] {
             config::node().node_id.set_value(std::nullopt);
         }).get();
+        if (invariants_buf.has_value()) {
+            auto invariants
+              = reflection::from_iobuf<cluster::configuration_invariants>(
+                std::move(invariants_buf.value()));
+            invariants.node_id = node_id;
+            storage.local()
+              .kvs()
+              .put(
+                storage::kvstore::key_space::controller,
+                cluster::controller::invariants_key(),
+                reflection::to_iobuf(
+                  cluster::configuration_invariants{invariants}))
+              .get();
+            vlog(_log.debug, "Force-updated local node_id to {}", node_id);
+        }
     } else {
         auto registration_result = cd.register_with_cluster().get();
         node_id = registration_result.assigned_node_id;

--- a/tests/rptest/tests/admin_uuid_operations_test.py
+++ b/tests/rptest/tests/admin_uuid_operations_test.py
@@ -409,3 +409,146 @@ class AdminUUIDOperationsTest(RedpandaTest):
 
         assert controller_leader is not None, "Didn't elect a controller leader"
         assert controller_leader not in to_stop, f"Unexpected controller leader {controller_leader.account.hostname}"
+
+    @cluster(num_nodes=3)
+    @matrix(
+        mode=[
+            TestMode.CFG_OVERRIDE,
+            TestMode.CLI_OVERRIDE,
+        ],
+        force=[
+            True,
+            False,
+        ],
+    )
+    def test_force_uuid_override(self, mode, force):
+        """
+        Test that we can force a UUID override in situations where the cluster
+        is healthy and the target node already has a node ID assigned
+        """
+        # create a topic so that the cluster is not completely empty
+        RpkTool(self.redpanda).create_topic("foo", 10, 3)
+
+        to_stop = self.redpanda.nodes[0]
+        initial_to_stop_id = self.redpanda.node_id(to_stop)
+
+        self._restart_node(to_stop, drop_disk=True)
+
+        # wait for the node to join with new ID
+        uuids = wait_until_result(
+            lambda: self._uuids_updated(),
+            timeout_sec=30,
+            backoff_sec=2,
+            err_msg="Node was unable to join the cluster")
+
+        old_uuid = None
+        for n in uuids:
+            id = n['node_id']
+            if id == initial_to_stop_id:
+                old_uuid = n['uuid']
+
+        assert old_uuid is not None, "Old uuid unexpectedly None"
+
+        current_uuid = self.admin.get_broker_uuid(to_stop)['node_uuid']
+
+        THE_OVERRIDE = f"{current_uuid} -> ID: '{initial_to_stop_id}' ; UUID: '{old_uuid}'"
+        if mode == TestMode.CFG_OVERRIDE:
+            self.logger.debug(
+                f"Override with known-good uuid/id via node config: {THE_OVERRIDE}"
+            )
+            self._restart_node(
+                to_stop,
+                dict(node_id_overrides=[
+                    dict(current_uuid=current_uuid,
+                         new_uuid=old_uuid,
+                         new_id=initial_to_stop_id,
+                         ignore_existing_node_id=force)
+                ], ),
+                drop_disk=False,
+            )
+        elif mode == TestMode.CLI_OVERRIDE:
+            self.logger.debug(
+                f"Override with known-good uuid/id via command line options: {THE_OVERRIDE}"
+            )
+            self._restart_node(
+                to_stop,
+                extra_cli=[
+                    "--node-id-overrides",
+                    f"{current_uuid}:{old_uuid}:{initial_to_stop_id}{'/ignore_existing_node_id' if force else ''}",
+                ],
+                drop_disk=False,
+            )
+
+        def wait_for_override():
+            wait_until(lambda: self.admin.get_broker_uuid(to_stop)['node_id']
+                       == initial_to_stop_id,
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       err_msg=f"{to_stop.name} did not take the ID override")
+
+            wait_until(
+                lambda: self.admin.get_broker_uuid(to_stop)['node_uuid'
+                                                            ] == old_uuid,
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg=f"{to_stop.name} did not take the UUID override")
+
+        def override_log():
+            OVERRIDE_LOG = "-P '(Overriding) ((UUID)|(node ID))'"
+
+            return [
+                s.strip()
+                for s in self.log_searcher._capture_log(to_stop, OVERRIDE_LOG)
+            ]
+
+        override_logs = override_log()
+
+        if force:
+            wait_for_override()
+            assert len(override_logs) == 2, \
+                f"Expected to find both override logs, got {json.dumps(override_logs, indent=1)}"
+        else:
+            with expect_exception(TimeoutError, lambda _: True):
+                wait_for_override()
+            assert len(override_logs) == 1, \
+                f"Expected to find only UUID log, got {json.dumps(override_logs, indent=1)}"
+
+        self.logger.debug(
+            f"Restart w/ the same config and confirm that current UUID mismatch prevents changes from taking effect"
+        )
+        if mode == TestMode.CFG_OVERRIDE:
+            self._restart_node(
+                to_stop,
+                dict(node_id_overrides=[
+                    dict(current_uuid=current_uuid,
+                         new_uuid=old_uuid,
+                         new_id=initial_to_stop_id,
+                         ignore_existing_node_id=force)
+                ], ),
+                drop_disk=False,
+            )
+        elif mode == TestMode.CLI_OVERRIDE:
+            self._restart_node(
+                to_stop,
+                extra_cli=[
+                    "--node-id-overrides",
+                    f"{current_uuid}:{old_uuid}:{initial_to_stop_id}{'/ignore_existing_node_id' if force else ''}",
+                ],
+                drop_disk=False,
+            )
+
+        with expect_exception(TimeoutError, lambda e: True):
+
+            def check_logs():
+                diff = set(override_log()) - set(override_logs)
+                self.logger.debug(
+                    f"New override logs: {json.dumps(list(diff), indent=1)}")
+                return diff
+
+            wait_until(
+                lambda: len(check_logs()) > 0,
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg=
+                f"Unexpected second override: {json.dumps(list(set(override_log()) - set(override_logs)), indent=1)}"
+            )

--- a/tests/rptest/tests/admin_uuid_operations_test.py
+++ b/tests/rptest/tests/admin_uuid_operations_test.py
@@ -21,7 +21,7 @@ from rptest.services.cluster import cluster
 from rptest.util import expect_exception
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.errors import TimeoutError
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, matrix
 
 from rptest.services.utils import LogSearchLocal
 from rptest.util import wait_until_result, wait_until
@@ -185,10 +185,23 @@ class AdminUUIDOperationsTest(RedpandaTest):
                 backoff_s=1))
 
     @cluster(num_nodes=3)
-    @parametrize(mode=TestMode.CFG_OVERRIDE)
-    @parametrize(mode=TestMode.NO_OVERRIDE)
-    @parametrize(mode=TestMode.CLI_OVERRIDE)
-    def test_force_uuid_override(self, mode):
+    @matrix(
+        mode=[
+            TestMode.CFG_OVERRIDE,
+            TestMode.NO_OVERRIDE,
+            TestMode.CLI_OVERRIDE,
+        ],
+        force=[
+            True,
+            False,
+        ],
+    )
+    def test_uuid_override(self, mode, force):
+        if mode == TestMode.NO_OVERRIDE and force is True:
+            self.logger.debug(
+                "Force flag doesn't apply if we're not overriding anything")
+            return
+
         # create a topic so that the cluster is not completely empty
         RpkTool(self.redpanda).create_topic("foo", 10, 3)
 
@@ -238,7 +251,8 @@ class AdminUUIDOperationsTest(RedpandaTest):
                 dict(node_id_overrides=[
                     dict(current_uuid=current_uuid,
                          new_uuid=old_uuid,
-                         new_id=initial_to_stop_id)
+                         new_id=initial_to_stop_id,
+                         ignore_existing_node_id=force)
                 ], ),
                 drop_disk=False,
             )
@@ -250,7 +264,7 @@ class AdminUUIDOperationsTest(RedpandaTest):
                 to_stop,
                 extra_cli=[
                     "--node-id-overrides",
-                    f"{current_uuid}:{old_uuid}:{initial_to_stop_id}",
+                    f"{current_uuid}:{old_uuid}:{initial_to_stop_id}{'/ignore_existing_node_id' if force else ''}",
                 ],
                 drop_disk=False,
             )
@@ -312,9 +326,17 @@ class AdminUUIDOperationsTest(RedpandaTest):
                    retry_on_exc=True)
 
     @cluster(num_nodes=3)
-    @parametrize(mode=TestMode.CFG_OVERRIDE)
-    @parametrize(mode=TestMode.CLI_OVERRIDE)
-    def test_force_uuid_override_multinode(self, mode):
+    @matrix(
+        mode=[
+            TestMode.CFG_OVERRIDE,
+            TestMode.CLI_OVERRIDE,
+        ],
+        force=[
+            True,
+            False,
+        ],
+    )
+    def test_uuid_override_multinode(self, mode, force):
         # create a topic so that the cluster is not completely empty
         RpkTool(self.redpanda).create_topic("foo", 10, 3)
 
@@ -361,7 +383,8 @@ class AdminUUIDOperationsTest(RedpandaTest):
                 override_cfg_params=dict(node_id_overrides=[
                     dict(current_uuid=current_uuids[n],
                          new_uuid=old_uuids[initial_to_stop_ids[n]],
-                         new_id=initial_to_stop_ids[n])
+                         new_id=initial_to_stop_ids[n],
+                         ignore_existing_node_id=force)
                     for n in range(0, len(to_stop))
                 ]),
                 auto_assign_node_id=True,
@@ -372,7 +395,7 @@ class AdminUUIDOperationsTest(RedpandaTest):
                 extra_cli=[
                     "--node-id-overrides",
                 ] + [
-                    f"{current_uuids[n]}:{old_uuids[initial_to_stop_ids[n]]}:{initial_to_stop_ids[n]}"
+                    f"{current_uuids[n]}:{old_uuids[initial_to_stop_ids[n]]}:{initial_to_stop_ids[n]}{'/ignore_existing_node_id' if force else '' }"
                     for n in range(0, len(to_stop))
                 ],
                 auto_assign_node_id=True,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Originally, the intended usage here revolved around situations where a blank
node was unable to join the cluster due to quorum loss caused by "ghost nodes".

Now, we would like to add the ability to force a known UUID:ID pair into a
node which is _already_ a member of the cluster (i.e. has a node ID already).
To distinguish this new usage from the original usage, we introduce
`node_id_overide::ignore_existing_node_id`.

For a YAML based config, we add a boolean 'ignore_existing_node_id' field to the existing YAML
map.

For a CLI based config, we introduce a '/ignore_existing_node_id' suffix for the node-id-overrides
option, as follows:

- regular usage (as before): `<uuid>:<uuid>:<id>`
- force usage: `<uuid>:<uuid>:<id>/ignore_existing_node_id`

In application.cc, force the override even if the node already has a node ID in its local kvstore.

This requires forcing the new ID into `kvs['configuration_invariants']` to
avoid triggering a guard during controller startup.

Note that (like the existing override) this action violates the letter of the
raft protocol and should only be taken with careful discretion.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
