### PR TITLE
storage: Use chunked_vector lock_manager::lease

### DIFF
--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -363,6 +363,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":log_manager_probe",
+        "//src/v/ssx:when_all",
         "//src/v/syschecks",
     ],
     include_prefix = "storage",

--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -9,7 +9,9 @@
 
 #include "storage/lock_manager.h"
 
+#include "container/fragmented_vector.h"
 #include "model/offset_interval.h"
+#include "ssx/when_all.h"
 #include "storage/segment.h"
 
 #include <seastar/core/future-util.hh>
@@ -24,14 +26,16 @@ static ss::future<std::unique_ptr<lock_manager::lease>>
 range(segment_set::underlying_t segs) {
     auto ctx = std::make_unique<lock_manager::lease>(
       segment_set(std::move(segs)));
-    std::vector<ss::future<ss::rwlock::holder>> dispatch;
+    chunked_vector<ss::future<ss::rwlock::holder>> dispatch;
     dispatch.reserve(ctx->range.size());
     for (auto& s : ctx->range) {
         dispatch.emplace_back(s->read_lock());
     }
-    return ss::when_all_succeed(dispatch.begin(), dispatch.end())
+
+    return ssx::when_all_succeed<chunked_vector<ss::rwlock::holder>>(
+             std::move(dispatch))
       .then(
-        [ctx = std::move(ctx)](std::vector<ss::rwlock::holder> lks) mutable {
+        [ctx = std::move(ctx)](chunked_vector<ss::rwlock::holder> lks) mutable {
             ctx->locks = std::move(lks);
             return std::move(ctx);
         });

--- a/src/v/storage/lock_manager.h
+++ b/src/v/storage/lock_manager.h
@@ -14,6 +14,7 @@
 // important to keep dependencies small because this type is used
 // in the log readers and throughout the code where segment_set.h is used
 // if it becomes large, consider making it a pimpl class
+#include "container/fragmented_vector.h"
 #include "storage/fwd.h"
 #include "storage/segment_set.h"
 
@@ -34,7 +35,7 @@ public:
         lease& operator=(const lease&) = delete;
 
         segment_set range;
-        std::vector<ss::rwlock::holder> locks;
+        chunked_vector<ss::rwlock::holder> locks;
 
         friend std::ostream& operator<<(std::ostream&, const lease&);
     };


### PR DESCRIPTION
With massive segment counts we might run into oversized allocs here so switch std::vector to chunked_vector.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


