### PR TITLE
storage/compaction: Implement max.compaction.lag.ms

### DIFF
--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -258,4 +258,9 @@ double failure_injectable_log::dirty_ratio() {
     return _underlying_log->dirty_ratio();
 }
 
+std::optional<model::timestamp>
+failure_injectable_log::earliest_dirty_segment_ts() const {
+    return _underlying_log->earliest_dirty_segment_ts();
+}
+
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -138,6 +138,9 @@ public:
 
     double dirty_ratio() final;
 
+    virtual std::optional<model::timestamp>
+    earliest_dirty_segment_ts() const final;
+
 private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -61,6 +61,7 @@
 #include <fmt/format.h>
 #include <roaring/roaring.hh>
 
+#include <algorithm>
 #include <chrono>
 #include <exception>
 #include <iterator>
@@ -2197,45 +2198,87 @@ ss::future<> disk_log_impl::apply_segment_ms() {
         co_return;
     }
 
+    // Find the max allowable age of a segment. There are two factors:
+    // 1. `segment.ms` configuration.
+    // 2. For a compacted topic, `max.compaction.lag.ms` configuration,
+    //    because this value is the maximum amount of time a segment
+    //    can be ineligible for compaction, and an active segment is
+    //    ineligible.
+    std::optional<std::chrono::milliseconds> max_age;
     auto seg_ms = config().segment_ms();
