### PR TITLE
[CORE-9229] kafka/server: Revert Metadata to v8

### DIFF
--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -25,6 +25,6 @@ namespace kafka {
 memory_estimate_fn metadata_memory_estimator;
 
 using metadata_handler
-  = single_stage_handler<metadata_api, 0, 11, metadata_memory_estimator>;
+  = single_stage_handler<metadata_api, 0, 8, metadata_memory_estimator>;
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/sasl_handshake.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
+#include "kafka/server/handlers/metadata.h"
 #include "model/ktp.h"
 #include "model/timeout_clock.h"
 #include "random/generators.h"
@@ -346,6 +347,9 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
 
 FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
     using kafka::api_version;
+    if (kafka::metadata_handler::max_supported < api_version{12}) {
+        return;
+    }
 
     auto client = make_kafka_client().get();
     client.connect().get();
@@ -381,6 +385,9 @@ FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
 
 FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
     using kafka::api_version;
+    if (kafka::metadata_handler::max_supported < api_version{12}) {
+        return;
+    }
     ss::sstring test_topic_name = "metadata_non_empty_topic_id";
 
     create_topic(test_topic_name, 1, 1);
@@ -417,7 +424,7 @@ FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
 FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
     // Cluster authorized operations are returned only from v8 to v10
     using namespace kafka;
-    using api = kafka::metadata_api;
+    constexpr auto max_supported = kafka::metadata_handler::max_supported;
 
     auto client = make_kafka_client().get();
     client.connect().get();
@@ -434,7 +441,7 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
     const auto cluster_ops = kafka::details::to_bit_field(
       kafka::details::get_allowed_operations<security::acl_cluster_name>());
 
-    for (api_version ver{1}; ver < api::max_valid; ++ver) {
+    for (api_version ver{1}; ver < max_supported; ++ver) {
         auto resp = client.dispatch(make_request(), ver).get();
         BOOST_REQUIRE(!resp.data.errored());
         const auto expected

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -40,7 +40,7 @@ class SaramaProduceTest(RedpandaTest):
                                                 extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0"])
     def test_produce(self, version):
         verifier_bin = "/opt/redpanda-tests/go/sarama/produce_test/produce_test"
 

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -41,7 +41,7 @@ class SaramaTest(RedpandaTest):
         self._timeout = 30 if self.scale.local else 1200
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0"])
     def test_sarama_interceptors(self, version):
         sarama_example = SaramaExamples.SaramaInterceptors(
             self.redpanda, version, self.topic)
@@ -57,7 +57,7 @@ class SaramaTest(RedpandaTest):
                    backoff_sec=1)
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0"])
     def test_sarama_http_server(self, version):
         sarama_example = SaramaExamples.SaramaHttpServer(
             self.redpanda, version)
@@ -95,7 +95,7 @@ class SaramaTest(RedpandaTest):
                    err_msg="sarama http_server test failed")
 
     @cluster(num_nodes=5)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0"])
     def test_sarama_consumergroup(self, version):
         count = 10 if self.scale.local else 5000
 
@@ -152,7 +152,7 @@ class SaramaScramTest(RedpandaTest):
         super(SaramaScramTest, self).__init__(test_context, security=security)
 
     @cluster(num_nodes=3)
-    @matrix(version=["2.1.0", "2.6.0"])
+    @matrix(version=["2.1.0"])
     def test_sarama_sasl_scram(self, version):
         # Get the SASL SCRAM command and a ducktape node
         cmd = SaramaExamples.sarama_sasl_scram(self.redpanda, version,

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -80,10 +80,8 @@ class SimpleEndToEndTest(EndToEndTest):
             error = e
 
         assert error is not None
-        # flaky: disabling until CORE-9229 is fixed
-        assert True or "Consumed from an unexpected" in str(
-            error) or "is behind the current committed offset" in str(
-                error), f"unexpected error: {error}"
+        assert "Consumed from an unexpected" in str(
+            error) or "is behind the current committed offset" in str(error)
 
     @skip_debug_mode
     @cluster(num_nodes=6)


### PR DESCRIPTION
This should fix the flaky test with metadata v9

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
