### PR TITLE
bazel: install docker command inside bazel docker image

### DIFF
--- a/tools/docker/bazel.dockerfile
+++ b/tools/docker/bazel.dockerfile
@@ -5,13 +5,21 @@ ARG TARGETARCH
 
 COPY --chown=0:0 bazel/install-deps.sh /
 
-RUN apt-get update && apt install -y wget python3 python3-venv curl pigz patchelf devscripts debhelper
+RUN apt-get update && apt install -y wget python3 python3-venv curl pigz patchelf devscripts debhelper rpm zip
 RUN wget -O /usr/local/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${TARGETARCH} && \
         chmod +x /usr/local/bin/bazel
 
 # run after wget installation to take advantage of pkg cache cleaning
 RUN CLEAN_PKG_CACHE=true /install-deps.sh && rm /install-deps.sh
+
+# install docker
+RUN bash -c \
+        "curl -fsSLo - https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.2.1.tgz | \
+           tar xzvf - --strip 1 -C /usr/local/bin docker/docker && \
+         mkdir -p /root/.docker/cli-plugins && \
+         curl -fsSL https://github.com/docker/buildx/releases/download/v0.17.1/buildx-v0.17.1.linux-${TARGETARCH} -o /root/.docker/cli-plugins/docker-buildx && \
+         chmod +x /root/.docker/cli-plugins/docker-buildx"
 
 # CI will run this container as root, but a non-root user will clone the repo and set it up,
 # so we should just ignore these warnings for now.


### PR DESCRIPTION
Install docker along with the rpm and zip packages. This allows us to replace the cmake-based docker image for all of the docker tasks in a `ci:redpanda` build.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none