### PR TITLE
`storage`: fix `get_file_offset()` for truncated segments

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2388,6 +2388,13 @@ disk_log_impl::offset_range_size(
         }
     }
 
+    // Recheck log offsets as well, as we could race with a prefix truncation
+    // while waiting for segment locks.
+    if (!log_contains_offset_range(first, last)) {
+        vlog(stlog.debug, "Log does not include entire range");
+        co_return std::nullopt;
+    }
+
     // Left subscan
     auto ix_left = segments.front()->index().find_nearest(first);
     if (ix_left.has_value()) {
@@ -2547,10 +2554,18 @@ disk_log_impl::offset_range_size(
     auto holders = co_await ss::when_all_succeed(
       std::begin(f_locks), std::end(f_locks));
 
+    // Check if anything was closed after the scheduling point.
     for (const auto& s : segments) {
         if (s->is_closed()) {
             co_return std::nullopt;
         }
+    }
+
+    // Recheck log offsets as well, as we could race with a prefix truncation
+    // while waiting for segment locks.
+    if (!log_contains_offset(first)) {
+        vlog(stlog.debug, "Log does not include offset {}", first);
+        co_return std::nullopt;
     }
 
     if (

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -31,6 +31,7 @@
 #include "storage/key_offset_map.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
+#include "storage/log_reader.h"
 #include "storage/logger.h"
 #include "storage/offset_assignment.h"
 #include "storage/offset_to_filepos.h"
@@ -2260,12 +2261,16 @@ ss::future<size_t> disk_log_impl::get_file_offset(
       .boundary = boundary,
     };
 
-    storage::log_reader_config reader_cfg(index_entry.offset, target, priority);
+    auto reader_start_offset = index_entry.offset;
+
+    storage::log_reader_config reader_cfg(
+      reader_start_offset, target, priority);
 
     reader_cfg.skip_batch_cache = true;
     reader_cfg.skip_readers_cache = true;
 
-    auto reader = co_await make_reader(reader_cfg);
+    auto reader = model::make_record_batch_reader<single_segment_reader>(
+      s, co_await s->read_lock(), reader_cfg, *_probe);
 
     try {
         co_await std::move(reader).consume(acc, model::no_timeout);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -114,6 +114,60 @@ bool deletion_exempt(const model::ntp& ntp) {
            || (is_consumer_offsets_ntp && !config::shard_local_cfg().unsafe_enable_consumer_offsets_delete_retention());
 }
 
+// Meant for reading batches from a single `segment`. This does not consider any
+// other `log` state- meaning, the `log` could have been prefix truncated and
+// batches read from the `segment` could be ahead of the new `_start_offset`.
+//
+// This class should only be used when it is necessary to consider the batches
+// still physically stored in a `segment` on disk, e.g for file position
+// calculations. For all other applications, the `log_reader` should be used.
+class single_segment_reader final : public model::record_batch_reader::impl {
+public:
+    using storage_t = model::record_batch_reader::storage_t;
+    single_segment_reader(
+      ss::lw_shared_ptr<segment> seg,
+      ss::rwlock::holder seg_read_lock,
+      log_reader_config reader_cfg,
+      probe& pb)
+      : _seg(seg)
+      , _seg_read_lock(std::move(seg_read_lock))
+      , _config(reader_cfg)
+      , _rdr(*_seg, _config, pb) {}
+
+    ~single_segment_reader() final = default;
+
+    bool is_end_of_stream() const final { return _is_end_of_stream; }
+
+    ss::future<storage_t>
+    do_load_slice(model::timeout_clock::time_point timeout) final {
+        auto recs = co_await _rdr.read_some(timeout);
+        if (!recs.has_value() || recs.value().empty()) {
+            _is_end_of_stream = true;
+            co_return storage_t{};
+        }
+
+        auto& batches = recs.value();
+        co_return std::move(batches);
+    }
+
+    ss::future<> finally() noexcept final { return _rdr.close(); }
+
+    void print(std::ostream& os) final {
+        fmt::print(
+          os,
+          "storage::single_segment_reader for {}, config {}",
+          _seg->filename(),
+          _config);
+    }
+
+private:
+    ss::lw_shared_ptr<segment> _seg;
+    ss::rwlock::holder _seg_read_lock;
+    log_reader_config _config;
+    log_segment_batch_reader _rdr;
+    bool _is_end_of_stream{false};
+};
+
 disk_log_impl::disk_log_impl(
   ntp_config cfg,
   raft::group_id group,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2284,6 +2284,33 @@ ss::future<size_t> disk_log_impl::get_file_offset(
     co_return size_bytes;
 }
 
+bool disk_log_impl::log_contains_offset(model::offset o) const noexcept {
+    auto log_offsets = offsets();
+    auto log_interval = model::bounded_offset_interval::optional(
+      log_offsets.start_offset, log_offsets.committed_offset);
+
+    if (!log_interval.has_value()) {
+        // Log is empty
+        return false;
+    }
+
+    return log_interval->contains(o);
+}
+
+bool disk_log_impl::log_contains_offset_range(
+  model::offset first, model::offset last) const noexcept {
+    auto log_offsets = offsets();
+    auto log_interval = model::bounded_offset_interval::optional(
+      log_offsets.start_offset, log_offsets.committed_offset);
+
+    if (!log_interval.has_value()) {
+        // Log is empty
+        return false;
+    }
+
+    return log_interval->contains(first) && log_interval->contains(last);
+}
+
 ss::future<std::optional<log::offset_range_size_result_t>>
 disk_log_impl::offset_range_size(
   model::offset first, model::offset last, ss::io_priority_class io_priority) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2314,20 +2314,14 @@ bool disk_log_impl::log_contains_offset_range(
 ss::future<std::optional<log::offset_range_size_result_t>>
 disk_log_impl::offset_range_size(
   model::offset first, model::offset last, ss::io_priority_class io_priority) {
-    auto log_offsets = offsets();
     vlog(
       stlog.debug,
       "Offset range size, first: {}, last: {}, lstat: {}",
       first,
       last,
-      log_offsets);
-    auto log_interval = model::bounded_offset_interval::optional(
-      log_offsets.start_offset, log_offsets.committed_offset);
-    if (!log_interval.has_value()) {
-        vlog(stlog.debug, "Log is empty, returning early");
-        co_return std::nullopt;
-    }
-    if (!log_interval->contains(first) || !log_interval->contains(last)) {
+      offsets());
+
+    if (!log_contains_offset_range(first, last)) {
         vlog(stlog.debug, "Log does not include entire range");
         co_return std::nullopt;
     }
@@ -2485,21 +2479,15 @@ disk_log_impl::offset_range_size(
   model::offset first,
   offset_range_size_requirements_t target,
   ss::io_priority_class io_priority) {
-    auto log_offsets = offsets();
     vlog(
       stlog.debug,
       "Offset range size, first: {}, target size: {}/{}, lstat: {}",
       first,
       target.target_size,
       target.min_size,
-      log_offsets);
-    auto log_interval = model::bounded_offset_interval::optional(
-      log_offsets.start_offset, log_offsets.committed_offset);
-    if (!log_interval.has_value()) {
-        vlog(stlog.debug, "Log is empty, returning early");
-        co_return std::nullopt;
-    }
-    if (!log_interval->contains(first)) {
+      offsets());
+
+    if (!log_contains_offset(first)) {
         vlog(stlog.debug, "Log does not include offset {}", first);
         co_return std::nullopt;
     }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -408,6 +408,15 @@ private:
 
     size_t get_log_truncation_counter() const noexcept override;
 
+    // Returns true iff the offset `o` is found within the bounds
+    // [start_offset, committed_offset] of the log, false otherwise.
+    bool log_contains_offset(model::offset o) const noexcept;
+
+    // Returns true iff the offsets `first` and `last` are both found within the
+    // bounds [start_offset, committed_offset] of the log, false otherwise.
+    bool log_contains_offset_range(
+      model::offset first, model::offset last) const noexcept;
+
 private:
     // Computes the segment size based on the latest max_segment_size
     // configuration. This takes into consideration any segment size

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5805,3 +5805,59 @@ FIXTURE_TEST(disk_usage_with_log_throwing_exception, storage_test_fixture) {
     // Reassign the gate so there is no double close().
     disk_log->gate() = ss::gate{};
 };
+
+FIXTURE_TEST(prefix_truncate_offset_range_size, storage_test_fixture) {
+    auto cfg = default_log_config(test_dir);
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(cfg);
+    info("Configuration: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "test-topic", 0);
+
+    storage::ntp_config::default_overrides overrides{
+      .cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion,
+    };
+    storage::ntp_config ntp_cfg(
+      ntp,
+      mgr.config().base_dir,
+      std::make_unique<storage::ntp_config::default_overrides>(overrides));
+
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
+
+    size_t num_segments = 1;
+    for (size_t i = 0; i < num_segments; i++) {
+        append_random_batches(
+          log, 10, model::term_id(0), key_limited_random_batch_generator());
+        log->force_roll(ss::default_priority_class()).get();
+    }
+
+    auto dirty_offset = log->offsets().dirty_offset;
+    auto new_start_offset = model::offset{
+      random_generators::get_int(dirty_offset())};
+
+    info("Prefix truncating at offset {}", new_start_offset);
+
+    log
+      ->truncate_prefix(storage::truncate_prefix_config(
+        new_start_offset, ss::default_priority_class()))
+      .get();
+
+    auto lstat = log->offsets();
+    BOOST_REQUIRE_EQUAL(lstat.start_offset, new_start_offset);
+
+    for (int64_t o = model::next_offset(new_start_offset)(); o < dirty_offset();
+         ++o) {
+        // Expect that no errors are thrown by querying the offset range size
+        // for any offset.
+        BOOST_REQUIRE_NO_THROW(
+          log
+            ->offset_range_size(
+              model::offset{o},
+              storage::log::offset_range_size_requirements_t{
+                .target_size = 0x10000,
+                .min_size = 1,
+              },
+              ss::default_priority_class())
+            .get());
+    }
+}


### PR DESCRIPTION
This function could run into issues with the log `_start_offset` when making a `log_reader`.

Consider the case in which:
1. A prefix truncation intersects a `segment`, which bumps `_start_offset` but doesn't alter the `segment` or `segment_index` on file.
2. A call to `offset_range_size()` is issued.

Currently, we are either assuming the found entry from a `segment_index` has a `base_offset >= _start_offset` AND we're assuming that `segment` passed has `s->offsets().get_base_offset() >= _start_offset`, neither of which may be true due to the prefix truncation. This can lead to a thrown exception in the `log_reader`: `std::runtime_error: Reader cannot read
before start`.

Fix the problem by using a `single_segment_reader` (which reads the physical batches on disk, not subject to the same constraints of `log` state) instead of the `log_reader` to avoid the problems due to having to read before the new `_start_offset`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
