### PR TITLE
disable two flaky tests

### DIFF
--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -20,7 +20,7 @@ from rptest.services.admin import OutboundDataMigration, InboundDataMigration, N
 
 import confluent_kafka as ck
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
@@ -571,6 +571,7 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
             {"ntr_no_topic_manifest", "missing_segments"})
 
     @cluster(num_nodes=3, log_allow_list=MIGRATION_LOG_ALLOW_LIST)
+    @ignore  # flaky: CORE-9921
     def test_conflicting_names(self):
         def on_delivery(err, msg):
             if err is not None:

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -80,8 +80,10 @@ class SimpleEndToEndTest(EndToEndTest):
             error = e
 
         assert error is not None
-        assert "Consumed from an unexpected" in str(
-            error) or "is behind the current committed offset" in str(error)
+        # flaky: disabling until CORE-9229 is fixed
+        assert True or "Consumed from an unexpected" in str(
+            error) or "is behind the current committed offset" in str(
+                error), f"unexpected error: {error}"
 
     @skip_debug_mode
     @cluster(num_nodes=6)


### PR DESCRIPTION
Ignore failures in two flaky tests

These fail with high probability and block most PRs. Ignore them or bypass the
error while we enhance the retry mechanism and/or fix the tests.

Specifically, bypass the faililng assert in
SimpleEndToEndTest.test_consumer_interruption (but leave the rest of the
test running) and @ignore DataMigrationsApiTest.test_conflicting_names.

See [CORE-9921] and [CORE-9229] for associated pt-flaky issues.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none


[CORE-9921]: https://redpandadata.atlassian.net/browse/CORE-9921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-9229]: https://redpandadata.atlassian.net/browse/CORE-9229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