### PR TITLE
rptest: ignore default allow list on crash check

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3753,12 +3753,7 @@ class RedpandaService(RedpandaServiceBase):
         are actually redpanda crashes.
         """
 
-        allow_list = []
-        if log_allow_list:
-            for a in log_allow_list:
-                if should_compile(a):
-                    a = re.compile(a)
-                allow_list.append(a)
+        allow_list = prepare_allow_list(log_allow_list)
 
         def is_allowed_log_line(line: str) -> bool:
             for a in allow_list:


### PR DESCRIPTION
We previously didn't account for DEFAULT_LOG_ALLOW_LIST in raise_on_crash(), meaning we could incorrectly label the following as a crash:

```
WARN  2025-04-22 17:52:41,135 [shard 2:main] iceberg - catalog_client.cc:342 - [/v1/namespaces/redpanda/tables/topic_000165] error: http_call_error: Conflict, message: '{"error":{"message":"Requirement failed: branch main was created concurrently","type":"CommitFailedException","code":409,"stack":["org.apache.iceberg.exceptions.CommitFailedException: Requirement failed: branch main was created concurrently","\tat org.apache.iceberg.UpdateRequirement$AssertRefSnapshotID.validate(UpdateRequirement.java:115)","\tat org.apache.iceberg.rest.CatalogHandlers.lambda$comm'
```

This fixes this by calling prepare_allow_list() to create the allowed logs (as is done by raise_on_bad_logs()), which takes the defaults into account.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
