### PR TITLE
tx/chaos: deflake TxSubscribeTest

### DIFF
--- a/tests/rptest/chaos_tests/single_fault_test.py
+++ b/tests/rptest/chaos_tests/single_fault_test.py
@@ -510,5 +510,8 @@ class TxSubscribeTest(SingleFaultTestBase):
 
         timings = TimingConfig()
 
+        # Avoid partition rebalancing during the test
+        self.redpanda.set_cluster_config(
+            {'partition_autobalancing_mode': 'off'})
         self.prepare(workload, timings)
         self.run(workload, fault, timings, case.check_progress_during_fault)


### PR DESCRIPTION
After https://github.com/redpanda-data/redpanda/pull/25841, balancer kicks in a bit later than before conflicting with the expected replica distribution in the test. The PR disables the balancer before allocating replicas but an alternative fix could be to wait for a quiescent state of the balancer.

Fixes

https://redpandadata.atlassian.net/browse/CORE-9964
https://redpandadata.atlassian.net/browse/CORE-9963
https://redpandadata.atlassian.net/browse/CORE-8115

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
