### PR TITLE
CORE-9874 Topic ID: introduce feature and migrator

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -169,6 +169,7 @@ redpanda_cc_library(
         "//src/v/serde:tristate",
         "//src/v/storage",
         "//src/v/utils:tristate",
+        "//src/v/utils:uuid",
         "@seastar",
     ],
 )

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -633,7 +633,8 @@ ss::future<errc> backend::create_topic(
       local_nt.ns,
       local_nt.tp,
       maybe_cfg->partition_count,
-      maybe_cfg->replication_factor);
+      maybe_cfg->replication_factor,
+      maybe_cfg->tp_id);
     auto& topic_properties = topic_to_create_cfg.properties;
 
     // copy all properties

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -558,6 +558,7 @@ cluster::topic_configuration old_random_topic_configuration() {
     tp_cfg.properties = old_random_topic_properties();
     tp_cfg.replication_factor = random_generators::get_int<int16_t>(0, 10);
     tp_cfg.partition_count = random_generators::get_int(0, 100);
+    tp_cfg.tp_id = model::create_topic_id();
     return tp_cfg;
 }
 
@@ -567,6 +568,7 @@ cluster::topic_configuration random_topic_configuration() {
     tp_cfg.properties = random_topic_properties();
     tp_cfg.replication_factor = random_generators::get_int<int16_t>(0, 10);
     tp_cfg.partition_count = random_generators::get_int(0, 100);
+    tp_cfg.tp_id = model::create_topic_id();
     return tp_cfg;
 }
 

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -14,6 +14,7 @@
 #include "model/namespace.h"
 #include "reflection/adl.h"
 #include "storage/ntp_config.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -79,6 +80,7 @@ void topic_configuration::serde_write(iobuf& out) {
     write(out, replication_factor);
     write(out, properties);
     write(out, is_migrated);
