### PR TITLE
`storage`: fix `non_data_timestamps` with overflow

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -255,8 +255,9 @@ bool index_state::maybe_index(
           time_col_reset,
           "Relative time index can not be reset, unexpected index size {} "
           "(expected 1). This can only happen if more than one non-data "
-          "timestamp was added to the index.",
-          index.size());
+          "timestamp was added to the index: {}.",
+          index.size(),
+          *this);
 
         base_timestamp = first_timestamp;
         max_timestamp = first_timestamp;
@@ -265,6 +266,7 @@ bool index_state::maybe_index(
 
     // index_state
     bool is_empty = false;
+    bool should_set_non_data_timestamp = false;
     if (empty()) {
         // Ordinarily, we do not allow configuration batches to contribute to
         // the segment's timestamp bounds (because config batches use walltime
@@ -272,7 +274,7 @@ bool index_state::maybe_index(
         // batch we set the timestamps, and then set a `non_data_timestamps`
         // flag so that the next time we see user data we will overwrite
         // the walltime timestamps with the user data timestamps.
-        non_data_timestamps = !user_data;
+        should_set_non_data_timestamp = !user_data;
 
         base_timestamp = first_timestamp;
         max_timestamp = first_timestamp;
@@ -308,7 +310,9 @@ bool index_state::maybe_index(
               batch_base_offset() - base_offset(),
               offset_time_index{last_timestamp - base_timestamp, with_offset},
               starting_position_in_file);
-
+            if (should_set_non_data_timestamp) {
+                non_data_timestamps = true;
+            }
             return true;
         } else {
             // We can't index anything beyond uint32 space. Presumably no

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -377,3 +377,34 @@ BOOST_AUTO_TEST_CASE(index_overflow) {
     BOOST_CHECK_EQUAL(res->offset, model::offset{0});
     BOOST_CHECK_EQUAL(res->filepos, 1);
 }
+
+BOOST_AUTO_TEST_CASE(non_data_timestamps_with_overflow) {
+    storage::index_state state;
+
+    // Need to ensure that non_data_timestamps in the segment_index is only set
+    // iff there is an entry in the index_state. Otherwise, a call to
+    // index.try_reset_relative_time_index() will trigger a vassert.
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    state.maybe_index(
+      0,
+      1,
+      0,
+      model::offset{uint32_max + 1},
+      model::offset{uint32_max + 1},
+      model::timestamp{0},
+      model::timestamp{0},
+      std::nullopt,
+      false,
+      0);
+    state.maybe_index(
+      1,
+      1,
+      1,
+      model::offset{uint32_max + 2},
+      model::offset{uint32_max + 2},
+      model::timestamp{0},
+      model::timestamp{0},
+      std::nullopt,
+      true,
+      0);
+}


### PR DESCRIPTION
After changes made to checking for overflows before indexing entries in the `segment_index`, this can trigger a `vassert`:

1. `maybe_index()` is called
2. We are adding the first entry for the index, `empty() == true`
3. Assume `user_data` is `false`, thereby setting `non_data_timestamps == true`
4. Previously this entry would have always been added to the `segment_index`, leading to the invariant that `non_data_timestamps` can only be `true` iff the size of `index == 1`.
4. But now, we check for overflows. Assume the batch we were trying to index is subject to the overflow. The previous invariant is now not true.
5. We end up NOT indexing an entry, and set `non_data_timestamps == true`.
6. The next time we call into `maybe_index()` with `user_data == true`, an attempt is made to reset the time index, and the assert is triggered because `_relative_time_index.size() == 0`.

Fix this case by only setting `non_data_timestamps` iff the previous conditions are true, AND we do end up indexing an entry.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x

## Release Notes

* none
