### PR TITLE
Fix flaky test_consumer_interruption

### DIFF
--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -21,6 +21,7 @@ import json
 import os
 import signal
 from collections import namedtuple
+from typing import Any
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.services.background_thread import BackgroundThreadService
@@ -158,7 +159,7 @@ class ConsumerEventHandler(object):
 class VerifiableConsumer(BackgroundThreadService):
     """
     This service wraps org.apache.kafka.tools.VerifiableConsumer for use in
-    system testing. 
+    system testing.
     """
 
     PERSISTENT_ROOT = "/mnt/verifiable_consumer"
@@ -265,7 +266,12 @@ class VerifiableConsumer(BackgroundThreadService):
                  on_record_consumed=None,
                  reset_policy="earliest",
                  verify_offsets=True,
-                 log_level="INFO"):
+                 log_level="INFO",
+                 consumer_properties: dict[str, Any] = {}):
+        """
+        Create a VerifiableConsumer service.
+        :param consumer_properties: A dictionary of properties to be passed to the
+        underlying Kafka (java) consumer."""
         super(VerifiableConsumer, self).__init__(context, num_nodes)
 
         self.redpanda = redpanda
@@ -277,7 +283,8 @@ class VerifiableConsumer(BackgroundThreadService):
         self.session_timeout_sec = session_timeout_sec
         self.enable_autocommit = enable_autocommit
         self.assignment_strategy = assignment_strategy
-        self.prop_file = ""
+        self.prop_file = "\n".join(
+            f"{k}={v}" for k, v in consumer_properties.items()) + "\n"
         self.stop_timeout_sec = stop_timeout_sec
         self.on_record_consumed = on_record_consumed
         self.verify_offsets = verify_offsets

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -19,7 +19,7 @@
 # - Imported annotate_missing_msgs helper from kafka test suite
 
 from collections import defaultdict, namedtuple
-from typing import Optional
+from typing import Any, Optional
 import os
 from typing import Optional
 from ducktape.tests.test import Test
@@ -30,9 +30,7 @@ from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.clients.default import DefaultClient
 from rptest.services.verifiable_consumer import VerifiableConsumer
 from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
-from rptest.archival.s3_client import S3Client
 from rptest.clients.rpk import RpkTool
-from rptest.clients.rpk import RpkException
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
@@ -70,8 +68,8 @@ class EndToEndTest(Test):
 
         self._extra_node_conf = extra_node_conf
 
-        self.records_consumed = []
-        self.last_consumed_offsets = {}
+        self.records_consumed: list[tuple[Any, Any]] = []
+        self.last_consumed_offsets: dict[TopicPartition, int] = {}
         self.redpanda: Optional[RedpandaService] = None
         self.si_settings = si_settings
         self.topic = None
@@ -165,7 +163,8 @@ class EndToEndTest(Test):
                        num_nodes=1,
                        group_id="test_group",
                        verify_offsets=True,
-                       redpanda_cluster=None):
+                       redpanda_cluster=None,
+                       **kwargs: Any):
         if redpanda_cluster is None:
             assert self.redpanda
             redpanda_cluster = self.redpanda
@@ -177,7 +176,8 @@ class EndToEndTest(Test):
             topic=self.topic,
             group_id=group_id,
             on_record_consumed=self.on_record_consumed,
-            verify_offsets=verify_offsets)
+            verify_offsets=verify_offsets,
+            **kwargs)
         self.consumer.start()
 
     def start_producer(self,
@@ -208,6 +208,13 @@ class EndToEndTest(Test):
         self.last_consumed_offsets[partition] = offset
         self.records_consumed.append((key, record_id))
 
+    def consumer_status(self):
+        pmsg = ",".join(f"{p}={o}"
+                        for p, o in self.last_consumed_offsets.items())
+        self.logger.debug(
+            f"Consumer consumed {len(self.records_consumed)} messages, offsets: {pmsg}"
+        )
+
     def await_consumed_offsets(self, last_acked_offsets, timeout_sec):
         def has_finished_consuming():
             # if consumer was interrupted with error there is no point waiting
@@ -237,16 +244,31 @@ class EndToEndTest(Test):
         )
 
     def await_num_produced(self, min_records, timeout_sec=30):