+    write(out, tp_id);
 }
 
 void topic_configuration::serde_read(iobuf_parser& in, const serde::header& h) {
@@ -93,6 +95,12 @@ void topic_configuration::serde_read(iobuf_parser& in, const serde::header& h) {
     } else {
         is_migrated = false;
     }
+    if (h._version >= 3) {
+        tp_id = read_nested<std::optional<model::topic_id>>(
+          in, h._bytes_left_limit);
+    } else {
+        tp_id = std::nullopt;
+    }
 
     if (h._version < 1) {
         // Legacy tiered storage topics do not delete data on
@@ -105,11 +113,12 @@ std::ostream& operator<<(std::ostream& o, const topic_configuration& cfg) {
     fmt::print(
       o,
       "{{ topic: {}, partition_count: {}, replication_factor: {}, is_migrated: "
-      "{}, properties: {}}}",
+      "{}, topic_id: {}, properties: {}}}",
       cfg.tp_ns,
       cfg.partition_count,
       cfg.replication_factor,
       cfg.is_migrated,
+      cfg.tp_id,
       cfg.properties);
 
     return o;

--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "cluster/topic_properties.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "serde/rw/envelope.h"
 #include "serde/rw/rw.h"
 #include "serde/rw/scalar.h"
 #include "storage/ntp_config.h"
+#include "utils/uuid.h"
 
 namespace cluster {
 
@@ -22,18 +24,20 @@ namespace cluster {
 struct topic_configuration
   : serde::envelope<
       topic_configuration,
-      serde::version<2>,
+      serde::version<3>,
       serde::compat_version<0>> {
     topic_configuration(
       model::ns ns,
       model::topic topic,
       int32_t partition_count,
       int16_t replication_factor,
+      std::optional<model::topic_id> topic_id = std::nullopt,
       bool is_migrated = false)
       : tp_ns(std::move(ns), std::move(topic))
       , partition_count(partition_count)
       , replication_factor(replication_factor)
-      , is_migrated(is_migrated) {}
+      , is_migrated(is_migrated)
+      , tp_id(topic_id) {}
 
     topic_configuration() = default;
 
@@ -80,6 +84,9 @@ struct topic_configuration
     int16_t replication_factor{0};
     // bypass migration restrictions
     bool is_migrated{false};
+    // topic id, a UUID (as introduced in KIP-516), only std::nullopt until the
+    // migration to using topic ids is completed
+    std::optional<model::topic_id> tp_id{std::nullopt};
 
     topic_properties properties;
 

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -373,7 +373,8 @@ static cluster::topic_configuration make_topic_config(
       topic_config->tp_ns.ns,
       topic_config->tp_ns.tp,
       topic_config->partition_count,
-      topic_config->replication_factor);
+      topic_config->replication_factor,
+      topic_config->tp_id);
     auto& topic_properties = topic_to_create_cfg.properties;
 
     // copy all properties

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -22,6 +22,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "storage/ntp_config.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -1172,6 +1173,15 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       migration_state
       != data_migrations::migrated_resource_state::non_restricted) {
         co_return errc::resource_is_being_migrated;
+    }
+
+    if (cmd.value.topic_id.op == incremental_update_operation::set) {
+        vlog(
+          clusterlog.trace,
+          "Assigning topic id {} to topic {}",
+          cmd.value.topic_id.value,
+          cmd.key);
+        tp->second.get_configuration().tp_id = cmd.value.topic_id.value;
     }
 
     auto updated_properties = update_topic_properties(

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -677,6 +677,15 @@ ss::future<topic_result> topics_frontend::do_create_topic(
           assignable_config.cfg.tp_ns, errc::resource_is_being_migrated);
     }
 
+    if (!assignable_config.cfg.tp_id.has_value()) {
+        assignable_config.cfg.tp_id = model::create_topic_id();
+        vlog(
+          clusterlog.debug,
+          "Configuring topic {} with id {}",
+          assignable_config.cfg.tp_ns,
+          assignable_config.cfg.tp_id.value());
+    }
+
     auto result = validate_topic_configuration(assignable_config);
 
     if (result.ec != errc::success) {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -408,7 +408,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "iceberg_partition_spec: {}, "
       "iceberg_invalid_record_action: {}, "
       "iceberg_target_lag_ms: {}, "
-      "remote_allow_gaps: {}",
+      "remote_allow_gaps: {}, "
+      "topic_id: {}}}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -443,7 +444,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.iceberg_partition_spec,
       i.iceberg_invalid_record_action,
       i.iceberg_target_lag_ms,
-      i.remote_allow_gaps);
+      i.remote_allow_gaps,
+      i.topic_id);
     return o;
 }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -650,6 +650,10 @@ struct incremental_topic_updates
     property_update<std::optional<std::chrono::milliseconds>>
       iceberg_target_lag_ms;
 
+    // Not a regular topic property. Used to assign topic UUIDs to pre-25-2
+    // topics that were created without one.
+    property_update<std::optional<model::topic_id>> topic_id;
+
     // To allow us to better control use of the deprecated shadow_indexing
     // field, use getters and setters instead.
     const auto& get_shadow_indexing() const { return shadow_indexing; }
@@ -693,7 +697,8 @@ struct incremental_topic_updates
           iceberg_invalid_record_action,
           iceberg_target_lag_ms,
           min_cleanable_dirty_ratio,
-          remote_allow_gaps);
+          remote_allow_gaps,
+          topic_id);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -16,6 +16,8 @@
 #include "compat/cluster_json.h"
 #include "compat/json.h"
 #include "compat/model_json.h"
+#include "model/fundamental.h"
+#include "utils/uuid.h"
 
 #include <vector>
 
@@ -470,6 +472,7 @@ struct compat_check<cluster::topic_configuration> {
         json_write(partition_count);
         json_write(replication_factor);
         json_write(is_migrated);
+        json_write(tp_id);
         json_write(properties);
     }
 
@@ -479,6 +482,7 @@ struct compat_check<cluster::topic_configuration> {
         json_read(partition_count);
         json_read(replication_factor);
         json_read(is_migrated);
+        json_read(tp_id);
         json_read(properties);
         return obj;
     }
