### PR TITLE
`storage`: fix math in `segment_index::estimate_size()`

### DIFF
--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -141,7 +141,7 @@ public:
     static uint64_t estimate_size(uint64_t log_size) {
         // Index entry every `step` bytes, each entry is 16 bytes
         // plus one entry that is with the first batch.
-        return 1 + 16 * log_size / default_data_buffer_step;
+        return 16 * (log_size / default_data_buffer_step + 1);
     }
 
     void maybe_track(


### PR DESCRIPTION
The order of operations here was incorrect for estimating the size of the `segment_index`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes


* none
