### PR TITLE
dt/data_migrations: add basic multi-cluster migration test

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -12,6 +12,7 @@ from enum import Enum
 from logging import Logger
 import random
 import json
+import copy
 import time
 import urllib.parse
 from typing import Any, Optional, Callable, NamedTuple, Protocol, cast
@@ -321,14 +322,41 @@ class OutboundDataMigration:
 
 class InboundTopic:
     def __init__(self,
-                 source_topic_reference: NamespacedTopic,
-                 alias: NamespacedTopic | None = None):
-        self.source_topic_reference = source_topic_reference
+                 topic_name: NamespacedTopic,
+                 alias: NamespacedTopic | None = None,
+                 cluster_uuid: str | None = None,
+                 remote_revision: int | None = None):
+        if remote_revision is not None:
+            assert cluster_uuid
+
+        self.topic_name = topic_name
         self.alias = alias
+        self.cluster_uuid = cluster_uuid
+        self.remote_revision = remote_revision
+
+    def location_hint(self):
+        """
+        A hint allowing to disambiguate different instances of topic data
+        in cloud storage when mounting a topic.
+        """
+
+        if self.remote_revision is not None:
+            return f"{self.cluster_uuid}/{self.remote_revision}"
+        elif self.cluster_uuid is not None:
+            return self.cluster_uuid
+        else:
+            return ""
+
+    def source_topic_reference(self):
+        ret = copy.copy(self.topic_name)
+        location_hint = self.location_hint()
+        if location_hint:
+            ret.topic += "/" + location_hint
+        return ret
 
     def as_dict(self):
         d = {
-            'source_topic_reference': self.source_topic_reference.as_dict(),
+            'source_topic_reference': self.source_topic_reference().as_dict(),
         }
         if self.alias:
             d['alias'] = self.alias.as_dict()

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -532,8 +532,7 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                 self.toggle_license(on=False)
             self.check_migrations(in_migration_id, len(inbound_topics), 2)
 
-            self.log_topics(t.source_topic_reference.topic
-                            for t in inbound_topics)
+            self.log_topics(t.topic_name.topic for t in inbound_topics)
 
             self.execute_data_migration_action_flaky(in_migration_id,
                                                      MigrationAction.prepare)
@@ -601,9 +600,9 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
         # mount and consume from them in random order
         cluster_uuid = self.admin.get_cluster_uuid(self.redpanda.nodes[0])
         for i in sorted(range(3), key=lambda element: random.random()):
-            hinted_ns_topic = make_namespaced_topic(
-                f"{ns_topic.topic}/{cluster_uuid}/{revisions[i]}")
-            in_topic = InboundTopic(hinted_ns_topic)
+            in_topic = InboundTopic(ns_topic,
+                                    cluster_uuid=cluster_uuid,
+                                    remote_revision=revisions[i])
             in_migr_id = self.admin.mount_topics([in_topic]).json()["id"]
             self.wait_partitions_appear([topic])
             self.wait_migration_disappear(in_migr_id)