@@ -528,8 +532,9 @@ struct compat_check<cluster::topic_configuration> {
 
         obj.properties.iceberg_target_lag_ms = std::nullopt;
 
-        // ADL will always squash is_migrated to false
+        // ADL will always squash is_migrated to false, tp_id to a std::nullopt
         obj.is_migrated = false;
+        obj.tp_id = std::nullopt;
 
         if (cfg != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -13,12 +13,17 @@
 #include "cluster/errc.h"
 #include "cluster/types.h"
 #include "compat/model_generator.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/tests/randoms.h"
 #include "random/generators.h"
 #include "test_utils/random_bytes.h"
 #include "test_utils/randoms.h"
 #include "utils/tristate.h"
+#include "utils/uuid.h"
+
+#include <cstdint>
+#include <optional>
 
 namespace compat {
 
@@ -682,20 +687,27 @@ struct instance_generator<cluster::topic_configuration> {
         tc.replication_factor = random_generators::get_int<int16_t>();
         tc.is_migrated = tests::random_bool();
         tc.properties = instance_generator<cluster::topic_properties>::random();
+        tc.tp_id = model::create_topic_id();
         return tc;
     }
 
     static std::vector<cluster::topic_configuration> limits() {
         return {
-          {model::ns(""),
-           model::topic(""),
-           std::numeric_limits<int32_t>::max(),
-           std::numeric_limits<int16_t>::max(),
-           std::numeric_limits<bool>::max()},
+          {
+            model::ns(""),
+            model::topic(""),
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<int16_t>::max(),
+            model::topic_id(std::vector<uint8_t>(
+              uuid_t::length, std::numeric_limits<uint8_t>::max())),
+            std::numeric_limits<bool>::max(),
+          },
           {model::ns(""),
            model::topic(""),
            std::numeric_limits<int32_t>::min(),
            std::numeric_limits<int16_t>::min(),
+           model::topic_id(std::vector<uint8_t>(
+             uuid_t::length, std::numeric_limits<uint8_t>::min())),
            std::numeric_limits<bool>::min()}};
     }
 };

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -718,6 +718,7 @@ inline void rjson_serialize(
     write_member(w, "partition_count", cfg.partition_count);
     write_member(w, "replication_factor", cfg.replication_factor);
     write_member(w, "is_migrated", cfg.is_migrated);
+    write_member(w, "tp_id", cfg.tp_id);
     write_member(w, "properties", cfg.properties);
     w.EndObject();
 }
@@ -728,6 +729,7 @@ read_value(const json::Value& rd, cluster::topic_configuration& cfg) {
     read_member(rd, "partition_count", cfg.partition_count);
     read_member(rd, "replication_factor", cfg.replication_factor);
     read_member(rd, "is_migrated", cfg.is_migrated);
+    read_member(rd, "tp_id", cfg.tp_id);
     read_member(rd, "properties", cfg.properties);
 }
 

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -20,6 +20,7 @@
 #include "security/acl.h"
 #include "utils/base64.h"
 #include "utils/unresolved_address.h"
+#include "utils/uuid.h"
 
 #include <seastar/net/inet_address.hh>
 
@@ -142,6 +143,18 @@ void read_value(const json::Value& v, std::optional<T>& target) {
         read_value(v, t);
         target = std::move(t);
     }
+}
+
+inline void read_value(const json::Value& v, uuid_t& target) {
+    std::vector<uint8_t> vec;
+    read_value(v, vec);
+    target = uuid_t(vec);
+}
+
+inline void
+rjson_serialize(json::Writer<json::StringBuffer>& w, const uuid_t& value) {
+    auto vec = value.to_vector();
+    rjson_serialize(w, vec);
 }
 
 inline void

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -104,6 +104,8 @@ std::string_view to_string_view(feature f) {
         return "cloud_storage_metadata_rw_fence";
     case feature::node_restart_risk_assessment:
         return "node_restart_risk_assessment";
+    case feature::topic_ids:
+        return "topic_ids";
 
     /*
      * testing features

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -147,7 +147,7 @@ constexpr cluster_version latest_version = to_cluster_version(
 // a freshly initialized node will start at. All features up to this cluster
 // version will automatically be enabled when Redpanda starts.
 constexpr cluster_version earliest_version = to_cluster_version(
-  release_version::v24_1_1);
+  release_version::v24_2_1);
 
 static_assert(
   latest_version - earliest_version == 3L,
@@ -182,6 +182,7 @@ bool is_major_version_release(cluster::cluster_version version) {
     case release_version::v24_2_1:
     case release_version::v24_3_1:
     case release_version::v25_1_1:
+    case release_version::v25_2_1:
         return true;
     }
     __builtin_unreachable();

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -143,7 +143,8 @@ enum class release_version : int64_t {
     v24_2_1 = 13,
     v24_3_1 = 14,
     v25_1_1 = 15,
-    MAX = v25_1_1, // affects the latest_version
+    v25_2_1 = 16,
+    MAX = v25_2_1, // affects the latest_version
 };
 
 constexpr cluster::cluster_version to_cluster_version(release_version rv) {
@@ -161,6 +162,7 @@ constexpr cluster::cluster_version to_cluster_version(release_version rv) {
     case release_version::v24_2_1:
     case release_version::v24_3_1:
     case release_version::v25_1_1:
+    case release_version::v25_2_1:
         return cluster::cluster_version{static_cast<int64_t>(rv)};
     }
     vassert(false, "Invalid release_version");

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -72,6 +72,7 @@ enum class feature : std::uint64_t {
     datalake_iceberg_ga = 1ULL << 56U,
     cloud_storage_metadata_rw_fence = 1ULL << 57U,
     node_restart_risk_assessment = 1ULL << 58U,
+    topic_ids = 1ULL << 59U,
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
     test_bravo = 1ULL << 62U,
@@ -437,6 +438,12 @@ inline constexpr std::array feature_schema{
     feature::node_restart_risk_assessment,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v25_2_1,
+    "topic_ids",
+    feature::topic_ids,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::requires_migration},
 };
 
 std::string_view to_string_view(feature);

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -84,7 +84,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 37,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 38,
       "If you added a property, please decide on it's default alter config "
       "policy, and handle the update in the loop below");
     static_assert(

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -424,6 +424,7 @@ redpanda_cc_btest(
     ],
     tags = ["exclusive"],
     deps = [
+        "//src/v/cluster",
         "//src/v/config",
         "//src/v/container:fragmented_vector",
         "//src/v/features:enterprise_feature_messages",

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/leaders_preference.h"
 #include "container/fragmented_vector.h"
@@ -17,6 +18,8 @@
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/tests/topic_properties_helpers.h"
 #include "model/errc.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
 
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
@@ -650,4 +653,27 @@ FIXTURE_TEST(create_dry_run_rejects_existing, create_topic_fixture) {
              .get();
     BOOST_REQUIRE_EQUAL(
       resp.data.topics[0].error_code, kafka::error_code::topic_already_exists);
+}
+
+FIXTURE_TEST(create_topic_assigns_topic_id, create_topic_fixture) {
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    auto topic = make_topic(ssx::sformat("topic_foo"));
+
+    // create the topic
+    auto resp = client
+                  .dispatch(
+                    make_req({topic}, /*validate_only = */ false),
+                    kafka::api_version(5))
+                  .get();
+    BOOST_REQUIRE_EQUAL(
+      resp.data.topics[0].error_code, kafka::error_code::none);
+
+    auto tpn = model::topic_namespace{
+      model::kafka_namespace, model::topic{"topic_foo"}};
+    auto md = app.controller->get_topics_state().local().get_topic_metadata(
+      tpn);
+    BOOST_REQUIRE(md.has_value());
+    BOOST_REQUIRE(md->get_configuration().tp_id.has_value());
 }

