### PR TITLE
[v25.1.x] `storage`: fix `non_data_timestamps` with overflow

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -255,8 +255,9 @@ bool index_state::maybe_index(
           time_col_reset,
           "Relative time index can not be reset, unexpected index size {} "
           "(expected 1). This can only happen if more than one non-data "
-          "timestamp was added to the index.",
-          index.size());
+          "timestamp was added to the index: {}.",
+          index.size(),
+          *this);
 
         base_timestamp = first_timestamp;
         max_timestamp = first_timestamp;
@@ -265,6 +266,7 @@ bool index_state::maybe_index(
 
     // index_state
     bool is_empty = false;
+    bool should_set_non_data_timestamp = false;
     if (empty()) {
         // Ordinarily, we do not allow configuration batches to contribute to
         // the segment's timestamp bounds (because config batches use walltime
@@ -272,7 +274,7 @@ bool index_state::maybe_index(
         // batch we set the timestamps, and then set a `non_data_timestamps`
         // flag so that the next time we see user data we will overwrite
         // the walltime timestamps with the user data timestamps.
-        non_data_timestamps = !user_data;
+        should_set_non_data_timestamp = !user_data;
 
         base_timestamp = first_timestamp;
         max_timestamp = first_timestamp;
@@ -308,7 +310,9 @@ bool index_state::maybe_index(
               batch_base_offset() - base_offset(),
               offset_time_index{last_timestamp - base_timestamp, with_offset},
               starting_position_in_file);
-
+            if (should_set_non_data_timestamp) {
+                non_data_timestamps = true;
+            }
             return true;
         } else {
             // We can't index anything beyond uint32 space. Presumably no

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -377,3 +377,34 @@ BOOST_AUTO_TEST_CASE(index_overflow) {
     BOOST_CHECK_EQUAL(res->offset, model::offset{0});
     BOOST_CHECK_EQUAL(res->filepos, 1);
 }
+
+BOOST_AUTO_TEST_CASE(non_data_timestamps_with_overflow) {
+    storage::index_state state;
+
+    // Need to ensure that non_data_timestamps in the segment_index is only set
+    // iff there is an entry in the index_state. Otherwise, a call to
+    // index.try_reset_relative_time_index() will trigger a vassert.
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    state.maybe_index(
+      0,
+      1,
+      0,
+      model::offset{uint32_max + 1},
+      model::offset{uint32_max + 1},
+      model::timestamp{0},
+      model::timestamp{0},
+      std::nullopt,
+      false,
+      0);
+    state.maybe_index(
+      1,
+      1,
+      1,
+      model::offset{uint32_max + 2},
+      model::offset{uint32_max + 2},
+      model::timestamp{0},
+      model::timestamp{0},
+      std::nullopt,
+      true,
+      0);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26080
