### PR TITLE
[Core-9938] pandaproxy/sr: Add support for format query parameter

### DIFF
--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -82,6 +82,10 @@ struct error_category final : std::error_category {
             return "Invalid mode. Valid values are READWRITE, READONLY";
         case error_code::version_exhausted:
             return "Versions exhausted, maximum 2147483647 reached";
+        case error_code::invalid_format:
+            return "Invalid format parameter";
+        case error_code::format_not_supported:
+            return "Format parameter not supported";
         }
         return "(unrecognized error)";
     }
@@ -137,6 +141,9 @@ struct error_category final : std::error_category {
             return reply_error_code::mode_invalid; // 42204
         case error_code::version_exhausted:
             return reply_error_code::internal_server_error; // 500
+        case error_code::invalid_format:
+        case error_code::format_not_supported:
+            return reply_error_code::bad_request; // 400
         }
         return {};
     }

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -40,6 +40,8 @@ enum class error_code {
     compatibility_level_invalid,
     mode_invalid,
     version_exhausted,
+    invalid_format,
+    format_not_supported,
 };
 
 std::error_code make_error_code(error_code);

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -201,6 +201,18 @@ inline error_info versions_exhausted(const subject& sub) {
       fmt::format("Versions exhausted for subject {}", sub())};
 }
 
