### PR TITLE
[Core-9143] pandaproxy/sr: Add support for serialized format option in protobuf

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -642,6 +642,12 @@
             "type": "boolean"
           },
           {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "schema_def",
             "in": "body",
             "schema": {

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -994,6 +994,12 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -876,6 +876,12 @@
             "in": "query",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -430,6 +430,12 @@
             "in": "path",
             "required": true,
             "type": "integer"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -660,6 +660,16 @@ ss::future<subject_schema> make_canonical_avro_schema(
       sanitize_avro_schema_definition(std::move(schema)).value()};
 }
 
+ss::future<schema_definition> format_avro_schema_definition(
+  schema_getter&, schema_definition schema, output_format format) {
+    switch (format) {
+    case output_format::resolved:
+        throw as_exception(format_not_supported(format));
+    default:
+        co_return std::move(schema);
+    }
+}
+
 compatibility_result check_compatible(
   const avro_schema_definition& reader,
   const avro_schema_definition& writer,

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -26,6 +26,9 @@ sanitize_avro_schema_definition(schema_definition def);
 ss::future<subject_schema> make_canonical_avro_schema(
   schema_getter& store, subject_schema schema, normalize norm = normalize::no);
 
+ss::future<schema_definition> format_avro_schema_definition(
+  schema_getter& store, schema_definition schema, output_format format);
+
 compatibility_result check_compatible(
   const avro_schema_definition& reader,
   const avro_schema_definition& writer,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -82,8 +82,6 @@ struct error_category final : std::error_category {
             return "Invalid mode. Valid values are READWRITE, READONLY";
         case error_code::version_exhausted:
             return "Versions exhausted, maximum 2147483647 reached";
-        case error_code::invalid_format:
-            return "Invalid format parameter";
         case error_code::format_not_supported:
             return "Format parameter not supported";
         }
@@ -141,7 +139,6 @@ struct error_category final : std::error_category {
             return reply_error_code::mode_invalid; // 42204
         case error_code::version_exhausted:
             return reply_error_code::internal_server_error; // 500
-        case error_code::invalid_format:
         case error_code::format_not_supported:
             return reply_error_code::bad_request; // 400
         }

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -140,7 +140,7 @@ struct error_category final : std::error_category {
         case error_code::version_exhausted:
             return reply_error_code::internal_server_error; // 500
         case error_code::format_not_supported:
-            return reply_error_code::bad_request; // 400
+            return reply_error_code::not_implemented; // 501
         }
         return {};
     }

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -40,7 +40,6 @@ enum class error_code {
     compatibility_level_invalid,
     mode_invalid,
     version_exhausted,
-    invalid_format,
     format_not_supported,
 };
 

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -201,12 +201,6 @@ inline error_info versions_exhausted(const subject& sub) {
       fmt::format("Versions exhausted for subject {}", sub())};
 }
 
-inline error_info invalid_format(const ss::sstring& ss) {
-    return error_info{
-      error_code::invalid_format,
-      fmt::format("Format value '{}' is invalid", ss)};
-}
-
 inline error_info format_not_supported(const output_format f) {
     return error_info{
       error_code::format_not_supported,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -448,12 +448,14 @@ post_subject(server::request_t rq, server::reply_t rp) {
         .value_or(include_deleted::no)};
     auto norm{parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
                 .value_or(normalize::no)};
+    const auto format = parse_output_format(*rq.req);
     vlog(
       srlog.debug,
-      "post_subject subject='{}', normalize='{}', deleted='{}'",
+      "post_subject subject='{}', normalize='{}', deleted='{}', format='{}'",
       sub,
       norm,
-      inc_del);
+      inc_del,
+      format);
     // We must sync
     co_await rq.service().writer().read_sync();
 
@@ -478,9 +480,13 @@ post_subject(server::request_t rq, server::reply_t rp) {
     auto sub_schema = co_await rq.service().schema_store().has_schema(
       std::move(schema), inc_del);
 
+    auto [subject, def] = std::move(sub_schema.schema).destructure();
+    auto formatted_schema = co_await rq.service().schema_store().format_schema(
+      std::move(def), format);
+
     auto resp = ppj::rjson_serialize_iobuf(
       post_subject_versions_version_response{
-        .schema{std::move(sub_schema.schema)},
+        .schema{std::move(subject), std::move(formatted_schema)},
         .id{sub_schema.id},
         .version{sub_schema.version}});
     log_response(*rq.req, resp);

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -591,6 +591,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
+    const auto format = parse_output_format(*rq.req);
 
     co_await rq.service().writer().read_sync();
 
@@ -599,7 +600,11 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
     auto get_res = co_await rq.service().schema_store().get_subject_schema(
       sub, version, inc_del);
 
-    auto resp = std::move(get_res.schema).def().raw();
+    auto [_, def] = std::move(get_res.schema).destructure();
+    auto formatted_schema = co_await rq.service().schema_store().format_schema(
+      std::move(def), format);
+
+    auto resp = std::move(formatted_schema).raw();
     log_response(*rq.req, resp);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)()));
     co_return rp;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -75,6 +75,12 @@ parse_schema_version(const ss::sstring& ver) {
              : parse_numerical_schema_version(ver).value();
 }
 
