### PR TITLE
Wait for the initial balancer run before stopping a node

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -1122,6 +1122,7 @@ class PartitionBalancerTest(PartitionBalancerService):
         )
         self.topic = TopicSpec(partition_count=random.randint(20, 30))
         self.client().create_topic(self.topic)
+        self.wait_until_ready()
 
         # throttle recovery to prevent partition moves from finishing
         self.logger.info("throttling recovery")

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -161,7 +161,7 @@ class PartitionBalancerService(EndToEndTest):
             disabled_node, expected_moving_partitions_amount),
                           timeout_sec=10)
 
-    def wait_until_status(self, predicate, timeout_sec=120):
+    def wait_until_status(self, predicate, timeout_sec=120, err_msg=""):
         # We may get a 504 if we proxy a status request to a suspended node.
         # It is okay to retry (the controller leader will get re-elected in the meantime).
         admin = Admin(self.redpanda, retry_codes=[503, 504], retries_amount=10)
@@ -187,7 +187,7 @@ class PartitionBalancerService(EndToEndTest):
             check,
             timeout_sec=timeout_sec,
             backoff_sec=2,
-            err_msg="failed to wait until status condition",
+            err_msg=err_msg,
         )
 
     def wait_until_ready(self,
@@ -206,7 +206,10 @@ class PartitionBalancerService(EndToEndTest):
                     ((node_id is None) or (node_id in status["violations"].get(
                         "unavailable_nodes", []))))
 
-        return self.wait_until_status(predicate, timeout_sec=timeout_sec)
+        return self.wait_until_status(
+            predicate,
+            timeout_sec=timeout_sec,
+            err_msg="Error waiting for partition balancer to become ready")
 
     def check_no_replicas_on_node(self, node):
         node2pc = self.node2partition_count()


### PR DESCRIPTION
Now that the partition balancer is waiting for the valid disk report
before running it may delay its run. The test failed as one of the nodes
was killed before partition balancer on the controller received its
health report. This delayed the execution and the test triggered
timeout.

fixes: CORE-9956
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none