### PR TITLE
Add {min,max}.compaction.lag.ms configuration

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -512,6 +512,8 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       tristate<double>{},
       std::nullopt,
+      std::nullopt,
+      std::nullopt,
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -334,6 +334,16 @@ metadata_cache::get_default_min_cleanable_dirty_ratio() const {
     return config::shard_local_cfg().min_cleanable_dirty_ratio();
 }
 
+std::chrono::milliseconds
+metadata_cache::get_default_min_compaction_lag_ms() const {
+    return config::shard_local_cfg().min_compaction_lag_ms();
+}
+
+std::chrono::milliseconds
+metadata_cache::get_default_max_compaction_lag_ms() const {
+    return config::shard_local_cfg().max_compaction_lag_ms();
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};
@@ -355,6 +365,8 @@ topic_properties metadata_cache::get_default_properties() const {
       get_default_delete_retention_ms()};
     tp.min_cleanable_dirty_ratio = tristate<double>{
       get_default_min_cleanable_dirty_ratio()};
+    tp.min_compaction_lag_ms = get_default_min_compaction_lag_ms();
+    tp.max_compaction_lag_ms = get_default_max_compaction_lag_ms();
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -206,6 +206,8 @@ public:
     get_default_delete_retention_ms() const;
     std::chrono::milliseconds get_default_iceberg_target_lag_ms() const;
     std::optional<double> get_default_min_cleanable_dirty_ratio() const;
+    std::chrono::milliseconds get_default_min_compaction_lag_ms() const;
+    std::chrono::milliseconds get_default_max_compaction_lag_ms() const;
 
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>

--- a/src/v/cluster/topic_configuration.cc
+++ b/src/v/cluster/topic_configuration.cc
@@ -61,6 +61,8 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .cloud_topic_enabled = properties.cloud_topic_enabled,
             .tombstone_retention_ms = properties.delete_retention_ms,
             .min_cleanable_dirty_ratio = properties.min_cleanable_dirty_ratio,
+            .min_compaction_lag_ms = properties.min_compaction_lag_ms,
+            .max_compaction_lag_ms = properties.max_compaction_lag_ms,
             .remote_allow_gaps = properties.remote_topic_allow_gaps,
           });
     }

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -47,7 +47,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "iceberg_partition_spec: {}, "
       "iceberg_invalid_record_action: {}, "
       "iceberg_target_lag_ms: {}, "
-      "min_cleanable_dirty_ratio: {}",
+      "min_cleanable_dirty_ratio: {}, "
+      "min_compaction_lag_ms: {}, "
+      "max_compaction_lag_ms: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -89,7 +91,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.iceberg_partition_spec,
       properties.iceberg_invalid_record_action,
       properties.iceberg_target_lag_ms,
-      properties.min_cleanable_dirty_ratio);
+      properties.min_cleanable_dirty_ratio,
+      properties.min_compaction_lag_ms,
+      properties.max_compaction_lag_ms);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(
@@ -139,6 +143,8 @@ bool topic_properties::has_overrides() const {
         || iceberg_invalid_record_action.has_value()
         || iceberg_target_lag_ms.has_value()
         || min_cleanable_dirty_ratio.is_engaged()
+        || min_compaction_lag_ms.has_value()
+        || max_compaction_lag_ms.has_value()
         || remote_topic_allow_gaps.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
@@ -183,6 +189,8 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.cloud_topic_enabled = cloud_topic_enabled;
     ret.tombstone_retention_ms = delete_retention_ms;
     ret.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio;
+    ret.min_compaction_lag_ms = min_compaction_lag_ms;
+    ret.max_compaction_lag_ms = max_compaction_lag_ms;
     ret.remote_allow_gaps = remote_topic_allow_gaps;
     return ret;
 }
@@ -281,6 +289,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       tristate<double>{std::nullopt},
+      std::nullopt,
+      std::nullopt,
       std::nullopt,
     };
 }

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -82,6 +82,8 @@ struct topic_properties
         iceberg_invalid_record_action,
       std::optional<std::chrono::milliseconds> iceberg_target_lag_ms,
       tristate<double> min_cleanable_dirty_ratio,
