### PR TITLE
`storage`: add checks for closed `segment`s in sliding window compaction

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -757,6 +757,14 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             cfg.asrc->check();
         }
 
+        if (seg->is_closed()) {
+            // We may have raced with a prefix truncation while waiting for the
+            // _segment_rewrite_lock, meaning some segments in the window may
+            // have been closed. It is safe to `continue` and rewrite the other,
+            // non-closed segments in the window.
+            continue;
+        }
+
         // A segment is considered "clean" if it has been fully indexed (all
         // keys are de-duplicated)
         const bool is_finished_window_compaction = true;
@@ -1307,6 +1315,13 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
     // happens multiple times in the below while() loop
     auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();
 
+    if (seg->is_closed()) {
+        // We may have raced with a prefix truncation while waiting for
+        // the _segment_rewrite_lock. Do not proceed with chunked compaction on
+        // `seg`.
+        co_return false;
+    }
+
     // The key offset map will be repeatedly built from "chunks" of the
     // unindexed segment and used to rewrite the segments in the sliding window
     // until the entirety of the unindexed segment has been indexed
@@ -1325,6 +1340,14 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
         for (auto& s : segs) {
             if (compact_cfg.asrc) {
                 compact_cfg.asrc->check();
+            }
+
+            if (s->is_closed()) {
+                // We may have raced with a prefix truncation while waiting for
+                // the _segment_rewrite_lock, meaning some segments in the
+                // window may have been closed. It is safe to `continue` and
+                // rewrite the other, non-closed segments in the window.
+                continue;
             }
 
             // Neither of these flags are true until chunked compaction is

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -721,7 +721,19 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     }
 
     if (needs_chunked_sliding_window_compact) {
-        co_return co_await chunked_sliding_window_compact(cfg, segs, map);
+        bool did_compact = false;
+        try {
+            did_compact = co_await chunked_sliding_window_compact(
+              cfg, segs, map);
+        } catch (...) {
+            vlog(
+              gclog.debug,
+              "[{}] failed to perform chunked sliding window compaction. "
+              "Stopping compaction: {}",
+              config().ntp(),
+              std::current_exception());
+        }
+        co_return did_compact;
     }
 
     vlog(

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -270,6 +270,9 @@ ss::future<bool> index_chunk_of_segment_for_map(
   key_offset_map& map,
   probe& pb,
   model::offset& last_indexed_offset) {
+    if (seg->is_closed()) {
+        throw segment_closed_exception();
+    }
     co_await map.reset();
     auto read_holder = co_await seg->read_lock();
     auto start_offset_inclusive = model::next_offset(last_indexed_offset);


### PR DESCRIPTION
The list of `segment`s considered for sliding window compaction is first created and then only later after a number of scheduling points is the `_segment_rewrite_lock` held.

This means that `segment`s in the window could be removed & closed by prefix truncation in the meantime. While there are other fail safes in place to check for a closed `segment` later in the compaction utils, it is better to check early and avoid any unnecessary I/O.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x
- [ ] v24.1.x

## Release Notes

* none
