### PR TITLE
`rptest`: remove `pynessie` import

### DIFF
--- a/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py
+++ b/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py
@@ -16,7 +16,6 @@ from rptest.services.spark_service import SparkService
 from rptest.tests.datalake.utils import supported_storage_types
 
 from ducktape.mark import matrix
-import pynessie
 
 from pyiceberg.schema import Schema
 from pyiceberg.types import (
@@ -57,15 +56,6 @@ class NessieCatalogSmokeTest(RedpandaTest):
     @cluster(num_nodes=5)
     @matrix(cloud_storage_type=supported_storage_types())
     def test_nessie_with_trino(self, cloud_storage_type):
-        """
-        Trino currently doesn't support Nessie management through SQL.
-        For that reason, pynessie is used here. Pynessie is considered
-        deprecated in favour of the CLI, so its use here should also be
-        limited/eventually replaced. Unfortunately, Trino also doesn't
-        support switching branches (references) without modifying the
-        catalog property iceberg.nessie-catalog.ref, which requires a
-        change to the redpanda.properties file and a restart.
-        """
         self.trino = TrinoService(self.test_ctx,
                                   self.catalog_service.vendor_api_url,
                                   self.catalog_service.cloud_storage_warehouse,
@@ -73,8 +63,6 @@ class NessieCatalogSmokeTest(RedpandaTest):
         self.trino.start()
         client = self.trino.make_client()
 
-        nessie_client_conf = {"endpoint": self.catalog_service.vendor_api_url}
-        nessie_client = pynessie.init(config_dict=nessie_client_conf)
         try:
             cursor = client.cursor()
             try:
@@ -94,16 +82,6 @@ class NessieCatalogSmokeTest(RedpandaTest):
                 row = cursor.fetchall()
                 assert len(row) == 1
                 assert row == [(2024, 'John', 60, 'Wick')]
-
-                main_branch = "main"
-                dev_branch = "dev"
-
-                main_branch_ref = nessie_client.get_reference(None)
-                nessie_client.create_branch(dev_branch, main_branch,
-                                            main_branch_ref.hash_)
-                refs = nessie_client.list_references()
-                assert len(refs.references) == 2
-
             finally:
                 cursor.close()
         finally:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -54,7 +54,6 @@ setup(
         "thrift==0.20.0",
         "thrift-sasl==0.4.3",
         "pyhive==0.7.0",
-        "pynessie",
         "python-snappy==0.7.3",
         "lz4==4.4.3",
         "databricks-sdk==0.49.0",


### PR DESCRIPTION
Pynessie is deprecated and furthermore seems to be running into issues in CI:

```
t=1747075535094 [ERROR:2025-05-12 18:45:35,094]: Failed to import rptest.tests.datalake.nessie_catalog_smoke_test, which may indicate a broken test that cannot be loaded: Traceback (most recent call last):
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/loader.py", line 287, in _import_module
t=1747075535094    module_and_file = ModuleAndFile(module=importlib.import_module(module_name), file=file_path)
t=1747075535094  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
t=1747075535094    return _bootstrap._gcd_import(name[level:], package, level)
t=1747075535094  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
t=1747075535094  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
t=1747075535094  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
t=1747075535094  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
t=1747075535094  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
t=1747075535094  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
t=1747075535094  File "/root/tests/rptest/tests/datalake/nessie_catalog_smoke_test.py", line 19, in <module>
t=1747075535094    import pynessie
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pynessie/__init__.py", line 21, in <module>
t=1747075535094    from pynessie.client import NessieClient
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pynessie/client/__init__.py", line 18, in <module>
t=1747075535094    from pynessie.client.nessie_client import NessieClient
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pynessie/client/nessie_client.py", line 22, in <module>
t=1747075535094    from pynessie.client._endpoints import (
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pynessie/client/_endpoints.py", line 27, in <module>
t=1747075535094    from pynessie.model import ContentKey
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pynessie/model.py", line 529, in <module>
t=1747075535094    class DiffEntry:
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/pynessie/model.py", line 533, in DiffEntry
t=1747075535094    from_content: Content = desert.ib(fields.Nested(ContentSchema, default=None, data_key="from", allow_none=True))
t=1747075535094  File "/opt/.ducktape-venv/lib/python3.10/site-packages/marshmallow/fields.py", line 522, in __init__
t=1747075535094    super().__init__(**kwargs)
t=1747075535094 TypeError: Field.__init__() got an unexpected keyword argument 'default'
```

Remove its usage from `nessie_catalog_smoke_test` and its dependency in `tests/setup.py`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