+output_format parse_output_format(const ss::http::request& req) {
+    return parse::query_param<std::optional<ss::sstring>>(req, "format")
+      .and_then(&from_string_view<output_format>)
+      .value_or(output_format::none);
+}
+
 template<ppj::impl::RjsonParseHandler Handler>
 typename ss::future<typename Handler::rjson_parse_result>
 rjson_parse(ss::http::request& req, Handler handler) {
@@ -333,11 +339,7 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
 
-    const auto format_str = parse::query_param<std::optional<ss::sstring>>(
-                              *rq.req, "format")
-                              .value_or("");
-    const auto format = from_string_view<output_format>(format_str)
-                          .value_or(output_format::none);
+    const auto format = parse_output_format(*rq.req);
 
     // With deferred schema validation, there might be a schema that
     // had invalid references. These might have already been posted, so

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -558,6 +558,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
     auto inc_del{
       parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
         .value_or(include_deleted::no)};
+    const auto format = parse_output_format(*rq.req);
 
     co_await rq.service().writer().read_sync();
 
@@ -568,9 +569,13 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
           sub, version, inc_del);
     });
 
+    auto [subject, def] = std::move(get_res.schema).destructure();
+    auto formatted_schema = co_await rq.service().schema_store().format_schema(
+      std::move(def), format);
+
     auto resp = ppj::rjson_serialize_iobuf(
       post_subject_versions_version_response{
-        .schema = std::move(get_res.schema),
+        .schema = {std::move(subject), std::move(formatted_schema)},
         .id = get_res.id,
         .version = get_res.version});
     log_response(*rq.req, resp);

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -336,10 +336,8 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     const auto format_str = parse::query_param<std::optional<ss::sstring>>(
                               *rq.req, "format")
                               .value_or("");
-    const auto format = from_string_view<output_format>(format_str);
-    if (!format.has_value()) {
-        throw as_exception(invalid_format(format_str));
-    }
+    const auto format = from_string_view<output_format>(format_str)
+                          .value_or(output_format::none);
 
     // With deferred schema validation, there might be a schema that
     // had invalid references. These might have already been posted, so
@@ -347,8 +345,7 @@ get_schemas_ids_id(server::request_t rq, server::reply_t rp) {
     co_await rq.service().writer().read_sync();
 
     auto def = co_await get_or_load(rq, [&rq, id, format]() {
-        return rq.service().schema_store().get_schema_definition(
-          id, format.value_or(output_format::none));
+        return rq.service().schema_store().get_schema_definition(id, format);
     });
 
     auto resp = ppj::rjson_serialize_iobuf(

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -546,13 +546,21 @@ struct protobuf_schema_definition::impl {
           "{}\n{}\n\n{}\n\n{}\n", header, package, imports, footer);
     }
 
-    schema_definition::raw_string raw() const {
+    schema_definition::raw_string raw(output_format format) const {
+        if (format == output_format::serialized) {
+            iobuf_ostream ios;
+            fdp.SerializeToOstream(&ios.ostream());
+
+            return schema_definition::raw_string{
+              iobuf_to_base64(std::move(ios).buf())};
+        }
         return schema_definition::raw_string{debug_string()};
     }
 };
 
-schema_definition::raw_string protobuf_schema_definition::raw() const {
-    return _impl->raw();
+schema_definition::raw_string
+protobuf_schema_definition::raw(output_format format) const {
+    return _impl->raw(format);
 }
 
 ::result<ss::sstring, kafka::error_code>
@@ -634,26 +642,37 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
 }
 
 ss::future<schema_definition> validate_protobuf_schema(
-  sharded_store& store, subject_schema schema, normalize norm) {
+  sharded_store& store,
+  subject_schema schema,
+  normalize norm,
+  output_format format) {
     auto res = co_await make_protobuf_schema_definition(
       store, std::move(schema), norm);
-    co_return schema_definition{std::move(res)};
+    co_return schema_definition{res.raw(format), res.type(), res.refs()};
 }
 
 ss::future<subject_schema> make_canonical_protobuf_schema(
-  sharded_store& store, subject_schema schema, normalize norm) {
+  sharded_store& store,
+  subject_schema schema,
+  normalize norm,
+  output_format format) {
     subject sub = schema.sub();
     co_return subject_schema{
       std::move(sub),
-      co_await validate_protobuf_schema(store, std::move(schema), norm)};
+      co_await validate_protobuf_schema(
+        store, std::move(schema), norm, format)};
 }
 
 ss::future<schema_definition> format_protobuf_schema_definition(
-  sharded_store&, schema_definition schema, output_format format) {
+  sharded_store& store, schema_definition schema, output_format format) {
     switch (format) {
     case output_format::ignore_extensions:
-    case output_format::serialized:
         throw as_exception(format_not_supported(format));
+    case output_format::serialized: {
+        auto serialized = co_await make_canonical_protobuf_schema(
+          store, {{}, std::move(schema)}, normalize::no, format);
+        co_return std::move(serialized).def();
+    }
     default:
         co_return std::move(schema);
     }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -648,6 +648,17 @@ ss::future<subject_schema> make_canonical_protobuf_schema(
       co_await validate_protobuf_schema(store, std::move(schema), norm)};
 }
 
