### PR TITLE
datalake: add metric for scratch space hard limit breaches

### DIFF
--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -543,6 +543,11 @@ ss::future<size_t> datalake_manager::reserve_disk(ss::shard_id shard) {
         _core0_disk_bytes_reservable.consume(units);
     }
 
+    // accounting for metrics
+    if (_core0_disk_bytes_reservable.current() == 0) {
+        _disk_bytes_hard_limit_reached_counter++;
+    }
+
     if (disk_space_soft_limit_exceeded()) {
         _disk_space_monitor_cv.signal();
     }
@@ -723,11 +728,15 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
     }
 }
 
-ss::future<uint64_t> datalake_manager::disk_usage() {
+ss::future<datalake_manager::disk_usage_stats> datalake_manager::disk_usage() {
     const auto path = config::node().datalake_staging_path();
+    auto stats = disk_usage_stats{
+      .total_bytes = 0,
+      .hard_limit_reached_counter = _disk_bytes_hard_limit_reached_counter,
+    };
 
     if (!co_await ss::file_exists(path.string())) {
-        co_return 0;
+        co_return stats;
     }
 
     chunked_vector<std::filesystem::path> files;
@@ -767,7 +776,8 @@ ss::future<uint64_t> datalake_manager::disk_usage() {
             });
       });
 
-    co_return total;
+    stats.total_bytes = total;
+    co_return stats;
 }
 
 bool datalake_manager::max_shares_assigned() const {

--- a/src/v/datalake/datalake_manager.h
+++ b/src/v/datalake/datalake_manager.h
@@ -89,7 +89,11 @@ public:
      *
      * This interface computes a global value, rather than shard local.
      */
-    static ss::future<uint64_t> disk_usage();
+    struct disk_usage_stats {
+        uint64_t total_bytes{0};
+        uint64_t hard_limit_reached_counter{0};
+    };
+    ss::future<disk_usage_stats> disk_usage();
 
     /**
      * Returns the number of partitions that the translator is not able to keep
@@ -223,6 +227,7 @@ private:
     config::binding<bool> _disk_space_manager_enable;
     config::binding<size_t> _scratch_space_size_bytes;
     config::binding<double> _scratch_space_soft_limit_size_percent;
+    size_t _disk_bytes_hard_limit_reached_counter;
 };
 
 } // namespace datalake

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2023,7 +2023,8 @@ void application::wire_up_redpanda_services(
       &storage,
       &storage_node,
       &shadow_index_cache,
-      &partition_manager);
+      &partition_manager,
+      &_datalake_manager);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         vassert(

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -36,7 +36,8 @@ disk_space_manager::disk_space_manager(
   ss::sharded<storage::api>* storage,
   ss::sharded<storage::node>* storage_node,
   ss::sharded<cloud_storage::cache>* cache,
-  ss::sharded<cluster::partition_manager>* pm)
+  ss::sharded<cluster::partition_manager>* pm,
+  ss::sharded<datalake::datalake_manager>* datalake_manager)
   : _enabled(std::move(enabled))
   , _enabled_override(std::move(enabled_override))
   , _local_monitor(local_monitor)
@@ -44,6 +45,7 @@ disk_space_manager::disk_space_manager(
   , _storage_node(storage_node)
   , _cache(cache->local_is_initialized() ? cache : nullptr)
   , _pm(pm)
+  , _datalake_manager(datalake_manager)
   , _retention_target_capacity_bytes(std::move(retention_target_capacity_bytes))
   , _retention_target_capacity_percent(std::move(retention_target_capacity_pct))
   , _disk_reservation_percent(std::move(disk_reservation_percent))
@@ -497,12 +499,19 @@ ss::future<storage::usage_report> disk_space_manager::disk_usage() {
      * the data used by datalake is not reclaimable. it is reported in the
      * report as more "log data" the same way that kvstore data is reported.
      */
-    const auto datalake_usage
-      = co_await datalake::datalake_manager::disk_usage();
-    vlog(rlog.debug, "Datalake usage: {}", human::bytes(datalake_usage));
+    if (_datalake_manager->local_is_initialized()) {
+        const auto datalake_stats
+          = co_await _datalake_manager->local().disk_usage();
+        vlog(
+          rlog.debug,
+          "Datalake usage: {}",
+          human::bytes(datalake_stats.total_bytes));
 
-    _probe.set_total_datalake_usage(datalake_usage);
-    report.usage.data += datalake_usage;
+        _probe.set_total_datalake_usage(datalake_stats.total_bytes);
+        _probe.set_datalake_hard_limit_reached(
+          datalake_stats.hard_limit_reached_counter);
+        report.usage.data += datalake_stats.total_bytes;
+    }
 
     co_return report;
 }