-    if (!seg_ms.has_value()) {
-        // skip, disabled or no default value
+    auto& local_config = config::shard_local_cfg();
+    static constexpr auto rate_limit = std::chrono::minutes(5);
+    thread_local static ss::logger::rate_limit rate(rate_limit);
+    if (seg_ms.has_value()) {
+        // Clamp user provided value with (hopefully sane) server min and max
+        // values, this should protect against overflow UB.
+        const auto clamped_seg_ms = std::clamp(
+          seg_ms.value(),
+          local_config.log_segment_ms_min(),
+          local_config.log_segment_ms_max());
+
+        if (seg_ms < clamped_seg_ms) {
+            stlog.log(
+              ss::log_level::warn,
+              rate,
+              "Configured segment.ms={} is lower than the configured cluster "
+              "bound {}={}",
+              seg_ms.value(),
+              local_config.log_segment_ms_min.name(),
+              local_config.log_segment_ms_min());
+        }
+
+        if (seg_ms > clamped_seg_ms) {
+            stlog.log(
+              ss::log_level::warn,
+              rate,
+              "Configured segment.ms={} is higher than the configured cluster "
+              "bound {}={}",
+              seg_ms.value(),
+              local_config.log_segment_ms_max.name(),
+              local_config.log_segment_ms_max());
+        }
+
+        max_age = clamped_seg_ms;
+    }
+
+    // Take max compaction lag into account if the topic is compacted.
+    // Skip if the configuration is the default, which is effectively
+    // no max compaction lag.
+    // Technically, we should roll if a message is too old based on
+    // its own timestamp; however, doing this simpler thing matches
+    // what Kafka does exactly.
+    auto max_lag = config().max_compaction_lag_ms();
+    if (
+      config().is_compacted()
+      && max_lag != local_config.max_compaction_lag_ms.default_value()) {
+        // Clamp for the same reasons.
+        const auto clamped_max_lag = std::clamp(
+          seg_ms.value(),
+          local_config.log_segment_ms_min(),
+          local_config.log_segment_ms_max());
+        max_age = max_age.has_value()
+                    ? std::min(max_age.value(), clamped_max_lag)
+                    : clamped_max_lag;
+
+        // If we're applying max_lag to roll segments, that's likely a
+        // misconfiguration, and it's definitely worth noting.
+        if (max_age == max_lag) {
+            stlog.log(
+              ss::log_level::warn,
+              rate,
+              "Segment roll controlled by max.compaction.lag.ms ({}): this is "
+              "likely a configuration problem",
+              max_lag);
+        }
+    }
+
+    if (!max_age.has_value()) {
+        // No time-based rolling.
         co_return;
     }
 
-    auto& local_config = config::shard_local_cfg();
-    // clamp user provided value with (hopefully sane) server min and max
-    // values, this should protect against overflow UB
-    const auto clamped_seg_ms = std::clamp(
-      seg_ms.value(),
-      local_config.log_segment_ms_min(),
-      local_config.log_segment_ms_max());
-
-    static constexpr auto rate_limit = std::chrono::minutes(5);
-    thread_local static ss::logger::rate_limit rate(rate_limit);
-    if (seg_ms < clamped_seg_ms) {
-        stlog.log(
-          ss::log_level::warn,
-          rate,
-          "Configured segment.ms={} is lower than the configured cluster "
-          "bound {}={}",
-          seg_ms.value(),
-          local_config.log_segment_ms_min.name(),
-          local_config.log_segment_ms_min());
-    }
-
-    if (seg_ms > clamped_seg_ms) {
-        stlog.log(
-          ss::log_level::warn,
-          rate,
-          "Configured segment.ms={} is higher than the configured cluster "
-          "bound {}={}",
-          seg_ms.value(),
-          local_config.log_segment_ms_max.name(),
-          local_config.log_segment_ms_max());
-    }
-
-    if (first_write_ts.value() + clamped_seg_ms > ss::lowres_clock::now()) {
+    if (first_write_ts.value() + max_age.value() > ss::lowres_clock::now()) {
         // skip, time hasn't expired
         co_return;
     }
@@ -2250,9 +2293,9 @@ ss::future<> disk_log_impl::apply_segment_ms() {
     co_await new_segment(new_so, offsets.get_term(), pc);
     vlog(
       stlog.trace,
-      "{} segment.ms applied, new segment start offset: {}",
+      "{} segment rolled, new segment start offset: {}",
       config().ntp(),
-      seg_ms.value());
+      new_so);
 }
 
 ss::future<model::record_batch_reader>
@@ -4447,6 +4490,21 @@ void disk_log_impl::reset_dirty_and_closed_bytes() {
     }
     _dirty_segment_bytes = dirty;
     _closed_segment_bytes = closed;
+}
+
+std::optional<model::timestamp>
+disk_log_impl::earliest_dirty_segment_ts() const {
+    auto dirty_segments_ts = _segs | std::views::filter([](const auto& seg) {
+                                 return !seg->has_appender()
+                                        && !seg->has_clean_compact_timestamp();
+                             })
+                             | std::views::transform([](const auto& seg) {
+                                   return seg->index().base_timestamp();
+                               });
+    if (std::ranges::empty(dirty_segments_ts)) {
+        return std::nullopt;
+    }
+    return *std::ranges::min_element(dirty_segments_ts);
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -286,6 +286,8 @@ public:
     // total number of bytes in all closed segments in the log.
     double dirty_ratio() final;
 
+    std::optional<model::timestamp> earliest_dirty_segment_ts() const final;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -241,6 +241,10 @@ public:
     // segments in the log.
     virtual double dirty_ratio() = 0;
 
+    // Return the earliest batch timestamp among all dirty segments.
+    virtual std::optional<model::timestamp>
+    earliest_dirty_segment_ts() const = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -310,7 +310,21 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         compaction_heuristic_to_log_metas;
     for (auto& log_meta : _logs_list) {
         auto should_compact_log = [](ss::shared_ptr<log> l) {
-            // Consider the dirty ratio.
+            // A log is eligible for compaction if at least one of the following
+            // is true:
+            // 1. It's gone long enough without compaction: the earliest first
+            //    batch timestamp of a dirty segment is longer ago than
+            //    the max compaction lag.
+            // 2. It's dirty enough: the dirty ratio is at least the minimum
+            //    cleanable dirty ratio.
+            const auto max_lag = l->config().max_compaction_lag_ms();
+            const auto now = to_time_point(model::timestamp::now());
+            const auto earliest_dirty_ts = l->earliest_dirty_segment_ts();
+            if (
+              earliest_dirty_ts
+              && (now - to_time_point(earliest_dirty_ts.value()) > max_lag)) {
+                return true;
+            }
             const auto min_cleanable_dirty_ratio
               = l->config().min_cleanable_dirty_ratio().value_or(0.0);
             const auto dirty_ratio = l->dirty_ratio();

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5762,6 +5762,75 @@ FIXTURE_TEST(compaction_scheduling, storage_test_fixture) {
     }
 }
 
+FIXTURE_TEST(max_compaction_lag, storage_test_fixture) {
+    using log_manager_accessor = storage::testing_details::log_manager_accessor;
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    std::vector<ss::shared_ptr<storage::log>> logs;
+
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    ov.min_cleanable_dirty_ratio = tristate<double>{1.0};
+    ov.max_compaction_lag_ms = 1000ms;
+
+    auto ntp = model::ntp("kafka", "tapioca", 0);
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    using bflags = storage::log_housekeeping_meta::bitflags;
+    static constexpr auto is_set = [](bflags var, auto flag) {
+        return (var & flag) == flag;
+    };
+
+    auto append_and_force_roll = [this, &log](int num_batches = 10) {
+        auto headers = append_random_batches<linear_int_kv_batch_generator>(
+          log, num_batches);
+        log->force_roll(ss::default_priority_class()).get();
+    };
+
+    // Append and close one segment, then compact.
+    // The one closed segment is compacted because the log is 100% dirty.
+    auto start = std::chrono::steady_clock::now();
+    append_and_force_roll();
+    BOOST_REQUIRE_EQUAL(log->dirty_ratio(), 1.0);
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    auto& meta = log_manager_accessor::logs_list(mgr).front();
+    BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+    BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+    BOOST_REQUIRE(is_set(meta.flags, bflags::compacted));
+    read_and_validate_all_batches(log);
+
+    // Append more batches and compact.
+    // Now the log is half-dirty, which isn't dirty enough to compact.
+    append_and_force_roll();
+    BOOST_REQUIRE_LT(log->dirty_ratio(), 1.0);
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+    BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+    // This test should run fast enough that the log is not compacted,
+    // but on the rare occasion it doesn't, let's not fail.
+    BOOST_REQUIRE(
+      !is_set(meta.flags, bflags::compacted)
+      || (std::chrono::steady_clock::now() - start >= ov.max_compaction_lag_ms.value()));
+    read_and_validate_all_batches(log);
+
+    // Wait for the max lag to pass, then compact.
+    // Compaction should happen despite the low dirty ratio.
+    ss::sleep(ov.max_compaction_lag_ms.value() + 50ms).get();
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    BOOST_REQUIRE(is_set(meta.flags, bflags::lifetime_checked));
+    BOOST_REQUIRE(is_set(meta.flags, bflags::compaction_checked));
+    BOOST_REQUIRE(is_set(meta.flags, bflags::compacted));
+    read_and_validate_all_batches(log);
+}
+
 // Ensures that the log_housekeeping_meta level locking/concurrency in
 // the log_manager is race free during ntp removal, addition, and housekeeping.
 // By allowing regular housekeeping to run on a quick interval and also

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1391,7 +1391,7 @@ class SegmentRolledByTimeout(Expression):
     def make_validators(self):
         return [
             LogBasedValidator("SegmentRolledByTimeout_log",
-                              "segment.ms applied, new segment start offset",
+                              "segment rolled, new segment start offset",
                               confidence_threshold=4,
                               execution_stage=TestRunStage.Produce),
         ]


### PR DESCRIPTION
This implements the configuration option max.compaction.lag.ms.
This option defines the maximum amount of time that a log can remain
ineligible for compaction, in terms of its uncompacted segments' batch
timestamps.
```
============================> time
           |--- max lag ---|
                          now
|_segment-0_||_segment-1_|
```
Uncompacted `segment-0` qualifies its log for compaction regardless of
the minimum dirty ratio, because its earliest timestamp is older than
`now - max lag`. `segment-1` may or may not make its log eligible for
compaction, depending on the minimum dirty ratio. The max lag does not
affect prioritization, only eligibility.

This option provides a way to try to compact logs periodically. It does
not guarantee a log will be compacted in a timely manner.

A small but important point about an unlikely scenario: the max
compaction lag is the longest a message can go without being eligible
for compaction. This implies the segment the message is in must roll
once the max lag passes. So max compaction lag also affects segment
rolling logic. The implementation here follows exactly how Kafka applies
max compaction lag to segment rolling.

NB: I'll add a release note for this with the follow-up that adds
min.compaction.lag.ms. I think it makes sense to have one release
note for the pair.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
