### PR TITLE
debug_bundle: fix order of operations

### DIFF
--- a/src/v/debug_bundle/debug_bundle_service.cc
+++ b/src/v/debug_bundle/debug_bundle_service.cc
@@ -738,17 +738,6 @@ ss::future<> service::set_metadata(job_id_t job_id) {
 
     vlog(lg.debug, "Emplacing metadata into keystore for job {}", job_id);
 
-    co_await _kvstore->put(
-      storage::kvstore::key_space::debug_bundle,
-      bytes::from_string(debug_bundle_metadata_key),
-      std::move(buf));
-
-    auto remove_kvstore_on_err = ss::defer([this] {
-        ssx::background = _kvstore->remove(
-          storage::kvstore::key_space::debug_bundle,
-          bytes::from_string(debug_bundle_metadata_key));
-    });
-
     process_output po{
       .cout = _rpk_process->cout().copy(), .cerr = _rpk_process->cerr().copy()};
     iobuf po_buf;
@@ -766,7 +755,6 @@ ss::future<> service::set_metadata(job_id_t job_id) {
           lg.debug,
           "Successfully wrote process output to file to {}",
           process_output_file.native());
-        remove_kvstore_on_err.cancel();
     } catch (const std::exception& e) {
         vlog(
           lg.warn,
@@ -774,7 +762,13 @@ ss::future<> service::set_metadata(job_id_t job_id) {
           process_output_file,
           job_id,
           e.what());
+        co_return;
     }
+
+    co_await _kvstore->put(
+      storage::kvstore::key_space::debug_bundle,
+      bytes::from_string(debug_bundle_metadata_key),
+      std::move(buf));
 }
 
 std::optional<debug_bundle_status> service::process_status() const {


### PR DESCRIPTION
In tests (and possibly elsewhere), we use the value being in the kvstore
to determine if the bundle is fully written (including the process
output). However the kvstore entry could be written before the actual
process output, so make sure to commit after everything is written.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
