### PR TITLE
cluster/archival: upload data from above log start offset

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1786,6 +1786,18 @@ ntp_archiver::schedule_uploads(model::offset max_offset_exclusive) {
                                  ? model::offset(0)
                                  : last_offset + model::offset(1);
 
+    // If tiered storage was paused and gaps were allowed to be created
+    // then we need to start from the first offset in the log.
+    if (start_upload_offset < _parent.log()->offsets().start_offset) {
+        vlog(
+          _rtclog.warn,
+          "Start upload offset {} is less than log start offset {}. Resetting "
+          "start upload offset to log start offset.",
+          start_upload_offset,
+          _parent.log()->offsets().start_offset);
+        start_upload_offset = _parent.log()->offsets().start_offset;
+    }
+
     auto compacted_segments_upload_start = model::next_offset(
       manifest().get_last_uploaded_compacted_offset());
 

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -34,6 +34,7 @@
 #include "storage/parser.h"
 #include "storage/storage_resources.h"
 #include "storage/tests/utils/disk_log_builder.h"
+#include "storage/types.h"
 #include "test_utils/archival.h"
 #include "test_utils/fixture.h"
 #include "test_utils/scoped_config.h"
@@ -1958,6 +1959,123 @@ FIXTURE_TEST(test_upload_with_gap_blocked, archiver_fixture) {
     BOOST_REQUIRE_EQUAL(stm_manifest.size(), 1);
     BOOST_REQUIRE_EQUAL(
       stm_manifest.last_segment()->base_offset, segments[0].base_offset);
+}
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(test_upload_with_gap, archiver_fixture) {
+    auto cfg = scoped_config{};
+    cfg.get("cloud_storage_enable_remote_allow_gaps").set_value(true);
+
+    std::vector<segment_desc> segments = {
+      {
+        .ntp = manifest_ntp,
+        .base_offset = model::offset(0),
+        .term = model::term_id(4),
+        .num_records = 1000,
+        .records_per_batch = 1,
+      },
+      {
+        .ntp = manifest_ntp,
+        .base_offset = model::offset(1000),
+        .term = model::term_id(4),
+        .num_records = 1000,
+        .records_per_batch = 1,
+      },
+    };
+
+    init_storage_api_local(segments);
+    wait_for_partition_leadership(manifest_ntp);
+
+    auto part = app.partition_manager.local().get(manifest_ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [&part]() {
+        return part->last_stable_offset() >= model::offset(1000);
+    }).get();
+
+    // Offset in the middle of the active segment.
+    auto truncate_offset = model::offset(1500);
+    auto truncate_kafka_offset = kafka::offset(
+      part->log()->from_log_offset(truncate_offset));
+
+    BOOST_REQUIRE(!part
+                     ->prefix_truncate(
+                       truncate_offset,
+                       truncate_kafka_offset,
+                       ss::lowres_clock::time_point::max())
+                     .get());
+
+    tests::cooperative_spin_wait_with_timeout(10s, [&part]() {
+        return part->log()->offsets().start_offset >= model::offset(1000);
+    }).get();
+
+    // As-if a segment was already uploaded but leave a gap before the local
+    // storage segment.
+    part->archival_meta_stm()
+      ->add_segments(
+        {
+          cloud_storage::segment_meta{
+            .is_compacted = false,
+            .size_bytes = 1, // doesn't matter
+            .base_offset = model::offset(0),
+            .committed_offset = model::offset(100),
+            .ntp_revision
+            = part->archival_meta_stm()->manifest().get_revision_id(),
+            .archiver_term = model::term_id(4),
+            .segment_term = model::term_id(4),
+            .delta_offset_end = model::offset_delta{0},
+          },
+        },
+        std::nullopt,
+        model::producer_id{},
+        ss::lowres_clock::now() + 1s,
+        never_abort,
+        cluster::segment_validated::yes)
+      .get();
+
+    vlog(
+      test_log.info,
+      "Partition is a leader, log start-offset: {}, high-watermark: {}, "
+      "partition: {}",
+      part->log()->offsets().start_offset(),
+      part->high_watermark(),
+      *part);
+
+    listen();
+
+    auto [arch_conf, remote_conf] = get_configurations();
+
+    auto manifest_view = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name,
+      path_provider);
+
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      manifest_view);
+
+    auto action = ss::defer([&archiver, &manifest_view] {
+        archiver.stop().get();
+        manifest_view->stop().get();
+    });
+
+    auto res = upload_next_with_retries(archiver).get();
+    BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_succeeded, 1);
+    BOOST_REQUIRE_EQUAL(res.non_compacted_upload_result.num_failed, 0);
+
+    BOOST_REQUIRE_EQUAL(
+      part->archival_meta_stm()->manifest().get_last_offset(),
+      model::offset(1999));
+
+    // Second segment start offset should be the same as the partition start
+    // offset.
+    BOOST_REQUIRE_EQUAL(
+      std::next(part->archival_meta_stm()->manifest().begin())->base_offset,
+      part->log()->offsets().start_offset);
 }
 
 FIXTURE_TEST(test_flush_not_leader, cloud_storage_manual_multinode_test_base) {


### PR DESCRIPTION

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

### Bug Fixes

* When Tiered Storage is paused and data is allowed to expire from local storage there will be gaps between last offset in tiered storage and first offset in local storage. If local storage was truncated in the middle of a segment (i.e. time based retention or via trim-prefix/delete records commands) tiered storage might get stuck with the following exception: `Failed to schedule upload: std::runtime_error (ntp {kafka/foo/0}: log offset N is outside the translation range (starting at M > N))`. Fix this by adjusting upload start offset to the first available and valid offset. Although we might have a bit more data in the segment, other information about that data (i.e. offset translation) is gone with prefix truncation.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
