### PR TITLE
storage/tests: part 1: Migrate 5 tests from Boost to GTest

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -216,7 +216,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "index_state_test",
     timeout = "short",
     srcs = [
@@ -227,7 +227,8 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/serde",
         "//src/v/storage:index_state",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar//:testing",
     ],
 )
@@ -369,7 +370,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "snapshot_test",
     timeout = "short",
     srcs = [
@@ -379,8 +380,9 @@ redpanda_cc_btest(
         "//src/v/base",
         "//src/v/random:generators",
         "//src/v/storage",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
+        "@googletest//:gtest",
         "@seastar//:testing",
     ],
 )
@@ -420,7 +422,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "offset_translator_state_test",
     timeout = "short",
     srcs = [
@@ -430,13 +432,14 @@ redpanda_cc_btest(
     deps = [
         "//src/v/model",
         "//src/v/storage",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "offset_to_filepos_test",
     timeout = "short",
     srcs = [
@@ -447,7 +450,8 @@ redpanda_cc_btest(
         "//src/v/storage",
         "//src/v/test_utils:archival",
         "//src/v/test_utils:fixture",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],
@@ -626,7 +630,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "offset_assignment_test",
     timeout = "short",
     srcs = [
@@ -635,8 +639,8 @@ redpanda_cc_btest(
     deps = [
         "//src/v/model/tests:random",
         "//src/v/storage",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -8,14 +8,16 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-#define BOOST_TEST_MODULE storage
 
 #include "bytes/bytes.h"
 #include "random/generators.h"
 #include "serde/rw/envelope.h"
 #include "storage/index_state.h"
+#include "test_utils/gtest_exception.h"
 
-#include <boost/test/unit_test.hpp>
+#include <gtest/gtest.h>
+
+using namespace redpanda::test_utils;
 
 static storage::index_state make_random_index_state(
   storage::offset_delta_time apply_offset = storage::offset_delta_time::yes) {
@@ -67,28 +69,28 @@ static void set_version(iobuf& buf, int8_t version) {
 }
 
 // encode/decode using new serde framework
-BOOST_AUTO_TEST_CASE(serde_basic) {
+TEST(IndexState, SerdeBasic) {
     for (int i = 0; i < 100; ++i) {
         auto input = make_random_index_state();
         const auto input_copy = input.copy();
-        BOOST_REQUIRE_EQUAL(input, input_copy);
+        ASSERT_EQ(input, input_copy);
 
         // objects are equal
         const auto buf = serde::to_iobuf(std::move(input));
         auto output = serde::from_iobuf<storage::index_state>(buf.copy());
 
-        BOOST_REQUIRE(output.batch_timestamps_are_monotonic == true);
-        BOOST_REQUIRE(output.with_offset == storage::offset_delta_time::yes);
+        ASSERT_TRUE(output.batch_timestamps_are_monotonic);
+        ASSERT_EQ(output.with_offset, storage::offset_delta_time::yes);
 
-        BOOST_REQUIRE_EQUAL(output, input_copy);
+        ASSERT_EQ(output, input_copy);
 
         // round trip back to equal iobufs
         const auto buf2 = serde::to_iobuf(std::move(output));
-        BOOST_REQUIRE_EQUAL(buf, buf2);
+        ASSERT_EQ(buf, buf2);
     }
 }
 
-BOOST_AUTO_TEST_CASE(serde_no_time_offseting_for_existing_indices) {
+TEST(IndexState, SerdeNoTimeOffsetingForExistingIndices) {
     for (int i = 0; i < 100; ++i) {
         // Create index without time offsetting
         auto input = make_random_index_state(storage::offset_delta_time::no);
@@ -99,45 +101,45 @@ BOOST_AUTO_TEST_CASE(serde_no_time_offseting_for_existing_indices) {
         // Read the index and check that time offsetting was not applied
         auto output = serde::from_iobuf<storage::index_state>(buf.copy());
 
-        BOOST_REQUIRE(output.batch_timestamps_are_monotonic == false);
-        BOOST_REQUIRE(output.with_offset == storage::offset_delta_time::no);
+        ASSERT_FALSE(output.batch_timestamps_are_monotonic);
+        ASSERT_EQ(output.with_offset, storage::offset_delta_time::no);
 
         auto output_copy = output.copy();
 
-        BOOST_REQUIRE_EQUAL(input_copy, output);
+        ASSERT_EQ(input_copy, output);
 
         // Re-encode with version 5 and verify that there is still no offsetting
         const auto buf2 = serde::to_iobuf(std::move(output));
         auto output2 = serde::from_iobuf<storage::index_state>(buf2.copy());
-        BOOST_REQUIRE_EQUAL(output_copy, output2);
+        ASSERT_EQ(output_copy, output2);
 
-        BOOST_REQUIRE(output2.batch_timestamps_are_monotonic == false);
-        BOOST_REQUIRE(output2.with_offset == storage::offset_delta_time::no);
+        ASSERT_FALSE(output2.batch_timestamps_are_monotonic);
+        ASSERT_EQ(output2.with_offset, storage::offset_delta_time::no);
     }
 }
 
 // accept decoding supported old version
-BOOST_AUTO_TEST_CASE(serde_supported_deprecated) {
+TEST(IndexState, SerdeSupportedDeprecated) {
     for (int i = 0; i < 100; ++i) {
         auto input = make_random_index_state(storage::offset_delta_time::no);
         const auto output = serde::from_iobuf<storage::index_state>(
           storage::serde_compat::index_state_serde::encode(input));
 
-        BOOST_REQUIRE(output.batch_timestamps_are_monotonic == false);
-        BOOST_REQUIRE(output.with_offset == storage::offset_delta_time::no);
+        ASSERT_FALSE(output.batch_timestamps_are_monotonic);
+        ASSERT_EQ(output.with_offset, storage::offset_delta_time::no);
 
-        BOOST_REQUIRE_EQUAL(input, output);
+        ASSERT_EQ(input, output);
     }
 }
 
-// reject decoding unsupported old versins
-BOOST_AUTO_TEST_CASE(serde_unsupported_deprecated) {
+// reject decoding unsupported old versions
+TEST(IndexState, SerdeUnsupportedDeprecated) {
     auto test = [](int version) {
         auto input = make_random_index_state(storage::offset_delta_time::no);
         auto buf = storage::serde_compat::index_state_serde::encode(input);
         set_version(buf, version);
 
-        BOOST_REQUIRE_EXCEPTION(
+        ASSERT_THROWS_WITH_PREDICATE(
           const auto output = serde::from_iobuf<storage::index_state>(
             buf.copy()),
           serde::serde_exception,
@@ -153,15 +155,15 @@ BOOST_AUTO_TEST_CASE(serde_unsupported_deprecated) {
 }
 
 // decoding should fail if all the data isn't available
-BOOST_AUTO_TEST_CASE(serde_clipped) {
+TEST(IndexState, SerdeClipped) {
     auto input = make_random_index_state(storage::offset_delta_time::no);
     auto buf = serde::to_iobuf(std::move(input));
 
     // trim off some data from the end
-    BOOST_REQUIRE_GT(buf.size_bytes(), 10);
+    ASSERT_GT(buf.size_bytes(), 10);
     buf.trim_back(buf.size_bytes() - 10);
 
-    BOOST_REQUIRE_EXCEPTION(
+    ASSERT_THROWS_WITH_PREDICATE(
       serde::from_iobuf<storage::index_state>(buf.copy()),
       serde::serde_exception,
       [](const serde::serde_exception& e) {
@@ -171,15 +173,15 @@ BOOST_AUTO_TEST_CASE(serde_clipped) {
 }
 
 // decoding deprecated format should fail if not all data is available
-BOOST_AUTO_TEST_CASE(serde_deprecated_clipped) {
+TEST(IndexState, SerdeDeprecatedClipped) {
     auto input = make_random_index_state(storage::offset_delta_time::no);
     auto buf = storage::serde_compat::index_state_serde::encode(input);
 
     // trim off some data from the end
-    BOOST_REQUIRE_GT(buf.size_bytes(), 10);
+    ASSERT_GT(buf.size_bytes(), 10);
     buf.trim_back(buf.size_bytes() - 10);
 
-    BOOST_REQUIRE_EXCEPTION(
+    ASSERT_THROWS_WITH_PREDICATE(
       serde::from_iobuf<storage::index_state>(buf.copy()),
       serde::serde_exception,
       [](const serde::serde_exception& e) {
@@ -189,7 +191,7 @@ BOOST_AUTO_TEST_CASE(serde_deprecated_clipped) {
       });
 }
 
-BOOST_AUTO_TEST_CASE(serde_crc) {
+TEST(IndexState, SerdeCrc) {
     auto input = make_random_index_state();
     auto good_buf = serde::to_iobuf(std::move(input));
 
@@ -198,7 +200,7 @@ BOOST_AUTO_TEST_CASE(serde_crc) {
     bad_byte += 1;
     auto bad_buf = bytes_to_iobuf(bad_bytes);
 
-    BOOST_REQUIRE_EXCEPTION(
+    ASSERT_THROWS_WITH_PREDICATE(
       serde::from_iobuf<storage::index_state>(bad_buf.copy()),
       serde::serde_exception,
       [](const serde::serde_exception& e) {
@@ -207,7 +209,7 @@ BOOST_AUTO_TEST_CASE(serde_crc) {
       });
 }
 
-BOOST_AUTO_TEST_CASE(serde_deprecated_crc) {
+TEST(IndexState, SerdeDeprecatedCrc) {
     auto input = make_random_index_state(storage::offset_delta_time::no);
     auto good_buf = storage::serde_compat::index_state_serde::encode(input);
 
@@ -216,7 +218,7 @@ BOOST_AUTO_TEST_CASE(serde_deprecated_crc) {
     bad_byte += 1;
     auto bad_buf = bytes_to_iobuf(bad_bytes);
 
-    BOOST_REQUIRE_EXCEPTION(
+    ASSERT_THROWS_WITH_PREDICATE(
       serde::from_iobuf<storage::index_state>(bad_buf.copy()),
       std::exception,
       [](const std::exception& e) {
@@ -229,7 +231,7 @@ BOOST_AUTO_TEST_CASE(serde_deprecated_crc) {
       });
 }
 
-BOOST_AUTO_TEST_CASE(offset_time_index_test) {
+TEST(IndexState, OffsetTimeIndexTest) {
     // Before offsetting: [0, ..., 2 ^ 31 - 1, ..., 2 ^ 32 - 1]
     //                    |             |              |
     //                    |             |______________|
@@ -246,17 +248,17 @@ BOOST_AUTO_TEST_CASE(offset_time_index_test) {
         auto non_offset_delta = storage::offset_time_index{
           model::timestamp{delta_before}, storage::offset_delta_time::no};
 
-        BOOST_REQUIRE(non_offset_delta() == delta_before);
+        ASSERT_EQ(non_offset_delta(), delta_before);
 
         if (delta_before >= max_delta) {
-            BOOST_REQUIRE(offset_delta() == max_delta);
+            ASSERT_EQ(offset_delta(), max_delta);
         } else {
-            BOOST_REQUIRE(offset_delta() == delta_before);
+            ASSERT_EQ(offset_delta(), delta_before);
         }
     }
 }
 
-BOOST_AUTO_TEST_CASE(binary_compatibility_test) {
+TEST(IndexState, BinaryCompatibilityTest) {
     // This test is checking that the binary representation of the serialized
     // index_state did not change. If new index format is introduced this test
     // should be removed. The goal here is to be able to make sure that the
@@ -353,11 +355,11 @@ BOOST_AUTO_TEST_CASE(binary_compatibility_test) {
     auto expected_bytes = serde::to_iobuf(std::move(expected_state));
     set_version(expected_bytes, 4);
     auto actual_bytes = bytes_to_iobuf(serde_serialized);
-    BOOST_REQUIRE_EQUAL(expected_bytes.size_bytes(), actual_bytes.size_bytes());
-    BOOST_REQUIRE(expected_bytes == actual_bytes);
+    ASSERT_EQ(expected_bytes.size_bytes(), actual_bytes.size_bytes());
+    ASSERT_EQ(expected_bytes, actual_bytes);
 }
 
-BOOST_AUTO_TEST_CASE(index_overflow) {
+TEST(IndexState, IndexOverflow) {
     storage::index_state state;
 
     // Previous versions of Redpanda can have an index with offsets spanning
@@ -373,12 +375,12 @@ BOOST_AUTO_TEST_CASE(index_overflow) {
     state.add_entry(static_cast<uint32_t>(uint32_max + 10), time_idx, 4);
     state.max_offset = model::offset{uint32_max + 10};
     auto res = state.find_nearest(model::offset(100));
-    BOOST_REQUIRE(res.has_value());
-    BOOST_CHECK_EQUAL(res->offset, model::offset{0});
-    BOOST_CHECK_EQUAL(res->filepos, 1);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->offset, model::offset{0});
+    EXPECT_EQ(res->filepos, 1);
 }
 
-BOOST_AUTO_TEST_CASE(non_data_timestamps_with_overflow) {
+TEST(IndexState, NonDataTimestampsWithOverflow) {
     storage::index_state state;
 
     // Need to ensure that non_data_timestamps in the segment_index is only set

--- a/src/v/storage/tests/offset_assignment_test.cc
+++ b/src/v/storage/tests/offset_assignment_test.cc
@@ -9,8 +9,11 @@
 
 #include "model/tests/random_batch.h"
 #include "storage/offset_assignment.h"
+#include "test_utils/gtest_exception.h"
 
 #include <seastar/testing/thread_test_case.hh>
+
+#include <gtest/gtest.h>
 
 using namespace storage; // NOLINT
 
@@ -19,7 +22,7 @@ struct offset_validating_consumer {
       : starting_offset(o) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch&& batch) {
-        BOOST_REQUIRE_EQUAL(batch.base_offset(), starting_offset);
+        EXPECT_EQ(batch.base_offset(), starting_offset);
         starting_offset += batch.record_count();
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
@@ -30,7 +33,7 @@ struct offset_validating_consumer {
     model::offset starting_offset;
 };
 
-SEASTAR_THREAD_TEST_CASE(test_offset_assignment) {
+TEST(OffsetAssignmentTest, TestOffsetAssignment) {
     auto batches = model::test::make_random_batches(model::offset(0), 10).get();
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     auto starting_offset = model::offset(123);
@@ -40,4 +43,4 @@ SEASTAR_THREAD_TEST_CASE(test_offset_assignment) {
           offset_validating_consumer(starting_offset), starting_offset),
         model::no_timeout)
       .get();
-};
+}

--- a/src/v/storage/tests/offset_to_filepos_test.cc
+++ b/src/v/storage/tests/offset_to_filepos_test.cc
@@ -10,12 +10,15 @@
 
 #include "storage/offset_to_filepos.h"
 #include "test_utils/archival.h"
+#include "test_utils/gtest_exception.h"
 #include "test_utils/tmp_dir.h"
 
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
-SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_not_found) {
+#include <gtest/gtest.h>
+
+TEST(OffsetToFileposTest, SearchBeginOffsetNotFound) {
     temporary_dir tmp_dir("offset_to_fpos_translate");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -46,10 +49,10 @@ SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_not_found) {
                     segment->index().base_timestamp(),
                     ss::default_priority_class())
                     .get();
-    BOOST_REQUIRE(result.error() == std::errc::invalid_seek);
+    ASSERT_EQ(result.error(), std::errc::invalid_seek);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_search_end_offset_not_found) {
+TEST(OffsetToFileposTest, SearchEndOffsetNotFound) {
     temporary_dir tmp_dir("offset_to_fpos_translate");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -80,10 +83,10 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_not_found) {
                     segment->index().max_timestamp(),
                     ss::default_priority_class())
                     .get();
-    BOOST_REQUIRE(result.error() == std::errc::invalid_seek);
+    ASSERT_EQ(result.error(), std::errc::invalid_seek);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_found) {
+TEST(OffsetToFileposTest, SearchBeginOffsetFound) {
     temporary_dir tmp_dir("offset_to_fpos_translate");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -121,10 +124,10 @@ SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_found) {
       model::offset{3},
       positions[2],
       model::timestamp{segment->index().base_timestamp().value() + 3}};
-    BOOST_REQUIRE(result.value() == expected);
+    ASSERT_EQ(result.value(), expected);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_search_end_offset_found) {
+TEST(OffsetToFileposTest, SearchEndOffsetFound) {
     temporary_dir tmp_dir("offset_to_fpos_translate");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -162,10 +165,10 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_found) {
       model::offset{3},
       positions[3], // the end byte offset of the batch containing the needle
       model::timestamp{segment->index().base_timestamp().value() + 3}};
-    BOOST_REQUIRE(result.value() == expected);
+    ASSERT_EQ(result.value(), expected);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_search_end_offset_allowed_to_be_missing) {
+TEST(OffsetToFileposTest, SearchEndOffsetAllowedToBeMissing) {
     temporary_dir tmp_dir("offset_to_fpos_translate");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -201,5 +204,5 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_allowed_to_be_missing) {
       model::offset{1},
       segment->size_bytes(),
       model::timestamp{segment->index().max_timestamp().value()}};
-    BOOST_REQUIRE(result.value() == expected);
+    ASSERT_EQ(result.value(), expected);
 }

--- a/src/v/storage/tests/offset_translator_state_test.cc
+++ b/src/v/storage/tests/offset_translator_state_test.cc
@@ -15,6 +15,8 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
+#include <gtest/gtest.h>
+
 #include <cstdint>
 #include <stdexcept>
 
@@ -29,7 +31,7 @@ constexpr model::offset_delta operator"" _do(unsigned long long o) {
     return model::offset_delta((int64_t)o);
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_add_normal) {
+TEST(OffsetTranslatorStateTest, AddNormal) {
     storage::offset_translator_state state(ntp);
 
     // base offset
@@ -37,26 +39,26 @@ SEASTAR_THREAD_TEST_CASE(offset_translator_state_add_normal) {
     // segment 2 |20          25..gap...28          |
 
     // segment 1
-    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    ASSERT_TRUE(state.add_absolute_delta(10_rp, 5));
+    ASSERT_EQ(state.last_delta(), 5_do);
+    ASSERT_EQ(state.last_gap_offset(), 9_rp);
     state.add_gap(10_rp, 14_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 14_rp);
     state.add_gap(18_rp, 19_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 12_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 19_rp);
+    ASSERT_EQ(state.last_delta(), 12_do);
+    ASSERT_EQ(state.last_gap_offset(), 19_rp);
 
     // segment 2
-    BOOST_REQUIRE(!state.add_absolute_delta(20_rp, 12));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 12_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 19_rp);
+    ASSERT_FALSE(state.add_absolute_delta(20_rp, 12));
+    ASSERT_EQ(state.last_delta(), 12_do);
+    ASSERT_EQ(state.last_gap_offset(), 19_rp);
     state.add_gap(25_rp, 28_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 16_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 28_rp);
+    ASSERT_EQ(state.last_delta(), 16_do);
+    ASSERT_EQ(state.last_gap_offset(), 28_rp);
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_overlap_non_data_batch) {
+TEST(OffsetTranslatorStateTest, OverlapNonDataBatch) {
     storage::offset_translator_state state(ntp);
 
     // base offset
@@ -64,28 +66,28 @@ SEASTAR_THREAD_TEST_CASE(offset_translator_state_overlap_non_data_batch) {
     // segment 2 |[18...gap...20] data              |
 
     // segment 1
-    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    ASSERT_TRUE(state.add_absolute_delta(10_rp, 5));
+    ASSERT_EQ(state.last_delta(), 5_do);
+    ASSERT_EQ(state.last_gap_offset(), 9_rp);
     state.add_gap(10_rp, 14_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 14_rp);
     state.add_gap(18_rp, 20_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    ASSERT_EQ(state.last_delta(), 13_do);
+    ASSERT_EQ(state.last_gap_offset(), 20_rp);
 
     // segment 2
     // This one wouldn't be added to the map because the gap length is 0
     // but the overlapping batch will be removed from it.
-    BOOST_REQUIRE(!state.add_absolute_delta(18_rp, 10));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    ASSERT_FALSE(state.add_absolute_delta(18_rp, 10));
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 14_rp);
     state.add_gap(18_rp, 20_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    ASSERT_EQ(state.last_delta(), 13_do);
+    ASSERT_EQ(state.last_gap_offset(), 20_rp);
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_duplicate) {
+TEST(OffsetTranslatorStateTest, Duplicate) {
     storage::offset_translator_state state(ntp);
 
     // base offset
@@ -93,61 +95,61 @@ SEASTAR_THREAD_TEST_CASE(offset_translator_state_duplicate) {
     // segment 2 |[10...gap...14] data [18..gap..20]|
 
     // segment 1
-    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    ASSERT_TRUE(state.add_absolute_delta(10_rp, 5));
+    ASSERT_EQ(state.last_delta(), 5_do);
+    ASSERT_EQ(state.last_gap_offset(), 9_rp);
     state.add_gap(10_rp, 14_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 14_rp);
     state.add_gap(18_rp, 20_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    ASSERT_EQ(state.last_delta(), 13_do);
+    ASSERT_EQ(state.last_gap_offset(), 20_rp);
 
     // segment 2
-    BOOST_REQUIRE(!state.add_absolute_delta(10_rp, 5));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    ASSERT_FALSE(state.add_absolute_delta(10_rp, 5));
+    ASSERT_EQ(state.last_delta(), 5_do);
+    ASSERT_EQ(state.last_gap_offset(), 9_rp);
     state.add_gap(10_rp, 14_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 14_rp);
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 14_rp);
     state.add_gap(18_rp, 20_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 13_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 20_rp);
+    ASSERT_EQ(state.last_delta(), 13_do);
+    ASSERT_EQ(state.last_gap_offset(), 20_rp);
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_inconsistency_1) {
+TEST(OffsetTranslatorStateTest, Inconsistency1) {
     storage::offset_translator_state state(ntp);
 
-    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 9));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 9_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
-    BOOST_REQUIRE_THROW(state.add_absolute_delta(11_rp, 5), std::runtime_error);
+    ASSERT_TRUE(state.add_absolute_delta(10_rp, 9));
+    ASSERT_EQ(state.last_delta(), 9_do);
+    ASSERT_EQ(state.last_gap_offset(), 9_rp);
+    ASSERT_THROW(state.add_absolute_delta(11_rp, 5), std::runtime_error);
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_inconsistency_2) {
+TEST(OffsetTranslatorStateTest, Inconsistency2) {
     storage::offset_translator_state state(ntp);
 
-    BOOST_REQUIRE(state.add_absolute_delta(10_rp, 5));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 5_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 9_rp);
+    ASSERT_TRUE(state.add_absolute_delta(10_rp, 5));
+    ASSERT_EQ(state.last_delta(), 5_do);
+    ASSERT_EQ(state.last_gap_offset(), 9_rp);
     state.add_gap(20_rp, 30_rp);
-    BOOST_REQUIRE_THROW(state.add_gap(15_rp, 20_rp), std::runtime_error);
+    ASSERT_THROW(state.add_gap(15_rp, 20_rp), std::runtime_error);
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_case_1) {
+TEST(OffsetTranslatorStateTest, Case1) {
     storage::offset_translator_state state(ntp);
 
-    BOOST_REQUIRE(state.add_absolute_delta(100_rp, 10));
-    BOOST_REQUIRE(!state.add_absolute_delta(110_rp, 10));
+    ASSERT_TRUE(state.add_absolute_delta(100_rp, 10));
+    ASSERT_FALSE(state.add_absolute_delta(110_rp, 10));
 }
 
-SEASTAR_THREAD_TEST_CASE(offset_translator_state_case_2) {
+TEST(OffsetTranslatorStateTest, Case2) {
     storage::offset_translator_state state(ntp);
-    BOOST_REQUIRE(state.add_absolute_delta(90_rp, 4));
+    ASSERT_TRUE(state.add_absolute_delta(90_rp, 4));
     state.add_gap(95_rp, 100_rp);
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 100_rp);
-    BOOST_REQUIRE(!state.add_absolute_delta(101_rp, 10));
-    BOOST_REQUIRE_EQUAL(state.last_delta(), 10_do);
-    BOOST_REQUIRE_EQUAL(state.last_gap_offset(), 100_rp);
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 100_rp);
+    ASSERT_FALSE(state.add_absolute_delta(101_rp, 10));
+    ASSERT_EQ(state.last_delta(), 10_do);
+    ASSERT_EQ(state.last_gap_offset(), 100_rp);
 }

--- a/src/v/storage/tests/snapshot_test.cc
+++ b/src/v/storage/tests/snapshot_test.cc
@@ -10,20 +10,23 @@
 #include "base/seastarx.h"
 #include "random/generators.h"
 #include "storage/snapshot.h"
+#include "test_utils/gtest_exception.h"
 #include "test_utils/random_bytes.h"
 
-#include <seastar/testing/thread_test_case.hh>
+#include <gtest/gtest.h>
 
-SEASTAR_THREAD_TEST_CASE(missing_snapshot_is_not_error) {
+using namespace redpanda::test_utils;
+
+TEST(SnapshotTest, MissingSnapshotIsNotError) {
     storage::simple_snapshot_manager mgr(
       "d/n/e",
       storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
     auto reader = mgr.open_snapshot().get();
-    BOOST_REQUIRE(!reader);
+    ASSERT_FALSE(reader);
 }
 
-SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
+TEST(SnapshotTest, ReadingFromEmptySnapshotIsError) {
     storage::simple_snapshot_manager mgr(
       ".",
       storage::simple_snapshot_manager::default_snapshot_filename,
@@ -41,11 +44,11 @@ SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
     fd.close().get();
 
     auto reader = mgr.open_snapshot().get();
-    BOOST_REQUIRE(reader);
-    BOOST_CHECK_EXCEPTION(
+    ASSERT_TRUE(reader);
+    ASSERT_THROWS_WITH_PREDICATE(
       reader->read_metadata().get(),
       std::runtime_error,
-      [](std::runtime_error e) {
+      [](const std::runtime_error& e) {
           return std::string(e.what()).find(
                    "Snapshot file does not contain full header")
                  != std::string::npos;
@@ -53,7 +56,7 @@ SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
     reader->close().get();
 }
 
-SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
+TEST(SnapshotTest, ReaderVerifiesHeaderCrc) {
     storage::simple_snapshot_manager mgr(
       ".",
       storage::simple_snapshot_manager::default_snapshot_filename,
@@ -72,25 +75,25 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
         // write some junk into the metadata. we're not using seastar i/o here
         // because for a test its too much to deal with i/o alignment, etc..
         int fd = ::open(mgr.snapshot_path().c_str(), O_WRONLY);
-        BOOST_REQUIRE(fd > 0);
-        BOOST_REQUIRE(::write(fd, &fd, sizeof(fd)) > 0);
-        BOOST_REQUIRE(::fsync(fd) == 0);
-        BOOST_REQUIRE(::close(fd) == 0);
+        ASSERT_GT(fd, 0);
+        ASSERT_GT(::write(fd, &fd, sizeof(fd)), 0);
+        ASSERT_EQ(::fsync(fd), 0);
+        ASSERT_EQ(::close(fd), 0);
     }
 
     auto reader = mgr.open_snapshot().get();
-    BOOST_REQUIRE(reader);
-    BOOST_CHECK_EXCEPTION(
+    ASSERT_TRUE(reader);
+    ASSERT_THROWS_WITH_PREDICATE(
       reader->read_metadata().get(),
       std::runtime_error,
-      [](std::runtime_error e) {
+      [](const std::runtime_error& e) {
           return std::string(e.what()).find("Failed to verify header crc")
                  != std::string::npos;
       });
     reader->close().get();
 }
 
-SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
+TEST(SnapshotTest, ReaderVerifiesMetadataCrc) {
     storage::simple_snapshot_manager mgr(
       ".",
       storage::simple_snapshot_manager::default_snapshot_filename,
@@ -110,26 +113,26 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
         // write some junk into the header. we're not using seastar i/o here
         // because for a test its too much to deal with i/o alignment, etc..
         int fd = ::open(mgr.snapshot_path().c_str(), O_WRONLY);
-        BOOST_REQUIRE(fd > 0);
+        ASSERT_GT(fd, 0);
         ::lseek(fd, storage::snapshot_header::ondisk_size, SEEK_SET);
-        BOOST_REQUIRE(::write(fd, &fd, sizeof(fd)) > 0);
-        BOOST_REQUIRE(::fsync(fd) == 0);
-        BOOST_REQUIRE(::close(fd) == 0);
+        ASSERT_GT(::write(fd, &fd, sizeof(fd)), 0);
+        ASSERT_EQ(::fsync(fd), 0);
+        ASSERT_EQ(::close(fd), 0);
     }
 
     auto reader = mgr.open_snapshot().get();
-    BOOST_REQUIRE(reader);
-    BOOST_CHECK_EXCEPTION(
+    ASSERT_TRUE(reader);
+    ASSERT_THROWS_WITH_PREDICATE(
       reader->read_metadata().get(),
       std::runtime_error,
-      [](std::runtime_error e) {
+      [](const std::runtime_error& e) {
           return std::string(e.what()).find("Failed to verify metadata crc")
                  != std::string::npos;
       });
     reader->close().get();
 }
 
-SEASTAR_THREAD_TEST_CASE(read_write) {
+TEST(SnapshotTest, ReadWrite) {
     storage::simple_snapshot_manager mgr(
       ".",
       storage::simple_snapshot_manager::default_snapshot_filename,
@@ -150,18 +153,17 @@ SEASTAR_THREAD_TEST_CASE(read_write) {
     mgr.finish_snapshot(writer).get();
 
     auto reader = mgr.open_snapshot().get();
-    BOOST_REQUIRE(reader);
+    ASSERT_TRUE(reader);
     auto read_metadata = reader->read_metadata().get();
-    BOOST_TEST(read_metadata == metadata_orig);
+    EXPECT_EQ(read_metadata, metadata_orig);
     auto blob_read = reader->input().read_exactly(blob.size()).get();
-    BOOST_TEST(
-      reader->get_snapshot_size().get() == mgr.get_snapshot_size().get());
+    EXPECT_EQ(reader->get_snapshot_size().get(), mgr.get_snapshot_size().get());
     reader->close().get();
-    BOOST_TEST(blob_read.size() == 1234);
-    BOOST_TEST(blob == ss::to_sstring(blob_read.clone()));
+    EXPECT_EQ(blob_read.size(), 1234);
+    EXPECT_EQ(blob, ss::to_sstring(blob_read.clone()));
 }
 
-SEASTAR_THREAD_TEST_CASE(remove_partial_snapshots) {
+TEST(SnapshotTest, RemovePartialSnapshots) {
     storage::simple_snapshot_manager mgr(
       ".",
       storage::simple_snapshot_manager::default_snapshot_filename,
@@ -176,11 +178,11 @@ SEASTAR_THREAD_TEST_CASE(remove_partial_snapshots) {
     auto p1 = mk_partial();
     auto p2 = mk_partial();
 
-    BOOST_REQUIRE(ss::file_exists(p1.string()).get());
-    BOOST_REQUIRE(ss::file_exists(p2.string()).get());
+    ASSERT_TRUE(ss::file_exists(p1.string()).get());
+    ASSERT_TRUE(ss::file_exists(p2.string()).get());
 
     mgr.remove_partial_snapshots().get();
 
-    BOOST_REQUIRE(!ss::file_exists(p1.string()).get());
-    BOOST_REQUIRE(!ss::file_exists(p2.string()).get());
+    ASSERT_FALSE(ss::file_exists(p1.string()).get());
+    ASSERT_FALSE(ss::file_exists(p2.string()).get());
 }

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -27,6 +27,7 @@ redpanda_test_cc_library(
     hdrs = [
         "async.h",
         "fixture.h",
+        "gtest_exception.h",
         "gtest_utils.h",
         "test.h",
         "test_macros.h",

--- a/src/v/test_utils/gtest_exception.h
+++ b/src/v/test_utils/gtest_exception.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace redpanda::test_utils {
+
+// Custom macro to replace BOOST_REQUIRE_EXCEPTION and
+// BOOST_CHECK_EXCEPTION functionality. Verifies that a statement
+// throws a specific exception type AND that the exception satisfies a
+// predicate.
+#define ASSERT_THROWS_WITH_PREDICATE(statement, exception_type, predicate)     \
+    try {                                                                      \
+        statement;                                                             \
+        FAIL() << "Expected " #exception_type " was not thrown";               \
+    } catch (const exception_type& e) {                                        \
+        if (!(predicate(e))) {                                                 \
+            FAIL() << "Exception message did not match predicate: "            \
+                   << e.what();                                                \
+        }                                                                      \
+    } catch (...) {                                                            \
+        FAIL() << "Expected " #exception_type " but got different exception";  \
+    }
+
+} // namespace redpanda::test_utils


### PR DESCRIPTION
Migrates 5 tests from Boost to Google Test. These are all pretty straightforward. I added
one helper for an assertion that Boost provides do but GTest doesn't: asserting code
throws and the exception satisfies a predicate.

The robot is pretty good at this, if you keep your eye on it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