--- a/src/v/migrations/BUILD
+++ b/src/v/migrations/BUILD
@@ -7,6 +7,7 @@ redpanda_cc_library(
         "feature_migrator.cc",
         "rbac_migrator.cc",
         "shard_placement_migrator.cc",
+        "topic_id_migrator.cc",
     ],
     hdrs = [
         "cloud_storage_config.h",
@@ -14,6 +15,7 @@ redpanda_cc_library(
         "migrators.h",
         "rbac_migrator.h",
         "shard_placement_migrator.h",
+        "topic_id_migrator.h",
     ],
     include_prefix = "migrations",
     visibility = ["//visibility:public"],
@@ -21,8 +23,10 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cluster",
         "//src/v/features",
+        "//src/v/model",
         "//src/v/security",
         "//src/v/ssx:future_util",
+        "//src/v/utils:uuid",
         "@seastar",
     ],
 )

--- a/src/v/migrations/CMakeLists.txt
+++ b/src/v/migrations/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     feature_migrator.cc
     rbac_migrator.cc
     shard_placement_migrator.cc
+    topic_id_migrator.cc
   DEPS
     Seastar::seastar
     v::model

--- a/src/v/migrations/topic_id_migrator.cc
+++ b/src/v/migrations/topic_id_migrator.cc
@@ -1,0 +1,54 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "migrations/topic_id_migrator.h"
+
+#include "base/vlog.h"
+#include "cluster/controller.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+#include "features/logger.h"
+#include "model/fundamental.h"
+#include "model/timeout_clock.h"
+
+namespace features::migrators {
+
+ss::future<> topic_id_migrator::do_mutate() {
+    vlog(featureslog.info, "Checking for topics to update...");
+
+    auto& tt = _controller.get_topics_state().local();
+    auto& tf = _controller.get_topics_frontend().local();
+
+    cluster::topic_properties_update_vector upd_vec;
+    for (const auto& topic : tt.all_topics_metadata()) {
+        if (!topic.second.get_configuration().tp_id.has_value()) {
+            auto upd = cluster::topic_properties_update{topic.first};
+            upd.properties.topic_id.op
+              = cluster::incremental_update_operation::set;
+            upd.properties.topic_id.value = model::create_topic_id();
+            upd_vec.emplace_back(std::move(upd));
+        }
+    }
+
+    vlog(featureslog.info, "Assigning UUIDs to {} topics", upd_vec.size());
+    auto res = co_await tf.update_topic_properties(
+      std::move(upd_vec), model::time_from_now(30s));
+
+    for (const auto& topic_res : res) {
+        if (topic_res.ec != cluster::errc::success) {
+            throw std::runtime_error(fmt::format(
+              "Failed to update topic {}: {}", topic_res.tp_ns, topic_res.ec));
+        }
+    }
+
+    vlog(
+      featureslog.info, "Successfully assigned a UUID to all existing topics");
+}
+
+} // namespace features::migrators

