### PR TITLE
[v24.1.x] `storage`: fix `non_data_timestamps` with overflow (Manual backport)

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -59,7 +59,16 @@ bool index_state::maybe_index(
     // to override the timestamps of any config batch that was indexed
     // by virtue of being the first in the segment.
     if (user_data && non_data_timestamps) {
-        vassert(relative_time_index.size() == 1, "");
+        // We can only add a non-data timestamp to the empty index. This
+        // is why we can assume that the index size is 1.
+        // Otherwise it will be impossible to to reset the non-data timestamp.
+        vassert(
+          relative_time_index.size() == 1,
+          "Relative time index can not be reset, unexpected index size {} "
+          "(expected 1). This can only happen if more than one non-data "
+          "timestamp was added to the index: {}.",
+          relative_time_index.size(),
+          *this);
         relative_time_index[0]
           = offset_time_index{last_timestamp, with_offset}.raw_value();
 
@@ -70,6 +79,7 @@ bool index_state::maybe_index(
 
     // index_state
     bool is_empty = false;
+    bool should_set_non_data_timestamp = false;
     if (empty()) {
         // Ordinarily, we do not allow configuration batches to contribute to
         // the segment's timestamp bounds (because config batches use walltime
@@ -77,7 +87,7 @@ bool index_state::maybe_index(
         // batch we set the timestamps, and then set a `non_data_timestamps`
         // flag so that the next time we see user data we will overwrite
         // the walltime timestamps with the user data timestamps.
-        non_data_timestamps = !user_data;
+        should_set_non_data_timestamp = !user_data;
 
         base_timestamp = first_timestamp;
         max_timestamp = first_timestamp;
@@ -113,7 +123,9 @@ bool index_state::maybe_index(
               batch_base_offset() - base_offset(),
               offset_time_index{last_timestamp - base_timestamp, with_offset},
               starting_position_in_file);
-
+            if (should_set_non_data_timestamp) {
+                non_data_timestamps = true;
+            }
             return true;
         } else {
             // We can't index anything beyond uint32 space. Presumably no

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -244,3 +244,34 @@ BOOST_AUTO_TEST_CASE(offset_time_index_test) {
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(non_data_timestamps_with_overflow) {
+    storage::index_state state;
+
+    // Need to ensure that non_data_timestamps in the segment_index is only set
+    // iff there is an entry in the index_state. Otherwise, a call to
+    // index.try_reset_relative_time_index() will trigger a vassert.
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    state.maybe_index(
+      0,
+      1,
+      0,
+      model::offset{uint32_max + 1},
+      model::offset{uint32_max + 1},
+      model::timestamp{0},
+      model::timestamp{0},
+      std::nullopt,
+      false,
+      0);
+    state.maybe_index(
+      1,
+      1,
+      1,
+      model::offset{uint32_max + 2},
+      model::offset{uint32_max + 2},
+      model::timestamp{0},
+      model::timestamp{0},
+      std::nullopt,
+      true,
+      0);
+}


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26080. `cherry-pick` conflict due to changes in `segment_index::maybe_index()` that didn't exist in previous version.

Fixes https://github.com/redpanda-data/redpanda/issues/26088

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
