### PR TITLE
tests/node_ops: log partition balancer status with decommission progress

### DIFF
--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -210,6 +210,8 @@ class NodeDecommissionWaiter():
             try:
                 decommission_status = self.admin.get_decommission_status(
                     self.node_id, self._not_decommissioned_node())
+                partition_balancer_status = self.admin.get_partition_balancer_status(
+                    self._not_decommissioned_node())
             except requests.exceptions.HTTPError as e:
                 self.logger.info(
                     f"unable to get decommission status, HTTP error",
@@ -223,7 +225,7 @@ class NodeDecommissionWaiter():
                 continue
 
             self.logger.debug(
-                f"Node {self.node_id} decommission status: {decommission_status}"
+                f"Node {self.node_id} decommission status: {decommission_status}, partition balancer status: {partition_balancer_status}"
             )
 
             replicas_left = decommission_status['replicas_left']


### PR DESCRIPTION
Logging partition balancer status will make debugging decommissioning issues easier as it will be straight forward to diagnose balancing issues.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none