### PR TITLE
Cloud Storage: Bazelize some tests

### DIFF
--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -620,3 +620,127 @@ redpanda_cc_fuzz_test(
         "@fmt",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "cloud_storage_e2e_test",
+    timeout = "moderate",
+    srcs = ["cloud_storage_e2e_test.cc"],
+    cpu = 1,
+    deps = [
+        ":common",
+        ":read_replica_e2e_fixture",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cluster",
+        "//src/v/cluster/cloud_metadata/tests:manual_mixin",
+        "//src/v/kafka/data:partition_proxy",
+        "//src/v/kafka/server/tests:kafka_test_utils",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/storage",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:scoped_config",
+        "@googletest//:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "delete_records_e2e_test",
+    timeout = "short",
+    srcs = [
+        "delete_records_e2e_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":common",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_storage",
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/kafka/server/tests:kafka_test_utils",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/storage",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@boost//:algorithm",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "read_replica_test",
+    timeout = "short",
+    srcs = [
+        "read_replica_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":common",
+        ":read_replica_e2e_fixture",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_storage",
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/kafka/server/tests:kafka_test_utils",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/storage",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "segment_chunk_hydration_test",
+    timeout = "short",
+    srcs = [
+        "segment_chunk_hydration_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":common",
+        ":read_replica_e2e_fixture",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_storage",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:lazy_abort_source",
+        "//src/v/utils:stream_provider",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_btest(
+    name = "topic_recovery_service_test",
+    timeout = "short",
+    srcs = [
+        "topic_recovery_service_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":common",
+        ":read_replica_e2e_fixture",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_storage",
+        "//src/v/cluster",
+        "//src/v/cluster/cloud_metadata/tests:manual_mixin",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:memory_data_source",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -702,6 +702,14 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
       archiver->manifest().get_spillover_map().begin()->base_offset,
       first_seg.base_offset);
 
+    // Supply some phony disk stats so that the cache doesn't panic and
+    // think it has zero bytes of space. Otherwise we seem to be racing
+    // against an async notification in release mode.
+    app.shadow_index_cache.local().notify_disk_status(
+      100ULL * 1024 * 1024 * 1024,
+      50ULL * 1024 * 1024 * 1024,
+      storage::disk_space_alert::ok);
+
     // To be sure we actually query S3, force removal of any cached files.
     app.shadow_index_cache.local()
       .trim_manually(

--- a/src/v/cloud_storage/tests/read_replica_e2e_fixture.h
+++ b/src/v/cloud_storage/tests/read_replica_e2e_fixture.h
@@ -50,7 +50,7 @@ public:
           std::vector<config::seed_server>{},
           test_directory(),
           app.sched_groups,
-          true,
+          false,
           get_s3_config(httpd_port_number()),
           get_archival_config(),
           get_cloud_config(httpd_port_number()));

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -109,3 +109,21 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
     ],
 )
+
+redpanda_cc_btest(
+    name = "client_pool_mt_test",
+    timeout = "short",
+    srcs = [
+        "client_pool_mt_test.cc",
+    ],
+    cpu = 2,
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_storage_clients",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:range",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

cloud_storage/tests:
- cloud_storage_e2e_test **[PASS]**
- delete_records_e2e_test **[PASS]**
- read_replica_test **[PASS]**
- segment_chunk_hydration_test **[PASS]**
- topic_recovery_service_test **[PASS]**

cloud_storage_clients/tests:
- client_pool_mt_test **[PASS]**

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
