### PR TITLE
Adding a separate test suite for iceberg cloud

### DIFF
--- a/tests/rptest/test_suite_iceberg_cloud.yml
+++ b/tests/rptest/test_suite_iceberg_cloud.yml
@@ -1,0 +1,17 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+# Tests to run on a Redpanda Cloud cluster.
+cloud:
+  included:
+    - redpanda_cloud_tests/config_profile_verify_test.py
+    - redpanda_cloud_tests/iceberg_catalogs_test.py
+  #  - redpanda_cloud_tests/omb_validation_test_iceberg.py::OMBValidationTest_iceberg
+    - redpanda_cloud_tests/cloud_self_test.py
+    - tests/services_self_test.py::SimpleSelfTest.test_cloud


### PR DESCRIPTION
Adding a separate test suite for iceberg cloud for debugging and to run them separately when needed. Also, good to have while more tests are being added or when we need to validate Iceberg on cloud specific tests and avoid running the whole cloud test suite.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
