### PR TITLE
[v24.2.x] `storage`: use `std::deque` as `segment_set::underlying_t` (Manual backport)

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1486,17 +1486,13 @@ offset_stats disk_log_impl::offsets() const {
         }
         return ret;
     }
-    // NOTE: we have to do this because ss::circular_buffer<> does not provide
-    // with reverse iterators, so we manually find the iterator
-    segment_set::type end;
-    for (int i = (int)_segs.size() - 1; i >= 0; --i) {
-        auto& seg = _segs[i];
-        if (!seg->empty()) {
-            end = seg;
-            break;
-        }
-    }
-    if (!end) {
+
+    auto it = std::find_if(
+      _segs.rbegin(), _segs.rend(), [](const segment_set::type& s) {
+          return !s->empty();
+      });
+
+    if (it == _segs.rend()) {
         offset_stats ret;
         ret.start_offset = _start_offset;
         if (ret.start_offset > model::offset(0)) {
@@ -1507,7 +1503,7 @@ offset_stats disk_log_impl::offsets() const {
     }
     // we have valid begin and end
     const auto& bof = _segs.front()->offsets();
-    const auto& eof = end->offsets();
+    const auto& eof = (*it)->offsets();
 
     const auto start_offset = _start_offset() >= 0 ? _start_offset
                                                    : bof.get_base_offset();
@@ -1530,8 +1526,8 @@ model::offset disk_log_impl::find_last_term_start_offset() const {
 
     segment_set::type end;
     segment_set::type term_start;
-    for (int i = (int)_segs.size() - 1; i >= 0; --i) {
-        auto& seg = _segs[i];
+    for (auto it = _segs.rbegin(); it != _segs.rend(); ++it) {
+        auto& seg = *it;
         if (!seg->empty()) {
             if (!end) {
                 end = seg;
@@ -1671,8 +1667,8 @@ uint64_t disk_log_impl::size_bytes_after_offset(model::offset o) const {
         return 0;
     }
     uint64_t size = 0;
-    for (size_t i = _segs.size(); i-- > 0;) {
-        auto& seg = _segs[i];
+    for (auto it = _segs.rbegin(); it != _segs.rend(); ++it) {
+        auto& seg = *it;
         if (seg->offsets().get_base_offset() < o) {
             break;
         }

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -365,13 +365,13 @@ void log_reader::maybe_log_load_slice_depth_warning(
     const auto size = segs.size();
     auto count = 0;
     constexpr auto max_segments = 10;
-    for (int i = (int)size - 1; i >= 0; --i) {
-        auto& seg = segs[i];
+    for (auto it = segs.rbegin(); it != segs.rend(); ++it) {
+        auto& seg = *it;
         vlog(
           stlog.warn,
           "load_slice recursion warning. lease range segment {}/{} "
           "empty {}: {}",
-          i,
+          std::distance(segs.begin(), it.base()) - 1,
           size,
           seg->empty(),
           seg);
@@ -516,18 +516,22 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
     }
 }
 
-static inline bool is_finished_offset(segment_set& s, model::offset o) {
-    if (s.empty()) {
+static inline bool is_finished_offset(segment_set& segs, model::offset o) {
+    if (segs.empty()) {
         return true;
     }
 
-    for (int i = (int)s.size() - 1; i >= 0; --i) {
-        auto& seg = s[i];
-        if (!seg->empty()) {
-            return o > seg->offsets().get_dirty_offset();
-        }
+    auto it = std::find_if(
+      segs.rbegin(), segs.rend(), [](const segment_set::type& seg) {
+          return !seg->empty();
+      });
+
+    if (it == segs.rend()) {
+        return true;
     }
-    return true;
+
+    auto& seg = *it;
+    return o > seg->offsets().get_dirty_offset();
 }
 bool log_reader::is_done() {
     return is_end_of_stream()

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -169,12 +169,13 @@ std::ostream& operator<<(std::ostream& o, const segment_set& s) {
             o << p;
         }
     } else {
-        for (size_t i = 0; i < halved; i++) {
-            o << s[i];
+        for (auto it = s.begin(); it != std::next(s.begin(), halved); ++it) {
+            o << *it;
         }
         o << "...";
-        for (size_t i = s.size() - halved; i < s.size(); i++) {
-            o << s[i];
+        for (auto it = std::next(s.begin(), s.size() - halved); it != s.end();
+             ++it) {
+            o << *it;
         }
     }
     return o << "]}";
@@ -202,11 +203,10 @@ static ss::future<segment_set> unsafe_do_recover(
         }
         segment_set::underlying_t good = std::move(segments).release();
         absl::btree_set<segment*> to_recover_set;
-        for (size_t i = 0; i < good.size(); ++i) {
-            auto& s = *good[i];
-            if (i > 0) {
-                auto& prev = *good[i - 1];
-
+        for (auto it = good.begin(); it != good.end(); ++it) {
+            auto& s = *(*it);
+            if (it != good.begin()) {
+                auto& prev = *(*std::prev(it));
                 if (
                   prev.offsets().get_dirty_offset()
                   >= s.offsets().get_base_offset()) {
@@ -357,7 +357,6 @@ static ss::future<segment_set> do_recover(
   ss::abort_source& as) {
     // light-weight copy used for clean-up if recovery fails
     segment_set::underlying_t copy;
-    copy.reserve(segments.size());
     std::copy(segments.cbegin(), segments.cend(), std::back_inserter(copy));
 
     // if an exception occurs during recovery close all the segments that are

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -17,7 +17,6 @@
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
 
-#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/sharded.hh>
 
 #include <deque>
@@ -41,13 +40,11 @@ public:
     // for readers and writers taking refs.
     using type = ss::lw_shared_ptr<segment>;
 
-    // NOTE: gcc has an ABI problem and cannot make std::deque noexcept
-    // so we use a circular instead of a dequeue that *is* noexcept ctor
-    // and allow us to truly have an empty container at ctor time
-    // We loose reverse-iterators tho
-    using underlying_t = ss::circular_buffer<type>;
+    using underlying_t = std::deque<type>;
     using const_iterator = underlying_t::const_iterator;
     using iterator = underlying_t::iterator;
+    using reverse_iterator = underlying_t::reverse_iterator;
+    using const_reverse_iterator = underlying_t::const_reverse_iterator;
 
     explicit segment_set(underlying_t);
     ~segment_set() noexcept;
@@ -87,6 +84,11 @@ public:
     iterator end() { return _handles.end(); }
     const_iterator begin() const { return _handles.begin(); }
     const_iterator end() const { return _handles.end(); }
+
+    reverse_iterator rbegin() { return _handles.rbegin(); }
+    reverse_iterator rend() { return _handles.rend(); }
+    const_reverse_iterator rbegin() const { return _handles.rbegin(); }
+    const_reverse_iterator rend() const { return _handles.rend(); }
 
 private:
     underlying_t _handles;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -467,7 +467,6 @@ model::record_batch_reader create_segment_full_reader(
       o.get_base_offset(), o.get_dirty_offset(), cfg.iopc);
     reader_cfg.skip_batch_cache = true;
     segment_set::underlying_t set;
-    set.reserve(1);
     set.push_back(s);
     auto lease = std::make_unique<lock_manager::lease>(
       segment_set(std::move(set)));

--- a/src/v/storage/tests/readers_cache_test.cc
+++ b/src/v/storage/tests/readers_cache_test.cc
@@ -31,7 +31,8 @@
 
 namespace storage {
 struct readers_cache_test_fixture : seastar_test {
-    using segment_ptr = ss::lw_shared_ptr<storage::segment>;
+    using segment_ptr = segment_set::type;
+    using segments_t = segment_set::underlying_t;
     bool intersects_locked_range(
       const readers_cache& cache, model::offset begin, model::offset end) {
         return cache.intersects_with_locked_range(begin, end);
@@ -64,8 +65,7 @@ struct readers_cache_test_fixture : seastar_test {
           default_value);
     }
 
-    std::unique_ptr<storage::log_reader>
-    make_reader(ss::circular_buffer<segment_ptr> segments = {}) {
+    std::unique_ptr<storage::log_reader> make_reader(segments_t segments = {}) {
         auto lease = std::make_unique<lock_manager::lease>(
           segment_set(std::move(segments)));
         return std::make_unique<log_reader>(
@@ -196,7 +196,7 @@ TEST_F(readers_cache_test_fixture, test_size_based_eviction) {
     auto close = ss::defer([&cache] { cache.stop().get(); });
 
     for (int i = 0; i < 10; ++i) {
-        ss::circular_buffer<segment_ptr> set;
+        segments_t set;
         set.push_back(make_segment(model::offset(i)));
         cache.put(make_reader(std::move(set)));
     }
@@ -212,7 +212,7 @@ TEST_F(readers_cache_test_fixture, test_size_based_eviction) {
      * in a background.
      */
     for (int i = 10; i < 15; ++i) {
-        ss::circular_buffer<segment_ptr> set;
+        segments_t set;
         set.push_back(make_segment(model::offset(i)));
         cache.put(make_reader(std::move(set)));
     }
@@ -222,7 +222,7 @@ TEST_F(readers_cache_test_fixture, test_size_based_eviction) {
     RPTEST_REQUIRE_EVENTUALLY(
       5s, [&] { return cache.get_stats().cached_readers == 10; });
 
-    ss::circular_buffer<segment_ptr> set;
+    segments_t set;
     set.push_back(make_segment(model::offset(100)));
     auto reader = cache.put(make_reader(std::move(set)));
     EXPECT_EQ(cache.get_stats().in_use_readers, 1);


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26113. `cherry-pick` conflict due to small (negligible) changes in `disk_log_impl.cc` not present in previous versions.

Fixes https://github.com/redpanda-data/redpanda/issues/26135.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Swap out an internal data structure in the `storage` layer to prevent oversized allocations and crashes when a large number of `segment`s are present in a `partition`.
