### PR TITLE
[v24.2.x] `storage`: consider `uint32_t` offset space in adjacent segment compaction (Manual backport)

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -809,6 +809,24 @@ disk_log_impl::find_compaction_range(const compaction_config& cfg) {
     // sliding window over segments. currently restricted to two segments
     auto range = std::make_pair(_segs.begin(), std::next(_segs.begin(), 2));
 
+    // Ensure that the adjacent segments do not span an offset space greater
+    // than the maximum value that can be represented by a uint32_t. This must
+    // be enforced due to use of roaring::bitmap in the compacted_offset_list,
+    // which is used to deduplicate records during self compaction and sliding
+    // window compaction. Overflows in this area could lead to incorrect
+    // compaction.
+    auto valid_offset_range = [](
+                                ss::lw_shared_ptr<segment>& first,
+                                ss::lw_shared_ptr<segment>& last) -> bool {
+        auto base_offset_first_seg = first->offsets().get_base_offset();
+        auto dirty_offset_last_seg = last->offsets().get_dirty_offset();
+        int64_t offset_delta = dirty_offset_last_seg()
+                               - base_offset_first_seg();
+        static constexpr int64_t u32_max = static_cast<int64_t>(
+          std::numeric_limits<uint32_t>::max());
+        return offset_delta <= u32_max;
+    };
+
     while (true) {
         // the simple compaction process in use right now builds a concatenation
         // of segments so we avoid processing a group that is too large.
@@ -835,7 +853,8 @@ disk_log_impl::find_compaction_range(const compaction_config& cfg) {
         // found a good range if all the tests pass
         if (
           same_term
-          && total_size < _manager.config().max_compacted_segment_size()) {
+          && total_size < _manager.config().max_compacted_segment_size()
+          && valid_offset_range(*range.first, *std::prev(range.second))) {
             break;
         }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -201,6 +201,15 @@ public:
 
     storage_resources& resources();
 
+    // Finds a range of adjacent segments that can be compacted together.
+    // A valid segment range consists of segments with the same raft term, and a
+    // combined size less than max_compacted_segment_size.
+    //
+    // Returns std::nullopt if a valid range of two segments could not be found.
+    // Otherwise, a pair of iterators to the segments.
+    std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
+    find_compaction_range(const compaction_config& cfg);
+
     ss::future<> adjacent_merge_compact(
       compaction_config, std::optional<model::offset> = std::nullopt);
 
@@ -250,8 +259,6 @@ private:
     ss::future<compaction_result> compact_adjacent_segments(
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);
-    std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
-    find_compaction_range(const compaction_config&);
 
     ss::future<std::optional<model::offset>> do_gc(gc_config);
     ss::future<> do_compact(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -202,8 +202,9 @@ public:
     storage_resources& resources();
 
     // Finds a range of adjacent segments that can be compacted together.
-    // A valid segment range consists of segments with the same raft term, and a
-    // combined size less than max_compacted_segment_size.
+    // A valid segment range consists of segments with the same raft term, a
+    // combined size less than max_compacted_segment_size, and spanning
+    // a range of offsets that fits in a uint32_t.
     //
     // Returns std::nullopt if a valid range of two segments could not be found.
     // Otherwise, a pair of iterators to the segments.

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -52,7 +52,9 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <stdexcept>
@@ -1966,6 +1968,72 @@ FIXTURE_TEST(max_adjacent_segment_compaction, storage_test_fixture) {
     log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
 }
+
+FIXTURE_TEST(
+  adjacent_segment_compaction_range_u32_bounds, storage_test_fixture) {
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "tapioca", 0);
+    auto log
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
+    auto* disk_log = static_cast<storage::disk_log_impl*>(log.get());
+
+    append_single_record_batch(log, 1, model::term_id(0));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    append_single_record_batch(log, 1, model::term_id(0));
+    disk_log->force_roll(ss::default_priority_class()).get();
+    log->flush().get();
+    BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 3);
+
+    auto& segs = disk_log->segments();
+
+    // Need to mark the segments as self compacted so that they are eligible for
+    // adjacent segment compaction.
+    for (auto& seg : segs) {
+        if (!seg->has_appender()) {
+            seg->mark_as_finished_self_compaction();
+        }
+    }
+
+    // Last non-active segment
+    auto& back = segs[1];
+
+    int64_t u32_max = static_cast<int64_t>(
+      std::numeric_limits<uint32_t>::max());
+
+    // const_cast is ridiculous
+    auto& back_offset_tracker = const_cast<storage::segment::offset_tracker&>(
+      back->offsets());
+
+    // Set the last non-active segment's dirty offset to one past the uint32_t
+    // max- this should make the segment non-eligible for adjacent compaction
+    // with the first segment with a base offset of 0.
+    int64_t one_past_u32_max = u32_max + 1;
+    back_offset_tracker.set_offset(
+      storage::segment::offset_tracker::dirty_offset_t{one_past_u32_max});
+
+    ss::abort_source as;
+    storage::compaction_config cfg(
+      model::offset::max(), ss::default_priority_class(), as);
+    auto range = disk_log->find_compaction_range(cfg);
+    BOOST_REQUIRE(!range.has_value());
+
+    // Set the last non-active segment's dirty offset to the uint32_t
+    // max- this should make the segment eligible for adjacent compaction
+    // with the first segment, since the offset range no longer exceeds the
+    // uint32_t max.
+    back_offset_tracker.set_offset(
+      storage::segment::offset_tracker::dirty_offset_t{u32_max});
+    range = disk_log->find_compaction_range(cfg);
+    BOOST_REQUIRE(range.has_value());
+
+    auto range_segments = std::vector<ss::lw_shared_ptr<storage::segment>>(
+      range->first, range->second);
+
+    // Compare filenames for equality
+    BOOST_REQUIRE_EQUAL(range_segments[0]->filename(), segs[0]->filename());
+    BOOST_REQUIRE_EQUAL(range_segments[1]->filename(), segs[1]->filename());
+};
 
 FIXTURE_TEST(many_segment_locking, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/25954, `cherry-pick` conflict due to missing function in `disk_log_impl` in previous version of `redpanda`.

Fixes https://github.com/redpanda-data/redpanda/issues/25996

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
