### PR TITLE
build-ducktape-image: use download cache

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,24 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM public.ecr.aws/docker/library/ubuntu:jammy-20240911.1 AS os_base
-
+FROM os_base AS base
+# 1 to use the download-utils caching, 0 to disable
+ARG DL_USE_CACHE=1
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive
-
-FROM os_base AS m2_seed
-ARG USE_MAVEN_SEED=1
-# Used to seed the maven cache for the java base image, see script for details
-COPY --chmod=0755 tests/docker/ducktape-deps/seed-maven-cache /
-RUN /seed-maven-cache && rm -rf /seed-maven-cache /var/lib/apt/lists/*
-
-FROM os_base AS base
 
 RUN mkdir -p /opt/redpanda-tests
 COPY --chown=0:0 tests/protobuf /opt/redpanda-tests/protobuf
 
+COPY --chmod=0755 tests/docker/ducktape-deps/download-utils /
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/java-dev-tools /
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/protobuf /
-RUN /java-dev-tools && \
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /java-dev-tools && \
     rm /java-dev-tools && \
     rm -rf /var/lib/apt/lists/*
 
@@ -45,7 +40,11 @@ RUN /tool-pkgs && \
 
 FROM base AS maven_base
 # maven_base is used for all maven-using java stages below
-COPY --from=m2_seed /root/.m2 /root/.m2
+ARG USE_MAVEN_SEED=1
+# Used to seed the maven cache for the java base image, see script for details
+COPY --chmod=0755 tests/docker/ducktape-deps/seed-maven-cache /
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /seed-maven-cache && rm -rf /seed-maven-cache /var/lib/apt/lists/*
+
 
 #################################
 
@@ -83,7 +82,7 @@ FROM maven_base AS kafka-tools
 
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/kafka-tools /
-RUN /kafka-tools && \
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /kafka-tools && \
     rm /kafka-tools
 
 #################################
@@ -174,7 +173,7 @@ RUN /franz-bench && \
 FROM base AS flink
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/flink /
-RUN /flink && \
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /flink && \
     rm /flink
 
 #################################
@@ -222,7 +221,7 @@ RUN /plugin-mock && rm /plugin-mock
 FROM base AS keycloak
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/keycloak /
-RUN /keycloak && rm /keycloak
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /keycloak && rm /keycloak
 
 #################################
 
@@ -271,14 +270,14 @@ RUN /iceberg-rest-catalog && rm /iceberg-rest-catalog
 
 FROM base AS trino
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/trino /
-RUN /trino && rm /trino
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /trino && rm /trino
 
 #################################
 
 FROM maven_base AS spark
 COPY --chown=0:0 tests/java/spark-iceberg-dependencies /opt/redpanda-tests/java/spark-iceberg-dependencies
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/spark /
-RUN /spark && rm /spark
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache /spark && rm /spark
 
 #################################
 # m2-collector creates the final .m2 cache from all images
@@ -296,6 +295,23 @@ COPY --from=omb /root/.m2 /root/.m2
 FROM m2-collector AS m2-all
 COPY --from=kafka-tools /root/.m2 /root/.m2
 COPY --from=spark /root/.m2 /root/.m2
+
+###################################
+# Not used by the final image, but useful for debugging.
+# You can invoke this like:
+# task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=debug-dl-cache --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
+FROM os_base AS debug-dl-cache
+ARG CACHE_BREAK=0
+COPY --chmod=0755 tests/docker/ducktape-deps/download-utils /
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache bash -c "source /download-utils && debug_cache"
+
+###################################
+# Not used by the final image, but useful to clean the cache mount(s).
+# You can invoke this like:
+# task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=clean-dl-cache --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
+FROM os_base AS clean-dl-cache
+ARG CACHE_BREAK=0
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache bash -c "rm -rf /dl-cache/* && echo CACHE CLEANED"
 
 
 #################################

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -2,6 +2,83 @@
 
 This Dockerfile is used to back the ducktape cluster nodes when running ducktape in docker/podman mode. It relies heavily on multi-root builds to build the relatively heavy dependencies (mostly large Java projects) in parallel and to limit layer rebuilds when only a subset change.
 
+## Caching
+
+### Cache mounts in docker
+
+The docker image build uses multiple caches of type `--mount=type=cache`: these caches are mounts which are stored separately by docker, are not included in the layer hash, do not affect caching on the layer (i.e., a cached layer may be re-used even if the cache mount contents have changed) and which do not propagate to later RUN commands nor the final image. The same mount is provided to all commands with the same `id` regardless of the dockerfile being run (or what layer is being built). They can be used to cache files whose presence or absence does not affect the outcome of a RUN command, and which may allow the RUN to complete more quickly if cache hits occur. For example, downloading a tar file (which does not change at the source) may first check in the cache to see if the tar already exists.
+
+You can look at your current cache mounts using `docker builder du --filter 'type=exec.cachemount' --verbose`, which gives output like this:
+
+```
+ID:             m14sema73ey9iwkwquskdjh8p
+Created at:     2025-04-28 18:33:19.198371074 +0000 UTC
+Mutable:        true
+Reclaimable:    true
+Shared:         false
+Size:           4.328GB
+Description:    cached mount /dl-cache from exec /bin/sh -c /keycloak && rm /keycloak
+Usage count:    77
+Last used:      13 seconds ago
+Type:           exec.cachemount
+
+ID:             65cc6wnfelmodpe8s6dx5sn58
+Created at:     2025-05-02 18:43:54.776165542 +0000 UTC
+Mutable:        true
+Reclaimable:    true
+Shared:         false
+Size:           2.783GB
+Description:    cached mount /root/.gradle from exec /bin/sh -c /nessie && rm /nessie with id "/gradle"
+Usage count:    10
+Last used:      About a minute ago
+Type:           exec.cachemount
+```
+
+This shows the "dl-cache" and "gradle" cache mounts.
+
+You can also examine the specific contents of the cache mounts using:
+
+
+
+#### Cleanup
+
+In general, cache mounts can use much less space over time than layers which download the same files, since the cache mounts are mutable singletons which contain only the most recent file at a given path, while a given layer may be duplicated many times (including the downloaded files) if any of its dependencies change.
+
+Still, you may want to clear the cache mount, which can be accomplished by building a specific `clean-dl-cache` image like so:
+
+```
+task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=clean-dl-cache --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
+```
+
+You may also prune runing the _entire_ builder cache, which also clears cache mounts, like so:
+
+```
+docker builder prune --all
+```
+
+Specific caches are documented below.
+
+
+### dl-cache cache mount
+
+This is a cache mount which caches downloaded files. Use the utility functions in `ducktape-deps/download-cache` to interact with it in other ducktape scripts, for example from [ducktape-deps/java-dev-tools]:
+
+```
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
+...
+
+download_extract $java22_url .
+```
+
+This downloads `$java22_url` and unpacks it to the current working directory. Caching is handled behind the scenes.
+
+The caching happens automatically: the URL is downloaded into the cache mount at a path like `/dl-cache/<url-hash>/<url-basename>` where `<url-hash>` is hash of the URL passed to the `download*` method (not of the _contents_ of the URL, just of the URL string itself). This ensures that different URLs get different cache directories.
+
+If the contents at a given URL change upstream, the old contents will continue to be used as long as the cache mount remains populated. This is not all that different than the docker behavior in any case: a layer whose input is textually unchanged (i.e., unchanged download URL) may simply be reused from the cache. The cache mount simply extends the period of time during which a re-download will not occur. We should try to always use "immutable" download targets whose contents do not change.
+
+
+
 ### .m2 caching
 
 #### Design
@@ -12,7 +89,6 @@ To solve this, we seed the java maven stages with an ~/.m2 directory (this is
 where maven stores its local repository of downloaded files) downloaded from our
 artifact repository. This happens in the m2_seed and java_base stages in the
 dockerfile. The contents of this seed cache do not need to be exact: the other stages in the file will work fine if it is empty or contain old jars, etc: as maven already separates files by version and will download any additional files.
-
 
 When the seed cache is up-to-date, there will be very little maven activity visible during the build. Over time, however, the seed cache may become out of date as project versions are updated and they pull in newer dependency versions. Furthermore, some projects may have -SNAPSHOT dependencies which mean that the jar version may change even if the project and pom.xml is unchanged. So it is useful to periodically refresh the seed cache as described below.
 

--- a/tests/docker/ducktape-deps/download-utils
+++ b/tests/docker/ducktape-deps/download-utils
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Common utilities for downloading files, intended to be sourced.
+
+set_vars() {
+    DL_SLEEP_TIME=0s
+    if [[ ${DL_USE_CACHE:=1} == "1" ]]; then
+        DL_DEFAULT_CACHE_DIR="/dl-cache"
+
+    else
+        DL_DEFAULT_CACHE_DIR="/tmp/dl-cache"
+    fi
+    echo >&2 "DL_CACHE_DIR=${DL_CACHE_DIR:=${DL_DEFAULT_CACHE_DIR}}"
+    echo >&2 "DL_STRIP=${DL_STRIP:=0}"
+    if [[ ${DL_USE_CACHE:=1} == "1" && ! -d $DL_CACHE_DIR ]]; then
+        echo >&2 "DL_CACHE_DIR does not exist, did you forget RUN --mount: $DL_CACHE_DIR"
+        exit 1
+    fi
+}
+
+_do_download() {
+    set -euo pipefail
+    local url url_hash out_dir out_path
+    url="$1"
+    url_hash=$(echo -n "$url" | sha256sum | head -c8)
+    out_dir="$DL_CACHE_DIR/$url_hash"
+    out_path="$out_dir/$(basename "$url")"
+    echo >&2 "Downloading $url to $out_path"
+    sleep $DL_SLEEP_TIME
+    # --no-if-modified-since is needed since otherwise a partially downloaded file will
+    # treated as complete, due to a wget bug.
+    wget --progress=dot:giga --no-if-modified-since -c -N -P "$out_dir" "$url"
+    echo "$out_path"
+}
+
+# we use _-prefixed helper functions so we can set -euo pipefail
+# but not have that persist to the caller (who may not be tolerant
+# of set -u in particular)
+_download() {
+    set -euo pipefail
+    set_vars
+    out_file=$(_do_download "$1")
+    echo "Copying $out_file to $2"
+    cp "$out_file" "$2"
+}
+
+_download_extract() {
+    set -euo pipefail
+    set_vars
+    out_file=$(_do_download "$1")
+    echo "Unpacking $out_file to $2"
+    tar xvf "$out_file" -C "$2" --strip-components="$DL_STRIP"
+}
+
+# Download a cached tarball from a URL $1 and unpack it to $2.
+download_extract() {
+    (_download_extract "$@")
+}
+
+# Do a cached download of a file from URL $1 and store it at $2
+download() {
+    (_download "$@")
+}
+
+debug_cache() {
+    set_vars
+    echo "DEBUG DL-CACHE:"
+    if [[ -d $DL_CACHE_DIR ]]; then
+        find $DL_CACHE_DIR -ls
+    else
+        echo "DL_CACHE_DIR does not exist: $DL_CACHE_DIR"
+    fi
+}

--- a/tests/docker/ducktape-deps/flink
+++ b/tests/docker/ducktape-deps/flink
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
 mkdir /opt/flink
 
 # Download
@@ -13,15 +16,12 @@ FLINK_FILE=flink-${FLINK_VERSION}-bin-scala_${FLINK_SCALA_VERSION}.tgz
 DEPS_BASEURL=https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies
 FLINK_URL=${DEPS_BASEURL}/${FLINK_FILE}
 KAFKA_CONNECTOR=flink-sql-connector-kafka-3.0.1-1.18.jar
-wget ${FLINK_URL}
 
-# Extract
-tar -xvf ${FLINK_FILE} -C /opt/flink --strip-components 1
-rm ${FLINK_FILE}
+DL_STRIP=1 download_extract ${FLINK_URL} /opt/flink
 
 # Download connector
 mkdir /opt/flink/connectors
-wget ${DEPS_BASEURL}/${KAFKA_CONNECTOR} -O /opt/flink/connectors/${KAFKA_CONNECTOR}
+download ${DEPS_BASEURL}/${KAFKA_CONNECTOR} /opt/flink/connectors/${KAFKA_CONNECTOR}
 
 # Show version
 /opt/flink/bin/flink --version

--- a/tests/docker/ducktape-deps/java-dev-tools
+++ b/tests/docker/ducktape-deps/java-dev-tools
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
 apt update
 apt install -y \
   build-essential \
@@ -33,7 +36,7 @@ fi
 tar_file=openjdk-22.0.2_linux-${architecture}_bin.tar.gz
 java22_url=https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL/${tar_file}
 
-wget $java22_url && tar xvf $tar_file && rm -f $tar_file
+download_extract $java22_url .
 mv jdk-22.0.2 /usr/lib/jvm/java-22-openjdk-${ARCH}
 
 update-java-alternatives -s java-1.17.0-openjdk-${ARCH}

--- a/tests/docker/ducktape-deps/kafka-tools
+++ b/tests/docker/ducktape-deps/kafka-tools
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -e
-for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0" "3.8.0" "3.9.0"; do
 
-  mkdir -p "/opt/kafka-${ver}"
-  chmod a+rw "/opt/kafka-${ver}"
-  curl "$KAFKA_MIRROR/kafka_2.12-${ver}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${ver}"
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
+for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0" "3.8.0" "3.9.0"; do
+  odir=/opt/kafka-${ver}
+  mkdir -p "$odir"
+  chmod a+rw "$odir"
+  DL_STRIP=1 download_extract "https://archive.apache.org/dist/kafka/${ver}/kafka_2.12-${ver}.tgz" "$odir"
 done
 ln -s /opt/kafka-3.9.0/ /opt/kafka-dev
 

--- a/tests/docker/ducktape-deps/keycloak
+++ b/tests/docker/ducktape-deps/keycloak
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
 # get keycloak binary
 KC_VERSION=23.0.3
-wget "https://github.com/keycloak/keycloak/releases/download/${KC_VERSION}/keycloak-${KC_VERSION}.tar.gz"
 
-tar -xvzf keycloak-${KC_VERSION}.tar.gz
-rm keycloak-${KC_VERSION}.tar.gz
+download_extract "https://github.com/keycloak/keycloak/releases/download/${KC_VERSION}/keycloak-${KC_VERSION}.tar.gz" .
 
 mv keycloak-${KC_VERSION} /opt/keycloak

--- a/tests/docker/ducktape-deps/seed-maven-cache
+++ b/tests/docker/ducktape-deps/seed-maven-cache
@@ -4,6 +4,8 @@ set -euo pipefail
 # This script is used to download the maven cache seed for the ducktape docker image.
 # Further documentation at ../docker/README.md.
 
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
 seed_file="m2-cache-2025-04-25-59e96a8aeb.tgz"
 
 seed_url="https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$seed_file"
@@ -12,14 +14,7 @@ seed_url="https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/$see
 
 if [[ ${USE_MAVEN_SEED:=unset} != 1 ]]; then
   echo "Skipping maven cache seeding (USE_MAVEN_SEED=$USE_MAVEN_SEED)"
-  # touch it since later COPY expect it to at least exist
-  mkdir -p /root/.m2
   exit 0
 fi
 
-# install axel & ssl deps for fast downloads
-apt-get update && apt-get install openssl ca-certificates axel -y
-echo "Downloading the maven cache seed from: $seed_url"
-axel -n 10 -o /tmp/m2.tgz "$seed_url"
-tar xzf /tmp/m2.tgz -C /root
-rm -f /tmp/m2.tgz
+download_extract "$seed_url" /root

--- a/tests/docker/ducktape-deps/spark
+++ b/tests/docker/ducktape-deps/spark
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
 mkdir /opt/spark
 
 SPARK_VERSION=3.5.4
 SPARK_FILE=spark-$SPARK_VERSION-bin-hadoop3.tgz
 SPARK_URL=https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop3.tgz
 
-wget ${SPARK_URL}
-tar xvf ${SPARK_FILE} -C /opt/spark --strip-components 1
-rm ${SPARK_FILE}
+DL_STRIP=1 download_extract ${SPARK_URL} /opt/spark
 
 # Copy over the jars needed for iceberg access.
 # These are not shipped with the binary distribution and are addons for iceberg
@@ -27,5 +27,5 @@ HADOOP_DEPS=(
 )
 
 for jar in "${HADOOP_DEPS[@]}"; do
-  wget $jar -P /opt/spark/jars
+  download $jar /opt/spark/jars
 done

--- a/tests/docker/ducktape-deps/trino
+++ b/tests/docker/ducktape-deps/trino
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
 mkdir /opt/trino
 
 TRINO_VERSION=463
-TRINO_FILE=trino-server-${TRINO_VERSION}.tar.gz
 TRINO_URL=https://repo1.maven.org/maven2/io/trino/trino-server/${TRINO_VERSION}/trino-server-${TRINO_VERSION}.tar.gz
 
-wget ${TRINO_URL}
-tar xvf ${TRINO_FILE} -C /opt/trino --strip-components 1 && rm -f ${TRINO_FILE}
+DL_STRIP=1 download_extract ${TRINO_URL} /opt/trino
 
 # Commonly used directories for data and configurations
 mkdir /opt/trino/data


### PR DESCRIPTION
Use a --mount=type=cache to mount a cache directory for large downloads. This is based on the observation that layers are rebuild much more frequently than the downloads are updated. This should speed up image rebuilds significantly, especially when the localhost is far from the download servers.

The README.md is updated and contains additional details on this change.

After this change the image build time is reduced from 15-60m (network dependent) to 7-8m. The critical path after this change is through nessie which has a long uncached gradle download/build.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