+ss::future<schema_definition> format_protobuf_schema_definition(
+  sharded_store&, schema_definition schema, output_format format) {
+    switch (format) {
+    case output_format::ignore_extensions:
+    case output_format::serialized:
+        throw as_exception(format_not_supported(format));
+    default:
+        co_return std::move(schema);
+    }
+}
+
 namespace {
 
 enum class encoding {

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -24,10 +24,16 @@ ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
   schema_getter& store, subject_schema schema, normalize norm = normalize::no);
 
 ss::future<schema_definition> validate_protobuf_schema(
-  sharded_store& store, subject_schema schema, normalize norm = normalize::no);
+  sharded_store& store,
+  subject_schema schema,
+  normalize norm = normalize::no,
+  output_format format = output_format::none);
 
 ss::future<subject_schema> make_canonical_protobuf_schema(
-  sharded_store& store, subject_schema schema, normalize norm = normalize::no);
+  sharded_store& store,
+  subject_schema schema,
+  normalize norm = normalize::no,
+  output_format format = output_format::none);
 
 ss::future<schema_definition> format_protobuf_schema_definition(
   sharded_store& store, schema_definition schema, output_format format);

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -29,6 +29,9 @@ ss::future<schema_definition> validate_protobuf_schema(
 ss::future<subject_schema> make_canonical_protobuf_schema(
   sharded_store& store, subject_schema schema, normalize norm = normalize::no);
 
+ss::future<schema_definition> format_protobuf_schema_definition(
+  sharded_store& store, schema_definition schema, output_format format);
+
 compatibility_result check_compatible(
   const protobuf_schema_definition& reader,
   const protobuf_schema_definition& writer,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -118,6 +118,21 @@ ss::future<> sharded_store::validate_schema(subject_schema schema) {
     __builtin_unreachable();
 }
 
+ss::future<schema_definition>
+sharded_store::format_schema(schema_definition schema, output_format format) {
+    switch (schema.type()) {
+    case schema_type::avro:
+        co_return co_await format_avro_schema_definition(
+          *this, std::move(schema), format);
+    case schema_type::protobuf:
+        co_return co_await format_protobuf_schema_definition(
+          *this, std::move(schema), format);
+    case schema_type::json:
+        // json doesn't act on format parameter
+        co_return schema;
+    }
+}
+
 ss::future<valid_schema>
 sharded_store::make_valid_schema(subject_schema schema) {
     // This method seems to confuse clang 12.0.1
@@ -376,15 +391,12 @@ sharded_store::get_schema_definition(schema_id id) {
 
 ss::future<schema_definition>
 sharded_store::get_schema_definition(schema_id id, output_format format) {
-    // TODO: Implement support for the different modes of format
-    if (format != output_format::none) {
-        throw as_exception(format_not_supported(format));
-    }
-
-    co_return co_await _store.invoke_on(
+    auto def = co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();
       });
+
+    co_return co_await format_schema(std::move(def), format);
 }
 
 ss::future<chunked_vector<subject_version>>

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -39,6 +39,10 @@ public:
     ///\brief Check the schema parses with the native format
     ss::future<void> validate_schema(subject_schema schema);
 
+    ///\brief Reformat schema to the output format
+    ss::future<schema_definition>
+    format_schema(schema_definition schema, output_format format);
+
     ///\brief Construct a schema in the native format
     ss::future<valid_schema> make_valid_schema(subject_schema schema);
 

--- a/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
@@ -60,10 +60,38 @@ struct simple_sharded_store {
     pps::sharded_store store;
 };
 
+std::filesystem::path test_dir() {
+    auto test_path = test_utils::get_runfile_path(
+      "src/v/pandaproxy/schema_registry/test/testdata/protobuf");
+    return {test_path.value_or(".")};
+}
+
+enum class SchemaType { input, sanitized, normalized };
+
+std::string_view to_string_view(const SchemaType st) {
+    switch (st) {
+    case SchemaType::input:
+        return "input";
+    case SchemaType::sanitized:
+        return "sanitized";
+    case SchemaType::normalized:
+        return "normalized";
+    }
+}
+
+ss::sstring read_schema(const std::string_view test_case, const SchemaType pt) {
+    const auto proto_file = fmt::format(
+      "{}_{}.proto", test_case, to_string_view(pt));
+    const auto proto_path = test_dir() / proto_file;
+    return read_fully_to_string(proto_path).get();
+};
+
 } // namespace
 
-std::string
-sanitize(std::string_view raw_proto, pps::normalize norm = pps::normalize::no) {
+std::string sanitize(
+  std::string_view raw_proto,
+  pps::normalize norm = pps::normalize::no,
+  pps::output_format format = pps::output_format::none) {
     simple_sharded_store s;
     iobuf buf = pps::make_canonical_protobuf_schema(
                   s.store,
@@ -71,7 +99,8 @@ sanitize(std::string_view raw_proto, pps::normalize norm = pps::normalize::no) {
                     pps::subject{"foo"},
                     pps::schema_definition{
                       raw_proto, pps::schema_type::protobuf, {}}},
-                  norm)
+                  norm,
+                  format)
                   .get()
                   .def()
                   .raw()();
@@ -83,38 +112,9 @@ auto normalize(std::string_view raw_proto) {
     return sanitize(raw_proto, pps::normalize::yes);
 }
 
-enum class SchemaType { input, sanitized, normalized };
-
-std::ostream& operator<<(std::ostream& os, const SchemaType st) {
-    switch (st) {
-    case SchemaType::input:
-        os << "input";
-        break;
-    case SchemaType::sanitized:
-        os << "sanitized";
-        break;
-    case SchemaType::normalized:
-        os << "normalized";
-        break;
-    }
-    return os;
-}
-
 class ProtoRendering : public testing::TestWithParam<std::string> {};
 
 TEST_P(ProtoRendering, test_protobuf_rendering) {
-    auto test_path = test_utils::get_runfile_path(
-      "src/v/pandaproxy/schema_registry/test/testdata/protobuf");
-    const std::filesystem::path test_dir{test_path.value_or(".")};
-
-    const auto read_schema = [&test_dir](
-                               const std::string_view test_case,
-                               const SchemaType pt) -> std::string {
-        const auto proto_file = fmt::format("{}_{}.proto", test_case, pt);
-        const auto proto_path = test_dir / proto_file;
-        return read_fully_to_string(proto_path).get();
-    };
-
     const auto& test_case = GetParam();
     const auto input = read_schema(test_case, SchemaType::input);
 
@@ -137,6 +137,18 @@ TEST_P(ProtoRendering, test_protobuf_rendering) {
     if (normalized_expected == normalized_processed) {
         EXPECT_EQ(normalized_processed, normalize(normalized_processed));
     }
+}
+
+TEST_P(ProtoRendering, test_protobuf_serialized_mode) {
+    const auto& test_case = GetParam();
+    const auto input = read_schema(test_case, SchemaType::sanitized);
+
+    // Validate that a round trip to serialized and
+    // back results in the starting schema
+    auto schema_b64 = sanitize(
+      input, pps::normalize::no, pps::output_format::serialized);
+    const auto schema_text = sanitize(schema_b64, pps::normalize::no);
+    EXPECT_EQ(input, schema_text);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -258,7 +258,8 @@ public:
       : _impl{std::move(p)}
       , _refs(std::move(refs)) {}
 
-    schema_definition::raw_string raw() const;
+    schema_definition::raw_string
+    raw(output_format format = output_format::none) const;
     const schema_definition::references& refs() const { return _refs; };
 
     const impl& operator()() const { return *_impl; }
@@ -271,10 +272,6 @@ public:
     operator<<(std::ostream& os, const protobuf_schema_definition& rhs);
 
     constexpr schema_type type() const { return schema_type::protobuf; }
-
-    explicit operator schema_definition() const {
-        return {raw(), type(), refs()};
-    }
 
     ::result<ss::sstring, kafka::error_code>
     name(const std::vector<int>& fields) const;

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -617,6 +617,11 @@ message ProtoType {
   float f = 1;
 }"""
 
+schema_proto_b64 = \
+"CgAiFgoJUHJvdG9UeXBlEgkKAWYYASABKAJKYQoGEgQAAAQBCggKAQwSAwAA" \
+"EgoKCgIEABIEAgAEAQoKCgMEAAESAwIIEQoLCgQEAAIAEgMDAg4KDAoFBAAC" \
+"AAUSAwMCBwoMCgUEAAIAARIDAwgJCgwKBQQAAgADEgMDDA1iBnByb3RvMw=="
+
 schema_avro_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 
 schema_proto_dependee_def = """
@@ -1204,6 +1209,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
                                data,
                                deleted=False,
                                normalize=False,
+                               format=None,
                                headers=HTTP_POST_HEADERS,
                                **kwargs):
         params = {}
@@ -1211,6 +1217,8 @@ class SchemaRegistryEndpoints(RedpandaTest):
             params['deleted'] = 'true'
         if (normalize):
             params['normalize'] = 'true'
+        if format is not None:
+            params['format'] = format
         return self._request("POST",
                              f"subjects/{subject}",
                              headers=headers,
@@ -3572,6 +3580,13 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "id": 1,
                 "failing_format": [ignore_extensions, serialized]
             },
+            "proto_b64": {
+                "schema": schema_proto_b64.strip(),
+                "type": "PROTOBUF",
+                "subject": "schema_proto",
+                "id": 1,
+                "failing_format": [ignore_extensions, serialized]
+            },
             "avro_def": {
                 "schema": schema_avro_def.strip(),
                 "type": "AVRO",
@@ -3635,6 +3650,42 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                         f"expected {501} but got {result_raw.status_code} for id {id} and format '{format}'"
 
         test_runner(test_ids_id)
+
+        def test_subjects_subject(schema_entry,
+                                  successful,
+                                  format=None,
+                                  expected_output=None):
+            subject = schema_entry["subject"]
+            schema = schema_entry["schema"]
+            schema_type = schema_entry["type"]
+            expected_schema = expected_output if expected_output else schema
+            result_raw = self._post_subjects_subject(subject=subject,
+                                                     format=format,
+                                                     data=json.dumps({
+                                                         "schema":
+                                                         schema,
+                                                         "schemaType":
+                                                         schema_type
+                                                     }))
+            if successful:
+                assert result_raw.status_code == requests.codes.ok, \
+                        f"expected {requests.codes.ok} but got {result_raw.status_code} " \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+                result = result_raw.json()['schema'].strip()
+                assert result == expected_schema.strip(), \
+                        f"expected:\n{schema}\ngot:\n{result}\n" \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+            else:
+                assert result_raw.status_code == 501, \
+                        f"expected {501} but got {result_raw.status_code} " \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+
+        #Test that the schema is discoverable in serialzed mode
+        test_subjects_subject(entries["proto_b64"],
+                              successful=True,
+                              expected_output=schema_proto_def.strip())
+
+        test_runner(test_subjects_subject)
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1257,6 +1257,21 @@ class SchemaRegistryEndpoints(RedpandaTest):
                              params=params,
                              **kwargs)
 
+    def _get_subjects_subject_versions_version_schema(self,
+                                                      subject,
+                                                      version,
+                                                      format=None,
+                                                      headers=HTTP_GET_HEADERS,
+                                                      **kwargs):
+        params = {}
+        if format is not None:
+            params['format'] = format
+        return self._request("GET",
+                             f"subjects/{subject}/versions/{version}/schema",
+                             headers=headers,
+                             params=params,
+                             **kwargs)
+
     def _get_subjects_subject_versions_version_referenced_by(
             self, subject, version, headers=HTTP_GET_HEADERS, **kwargs):
         deprecated = self._request(
@@ -3719,6 +3734,31 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                         f"for subject {subject}, schema {schema} and format '{format}'"
 
         test_runner(test_subjects_subject_versions_version)
+
+        def test_subjects_subject_versions_version_schema(
+                schema_entry, successful, format=None):
+            subject = schema_entry["subject"]
+            version = schema_entry["version"]
+            schema = schema_entry["schema"]
+            result_raw = self._get_subjects_subject_versions_version_schema(
+                subject=subject, version=version, format=format)
+            schema = schema.strip()
+
+            if successful:
+                assert result_raw.status_code == requests.codes.ok, \
+                        f"expected {requests.codes.ok} but got {result_raw.status_code} " \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+                result = result_raw.text.strip()
+
+                assert result == schema.strip(), \
+                        f"expected:\n{schema}\ngot:\n{result}\n" \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+            else:
+                assert result_raw.status_code == 501, \
+                        f"expected {501} but got {result_raw.status_code} " \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+
+        test_runner(test_subjects_subject_versions_version_schema)
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3599,7 +3599,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "subject": "schema_proto",
                 "version": 1,
                 "id": 1,
-                "failing_format": [ignore_extensions, serialized]
+                "failing_format": [ignore_extensions]
             },
             "proto_b64": {
                 "schema": schema_proto_b64.strip(),
@@ -3607,7 +3607,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "subject": "schema_proto",
                 "version": 1,
                 "id": 1,
-                "failing_format": [ignore_extensions, serialized]
+                "failing_format": [ignore_extensions]
             },
             "avro_def": {
                 "schema": schema_avro_def.strip(),
@@ -3653,11 +3653,14 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         def test_runner(test_func):
             for entry in ["proto_def", "avro_def", "json_def"]:
                 for format in [
-                        default_format, bad_value, resolved, ignore_extensions,
-                        serialized
+                        default_format, bad_value, resolved, ignore_extensions
                 ]:
                     successful = is_successful(entries[entry], format)
                     test_func(entries[entry], successful, format)
+
+            for entry in ["proto_b64", "avro_def", "json_def"]:
+                successful = is_successful(entries[entry], serialized)
+                test_func(entries[entry], successful, serialized)
 
         def test_ids_id(schema_entry, successful, format=None):
             id = schema_entry["id"]

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1245,11 +1245,16 @@ class SchemaRegistryEndpoints(RedpandaTest):
     def _get_subjects_subject_versions_version(self,
                                                subject,
                                                version,
+                                               format=None,
                                                headers=HTTP_GET_HEADERS,
                                                **kwargs):
+        params = {}
+        if format is not None:
+            params['format'] = format
         return self._request("GET",
                              f"subjects/{subject}/versions/{version}",
                              headers=headers,
+                             params=params,
                              **kwargs)
 
     def _get_subjects_subject_versions_version_referenced_by(
@@ -3577,6 +3582,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "schema": schema_proto_def.strip(),
                 "type": "PROTOBUF",
                 "subject": "schema_proto",
+                "version": 1,
                 "id": 1,
                 "failing_format": [ignore_extensions, serialized]
             },
@@ -3584,6 +3590,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "schema": schema_proto_b64.strip(),
                 "type": "PROTOBUF",
                 "subject": "schema_proto",
+                "version": 1,
                 "id": 1,
                 "failing_format": [ignore_extensions, serialized]
             },
@@ -3591,6 +3598,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "schema": schema_avro_def.strip(),
                 "type": "AVRO",
                 "subject": "schema_avro",
+                "version": 1,
                 "id": 2,
                 "failing_format": [resolved]
             },
@@ -3598,6 +3606,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                 "schema": json_number_schema_def.strip(),
                 "type": "JSON",
                 "subject": "schema_json",
+                "version": 1,
                 "id": 3,
             }
         }
@@ -3686,6 +3695,30 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
                               expected_output=schema_proto_def.strip())
 
         test_runner(test_subjects_subject)
