### PR TITLE
[CORE-9876] kafka: Support ApiVersions v4

### DIFF
--- a/src/v/kafka/protocol/schemata/api_versions_request.json
+++ b/src/v/kafka/protocol/schemata/api_versions_request.json
@@ -16,12 +16,14 @@
 {
   "apiKey": 18,
   "type": "request",
-  "listeners": ["zkBroker", "broker", "controller"],
+  "listeners": ["broker", "controller"],
   "name": "ApiVersionsRequest",
   // Versions 0 through 2 of ApiVersionsRequest are the same.
   //
   // Version 3 is the first flexible version and adds ClientSoftwareName and ClientSoftwareVersion.
-  "validVersions": "0-3",
+  //
+  // Version 4 fixes KAFKA-17011, which blocked SupportedFeatures.MinVersion in the response from being 0.
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ClientSoftwareName", "type": "string", "versions": "3+",

--- a/src/v/kafka/protocol/schemata/api_versions_response.json
+++ b/src/v/kafka/protocol/schemata/api_versions_response.json
@@ -27,12 +27,14 @@
   //
   // Starting from Apache Kafka 2.4 (KIP-511), ApiKeys field is populated with the supported
   // versions of the ApiVersionsRequest when an UNSUPPORTED_VERSION error is returned.
-  "validVersions": "0-3",
+  //
+  // Version 4 fixes KAFKA-17011, which blocked SupportedFeatures.MinVersion from being 0.
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top-level error code." },
-    { "name": "ApiKeys", "type": "[]ApiVersionsResponseKey", "versions": "0+",
+    { "name": "ApiKeys", "type": "[]ApiVersion", "versions": "0+",
       "about": "The APIs supported by the broker.", "fields": [
       { "name": "ApiKey", "type": "int16", "versions": "0+", "mapKey": true,
         "about": "The API index." },
@@ -43,10 +45,10 @@
     ]},
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name":  "SupportedFeatures", "type": "[]SupportedFeatureKey", "ignorable": true,
-      "versions":  "3+", "tag": 0, "taggedVersions": "3+",
-      "about": "Features supported by the broker.",
-      "fields":  [
+    { "name": "SupportedFeatures", "type": "[]SupportedFeatureKey", "ignorable": true,
+      "versions": "3+", "tag": 0, "taggedVersions": "3+",
+      "about": "Features supported by the broker. Note: in v0-v3, features with MinSupportedVersion = 0 are omitted.",
+      "fields": [
         { "name": "Name", "type": "string", "versions": "3+", "mapKey": true,
           "about": "The name of the feature." },
         { "name": "MinVersion", "type": "int16", "versions": "3+",
@@ -57,18 +59,21 @@
     },
     { "name": "FinalizedFeaturesEpoch", "type": "int64", "versions": "3+",
       "tag": 1, "taggedVersions": "3+", "default": "-1", "ignorable": true,
-      "about": "The monotonically increasing epoch for the finalized features information. Valid values are >= 0. A value of -1 is special and represents unknown epoch."},
-    { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey", "ignorable": true,
-      "versions":  "3+", "tag": 2, "taggedVersions": "3+",
+      "about": "The monotonically increasing epoch for the finalized features information. Valid values are >= 0. A value of -1 is special and represents unknown epoch." },
+    { "name": "FinalizedFeatures", "type": "[]FinalizedFeatureKey", "ignorable": true,
+      "versions": "3+", "tag": 2, "taggedVersions": "3+",
       "about": "List of cluster-wide finalized features. The information is valid only if FinalizedFeaturesEpoch >= 0.",
-      "fields":  [
-        {"name": "Name", "type": "string", "versions":  "3+", "mapKey": true,
-          "about": "The name of the feature."},
-        {"name":  "MaxVersionLevel", "type": "int16", "versions":  "3+",
-          "about": "The cluster-wide finalized max version level for the feature."},
-        {"name":  "MinVersionLevel", "type": "int16", "versions":  "3+",
-          "about": "The cluster-wide finalized min version level for the feature."}
+      "fields": [
+        { "name": "Name", "type": "string", "versions":  "3+", "mapKey": true,
+          "about": "The name of the feature." },
+        { "name": "MaxVersionLevel", "type": "int16", "versions":  "3+",
+          "about": "The cluster-wide finalized max version level for the feature." },
+        { "name": "MinVersionLevel", "type": "int16", "versions":  "3+",
+          "about": "The cluster-wide finalized min version level for the feature." }
       ]
-    }
+    },
+    { "name": "ZkMigrationReady", "type": "bool", "versions": "3+", "taggedVersions": "3+",
+      "tag": 3, "ignorable": true, "default": "false",
+      "about": "Set by a KRaft controller if the required configurations for ZK migration are present." }
   ]
 }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -433,6 +433,9 @@ sensitive_map = {
 # mapping to the new type name.
 # yapf: disable
 struct_renames = {
+    ("ApiVersionsResponseData", "ApiKeys"):
+        ("ApiVersion", "ApiVersionsResponseKey"),
+
     ("IncrementalAlterConfigsRequestData", "Resources"):
         ("AlterConfigsResource", "IncrementalAlterConfigsResource"),
 
@@ -524,8 +527,7 @@ def make_context_field(path):
 
 # a listing of expected struct types
 STRUCT_TYPES = [
-    "ApiVersionsRequestKey",
-    "ApiVersionsResponseKey",
+    "ApiVersion",
     "OffsetFetchRequestTopic",
     "OffsetFetchResponseTopic",
     "OffsetFetchResponsePartition",

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "features/feature_table.h"
 #include "kafka/protocol/types.h"
 #include "kafka/protocol/wire.h"
 #include "kafka/server/handlers/handlers.h"
@@ -85,6 +86,28 @@ chunked_vector<api_versions_response_key> get_supported_apis() {
       config::shard_local_cfg().enable_transactions.value());
 }
 
+void topic_id_api_version_limiter(api_versions_response& r) {
+    for (auto& api : r.data.api_keys) {
+        auto apply_limit = [&api](int16_t limit) {
+            api.max_version = std::min(api.max_version, limit);
+        };
+        switch (api.api_key) {
+        case fetch_api::key:
+            apply_limit(12);
+            break;
+        case metadata_api::key:
+            apply_limit(11);
+            break;
+        case create_topics_api::key:
+            apply_limit(6);
+            break;
+        case delete_topics_api::key:
+            apply_limit(5);
+            break;
+        };
+    }
+}
+
 api_versions_response api_versions_handler::handle_raw(request_context& ctx) {
     // Unlike other request types, we handle ApiVersion requests
     // with higher versions than supported. We treat such a request
@@ -111,6 +134,14 @@ api_versions_response api_versions_handler::handle_raw(request_context& ctx) {
             r.data.api_keys = supported_apis.idempotence.copy();
         } else {
             r.data.api_keys = supported_apis.transactions.copy();
+        }
+    }
+
+    {
+        // If feature::topic_ids is not active, limit reported API versions
+        const auto& features = ctx.feature_table().local();
+        if (unlikely(!features.is_active(features::feature::topic_ids))) {
+            topic_id_api_version_limiter(r);
         }
     }
     return r;

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -16,7 +16,7 @@
 namespace kafka {
 
 struct api_versions_handler
-  : public single_stage_handler<api_versions_api, 0, 3> {
+  : public single_stage_handler<api_versions_api, 0, 4> {
     static constexpr api_version min_flexible = api_version(3);
 
     static ss::future<response_ptr>


### PR DESCRIPTION
If `feature::topic_ids` is not active, do not report versions of APIs that use topic identifiers.

Also support ApiVersion v4 whilst in the area.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

