### PR TITLE
Fixed upgrade test to actually restart consumer in older Redpanda versions

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -169,6 +169,7 @@ class KgoVerifierService(Service):
         # Check that the PID we just launched is still running as a confirmation
         # that it is the one.
         self._assert_running(node)
+        self._stopped = False
 
     def _await_ready(self, node):
         """
@@ -199,9 +200,13 @@ class KgoVerifierService(Service):
         node.account.ssh_output(f"ps -p {self._pid}", allow_fail=False)
 
     def stop_node(self, node, **kwargs):
+        error = None
         if self._status_thread:
             self._status_thread.stop()
-            self._status_thread.raise_on_error()
+            try:
+                self._status_thread.raise_on_error()
+            except Exception as e:
+                error = e
             self._status_thread = None
             # Record that we just stopped, so that we can't wait() after.
             # This is done inside this if statement because stop_node() is also
@@ -223,6 +228,8 @@ class KgoVerifierService(Service):
 
         self._pid = None
         self._release_port()
+        if error:
+            raise error
 
     def clean_node(self, node: ClusterNode):
         self._redpanda.logger.info(f"{self.__class__.__name__}.clean_node")
@@ -726,7 +733,6 @@ class KgoVerifierProducer(KgoVerifierService):
             cmd += " --validate-latest-values"
 
         self.spawn(cmd, node)
-
         self._status_thread = StatusThread(self, node, ProduceStatus)
         self._status_thread.start()
 

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -257,19 +257,23 @@ class UpgradeBackToBackTest(PreallocNodesTest):
                 while max_retries > 0:
                     max_retries -= 1
                     try:
+                        self.logger.info(
+                            f"Waiting for consumer {consumer} to finish work..."
+                        )
                         consumer.wait()
                         break
                     except Exception as e:
                         # consumer status endpoint timeout, in v22 we need to tolerate the offset for leader epoch handler error
                         if current_version[0] <= 22:
                             self.logger.info(
-                                f"restarting consumer, Redpanda running {current_version} version"
+                                f"restarting consumer, Redpanda running {current_version} version, error: {e}"
                             )
                             try:
                                 consumer.stop()
-                            except Exception:
+                            except Exception as stop_exception:
                                 self.logger.info(
-                                    f"failed to stop consumer {consumer}")
+                                    f"failed to stop consumer {consumer} - {stop_exception}"
+                                )
                             consumer.start(clean=False)
                         else:
                             raise e


### PR DESCRIPTION
Fixes the way how stop is handled in KgoVerifierServices to make it possible to restart the service.

Fixes: CORE-10021
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none