### PR TITLE
[CORE-9871] kafka/protocol: Update fetch schemata to v13

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -379,7 +379,7 @@ ss::future<fetch_response> maybe_throw_exception(
           broker_error(b->id(), res.data.error_code));
     }
 
-    const auto& topics = res.data.topics;
+    const auto& topics = res.data.responses;
     if (topics.size() != 1 || topics[0].partitions.size() != 1) {
         return ss::make_exception_future<fetch_response>(
           partition_error(tp, error_code::unknown_server_error));
@@ -560,8 +560,8 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
           })
           .then([this](kafka::fetch_response res) {
               bool has_error = std::any_of(
-                res.data.topics.begin(),
-                res.data.topics.end(),
+                res.data.responses.begin(),
+                res.data.responses.end(),
                 [](const auto& topics) {
                     return std::any_of(
                       topics.partitions.begin(),

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -76,9 +76,9 @@ fetch_response
 reduce_fetch_response(fetch_response result, fetch_response val) {
     result.data.throttle_time_ms += val.data.throttle_time_ms;
     std::move(
-      val.data.topics.begin(),
-      val.data.topics.end(),
-      std::back_inserter(result.data.topics));
+      val.data.responses.begin(),
+      val.data.responses.end(),
+      std::back_inserter(result.data.responses));
     return result;
 };
 
@@ -444,15 +444,15 @@ ss::future<fetch_response> consumer::fetch(
                             }})
                           .first->second;
 
-            if (req.data.topics.empty() || req.data.topics.back().name != t) {
-                req.data.topics.push_back(fetch_request::topic{.name{t}});
+            if (req.data.topics.empty() || req.data.topics.back().topic != t) {
+                req.data.topics.push_back(fetch_request::topic{.topic{t}});
             }
 
-            req.data.topics.back().fetch_partitions.push_back(
+            req.data.topics.back().partitions.push_back(
               fetch_request::partition{
-                .partition_index = p,
+                .partition = p,
                 .fetch_offset = session.offset(tp),
-                .max_bytes = max_bytes.value_or(
+                .partition_max_bytes = max_bytes.value_or(
                   _config.consumer_request_max_bytes)});
         }
     }

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -41,7 +41,7 @@ bool fetch_session::apply(fetch_response& res) {
         if (part.partition_response->error_code != error_code::none) {
             continue;
         }
-        const auto& topic = part.partition->name;
+        const auto& topic = part.partition->topic;
         const auto p_id = part.partition_response->partition_index;
         auto& record_set = part.partition_response->records;
         if (!record_set || record_set->empty()) {

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -29,14 +29,14 @@ fetch_request make_fetch_request(
   std::chrono::milliseconds timeout) {
     chunked_vector<fetch_request::partition> partitions;
     partitions.push_back(fetch_request::partition{
-      .partition_index{tp.partition},
+      .partition{tp.partition},
       .current_leader_epoch = kafka::invalid_leader_epoch,
       .fetch_offset{offset},
       .log_start_offset{model::offset{-1}},
-      .max_bytes = max_bytes});
+      .partition_max_bytes = max_bytes});
     chunked_vector<fetch_request::topic> topics;
     topics.push_back(fetch_request::topic{
-      .name{tp.topic}, .fetch_partitions{std::move(partitions)}});
+      .topic{tp.topic}, .partitions{std::move(partitions)}});
 
     return fetch_request{
       .data = {
@@ -72,19 +72,19 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
       .high_watermark{model::offset{-1}},
       .last_stable_offset{model::offset{-1}},
       .log_start_offset{model::offset{-1}},
-      .aborted{},
+      .aborted_transactions{},
       .records{}};
 
     small_fragment_vector<fetch_response::partition_response> responses;
     responses.push_back(std::move(pr));
-    auto response = fetch_response::partition{.name = tp.topic};
+    auto response = fetch_response::partition{.topic = tp.topic};
     response.partitions = std::move(responses);
     chunked_vector<fetch_response::partition> parts;
     parts.push_back(std::move(response));
     return fetch_response{
       .data = {
         .error_code = error,
-        .topics = std::move(parts),
+        .responses = std::move(parts),
       }};
 }
 

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -290,8 +290,8 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
               auto res
                 = client.consumer_fetch(group_id, m_id, 200ms, 1_MiB).get();
               BOOST_REQUIRE_EQUAL(res.data.error_code, kafka::error_code::none);
-              BOOST_REQUIRE_EQUAL(res.data.topics.size(), 3);
-              for (const auto& p : res.data.topics) {
+              BOOST_REQUIRE_EQUAL(res.data.responses.size(), 3);
+              for (const auto& p : res.data.responses) {
                   BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
                   const auto& res = p.partitions[0];
                   BOOST_REQUIRE_EQUAL(res.error_code, kafka::error_code::none);
@@ -394,7 +394,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
                   fetch_responses[i].begin(),
                   fetch_responses[i].end(),
                   [&](const auto& res) {
-                      return res.partition->name == t.name
+                      return res.partition->topic == t.name
                              && res.partition_response->partition_index
                                   == p.partition_index;
                   });

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -45,8 +45,8 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
           model::topic("unknown"), model::partition_id(0));
         auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
-        const auto& p = res.data.topics[0];
-        BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
+        const auto& p = res.data.responses[0];
+        BOOST_REQUIRE_EQUAL(p.topic, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
         BOOST_REQUIRE_EQUAL(p.partitions[0].partition_index, ntp.tp.partition);
         BOOST_REQUIRE_EQUAL(
@@ -66,8 +66,8 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
         client.config().retries.set_value(size_t(3));
         auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
-        const auto& p = res.data.topics[0];
-        BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
+        const auto& p = res.data.responses[0];
+        BOOST_REQUIRE_EQUAL(p.topic, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
         const auto& r = p.partitions[0];
         BOOST_REQUIRE_EQUAL(r.partition_index, ntp.tp.partition);

--- a/src/v/kafka/client/test/fetch_session.cc
+++ b/src/v/kafka/client/test/fetch_session.cc
@@ -43,17 +43,17 @@ kafka::fetch_response make_fetch_response(
         .throttle_time_ms = std::chrono::milliseconds{0},
         .error_code = kafka::error_code::none,
         .session_id = s_id,
-        .topics{}}};
-    kafka::fetch_response::partition p{.name = tpv.topic};
+        .responses{}}};
+    kafka::fetch_response::partition p{.topic = tpv.topic};
     p.partitions.push_back(kafka::fetch_response::partition_response{
       .partition_index = tpv.partition,
       .error_code = kafka::error_code::none,
       .high_watermark = model::offset{-1},
       .last_stable_offset = model::offset{-1},
       .log_start_offset = model::offset{-1},
-      .aborted = {},
+      .aborted_transactions = {},
       .records{std::move(record_set)}});
-    res.data.topics.push_back(std::move(p));
+    res.data.responses.push_back(std::move(p));
     return res;
 }
 

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -61,7 +61,7 @@ struct fetch_request final {
         return data.topics.empty()
                || std::all_of(
                  data.topics.cbegin(), data.topics.cend(), [](const topic& t) {
-                     return t.fetch_partitions.empty();
+                     return t.partitions.empty();
                  });
     }
 
@@ -111,7 +111,7 @@ struct fetch_request final {
           : state_({.new_topic = true, .topic = begin})
           , t_end_(end) {
             if (likely(state_.topic != t_end_)) {
-                state_.partition = state_.topic->fetch_partitions.cbegin();
+                state_.partition = state_.topic->partitions.cbegin();
                 normalize();
             }
         }
@@ -149,11 +149,11 @@ struct fetch_request final {
 
     private:
         void normalize() {
-            while (state_.partition == state_.topic->fetch_partitions.cend()) {
+            while (state_.partition == state_.topic->partitions.cend()) {
                 state_.topic++;
                 state_.new_topic = true;
                 if (state_.topic != t_end_) {
-                    state_.partition = state_.topic->fetch_partitions.cbegin();
+                    state_.partition = state_.topic->partitions.cbegin();
                 } else {
                     break;
                 }
@@ -180,7 +180,7 @@ struct fetch_request final {
 struct fetch_response final {
     using api_type = fetch_api;
     using aborted_transaction = kafka::aborted_transaction;
-    using partition_response = fetchable_partition_response;
+    using partition_response = partition_data;
     using partition = fetchable_topic_response;
 
     fetch_response_data data;
@@ -303,11 +303,10 @@ struct fetch_response final {
     };
 
     iterator begin(bool enable_filtering = false) {
-        return iterator(
-          data.topics.begin(), data.topics.end(), enable_filtering);
+        return {data.responses.begin(), data.responses.end(), enable_filtering};
     }
 
-    iterator end() { return iterator(data.topics.end(), data.topics.end()); }
+    iterator end() { return {data.responses.end(), data.responses.end()}; }
 
     friend std::ostream& operator<<(std::ostream& os, const fetch_response& r) {
         return os << r.data;

--- a/src/v/kafka/protocol/schemata/fetch_request.json
+++ b/src/v/kafka/protocol/schemata/fetch_request.json
@@ -16,6 +16,7 @@
 {
   "apiKey": 1,
   "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
   "name": "FetchRequest",
   //
   // Version 1 is the same as version 0.
@@ -43,11 +44,17 @@
   //
   // Version 10 indicates that we can use the ZStd compression algorithm, as
   // described in KIP-110.
+  // Version 12 adds flexible versions support as well as epoch validation through
+  // the `LastFetchedEpoch` field
   //
-  "validVersions": "0-11",
-  "flexibleVersions": "none",
+  // Version 13 replaces topic names with topic IDs (KIP-516). May return UNKNOWN_TOPIC_ID error code.
+  "validVersions": "0-13",
+  "flexibleVersions": "12+",
   "fields": [
-    { "name": "ReplicaId", "type": "int32", "versions": "0+",
+    { "name": "ClusterId", "type": "string", "versions": "12+", "nullableVersions": "12+", "default": "null",
+      "taggedVersions": "12+", "tag": 0, "ignorable": true,
+      "about": "The clusterId if known. This is used to validate metadata fetches prior to broker registration." },
+    { "name": "ReplicaId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The broker ID of the follower, of -1 if this request is from a consumer." },
     { "name": "MaxWaitMs", "type": "int32", "versions": "0+",
       "about": "The maximum time in milliseconds to wait for the response." },
@@ -55,35 +62,39 @@
       "about": "The minimum bytes to accumulate in the response." },
     { "name": "MaxBytes", "type": "int32", "versions": "3+", "default": "0x7fffffff", "ignorable": true,
       "about": "The maximum bytes to fetch.  See KIP-74 for cases where this limit may not be honored." },
-    { "name": "IsolationLevel", "type": "int8", "versions": "4+", "default": "0", "ignorable": false,
+    { "name": "IsolationLevel", "type": "int8", "versions": "4+", "default": "0", "ignorable": true,
       "about": "This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allows consumers to discard ABORTED transactional records" },
-    { "name": "SessionId", "type": "int32", "versions": "7+", "default": "0", "ignorable": false,
+    { "name": "SessionId", "type": "int32", "versions": "7+", "default": "0", "ignorable": true,
       "about": "The fetch session ID." },
-    { "name": "SessionEpoch", "type": "int32", "versions": "7+", "default": "-1", "ignorable": false,
-      "about": "The fetch session epoch, which is used for ordering requests in a session" },
+    { "name": "SessionEpoch", "type": "int32", "versions": "7+", "default": "-1", "ignorable": true,
+      "about": "The fetch session epoch, which is used for ordering requests in a session." },
     { "name": "Topics", "type": "[]FetchTopic", "versions": "0+",
       "about": "The topics to fetch.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Topic", "type": "string", "versions": "0-12", "entityType": "topicName", "ignorable": true,
         "about": "The name of the topic to fetch." },
-      { "name": "FetchPartitions", "type": "[]FetchPartition", "versions": "0+",
+      { "name": "TopicId", "type": "uuid", "versions": "13+", "ignorable": true, "about": "The unique topic ID"},
+      { "name": "Partitions", "type": "[]FetchPartition", "versions": "0+",
         "about": "The partitions to fetch.", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "Partition", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "9+", "default": "-1", "ignorable": true,
           "about": "The current leader epoch of the partition." },
         { "name": "FetchOffset", "type": "int64", "versions": "0+",
           "about": "The message offset." },
-        { "name": "LogStartOffset", "type": "int64", "versions": "5+", "default": "-1", "ignorable": false,
+        { "name": "LastFetchedEpoch", "type": "int32", "versions": "12+", "default": "-1", "ignorable": false,
+          "about": "The epoch of the last fetched record or -1 if there is none"},
+        { "name": "LogStartOffset", "type": "int64", "versions": "5+", "default": "-1", "ignorable": true,
           "about": "The earliest available offset of the follower replica.  The field is only used when the request is sent by the follower."},
-        { "name": "MaxBytes", "type": "int32", "versions": "0+",
+        { "name": "PartitionMaxBytes", "type": "int32", "versions": "0+",
           "about": "The maximum bytes to fetch from this partition.  See KIP-74 for cases where this limit may not be honored." }
       ]}
     ]},
-    { "name": "Forgotten", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,
+    { "name": "ForgottenTopicsData", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,
       "about": "In an incremental fetch request, the partitions to remove.", "fields": [
-      { "name": "Name", "type": "string", "versions": "7+", "entityType": "topicName",
+      { "name": "Topic", "type": "string", "versions": "7-12", "entityType": "topicName", "ignorable": true,
         "about": "The partition name." },
-      { "name": "ForgottenPartitionIndexes", "type": "[]int32", "versions": "7+",
+      { "name": "TopicId", "type": "uuid", "versions": "13+", "ignorable": true, "about": "The unique topic ID"},
+      { "name": "Partitions", "type": "[]int32", "versions": "7+",
         "about": "The partitions indexes to forget." }
     ]},
     { "name": "RackId", "type":  "string", "versions": "11+", "default": "", "ignorable": true,

--- a/src/v/kafka/protocol/schemata/fetch_response.json
+++ b/src/v/kafka/protocol/schemata/fetch_response.json
@@ -37,24 +37,28 @@
   //
   // Version 10 indicates that the response data can use the ZStd compression
   // algorithm, as described in KIP-110.
+  // Version 12 adds support for flexible versions, epoch detection through the `TruncationOffset` field,
+  // and leader discovery through the `CurrentLeader` field
   //
-  "validVersions": "0-11",
-  "flexibleVersions": "none",
+  // Version 13 replaces the topic name field with topic ID (KIP-516).
+  "validVersions": "0-13",
+  "flexibleVersions": "12+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "ErrorCode", "type": "int16", "versions": "7+", "ignorable": false,
+    { "name": "ErrorCode", "type": "int16", "versions": "7+", "ignorable": true,
       "about": "The top level response error code." },
     { "name": "SessionId", "type": "int32", "versions": "7+", "default": "0", "ignorable": false,
       "about": "The fetch session ID, or 0 if this is not part of a fetch session." },
-    { "name": "Topics", "type": "[]FetchableTopicResponse", "versions": "0+",
+    { "name": "Responses", "type": "[]FetchableTopicResponse", "versions": "0+",
       "about": "The response topics.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Topic", "type": "string", "versions": "0-12", "ignorable": true, "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]FetchablePartitionResponse", "versions": "0+",
+      { "name": "TopicId", "type": "uuid", "versions": "13+", "ignorable": true, "about": "The unique topic ID"},
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+",
         "about": "The topic partitions.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
-          "about": "The partiiton index." },
+          "about": "The partition index." },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code, or 0 if there was no fetch error." },
         { "name": "HighWatermark", "type": "int64", "versions": "0+",
@@ -63,17 +67,36 @@
           "about": "The last stable offset (or LSO) of the partition. This is the last offset such that the state of all transactional records prior to this offset have been decided (ABORTED or COMMITTED)" },
         { "name": "LogStartOffset", "type": "int64", "versions": "5+", "default": "-1", "ignorable": true,
           "about": "The current log start offset." },
-        { "name": "Aborted", "type": "[]AbortedTransaction", "versions": "4+", "nullableVersions": "4+", "ignorable": false,
+        { "name": "DivergingEpoch", "type": "EpochEndOffset", "versions": "12+", "taggedVersions": "12+", "tag": 0,
+          "about": "In case divergence is detected based on the `LastFetchedEpoch` and `FetchOffset` in the request, this field indicates the largest epoch and its end offset such that subsequent records are known to diverge",
+          "fields": [
+            { "name": "Epoch", "type": "int32", "versions": "12+", "default": "-1" },
+            { "name": "EndOffset", "type": "int64", "versions": "12+", "default": "-1" }
+        ]},
+        { "name": "CurrentLeader", "type": "LeaderIdAndEpoch",
+          "versions": "12+", "taggedVersions": "12+", "tag": 1, "fields": [
+          { "name": "LeaderId", "type": "int32", "versions": "12+", "default": "-1", "entityType": "brokerId",
+            "about": "The ID of the current leader or -1 if the leader is unknown."},
+          { "name": "LeaderEpoch", "type": "int32", "versions": "12+", "default": "-1",
+            "about": "The latest known leader epoch"}
+        ]},
+        { "name": "SnapshotId", "type": "SnapshotId",
+          "versions": "12+", "taggedVersions": "12+", "tag": 2,
+          "about": "In the case of fetching an offset less than the LogStartOffset, this is the end offset and epoch that should be used in the FetchSnapshot request.",
+          "fields": [
+            { "name": "EndOffset", "type": "int64", "versions": "0+", "default": "-1" },
+            { "name": "Epoch", "type": "int32", "versions": "0+", "default": "-1" }
+        ]},
+        { "name": "AbortedTransactions", "type": "[]AbortedTransaction", "versions": "4+", "nullableVersions": "4+", "ignorable": true,
           "about": "The aborted transactions.",  "fields": [
           { "name": "ProducerId", "type": "int64", "versions": "4+", "entityType": "producerId",
             "about": "The producer id associated with the aborted transaction." },
           { "name": "FirstOffset", "type": "int64", "versions": "4+",
             "about": "The first offset in the aborted transaction." }
         ]},
-        { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "default": "-1", "ignorable": true,
+        { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "default": "-1", "ignorable": false, "entityType": "brokerId",
           "about": "The preferred read replica for the consumer to use on its next fetch request"},
-        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
-          "about": "The record data." }
+        { "name": "Records", "type": "records", "versions": "0+", "nullableVersions": "0+", "about": "The record data."}
       ]}
     ]}
   ]

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -632,6 +632,9 @@ STRUCT_TYPES = [
     "ValueData",
 ]
 
+# A list of StructTypes that are allowed to be not arrays in the schema.
+ALLOWED_SINGULAR_STRUCT_TYPES = []
+
 DROP_STREAM_OPERATOR = [
     "metadata_response_data",
     "metadata_response_topic",
@@ -650,6 +653,12 @@ WITHOUT_DEFAULT_EQUALITY_OPERATOR = {
 # respective types are not prefixed with []. The generator special cases these
 # as ArrayTypes
 TAGGED_WITH_FIELDS = []
+
+# The following is a list of tag types which contain fields where their
+# respective types are correctly not prefixed with [].
+# They must not be treated as ArrayTypes
+# This list is the names after struct_renames have been applied.
+SINGULAR_STRUCT_TYPES = []
 
 SCALAR_TYPES = list(basic_type_map.keys())
 ENTITY_TYPES = list(entity_type_map.keys())
@@ -773,11 +782,13 @@ class FieldType:
             t = ScalarType(type_name)
         else:
             # Its possible for tagged types to contain fields where the type is not
-            # prefixed with [], these types are listed in the TAGGED_WITH_FIELDS map
+            # prefixed with [].
+            # Types in TAGGED_WITH_FIELDS map are treated as ArrayTypes
+            # Types in SINGULAR_STRUCT_TYPES map are not treated as ArrayTypes
             is_array = is_array or (type_name in TAGGED_WITH_FIELDS)
-            assert is_array
             path = path + (field["name"], )
             type_name = apply_struct_renames(path, type_name)
+            assert is_array or (type_name in SINGULAR_STRUCT_TYPES)
             t = StructType(type_name, field["fields"], path)
 
         if is_array:
@@ -1383,7 +1394,7 @@ if ({{ cond }}) {
 {%- endif %}
 {%- endmacro %}
 
-{% macro field_decoder(field, methods, obj) %}
+{% macro field_decoder(field, methods, obj, unused = "") %}
 {%- set flex = methods|length > 1 %}
 {%- if obj %}
 {%- set fname = obj + "." + field.name %}
@@ -1410,6 +1421,9 @@ if ({{ cond }}) {
 {%- endif %}
 });
 {%- else %}
+{%- if field.type().is_struct -%}
+{{- struct_serde(field.type(), methods, "v." ~ field.name) -}}
+{%- else -%}
 {%- set decoder, named_type = field.decoder(flex) %}
 {%- if named_type == None %}
 {{ fname }} = reader.{{ decoder }};
@@ -1426,6 +1440,7 @@ if ({{ cond }}) {
 }
 {%- else %}
 {{ fname }} = {{ named_type }}(reader.{{ decoder }});
+{%- endif %}
 {%- endif %}
 {%- endif %}
 {%- endmacro %}
@@ -1452,7 +1467,7 @@ while(num_tags-- > 0) {
 }
 {%- endmacro %}
 
-{% macro tag_decoder(tag_definitions, obj = "") %}
+{% macro tag_decoder(tag_definitions, obj = "", unused = "") %}
 {%- if tag_definitions|length == 0 %}
 {%- set tf = "unknown_tags" %}
 {%- if obj != "" %}
@@ -1478,6 +1493,10 @@ if ({{ fname }}) {
 }
 {%- elif tdef.is_array %}
 if (!{{ fname }}.empty()) {
+    {{ vec }}.push_back({{ tdef.tag() }});
+}
+{%- elif tdef.type().is_struct  %}
+if ({{ fname }} != {{ tdef.type().name }}{}) {
     {{ vec }}.push_back({{ tdef.tag() }});
 }
 {%- elif tdef.default_value() != "" %}
@@ -1510,7 +1529,11 @@ for(uint32_t tag : to_encode) {
     switch(tag){
 {%- for tdef in tag_definitions %}
     case {{ tdef.tag() }}:
+{%- if tdef.type().is_struct -%}
+{{- struct_serde(tdef.type(), (field_encoder, tag_encoder), obj ~ "." ~ tdef.name, "rw") | indent | indent }}
+{%- else %}
 {{- field_encoder(tdef, (field_encoder, tag_encoder), obj, "rw") | indent | indent }}
+{%- endif %}
         break;
 {%- endfor %}
     default:
@@ -1521,13 +1544,13 @@ for(uint32_t tag : to_encode) {
 writer.write_tags(tagged_fields(std::move(tags_to_encode)));
 {%- endmacro %}
 
-{% macro tag_encoder(tag_definitions, obj = "") %}
+{% macro tag_encoder(tag_definitions, obj = "", writer = "writer") %}
 {%- if tag_definitions|length == 0 %}
 {%- set tf = "unknown_tags" %}
 {%- if obj != "" %}
 {%- set tf = obj + '.unknown_tags' %}
 {%- endif %}
-writer.write_tags(std::move({{ tf }}));
+{{ writer }}.write_tags(std::move({{ tf }}));
 {%- else %}
 {
 {{- tag_encoder_impl(tag_definitions, obj) | indent }}
@@ -1540,15 +1563,15 @@ writer.write_tags(std::move({{ tf }}));
 {% set flex_encoder = (field_encoder, tag_encoder) %}
 {% set flex_decoder = (field_decoder, tag_decoder) %}
 
-{% macro struct_serde(struct, serde_methods, obj = "") %}
+{% macro struct_serde(struct, serde_methods, obj = "", writer = "writer") %}
 {%- set flex = serde_methods|length > 1 %}
 {%- for field in struct.fields %}
 {%- call version_guard(field, flex) %}
-{{- serde_methods[0](field, serde_methods, obj) }}
+{{- serde_methods[0](field, serde_methods, obj, writer) }}
 {%- endcall %}
 {%- endfor %}
 {%- if flex %}
-{{- serde_methods[1](struct.tags, obj) }}
+{{- serde_methods[1](struct.tags, obj, writer) }}
 {%- endif %}
 {%- endmacro %}
 
@@ -1801,9 +1824,9 @@ std::ostream& operator<<(std::ostream& o, const {{ struct.name }}&) {
 # generator for some scenarios involving overloads / customizing output.
 ALLOWED_SCALAR_TYPES = list(set(SCALAR_TYPES) - set(["iobuf"]))
 ALLOWED_TYPES = \
-    ALLOWED_SCALAR_TYPES + \
-    [f"[]{t}" for t in ALLOWED_SCALAR_TYPES +
-        STRUCT_TYPES] + TAGGED_WITH_FIELDS
+    SINGULAR_STRUCT_TYPES + ALLOWED_SINGULAR_STRUCT_TYPES + \
+    ALLOWED_SCALAR_TYPES + TAGGED_WITH_FIELDS  + \
+    [f"[]{t}" for t in ALLOWED_SCALAR_TYPES + STRUCT_TYPES]
 
 # yapf: disable
 SCHEMA = {

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -266,21 +266,31 @@ path_type_map = {
         "ReplicaId": ("model::node_id", "int32"),
         "RackId": ("model::rack_id", "string"),
         "Topics": {
-            "FetchPartitions": {
-                "PartitionIndex": ("model::partition_id", "int32"),
+            "Partitions": {
+                "Partition": ("model::partition_id", "int32"),
                 "FetchOffset": ("model::offset", "int64"),
                 "CurrentLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
     },
     "FetchResponseData": {
-        "Topics": {
+        "Responses": {
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "HighWatermark": ("model::offset", "int64"),
                 "LastStableOffset": ("model::offset", "int64"),
                 "LogStartOffset": ("model::offset", "int64"),
-                "Records": ("kafka::batch_reader", "fetch_record_set"),
+                "DivergingEpoch": {
+                    "Epoch": ("kafka::leader_epoch", "int32"),
+                    "EndOffset": ("model::offset", "int64"),
+                },
+                "CurrentLeader": {
+                    "LeaderEpoch": ("kafka::leader_epoch", "int32"),
+                },
+                "SnapshotId": {
+                    "EndOffset": ("model::offset", "int64"),
+                    "Epoch": ("kafka::leader_epoch", "int32"),
+                },
                 "PreferredReadReplica": ("model::node_id", "int32"),
             },
         },
@@ -409,8 +419,8 @@ basic_type_map = dict(
     uuid=("uuid", "read_uuid()"),
     iobuf=("iobuf", None, "read_fragmented_nullable_bytes()", None,
            "read_fragmented_nullable_flex_bytes()"),
-    fetch_record_set=("batch_reader", None, "read_nullable_batch_reader()",
-                      None, "read_nullable_flex_batch_reader()"),
+    records=("kafka::batch_reader", None, "read_nullable_batch_reader()", None,
+             "read_nullable_flex_batch_reader()"),
 )
 
 # Declare some fields as sensitive. Utmost care should be taken to ensure the
@@ -455,6 +465,9 @@ struct_renames = {
         ("EntityData", "AlterClientQuotasResponseEntityData"),
     ("DescribeClientQuotasResponseData", "Entries", "Entity"):
         ("EntityData", "DescribeClientQuotasResponseEntityData"),
+
+    ("FetchResponseData", "Responses", "Partitions", "DivergingEpoch"):
+        ("EpochEndOffset", "DivergingEpochEndOffset"),
 }
 
 # extra header per type name
@@ -486,7 +499,7 @@ extra_headers = {
 override_member_container = {
     'metadata_response_partition': 'large_fragment_vector',
     'metadata_response_topic': 'small_fragment_vector',
-    'fetchable_partition_response': 'small_fragment_vector',
+    'partition_data': 'small_fragment_vector',
     'offset_fetch_response_partition': 'small_fragment_vector',
     'int32_t': 'std::vector',
     'model::node_id': 'std::vector',
@@ -518,7 +531,7 @@ def make_context_field(path):
     structure. This structure will not be encoded/decoded on the wire and is
     used to add some extra context.
     """
-    if path == ("FetchResponseData", "Topics", "Partitions"):
+    if path == ("FetchResponseData", "Responses", "Partitions"):
         return ("bool", "has_to_be_included{true}")
 
 
@@ -591,7 +604,7 @@ STRUCT_TYPES = [
     "ForgottenTopic",
     "FetchPartition",
     "FetchableTopicResponse",
-    "FetchablePartitionResponse",
+    "PartitionData",
     "AbortedTransaction",
     "CreatePartitionsTopic",
     "CreatePartitionsTopicResult",
@@ -633,7 +646,7 @@ STRUCT_TYPES = [
 ]
 
 # A list of StructTypes that are allowed to be not arrays in the schema.
-ALLOWED_SINGULAR_STRUCT_TYPES = []
+ALLOWED_SINGULAR_STRUCT_TYPES = ["EpochEndOffset"]
 
 DROP_STREAM_OPERATOR = [
     "metadata_response_data",
@@ -646,7 +659,9 @@ DROP_STREAM_OPERATOR = [
 # `operator==()`, because one or more of its member variables are not
 # comparable
 WITHOUT_DEFAULT_EQUALITY_OPERATOR = {
-    'kafka::batch_reader', 'kafka::produce_request_record_data'
+    'kafka::batch_reader',
+    'kafka::produce_request_record_data',
+    "kafka::fetchable_topic_response",
 }
 
 # The following is a list of tag types which contain fields where their
@@ -658,7 +673,9 @@ TAGGED_WITH_FIELDS = []
 # respective types are correctly not prefixed with [].
 # They must not be treated as ArrayTypes
 # This list is the names after struct_renames have been applied.
-SINGULAR_STRUCT_TYPES = []
+SINGULAR_STRUCT_TYPES = [
+    "DivergingEpochEndOffset", "LeaderIdAndEpoch", "SnapshotId"
+]
 
 SCALAR_TYPES = list(basic_type_map.keys())
 ENTITY_TYPES = list(entity_type_map.keys())
@@ -735,8 +752,6 @@ class VersionRange:
                     return self.guard_enum.NO_GUARD, None
             elif self.max < first_flex:
                 return self.guard_enum.NO_SOURCE, None
-            elif self.max == first_flex:
-                return self.guard_enum.NO_GUARD, None
 
         return self._guard()
 
@@ -813,7 +828,7 @@ class ScalarType(FieldType):
     def potentially_flexible_type(self):
         """Evaluates to true if the scalar type would be parsed as flex
         if the version is high enough"""
-        return self.name == "string" or self.name == "bytes" or self.name == "iobuf"
+        return self.name == "string" or self.name == "bytes" or self.name == "records" or self.name == "iobuf"
 
 
 class StructType(FieldType):

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -107,12 +107,20 @@ bytes invoke_franz_harness(
           }),
           boost::process::std_out > is);
 
-        c.wait();
+        auto read_stream = [](boost::process::ipstream& stream) -> ss::sstring {
+            std::ostringstream oss;
+            std::array<char, 4096> buffer;
+            while (stream && !stream.eof()) {
+                stream.read(buffer.data(), buffer.size());
+                oss.write(buffer.data(), stream.gcount());
+            }
+            return oss.str();
+        };
 
-        /// Capture data on stdout
-        std::stringstream ss;
-        ss << is.rdbuf();
-        stdout = ss.str();
+        std::thread out_thread([&]() { stdout = read_stream(is); });
+
+        c.wait();          // Wait for process to finish
+        out_thread.join(); // Wait for reading to complete
 
         /// If the program doesn't exit with success, issue is with test binary
         /// fail hard as author should fix to account for diff in feature set

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -34,8 +34,8 @@ struct fetch_session_partition {
 
     fetch_session_partition(
       const model::topic& tp, const fetch_request::partition& p)
-      : topic_partition(tp, p.partition_index)
-      , max_bytes(p.max_bytes)
+      : topic_partition(tp, p.partition)
+      , max_bytes(p.partition_max_bytes)
       , fetch_offset(p.fetch_offset)
       , high_watermark(model::offset(-1))
       , last_stable_offset(model::offset(-1))

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -18,25 +18,25 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
     for (auto it = req.cbegin(); it != req.cend(); ++it) {
         auto& topic = *it->topic;
         auto& partition = *it->partition;
-        model::topic_partition tp(topic.name, partition.partition_index);
+        model::topic_partition tp(topic.topic, partition.partition);
 
         if (auto s_it = session.partitions().find(tp);
             s_it != session.partitions().end()) {
-            s_it->second->partition.max_bytes = partition.max_bytes;
+            s_it->second->partition.max_bytes = partition.partition_max_bytes;
             s_it->second->partition.fetch_offset = partition.fetch_offset;
             s_it->second->partition.current_leader_epoch
               = partition.current_leader_epoch;
         } else {
             session.partitions().emplace(
-              fetch_session_partition(topic.name, partition));
+              fetch_session_partition(topic.topic, partition));
         }
     }
 
-    for (auto& ft : req.data.forgotten) {
-        for (auto& fp : ft.forgotten_partition_indexes) {
-            model::topic_partition tp(ft.name, model::partition_id(fp));
+    for (auto& ft : req.data.forgotten_topics_data) {
+        for (auto& fp : ft.partitions) {
+            model::topic_partition tp(ft.topic, model::partition_id(fp));
             session.partitions().erase(
-              model::topic_partition_view(ft.name, model::partition_id(fp)));
+              model::topic_partition_view(ft.topic, model::partition_id(fp)));
         }
     }
 }

--- a/src/v/kafka/server/handlers/describe_log_dirs.cc
+++ b/src/v/kafka/server/handlers/describe_log_dirs.cc
@@ -27,16 +27,16 @@
 
 namespace kafka {
 
-struct partition_data {
+struct log_partition_data {
     describe_log_dirs_partition local;
     std::optional<describe_log_dirs_partition> remote;
 };
 
 using partition_dir_set
-  = chunked_hash_map<model::topic, chunked_vector<partition_data>>;
+  = chunked_hash_map<model::topic, chunked_vector<log_partition_data>>;
 
-static partition_data describe_partition(cluster::partition& p) {
-    auto result = partition_data{
+static log_partition_data describe_partition(cluster::partition& p) {
+    auto result = log_partition_data{
       .local = describe_log_dirs_partition{
         .partition_index = p.ntp().tp.partition(),
         .partition_size = static_cast<int64_t>(p.size_bytes()),

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -538,7 +538,7 @@ static void fill_fetch_responses(
                         .producer_id = kafka::producer_id(range.pid.id),
                         .first_offset = range.first};
                   });
-                resp.aborted = std::move(aborted);
+                resp.aborted_transactions = std::move(aborted);
             }
             resp.records = batch_reader(std::move(res).release_data());
         } else {
@@ -1304,7 +1304,7 @@ void op_context::for_each_fetch_partition(Func&& f) const {
           request.cend(),
           [f = std::forward<Func>(f)](
             const fetch_request::const_iterator::value_type& p) {
-              f(fetch_session_partition(p.topic->name, *p.partition));
+              f(fetch_session_partition(p.topic->topic, *p.partition));
           });
     } else {
         std::for_each(
@@ -1581,7 +1581,7 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
      */
     request.decode(rctx.reader(), rctx.header().version);
     if (likely(!request.data.topics.empty())) {
-        response.data.topics.reserve(request.data.topics.size());
+        response.data.responses.reserve(request.data.topics.size());
     }
 
     if (auto delay = request.debounce_delay(); delay) {
@@ -1602,14 +1602,14 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
 
 // insert and reserve space for a new topic in the response
 void op_context::start_response_topic(const fetch_request::topic& topic) {
-    response.data.topics.emplace_back(
-      fetchable_topic_response{.name = topic.name});
+    response.data.responses.emplace_back(
+      fetchable_topic_response{.topic = topic.topic});
 }
 
 void op_context::start_response_partition(const fetch_request::partition& p) {
-    response.data.topics.back().partitions.push_back(
+    response.data.responses.back().partitions.push_back(
       fetch_response::partition_response{
-        .partition_index = p.partition_index,
+        .partition_index = p.partition,
         .error_code = error_code::none,
         .high_watermark = model::offset(-1),
         .last_stable_offset = model::offset(-1),
@@ -1635,8 +1635,8 @@ void op_context::create_response_placeholders() {
           [this, &last_topic](const fetch_session_partition& fp) {
               auto& topic = fp.topic_partition.get_topic();
               if (last_topic != topic) {
-                  response.data.topics.emplace_back(
-                    fetchable_topic_response{.name = topic});
+                  response.data.responses.emplace_back(
+                    fetchable_topic_response{.topic = topic});
                   last_topic = topic;
               }
               fetch_response::partition_response p{
@@ -1646,7 +1646,7 @@ void op_context::create_response_placeholders() {
                 .last_stable_offset = fp.last_stable_offset,
                 .records = batch_reader()};
 
-              response.data.topics.back().partitions.push_back(std::move(p));
+              response.data.responses.back().partitions.push_back(std::move(p));
           });
     }
     for (auto it = response.begin(); it != response.end(); ++it) {
@@ -1713,11 +1713,11 @@ ss::future<response_ptr> op_context::send_response() && {
     final_response.data.session_id = response.data.session_id;
 
     /// Account for special internal topic bytes for usage
-    for (const auto& topic : response.data.topics) {
+    for (const auto& topic : response.data.responses) {
         const bool bytes_to_exclude = std::find(
                                         usage_excluded_topics.cbegin(),
                                         usage_excluded_topics.cend(),
-                                        topic.name)
+                                        topic.topic)
                                       != usage_excluded_topics.cend();
         if (bytes_to_exclude) {
             for (const auto& part : topic.partitions) {
@@ -1731,8 +1731,8 @@ ss::future<response_ptr> op_context::send_response() && {
 
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {
-            final_response.data.topics.emplace_back(
-              fetchable_topic_response{.name = it->partition->name});
+            final_response.data.responses.emplace_back(
+              fetchable_topic_response{.topic = it->partition->topic});
         }
 
         fetch_response::partition_response r{
@@ -1741,12 +1741,13 @@ ss::future<response_ptr> op_context::send_response() && {
           .high_watermark = it->partition_response->high_watermark,
           .last_stable_offset = it->partition_response->last_stable_offset,
           .log_start_offset = it->partition_response->log_start_offset,
-          .aborted = std::move(it->partition_response->aborted),
+          .aborted_transactions = std::move(
+            it->partition_response->aborted_transactions),
           .preferred_read_replica
           = it->partition_response->preferred_read_replica,
           .records = std::move(it->partition_response->records)};
 
-        final_response.data.topics.back().partitions.push_back(std::move(r));
+        final_response.data.responses.back().partitions.push_back(std::move(r));
     }
 
     return rctx.respond(std::move(final_response));
@@ -1805,7 +1806,7 @@ void op_context::response_placeholder::set(
     if (!_ctx->session_ctx.is_sessionless()) {
         auto& session_partitions = _ctx->session_ctx.session()->partitions();
         auto key = model::topic_partition_view(
-          _it->partition->name, _it->partition_response->partition_index);
+          _it->partition->topic, _it->partition_response->partition_index);
 
         if (auto it = session_partitions.find(key);
             it != session_partitions.end()) {

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -50,7 +50,7 @@ struct op_context {
 
         void set(fetch_response::partition_response&&);
 
-        const model::topic& topic() { return _it->partition->name; }
+        const model::topic& topic() { return _it->partition->topic; }
         model::partition_id partition_id() {
             return _it->partition_response->partition_index;
         }

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -84,18 +84,19 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
             chunked_vector<kafka::fetch_topic> fetch_topics;
             for (auto& topic_fetch : req_config) {
                 kafka::fetch_topic ft;
-                ft.name = topic_fetch.name;
+                ft.topic = topic_fetch.name;
 
                 // add the partitions to the fetch request
                 for (const auto& part : topic_fetch.partitions) {
                     kafka::fetch_partition fp;
-                    fp.partition_index = model::partition_id(part.pid);
+                    fp.partition = model::partition_id(part.pid);
                     fp.fetch_offset = part.offset;
                     fp.current_leader_epoch = kafka::leader_epoch(-1);
                     fp.log_start_offset = model::offset(-1);
-                    fp.max_bytes = part.num_batches
-                                   * (cfg.batch_size + cfg.batch_overhead);
-                    ft.fetch_partitions.push_back(std::move(fp));
+                    fp.partition_max_bytes
+                      = part.num_batches
+                        * (cfg.batch_size + cfg.batch_overhead);
+                    ft.partitions.push_back(std::move(fp));
                     total_batches += part.num_batches;
                 }
 

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -33,17 +33,16 @@ struct fixture {
     static kafka::fetch_request::topic
     make_fetch_request_topic(model::topic tp, int partitions_count) {
         kafka::fetch_request::topic fetch_topic{
-          .name = std::move(tp),
-          .fetch_partitions = {},
+          .topic = std::move(tp),
+          .partitions = {},
         };
 
         for (int i = 0; i < partitions_count; ++i) {
-            fetch_topic.fetch_partitions.push_back(
-              kafka::fetch_request::partition{
-                .partition_index = model::partition_id(i),
-                .fetch_offset = model::offset(i * 10),
-                .max_bytes = 100_KiB,
-              });
+            fetch_topic.partitions.push_back(kafka::fetch_request::partition{
+              .partition = model::partition_id(i),
+              .fetch_offset = model::offset(i * 10),
+              .partition_max_bytes = 100_KiB,
+            });
         }
         return fetch_topic;
     }
@@ -83,17 +82,17 @@ PERF_TEST_F(fetch_plan_fixture, test_fetch_plan) {
     auto make_fetch_req = [this]() {
         // make the fetch topic
         kafka::fetch_topic ft;
-        ft.name = t;
+        ft.topic = t;
 
         // add the partitions to the fetch request
         for (size_t pid = 0; pid < session_partition_count; pid++) {
             kafka::fetch_partition fp;
-            fp.partition_index = model::partition_id(static_cast<int32_t>(pid));
+            fp.partition = model::partition_id(static_cast<int32_t>(pid));
             fp.fetch_offset = model::offset(0);
             fp.current_leader_epoch = kafka::leader_epoch(-1);
             fp.log_start_offset = model::offset(-1);
-            fp.max_bytes = 1048576;
-            ft.fetch_partitions.push_back(std::move(fp));
+            fp.partition_max_bytes = 1048576;
+            ft.partitions.push_back(std::move(fp));
         }
 
         BOOST_TEST_CHECKPOINT("HERE");

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -30,23 +30,23 @@ struct fixture {
     static kafka::fetch_partition
     make_fetch_partition(const model::partition_id p_id) {
         return {
-          .partition_index = p_id,
+          .partition = p_id,
           .current_leader_epoch = kafka::leader_epoch(
             random_generators::get_int(100)),
           .fetch_offset = model::offset(random_generators::get_int(10000)),
-          .max_bytes = random_generators::get_int(1024, 1024 * 1024),
+          .partition_max_bytes = random_generators::get_int(1024, 1024 * 1024),
         };
     }
 
     static kafka::fetch_request::topic
     make_fetch_request_topic(model::topic tp, int partitions_count) {
         kafka::fetch_request::topic fetch_topic{
-          .name = std::move(tp),
-          .fetch_partitions = {},
+          .topic = std::move(tp),
+          .partitions = {},
         };
 
         for (int i = 0; i < partitions_count; ++i) {
-            fetch_topic.fetch_partitions.push_back(
+            fetch_topic.partitions.push_back(
               make_fetch_partition(model::partition_id(i)));
         }
         return fetch_topic;
@@ -79,16 +79,16 @@ FIXTURE_TEST(test_fetch_session_basic_operations, fixture) {
     for (int i = 0; i < 20; ++i) {
         auto req = make_fetch_request_topic(
           model::topic(random_generators::gen_alphanum_string(5)), 1);
-        req.fetch_partitions[0].partition_index = model::partition_id(
+        req.partitions[0].partition = model::partition_id(
           random_generators::get_int(i * 10, ((i + 1) * 10) - 1));
 
         expected.push_back(tpo{
           model::ktp{
-            model::topic(req.name),
-            model::partition_id(req.fetch_partitions[0].partition_index)},
-          model::offset(req.fetch_partitions[0].fetch_offset)});
+            model::topic(req.topic),
+            model::partition_id(req.partitions[0].partition)},
+          model::offset(req.partitions[0].fetch_offset)});
         session.partitions().emplace(
-          kafka::fetch_session_partition(req.name, req.fetch_partitions[0]));
+          kafka::fetch_session_partition(req.topic, req.partitions[0]));
     }
 
     BOOST_TEST_MESSAGE("test insertion order iteration");
@@ -153,18 +153,18 @@ FIXTURE_TEST(test_session_operations, fixture) {
         BOOST_REQUIRE_EQUAL(ctx.session()->partitions().size(), 3);
         for (const auto& fp : rng) {
             BOOST_REQUIRE_EQUAL(
-              fp.topic_partition.get_topic(), req.data.topics[0].name);
+              fp.topic_partition.get_topic(), req.data.topics[0].topic);
             BOOST_REQUIRE_EQUAL(
               fp.topic_partition.get_partition(),
-              req.data.topics[0].fetch_partitions[i].partition_index);
+              req.data.topics[0].partitions[i].partition);
             BOOST_REQUIRE_EQUAL(
               fp.current_leader_epoch,
-              req.data.topics[0].fetch_partitions[i].current_leader_epoch);
+              req.data.topics[0].partitions[i].current_leader_epoch);
             BOOST_REQUIRE_EQUAL(
-              fp.fetch_offset,
-              req.data.topics[0].fetch_partitions[i].fetch_offset);
+              fp.fetch_offset, req.data.topics[0].partitions[i].fetch_offset);
             BOOST_REQUIRE_EQUAL(
-              fp.max_bytes, req.data.topics[0].fetch_partitions[i].max_bytes);
+              fp.max_bytes,
+              req.data.topics[0].partitions[i].partition_max_bytes);
             i++;
         }
 
@@ -175,20 +175,21 @@ FIXTURE_TEST(test_session_operations, fixture) {
     BOOST_TEST_MESSAGE("test updating session");
     {
         // Remove and forget about the first partition.
-        auto fp_v = std::vector<
-          decltype(req.data.topics[0].fetch_partitions)::value_type>{
-          req.data.topics[0].fetch_partitions.begin(),
-          req.data.topics[0].fetch_partitions.end()};
+        auto fp_v
+          = std::vector<decltype(req.data.topics[0].partitions)::value_type>{
+            req.data.topics[0].partitions.begin(),
+            req.data.topics[0].partitions.end()};
         fp_v.erase(std::next(fp_v.begin()));
 
-        req.data.topics[0].fetch_partitions = {
+        req.data.topics[0].partitions = {
           std::make_move_iterator(fp_v.begin()),
           std::make_move_iterator(fp_v.end())};
-        req.data.forgotten.push_back(kafka::fetch_request::forgotten_topic{
-          .name = model::topic("test"), .forgotten_partition_indexes = {1}});
+        req.data.forgotten_topics_data.push_back(
+          kafka::fetch_request::forgotten_topic{
+            .topic = model::topic("test"), .partitions = {1}});
         // Update the second partition.
-        req.data.topics[0].fetch_partitions[0] = make_fetch_partition(
-          req.data.topics[0].fetch_partitions[0].partition_index);
+        req.data.topics[0].partitions[0] = make_fetch_partition(
+          req.data.topics[0].partitions[0].partition);
         // Add 2 partitions from new topic.
         req.data.topics.push_back(
           make_fetch_request_topic(model::topic("test-new"), 2));
@@ -214,21 +215,19 @@ FIXTURE_TEST(test_session_operations, fixture) {
             auto p_idx = i < 2 ? i : i - 2;
 
             BOOST_REQUIRE_EQUAL(
-              fp.topic_partition.get_topic(), req.data.topics[t_idx].name);
+              fp.topic_partition.get_topic(), req.data.topics[t_idx].topic);
             BOOST_REQUIRE_EQUAL(
               fp.topic_partition.get_partition(),
-              req.data.topics[t_idx].fetch_partitions[p_idx].partition_index);
+              req.data.topics[t_idx].partitions[p_idx].partition);
             BOOST_REQUIRE_EQUAL(
               fp.current_leader_epoch,
-              req.data.topics[t_idx]
-                .fetch_partitions[p_idx]
-                .current_leader_epoch);
+              req.data.topics[t_idx].partitions[p_idx].current_leader_epoch);
             BOOST_REQUIRE_EQUAL(
               fp.fetch_offset,
-              req.data.topics[t_idx].fetch_partitions[p_idx].fetch_offset);
+              req.data.topics[t_idx].partitions[p_idx].fetch_offset);
             BOOST_REQUIRE_EQUAL(
               fp.max_bytes,
-              req.data.topics[t_idx].fetch_partitions[p_idx].max_bytes);
+              req.data.topics[t_idx].partitions[p_idx].partition_max_bytes);
             i++;
         }
     }

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -38,14 +38,14 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
           [&res](const kafka::fetch_request::const_iterator::value_type& v) {
               if (v.new_topic) {
                   if (!res.empty()) {
-                      BOOST_TEST(res.back().topic != v.topic->name);
+                      BOOST_TEST(res.back().topic != v.topic->topic);
                   }
               } else {
                   BOOST_TEST(!res.empty());
-                  BOOST_TEST(res.back().topic == v.topic->name);
+                  BOOST_TEST(res.back().topic == v.topic->topic);
               }
               return model::topic_partition(
-                v.topic->name, v.partition->partition_index);
+                v.topic->topic, v.partition->partition);
           });
         return res;
     };
@@ -60,7 +60,7 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
     {
         // 1 topic, no partitions -> empty
         kafka::fetch_request req;
-        req.data.topics.push_back({.name = model::topic("t0")});
+        req.data.topics.push_back({.topic = model::topic("t0")});
         auto parts = transform(req);
         BOOST_TEST(parts.empty());
     }
@@ -68,8 +68,8 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
     {
         // 2 topics, no partitions -> empty
         kafka::fetch_request req;
-        req.data.topics.push_back({.name = model::topic("t0")});
-        req.data.topics.push_back({.name = model::topic("t1")});
+        req.data.topics.push_back({.topic = model::topic("t0")});
+        req.data.topics.push_back({.topic = model::topic("t1")});
         auto parts = transform(req);
         BOOST_TEST(parts.empty());
     }
@@ -78,8 +78,8 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
         // 1 topic, 1 partition
         kafka::fetch_request req;
         req.data.topics.push_back({
-          .name = model::topic("t0"),
-          .fetch_partitions = {{.partition_index = model::partition_id(100)}},
+          .topic = model::topic("t0"),
+          .partitions = {{.partition = model::partition_id(100)}},
         });
         auto parts = transform(req);
         BOOST_TEST(parts.size() == 1);
@@ -91,10 +91,10 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
         // 1 topic, 2 partitions
         kafka::fetch_request req;
         req.data.topics.push_back(
-          {.name = model::topic("t0"),
-           .fetch_partitions = {
-             {.partition_index = model::partition_id(100)},
-             {.partition_index = model::partition_id(101)}}});
+          {.topic = model::topic("t0"),
+           .partitions = {
+             {.partition = model::partition_id(100)},
+             {.partition = model::partition_id(101)}}});
         auto parts = transform(req);
         BOOST_TEST(parts.size() == 2);
         BOOST_TEST(parts[0].topic == model::topic("t0"));
@@ -107,14 +107,13 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
         // 2 topics, 2/1 partition
         kafka::fetch_request req;
         req.data.topics.push_back(
-          {.name = model::topic("t0"),
-           .fetch_partitions = {
-             {.partition_index = model::partition_id(100)},
-             {.partition_index = model::partition_id(101)}}});
+          {.topic = model::topic("t0"),
+           .partitions = {
+             {.partition = model::partition_id(100)},
+             {.partition = model::partition_id(101)}}});
         req.data.topics.push_back(
-          {.name = model::topic("t1"),
-           .fetch_partitions = {
-             {.partition_index = model::partition_id(102)}}});
+          {.topic = model::topic("t1"),
+           .partitions = {{.partition = model::partition_id(102)}}});
         auto parts = transform(req);
         BOOST_TEST(parts.size() == 3);
         BOOST_TEST(parts[0].topic == model::topic("t0"));
@@ -129,17 +128,17 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
         // 4 topics, 2/{}/{}/2 partition
         kafka::fetch_request req;
         req.data.topics.push_back(
-          {.name = model::topic("t0"),
-           .fetch_partitions = {
-             {.partition_index = model::partition_id(100)},
-             {.partition_index = model::partition_id(101)}}});
-        req.data.topics.push_back({.name = model::topic("t1")});
-        req.data.topics.push_back({.name = model::topic("t2")});
+          {.topic = model::topic("t0"),
+           .partitions = {
+             {.partition = model::partition_id(100)},
+             {.partition = model::partition_id(101)}}});
+        req.data.topics.push_back({.topic = model::topic("t1")});
+        req.data.topics.push_back({.topic = model::topic("t2")});
         req.data.topics.push_back(
-          {.name = model::topic("t3"),
-           .fetch_partitions = {
-             {.partition_index = model::partition_id(102)},
-             {.partition_index = model::partition_id(103)}}});
+          {.topic = model::topic("t3"),
+           .partitions = {
+             {.partition = model::partition_id(102)},
+             {.partition = model::partition_id(103)}}});
         auto parts = transform(req);
         BOOST_TEST(parts.size() == 4);
         BOOST_TEST(parts[0].topic == model::topic("t0"));
@@ -259,9 +258,9 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
         req.data.session_id = kafka::invalid_fetch_session_id;
         req.data.session_epoch = kafka::final_fetch_session_epoch;
         req.data.topics.emplace_back(kafka::fetch_topic{
-          .name = topic,
-          .fetch_partitions = {{
-            .partition_index = pid,
+          .topic = topic,
+          .partitions = {{
+            .partition = pid,
             .fetch_offset = offset,
           }},
         });
@@ -272,23 +271,24 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
           = client.dispatch(std::move(req), kafka::api_version(version)).get();
         client.stop().then([&client] { client.shutdown(); }).get();
 
-        BOOST_REQUIRE(resp.data.topics.size() == 1);
-        BOOST_REQUIRE(resp.data.topics[0].name == topic());
-        BOOST_REQUIRE(resp.data.topics[0].partitions.size() == 1);
+        BOOST_REQUIRE(resp.data.responses.size() == 1);
+        BOOST_REQUIRE(resp.data.responses[0].topic == topic());
+        BOOST_REQUIRE(resp.data.responses[0].partitions.size() == 1);
         BOOST_REQUIRE(
-          resp.data.topics[0].partitions[0].error_code
+          resp.data.responses[0].partitions[0].error_code
           == kafka::error_code::none);
-        BOOST_REQUIRE(resp.data.topics[0].partitions[0].partition_index == pid);
-        BOOST_REQUIRE(resp.data.topics[0].partitions[0].records);
         BOOST_REQUIRE(
-          resp.data.topics[0].partitions[0].records->size_bytes() > 0);
+          resp.data.responses[0].partitions[0].partition_index == pid);
+        BOOST_REQUIRE(resp.data.responses[0].partitions[0].records);
+        BOOST_REQUIRE(
+          resp.data.responses[0].partitions[0].records->size_bytes() > 0);
     }
 }
 
 FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
     static auto make_partition = [](ss::sstring topic) {
         return kafka::fetch_response::partition{
-          .name = model::topic(std::move(topic))};
+          .topic = model::topic(std::move(topic))};
     };
 
     static auto make_partition_response = [](int id) {
@@ -301,23 +301,23 @@ FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
 
     auto make_test_fetch_response = []() {
         kafka::fetch_response response;
-        response.data.topics.push_back(make_partition("tp-1"));
-        response.data.topics.push_back(make_partition("tp-2"));
-        response.data.topics.push_back(make_partition("tp-3"));
+        response.data.responses.push_back(make_partition("tp-1"));
+        response.data.responses.push_back(make_partition("tp-2"));
+        response.data.responses.push_back(make_partition("tp-3"));
 
-        response.data.topics[0].partitions.push_back(
+        response.data.responses[0].partitions.push_back(
           make_partition_response(0));
-        response.data.topics[0].partitions.push_back(
+        response.data.responses[0].partitions.push_back(
           make_partition_response(1));
-        response.data.topics[0].partitions.push_back(
+        response.data.responses[0].partitions.push_back(
           make_partition_response(2));
 
-        response.data.topics[1].partitions.push_back(
+        response.data.responses[1].partitions.push_back(
           make_partition_response(0));
 
-        response.data.topics[2].partitions.push_back(
+        response.data.responses[2].partitions.push_back(
           make_partition_response(0));
-        response.data.topics[2].partitions.push_back(
+        response.data.responses[2].partitions.push_back(
           make_partition_response(1));
         return response;
     };
@@ -328,13 +328,13 @@ FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
 
     for (auto it = response.begin(); it != response.end(); ++it) {
         if (i < 3) {
-            BOOST_REQUIRE_EQUAL(it->partition->name(), "tp-1");
+            BOOST_REQUIRE_EQUAL(it->partition->topic(), "tp-1");
             BOOST_REQUIRE_EQUAL(it->partition_response->partition_index(), i);
         } else if (i == 3) {
-            BOOST_REQUIRE_EQUAL(it->partition->name(), "tp-2");
+            BOOST_REQUIRE_EQUAL(it->partition->topic(), "tp-2");
             BOOST_REQUIRE_EQUAL(it->partition_response->partition_index(), 0);
         } else {
-            BOOST_REQUIRE_EQUAL(it->partition->name(), "tp-3");
+            BOOST_REQUIRE_EQUAL(it->partition->topic(), "tp-3");
             BOOST_REQUIRE_EQUAL(
               it->partition_response->partition_index(), i - 4);
         }
@@ -352,9 +352,9 @@ FIXTURE_TEST(fetch_non_existent, redpanda_thread_fixture) {
     kafka::fetch_request non_existent_ntp;
     non_existent_ntp.data.max_wait_ms = std::chrono::milliseconds(1000);
     non_existent_ntp.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic,
-      .fetch_partitions = {{
-        .partition_index = model::partition_id{-1},
+      .topic = topic,
+      .partitions = {{
+        .partition = model::partition_id{-1},
         .current_leader_epoch = kafka::leader_epoch(0),
         .fetch_offset = model::offset(0),
       }}});
@@ -367,11 +367,11 @@ FIXTURE_TEST(fetch_non_existent, redpanda_thread_fixture) {
     auto resp = client
                   .dispatch(std::move(non_existent_ntp), kafka::api_version(6))
                   .get();
-    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
-    BOOST_REQUIRE(resp.data.topics.at(0).errored());
-    BOOST_REQUIRE_EQUAL(resp.data.topics.at(0).partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE(resp.data.responses.at(0).errored());
+    BOOST_REQUIRE_EQUAL(resp.data.responses.at(0).partitions.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      resp.data.topics.at(0).partitions.at(0).error_code,
+      resp.data.responses.at(0).partitions.at(0).error_code,
       kafka::error_code::unknown_topic_or_partition);
 }
 
@@ -396,14 +396,14 @@ FIXTURE_TEST(fetch_empty, redpanda_thread_fixture) {
     auto resp_1
       = client.dispatch(std::move(no_topics), kafka::api_version(6)).get();
 
-    BOOST_REQUIRE(resp_1.data.topics.empty());
+    BOOST_REQUIRE(resp_1.data.responses.empty());
 
     kafka::fetch_request no_partitions;
     no_partitions.data.max_bytes = std::numeric_limits<int32_t>::max();
     no_partitions.data.min_bytes = 1;
     no_partitions.data.max_wait_ms = std::chrono::milliseconds(1000);
     no_partitions.data.topics.emplace_back(
-      kafka::fetch_topic{.name = topic, .fetch_partitions = {}});
+      kafka::fetch_topic{.topic = topic, .partitions = {}});
 
     // NOTE(oren): this looks like it was ill-formed before? see surrounding
     // code
@@ -411,7 +411,7 @@ FIXTURE_TEST(fetch_empty, redpanda_thread_fixture) {
       = client.dispatch(std::move(no_partitions), kafka::api_version(6)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE(resp_2.data.topics.empty());
+    BOOST_REQUIRE(resp_2.data.responses.empty());
 }
 
 FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
@@ -465,9 +465,9 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
     req.data.min_bytes = 1;
     req.data.max_wait_ms = std::chrono::milliseconds(1000);
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic,
-      .fetch_partitions = {{
-        .partition_index = pid,
+      .topic = topic,
+      .partitions = {{
+        .partition = pid,
         .current_leader_epoch = kafka::leader_epoch(1),
         .fetch_offset = model::offset(6),
       }}});
@@ -478,9 +478,10 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_REQUIRE_MESSAGE(
-      resp.data.topics[0].partitions[0].error_code
+      resp.data.responses[0].partitions[0].error_code
         == kafka::error_code::fenced_leader_epoch,
-      fmt::format("error: {}", resp.data.topics[0].partitions[0].error_code));
+      fmt::format(
+        "error: {}", resp.data.responses[0].partitions[0].error_code));
 }
 
 FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
@@ -503,16 +504,16 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
     req.data.max_wait_ms = std::chrono::milliseconds(3000);
     req.data.session_id = kafka::invalid_fetch_session_id;
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic,
-      .fetch_partitions = {},
+      .topic = topic,
+      .partitions = {},
     });
     for (int i = 0; i < 6; ++i) {
         kafka::fetch_request::partition p;
-        p.partition_index = model::partition_id(i);
+        p.partition = model::partition_id(i);
         p.log_start_offset = offset;
         p.fetch_offset = offset;
-        p.max_bytes = std::numeric_limits<int32_t>::max();
-        req.data.topics[0].fetch_partitions.push_back(p);
+        p.partition_max_bytes = std::numeric_limits<int32_t>::max();
+        req.data.topics[0].partitions.push_back(p);
     }
     auto client = make_kafka_client().get();
     client.connect().get();
@@ -541,20 +542,21 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
     auto resp = fresp.get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
-    BOOST_REQUIRE_EQUAL(resp.data.topics[0].name, topic());
-    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 6);
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].topic, topic());
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].partitions.size(), 6);
     size_t total_size = 0;
     for (int i = 0; i < 6; ++i) {
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].error_code,
+          resp.data.responses[0].partitions[i].error_code,
           kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].partition_index,
+          resp.data.responses[0].partitions[i].partition_index,
           model::partition_id(i));
-        BOOST_REQUIRE(resp.data.topics[0].partitions[i].records);
+        BOOST_REQUIRE(resp.data.responses[0].partitions[i].records);
 
-        total_size += resp.data.topics[0].partitions[i].records->size_bytes();
+        total_size
+          += resp.data.responses[0].partitions[i].records->size_bytes();
     }
     BOOST_REQUIRE_GT(total_size, 0);
 }
@@ -578,9 +580,9 @@ FIXTURE_TEST(fetch_leader_ack, redpanda_thread_fixture) {
     req.data.max_wait_ms = std::chrono::milliseconds(5000);
     req.data.session_id = kafka::invalid_fetch_session_id;
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic,
-      .fetch_partitions = {{
-        .partition_index = pid,
+      .topic = topic,
+      .partitions = {{
+        .partition = pid,
         .fetch_offset = offset,
       }},
     });
@@ -608,14 +610,16 @@ FIXTURE_TEST(fetch_leader_ack, redpanda_thread_fixture) {
     auto resp = fresp.get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE(resp.data.topics.size() == 1);
-    BOOST_REQUIRE(resp.data.topics[0].name == topic());
-    BOOST_REQUIRE(resp.data.topics[0].partitions.size() == 1);
+    BOOST_REQUIRE(resp.data.responses.size() == 1);
+    BOOST_REQUIRE(resp.data.responses[0].topic == topic());
+    BOOST_REQUIRE(resp.data.responses[0].partitions.size() == 1);
     BOOST_REQUIRE(
-      resp.data.topics[0].partitions[0].error_code == kafka::error_code::none);
-    BOOST_REQUIRE(resp.data.topics[0].partitions[0].partition_index == pid);
-    BOOST_REQUIRE(resp.data.topics[0].partitions[0].records);
-    BOOST_REQUIRE(resp.data.topics[0].partitions[0].records->size_bytes() > 0);
+      resp.data.responses[0].partitions[0].error_code
+      == kafka::error_code::none);
+    BOOST_REQUIRE(resp.data.responses[0].partitions[0].partition_index == pid);
+    BOOST_REQUIRE(resp.data.responses[0].partitions[0].records);
+    BOOST_REQUIRE(
+      resp.data.responses[0].partitions[0].records->size_bytes() > 0);
 }
 
 FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
@@ -635,9 +639,9 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
     req.data.max_wait_ms = std::chrono::milliseconds(5000);
     req.data.session_id = kafka::invalid_fetch_session_id;
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic,
-      .fetch_partitions = {{
-        .partition_index = pid,
+      .topic = topic,
+      .partitions = {{
+        .partition = pid,
         .fetch_offset = offset,
       }},
     });
@@ -665,14 +669,16 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
     auto resp = fresp.get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE(resp.data.topics.size() == 1);
-    BOOST_REQUIRE(resp.data.topics[0].name == topic());
-    BOOST_REQUIRE(resp.data.topics[0].partitions.size() == 1);
+    BOOST_REQUIRE(resp.data.responses.size() == 1);
+    BOOST_REQUIRE(resp.data.responses[0].topic == topic());
+    BOOST_REQUIRE(resp.data.responses[0].partitions.size() == 1);
     BOOST_REQUIRE(
-      resp.data.topics[0].partitions[0].error_code == kafka::error_code::none);
-    BOOST_REQUIRE(resp.data.topics[0].partitions[0].partition_index == pid);
-    BOOST_REQUIRE(resp.data.topics[0].partitions[0].records);
-    BOOST_REQUIRE(resp.data.topics[0].partitions[0].records->size_bytes() > 0);
+      resp.data.responses[0].partitions[0].error_code
+      == kafka::error_code::none);
+    BOOST_REQUIRE(resp.data.responses[0].partitions[0].partition_index == pid);
+    BOOST_REQUIRE(resp.data.responses[0].partitions[0].records);
+    BOOST_REQUIRE(
+      resp.data.responses[0].partitions[0].records->size_bytes() > 0);
 }
 
 FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
@@ -702,22 +708,22 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
     req.data.max_wait_ms = std::chrono::milliseconds(3000);
     req.data.session_id = kafka::invalid_fetch_session_id;
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic_1,
-      .fetch_partitions = {},
+      .topic = topic_1,
+      .partitions = {},
     });
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic_2,
-      .fetch_partitions = {},
+      .topic = topic_2,
+      .partitions = {},
     });
 
     for (auto& ntp : ntps) {
         kafka::fetch_request::partition p;
-        p.partition_index = model::partition_id(ntp.tp.partition);
+        p.partition = model::partition_id(ntp.tp.partition);
         p.log_start_offset = zero;
         p.fetch_offset = zero;
-        p.max_bytes = std::numeric_limits<int32_t>::max();
+        p.partition_max_bytes = std::numeric_limits<int32_t>::max();
         auto idx = ntp.tp.topic == topic_1 ? 0 : 1;
-        req.data.topics[idx].fetch_partitions.push_back(p);
+        req.data.topics[idx].partitions.push_back(p);
     }
 
     auto client = make_kafka_client().get();
@@ -745,22 +751,23 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
     auto resp = client.dispatch(std::move(req), kafka::api_version(4)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 2);
-    BOOST_REQUIRE_EQUAL(resp.data.topics[0].name, topic_1);
-    BOOST_REQUIRE_EQUAL(resp.data.topics[1].name, topic_2);
-    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 6);
-    BOOST_REQUIRE_EQUAL(resp.data.topics[1].partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 2);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].topic, topic_1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[1].topic, topic_2);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].partitions.size(), 6);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[1].partitions.size(), 1);
     size_t total_size = 0;
     for (int i = 0; i < 6; ++i) {
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].error_code,
+          resp.data.responses[0].partitions[i].error_code,
           kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].partition_index,
+          resp.data.responses[0].partitions[i].partition_index,
           model::partition_id(i));
-        BOOST_REQUIRE(resp.data.topics[0].partitions[i].records);
+        BOOST_REQUIRE(resp.data.responses[0].partitions[i].records);
 
-        total_size += resp.data.topics[0].partitions[i].records->size_bytes();
+        total_size
+          += resp.data.responses[0].partitions[i].records->size_bytes();
     }
     BOOST_REQUIRE_GT(total_size, 0);
 }
@@ -798,9 +805,9 @@ FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
         req.data.max_wait_ms = std::chrono::milliseconds(0);
         req.data.session_id = kafka::invalid_fetch_session_id;
         req.data.topics.emplace_back(kafka::fetch_topic{
-          .name = topic,
-          .fetch_partitions = {{
-            .partition_index = pid,
+          .topic = topic,
+          .partitions = {{
+            .partition = pid,
             .fetch_offset = model::offset(0),
           }},
         });
@@ -817,17 +824,17 @@ FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
     /**
      * At least one record has to be returned since KiP-74
      */
-    BOOST_REQUIRE(fetch_one_byte.data.topics.size() == 1);
-    BOOST_REQUIRE(fetch_one_byte.data.topics[0].name == topic());
-    BOOST_REQUIRE(fetch_one_byte.data.topics[0].partitions.size() == 1);
+    BOOST_REQUIRE(fetch_one_byte.data.responses.size() == 1);
+    BOOST_REQUIRE(fetch_one_byte.data.responses[0].topic == topic());
+    BOOST_REQUIRE(fetch_one_byte.data.responses[0].partitions.size() == 1);
     BOOST_REQUIRE(
-      fetch_one_byte.data.topics[0].partitions[0].error_code
+      fetch_one_byte.data.responses[0].partitions[0].error_code
       == kafka::error_code::none);
     BOOST_REQUIRE(
-      fetch_one_byte.data.topics[0].partitions[0].partition_index == pid);
-    BOOST_REQUIRE(fetch_one_byte.data.topics[0].partitions[0].records);
+      fetch_one_byte.data.responses[0].partitions[0].partition_index == pid);
+    BOOST_REQUIRE(fetch_one_byte.data.responses[0].partitions[0].records);
     BOOST_REQUIRE(
-      fetch_one_byte.data.topics[0].partitions[0].records->size_bytes() > 0);
+      fetch_one_byte.data.responses[0].partitions[0].records->size_bytes() > 0);
 }
 
 FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
@@ -888,9 +895,9 @@ FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
     req.data.max_wait_ms = std::chrono::milliseconds(0);
     req.data.session_id = kafka::invalid_fetch_session_id;
     req.data.topics.emplace_back(kafka::fetch_topic{
-      .name = topic,
-      .fetch_partitions = {{
-        .partition_index = pid,
+      .topic = topic,
+      .partitions = {{
+        .partition = pid,
         .fetch_offset = model::offset(0),
       }},
     });
@@ -902,18 +909,19 @@ FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
     auto resp = fresp.get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
-    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].partitions.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      resp.data.topics[0].partitions[0].error_code,
+      resp.data.responses[0].partitions[0].error_code,
       kafka::error_code::offset_out_of_range);
 
     // This is used by the clients to determine what should be done with the
     // offset out of range error. See
     // https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica
     BOOST_REQUIRE_EQUAL(
-      resp.data.topics[0].partitions[0].log_start_offset, model::offset(5));
-    BOOST_REQUIRE_EQUAL(resp.data.topics[0].partitions[0].high_watermark, hwm);
+      resp.data.responses[0].partitions[0].log_start_offset, model::offset(5));
     BOOST_REQUIRE_EQUAL(
-      resp.data.topics[0].partitions[0].last_stable_offset, hwm);
+      resp.data.responses[0].partitions[0].high_watermark, hwm);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].partitions[0].last_stable_offset, hwm);
 }

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -129,12 +129,12 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
     fetch_next(kafka::client::transport& consumer, model::partition_id p_id) {
         kafka::fetch_request::partition partition;
         partition.fetch_offset = fetch_offsets[p_id()];
-        partition.partition_index = p_id;
+        partition.partition = p_id;
         partition.log_start_offset = model::offset(0);
-        partition.max_bytes = 1_MiB;
+        partition.partition_max_bytes = 1_MiB;
         kafka::fetch_request::topic topic;
-        topic.name = test_topic;
-        topic.fetch_partitions.push_back(partition);
+        topic.topic = test_topic;
+        topic.partitions.push_back(partition);
 
         kafka::fetch_request req;
         req.data.min_bytes = 1;
@@ -144,10 +144,10 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
 
         return consumer.dispatch(std::move(req), kafka::api_version(4))
           .then([this, p_id](kafka::fetch_response resp) {
-              if (resp.data.topics.empty()) {
+              if (resp.data.responses.empty()) {
                   return resp;
               }
-              auto& part = *resp.data.topics.begin();
+              auto& part = *resp.data.responses.begin();
 
               for ([[maybe_unused]] auto& r : part.partitions) {
                   const auto& data = part.partitions.begin()->records;
@@ -202,21 +202,23 @@ FIXTURE_TEST(test_produce_consume_small_batches, prod_consume_fixture) {
                     }).get();
     auto resp_2 = fetch_next().get();
 
-    BOOST_REQUIRE_EQUAL(resp_1.data.topics.empty(), false);
-    BOOST_REQUIRE_EQUAL(resp_2.data.topics.empty(), false);
-    BOOST_REQUIRE_EQUAL(resp_1.data.topics.begin()->partitions.empty(), false);
+    BOOST_REQUIRE_EQUAL(resp_1.data.responses.empty(), false);
+    BOOST_REQUIRE_EQUAL(resp_2.data.responses.empty(), false);
     BOOST_REQUIRE_EQUAL(
-      resp_1.data.topics.begin()->partitions.begin()->error_code,
+      resp_1.data.responses.begin()->partitions.empty(), false);
+    BOOST_REQUIRE_EQUAL(
+      resp_1.data.responses.begin()->partitions.begin()->error_code,
       kafka::error_code::none);
     BOOST_REQUIRE_EQUAL(
-      resp_1.data.topics.begin()->partitions.begin()->records->last_offset(),
+      resp_1.data.responses.begin()->partitions.begin()->records->last_offset(),
       offset_1);
-    BOOST_REQUIRE_EQUAL(resp_2.data.topics.begin()->partitions.empty(), false);
     BOOST_REQUIRE_EQUAL(
-      resp_2.data.topics.begin()->partitions.begin()->error_code,
+      resp_2.data.responses.begin()->partitions.empty(), false);
+    BOOST_REQUIRE_EQUAL(
+      resp_2.data.responses.begin()->partitions.begin()->error_code,
       kafka::error_code::none);
     BOOST_REQUIRE_EQUAL(
-      resp_2.data.topics.begin()->partitions.begin()->records->last_offset(),
+      resp_2.data.responses.begin()->partitions.begin()->records->last_offset(),
       offset_2);
 };
 
@@ -401,11 +403,12 @@ struct throughput_limits_fixure : prod_consume_fixture {
                 ss::sleep(throttle_time).get();
             }
             const auto fetch_resp = fetch_next(consumers[i], p_id).get();
-            BOOST_REQUIRE_EQUAL(fetch_resp.data.topics.size(), 1);
-            BOOST_REQUIRE_EQUAL(fetch_resp.data.topics[0].partitions.size(), 1);
+            BOOST_REQUIRE_EQUAL(fetch_resp.data.responses.size(), 1);
+            BOOST_REQUIRE_EQUAL(
+              fetch_resp.data.responses[0].partitions.size(), 1);
             BOOST_TEST_REQUIRE(
-              fetch_resp.data.topics[0].partitions[0].records.has_value());
-            const auto kafka_data_len = fetch_resp.data.topics[0]
+              fetch_resp.data.responses[0].partitions[0].records.has_value());
+            const auto kafka_data_len = fetch_resp.data.responses[0]
                                           .partitions[0]
                                           .records.value()
                                           .size_bytes();

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -132,15 +132,15 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
   std::vector<model::partition_id> pids,
   model::offset offset_inclusive) {
     kafka::fetch_request::topic topic;
-    topic.name = topic_name;
-    topic.fetch_partitions.reserve(pids.size());
+    topic.topic = topic_name;
+    topic.partitions.reserve(pids.size());
     for (const auto& pid : pids) {
         kafka::fetch_request::partition partition;
         partition.fetch_offset = offset_inclusive;
-        partition.partition_index = pid;
+        partition.partition = pid;
         partition.log_start_offset = model::offset(0);
-        partition.max_bytes = 1_MiB;
-        topic.fetch_partitions.emplace_back(std::move(partition));
+        partition.partition_max_bytes = 1_MiB;
+        topic.partitions.emplace_back(std::move(partition));
     }
 
     kafka::fetch_request req;
@@ -160,11 +160,11 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
         ret.emplace(pid, std::vector<kv_t>{});
     }
     auto& data = fetch_resp.data;
-    for (auto& topic : data.topics) {
+    for (auto& topic : data.responses) {
         vlog(
           test_log.trace,
           "Processing topic {} from the fetch response",
-          topic.name);
+          topic.topic);
         for (auto& partition : topic.partitions) {
             if (partition.error_code != kafka::error_code::none) {
                 throw std::runtime_error(fmt::format(
@@ -173,13 +173,13 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
             vlog(
               test_log.trace,
               "Processing ntp {}/{} from the fetch response",
-              topic.name,
+              topic.topic,
               partition.partition_index);
             if (!partition.records.has_value()) {
                 vlog(
                   test_log.trace,
                   "No data in ntp {}/{}",
-                  topic.name,
+                  topic.topic,
                   partition.partition_index);
                 continue;
             }
@@ -189,7 +189,7 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
                     vlog(
                       test_log.trace,
                       "EOS ntp {}/{}",
-                      topic.name,
+                      topic.topic,
                       partition.partition_index);
                     break;
                 }
@@ -198,7 +198,7 @@ ss::future<pid_to_kvs_map_t> kafka_consume_transport::consume(
                   test_log.trace,
                   "Reading {} records, ntp {}/{}",
                   records.size(),
-                  topic.name,
+                  topic.topic,
                   partition.partition_index);
                 auto& records_for_partition = ret[partition.partition_index];
                 for (auto& r : records) {

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -106,7 +106,7 @@ public:
         for (auto& v : res) {
             auto r = std::move(*v.partition_response);
             model::topic_partition_view tpv(
-              v.partition->name, r.partition_index);
+              v.partition->topic, r.partition_index);
             while (r.records && !r.records->empty()) {
                 auto adapter = r.records->consume_batch();
                 if (

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -50,14 +50,14 @@ auto make_fetch_response(
           .high_watermark{model::offset{0}},
           .last_stable_offset{model::offset{1}},
           .log_start_offset{model::offset{0}},
-          .aborted{},
+          .aborted_transactions{},
           .records{make_record_set(offset, count)}});
         parts.push_back(std::move(res));
     }
     return kafka::fetch_response{
       .data = {
         .error_code = kafka::error_code::none,
-        .topics = std::move(parts),
+        .responses = std::move(parts),
       }};
 }
 

--- a/src/v/test_utils/go/go.mod
+++ b/src/v/test_utils/go/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/parquet-go/parquet-go v0.24.1-0.20250203011650-a58243e6e9c1
 	github.com/segmentio/encoding v0.4.1
 	github.com/sergi/go-diff v1.3.1
-	github.com/twmb/franz-go/pkg/kmsg v1.9.0
+	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 )
 
 require (

--- a/src/v/test_utils/go/go.sum
+++ b/src/v/test_utils/go/go.sum
@@ -43,8 +43,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
-github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
+github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
+github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=


### PR DESCRIPTION
This fixes a number of issues:
* Update kmsg to latest
* Avoid deadlock when `kreq-gen` has large output
* Support singular structs in the generator
* Set type overrides for the tagged structs

The schemata is updated to v13.

I'll implement future versions of fetch in another PR

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
