### PR TITLE
kafka/write_at_offset_stm: expose expected last offset from the stm

### DIFF
--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -318,6 +318,19 @@ write_at_offset_stm::take_local_snapshot(ssx::semaphore_units) {
     co_return raft::stm_snapshot{.header = hdr, .data = std::move(data)};
 }
 
+ss::future<result<kafka::offset>> write_at_offset_stm::get_expected_last_offset(
+  model::timeout_clock::duration sync_timeout) {
+    auto u = co_await _sync_lock.get_units();
+    auto sync_result = co_await sync(sync_timeout);
+    if (!sync_result) {
+        vlog(
+          _log.info,
+          "unable to retrieve expected last offset. State machine sync failed");
+        co_return raft::errc::not_leader;
+    }
+    co_return expected_last_offset();
+}
+
 write_at_offset_stm_factory::write_at_offset_stm_factory(
   storage::kvstore& kvstore,
   std::vector<model::record_batch_type> offset_translated_batches)

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -108,6 +108,17 @@ public:
     get_initial_recovery_policy() const final {
         return raft::stm_initial_recovery_policy::skip_to_end;
     }
+    /**
+     * Returns the effective last offset as perceived by the state machine. This
+     * function calls `persisted_stm::sync()` to make sure the returned offset
+     * is up to date.
+
+     * NOTE: the resulting offset can move backward if the inflight replicate
+     * request fails
+     *
+     */
+    ss::future<result<kafka::offset>>
+    get_expected_last_offset(model::timeout_clock::duration sync_timeout);
 
 private:
     ss::future<> do_apply(const model::record_batch& b) final;


### PR DESCRIPTION
Exposed expected last offset from the STM API for the error handling. When a caller experience an error it should always query the `write_at_offset_stm::get_expected_last_offset` and retry the next offset.

fixes: CORE-10029

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none