### PR TITLE
[v25.1.x] [UX-29] rpk: fix handling *.tls.enabled=<true/false> flags

### DIFF
--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -150,9 +150,20 @@ var xflags = map[string]xflag{
 		"kafka_api.tls.enabled",
 		"true",
 		xkindProfile,
-		func(_ string, y *RpkYaml) error {
+		func(v string, y *RpkYaml) error {
 			p := y.Profile(y.CurrentProfile)
-			mkKafkaTLS(&p.KafkaAPI)
+			if v == "" {
+				v = "true"
+			}
+			enabled, err := strconv.ParseBool(v)
+			if err != nil {
+				return err
+			}
+			if enabled {
+				mkKafkaTLS(&p.KafkaAPI)
+			} else {
+				p.KafkaAPI.TLS = nil
+			}
 			return nil
 		},
 	},
@@ -245,9 +256,20 @@ var xflags = map[string]xflag{
 		"admin_api.tls.enabled",
 		"false",
 		xkindProfile,
-		func(_ string, y *RpkYaml) error {
+		func(v string, y *RpkYaml) error {
 			p := y.Profile(y.CurrentProfile)
-			mkAdminTLS(&p.AdminAPI)
+			if v == "" {
+				v = "true"
+			}
+			enabled, err := strconv.ParseBool(v)
+			if err != nil {
+				return err
+			}
+			if enabled {
+				mkAdminTLS(&p.AdminAPI)
+			} else {
+				p.AdminAPI.TLS = nil
+			}
 			return nil
 		},
 	},
@@ -308,9 +330,20 @@ var xflags = map[string]xflag{
 		"schema_registry.tls.enabled",
 		"false",
 		xkindProfile,
-		func(_ string, y *RpkYaml) error {
+		func(v string, y *RpkYaml) error {
 			p := y.Profile(y.CurrentProfile)
-			mkSchemaRegistryTLS(&p.SR)
+			if v == "" {
+				v = "true"
+			}
+			enabled, err := strconv.ParseBool(v)
+			if err != nil {
+				return err
+			}
+			if enabled {
+				mkSchemaRegistryTLS(&p.SR)
+			} else {
+				p.SR.TLS = nil
+			}
 			return nil
 		},
 	},
@@ -619,7 +652,7 @@ brokers=127.0.0.1:9092,localhost:9094
   By default, this is 127.0.0.1:9092.
 
 tls.enabled=true
-  A boolean that enableenables rpk to speak TLS to your broker's Kafka API listeners.
+  A boolean that enables rpk to speak TLS to your broker's Kafka API listeners.
   You can use this if you have well known certificates setup on your Kafka API.
   If you use mTLS, specifying mTLS certificate filepaths automatically opts
   into TLS enabled.

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -1421,3 +1421,238 @@ func TestConfig_fixSchemePorts(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessOverrides(t *testing.T) {
+	tests := []struct {
+		name          string
+		envOverrides  map[string]string
+		flagOverrides []string
+		applyCfg      func(*Config)
+		expErr        string
+		verify        func(t *testing.T, y *RpkYaml)
+	}{
+		{
+			name: "Apply flag override to kafka brokers",
+			flagOverrides: []string{
+				"brokers=127.0.0.1:9092,localhost:9092",
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				want := []string{"127.0.0.1:9092", "localhost:9092"}
+				require.Equal(t, want, p.KafkaAPI.Brokers)
+			},
+		},
+		{
+			name: "Apply env override to admin addresses",
+			envOverrides: map[string]string{
+				"RPK_ADMIN_HOSTS": "admin.redpanda.com,admin2.redpanda.com",
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				want := []string{"admin.redpanda.com", "admin2.redpanda.com"}
+				require.Equal(t, want, p.AdminAPI.Addresses)
+			},
+		},
+		{
+			name: "Flag override takes precedence over env and cfg",
+			envOverrides: map[string]string{
+				"RPK_BROKERS": "from.env:9092",
+			},
+			flagOverrides: []string{
+				"brokers=from.flag:9092",
+			},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.KafkaAPI.Brokers = []string{"from.cfg:9092"}
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				want := []string{"from.flag:9092"}
+				require.Equal(t, want, y.Profile(y.CurrentProfile).KafkaAPI.Brokers)
+			},
+		},
+		{
+			name:          "Apply tls enabled to kafka brokers",
+			flagOverrides: []string{"tls.enabled=true"},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.True(t, p.KafkaAPI.TLS != nil)
+			},
+		},
+		{
+			name: "Apply kafka TLS enabled via env",
+			envOverrides: map[string]string{
+				"RPK_TLS_ENABLED": "true",
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.NotNil(t, p.KafkaAPI.TLS)
+			},
+		},
+		{
+			name:          "Apply tls.enabled=false to kafka brokers",
+			flagOverrides: []string{"tls.enabled=false"},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.KafkaAPI.TLS = new(TLS)
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.Nil(t, p.KafkaAPI.TLS)
+			},
+		},
+		{
+			name: "Apply kafka TLS disabled via env",
+			envOverrides: map[string]string{
+				"RPK_TLS_ENABLED": "false",
+			},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.KafkaAPI.TLS = new(TLS)
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.Nil(t, p.KafkaAPI.TLS)
+			},
+		},
+		{
+			name:          "Apply tls enabled to admin hosts",
+			flagOverrides: []string{"admin.tls.enabled=true"},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.True(t, p.AdminAPI.TLS != nil)
+			},
+		},
+		{
+			name: "Apply admin TLS enabled via env",
+			envOverrides: map[string]string{
+				"RPK_ADMIN_TLS_ENABLED": "true",
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.NotNil(t, p.AdminAPI.TLS)
+			},
+		},
+		{
+			name:          "Apply tls.enabled=false to admin hosts",
+			flagOverrides: []string{"admin.tls.enabled=false"},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.AdminAPI.TLS = new(TLS)
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.Nil(t, p.AdminAPI.TLS)
+			},
+		},
+		{
+			name: "Apply admin TLS disabled via env",
+			envOverrides: map[string]string{
+				"RPK_ADMIN_TLS_ENABLED": "false",
+			},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.AdminAPI.TLS = new(TLS)
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.Nil(t, p.AdminAPI.TLS)
+			},
+		},
+		{
+			name:          "Apply tls enabled to SR hosts",
+			flagOverrides: []string{"registry.tls.enabled=true"},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.True(t, p.SR.TLS != nil)
+			},
+		},
+		{
+			name: "Apply schema registry TLS enabled via env",
+			envOverrides: map[string]string{
+				"RPK_REGISTRY_TLS_ENABLED": "true",
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.NotNil(t, p.SR.TLS)
+			},
+		},
+		{
+			name:          "Apply tls.enabled=false to SR hosts",
+			flagOverrides: []string{"registry.tls.enabled=false"},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.SR.TLS = new(TLS)
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.Nil(t, p.SR.TLS)
+			},
+		},
+		{
+			name: "Apply schema registry TLS disabled via env",
+			envOverrides: map[string]string{
+				"RPK_REGISTRY_TLS_ENABLED": "false",
+			},
+			applyCfg: func(cfg *Config) {
+				p := cfg.rpkYaml.Profile(cfg.rpkYaml.CurrentProfile)
+				p.SR.TLS = new(TLS)
+			},
+			verify: func(t *testing.T, y *RpkYaml) {
+				p := y.Profile(y.CurrentProfile)
+				require.Nil(t, p.SR.TLS)
+			},
+		},
+		{
+			name: "Error - invalid key format (missing =val)",
+			flagOverrides: []string{
+				"kafka_api.brokers",
+			},
+			expErr: `flag config: "kafka_api.brokers" is not a key=value`,
+		},
+		{
+			name: "Error - unknown key",
+			flagOverrides: []string{
+				"unknown.key=value",
+			},
+			expErr: `flag config: unknown key "unknown.key"`,
+		},
+		{
+			name: "Error - parse failure",
+			flagOverrides: []string{
+				"tls.insecure_skip_verify=notabool",
+			},
+			expErr: `flag config key "tls.insecure_skip_verify": strconv.ParseBool: parsing "notabool": invalid syntax`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{
+				rpkYaml: RpkYaml{
+					CurrentProfile: "default",
+					Profiles:       []RpkProfile{{Name: "default"}},
+				},
+			}
+			if tt.applyCfg != nil {
+				tt.applyCfg(c)
+			}
+			p := &Params{
+				FlagOverrides: tt.flagOverrides,
+			}
+			if tt.envOverrides != nil {
+				for k, v := range tt.envOverrides {
+					t.Setenv(k, v)
+				}
+			}
+			err := p.processOverrides(c)
+			if tt.expErr != "" {
+				require.ErrorContains(t, err, tt.expErr, "expected error containing %q, got %v", tt.expErr, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.verify != nil {
+				tt.verify(t, &c.rpkYaml)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25961
Fixes: https://github.com/redpanda-data/redpanda/issues/25986,