+      std::optional<std::chrono::milliseconds> min_compaction_lag_ms,
+      std::optional<std::chrono::milliseconds> max_compaction_lag_ms,
       std::optional<bool> remote_topic_allow_gaps)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
@@ -129,7 +131,9 @@ struct topic_properties
       , iceberg_partition_spec(std::move(iceberg_partition_spec))
       , iceberg_invalid_record_action(iceberg_invalid_record_action)
       , iceberg_target_lag_ms(iceberg_target_lag_ms)
-      , min_cleanable_dirty_ratio(min_cleanable_dirty_ratio) {}
+      , min_cleanable_dirty_ratio(min_cleanable_dirty_ratio)
+      , min_compaction_lag_ms(min_compaction_lag_ms)
+      , max_compaction_lag_ms(max_compaction_lag_ms) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -219,6 +223,8 @@ struct topic_properties
     std::optional<std::chrono::milliseconds> iceberg_target_lag_ms{};
 
     tristate<double> min_cleanable_dirty_ratio{std::nullopt};
+    std::optional<std::chrono::milliseconds> min_compaction_lag_ms{};
+    std::optional<std::chrono::milliseconds> max_compaction_lag_ms{};
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -271,7 +277,9 @@ struct topic_properties
           iceberg_invalid_record_action,
           iceberg_target_lag_ms,
           min_cleanable_dirty_ratio,
-          remote_topic_allow_gaps);
+          remote_topic_allow_gaps,
+          min_compaction_lag_ms,
+          max_compaction_lag_ms);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1156,6 +1156,12 @@ topic_properties topic_table::update_topic_properties(
       updated_properties.min_cleanable_dirty_ratio,
       overrides.min_cleanable_dirty_ratio);
     incremental_update(
+      updated_properties.min_compaction_lag_ms,
+      overrides.min_compaction_lag_ms);
+    incremental_update(
+      updated_properties.max_compaction_lag_ms,
+      overrides.max_compaction_lag_ms);
+    incremental_update(
       updated_properties.remote_topic_allow_gaps, overrides.remote_allow_gaps);
     return updated_properties;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -645,6 +645,10 @@ struct incremental_topic_updates
     property_update<std::optional<model::iceberg_invalid_record_action>>
       iceberg_invalid_record_action;
     property_update<tristate<double>> min_cleanable_dirty_ratio;
+    property_update<std::optional<std::chrono::milliseconds>>
+      min_compaction_lag_ms;
+    property_update<std::optional<std::chrono::milliseconds>>
+      max_compaction_lag_ms;
     property_update<std::optional<bool>> remote_allow_gaps;
 
     property_update<std::optional<std::chrono::milliseconds>>
@@ -698,7 +702,9 @@ struct incremental_topic_updates
           iceberg_target_lag_ms,
           min_cleanable_dirty_ratio,
           remote_allow_gaps,
-          topic_id);
+          topic_id,
+          min_compaction_lag_ms,
+          max_compaction_lag_ms);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -366,6 +366,8 @@ struct compat_check<cluster::topic_properties> {
           obj.iceberg_invalid_record_action);
         json_write(iceberg_target_lag_ms);
         json_write(min_cleanable_dirty_ratio);
+        json_write(min_compaction_lag_ms);
+        json_write(max_compaction_lag_ms);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -405,6 +407,8 @@ struct compat_check<cluster::topic_properties> {
         json_read(iceberg_invalid_record_action);
         json_read(iceberg_target_lag_ms);
         json_read(min_cleanable_dirty_ratio);
+        json_read(min_compaction_lag_ms);
+        json_read(max_compaction_lag_ms);
         return obj;
     }
 
