### PR TITLE
k/connection_ctx: wait for response future in foreground when stopping

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -850,7 +850,18 @@ ss::future<> connection_context::client_protocol_state::process_request(
         sres->tracker->mark_errored();
         co_return;
     }
-
+    /**
+     * If the gate is closed, then we are shutting down and need to wait for the
+     * response future in the foreground.
+     */
+    if (connection_ctx->_server.conn_gate().is_closed()) {
+        co_return co_await handle_response(
+          std::move(connection_ctx),
+          std::move(res.response),
+          sres,
+          seq,
+          correlation);
+    }
     /**
      * second stage processed in background.
      */


### PR DESCRIPTION
When stopping Redpanda the server connection gate may be closed before the `spawn_with_gate` is executed. In this case the future that is captured in the lambda that is supposed to execute in the background is not waited for. If the future failed it will trigger Seastar warning about ignored failed future. To prevent this from happening added waiting for result future to finish before returning from `process_request` function.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none