### PR TITLE
Remove v24.1.x backport option as v24.1.x is end of support.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,6 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] v25.1.x
 - [ ] v24.3.x
 - [ ] v24.2.x
-- [ ] v24.1.x
 
 ## Release Notes
 


### PR DESCRIPTION
Remove v24.1.x backport option as v24.1.x is end of support.