+
+        self.redpanda.logger.debug(
+            f"Waiting for producer to produce {min_records}"
+            f" records (current: {self.producer.num_acked})")
+
         wait_until(lambda: self.producer.num_acked > min_records,
                    timeout_sec=timeout_sec,
                    err_msg="Producer failed to produce messages for %ds." %\
                    timeout_sec)
 
     def await_num_consumed(self, min_records, timeout_sec=30):
-        wait_until(lambda: self.consumer.total_consumed() >= min_records,
+        def consumed():
+            return self.consumer.total_consumed()
+
+        start = consumed()
+
+        def err():
+            return (
+                f"Timed out after {timeout_sec}s "
+                f"while awaiting record consumption of {min_records} records, "
+                f"consumed at start: {start}, end: {consumed()}.")
+
+        wait_until(lambda: consumed() >= min_records,
                    timeout_sec=timeout_sec,
-                   err_msg="Timed out after %ds while awaiting record consumption of %d records" %\
-                   (timeout_sec, min_records))
+                   err_msg=err)
 
     def _collect_segment_data(self):
         # TODO: data collection is disabled because it was
@@ -273,6 +295,7 @@ class EndToEndTest(Test):
                        enable_compaction=False):
         try:
             self.await_num_produced(min_records, producer_timeout_sec)
+            self.consumer_status()
 
             self.logger.info("Stopping producer after writing up to offsets %s" %\
                          str(self.producer.last_acked_offsets))

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -57,6 +57,7 @@ class SimpleEndToEndTest(EndToEndTest):
         '''
         This test validates if verifiable consumer is exiting early when consumed from unexpected offset
         '''
+        target_messages = 30000
 
         self.start_redpanda(num_nodes=3)
 
@@ -65,15 +66,22 @@ class SimpleEndToEndTest(EndToEndTest):
         self.topic = spec.name
 
         self.start_producer(1, throughput=1000)
-        self.start_consumer(1)
-        # wait for at least 15000 records to be consumed
-        self.await_startup(min_records=15000)
-        self.client().delete_topic(spec.name)
+        # we decrease the max.metadata.age.ms in order to ensure that the consumer
+        # starts re-consuming from the recreated topic in a timely matter. See
+        # CORE-9229 for details.
+        self.start_consumer(1,
+                            consumer_properties={"metadata.max.age.ms": 1000})
+        # wait for at least half the records to be consumed
+        self.await_startup(min_records=target_messages // 2)
 
+        self.consumer_status()
+        self.client().delete_topic(spec.name)
         self.client().create_topic(spec)
+
+        self.consumer_status()
         error = None
         try:
-            self.run_validation(min_records=30000,
+            self.run_validation(min_records=target_messages,
                                 producer_timeout_sec=300,
                                 consumer_timeout_sec=300)
         except AssertionError as e:


### PR DESCRIPTION
Decrease max.metadata.age to 1000 ms for this test, so even if the consumer has its assignment revoked it will quickly notice the topic being recreated and join again. With this fix, the test passes locally 100% for me over 60 runs (vs about 50% fail before).

Details:

We delete and recreate a topic while a consumer is connected and look for an error message which complains that the offset is wrong: this occurs when the consumer starts consuming from the recreated topic after already consuming from the original: in this case it try to consume from a non-existent offset and get one of the expected errors.

The flakiness occurs because sometimes when the topic is deleted, the consumer group handling will actually notice the topic deletion and revoke the assignment of the topic to the consumer. In this case, the consumer will need to wait max.metadata.age (5 minutes) in order to “discover” the topic has been recreated. The result is that the consumer doesn’t consume anything during the remaining period (about 15 seconds, needed for the producer to produce 15,000 more messages at throughput 1000/s), so the expected errors (which originate either from the on_consume callback or other message-consumed triggered code) do not occur and instead we get a different error about the consumer losing produced messages (which is also expected).

Which scenario occurs is really just a race between CG heartbeats vs offset commit vs fetch requests: depending on which one “sees” the deleted topic first, a different scenario develops.

To fix it, we increase the metadata query frequency, so it even if it briefly loses the assignment, it will quickly notice the topic being recreated and get assigned again.

Fixes CORE-9229.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

Test-only change to fix a flake.

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
