### PR TITLE
[v24.3.x] `rptest`: fix `cloud_storage_type` parameterization in `random_node_operations_test.py`

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -23,7 +23,7 @@ from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
-from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST, CloudStorageType, LoggingConfig, PandaproxyConfig, SISettings, SchemaRegistryConfig
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, PREV_VERSION_LOG_ALLOW_LIST, CloudStorageType, LoggingConfig, PandaproxyConfig, SISettings, SchemaRegistryConfig, get_cloud_storage_type
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.utils.mode_checks import cleanup_on_early_exit, skip_debug_mode, skip_fips_mode
 from rptest.utils.node_operations import FailureInjectorBackgroundThread, NodeOpsExecutor, generate_random_workload, verify_offset_translator_state_consistent
@@ -325,7 +325,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             mixed_versions=[True, False],
             with_tiered_storage=[True, False],
             with_iceberg=[True, False],
-            cloud_storage_type=[CloudStorageType.S3])
+            cloud_storage_type=get_cloud_storage_type())
     def test_node_operations(self, enable_failures, mixed_versions,
                              with_tiered_storage, with_iceberg,
                              cloud_storage_type):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/24550