+
+        def test_subjects_subject_versions_version(schema_entry,
+                                                   successful,
+                                                   format=None):
+            subject = schema_entry["subject"]
+            version = schema_entry["version"]
+            schema = schema_entry["schema"]
+            result_raw = self._get_subjects_subject_versions_version(
+                subject=subject, version=version, format=format)
+
+            if successful:
+                assert result_raw.status_code == requests.codes.ok, \
+                        f"expected {requests.codes.ok} but got {result_raw.status_code} " \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+                result = result_raw.json()['schema'].strip()
+                assert result == schema.strip(), \
+                        f"expected:\n{schema}\ngot:\n{result}\n" \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+            else:
+                assert result_raw.status_code == 501, \
+                        f"expected {501} but got {result_raw.status_code} " \
+                        f"for subject {subject}, schema {schema} and format '{format}'"
+
+        test_runner(test_subjects_subject_versions_version)
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -943,7 +943,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
 
         # Error codes that may appear during normal API operation, do not
         # indicate an issue with the service
-        acceptable_errors = {409, 422, 404}
+        acceptable_errors = {409, 422, 404, 501}
 
         def accept_response(resp):
             return 200 <= resp.status_code < 300 or resp.status_code in acceptable_errors
@@ -3612,15 +3612,15 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         resolved = "resolved"
         test_ids_id(1, schema_proto_def.strip(), format=resolved)
         result_raw = self._get_schemas_ids_id(2, format=resolved)
