### PR TITLE
bazel: Fix OpenSSL build to get correct openssldir

### DIFF
--- a/bazel/thirdparty/openssl-fips.BUILD
+++ b/bazel/thirdparty/openssl-fips.BUILD
@@ -8,9 +8,20 @@ filegroup(
 
 configure_make(
     name = "openssl-fips",
+    args = [
+        "-j$OPENSSL_BUILD_JOBS",
+        # This will cause OpenSSL to ignore the prefix flag and install at the specified DESTDIR
+        "DESTDIR=$BUILD_TMPDIR/openssl-fips",
+    ],
     configure_command = "Configure",
     configure_options = [
+        # OpenSSL will look for system certs in a path relative to the OPENSSLDIR macro
+        # This macro is defined as <prefix>/<openssldir>
+        # Most linux environments install system certs in /etc/ssl/certs, so we set
+        # the OPENSSLDIR macro to /etc/ssl
         "enable-fips",
+        "--prefix=/",
+        "--openssldir=/etc/ssl",
         "--libdir=lib",
         "no-tests",
     ] + select({
@@ -57,7 +68,7 @@ genrule(
     name = "fipsmodule_cnf",
     srcs = [":gen_dir"],
     outs = ["fipsmodule.cnf"],
-    cmd = "cp -L $(SRCS)/ssl/fipsmodule.cnf $@",
+    cmd = "cp -L $(SRCS)/etc/ssl/fipsmodule.cnf $@",
     visibility = [
         "//visibility:public",
     ],

--- a/bazel/thirdparty/openssl.BUILD
+++ b/bazel/thirdparty/openssl.BUILD
@@ -43,9 +43,19 @@ filegroup(
 configure_make(
     name = "openssl",
     # These don't get make variables expanded, so use the injected environment variable.
-    args = ["-j$OPENSSL_BUILD_JOBS"],
+    args = [
+        "-j$OPENSSL_BUILD_JOBS",
+        # This will cause OpenSSL to ignore the prefix flag and install at the specified DESTDIR
+        "DESTDIR=$BUILD_TMPDIR/openssl",
+    ],
     configure_command = "Configure",
     configure_options = [
+        # OpenSSL will look for system certs in a path relative to the OPENSSLDIR macro
+        # This macro is defined as <prefix>/<openssldir>
+        # Most linux environments install system certs in /etc/ssl/certs, so we set
+        # the OPENSSLDIR macro to /etc/ssl
+        "--prefix=/",
+        "--openssldir=/etc/ssl",
         "--libdir=lib",
         "no-tests",
     ] + select({
@@ -61,7 +71,7 @@ configure_make(
         "openssl",
     ],
     out_data_dirs = [
-        "ssl",
+        "etc/ssl",
     ],
     out_shared_libs = [
         "libssl.so.3",


### PR DESCRIPTION
When OpenSSL looks for system certificates, it uses a path relative to the macro "OPENSSLDIR".  This is compiled into the OpenSSL library and is set when the build is configured.

The OpenSSL Configure script takes in `--openssldir` which sets the OPENSSLDIR macro to the path specified, relative to the value set to `--prefix`, so the OPENSSLDIR macro becomes `<prefix>/<openssldir>`.

In most Linux systems, the system certificates are installed in `/etc/ssl/certs`, so OpenSSL needs to have its OPENSSLDIR macro set to `/etc/ssl`.  To do this in bazel we have to do the following:

* Set `--prefix` to `/`
* Set `--openssldir` to `/etc/ssl`
* Run `make` with `DESTDIR` set to the directory where the build products should be installed into.

This arised when errors were observed in the OIDC ducktape tests when using TLS.  In ducktape, we install root certificates into /etc/ssl/certs, however because the OpenSSL build was not looking for the system certificates there, the test would fail because OpenSSL did not trust our root CA certificate.  This change addresses this issue.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