@@ -717,6 +726,12 @@ void disk_space_manager::probe::setup_metrics() {
       "datalake_disk_usage_bytes",
       [this]() { return _total_datalake_usage; },
       sm::description("Total amount of disk usage by datalake.")));
+
+    defs.emplace_back(sm::make_counter(
+      "datalake_disk_usage_hard_limit_reached",
+      [this]() { return _datalake_hard_limit_reached; },
+      sm::description(
+        "Number of times datalake disk usage hard limit has been reached.")));
 
     defs.emplace_back(sm::make_gauge(
       "retention_reclaimable_bytes",

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -30,6 +30,10 @@ class local_monitor;
 }
 } // namespace cluster
 
+namespace datalake {
+class datalake_manager;
+}
+
 namespace storage {
 
 class api;
@@ -227,7 +231,8 @@ public:
       ss::sharded<storage::api>* storage,
       ss::sharded<storage::node>* storage_node,
       ss::sharded<cloud_storage::cache>* cache,
-      ss::sharded<cluster::partition_manager>* pm);
+      ss::sharded<cluster::partition_manager>* pm,
+      ss::sharded<datalake::datalake_manager>*);
 
     disk_space_manager(disk_space_manager&&) noexcept = delete;
     disk_space_manager& operator=(disk_space_manager&&) noexcept = delete;
@@ -262,6 +267,13 @@ private:
          */
         void set_total_datalake_usage(size_t usage) noexcept {
             _total_datalake_usage = usage;
+        }
+
+        /*
+         * Number of times datalake disk usage hard limit has been reached.
+         */
+        void set_datalake_hard_limit_reached(size_t count) noexcept {
+            _datalake_hard_limit_reached = count;
         }
 
         /*
@@ -348,6 +360,7 @@ private:
         metrics::internal_metric_groups _metrics;
         size_t _total_usage{0};
         size_t _total_datalake_usage{0};
+        size_t _datalake_hard_limit_reached{0};
         size_t _retention_reclaimable{0};
         size_t _available_reclaimable{0};
         size_t _local_retention_reclaimable{0};
@@ -366,6 +379,7 @@ private:
     ss::sharded<storage::node>* _storage_node;
     ss::sharded<cloud_storage::cache>* _cache;
     ss::sharded<cluster::partition_manager>* _pm;
+    ss::sharded<datalake::datalake_manager>* _datalake_manager;
 
     node::notification_id _cache_disk_nid;
     node::notification_id _data_disk_nid;

--- a/tests/rptest/tests/datalake/disk_budget_test.py
+++ b/tests/rptest/tests/datalake/disk_budget_test.py
@@ -75,6 +75,11 @@ class DatalakeDiskUsageTest(RedpandaTest):
         metric_name = "vectorized_space_management_datalake_disk_usage_bytes"
         return self.redpanda.metric_sum(metric_name, expect_metric=True)
 
+    def datalake_hardlimit_reached(self):
+        # returns number of times datalake hard limit is enforced
+        metric_name = "vectorized_space_management_datalake_disk_usage_hard_limit_reached_total"
+        return self.redpanda.metric_sum(metric_name, expect_metric=True)
+
     def create_topic(self, num_partitions):
         rpk = RpkTool(self.redpanda)
         rpk.create_topic(self.topic_name,
@@ -205,3 +210,6 @@ class DatalakeDiskUsageTest(RedpandaTest):
         finally:
             self.stopped.set()
             usage_monitor_thread.join()
+
+        hardlimit_reached = self.datalake_hardlimit_reached()
+        assert hardlimit_reached > 0


### PR DESCRIPTION
Adds a metric which tracks the number of times that the datalake scratch space hard limit is reached.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