--- a/src/v/migrations/topic_id_migrator.h
+++ b/src/v/migrations/topic_id_migrator.h
@@ -1,0 +1,31 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "migrations/feature_migrator.h"
+
+namespace features::migrators {
+
+/// topic_id_migrator assigns topic ids (KIP-516) to pre-25.2 topics that were
+/// created without a topic id.
+class topic_id_migrator final : public feature_migrator {
+public:
+    explicit topic_id_migrator(cluster::controller& c)
+      : feature_migrator(c) {}
+
+private:
+    features::feature get_feature() final { return _feature; }
+    ss::future<> do_mutate() final;
+
+    features::feature _feature{features::feature::topic_ids};
+};
+
+} // namespace features::migrators

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -522,6 +522,11 @@ constexpr std::string_view to_string_view(fips_mode_flag f) {
 
 std::ostream& operator<<(std::ostream& os, const fips_mode_flag& f);
 std::istream& operator>>(std::istream& is, fips_mode_flag& f);
+
+using topic_id = named_type<uuid_t, struct topic_id_type>;
+
+inline topic_id create_topic_id() { return topic_id{uuid_t::create()}; }
+
 } // namespace model
 
 namespace kafka {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -115,6 +115,7 @@
 #include "metrics/prometheus_sanitize.h"
 #include "migrations/migrators.h"
 #include "migrations/rbac_migrator.h"
+#include "migrations/topic_id_migrator.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/dns.h"
@@ -2840,6 +2841,9 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
           std::make_unique<features::migrators::rbac_migrator>(*controller));
         _migrators.push_back(
           std::make_unique<features::migrators::shard_placement_migrator>(
+            *controller));
+        _migrators.push_back(
+          std::make_unique<features::migrators::topic_id_migrator>(
             *controller));
     }
 

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -104,7 +104,8 @@ class InstallOptions:
     def __init__(self,
                  install_previous_version=False,
                  version=None,
-                 num_to_upgrade=0):
+                 num_to_upgrade=0,
+                 upgraded_version=REDPANDA_INSTALLER_HEAD_TAG):
         # If true, install the highest version of the prior feature version
         # before HEAD.
         self.install_previous_version = install_previous_version
@@ -117,6 +118,9 @@ class InstallOptions:
         # cluster on an older version, e.g. to simulate a mixed-version
         # environment.
         self.num_to_upgrade = num_to_upgrade
+
+        # Target version to upgrade to from "version"
+        self.upgraded_version = upgraded_version
 
 
 class RedpandaInstaller:

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -524,8 +524,7 @@ class AlterConfigMixedNodeTest(EndToEndTest):
         alter_and_check(check_consistent_properties_across_nodes)
 
         # Install updated version of redpanda across all nodes.