+inline error_info invalid_format(const ss::sstring& ss) {
+    return error_info{
+      error_code::invalid_format,
+      fmt::format("Format value '{}' is invalid", ss)};
+}
+
+inline error_info format_not_supported(const output_format f) {
+    return error_info{
+      error_code::format_not_supported,
+      fmt::format("Format value '{}' is not supported", f)};
+}
+
 inline bool failed_subject_schema_lookup(std::error_code ec) {
     return ec == error_code::subject_not_found
            || ec == error_code::subject_version_not_found;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -333,13 +333,22 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
 
+    const auto format_str = parse::query_param<std::optional<ss::sstring>>(
+                              *rq.req, "format")
+                              .value_or("");
+    const auto format = from_string_view<output_format>(format_str);
+    if (!format.has_value()) {
+        throw as_exception(invalid_format(format_str));
+    }
+
     // With deferred schema validation, there might be a schema that
     // had invalid references. These might have already been posted, so
     // we need to sync
     co_await rq.service().writer().read_sync();
 
-    auto def = co_await get_or_load(rq, [&rq, id]() {
-        return rq.service().schema_store().get_schema_definition(id);
+    auto def = co_await get_or_load(rq, [&rq, id, format]() {
+        return rq.service().schema_store().get_schema_definition(
+          id, format.value_or(output_format::none));
     });
 
     auto resp = ppj::rjson_serialize_iobuf(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -371,6 +371,16 @@ sharded_store::maybe_get_schema_definition(schema_id id) {
 
 ss::future<schema_definition>
 sharded_store::get_schema_definition(schema_id id) {
+    return get_schema_definition(id, output_format::none);
+}
+
+ss::future<schema_definition>
+sharded_store::get_schema_definition(schema_id id, output_format format) {
+    // TODO: Implement support for the different modes of format
+    if (format != output_format::none) {
+        throw as_exception(format_not_supported(format));
+    }
+
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -74,6 +74,10 @@ public:
     ///\brief Return a schema definition by id.
     ss::future<schema_definition> get_schema_definition(schema_id id) override;
 
+    ///\brief Return a schema definition by id.
+    ss::future<schema_definition>
+    get_schema_definition(schema_id id, output_format format);
+
     ss::future<std::optional<schema_definition>>
     maybe_get_schema_definition(schema_id id) override;
 

--- a/src/v/pandaproxy/schema_registry/types.cc
+++ b/src/v/pandaproxy/schema_registry/types.cc
@@ -23,6 +23,10 @@ std::ostream& operator<<(std::ostream& os, const schema_type& v) {
     return os << to_string_view(v);
 }
 
+std::ostream& operator<<(std::ostream& os, const output_format& v) {
+    return os << to_string_view(v);
+}
+
 std::ostream& operator<<(std::ostream& os, const seq_marker& v) {
     if (v.seq.has_value() && v.node.has_value()) {
         fmt::print(

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -89,6 +89,38 @@ from_string_view<schema_type>(std::string_view sv) {
 
 std::ostream& operator<<(std::ostream& os, const schema_type& v);
 
+enum class output_format { none = 0, resolved, ignore_extensions, serialized };
+
+constexpr std::string_view to_string_view(output_format of) {
+    switch (of) {
+    case output_format::resolved:
+        return "resolved";
+    case output_format::ignore_extensions:
+        return "ignore_extensions";
+    case output_format::serialized:
+        return "serialized";
+    case output_format::none:
+        break;
+    }
+    return "";
+}
+
+template<>
+inline std::optional<output_format>
+from_string_view<output_format>(std::string_view sv) {
+    return string_switch<std::optional<output_format>>(sv)
+      .match(to_string_view(output_format::none), output_format::none)
+      .match(to_string_view(output_format::resolved), output_format::resolved)
+      .match(
+        to_string_view(output_format::ignore_extensions),
+        output_format::ignore_extensions)
+      .match(
+        to_string_view(output_format::serialized), output_format::serialized)
+      .default_match(std::nullopt);
+}
+
+std::ostream& operator<<(std::ostream& os, const output_format& of);
+
 ///\brief A subject is the name under which a schema is registered.
 ///
 /// Typically it will be "<topic>-key" or "<topic>-value".

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -614,20 +614,10 @@ schema_proto_def = """
 syntax = "proto3";
 
 message ProtoType {
-  float f =  1;
+  float f = 1;
 }"""
 
-schema_avro_def = """
-{
-    "type": "record",
-    "name": "myrecord",
-    "fields": [
-        {
-            "name": "f1",
-            "type": "string"
-        }
-    ]
-}"""
+schema_avro_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 
 schema_proto_dependee_def = """
 syntax = "proto3";
@@ -1162,9 +1152,14 @@ class SchemaRegistryEndpoints(RedpandaTest):
                              tls_enabled=tls_enabled,
                              **kwargs)
 
-    def _get_schemas_ids_id(self, id, headers=HTTP_GET_HEADERS, **kwargs):
+    def _get_schemas_ids_id(self,
+                            id,
+                            format=None,
+                            headers=HTTP_GET_HEADERS,
+                            **kwargs):
+        format_arg = f'?format={format}' if format is not None else ''
         return self._request("GET",
-                             f"schemas/ids/{id}",
+                             f"schemas/ids/{id}{format_arg}",
                              headers=headers,
                              **kwargs)
 
@@ -3555,6 +3550,66 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             assert result_id == schema["id"], \
                     f"Expected id {schema['id']} but got {result_id}. "\
                     f"Request content: {result_raw.content}. Processing {name}."
+
+    @cluster(num_nodes=3)
+    def test_format_keyword(self):
+        """
+        Test support for the format keyword
+        """
+        result_raw = self._post_subjects_subject_versions(
+            subject="schema_proto",
+            data=json.dumps({
+                "schema": schema_proto_def,
+                "schemaType": "PROTOBUF"
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                f"Request content: {result_raw.content}. Posting PROTOBUF."
+
+        result_raw = self._post_subjects_subject_versions(
+            subject="schema_avro",
+            data=json.dumps({
+                "schema": schema_avro_def,
+                "schemaType": "AVRO"
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                f"Request content: {result_raw.content}. Posting AVRO."
+
+        result_raw = self._post_subjects_subject_versions(
+            subject="schema_json",
+            data=json.dumps({
+                "schema": json_number_schema_def,
+                "schemaType": "JSON"
+            }))
+        assert result_raw.status_code == requests.codes.ok, \
+                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                f"Request content: {result_raw.content}. Posting JSON."
+
+        def test_ids_id(id, schema, format=None):
+            result_raw = self._get_schemas_ids_id(id, format)
+            assert result_raw.status_code == requests.codes.ok, \
+                    f"expected {requests.codes.ok} but got {result_raw.status_code} for id {id} and format {format}"
+            result = result_raw.json()['schema'].strip()
+            assert result == schema, \
+                    f"expected:\n{schema}\ngot:\n{result}\nfor id {id} and format {format}"
+
+        test_ids_id(1, schema_proto_def.strip())
+        test_ids_id(2, schema_avro_def.strip())
+        test_ids_id(3, json_number_schema_def.strip())
+
+        test_ids_id(1, schema_proto_def.strip(), format="")
+        test_ids_id(2, schema_avro_def.strip(), format="")
+        test_ids_id(3, json_number_schema_def.strip(), format="")
+
+        #Test invalid format value
+        result_raw = self._get_schemas_ids_id(1, format="badvalue")
+        assert result_raw.status_code == 400, \
+                f"expected {400} but got {result_raw.status_code} for id 1 and format 'badvalue'"
+        #Test unimplemented format value
+        result_raw = self._get_schemas_ids_id(2, format="resolved")
+        assert result_raw.status_code == 400, \
+                f"expected {400} but got {result_raw.status_code} for id 2 and format 'resolved'"
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):


### PR DESCRIPTION
Implements: [CORE-9938](https://redpandadata.atlassian.net/browse/CORE-9938)

First commit to enable support for "serialized" format mode. This PR introduces the parsing of the `format` parameter and every value apart from the default (empty string) will produce an error.

The implementation of each mode is completely independent. "serialized" will be implemented in a followup commit.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-9938]: https://redpandadata.atlassian.net/browse/CORE-9938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