-        assert result_raw.status_code == 400, \
-                f"expected {400} but got {result_raw.status_code} for id 2 and format '{resolved}'"
+        assert result_raw.status_code == 501, \
+                f"expected {501} but got {result_raw.status_code} for id 2 and format '{resolved}'"
         test_ids_id(3, json_number_schema_def.strip(), format=resolved)
 
         #Test unimplemented format value - ignore extensions
         ignore_extensions = "ignore_extensions"
         result_raw = self._get_schemas_ids_id(1, format=ignore_extensions)
-        assert result_raw.status_code == 400, \
-                f"expected {400} but got {result_raw.status_code} for id 1 and format '{ignore_extensions}'"
+        assert result_raw.status_code == 501, \
+                f"expected {501} but got {result_raw.status_code} for id 1 and format '{ignore_extensions}'"
         test_ids_id(2, schema_avro_def.strip(), format=ignore_extensions)
         test_ids_id(3,
                     json_number_schema_def.strip(),
@@ -3629,8 +3629,8 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         #Test unimplemented format value - ignore serialized
         serialized = "serialized"
         result_raw = self._get_schemas_ids_id(1, format=serialized)
-        assert result_raw.status_code == 400, \
-                f"expected {400} but got {result_raw.status_code} for id 1 and format '{serialized}'"
+        assert result_raw.status_code == 501, \
+                f"expected {501} but got {result_raw.status_code} for id 1 and format '{serialized}'"
         test_ids_id(2, schema_avro_def.strip(), format=serialized)
         test_ids_id(3, json_number_schema_def.strip(), format=serialized)
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3608,10 +3608,31 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         test_ids_id(2, schema_avro_def.strip(), format=bad_value)
         test_ids_id(3, json_number_schema_def.strip(), format=bad_value)
 
-        #Test unimplemented format value
-        result_raw = self._get_schemas_ids_id(2, format="resolved")
+        #Test unimplemented format value - resolved
+        resolved = "resolved"
+        test_ids_id(1, schema_proto_def.strip(), format=resolved)
+        result_raw = self._get_schemas_ids_id(2, format=resolved)
         assert result_raw.status_code == 400, \
-                f"expected {400} but got {result_raw.status_code} for id 2 and format 'resolved'"
+                f"expected {400} but got {result_raw.status_code} for id 2 and format '{resolved}'"
+        test_ids_id(3, json_number_schema_def.strip(), format=resolved)
+
+        #Test unimplemented format value - ignore extensions
+        ignore_extensions = "ignore_extensions"
+        result_raw = self._get_schemas_ids_id(1, format=ignore_extensions)
+        assert result_raw.status_code == 400, \
+                f"expected {400} but got {result_raw.status_code} for id 1 and format '{ignore_extensions}'"
+        test_ids_id(2, schema_avro_def.strip(), format=ignore_extensions)
+        test_ids_id(3,
+                    json_number_schema_def.strip(),
+                    format=ignore_extensions)
+
+        #Test unimplemented format value - ignore serialized
+        serialized = "serialized"
+        result_raw = self._get_schemas_ids_id(1, format=serialized)
+        assert result_raw.status_code == 400, \
+                f"expected {400} but got {result_raw.status_code} for id 1 and format '{serialized}'"
+        test_ids_id(2, schema_avro_def.strip(), format=serialized)
+        test_ids_id(3, json_number_schema_def.strip(), format=serialized)
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3556,83 +3556,85 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         """
         Test support for the format keyword
         """
-        result_raw = self._post_subjects_subject_versions(
-            subject="schema_proto",
-            data=json.dumps({
-                "schema": schema_proto_def,
-                "schemaType": "PROTOBUF"
-            }))
-        assert result_raw.status_code == requests.codes.ok, \
-                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
-                f"Request content: {result_raw.content}. Posting PROTOBUF."
 
-        result_raw = self._post_subjects_subject_versions(
-            subject="schema_avro",
-            data=json.dumps({
-                "schema": schema_avro_def,
-                "schemaType": "AVRO"
-            }))
-        assert result_raw.status_code == requests.codes.ok, \
-                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
-                f"Request content: {result_raw.content}. Posting AVRO."
-
-        result_raw = self._post_subjects_subject_versions(
-            subject="schema_json",
-            data=json.dumps({
-                "schema": json_number_schema_def,
-                "schemaType": "JSON"
-            }))
-        assert result_raw.status_code == requests.codes.ok, \
-                f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
-                f"Request content: {result_raw.content}. Posting JSON."
-
-        def test_ids_id(id, schema, format=None):
-            result_raw = self._get_schemas_ids_id(id, format)
-            assert result_raw.status_code == requests.codes.ok, \
-                    f"expected {requests.codes.ok} but got {result_raw.status_code} for id {id} and format {format}"
-            result = result_raw.json()['schema'].strip()
-            assert result == schema, \
-                    f"expected:\n{schema}\ngot:\n{result}\nfor id {id} and format {format}"
-
-        test_ids_id(1, schema_proto_def.strip())
-        test_ids_id(2, schema_avro_def.strip())
-        test_ids_id(3, json_number_schema_def.strip())
-
-        test_ids_id(1, schema_proto_def.strip(), format="")
-        test_ids_id(2, schema_avro_def.strip(), format="")
-        test_ids_id(3, json_number_schema_def.strip(), format="")
-
-        #Test invalid format value - format should be ignored
+        #Format values to test
+        default_format = ""
         bad_value = "bad_value"
-        test_ids_id(1, schema_proto_def.strip(), format=bad_value)
-        test_ids_id(2, schema_avro_def.strip(), format=bad_value)
-        test_ids_id(3, json_number_schema_def.strip(), format=bad_value)
-
-        #Test unimplemented format value - resolved
         resolved = "resolved"
-        test_ids_id(1, schema_proto_def.strip(), format=resolved)
-        result_raw = self._get_schemas_ids_id(2, format=resolved)
-        assert result_raw.status_code == 501, \
-                f"expected {501} but got {result_raw.status_code} for id 2 and format '{resolved}'"
-        test_ids_id(3, json_number_schema_def.strip(), format=resolved)
-
-        #Test unimplemented format value - ignore extensions
         ignore_extensions = "ignore_extensions"
-        result_raw = self._get_schemas_ids_id(1, format=ignore_extensions)
-        assert result_raw.status_code == 501, \
-                f"expected {501} but got {result_raw.status_code} for id 1 and format '{ignore_extensions}'"
-        test_ids_id(2, schema_avro_def.strip(), format=ignore_extensions)
-        test_ids_id(3,
-                    json_number_schema_def.strip(),
-                    format=ignore_extensions)
-
-        #Test unimplemented format value - ignore serialized
         serialized = "serialized"
-        result_raw = self._get_schemas_ids_id(1, format=serialized)
-        assert result_raw.status_code == 501, \
-                f"expected {501} but got {result_raw.status_code} for id 1 and format '{serialized}'"
-        test_ids_id(2, schema_avro_def.strip(), format=serialized)
-        test_ids_id(3, json_number_schema_def.strip(), format=serialized)
+
+        entries = {
+            "proto_def": {
+                "schema": schema_proto_def.strip(),
+                "type": "PROTOBUF",
+                "subject": "schema_proto",
+                "id": 1,
+                "failing_format": [ignore_extensions, serialized]
+            },
+            "avro_def": {
+                "schema": schema_avro_def.strip(),
+                "type": "AVRO",
+                "subject": "schema_avro",
+                "id": 2,
+                "failing_format": [resolved]
+            },
+            "json_def": {
+                "schema": json_number_schema_def.strip(),
+                "type": "JSON",
+                "subject": "schema_json",
+                "id": 3,
+            }
+        }
+
+        def insert_schema(schema_entry):
+            schema = schema_entry["schema"]
+            schema_type = schema_entry["type"]
+            subject = schema_entry["subject"]
+            result_raw = self._post_subjects_subject_versions(subject=subject,
+                                                              data=json.dumps({
+                                                                  "schema":
+                                                                  schema,
+                                                                  "schemaType":
+                                                                  schema_type
+                                                              }))
+            assert result_raw.status_code == requests.codes.ok, \
+                    f"Expected {requests.codes.ok} but got {result_raw.status_code} during test setup. "\
+                    f"Request content: {result_raw.content}. Posting {schema_type}."
+
+        insert_schema(entries["proto_def"])
+        insert_schema(entries["avro_def"])
+        insert_schema(entries["json_def"])
+
+        def is_successful(schema_entry, format):
+            if "failing_format" not in schema_entry:
+                return True
+            return format not in schema_entry["failing_format"]
+
+        def test_runner(test_func):
+            for entry in ["proto_def", "avro_def", "json_def"]:
+                for format in [
+                        default_format, bad_value, resolved, ignore_extensions,
+                        serialized
+                ]:
+                    successful = is_successful(entries[entry], format)
+                    test_func(entries[entry], successful, format)
+
+        def test_ids_id(schema_entry, successful, format=None):
+            id = schema_entry["id"]
+            result_raw = self._get_schemas_ids_id(id, format)
+            if successful:
+                assert result_raw.status_code == requests.codes.ok, \
+                        f"expected {requests.codes.ok} but got {result_raw.status_code} for id {id} and format '{format}'"
+                schema = schema_entry["schema"]
+                result = result_raw.json()['schema'].strip()
+                assert result == schema, \
+                        f"expected:\n{schema}\ngot:\n{result}\nfor id {id} and format '{format}'"
+            else:
+                assert result_raw.status_code == 501, \
+                        f"expected {501} but got {result_raw.status_code} for id {id} and format '{format}'"
+
+        test_runner(test_ids_id)
 
 
 class SchemaRegistryModeNotMutableTest(SchemaRegistryEndpoints):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3602,10 +3602,12 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
         test_ids_id(2, schema_avro_def.strip(), format="")
         test_ids_id(3, json_number_schema_def.strip(), format="")
 
-        #Test invalid format value
-        result_raw = self._get_schemas_ids_id(1, format="badvalue")
-        assert result_raw.status_code == 400, \
-                f"expected {400} but got {result_raw.status_code} for id 1 and format 'badvalue'"
+        #Test invalid format value - format should be ignored
+        bad_value = "bad_value"
+        test_ids_id(1, schema_proto_def.strip(), format=bad_value)
+        test_ids_id(2, schema_avro_def.strip(), format=bad_value)
+        test_ids_id(3, json_number_schema_def.strip(), format=bad_value)
+
         #Test unimplemented format value
         result_raw = self._get_schemas_ids_id(2, format="resolved")
         assert result_raw.status_code == 400, \


### PR DESCRIPTION
Implements: [CORE-9143](https://redpandadata.atlassian.net/browse/CORE-9143)

Also acts as a followup to #25971 where:
- missing api specification is added
- support for format query parameter is added to endpoints:
  - `post subject/{sub}`
  - `get subject/{subject}/version/{version}`
  - `get subject/{subject}/version/{version}/schema`
- relax error handling
- change error thrown from `400` -> `501`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Features

- Added support for the `format=serialized` query parameter for protobuf schemas for the following schema registry endpoints:
  - `get schema/ids/{id}`
  - `post subject/{sub}`
  - `get subject/{subject}/version/{version}`
  - `get subject/{subject}/version/{version}/schema`


[CORE-9143]: https://redpandadata.atlassian.net/browse/CORE-9143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