### PR TITLE
storage: CORE-10056: Remove contiguous allocations in lock_manager

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -416,6 +416,7 @@ redpanda_cc_library(
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
         "//src/v/ssx:watchdog",
+        "//src/v/ssx:when_all",
         "//src/v/strings:static_str",
         "//src/v/strings:string_switch",
         "//src/v/utils:adjustable_semaphore",

--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -9,7 +9,9 @@
 
 #include "storage/lock_manager.h"
 
+#include "container/fragmented_vector.h"
 #include "model/offset_interval.h"
+#include "ssx/when_all.h"
 #include "storage/segment.h"
 
 #include <seastar/core/future-util.hh>
@@ -24,14 +26,16 @@ static ss::future<std::unique_ptr<lock_manager::lease>>
 range(segment_set::underlying_t segs) {
     auto ctx = std::make_unique<lock_manager::lease>(
       segment_set(std::move(segs)));
-    std::vector<ss::future<ss::rwlock::holder>> dispatch;
-    dispatch.reserve(ctx->range.size());
+
+    chunked_vector<ss::future<ss::rwlock::holder>> dispatch;
     for (auto& s : ctx->range) {
-        dispatch.emplace_back(s->read_lock());
+        dispatch.push_back(s->read_lock());
     }
-    return ss::when_all_succeed(dispatch.begin(), dispatch.end())
+
+    return ssx::when_all_succeed<chunked_vector<ss::rwlock::holder>>(
+             std::move(dispatch))
       .then(
-        [ctx = std::move(ctx)](std::vector<ss::rwlock::holder> lks) mutable {
+        [ctx = std::move(ctx)](chunked_vector<ss::rwlock::holder> lks) mutable {
             ctx->locks = std::move(lks);
             return std::move(ctx);
         });

--- a/src/v/storage/lock_manager.h
+++ b/src/v/storage/lock_manager.h
@@ -14,6 +14,7 @@
 // important to keep dependencies small because this type is used
 // in the log readers and throughout the code where segment_set.h is used
 // if it becomes large, consider making it a pimpl class
+#include "container/fragmented_vector.h"
 #include "storage/fwd.h"
 #include "storage/segment_set.h"
 
@@ -34,7 +35,7 @@ public:
         lease& operator=(const lease&) = delete;
 
         segment_set range;
-        std::vector<ss::rwlock::holder> locks;
+        chunked_vector<ss::rwlock::holder> locks;
 
         friend std::ostream& operator<<(std::ostream&, const lease&);
     };


### PR DESCRIPTION
The `range` function allocated a std::vector of futures before acquiring all locks, and then held the locks in a std::vector. This was observed causing OOM in a large cluster. The std::vector usage has been replaced with chunked_vector.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x

## Release Notes

* none
