### PR TITLE
CORE-9875: Topic ids: add `topic_table::get_name_by_id(...)`

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -98,6 +98,7 @@ enum class errc : int16_t {
     data_migrations_disabled,
     resource_is_being_migrated,
     invalid_target_node_id,
+    topic_id_already_exists,
 };
 
 std::ostream& operator<<(std::ostream& o, errc err);
@@ -288,6 +289,8 @@ struct errc_category final : public std::error_category {
                    "undergoing data migration";
         case errc::invalid_target_node_id:
             return "Request was intended for the node with different node id";
+        case errc::topic_id_already_exists:
+            return "A topic with the given id already exists";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/errors.cc
+++ b/src/v/cluster/errors.cc
@@ -182,6 +182,8 @@ std::ostream& operator<<(std::ostream& o, cluster::errc err) {
         return o << "cluster::errc::resource_is_being_migrated";
     case errc::invalid_target_node_id:
         return o << "cluster::errc::invalid_target_node_id";
+    case errc::topic_id_already_exists:
+        return o << "cluster::errc::topic_id_already_exists";
     }
 }
 } // namespace cluster

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -23,6 +23,7 @@
 #include "config/configuration.h"
 #include "config/property.h"
 #include "features/feature_table.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "random/generators.h"
 #include "test_utils/fixture.h"
@@ -94,7 +95,11 @@ struct topic_table_fixture {
     cluster::topic_configuration_assignment make_tp_configuration(
       const ss::sstring& topic, int partitions, int16_t replication_factor) {
         cluster::topic_configuration cfg(
-          test_ns, model::topic(topic), partitions, replication_factor);
+          test_ns,
+          model::topic(topic),
+          partitions,
+          replication_factor,
+          model::create_topic_id());
 
         cluster::allocation_request req(cfg.tp_ns);
         req.partitions.reserve(partitions);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/controller_snapshot.h"
 #include "cluster/tests/topic_table_fixture.h"
+#include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -52,6 +54,16 @@ static void validate_ntp_deltas(
     BOOST_REQUIRE_EQUAL(deletions, removed_partitions);
 }
 