-        self.redpanda._installer.install(self.redpanda.nodes,
-                                         RedpandaInstaller.HEAD)
+        self.redpanda._installer.install(self.redpanda.nodes, (24, 3))
         # Restart one node.
         restart_node_and_await_stable_leader(self.redpanda.nodes[0])
 

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -138,7 +138,7 @@ class EndToEndTest(Test):
                 for i in range(install_opts.num_to_upgrade)
             ]
             self.redpanda._installer.install(nodes_to_upgrade,
-                                             RedpandaInstaller.HEAD)
+                                             install_opts.upgraded_version)
             self.redpanda.restart_nodes(nodes_to_upgrade)
 
         self._client = DefaultClient(self.redpanda)

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -278,6 +278,8 @@ class SelfTestTest(EndToEndTest):
         num_nodes = 3
 
         install_opts = InstallOptions(version=RedpandaVersionLine((24, 1)),
+                                      upgraded_version=RedpandaVersionLine(
+                                          (24, 3)),
                                       num_to_upgrade=2)
         self.start_redpanda(
             num_nodes=num_nodes,

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -269,7 +269,7 @@ class ShardPlacementTest(PreallocNodesTest):
 
         # Upgrade the cluster and wait for the feature activation.
 
-        installer.install(seed_nodes, RedpandaInstaller.HEAD)
+        installer.install(seed_nodes, (24, 3))
         self.redpanda.restart_nodes(seed_nodes)
         self.redpanda.wait_for_membership(first_start=False)
 

--- a/tests/rptest/tests/topic_id_migrator.py
+++ b/tests/rptest/tests/topic_id_migrator.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.util import wait_until_result
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, LoggingConfig
+from rptest.services.redpanda_installer import wait_for_num_versions, RedpandaInstaller
+from rptest.clients.kcl import RawKCL
+
+
+class TopicIDUpgradeTest(RedpandaTest):
+    def __init__(self, test_ctx, **kwargs):
+        super().__init__(test_ctx,
+                         num_brokers=7,
+                         log_config=LoggingConfig('info',
+                                                  logger_levels={
+                                                      'cluster': 'trace',
+                                                      'features': 'trace',
+                                                  }),
+                         **kwargs)
+        self.installer = self.redpanda._installer
+        self.kcl = RawKCL(self.redpanda)
+
+    def setUp(self):
+        # 25.2.x is when topic ids went live, so start with 25.1.x
+        self.old_version = self.redpanda._installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD)
+        self.installer.install(self.redpanda.nodes, self.old_version)
+        super(TopicIDUpgradeTest, self).setUp()
+
+    @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_topic_id_migration(self):
+        n_topics = 500
+
+        # There are a large number of controller records created when the topics are created
+        self.redpanda.set_expected_controller_records(n_topics * 2 + 1000)
+
+        # Create the topics to be migrated
+        topics = [{
+            'name': f"test_topic_{i}",
+            'partition_count': 1,
+            'replication_factor': 1,
+        } for i in range(n_topics)]
+        res = self.kcl.create_topics(6, topics=topics)
+        self.redpanda.logger.info(f"Response: {res}")
+        assert len(res) == n_topics, f"Unexpected response length: {len(res)}"
+        for t in res:
+            assert t['ErrorCode'] == 0, f"Failed to create topic: {t}"
+
+        # Update all nodes to newest version
+        # TODO: replace HEAD with (25, 2) once available
+        self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        _ = wait_for_num_versions(self.redpanda, 1)
+
+        # Verify that the old topics have been migrated
+        def topic_migrated():
+            return self.redpanda.search_log_any(f"Assigning topic id .* to topic {{kafka/test_topic_{n_topics-1}}}") and \
+                self.redpanda.search_log_any("Successfully assigned a UUID to all existing topics")
+
+        wait_until_result(topic_migrated,
+                          timeout_sec=30,
+                          backoff_sec=1,
+                          retry_on_exc=True,
+                          err_msg="Timeout waiting for topics to be migrated")

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -189,6 +189,8 @@ def read_topic_config(rdr: Reader, version):
         # see https://github.com/redpanda-data/redpanda/pull/6613
         decoded['properties']['remote_delete'] = False
     decoded['is_migrated'] = rdr.read_bool() if version >= 2 else False
+    decoded['tp_id'] = rdr.read_optional(
+        Reader.read_uuid) if version >= 3 else None
 
     return decoded
 
