### PR TITLE
Offline partitions in health overview

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -1042,6 +1042,57 @@ health_monitor_backend::get_node_drain_status(
 
     co_return it->second->drain_status;
 }
+namespace {
+bool is_partition_offline(
+  const cluster::partition_assignment& p_as,
+  const std::vector<model::node_id>& offline_nodes) {
+    return std::ranges::all_of(
+      p_as.replicas, [&offline_nodes](const model::broker_shard bs) {
+          return std::ranges::find(offline_nodes, bs.node_id)
+                 != offline_nodes.end();
+      });
+}
+} // namespace
+
+ss::future<> health_monitor_backend::fill_aggregate_with_offline_partitions(
+  const std::vector<model::node_id>& offline_nodes,
+  aggregated_report& aggr_report) {
+    size_t retries_left = 5;
+
+    ssx::async_counter counter;
+    while (retries_left > 0) {
+        try {
+            for (auto it = _topic_table.local().topics_iterator_begin();
+                 it != _topic_table.local().topics_iterator_end();
+                 ++it) {
+                const auto& topic = it->first;
+                const auto& assignment_set = it->second.get_assignments();
+                co_await ssx::async_for_each_counter(
+                  counter,
+                  assignment_set,
+                  [&offline_nodes, &aggr_report, &topic, &it](
+                    const auto& p_as) {
+                      it.check();
+                      if (!is_partition_offline(p_as.second, offline_nodes)) {
+                          return;
+                      }
+                      aggr_report.leaderless_count++;
+                      if (
+                        aggr_report.leaderless_count
+                        > aggregated_report::max_partitions_report) {
+                          return;
+                      }
+                      aggr_report.leaderless.emplace(
+                        model::ntp(topic.ns, topic.tp, p_as.first));
+                  });
+            }
+            // success, return from the function
+            co_return;
+        } catch (const iterator_stability_violation&) {
+            --retries_left;
+        }
+    }
+}
 
 health_monitor_backend::aggregated_report
 health_monitor_backend::aggregate_reports(const report_cache_t& reports) {
@@ -1131,6 +1182,8 @@ health_monitor_backend::get_cluster_health_overview(
       ret.nodes_in_recovery_mode.begin(), ret.nodes_in_recovery_mode.end());
 
     auto aggr_report = aggregate_reports(reports());
+    co_await fill_aggregate_with_offline_partitions(
+      ret.nodes_down, aggr_report);
 
     auto move_into = [](auto& dest, auto& src) {
         dest.reserve(src.size());

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -198,6 +198,15 @@ private:
     };
 
     static aggregated_report aggregate_reports(const report_cache_t& reports);
+    /**
+     * Offline nodes are missing the health reports, therefore the partitions
+     * that replicas are only on those nodes will not be directly reported as
+     * leader less. Therefore, we need to check the partitions that are only on
+     * offline nodes and add them to the report.
+     */
+    ss::future<> fill_aggregate_with_offline_partitions(
+      const std::vector<model::node_id>& offline_nodes,
+      aggregated_report& aggr_report);
 
     ss::lw_shared_ptr<raft::consensus> _raft0;
     ss::sharded<members_table>& _members;

--- a/tests/rptest/tests/cluster_health_overview_test.py
+++ b/tests/rptest/tests/cluster_health_overview_test.py
@@ -16,6 +16,8 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 
 from ducktape.utils.util import wait_until
 
+from rptest.util import wait_until_result
+
 
 class ClusterHealthOverviewTest(RedpandaTest):
     def __init__(self, test_context):
@@ -36,8 +38,12 @@ class ClusterHealthOverviewTest(RedpandaTest):
             topics.append(
                 TopicSpec(partition_count=random.randint(1, 6),
                           replication_factor=3))
-
+        for i in range(0, 8):
+            topics.append(
+                TopicSpec(partition_count=random.randint(1, 6),
+                          replication_factor=1))
         self.client().create_topic(topics)
+        return topics
 
     def get_health(self):
         """Wrapper around admin.get_cluster_health_overview which validates some invariants
@@ -73,7 +79,7 @@ class ClusterHealthOverviewTest(RedpandaTest):
 
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def cluster_health_overview_baseline_test(self):
-        self.create_topics()
+        topics = self.create_topics()
 
         # in initial state after all nodes joined cluster should be healthy
         self.wait_until_healthy()
@@ -92,10 +98,23 @@ class ClusterHealthOverviewTest(RedpandaTest):
                 assert [self.redpanda.idx(first_down)] == hov['nodes_down']
                 # next check is "in" instead of "==" because we may also have under_replicated_partitions
                 assert 'nodes_down' in hov['unhealthy_reasons']
-                return True
-            return False
+                return True, hov
+            return False, None
 
-        wait_until(one_node_down, 30, 2)
+        hov = wait_until_result(one_node_down, 30, 2)
+
+        # when one node is down some partitions with replication factor of 1
+        # should be reported as leaderless
+        rf_1_topics = {
+            spec.name
+            for spec in topics if spec.replication_factor == 1
+        }
+
+        assert len(hov['leaderless_partitions']) > 0
+        assert hov['leaderless_count'] > 0
+
+        assert all(ntp.split("/")[1] in rf_1_topics for ntp in hov['leaderless_partitions']),\
+            "Only rf=1 topics should be leaderless after one node is stopped"
 
         # stop another node, cluster should start reporting leaderless
         # partitions with two out of five nodes down
@@ -114,9 +133,13 @@ class ClusterHealthOverviewTest(RedpandaTest):
             if len(hov['leaderless_partitions']) == 0:
                 return False
 
+            contains_rf_3_topics = not all(
+                ntp.split("/")[1] in rf_1_topics
+                for ntp in hov['leaderless_partitions'])
+
             assert 'leaderless_partitions' in hov['unhealthy_reasons']
 
-            return True
+            return contains_rf_3_topics
 
         wait_until(two_nodes_down, 30, 2)
 


### PR DESCRIPTION
When all the nodes hosting partition replicas are offline their health
reports are not available. This leads to a situation in which a
partition which is clearly leaderless (there are no online replicas so
there must be no leader) is not included into the cluster health
overview.

Fixed that issue by detecting the offline partitions and accounting them
as leaderless. The detection is based on the topics table as the health
report for the offline node is unavailable.

Fixes: INC-258

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Improved handling rf=1 partitions health reporting