### PR TITLE
rpk: enable get config command for cloud env

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/BUILD
+++ b/src/go/rpk/pkg/cli/cluster/config/BUILD
@@ -28,6 +28,7 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/fieldmaskpb",
@@ -41,6 +42,7 @@ go_test(
     size = "small",
     srcs = [
         "edit_test.go",
+        "get_test.go",
         "import_test.go",
         "set_test.go",
     ],
@@ -49,5 +51,6 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v3//:yaml_v3",
+        "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/src/go/rpk/pkg/cli/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get.go
@@ -10,12 +10,23 @@
 package config
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
+	"connectrpc.com/connect"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/publicapi"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -33,9 +44,18 @@ output, use the 'edit' and 'export' commands respectively.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			key := args[0]
 
-			p, err := p.LoadVirtualProfile(fs)
+			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
-			config.CheckExitCloudAdmin(p)
+
+			p := cfg.VirtualProfile()
+			if p.FromCloud {
+				if p.CloudCluster.IsServerless() {
+					out.Die("rpk cluster config get is not supported for serverless clusters")
+				}
+				configValue, e := getCloudConfig(cmd.Context(), cfg, p, key)
+				out.MaybeDie(e, "rpk unable to get cloud config: %v", e)
+				out.Exit(configValue)
+			}
 
 			client, err := adminapi.NewClient(cmd.Context(), fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
@@ -68,4 +88,55 @@ output, use the 'edit' and 'export' commands respectively.`,
 	}
 
 	return cmd
+}
+
+func getCloudConfig(ctx context.Context, cfg *config.Config, p *config.RpkProfile, configName string) (string, error) {
+	cloudClient := publicapi.NewCloudClientSet(cfg.DevOverrides().PublicAPIURL, p.CurrentAuth().AuthToken)
+	req := connect.NewRequest(&controlplanev1.GetClusterRequest{
+		Id: p.CloudCluster.ClusterID,
+	})
+
+	cluster, err := cloudClient.Cluster.GetCluster(ctx, req)
+	if err != nil {
+		var ce *connect.Error
+		if errors.As(err, &ce) {
+			if ce.Code() == connect.CodePermissionDenied {
+				return "", fmt.Errorf("this user does not have permission to get cluster information, please check your role or contact admin")
+			}
+			if ce.Code() == connect.CodeNotFound {
+				return "", fmt.Errorf("cluster not found. Please ensure the cluster exists in Redpanda Cloud organization")
+			}
+		}
+		return "", fmt.Errorf("internal error while getting Redpanda cloud configs: %v", err)
+	}
+	configs := cluster.Msg.GetCluster().GetClusterConfiguration().GetComputedProperties()
+	value, ok := configs.GetFields()[configName]
+	if !ok {
+		return "", fmt.Errorf("unknown property: %s. \nsome configurations are not available for retrieval from cloud clusters", configName)
+	}
+
+	return fromStructPbToString(value), nil
+}
+
+func fromStructPbToString(s *structpb.Value) string {
+	switch s.Kind.(type) {
+	case *structpb.Value_ListValue:
+		var v []string
+		for _, value := range s.GetListValue().Values {
+			v = append(v, fromStructPbToString(value))
+		}
+		return fmt.Sprintf("%v", strings.Join(v, ", "))
+	case *structpb.Value_StructValue:
+		return protojson.MarshalOptions{Multiline: false}.Format(s.GetStructValue())
+	case *structpb.Value_NullValue:
+		return "null"
+	case *structpb.Value_NumberValue:
+		return fmt.Sprintf("%v", s.GetNumberValue())
+	case *structpb.Value_StringValue:
+		return s.GetStringValue()
+	case *structpb.Value_BoolValue:
+		return fmt.Sprintf("%t", s.GetBoolValue())
+	default:
+		return s.String()
+	}
 }

--- a/src/go/rpk/pkg/cli/cluster/config/get_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestFromStructPbToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *structpb.Value
+		expected string
+	}{
+		{
+			name:     "String value",
+			input:    structpb.NewStringValue("test"),
+			expected: "test",
+		},
+		{
+			name: "List value",
+			input: structpb.NewListValue(&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("value1"),
+					structpb.NewStringValue("value2"),
+				},
+			}),
+			expected: "value1, value2",
+		},
+		{
+			name:     "Null value",
+			input:    structpb.NewNullValue(),
+			expected: "null",
+		},
+		{
+			name:     "Number value",
+			input:    structpb.NewNumberValue(123.45),
+			expected: "123.45",
+		},
+		{
+			name:     "String value",
+			input:    structpb.NewStringValue("example"),
+			expected: "example",
+		},
+		{
+			name:     "Boolean value (true)",
+			input:    structpb.NewBoolValue(true),
+			expected: "true",
+		},
+		{
+			name:     "Boolean value (false)",
+			input:    structpb.NewBoolValue(false),
+			expected: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromStructPbToString(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFromStructPbToStringWithStruct(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *structpb.Value
+		expected string
+	}{
+		{
+			name: "Struct value",
+			input: structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"key1": structpb.NewStringValue("value1"),
+					"key2": structpb.NewNumberValue(42),
+				},
+			}),
+			expected: `{"key1":"value1", "key2":42}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fromStructPbToString(tt.input)
+			require.JSONEq(t, tt.expected, result, "expected JSON output does not match")
+		})
+	}
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

Enable `rpk cluster config get` for cloud env


https://github.com/user-attachments/assets/fa75823c-dd00-48c5-a4a1-360cef04e7a4


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.



Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.


* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features
* allow use `rpk cluster config get` in cloud cluster.

## Outputs

```bash
 rpk cluster config get http_authentication
BASIC
```

```bash
rpk cluster config get no-property
rpk unable to get cloud config: unknown property: no-property.
some configurations are not available for retrieval from cloud clusters
```

```bash
rpk cluster config get http_authentication
rpk unable to get cloud config: this user does not have permission to get cluster information, please check your role or contact admin
```