@@ -439,6 +443,8 @@ struct compat_check<cluster::topic_properties> {
         obj.iceberg_invalid_record_action = std::nullopt;
         obj.iceberg_target_lag_ms = std::nullopt;
         obj.min_cleanable_dirty_ratio = tristate<double>{std::nullopt};
+        obj.min_compaction_lag_ms = std::nullopt;
+        obj.max_compaction_lag_ms = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -529,6 +535,8 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.iceberg_invalid_record_action = std::nullopt;
         obj.properties.min_cleanable_dirty_ratio = tristate<double>{
           std::nullopt};
+        obj.properties.min_compaction_lag_ms = std::nullopt;
+        obj.properties.max_compaction_lag_ms = std::nullopt;
 
         obj.properties.iceberg_target_lag_ms = std::nullopt;
 

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -672,6 +672,8 @@ struct instance_generator<cluster::topic_properties> {
           tests::random_optional([] { return tests::random_duration_ms(); }),
           tristate<double>{disable_tristate},
           std::nullopt,
+          std::nullopt,
+          std::nullopt,
         };
     }
 

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -632,6 +632,8 @@ inline void rjson_serialize(
       w, "iceberg_invalid_record_action", tps.iceberg_invalid_record_action);
     write_member(w, "iceberg_target_lag_ms", tps.iceberg_target_lag_ms);
     write_member(w, "min_cleanable_dirty_ratio", tps.min_cleanable_dirty_ratio);
+    write_member(w, "min_compaction_lag_ms", tps.min_compaction_lag_ms);
+    write_member(w, "max_compaction_lag_ms", tps.max_compaction_lag_ms);
     w.EndObject();
 }
 
@@ -708,6 +710,8 @@ inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
       rd, "iceberg_invalid_record_action", obj.iceberg_invalid_record_action);
     read_member(rd, "iceberg_target_lag_ms", obj.iceberg_target_lag_ms);
     read_member(rd, "min_cleanable_dirty_ratio", obj.min_cleanable_dirty_ratio);
+    read_member(rd, "min_compaction_lag_ms", obj.min_compaction_lag_ms);
+    read_member(rd, "max_compaction_lag_ms", obj.max_compaction_lag_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1022,6 +1022,40 @@ configuration::configuration()
        .visibility = visibility::user},
       0.2,
       {.min = 0.0, .max = 1.0})