@@ -653,7 +652,7 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
             for i, t in enumerate(topics[:3])
         ]
         inbound_topics_spec = [
-            TopicSpec(name=(it.alias or it.source_topic_reference).topic,
+            TopicSpec(name=(it.alias or it.topic_name).topic,
                       partition_count=3) for it in inbound_topics
         ]
         reply = self.admin.mount_topics(inbound_topics).json()
@@ -972,8 +971,7 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
             # two cycles max: to cancel halfway and to complete + check e2e
             while not remounted:
                 in_migration = InboundDataMigration(topics=[
-                    InboundTopic(source_topic_reference=workload_ns_topic,
-                                 alias=alias)
+                    InboundTopic(topic_name=workload_ns_topic, alias=alias)
                 ],
                                                     consumer_groups=[])
                 in_migration_id = self.create_and_wait(in_migration)

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -24,7 +24,7 @@ from ducktape.mark import matrix, ignore
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RedpandaService, RedpandaServiceBase, SISettings
+from rptest.services.redpanda import RedpandaService, RedpandaServiceBase, SISettings, make_redpanda_service
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
 from rptest.services.redpanda import SISettings
 from rptest.tests.redpanda_test import RedpandaTest
@@ -1133,3 +1133,150 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
         list_mountable_res = admin.list_mountable_topics().json()
         assert len(list_mountable_res["topics"]
                    ) == 2, "There should be 2 mountable topics"
+
+
+class DataMigrationsMultiClusterTest(RedpandaTest, DataMigrationTestMixin):
+    log_segment_size = 10 * 1024
+    msg_size = 128
+
+    def __init__(self, test_context: TestContext, *args, **kwargs):
+        kwargs['si_settings'] = SISettings(
+            test_context=test_context,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_max_connections=5,
+        )
+        RedpandaTest.__init__(self, test_context=test_context, *args, **kwargs)
+        self.producer = None
+        self.extra_clusters = []
+
+    @property
+    def producer_throughput(self):
+        return 16 * 1024 if self.debug_mode else 1024 * 1024
+
+    def start_producer(self, topic, redpanda) -> None:
+        assert self.producer is None
+        self.producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=redpanda,
+            topic=topic,
+            msg_size=self.msg_size,
+            msg_count=100_000_000,
+            rate_limit_bps=self.producer_throughput,
+            tolerate_failed_produce=True,
+            trace_logs=True,
+        )
+
+        self.producer.start()
+        self.producer.wait_for_acks(1000, timeout_sec=60, backoff_sec=2)
+
+    def stop_producer(self) -> int:
+        "return the number of acked messages"
+        if self.producer is None:
+            return
+
+        self.producer.stop()
+        acked = self.producer.produce_status.acked
+        self.producer.free()
+        self.logger.info(f"stopped producer, {acked=}")
+        self.producer = None
+        return acked
+
+    def start_consumer(self, topic,
+                       redpanda) -> KgoVerifierConsumerGroupConsumer:
+        consumer = KgoVerifierConsumerGroupConsumer(self.test_context,
+                                                    redpanda,
+                                                    topic,
+                                                    self.msg_size,
+                                                    readers=3,
+                                                    group_name="test-group",
+                                                    trace_logs=True)
+
+        consumer.start()
+        return consumer
+
+    def consume(self, topic, redpanda, msg_count) -> None:
+        consumer = self.start_consumer(topic, redpanda)
+        self.logger.info(f"expecting to consume {msg_count} messages")
+        consumer.wait_total_reads(msg_count, timeout_sec=30, backoff_sec=1)
+        consumer.free()
+
+    def start_extra_cluster(self, num_brokers=3):
+        si_settings = SISettings(
+            self.test_context,
+            bypass_bucket_creation=True,
+            log_segment_size=self.log_segment_size,
+            cloud_storage_max_connections=5,
+        )
+        si_settings.reset_cloud_storage_bucket(
+            self.si_settings.cloud_storage_bucket)
+
+        cluster = make_redpanda_service(
+            self.test_context,
+            num_brokers=num_brokers,
+            si_settings=si_settings,
+        )
+        self.extra_clusters.append(cluster)
+
+        cluster.start()
+        return cluster
+
+    @cluster(num_nodes=10)
+    def test_basic(self):
+        """
+        Test that basic functionality like producing and consuming works when we
+        migrate topics between different clusters.
+        """
+        n_partitions = 10
+        workload_topic = TopicSpec(name="foo", partition_count=n_partitions)
+        workload_ns_topic = make_namespaced_topic(workload_topic.name)
+
+        dest_redpanda = self.start_extra_cluster()
+
+        self.client().create_topic(workload_topic)
+        self.logger.info(f"created topic {workload_topic}")
+
+        self.start_producer(workload_topic.name, self.redpanda)
+        self.migrate_between_clusters([workload_ns_topic], self.redpanda,
+                                      dest_redpanda)
+        total_acked = self.stop_producer()
+
+        def wait_for_offsets(redpanda, expected):
+            def predicate():
+                rpk = RpkTool(redpanda)
+                partitions = list(rpk.describe_topic(workload_topic.name))
+                if len(partitions) != n_partitions:
+                    return False
+                total = sum(p.high_watermark for p in partitions)
+                self.logger.info(f"offsets: {total=}, {expected=}")
+                return total == expected
+
+            wait_until(
+                predicate,
+                timeout_sec=15,
+                backoff_sec=1,
+                err_msg="timed out waiting for offsets of migrated topic")
+
+        wait_for_offsets(dest_redpanda, total_acked)
+
+        self.logger.info("producing more to the second cluster")
+        self.start_producer(workload_topic.name, dest_redpanda)
+
+        self.consume(workload_topic.name,
+                     redpanda=dest_redpanda,
+                     msg_count=total_acked +
+                     self.producer.produce_status.acked)
+
+        another_redpanda = self.start_extra_cluster()
+        self.migrate_between_clusters([workload_ns_topic], dest_redpanda,
+                                      another_redpanda)
+
+        total_acked += self.stop_producer()
+        wait_for_offsets(another_redpanda, total_acked)
+
+        self.logger.info("producing more to the third cluster")
+        self.start_producer(workload_topic.name, another_redpanda)
+        total_acked += self.stop_producer()
+
+        self.consume(workload_topic.name,
+                     redpanda=another_redpanda,
+                     msg_count=total_acked)

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -10,8 +10,10 @@
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
+from rptest.clients.default import DefaultClient
 
 from rptest.services.admin import OutboundDataMigration, InboundDataMigration
