### PR TITLE
make ntp_callbacks actually support multiple callbacks

### DIFF
--- a/src/v/cluster/archival/archiver_manager.cc
+++ b/src/v/cluster/archival/archiver_manager.cc
@@ -750,8 +750,8 @@ public:
 
         _unmanage_notifications = _pm.local().register_unmanage_notification(
           model::kafka_namespace, [this](model::topic_partition_view tpv) {
-              model::ntp ntp(model::kafka_namespace, tpv.topic, tpv.partition);
-              stop_managing_partition(ntp);
+              stop_managing_partition(
+                {model::kafka_namespace, tpv.topic, tpv.partition});
           });
 
         vassert(_gm.local_is_initialized(), "group_manager is not initialized");

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -224,7 +224,7 @@ ss::future<> config_manager::start() {
     _raft0_leader_changed_notification
       = _leaders.local().register_leadership_change_notification(
         model::controller_ntp,
-        [this](model::ntp, model::term_id, model::node_id) {
+        [this](const model::ntp&, model::term_id, model::node_id) {
             _reconcile_wait.signal();
         });
 

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -113,7 +113,8 @@ ss::future<> backend::start() {
     _plt_raft0_leadership_notification_id
       = _leaders_table.register_leadership_change_notification(
         model::controller_ntp,
-        [this](model::ntp, model::term_id, model::node_id leader_node_id) {
+        [this](
+          const model::ntp&, model::term_id, model::node_id leader_node_id) {
             _is_raft0_leader = leader_node_id == _self;
             if (_is_raft0_leader != _is_coordinator) {
                 ssx::spawn_with_gate(

--- a/src/v/cluster/ntp_callbacks.h
+++ b/src/v/cluster/ntp_callbacks.h
@@ -62,9 +62,8 @@ public:
 
     /// Invoke all matching callbacks.
     template<typename... Args>
-    void notify(const model::ntp& ntp, Args&&... args) const {
-        notify(
-          ntp.ns, ntp.tp.topic, ntp.tp.partition, std::forward<Args>(args)...);
+    void notify(const model::ntp& ntp, const Args&... args) const {
+        notify(ntp.ns, ntp.tp.topic, ntp.tp.partition, args...);
     }
 
     /// Invoke all matching callbacks.
@@ -73,24 +72,24 @@ public:
       const model::ns& ns,
       const model::topic& topic,
       model::partition_id part,
-      Args&&... args) const {
+      const Args&... args) const {
         // invoke for wildcard watchers
-        notify(_root.callbacks, std::forward<Args>(args)...);
+        notify(_root.callbacks, args...);
 
         // invoke for namespace watchers
         const auto& n_nodes = _root.next;
         if (auto n = n_nodes.find(ns); n != n_nodes.end()) {
-            notify(n->second.callbacks, std::forward<Args>(args)...);
+            notify(n->second.callbacks, args...);
 
             // invoke for topic watchers
             const auto& t_nodes = n->second.next;
             if (auto t = t_nodes.find(topic); t != t_nodes.end()) {
-                notify(t->second.callbacks, std::forward<Args>(args)...);
+                notify(t->second.callbacks, args...);
 
                 // invoke for partition watchers
                 const auto& p_nodes = t->second.next;
                 if (auto p = p_nodes.find(part); p != p_nodes.end()) {
-                    notify(p->second, std::forward<Args>(args)...);
+                    notify(p->second, args...);
                 }
             }
         }
@@ -160,9 +159,9 @@ private:
     }
 
     template<typename... Args>
-    void notify(const callbacks_t& callbacks, Args&&... args) const {
+    void notify(const callbacks_t& callbacks, const Args&... args) const {
         for (auto cb_i = callbacks.cbegin(); cb_i != callbacks.cend();) {
-            (cb_i++)->second(std::forward<Args>(args)...);
+            (cb_i++)->second(args...);
         }
     }
 

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -316,7 +316,8 @@ ss::future<model::node_id> partition_leaders_table::wait_for_leader(
     auto holder = _gate.hold();
     auto promise = ss::make_lw_shared<expiring_promise<model::node_id>>();
     auto n_id = register_leadership_change_notification(
-      ntp, [promise](model::ntp, model::term_id, model::node_id leader_id) {
+      ntp,
+      [promise](const model::ntp&, model::term_id, model::node_id leader_id) {
           promise->set_value(leader_id);
       });
 

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -162,7 +162,7 @@ public:
     }
 
     using leader_change_cb_t = ss::noncopyable_function<void(
-      model::ntp, model::term_id, model::node_id)>;
+      const model::ntp&, model::term_id, model::node_id)>;
 
     // Register a callback for all leadership changes
     notification_id_type

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -54,7 +54,7 @@ public:
     ~partition_manager();
 
     using manage_cb_t
-      = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
+      = ss::noncopyable_function<void(const ss::lw_shared_ptr<partition>&)>;
     using unmanage_cb_t
       = ss::noncopyable_function<void(model::topic_partition_view)>;
 
@@ -118,9 +118,8 @@ public:
          * partitions.
          */
         ntp_callbacks<manage_cb_t> init;
-        init.register_notify(ns, topic, [&cb](ss::lw_shared_ptr<partition> p) {
-            cb(std::move(p));
-        });
+        init.register_notify(
+          ns, topic, [&cb](const ss::lw_shared_ptr<partition>& p) { cb(p); });
         for (auto& e : _ntp_table) {
             if (e.second->started()) {
                 init.notify(e.first, e.second);
@@ -134,7 +133,7 @@ public:
     register_manage_notification(const model::ns& ns, manage_cb_t cb) {
         ntp_callbacks<manage_cb_t> init;
         init.register_notify(
-          ns, [&cb](ss::lw_shared_ptr<partition> p) { cb(std::move(p)); });
+          ns, [&cb](const ss::lw_shared_ptr<partition>& p) { cb(p); });
         for (auto& e : _ntp_table) {
             if (e.second->started()) {
                 init.notify(e.first, e.second);

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -94,7 +94,7 @@ leader_balancer::leader_balancer(
 }
 
 void leader_balancer::check_if_controller_leader(
-  model::ntp, model::term_id, model::node_id) {
+  const model::ntp&, model::term_id, model::node_id) {
     // Don't bother doing anything if it's not enabled
     if (should_stop_balance()) {
         return;
@@ -121,7 +121,7 @@ void leader_balancer::check_if_controller_leader(
 }
 
 void leader_balancer::on_leadership_change(
-  model::ntp ntp, model::term_id, model::node_id) {
+  const model::ntp& ntp, model::term_id, model::node_id) {
     if (should_stop_balance()) {
         return;
     }

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -128,9 +128,11 @@ private:
     void on_enable_changed();
     void on_default_preference_changed();
 
-    void check_if_controller_leader(model::ntp, model::term_id, model::node_id);
+    void check_if_controller_leader(
+      const model::ntp&, model::term_id, model::node_id);
 
-    void on_leadership_change(model::ntp, model::term_id, model::node_id);
+    void
+    on_leadership_change(const model::ntp&, model::term_id, model::node_id);
 
     void on_maintenance_change(model::node_id, model::maintenance_state);
 

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -66,7 +66,9 @@ ss::future<> coordinator_manager::start() {
 
     manage_notifications_ = pm_.register_manage_notification(
       model::datalake_coordinator_nt.ns,
-      [this](ss::lw_shared_ptr<cluster::partition> p) { start_managing(*p); });
+      [this](const ss::lw_shared_ptr<cluster::partition>& p) {
+          start_managing(*p);
+      });
     unmanage_notifications_ = pm_.register_unmanage_notification(
       model::datalake_coordinator_nt.ns,
       [this](model::topic_partition_view tp) {

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -237,7 +237,7 @@ ss::future<> datalake_manager::start() {
     auto partition_managed_notification
       = _partition_mgr->local().register_manage_notification(
         model::kafka_namespace,
-        [this](ss::lw_shared_ptr<cluster::partition> new_partition) {
+        [this](const ss::lw_shared_ptr<cluster::partition>& new_partition) {
             _queue.submit([this, ntp = new_partition->ntp()]() {
                 return handle_translator_state_change(ntp);
             });


### PR DESCRIPTION
It was broken due to use-after-move.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