+static void validate_topic_id_mapping(const cluster::topic_table& table) {
+    BOOST_REQUIRE_EQUAL(
+      table.get_topic_id_mapping().size(), table.topics_map().size());
+    for (const auto& [tp, md] : table.topics_map()) {
+        auto& tp_id = md.get_configuration().tp_id;
+        BOOST_REQUIRE(tp_id.has_value());
+        BOOST_REQUIRE_EQUAL(table.get_name_by_id(*tp_id), tp);
+    }
+}
+
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     std::vector<cluster::topic_table_topic_delta> topic_deltas;
     table.local().register_topic_delta_notification([&](const auto& d) {
@@ -80,6 +92,7 @@ FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
 
     validate_topic_deltas(topic_deltas, 3, 0);
     validate_ntp_deltas(deltas, 21, 0);
+    validate_topic_id_mapping(table.local());
 }
 
 FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
@@ -116,6 +129,7 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
 
     validate_topic_deltas(topic_deltas, 0, 2);
     validate_ntp_deltas(deltas, 0, 20);
+    validate_topic_id_mapping(table.local());
 }
 
 FIXTURE_TEST(test_conflicts, topic_table_fixture) {
@@ -597,6 +611,69 @@ FIXTURE_TEST(test_topic_with_schema_id_validation_ops, topic_table_fixture) {
     BOOST_REQUIRE(!cfg->properties.record_key_schema_id_validation.has_value());
     BOOST_REQUIRE(
       !cfg->properties.record_key_schema_id_validation_compat.has_value());
+}
+
+FIXTURE_TEST(test_topic_id_assignment, topic_table_fixture) {
+    auto& topics = table.local();
+
+    info("Create an old topic without a topic id");
+    auto create1 = make_create_topic_cmd("pre_25_2_topic", 1, 1);
+    auto tp_ns1 = create1.value.cfg.tp_ns;
+    create1.value.cfg.tp_id = std::nullopt;
+    auto offset = model::offset{10};
+    auto ec = topics.apply(create1, offset++).get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(topics.get_topic_id_mapping().size(), 0);
+
+    info("Create a new topic with a topic id");
+    auto create2 = make_create_topic_cmd("post_25_2_topic", 1, 1);
+    auto tp_ns2 = create2.value.cfg.tp_ns;
+    auto tp_id2 = create2.value.cfg.tp_id;
+    ec = topics.apply(create2, offset++).get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(topics.get_topic_id_mapping().size(), 1);
+    BOOST_REQUIRE_EQUAL(topics.get_name_by_id(*tp_id2), tp_ns2);
+
+    info("Assign a topic id to the old topic");
+    auto tp_1_new_id = model::create_topic_id();
+    cluster::incremental_topic_updates update;
+    update.topic_id.op = cluster::incremental_update_operation::set;
+    update.topic_id.value = tp_1_new_id;
+    ec = topics
+           .apply(
+             cluster::update_topic_properties_cmd{tp_ns1, update}, offset++)
+           .get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
+    auto check_final_state = [&] {
+        BOOST_REQUIRE_EQUAL(topics.get_topic_id_mapping().size(), 2);
+        BOOST_REQUIRE_EQUAL(topics.get_name_by_id(tp_1_new_id), tp_ns1);
+        BOOST_REQUIRE_EQUAL(topics.get_name_by_id(*tp_id2), tp_ns2);
+    };
+    check_final_state();
+
+    info("Try to create a new topic with a topic id that already exists");
+    auto create3 = make_create_topic_cmd("new_topic_with_id_reused", 1, 1);
+    create3.value.cfg.tp_id = tp_id2;
+    ec = topics.apply(create3, offset++).get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::topic_id_already_exists);
+    check_final_state();
+
+    info("Try to assign an already used topic id to a topic");
+    cluster::incremental_topic_updates update2;
+    update2.topic_id.op = cluster::incremental_update_operation::set;
+    update2.topic_id.value = tp_id2;
+    ec = topics
+           .apply(
+             cluster::update_topic_properties_cmd{tp_ns1, update2}, offset++)
+           .get();
+    BOOST_REQUIRE_EQUAL(ec, cluster::errc::topic_id_already_exists);
+    check_final_state();
+
+    info("Fill and apply a snapshot");
+    cluster::controller_snapshot snap;
+    topics.fill_snapshot(snap).get();
+    topics.apply_snapshot(offset++, snap).get();
+    check_final_state();
 }
 
 FIXTURE_TEST(test_topic_table_iterator_basic, topic_table_fixture) {

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -230,8 +230,8 @@ void validate_brokers_revisions(
     auto tp_it = all_metadata.find(model::topic_namespace_view(ntp));
     BOOST_REQUIRE(tp_it != all_metadata.end());
 
-    auto p_it = tp_it->second.metadata.get_assignments().find(ntp.tp.partition);
-    BOOST_REQUIRE(p_it != tp_it->second.metadata.get_assignments().end());
+    auto p_it = tp_it->second.get_assignments().find(ntp.tp.partition);
+    BOOST_REQUIRE(p_it != tp_it->second.get_assignments().end());
 
     auto p_meta_it = tp_it->second.partitions.find(ntp.tp.partition);
     BOOST_REQUIRE(p_meta_it != tp_it->second.partitions.end());

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -48,6 +48,11 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
         co_return errc::topic_already_exists;
     }
 
+    auto& tp_id = cmd.value.cfg.tp_id;
+    if (tp_id && _topics.get_name(*tp_id)) {
+        co_return errc::topic_id_already_exists;
+    }
+
     const auto migration_state = _migrated_resources.get_topic_state(cmd.key);
     if (
       !cmd.value.cfg.is_migrated
@@ -79,9 +84,8 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
           ? std::make_optional(
               cmd.value.cfg.properties.remote_topic_properties->remote_revision)
           : std::nullopt;
-    auto md = topic_metadata_item{
-      .metadata = topic_metadata(
-        std::move(cmd.value), model::revision_id(offset()), remote_revision)};
+    auto md = topic_metadata_item{topic_metadata(
+      std::move(cmd.value), model::revision_id(offset()), remote_revision)};
 
     // generate deltas
 
@@ -112,10 +116,7 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
           topic_table_ntp_delta_type::added);
     }
 
-    _topics.insert({
-      cmd.key,
-      std::move(md),
-    });
+    _topics.emplace(std::move(md));
     _topics_map_revision++;
     _probe.handle_topic_creation(std::move(cmd.key));
 
@@ -329,8 +330,7 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
     // add partitions
     auto prev_partition_count = tp->second.get_configuration().partition_count;
     // update partitions count
