### PR TITLE
storage: work around segment index overflows

### DIFF
--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -191,8 +191,12 @@ model::record_batch make_random_batch(record_batch_spec spec) {
 }
 
 model::record_batch make_random_batch(
-  model::offset o, bool allow_compression, std::optional<model::timestamp> ts) {
-    auto num_records = get_int(2, 30);
+  model::offset o,
+  bool allow_compression,
+  std::optional<model::timestamp> ts,
+  int records_per_batch) {
+    auto num_records = records_per_batch > 0 ? records_per_batch
+                                             : get_int(2, 30);
     return make_random_batch(
       o,
       num_records,
@@ -206,7 +210,8 @@ ss::future<ss::circular_buffer<model::record_batch>> make_random_batches(
   model::offset o,
   int count,
   bool allow_compression,
-  std::optional<model::timestamp> base_ts) {
+  std::optional<model::timestamp> base_ts,
+  int records_per_batch) {
     // start offset + count
     ss::circular_buffer<model::record_batch> ret;
     ret.reserve(count);
@@ -215,7 +220,7 @@ ss::future<ss::circular_buffer<model::record_batch>> make_random_batches(
         // TODO: it looks like a bug: make_random_batch adds
         // random number of records like we increment offset
         // always by one
-        auto b = make_random_batch(o, allow_compression, ts);
+        auto b = make_random_batch(o, allow_compression, ts, records_per_batch);
         o = b.last_offset() + model::offset(1);
         b.set_term(model::term_id(0));
         ret.push_back(std::move(b));

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -60,13 +60,15 @@ model::record_batch make_random_batch(record_batch_spec);
 model::record_batch make_random_batch(
   model::offset o,
   bool allow_compression = true,
-  std::optional<model::timestamp> ts = std::nullopt);
+  std::optional<model::timestamp> ts = std::nullopt,
+  int records_per_batch = 0);
 
 ss::future<ss::circular_buffer<model::record_batch>> make_random_batches(
   model::offset o,
   int count,
   bool allow_compression = true,
-  std::optional<model::timestamp> ts = std::nullopt);
+  std::optional<model::timestamp> ts = std::nullopt,
+  int records_per_batch = 0);
 
 ss::future<ss::circular_buffer<model::record_batch>>
 make_random_batches(model::offset o = model::offset(0));

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -239,8 +239,6 @@ bool index_state::maybe_index(
       base_offset,
       *this);
 
-    bool retval = false;
-
     // The first non-config batch in the segment, use its timestamp
     // to override the timestamps of any config batch that was indexed
     // by virtue of being the first in the segment.
@@ -264,6 +262,7 @@ bool index_state::maybe_index(
     }
 
     // index_state
+    bool is_empty = false;
     if (empty()) {
         // Ordinarily, we do not allow configuration batches to contribute to
         // the segment's timestamp bounds (because config batches use walltime
@@ -275,7 +274,7 @@ bool index_state::maybe_index(
 
         base_timestamp = first_timestamp;
         max_timestamp = first_timestamp;
-        retval = true;
+        is_empty = true;
     }
 
     // NOTE: we don't need the 'max()' trick below because we controll the
@@ -299,16 +298,23 @@ bool index_state::maybe_index(
           = num_compactible_records_appended.value_or(0) + compactible_records;
     }
     // always saving the first batch simplifies a lot of book keeping
-    if ((accumulator >= step && user_data) || retval) {
-        add_entry(
-          // We know that a segment cannot be > 4GB
-          batch_base_offset() - base_offset(),
-          offset_time_index{last_timestamp - base_timestamp, with_offset},
-          starting_position_in_file);
+    if ((accumulator >= step && user_data) || is_empty) {
+        auto offset_delta = batch_base_offset() - base_offset();
+        if (offset_delta <= std::numeric_limits<uint32_t>::max()) {
+            add_entry(
+              // We know that a segment cannot be > 4GB
+              batch_base_offset() - base_offset(),
+              offset_time_index{last_timestamp - base_timestamp, with_offset},
+              starting_position_in_file);
 
-        retval = true;
+            return true;
+        } else {
+            // We can't index anything beyond uint32 space. Presumably no
+            // further entries will be added because of this same condition.
+            return false;
+        }
     }
-    return retval;
+    return false;
 }
 
 std::ostream& operator<<(std::ostream& o, const index_state& s) {

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -680,7 +680,15 @@ std::optional<index_state::entry> index_state::find_nearest(model::offset o) {
     if (o < base_offset || empty()) {
         return std::nullopt;
     }
-    const uint32_t needle = o() - base_offset();
+    int64_t query_offset_delta = o() - base_offset();
+    int64_t seg_offset_delta = max_offset - base_offset;
+    static constexpr int64_t uint32_max = std::numeric_limits<uint32_t>::max();
+    if (query_offset_delta > uint32_max || seg_offset_delta > uint32_max) {
+        // TODO: this is a major hack! Older versions of Redpanda may index
+        // this segment incorrectly. Conservatively return the first entry.
+        return translate_index_entry(get_entry(0));
+    }
+    const auto needle = static_cast<uint32_t>(query_offset_delta);
 
     auto ix = index.offset_lower_bound(needle).value_or(index.size() - 1);
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -252,6 +252,8 @@ public:
      */
     ss::future<size_t> disk_usage();
     void clear_cached_disk_usage() { _disk_usage_size.reset(); }
+    void set_step_for_tests(size_t step) { _step = step; }
+    void set_base_offset_for_tests(model::offset o) { _state.base_offset = o; }
 
 private:
     ss::future<bool> materialize_index_from_file(ss::file);

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -356,3 +356,24 @@ BOOST_AUTO_TEST_CASE(binary_compatibility_test) {
     BOOST_REQUIRE_EQUAL(expected_bytes.size_bytes(), actual_bytes.size_bytes());
     BOOST_REQUIRE(expected_bytes == actual_bytes);
 }
+
+BOOST_AUTO_TEST_CASE(index_overflow) {
+    storage::index_state state;
+
+    // Previous versions of Redpanda can have an index with offsets spanning
+    // greater than uint32 offset space. In these cases, the index is not
+    // reliable and querying the index should just return the first entry.
+    const model::timestamp dummy_ts;
+    const storage::offset_delta_time should_offset{false};
+    storage::offset_time_index time_idx{dummy_ts, should_offset};
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    state.add_entry(0, time_idx, 1);
+    state.add_entry(100, time_idx, 2);
+    state.add_entry(static_cast<uint32_t>(uint32_max + 1), time_idx, 3);
+    state.add_entry(static_cast<uint32_t>(uint32_max + 10), time_idx, 4);
+    state.max_offset = model::offset{uint32_max + 10};
+    auto res = state.find_nearest(model::offset(100));
+    BOOST_REQUIRE(res.has_value());
+    BOOST_CHECK_EQUAL(res->offset, model::offset{0});
+    BOOST_CHECK_EQUAL(res->filepos, 1);
+}

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -332,3 +332,100 @@ SEASTAR_THREAD_TEST_CASE(test_ghosts_gap) {
     }
     BOOST_REQUIRE_EQUAL(twice_i32max + 1, num_records);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_ghost_read_with_index_overflow) {
+    auto cfg = log_builder_config();
+    cfg.cache = with_cache::no;
+    disk_log_builder b(cfg);
+    b | start() | add_segment(model::offset{0});
+    auto s = b.get_log_segments().back();
+
+    // Set a pathologically low step size so we'll add every batch into the
+    // index.
+    s->index().set_step_for_tests(1);
+    ss::circular_buffer<model::record_batch> batches;
+    auto add = [&batches](model::offset o) {
+        auto b = model::test::make_random_batches(
+                   o, /*count=*/1, false, std::nullopt, /*records_per_batch=*/1)
+                   .get();
+        batches.push_back(std::move(b.front()));
+    };
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    add(model::offset(0));
+    add(model::offset(100));
+    add(model::offset(uint32_max + 1));
+    add(model::offset(uint32_max + 100));
+    add(model::offset(uint32_max + 200));
+    write(copy(batches), b);
+
+    // Regression test: a bug previously meant that we would seek to an
+    // incorrect offset and return the wrong batch.
+    storage::log_reader_config reader_config(
+      model::offset{100},
+      model::offset::max(),
+      0,
+      model::model_limits<model::offset>::max(),
+      ss::default_priority_class(),
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
+    reader_config.fill_gaps = true;
+    auto res = b.consume(reader_config).get();
+    b | stop();
+    BOOST_REQUIRE(!res.empty());
+    auto& first = res.front();
+    BOOST_CHECK_EQUAL(first.base_offset(), model::offset{100});
+    BOOST_CHECK_EQUAL(first.last_offset(), model::offset{100});
+    BOOST_CHECK_EQUAL(first.header().type, model::record_batch_type::raft_data);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_read_with_index_overflow_base) {
+    auto cfg = log_builder_config();
+    cfg.cache = with_cache::no;
+    disk_log_builder b(cfg);
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    b | start() | add_segment(model::offset{uint32_max});
+    auto s = b.get_log_segments().back();
+
+    // Set a pathologically low step size so we'll add every batch into the
+    // index.
+    s->index().set_step_for_tests(1);
+    // Reset the index base offset to 0 before adding any entries, simulating a
+    // bug in Redpanda where compaction would start indexes off with base
+    // offset 0. This is important to have this test reproduce a bad seek to
+    // the start of the segment.
+    s->index().set_base_offset_for_tests(model::offset(0));
+    ss::circular_buffer<model::record_batch> batches;
+    auto add = [&batches](model::offset o) {
+        auto b = model::test::make_random_batches(
+                   o, /*count=*/1, false, std::nullopt, /*records_per_batch=*/1)
+                   .get();
+        batches.push_back(std::move(b.front()));
+    };
+    add(model::offset(uint32_max));
+    add(model::offset(uint32_max + 100));
+    add(model::offset(2 * uint32_max + 1));
+    add(model::offset(2 * uint32_max + 100));
+    add(model::offset(2 * uint32_max + 200));
+    write(copy(batches), b);
+
+    // Regression test: a bug previously meant that we would seek to an
+    // incorrect offset and return the wrong batch even when seeking at the
+    // start of the segment.
+    storage::log_reader_config reader_config(
+      s->offsets().get_base_offset(),
+      model::offset::max(),
+      0,
+      model::model_limits<model::offset>::max(),
+      ss::default_priority_class(),
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
+    auto res = b.consume(reader_config).get();
+    b | stop();
+    BOOST_REQUIRE(!res.empty());
+    auto& first = res.front();
+    BOOST_CHECK_EQUAL(first.base_offset(), model::offset{uint32_max});
+    BOOST_CHECK_EQUAL(first.last_offset(), model::offset{uint32_max});
+    BOOST_CHECK_EQUAL(first.header().type, model::record_batch_type::raft_data);
+}


### PR DESCRIPTION
The segment index on offset deltas (difference between offset and segment's base offset) could overflow, resulting in very odd behavior, including returning ghost batches incorrectly which could result in lost batches during recovery.

To fix, this PR does two things:
- stops indexing offset deltas above `uint32_t::max`
- avoids using the index for offsets when we can tell the index spans more than `uint32_t::max` offsets

These changes feel pretty hacky, and our segment index still has a fundamental limitation for large segments. But this at least stops the bleeding.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

### Bug Fixes

* Fixes an issue with local segment indexes that could result in incorrect Raft recovery, compaction, or fetches in topic partitions with very large offsets (greater than 4294967295).
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
