### PR TITLE
`storage`: remove dead code in `compacted_index`

### DIFF
--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -43,16 +43,17 @@ struct compacted_index {
       std::numeric_limits<uint16_t>::max());
 
     enum class entry_type : uint8_t {
-        none, // error detection
+        none, // error detection. Deprecated.
         key,  // most common - just keys
         /// \brief because of raft truncations, we write a truncation, for
         /// the recovery thread to compact up to key-point on the index.
+        /// Deprecated.
         truncation,
     };
     // bitflags for index
     enum class footer_flags : uint32_t {
         none = 0,
-        /// needed for truncation events in the same raft-term
+        /// needed for truncation events in the same raft-term. Deprecated.
         truncation = 1U,
         /// needed to determine if we should self compact first
         self_compaction = 1U << 1U,

--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -73,7 +73,6 @@ public:
 
     virtual ss::future<> append(compacted_index::entry) = 0;
 
-    virtual ss::future<> truncate(model::offset) = 0;
     virtual ss::future<> close() = 0;
     virtual void set_flag(compacted_index::footer_flags) = 0;
     virtual void print(std::ostream&) const = 0;

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -324,25 +324,6 @@ void spill_key_index::set_flag(compacted_index::footer_flags f) {
     _footer.flags |= f;
 }
 
-ss::future<> spill_key_index::truncate(model::offset o) {
-    return ss::try_with_gate(_gate, [this, o]() {
-        set_flag(compacted_index::footer_flags::truncation);
-        return drain_all_keys().then([this, o] {
-            static constexpr std::string_view compacted_key = "compaction";
-            return spill(
-              compacted_index::entry_type::truncation,
-              bytes_view(
-                // NOLINTNEXTLINE
-                reinterpret_cast<const uint8_t*>(compacted_key.data()),
-                compacted_key.size()),
-              // this is actually the base_offset + max_delta so everything
-              // upto and including this offset must be ignored during self
-              // compaction
-              value_type{o, 0});
-        });
-    });
-}
-
 ss::future<> spill_key_index::maybe_open() {
     if (!_appender.has_value()) {
         co_await open();

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -78,7 +78,6 @@ public:
       bytes&&,
       model::offset,
       int32_t) final;
-    ss::future<> truncate(model::offset) final;
     ss::future<> append(compacted_index::entry) final;
     ss::future<> close() final;
     void print(std::ostream&) const final;


### PR DESCRIPTION
* The `compacted_index_writer::truncate()` function is not used anywhere in the current tree. Remove it.
* In the `compacted_index`, we now only ever write entries of `entry_type::key` via the `spill_key_index`. Note this in the `compacted_index::entry_type` enum for future reference. Also, the `compacted_index::footer_flag::truncation` bitflag is not used in the tree either. Append a "deprecated" comment here as well.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