@@ -197,7 +199,7 @@ def read_topic_configuration_assignment_serde(rdr: Reader):
     return rdr.read_envelope(
         lambda rdr, _: {
             'cfg':
-            rdr.read_envelope(read_topic_config, 2),
+            rdr.read_envelope(read_topic_config, 3),
             'assignments':
             rdr.read_serde_vector(lambda r: r.read_envelope(
                 lambda ir, _: {

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -222,10 +222,11 @@ def read_inc_update_op_serde(rdr: Reader):
 
 
 def read_property_update_serde(rdr: Reader, type_reader):
-    return rdr.read_envelope(lambda rdr, _: {
-        'value': type_reader(rdr),
-        'op': read_inc_update_op_serde(rdr),
-    })
+    return rdr.read_envelope(
+        lambda rdr, _: {
+            'value': rdr.read_tristate(type_reader),
+            'op': read_inc_update_op_serde(rdr),
+        })
 
 
 def read_incremental_topic_update_serde(rdr: Reader):
@@ -280,35 +281,43 @@ def read_incremental_topic_update_serde(rdr: Reader):
         if version >= 4:
             incr_obj |= {
                 'record_key_schema_id_validation':
-                rdr.read_optional(Reader.read_bool)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_bool))
             }
             incr_obj |= {
                 'record_key_schema_id_validation_compat':
-                rdr.read_optional(Reader.read_bool)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_bool))
             }
             incr_obj |= {
                 'record_key_subject_name_strategy':
-                rdr.read_optional(Reader.read_serde_enum)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_serde_enum))
             }
             incr_obj |= {
                 'record_key_subject_name_strategy_compat':
-                rdr.read_optional(Reader.read_serde_enum)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_serde_enum))
             }
             incr_obj |= {
                 'record_value_schema_id_validation':
-                rdr.read_optional(Reader.read_bool)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_bool))
             }
             incr_obj |= {
                 'record_value_schema_id_validation_compat':
-                rdr.read_optional(Reader.read_bool)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_bool))
             }
             incr_obj |= {
                 'record_value_subject_name_strategy':
-                rdr.read_optional(Reader.read_serde_enum)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_serde_enum))
             }
             incr_obj |= {
                 'record_value_subject_name_strategy_compat':
-                rdr.read_optional(Reader.read_serde_enum)
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_serde_enum))
             }
         if version >= 5:
             incr_obj |= {
@@ -321,21 +330,32 @@ def read_incremental_topic_update_serde(rdr: Reader):
             }
         if version >= 6:
             incr_obj |= {
-                'write_caching': rdr.read_optional(Reader.read_serde_enum),
-                'flush_ms': rdr.read_optional(Reader.read_int64),
-                'flush_bytes': rdr.read_optional(Reader.read_int64)
+                'write_caching':
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_serde_enum)),
+                'flush_ms':
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_int64)),
+                'flush_bytes':
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_int64))
             }
         if version >= 7:
             incr_obj |= {
-                'iceberg_mode': read_iceberg_mode(rdr),
+                'iceberg_mode':
+                read_property_update_serde(rdr, read_iceberg_mode),
                 'leaders_preference':
-                rdr.read_optional(read_leaders_preference),
-                'iceberg_delete': rdr.read_optional(Reader.read_bool),
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(read_leaders_preference)),
+                'iceberg_delete':
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_bool)),
             }
         if version >= 8:
             incr_obj |= {
                 'iceberg_partition_spec':
-                rdr.read_optional(Reader.read_string),
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_string)),
             }
 
         return incr_obj

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -358,11 +358,14 @@ def read_incremental_topic_update_serde(rdr: Reader):
                 'iceberg_partition_spec':
                 read_property_update_serde(
                     rdr, lambda r: r.read_optional(Reader.read_string)),
+                'topic_id':
+                read_property_update_serde(
+                    rdr, lambda r: r.read_optional(Reader.read_uuid)),
             }
 
         return incr_obj
 
-    return rdr.read_envelope(incr_topic_upd, reader_version=7)
+    return rdr.read_envelope(incr_topic_upd, reader_version=8)
 
 
 def read_create_partitions_serde(rdr: Reader):


### PR DESCRIPTION
This PR introduces the `model::topic_id` to represent the topic id described in KIP-516. This is stored inside the `topic_configuration` of each topic.

This a new feature (`topic_ids`) is introduces, as well as an associated migrator. The migrator assigns a topic id to all existing topics which didn't perviously have a topic id. This relies on the `update_topic_properties_cmd` to assign the topic id.

To ensure that going forward, all newly created topics are assigned a topic id, `topic_frontend::do_create_topic` is updated to assign a topic id to all newly created topics.

As part of this, the PR also makes the following changes:
- Update the latest version in the feature table to 16 (25.2)
- Correct the expected serde types in `offline_log_viewer`'s reader of incremental topic updates

Fixes https://redpandadata.atlassian.net/browse/CORE-9874

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
