### PR TITLE
bazel: Add fastbuild mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -59,6 +59,13 @@ build --@seastar//:stack_guards=True
 build --@seastar//:debug=True
 
 # =================================
+# Fastbuild
+# =================================
+# We want to have a --config=fastbuild that is effectively the same as no args
+# so specify a flag that does nothing to enable this
+build:fastbuild --build
+
+# =================================
 # Sanitizer
 # =================================
 build:sanitizer --compilation_mode=dbg


### PR DESCRIPTION
Adds a noop fastbuild mode such that one can do `--config=fastbuild`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