+from rptest.services.redpanda import RedpandaService
 from requests.exceptions import ConnectionError
 
 import time
@@ -23,12 +25,17 @@ def now():
 
 
 class DataMigrationTestMixin:
-    """ assumes self.redpanda, self.admin and self.client() present """
-    def wait_partitions_appear(self, topics: list[TopicSpec]):
+    def wait_partitions_appear(self,
+                               topics: list[TopicSpec],
+                               redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+        client = DefaultClient(redpanda)
+
         # we may be unlucky to query a slow node
         def topic_has_all_partitions(t: TopicSpec):
-            part_cnt = len(self.client().describe_topic(t.name).partitions)
-            self.redpanda.logger.debug(
+            part_cnt = len(client.describe_topic(t.name).partitions)
+            redpanda.logger.debug(
                 f"topic {t.name} has {part_cnt} partitions out of {t.partition_count} expected"
             )
             return t.partition_count == part_cnt
@@ -37,7 +44,7 @@ class DataMigrationTestMixin:
             msg = "Failed waiting for partitions to appear:\n"
             for t in topics:
                 msg += f"   {t.name} expected {t.partition_count} partitions, "
-                msg += f"got {len(self.client().describe_topic(t.name).partitions)} partitions\n"
+                msg += f"got {len(client.describe_topic(t.name).partitions)} partitions\n"
             return msg
 
         wait_until(lambda: all(topic_has_all_partitions(t) for t in topics),
@@ -45,41 +52,64 @@ class DataMigrationTestMixin:
                    backoff_sec=1,
                    err_msg=err_msg)
 
-    def wait_partitions_disappear(self, topics: list[str]):
-        # we may be unlucky to query a slow node
-        wait_until(
-            lambda: all(self.client().describe_topic(t).partitions == []
-                        for t in topics),
-            timeout_sec=90,
-            backoff_sec=1,
-            err_msg=f"Failed waiting for partitions to disappear")
+    def wait_partitions_disappear(self,
+                                  topics: list[str],
+                                  redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+        client = DefaultClient(redpanda)
 
-    def get_migration(self, id, node=None):
+        # we may be unlucky to query a slow node
+        wait_until(lambda: all(
+            client.describe_topic(t).partitions == [] for t in topics),
+                   timeout_sec=90,
+                   backoff_sec=1,
+                   err_msg=f"Failed waiting for partitions to disappear")
+
+    def get_migration(self,
+                      id,
+                      node=None,
+                      redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
         try:
-            return self.admin.get_data_migration(id, node).json()
+            return redpanda._admin.get_data_migration(id, node).json()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 return None
             else:
                 raise
 
-    def get_migrations_map(self, node=None):
-        self.redpanda.logger.debug("calling self.admin.list_data_migrations")
-        migrations = self.admin.list_data_migrations(node).json()
-        self.redpanda.logger.debug(
+    def get_migrations_map(self,
+                           node=None,
+                           redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
+        redpanda.logger.debug("calling self.admin.list_data_migrations")
+        migrations = redpanda._admin.list_data_migrations(node).json()
+        redpanda.logger.debug(
             "received self.admin.list_data_migrations result")
         return {migration["id"]: migration for migration in migrations}
 
-    def on_all_live_nodes(self, migration_id, predicate):
+    def on_all_live_nodes(self,
+                          migration_id,
+                          predicate,
+                          redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
         success_cnt = 0
         exception_cnt = 0
-        for n in self.redpanda.nodes:
+        for n in redpanda.nodes:
             try:
-                map = self.get_migrations_map(n)
-                self.redpanda.logger.debug(
-                    f"migrations on node {n.name}: {map}")
+                map = self.get_migrations_map(n, redpanda=redpanda)
+                redpanda.logger.debug(f"migrations on node {n.name}: {map}")
                 list_item = map[migration_id] if migration_id in map else None
-                individual = self.get_migration(migration_id, n)
+                individual = self.get_migration(migration_id,
+                                                n,
+                                                redpanda=redpanda)
 
                 if predicate(list_item) and predicate(individual):
                     success_cnt += 1
@@ -95,7 +125,13 @@ class DataMigrationTestMixin:
         err_ms = 5  # allow for ntp error across nodes
         assert time_before - err_ms <= happened_at <= time_now + err_ms
 
-    def wait_migration_appear(self, migration_id, assure_created_after):
+    def wait_migration_appear(self,
+                              migration_id,
+                              assure_created_after,
+                              redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
         def migration_present_on_node(m):
             if m is None:
                 return False
@@ -103,7 +139,9 @@ class DataMigrationTestMixin:
             return True
 
         def migration_is_present(id: int):
-            return self.on_all_live_nodes(id, migration_present_on_node)
+            return self.on_all_live_nodes(id,
+                                          migration_present_on_node,
+                                          redpanda=redpanda)
 
         wait_until(
             lambda: migration_is_present(migration_id),
@@ -111,36 +149,48 @@ class DataMigrationTestMixin:
             backoff_sec=2,
             err_msg=f"Expected migration with id {migration_id} is present")
 
-    def create_and_wait(self, migration: InboundDataMigration
-                        | OutboundDataMigration):
+    def create_and_wait(self,
+                        migration: InboundDataMigration
+                        | OutboundDataMigration,
+                        redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
         def migration_id_if_exists():
-            for n in self.redpanda.nodes:
-                for m in self.admin.list_data_migrations(n).json():
+            for n in redpanda.nodes:
+                for m in redpanda._admin.list_data_migrations(n).json():
                     if m == migration:
                         return m[id]
             return None
 
         time_before_creation = now()
         try:
-            reply = self.admin.create_data_migration(migration).json()
-            self.redpanda.logger.info(f"create migration reply: {reply}")
+            reply = redpanda._admin.create_data_migration(migration).json()
+            redpanda.logger.info(f"create migration reply: {reply}")
             migration_id = reply["id"]
         except requests.exceptions.HTTPError as e:
             maybe_id = migration_id_if_exists()
             if maybe_id is None:
                 raise
             migration_id = maybe_id
-            self.redpanda.logger.info(
-                f"create migration failed "
-                f"but migration {migration_id} present: {e}")
+            redpanda.logger.info(f"create migration failed "
+                                 f"but migration {migration_id} present: {e}")
 
-        self.wait_migration_appear(migration_id, time_before_creation)
+        self.wait_migration_appear(migration_id,
+                                   time_before_creation,
+                                   redpanda=redpanda)
 
         return migration_id
 
-    def assure_not_deletable(self, id, node=None):
+    def assure_not_deletable(self,
+                             id,
+                             node=None,
+                             redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
         try:
-            self.admin.delete_data_migration(id, node)
+            redpanda._admin.delete_data_migration(id, node)
             assert False
         except requests.exceptions.HTTPError:
             pass
@@ -148,7 +198,11 @@ class DataMigrationTestMixin:
     def wait_for_migration_states(self,
                                   id: int,
                                   states: list[str],
-                                  assure_completed_after: int = 0):
+                                  assure_completed_after: int = 0,
+                                  redpanda: RedpandaService | None = None):
+        if redpanda is None:
+            redpanda = self.redpanda
+
         def migration_in_one_of_states_on_node(m):
             if m is None:
                 return False
@@ -161,7 +215,8 @@ class DataMigrationTestMixin:
 
         def migration_in_one_of_states():
             return self.on_all_live_nodes(id,
-                                          migration_in_one_of_states_on_node)
+                                          migration_in_one_of_states_on_node,
+                                          redpanda=redpanda)
 
         self.logger.info(f'waiting for {" or ".join(states)}')
         wait_until(
@@ -173,4 +228,4 @@ class DataMigrationTestMixin:
         )
         if all(state not in ('planned', 'finished', 'cancelled')
                for state in states):
-            self.assure_not_deletable(id)
+            self.assure_not_deletable(id, redpanda=redpanda)

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -12,7 +12,7 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
 
-from rptest.services.admin import OutboundDataMigration, InboundDataMigration
+from rptest.services.admin import OutboundDataMigration, InboundDataMigration, NamespacedTopic, InboundTopic, MigrationAction
 from rptest.services.redpanda import RedpandaService
 from requests.exceptions import ConnectionError
 
@@ -229,3 +229,79 @@ class DataMigrationTestMixin:
         if all(state not in ('planned', 'finished', 'cancelled')
                for state in states):
             self.assure_not_deletable(id, redpanda=redpanda)
+
+    def migrate_between_clusters(self, topics: list[NamespacedTopic],
+                                 source: RedpandaService,
+                                 dest: RedpandaService) -> None:
+        assert source != dest
+
+        out_migration = OutboundDataMigration(topics=topics,
+                                              consumer_groups=[])
+
+        out_migration_id = self.create_and_wait(out_migration, redpanda=source)
+        source.logger.info(
+            f"created outbound migration, id {out_migration_id}")
+
+        # TODO: Outbound migrations should provide a better way of determining
+        # location hints for migrated topic instances. Currently if we don't know the
+        # originating cluster UUID, we can't determine the location hint at all.
+        # Here we assume that the topic was first created on self.redpanda.
+        # Getting the remote revision by calling an unrelated API is inefficient
+        # and awkward as well.
+        orig_cluster_uuid = self.redpanda._admin.get_cluster_uuid()
+        in_topics = []
+        for topic in topics:
+            anomalies = source._admin.get_cloud_storage_anomalies(
+                namespace="kafka", topic=topic.topic, partition=0)
+            remote_revision_id = anomalies["revision_id"]
+
+            in_topics.append(
+                InboundTopic(topic,
+                             cluster_uuid=orig_cluster_uuid,
+                             remote_revision=remote_revision_id))
+
+        in_migration = InboundDataMigration(topics=in_topics,
+                                            consumer_groups=[])
+        in_migration_id = self.create_and_wait(in_migration, redpanda=dest)
+        dest.logger.info(f"created inbound migration, id {in_migration_id}")
+
+        source._admin.execute_data_migration_action(out_migration_id,
+                                                    MigrationAction.prepare)
+        self.wait_for_migration_states(out_migration_id, ['prepared'],
+                                       redpanda=source)
+        self.logger.info(f"prepared on source")
+
+        source._admin.execute_data_migration_action(out_migration_id,
+                                                    MigrationAction.execute)
+        self.wait_for_migration_states(out_migration_id, ['executed'],
+                                       redpanda=source)
+        self.logger.info(f"executed on source")
+
+        source._admin.execute_data_migration_action(out_migration_id,
+                                                    MigrationAction.finish)
+        self.wait_for_migration_states(out_migration_id, ['finished'],
+                                       redpanda=source)
+        self.logger.info(f"finished on source")
+
+        # TODO: currently migrations need to be executed sequentially (on source
+        # then on destination). Ideally the implementation should allow for concurrent
+        # execution (i.e. we could start some preparations on destination while
+        # source migration is still being executed).
+
+        dest._admin.execute_data_migration_action(in_migration_id,
+                                                  MigrationAction.prepare)
+        self.wait_for_migration_states(in_migration_id, ['prepared'],
+                                       redpanda=dest)
+        self.logger.info(f"prepared on dest")
+
+        dest._admin.execute_data_migration_action(in_migration_id,
+                                                  MigrationAction.execute)
+        self.wait_for_migration_states(in_migration_id, ['executed'],
+                                       redpanda=dest)
+        self.logger.info(f"executed on dest")
+
+        dest._admin.execute_data_migration_action(in_migration_id,
+                                                  MigrationAction.finish)
+        self.wait_for_migration_states(in_migration_id, ['finished'],
+                                       redpanda=dest)
+        self.logger.info(f"finished on dest")


### PR DESCRIPTION
Add a test verifying that basic functionality like producing and consuming works when we migrate topics between different clusters.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none