+  , min_compaction_lag_ms(
+      *this,
+      "min_compaction_lag_ms",
+      "For a compacted topic, the minimum time a message remains uncompacted "
+      "in the log. "
+      "The topic property `min.compaction.lag.ms` overrides this property.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      0ms,
+      [](const auto& v) -> std::optional<ss::sstring> {
+          // Maximum duration imposed by serde serialization.
+          if (v < 0ms || v > serde::max_serializable_ms) {
+              return fmt::format(
+                "min compaction lag should be in range: [0, {}]",
+                serde::max_serializable_ms);
+          }
+          return std::nullopt;
+      })
+  , max_compaction_lag_ms(
+      *this,
+      "max_compaction_lag_ms",
+      "For a compacted topic, the maximum time a message remains ineligible "
+      "for compaction. "
+      "The topic property `max.compaction.lag.ms` overrides this property.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      serde::max_serializable_ms,
+      [](const auto& v) -> std::optional<ss::sstring> {
+          // Maximum duration imposed by serde serialization.
+          if (v < 1ms || v > serde::max_serializable_ms) {
+              return fmt::format(
+                "max compaction lag should be in range: [1, {}]",
+                serde::max_serializable_ms);
+          }
+          return std::nullopt;
+      })
   , log_disable_housekeeping_for_tests(
       *this,
       "log_disable_housekeeping_for_tests",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -256,6 +256,8 @@ struct configuration final : public config_store {
     property<std::optional<std::chrono::milliseconds>> tombstone_retention_ms;
     bounded_property<std::optional<double>, numeric_bounds>
       min_cleanable_dirty_ratio;
+    property<std::chrono::milliseconds> min_compaction_lag_ms;
+    property<std::chrono::milliseconds> max_compaction_lag_ms;
     property<bool> log_disable_housekeeping_for_tests;
     property<bool> log_compaction_use_sliding_window;
     property<std::optional<size_t>>

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -84,12 +84,12 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 38,
-      "If you added a property, please decide on it's default alter config "
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 40,
+      "If you add a property, decide on its default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
       std::tuple_size_v<decltype(update.custom_properties.serde_fields())> == 2,
-      "If you added a property, please decide on it's default alter config "
+      "If you add a property, decide on its default alter config "
       "policy, and handle the update in the loop below");
 
     /*
@@ -318,7 +318,7 @@ create_topic_properties_update(
                   update.properties.flush_ms,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  flush_ms_validator{},
+                  flush_ms_validator,
                   true);
                 continue;
             }
@@ -395,7 +395,7 @@ create_topic_properties_update(
                   update.properties.iceberg_target_lag_ms,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  iceberg_target_lag_ms_validator{},
+                  iceberg_target_lag_ms_validator,
                   [](const ss::sstring& v) {
                       auto parsed
                         = boost::lexical_cast<std::chrono::milliseconds::rep>(
@@ -411,6 +411,26 @@ create_topic_properties_update(
                   cfg.value,
                   kafka::config_resource_operation::set,
                   min_cleanable_dirty_ratio_validator{});
+                continue;
+            }
+
+            if (cfg.name == topic_property_min_compaction_lag_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.min_compaction_lag_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  min_compaction_lag_ms_validator,
+                  /*clamp_to_duration_max=*/true);
+                continue;
+            }
+
+            if (cfg.name == topic_property_max_compaction_lag_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.max_compaction_lag_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  max_compaction_lag_ms_validator,
+                  /*clamp_to_duration_max=*/true);
                 continue;
             }
 

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -1034,6 +1034,32 @@ config_response_container_t make_topic_configs(
     add_topic_config_if_requested(
       config_keys,
       result,
+      topic_property_min_compaction_lag_ms,
+      metadata_cache.get_default_min_compaction_lag_ms(),
+      topic_property_min_compaction_lag_ms,
+      topic_properties.min_compaction_lag_ms,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().min_compaction_lag_ms.desc()),
+      describe_as_string<std::chrono::milliseconds>);
+
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      topic_property_max_compaction_lag_ms,
+      metadata_cache.get_default_max_compaction_lag_ms(),
+      topic_property_max_compaction_lag_ms,
+      topic_properties.max_compaction_lag_ms,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().max_compaction_lag_ms.desc()),
+      describe_as_string<std::chrono::milliseconds>);
+
+    add_topic_config_if_requested(
+      config_keys,
+      result,
       config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps.name(),
       config::shard_local_cfg().cloud_storage_enable_remote_allow_gaps(),
       topic_property_remote_allow_gaps,

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <string_view>
 #include <type_traits>
 
 namespace kafka {
@@ -438,27 +439,42 @@ struct write_caching_config_validator {
     }
 };
 
-struct flush_ms_validator {
+struct duration_validator {
+    std::string_view name;
+    std::chrono::milliseconds min = std::chrono::milliseconds{0};
+    std::chrono::milliseconds max = serde::max_serializable_ms;
+
     std::optional<ss::sstring> operator()(
       const ss::sstring&,
       const std::optional<std::chrono::milliseconds>& maybe_value) {
-        if (!maybe_value) {
+        if (!maybe_value.has_value()) {
             return std::nullopt;
         }
         auto value = maybe_value.value();
-        if (value < 1ms || value > serde::max_serializable_ms) {
+        if (value < min || value > max) {
             return fmt::format(
-              "flush.ms value invalid, expected to be in range [1, {}]",
-              serde::max_serializable_ms);
+              "{} value invalid, expected to be in range [{}, {}]",
+              name,
+              min,
+              max);
         }
         return std::nullopt;
     }
 };
 
+const auto flush_ms_validator = duration_validator{
+  .name = "flush.ms", .min = 1ms};
+const auto iceberg_target_lag_ms_validator = duration_validator{
+  .name = "target.lag.ms", .min = 10s};
+const auto min_compaction_lag_ms_validator = duration_validator{
+  .name = "min.compaction.lag.ms"};
+const auto max_compaction_lag_ms_validator = duration_validator{
+  .name = "max.compaction.lag.ms", .min = 1ms};
+
 struct flush_bytes_validator {
     std::optional<ss::sstring>
     operator()(const ss::sstring&, const std::optional<size_t>& maybe_value) {
-        if (!maybe_value) {
+        if (!maybe_value.has_value()) {
             return std::nullopt;
         }
         auto value = maybe_value.value();
@@ -516,25 +532,6 @@ struct iceberg_partition_spec_validator {
               "couldn't parse iceberg partition spec `{}': {}",
               value,
               parsed.error());
-        }
-        return std::nullopt;
-    }
-};
-
-struct iceberg_target_lag_ms_validator {
-    std::optional<ss::sstring> operator()(
-      const ss::sstring& /*raw*/,
-      const std::optional<std::chrono::milliseconds>& maybe_value) {
-        if (maybe_value.has_value()) {
-            const auto& value = maybe_value.value();
-            constexpr auto min_lag = std::chrono::milliseconds(10s);
-            if (value < min_lag || value > serde::max_serializable_ms) {
-                return fmt::format(
-                  "target.lag.ms value invalid, expected to be in range "
-                  "[{},{}]",
-                  min_lag,
-                  serde::max_serializable_ms);
-            }
         }
         return std::nullopt;
     }

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -81,6 +81,8 @@ bool is_supported(std::string_view name) {
        topic_property_iceberg_invalid_record_action,
        topic_property_iceberg_target_lag_ms,
        topic_property_min_cleanable_dirty_ratio,
+       topic_property_min_compaction_lag_ms,
+       topic_property_max_compaction_lag_ms,
        topic_property_remote_allow_gaps});
 
     if (std::any_of(
@@ -126,7 +128,8 @@ using validators = make_validator_types<
   iceberg_invalid_record_action_validator,
   cloud_topic_config_validator,
   delete_retention_ms_validator,
-  iceberg_target_lag_ms_validator>;
+  iceberg_target_lag_ms_validator,
+  min_max_compaction_lag_ms_validator>;
 
 static void
 append_topic_configs(request_context& ctx, create_topics_response& response) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -324,7 +324,7 @@ create_topic_properties_update(
                   update.properties.flush_ms,
                   cfg.value,
                   op,
-                  flush_ms_validator{});
+                  flush_ms_validator);
                 continue;
             }
             if (cfg.name == topic_property_flush_bytes) {
@@ -403,7 +403,7 @@ create_topic_properties_update(
                   update.properties.iceberg_target_lag_ms,
                   cfg.value,
                   op,
-                  iceberg_target_lag_ms_validator{});
+                  iceberg_target_lag_ms_validator);
                 continue;
             }
 
@@ -413,6 +413,24 @@ create_topic_properties_update(
                   cfg.value,
                   op,
                   min_cleanable_dirty_ratio_validator{});
+                continue;
+            }
+
+            if (cfg.name == topic_property_min_compaction_lag_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.min_compaction_lag_ms,
+                  cfg.value,
+                  op,
+                  min_compaction_lag_ms_validator);
+                continue;
+            }
+
+            if (cfg.name == topic_property_max_compaction_lag_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.max_compaction_lag_ms,
+                  cfg.value,
+                  op,
+                  max_compaction_lag_ms_validator);
                 continue;
             }
         } catch (const validation_error& e) {

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -290,6 +290,18 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.min_cleanable_dirty_ratio = get_tristate_value<double>(
       config_entries, topic_property_min_cleanable_dirty_ratio);
 
+    cfg.properties.min_compaction_lag_ms
+      = get_duration_value<std::chrono::milliseconds>(
+        config_entries,
+        topic_property_min_compaction_lag_ms,
+        /*clamp_to_duration_max=*/true);
+
+    cfg.properties.max_compaction_lag_ms
+      = get_duration_value<std::chrono::milliseconds>(
+        config_entries,
+        topic_property_max_compaction_lag_ms,
+        /*clamp_to_duration_max=*/true);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -123,6 +123,12 @@ inline constexpr std::string_view topic_property_iceberg_target_lag_ms
 inline constexpr std::string_view topic_property_min_cleanable_dirty_ratio
   = "min.cleanable.dirty.ratio";
 
+inline constexpr std::string_view topic_property_min_compaction_lag_ms
+  = "min.compaction.lag.ms";
+
+inline constexpr std::string_view topic_property_max_compaction_lag_ms
+  = "max.compaction.lag.ms";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {
@@ -133,10 +139,8 @@ inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {
   "segment.index.bytes",
   "segment.jitter.ms",
   "min.insync.replicas",
-  "min.compaction.lag.ms",
   "message.timestamp.difference.max.ms",
   "message.format.version",
-  "max.compaction.lag.ms",
   "leader.replication.throttled.replicas",
   "index.interval.bytes",
   "follower.replication.throttled.replicas",

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -580,6 +580,21 @@ struct vcluster_id_validator {
     }
 };
 
+struct min_max_compaction_lag_ms_validator {
+    static constexpr const char* error_message
+      = "max.compaction.lag.ms must be at least min.compaction.lag.ms";
+    static constexpr error_code ec = error_code::invalid_config;
+
+    static bool is_valid(const creatable_topic& c) {
+        const auto entries = config_map(c.configs);
+        const auto min_lag = get_config_value<int64_t>(
+          entries, topic_property_min_compaction_lag_ms);
+        const auto max_lag = get_config_value<int64_t>(
+          entries, topic_property_max_compaction_lag_ms);
+        return !(min_lag && max_lag && (min_lag > max_lag));
+    }
+};
+
 using compression_type_validator
   = configuration_value_validator<compression_type_validator_details>;
 using compaction_strategy_validator

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -751,7 +751,8 @@ FIXTURE_TEST(
       "delete.retention.ms",
       "min.cleanable.dirty.ratio",
       "redpanda.remote.allowgaps",
-    };
+      "min.compaction.lag.ms",
+      "max.compaction.lag.ms"};
 
     // All properties_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -86,7 +86,11 @@ public:
         // properties.
         tristate<std::chrono::milliseconds> tombstone_retention_ms;
 
+        // Controls segment compaction eligiblity.
         tristate<double> min_cleanable_dirty_ratio;
+        std::optional<std::chrono::milliseconds> min_compaction_lag_ms;
+        std::optional<std::chrono::milliseconds> max_compaction_lag_ms;
+
         // Controls behavior during pause
         std::optional<bool> remote_allow_gaps;
 
@@ -388,6 +392,20 @@ public:
             }
         }
         return config::shard_local_cfg().min_cleanable_dirty_ratio();