-    tp->second.get_configuration().partition_count
-      = cmd.value.cfg.new_total_partition_count;
+    tp->second.get_partition_count() = cmd.value.cfg.new_total_partition_count;
     // add assignments of newly created partitions
     auto rev_id = model::revision_id{offset};
     for (auto& p_as : cmd.value.assignments) {
@@ -1176,18 +1176,25 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     }
 
     if (cmd.value.topic_id.op == incremental_update_operation::set) {
+        auto& tp_id = cmd.value.topic_id.value;
+        if (tp_id && _topics.get_name(*tp_id)) {
+            co_return errc::topic_id_already_exists;
+        }
+
         vlog(
           clusterlog.trace,
           "Assigning topic id {} to topic {}",
-          cmd.value.topic_id.value,
+          tp_id,
           cmd.key);
-        tp->second.get_configuration().tp_id = cmd.value.topic_id.value;
+        _topics.mutate(tp, [&](auto& md_item_mut) {
+            md_item_mut.get_configuration().tp_id = tp_id;
+        });
     }
 
     auto updated_properties = update_topic_properties(
       tp->second.get_configuration().properties, std::move(cmd));
 
-    auto& properties = tp->second.get_configuration().properties;
+    auto& properties = tp->second.get_configuration_properties();
     // no configuration change, no need to generate delta
     if (updated_properties == properties) {
         co_return errc::success;
@@ -1285,7 +1292,7 @@ topic_table::fill_snapshot(controller_snapshot& controller_snap) const {
         snap.topics.emplace(
           ns_tp,
           controller_snapshot_parts::topics_t::topic_t{
-            .metadata = md_item.metadata.get_fields(),
+            .metadata = md_item.get_metadata().get_fields(),
             .partitions = std::move(partitions),
             .updates = std::move(updates),
             .disabled_set = std::move(disabled_set),
@@ -1559,10 +1566,14 @@ ss::future<> topic_table::apply_snapshot(
             const auto& topic_snapshot = new_it->second;
             if (
               topic_snapshot.metadata.revision
-              != md_item.metadata.get_revision()) {
+              != md_item.get_metadata().get_revision()) {
                 // The topic was re-created, delete and add it anew.
                 co_await applier.delete_topic(ns_tp, md_item);
-                md_item = co_await applier.create_topic(ns_tp, topic_snapshot);
+                auto new_md = co_await applier.create_topic(
+                  ns_tp, topic_snapshot);
+                _topics.mutate(old_it, [&](auto& md_item_mut) {
+                    md_item_mut = std::move(new_md);
+                });
                 _topics_map_revision++;
             } else {
                 // The topic was present in the previous set, now we need to
@@ -1574,7 +1585,10 @@ ss::future<> topic_table::apply_snapshot(
                   = md_item.get_configuration().properties
                     != topic_snapshot.metadata.configuration.properties;
 
-                md_item.metadata.get_fields() = topic_snapshot.metadata;
+                _topics.mutate(old_it, [&](auto& md_item_mut) {
+                    md_item_mut.get_metadata().get_fields()
+                      = topic_snapshot.metadata;
+                });
 
                 topic_disabled_partitions_set old_disabled_set;
                 if (topic_snapshot.disabled_set) {
@@ -1652,7 +1666,7 @@ ss::future<> topic_table::apply_snapshot(
     // Next, go over the new topics set and add state for new topics.
     for (const auto& [ns_tp, topic] : snap.topics) {
         if (!_topics.contains(ns_tp)) {
-            _topics.emplace(ns_tp, co_await applier.create_topic(ns_tp, topic));
+            _topics.emplace(co_await applier.create_topic(ns_tp, topic));
             _topics_map_revision++;
         }
     }
@@ -1671,7 +1685,7 @@ ss::future<> topic_table::apply_snapshot(
 
     _partition_count = 0;
     for (const auto& [ns_tp, md_item] : _topics) {
-        _partition_count += md_item.metadata.get_assignments().size();
+        _partition_count += md_item.get_assignments().size();
         co_await ss::coroutine::maybe_yield();
     }
 
@@ -1738,14 +1752,14 @@ size_t topic_table::all_topics_count() const { return _topics.size(); }
 std::optional<topic_metadata>
 topic_table::get_topic_metadata(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
-        return it->second.metadata.copy();
+        return it->second.get_metadata().copy();
     }
     return {};
 }
 std::optional<std::reference_wrapper<const topic_metadata>>
 topic_table::get_topic_metadata_ref(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
-        return it->second.metadata;
+        return it->second.get_metadata();
     }
     return {};
 }
@@ -1783,7 +1797,7 @@ topic_table::get_topic_timestamp_type(model::topic_namespace_view tp) const {
 }
 
 const topic_table::underlying_t& topic_table::all_topics_metadata() const {
-    return _topics;
+    return _topics.by_tp();
 }
 
 std::optional<topic_table::partition_replicas_view>

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -17,6 +17,7 @@
 #include "cluster/topic_table_probe.h"
 #include "container/chunked_hash_map.h"
 #include "container/contiguous_range_map.h"
+#include "logger.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "utils/stable_iterator_adaptor.h"
@@ -215,17 +216,23 @@ public:
     };
 
     struct topic_metadata_item {
+    protected:
         topic_metadata metadata;
+
+    public:
+        explicit topic_metadata_item(topic_metadata md)
+          : metadata{std::move(md)} {};
+
+        const topic_metadata& get_metadata() const { return metadata; }
+
         contiguous_range_map<model::partition_id::type, partition_meta>
           partitions;
 
-        assignments_set& get_assignments() {
-            return metadata.get_assignments();
+        template<typename Self>
+        decltype(auto) get_assignments(this Self&& self) {
+            return (std::forward<Self>(self).metadata.get_assignments());
         }
 
-        const assignments_set& get_assignments() const {
-            return metadata.get_assignments();
-        }
         model::revision_id get_revision() const {
             return metadata.get_revision();
         }
@@ -236,12 +243,42 @@ public:
         const topic_configuration& get_configuration() const {
             return metadata.get_configuration();
         }
-        topic_configuration& get_configuration() {
-            return metadata.get_configuration();
+
+        template<typename Self>
+        decltype(auto) get_configuration_properties(this Self&& self) {
+            return (
+              std::forward<Self>(self).metadata.get_configuration().properties);
+        }
+
+        template<typename Self>
+        decltype(auto) get_partition_count(this Self&& self) {
+            return (std::forward<Self>(self)
+                      .metadata.get_configuration()
+                      .partition_count);
         }
 
         replication_factor get_replication_factor() const {
             return metadata.get_replication_factor();
+        }
+    };
+
+    // Unsafe wrapper around topic_metadata_item that allows to mutate
+    // configuration that forms part of the key in the underlying map.
+    //
+    // NOTE: Do not add data members.
+    struct unsafe_topic_metadata_item : topic_metadata_item {
+        explicit unsafe_topic_metadata_item(topic_metadata md)
+          : topic_metadata_item(std::move(md)) {}
+
+        unsafe_topic_metadata_item& operator=(topic_metadata_item&& item) {
+            topic_metadata_item::operator=(std::move(item));
+            return *this;
+        }
+
+        topic_metadata& get_metadata() { return metadata; }
+
+        topic_configuration& get_configuration() {
+            return metadata.get_configuration();
         }
     };
 
@@ -250,6 +287,123 @@ public:
       topic_metadata_item,
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
+
+    using topic_id_mapping_t
+      = chunked_hash_map<model::topic_id, model::topic_namespace>;
+
+    // Wrapper around underlying_t that maintains a consistent mapping from
+    // topic id to topic name
+    class underlying_map {
+    public:
+        const auto& by_tp() const { return _by_tp; }
+
+        const auto& by_id() const { return _by_id; }
+
+        template<typename Self>
+        auto begin(this Self&& self) {
+            return std::forward<Self>(self)._by_tp.begin();
+        }
+        template<typename Self>
+        auto end(this Self&& self) {
+            return std::forward<Self>(self)._by_tp.end();
+        }
+        auto size() const { return _by_tp.size(); }
+        auto empty() const { return _by_tp.empty(); }
+
+        template<typename Self>
+        auto find(this Self&& self, model::topic_namespace_view key) {
+            return std::forward<Self>(self)._by_tp.find(key);
+        }
+
+        auto contains(model::topic_namespace_view key) const {
+            return _by_tp.contains(key);
+        }
+
+        auto emplace(topic_metadata_item val) {
+            auto key = val.get_configuration().tp_ns;
+            auto r = _by_tp.emplace(std::move(key), std::move(val));
+            if (r.second) {
+                auto& tp_id = r.first->second.get_configuration().tp_id;
+                if (tp_id) {
+                    auto [_, inserted] = _by_id.insert_or_assign(
+                      *tp_id, r.first->first);
+                    vassert(
+                      inserted,
+                      "must not reassign the same id to multiple topics");
+                } else {
+                    // Should be unreachable once the topic_ids feature is
+                    // active and all topics have a topic id assigned
+                    vlog(
+                      clusterlog.debug,
+                      "Missing topic id while inserting topic: {}",
+                      r.first->first);
+                }
+            }
+            return r;
+        }
+
+        auto erase(underlying_t::const_iterator it) {
+            if (it != _by_tp.end()) {
+                auto& tp_id = it->second.get_configuration().tp_id;
+                if (tp_id) {
+                    _by_id.erase(*tp_id);
+                } else {
+                    // Should be unreachable once the topic_ids feature is
+                    // active and all topics have a topic id assigned
+                    vlog(
+                      clusterlog.debug,
+                      "Missing topic id while erasing topic: {}",
+                      it->first);
+                }
+            }
+            return _by_tp.erase(it);
+        }
+
+        template<std::invocable<unsafe_topic_metadata_item&> Func>
+        bool mutate(const underlying_t::const_iterator it, Func&& func) {
+            auto old_tp = it->second.get_configuration().tp_ns;
+            auto old_id = it->second.get_configuration().tp_id;
+
+            // This is safe because the underlying _by_tp is mutable
+            // NOLINTBEGIN(*-const-cast, *static-cast-downcast)
+            auto& md_item_mut
+              = const_cast<underlying_t::value_type::second_type&>(it->second);
+            // This is safe because unsafe_topic_metadata_item has no new data
+            // members
+            func(static_cast<unsafe_topic_metadata_item&>(md_item_mut));
+            // NOLINTEND(*-const-cast, *static-cast-downcast)
+
+            auto& new_tp = it->second.get_configuration().tp_ns;
+            vassert(old_tp == new_tp, "func must not change the topic name");
+
+            auto& new_id = it->second.get_configuration().tp_id;
+            if (old_id != new_id) {
+                if (old_id) {
+                    _by_id.erase(*old_id);
+                }
+                if (new_id) {
+                    auto [_, inserted] = _by_id.insert_or_assign(
+                      *new_id, it->first);
+                    vassert(
+                      inserted,
+                      "must not reassign the same id to multiple topics");
+                }
+            }
+            return true;
+        }
+
+        std::optional<model::topic_namespace>
+        get_name(const model::topic_id& tp_id) const {
+            if (auto it = _by_id.find(tp_id); it != _by_id.end()) {
+                return it->second;
+            }
+            return std::nullopt;
+        }
+
+    private:
+        underlying_t _by_tp;
+        topic_id_mapping_t _by_id;
+    };
 
     using lifecycle_markers_t = absl::node_hash_map<
       nt_revision,
@@ -502,7 +656,7 @@ public:
     std::optional<partition_assignment>
     get_partition_assignment(const model::ntp&) const;
 
-    const underlying_t& topics_map() const { return _topics; }
+    const underlying_t& topics_map() const { return _topics.by_tp(); }
 
     bool is_update_in_progress(const model::ntp&) const;
 
@@ -661,6 +815,15 @@ public:
     static topic_properties update_topic_properties(
       topic_properties updated_properties, update_topic_properties_cmd cmd);
 
+    const topic_id_mapping_t& get_topic_id_mapping() const {
+        return _topics.by_id();
+    }
+
+    std::optional<model::topic_namespace>
+    get_name_by_id(model::topic_id tp_id) const {
+        return _topics.get_name(tp_id);
+    }
+
 private:
     friend topic_table_probe;
 
@@ -708,7 +871,7 @@ private:
     bool
     topic_multi_property_validation(const topic_properties& properties) const;
 
-    underlying_t _topics;
+    underlying_map _topics;
     lifecycle_markers_t _lifecycle_markers;
     disabled_partitions_t _disabled_partitions;
     iceberg_tombstones_t _iceberg_tombstones;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -116,6 +116,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::data_migration_invalid_definition:
     case cluster::errc::data_migrations_disabled:
     case cluster::errc::invalid_target_node_id:
+    case cluster::errc::topic_id_already_exists:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -293,8 +293,8 @@ get_topic_metadata(
                   authz_quiet{true})) {
                 continue;
             }
-            res.push_back(
-              make_topic_response(ctx, request, md.metadata, is_node_isolated));
+            res.push_back(make_topic_response(
+              ctx, request, md.get_metadata(), is_node_isolated));
         }
 
         return ss::make_ready_future<

--- a/src/v/migrations/cloud_storage_config.cc
+++ b/src/v/migrations/cloud_storage_config.cc
@@ -38,7 +38,7 @@ ss::future<> cloud_storage_config::do_mutate() {
     vlog(featureslog.info, "Checking for topic configs to update...");
     size_t update_count = 0;
     for (const auto& i : topic_table.topics_map()) {
-        auto& topic_conf = i.second.metadata.get_configuration();
+        auto& topic_conf = i.second.get_configuration();
 
         auto& props = topic_conf.properties;
 


### PR DESCRIPTION
This PR implements an efficient lookup of topic names by topic id on the `topic_table`. This will be used by kafka handlers to translate the topic id received on a request to its topic name.

This is implemented as a derived map from topic id to topic name that is updated on every topic modification command.

Fixes https://redpandadata.atlassian.net/browse/CORE-9875

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
