### PR TITLE
`storage`: set `base_offset` for `index_state` during compaction

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -318,7 +318,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
     // caller who has more context
     if (_idx.maybe_index(
           _acc,
-          32_KiB,
+          segment_index::default_data_buffer_step,
           start_pos,
           batch.base_offset(),
           batch.last_offset(),

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -162,6 +162,7 @@ public:
       segment_appender* a,
       bool internal_topic,
       offset_delta_time apply_offset,
+      model::offset index_base_offset,
       model::offset segment_last_offset,
       bool compaction_placeholder_enabled,
       compacted_index_writer* cidx = nullptr,
@@ -172,7 +173,7 @@ public:
       , _compaction_placeholder_enabled(compaction_placeholder_enabled)
       , _appender(a)
       , _compacted_idx(cidx)
-      , _idx(index_state::make_empty_index(apply_offset))
+      , _idx(index_state::make_empty_index(index_base_offset, apply_offset))
       , _internal_topic(internal_topic)
       , _inject_failure(inject_failure)
       , _as(as) {}

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -208,8 +208,10 @@ offset_time_index::offset_time_index(
 
 uint32_t offset_time_index::raw_value() const { return _val; }
 
-index_state index_state::make_empty_index(offset_delta_time with_offset) {
+index_state index_state::make_empty_index(
+  model::offset base_offset, offset_delta_time with_offset) {
     index_state idx{};
+    idx.base_offset = base_offset;
     idx.with_offset = with_offset;
 
     return idx;

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -138,7 +138,8 @@ struct index_state
     static constexpr auto clean_compact_timestamp_version = 8;
     static constexpr auto may_have_tombstone_records_version = 9;
 
-    static index_state make_empty_index(offset_delta_time with_offset);
+    static index_state
+    make_empty_index(model::offset base_offset, offset_delta_time with_offset);
 
     struct entry {
         model::offset offset;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -224,6 +224,7 @@ ss::future<index_state> deduplicate_segment(
       &appender,
       seg->path().is_internal_topic(),
       should_offset_delta_times,
+      seg->index().base_offset(),
       segment_last_offset,
       compaction_placeholder_enabled,
       &cmp_idx_writer,

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -42,9 +42,8 @@ segment_index::segment_index(
   , _step(step)
   , _feature_table(std::ref(feature_table))
   , _state(index_state::make_empty_index(
-      storage::internal::should_apply_delta_time_offset(_feature_table)))
+      base, storage::internal::should_apply_delta_time_offset(_feature_table)))
   , _sanitizer_config(std::move(sanitizer_config)) {
-    _state.base_offset = base;
     _state.broker_timestamp = broker_timestamp;
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
@@ -60,10 +59,8 @@ segment_index::segment_index(
   , _step(step)
   , _feature_table(std::ref(feature_table))
   , _state(index_state::make_empty_index(
-      storage::internal::should_apply_delta_time_offset(_feature_table)))
-  , _mock_file(mock_file) {
-    _state.base_offset = base;
-}
+      base, storage::internal::should_apply_delta_time_offset(_feature_table)))
+  , _mock_file(mock_file) {}
 
 ss::future<ss::file> segment_index::open() {
     if (_mock_file) {
@@ -86,9 +83,8 @@ void segment_index::reset() {
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
 
     _state = index_state::make_empty_index(
-      storage::internal::should_apply_delta_time_offset(_feature_table));
+      base, storage::internal::should_apply_delta_time_offset(_feature_table));
 
-    _state.base_offset = base;
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -253,6 +253,8 @@ public:
     ss::future<size_t> disk_usage();
     void clear_cached_disk_usage() { _disk_usage_size.reset(); }
 
+    const index_state& get_index_state() const { return _state; }
+
 private:
     ss::future<bool> materialize_index_from_file(ss::file);
     ss::future<> flush_to_file(ss::file);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -349,8 +349,9 @@ ss::future<storage::index_state> do_copy_segment_data(
   storage_resources& resources,
   offset_delta_time apply_offset,
   ss::sharded<features::feature_table>& feature_table) {
-    // preserve broker_timestamp and clean_compact_timestamp from the segment's
-    // index
+    // preserve base_offset, broker_timestamp, and clean_compact_timestamp from
+    // the segment's index
+    auto old_base_offset = seg->index().base_offset();
     auto old_broker_timestamp = seg->index().broker_timestamp();
     auto old_clean_compact_timestamp = seg->index().clean_compact_timestamp();
 
@@ -428,6 +429,7 @@ ss::future<storage::index_state> do_copy_segment_data(
       appender.get(),
       seg->path().is_internal_topic(),
       apply_offset,
+      old_base_offset,
       segment_last_offset,
       compaction_placeholder_enabled,
       /*cidx=*/nullptr,

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -838,6 +838,7 @@ redpanda_cc_gtest(
         "//src/v/base",
         "//src/v/cluster",
         "//src/v/cluster:features",
+        "//src/v/container:fragmented_vector",
         "//src/v/features",
         "//src/v/kafka/server/tests:kafka_test_utils",
         "//src/v/model",

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -348,6 +348,10 @@ TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
                                       model::offset(0))
                                     .get();
     ASSERT_EQ(consumed_kvs, consumed_kvs_restarted);
+
+    for (const auto& seg : log->segments()) {
+        ASSERT_EQ(seg->offsets().get_base_offset(), seg->index().base_offset());
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -389,6 +393,10 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPass) {
     ASSERT_EQ(segments_compacted_2, segments_compacted_3);
 
     ASSERT_NO_FATAL_FAILURE(check_records(cardinality, num_segments - 1).get());
+
+    for (const auto& seg : disk_log.segments()) {
+        ASSERT_EQ(seg->offsets().get_base_offset(), seg->index().base_offset());
+    }
 }
 
 TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
@@ -478,6 +486,10 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
     num_chunked_compaction_runs
       = disk_log.get_probe().get_chunked_compaction_runs();
     ASSERT_EQ(num_chunked_compaction_runs, 1);
+
+    for (const auto& seg : disk_log.segments()) {
+        ASSERT_EQ(seg->offsets().get_base_offset(), seg->index().base_offset());
+    }
 }
 
 TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
@@ -564,6 +576,10 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
       disk_log.get_last_compaction_window_start_offset().has_value());
 
     ASSERT_NO_FATAL_FAILURE(check_records(cardinality, num_segments - 1).get());
+
+    for (const auto& seg : disk_log.segments()) {
+        ASSERT_EQ(seg->offsets().get_base_offset(), seg->index().base_offset());
+    }
 }
 
 class CompactionFixtureBatchSizeParamTest
@@ -1451,6 +1467,9 @@ TEST_P(
         auto num_expected_data_batches = placeholder_batch_enabled ? 0 : 1;
         check_num_data_batches(seg_0_batches, num_expected_data_batches);
     }
+
+    ASSERT_EQ(
+      segs[0]->offsets().get_base_offset(), segs[0]->index().base_offset());
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -10,6 +10,7 @@
 #include "base/vlog.h"
 #include "cluster/feature_manager.h"
 #include "cluster/feature_update_action.h"
+#include "container/fragmented_vector.h"
 #include "features/feature_state.h"
 #include "features/feature_table.h"
 #include "gtest/gtest.h"
@@ -1476,3 +1477,70 @@ INSTANTIATE_TEST_SUITE_P(
   PlaceholderBatchEnabled,
   CompactionFixturePlaceHolderBatchTest,
   ::testing::Bool());
+
+TEST_F(CompactionFixtureTest, TestSegmentIndexReconstructed) {
+    constexpr auto num_segments = 5;
+    constexpr auto cardinality
+      = 1000000; // Large enough to ensure no duplicates- segment index relative
+                 // offsets _should_ be the same before and after compaction.
+    size_t batches_per_segment = 100;
+    size_t records_per_batch = 10;
+    generate_data(
+      num_segments, cardinality, batches_per_segment, records_per_batch)
+      .get();
+
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    auto& segs = disk_log.segments();
+
+    for (const auto& seg : segs) {
+        if (!seg->has_appender()) {
+            auto pre_compact_relative_offset_index
+              = seg->index()
+                  .get_index_state()
+                  .index.copy_relative_offset_index();
+            // Self compact the segment
+            do_segment_self_compact(seg, model::offset::max()).get();
+            auto post_compact_relative_offset_index
+              = seg->index()
+                  .get_index_state()
+                  .index.copy_relative_offset_index();
+
+            ASSERT_EQ(
+              pre_compact_relative_offset_index,
+              post_compact_relative_offset_index);
+            ASSERT_EQ(
+              seg->offsets().get_base_offset(), seg->index().base_offset());
+        }
+    }
+
+    std::vector<chunked_vector<uint32_t>>
+      pre_sliding_window_index_relative_offsets;
+    for (const auto& seg : segs) {
+        if (!seg->has_appender()) {
+            pre_sliding_window_index_relative_offsets.push_back(
+              seg->index()
+                .get_index_state()
+                .index.copy_relative_offset_index());
+        }
+    }
+
+    bool did_compact = do_sliding_window_compact(model::offset::max()).get();
+    ASSERT_TRUE(did_compact);
+
+    std::vector<chunked_vector<uint32_t>>
+      post_sliding_window_index_relative_offsets;
+    for (const auto& seg : segs) {
+        if (!seg->has_appender()) {
+            post_sliding_window_index_relative_offsets.push_back(
+              seg->index()
+                .get_index_state()
+                .index.copy_relative_offset_index());
+            ASSERT_EQ(
+              seg->offsets().get_base_offset(), seg->index().base_offset());
+        }
+    }
+
+    ASSERT_EQ(
+      pre_sliding_window_index_relative_offsets,
+      post_sliding_window_index_relative_offsets);
+}

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -19,9 +19,9 @@
 
 static storage::index_state make_random_index_state(
   storage::offset_delta_time apply_offset = storage::offset_delta_time::yes) {
-    auto st = storage::index_state::make_empty_index(apply_offset);
+    auto base_offset = model::offset(random_generators::get_int<int64_t>());
+    auto st = storage::index_state::make_empty_index(base_offset, apply_offset);
     st.bitflags = random_generators::get_int<uint32_t>();
-    st.base_offset = model::offset(random_generators::get_int<int64_t>());
     st.max_offset = model::offset(random_generators::get_int<int64_t>());
     st.base_timestamp = model::timestamp(random_generators::get_int<int64_t>());
     st.max_timestamp = model::timestamp(random_generators::get_int<int64_t>());
@@ -265,10 +265,10 @@ BOOST_AUTO_TEST_CASE(binary_compatibility_test) {
     // format. In order to do this the index_state has to be refactored and the
     // columnar part has to be extracted. But the serialized form shouldn't
     // change.
+    auto base_offset = model::offset(6321451485771820344);
     auto expected_state = storage::index_state::make_empty_index(
-      storage::offset_delta_time::yes);
+      base_offset, storage::offset_delta_time::yes);
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
-    expected_state.base_offset = model::offset(6321451485771820344);
     expected_state.base_timestamp = model::timestamp(5331697842032508203);
     expected_state.max_offset = model::offset(6925876299231340900);
     expected_state.max_timestamp = model::timestamp(659192121601013627);


### PR DESCRIPTION
This value would be incorrectly persisted as `0` during and after compaction.

This means batches indexed in the `index_state` during compaction would have an incorrect `relative_offset` added, and furthermore, the value of `base_offset` would forever be `0` on disk.

Fix this by adding `base_offset` as a required parameter in `index_state::make_empty_index()` and setting the `index_base_offset` when constructing the `copy_data_segment_reducer` for use with self compaction and sliding window compaction.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x
- [X] v24.1.x

## Release Notes

### Bug Fixes

* Fixes a bug that lead to the `base_offset` in `segment_index`es being persisted as 0 during and after compaction.