+    }
+
+    std::chrono::milliseconds min_compaction_lag_ms() const {
+        if (_overrides && _overrides->min_compaction_lag_ms.has_value()) {
+            return _overrides->min_compaction_lag_ms.value();
+        }
+        return config::shard_local_cfg().min_compaction_lag_ms();
+    }
+
+    std::chrono::milliseconds max_compaction_lag_ms() const {
+        if (_overrides && _overrides->max_compaction_lag_ms.has_value()) {
+            return _overrides->max_compaction_lag_ms.value();
+        }
+        return config::shard_local_cfg().max_compaction_lag_ms();
     }
 
     ntp_config copy() const {

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -44,6 +44,8 @@ class TopicSpec:
     PROPERTY_ICEBERG_INVALID_RECORD_ACTION = "redpanda.iceberg.invalid.record.action"
     PROPERTY_ICEBERG_TARGET_LAG_MS = "redpanda.iceberg.target.lag.ms"
     PROPERTY_MIN_CLEANABLE_DIRTY_RATIO = "min.cleanable.dirty.ratio"
+    PROPERTY_MIN_COMPACTION_LAG_MS = "min.compaction.lag.ms"
+    PROPERTY_MAX_COMPACTION_LAG_MS = "max.compaction.lag.ms"
 
     class CompressionTypes(str, Enum):
         """
@@ -127,7 +129,9 @@ class TopicSpec:
             initial_retention_local_target_ms: int | None = None,
             virtual_cluster_id: str | None = None,
             delete_retention_ms: int | None = None,
-            min_cleanable_dirty_ratio: float | None = None):
+            min_cleanable_dirty_ratio: float | None = None,
+            min_compaction_lag_ms: int | None = None,
+            max_compaction_lag_ms: int | None = None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -155,6 +159,8 @@ class TopicSpec:
         self.virtual_cluster_id = virtual_cluster_id
         self.delete_retention_ms = delete_retention_ms
         self.min_cleanable_dirty_ratio = min_cleanable_dirty_ratio
+        self.min_compaction_lag_ms = min_compaction_lag_ms
+        self.max_compaction_lag_ms = max_compaction_lag_ms
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -298,6 +298,55 @@ class AlterTopicConfiguration(RedpandaTest):
             topic
         ).min_cleanable_dirty_ratio == initial_spec.min_cleanable_dirty_ratio
 
+    @cluster(num_nodes=3)
+    def test_min_and_max_compaction_lag_ms_validation(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        self.redpanda.set_cluster_config({
+            "min_compaction_lag_ms": 10000,
+            "max_compaction_lag_ms": 20000
+        })
+        initial_spec = kafka_tools.describe_topic(topic)
+
+        # Check that values outsides the valid ranges are rejected and
+        # don't change the configured value.
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_MIN_COMPACTION_LAG_MS: -1})
+        except subprocess.CalledProcessError as e:
+            assert "invalid, expected to be in range" in e.output
+
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_MAX_COMPACTION_LAG_MS: 0})
+        except subprocess.CalledProcessError as e:
+            assert "invalid, expected to be in range" in e.output
+
+        not_updated = kafka_tools.describe_topic(topic)
+        assert initial_spec.min_compaction_lag_ms == not_updated.min_compaction_lag_ms, "min.compaction.lag.ms should not have changed"
+        assert initial_spec.max_compaction_lag_ms == not_updated.max_compaction_lag_ms, "max.compaction.lag.ms should not have changed"
+
+        # Check that values in the accepted ranges are accepted, and
+        # that the properties can be unset and revert to the cluster default.
+        self.client().alter_topic_configs(
+            topic, {
+                TopicSpec.PROPERTY_MIN_COMPACTION_LAG_MS: 5000,
+                TopicSpec.PROPERTY_MAX_COMPACTION_LAG_MS: 25000,
+            })
+
+        updated = kafka_tools.describe_topic(topic)
+        assert updated.min_compaction_lag_ms == '5000', "min.compaction.lag.ms should have changed"
+        assert updated.max_compaction_lag_ms == '25000', "max.compaction.lag.ms should have changed"
+
+        self.client().delete_topic_config(
+            topic, TopicSpec.PROPERTY_MIN_COMPACTION_LAG_MS)
+        self.client().delete_topic_config(
+            topic, TopicSpec.PROPERTY_MAX_COMPACTION_LAG_MS)
+
+        cleared = kafka_tools.describe_topic(topic)
+        assert initial_spec.min_compaction_lag_ms == cleared.min_compaction_lag_ms, "min.compaction.lag.ms should have reverted to default"
+        assert initial_spec.max_compaction_lag_ms == cleared.max_compaction_lag_ms, "max.compaction.lag.ms should have reverted to default"
+
 
 class ShadowIndexingGlobalConfig(RedpandaTest):
     topics = (TopicSpec(partition_count=1, replication_factor=3), )

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -727,6 +727,11 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 valid_value = random.choice(
                     [e for e in p['enum_values'] if e != initial_value])
 
+            if name == "max_compaction_lag_ms":
+                # Doubling the default puts it out of the valid range.
+                # Do this instead.
+                valid_value = 10000
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -335,6 +335,22 @@ class DescribeTopicsTest(RedpandaTest):
                 "throttle producers. set to `true` to allow the eviction of "
                 "locally-stored log segments, which may create gaps in "
                 "offsets."),
+            "min.compaction.lag.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="0",
+                doc_string=
+                "For a compacted topic, the minimum time a message remains uncompacted "
+                "in the log. The topic property `min.compaction.lag.ms` overrides "
+                "this property."),
+            "max.compaction.lag.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="9223372036854",
+                doc_string=
+                "For a compacted topic, the maximum time a message remains ineligible "
+                "for compaction. The topic property `max.compaction.lag.ms` overrides "
+                "this property."),
         }
 
         tp_spec = TopicSpec()


### PR DESCRIPTION
This adds the node and topic configuration properties `min.compaction.lag.ms` and `max.lag.compaction.ms`.

The implementation of the semantics will follow.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
