### PR TITLE
dl/iceberg: allow dynamic iceberg mode change

### DIFF
--- a/src/v/datalake/data_writer_interface.cc
+++ b/src/v/datalake/data_writer_interface.cc
@@ -34,6 +34,8 @@ std::ostream& operator<<(std::ostream& os, const writer_error& ev) {
         return os << "Disk exhausted";
     case writer_error::unknown_error:
         return os << "Unknown error";
+    case writer_error::retryable_type_resolution_error:
+        return os << "Retryable type resolution error";
     }
 }
 std::string data_writer_error_category::message(int ev) const {
@@ -57,19 +59,20 @@ writer_error map_to_writer_error(reservation_error reservation_err) {
     }
 }
 
-bool is_recoverable_error(datalake::writer_error err) {
+bool is_recoverable_error(writer_error err) {
     switch (err) {
-    case datalake::writer_error::ok:
-    case datalake::writer_error::oom_error:
-    case datalake::writer_error::time_limit_exceeded:
-    case datalake::writer_error::out_of_disk:
+    case writer_error::ok:
+    case writer_error::oom_error:
+    case writer_error::time_limit_exceeded:
+    case writer_error::out_of_disk:
         return true;
-    case datalake::writer_error::parquet_conversion_error:
-    case datalake::writer_error::file_io_error:
-    case datalake::writer_error::no_data:
-    case datalake::writer_error::flush_error:
-    case datalake::writer_error::shutting_down:
-    case datalake::writer_error::unknown_error:
+    case writer_error::parquet_conversion_error:
+    case writer_error::retryable_type_resolution_error:
+    case writer_error::file_io_error:
+    case writer_error::no_data:
+    case writer_error::flush_error:
+    case writer_error::shutting_down:
+    case writer_error::unknown_error:
         return false;
     }
 }

--- a/src/v/datalake/data_writer_interface.h
+++ b/src/v/datalake/data_writer_interface.h
@@ -23,6 +23,7 @@ namespace datalake {
 enum class writer_error {
     ok = 0,
     parquet_conversion_error,
+    retryable_type_resolution_error,
     file_io_error,
     no_data,
     flush_error,

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -303,8 +303,9 @@ ss::future<> datalake_manager::start() {
           topic_properties_registration);
     });
     _iceberg_invalid_record_action.watch([this] {
-        for (auto& [_, entry] : _scheduler.all_translators()) {
-            entry.translator_ptr()->reconcile_properties();
+        for (auto& [ntp, _] : _scheduler.all_translators()) {
+            _queue.submit(
+              [this, ntp]() { return handle_translator_state_change(ntp); });
         }
     });
 
@@ -644,20 +645,30 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
                                  == model::iceberg_mode::disabled;
     auto requires_active_translator = partition && topic_cfg
                                       && !iceberg_disabled && is_leader;
-
     if (translator_exists) {
-        if (requires_active_translator) {
-            // TODO: add more tests that exercise this code path (to ensure new
-            // property updates are getting picked up correctly)
-            translator_it->second.translator_ptr()->reconcile_properties();
-        } else {
-            co_await _scheduler.remove_translator(ntp);
+        // stop the existing translator first and restart if needed
+        // The newer incarnation will pickup any changes to the iceberg
+        // mode or properties.
+        // This is ok because the changes to properties are very rare.
+        auto remove_f = co_await ss::coroutine::as_future(
+          _scheduler.remove_translator(ntp));
+        if (remove_f.failed()) {
+            vlog(
+              datalake_log.warn,
+              "removing existing translator for {} failed {}, retrying in 10s.",
+              ntp,
+              remove_f.get_exception());
+            if (!_gate.is_closed()) {
+                _queue.submit_delayed(10s, [this, ntp]() {
+                    return handle_translator_state_change(ntp);
+                });
+            }
+            co_return;
         }
-        co_return;
     }
 
     if (!requires_active_translator) {
-        // no active translator, so nothing to do
+        // no active translator needed, so nothing to do
         co_return;
     }
 

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -120,10 +120,17 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
         auto val_type_res = co_await _type_resolver.resolve_buf_type(
           std::move(val));
         if (val_type_res.has_error()) {
-            switch (val_type_res.error()) {
+            auto err = val_type_res.error();
+            vlog(
+              _log.warn,
+              "Error resolving type for record at offset {}, batch: {}: {}",
+              offset,
+              batch.header(),
+              err);
+            switch (err) {
             case type_resolver::errc::registry_error:
             case type_resolver::errc::invalid_config:
-                _error = writer_error::parquet_conversion_error;
+                _error = writer_error::retryable_type_resolution_error;
                 co_return ss::stop_iteration::yes;
             case type_resolver::errc::bad_input:
             case type_resolver::errc::translation_error:
@@ -153,14 +160,16 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
           timestamp,
           header_kvs);
         if (record_data_res.has_error()) {
-            switch (record_data_res.error()) {
+            auto err = record_data_res.error();
+            vlog(
+              _log.warn,
+              "Error translating data for record at offset {}, batch: {}: {}",
+              offset,
+              batch.header(),
+              err);
+            switch (err) {
             case record_translator::errc::unexpected_schema:
             case record_translator::errc::translation_error:
-                vlog(
-                  _log.debug,
-                  "Error translating data for record {}: {}",
-                  offset,
-                  record_data_res.error());
                 auto invalid_res = co_await handle_invalid_record(
                   translation_probe::invalid_record_cause::
                     failed_data_translation,
@@ -205,11 +214,13 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 case table_creator::errc::failed:
                     vlog(
                       _log.warn,
-                      "Error ensuring table schema for record {}",
-                      offset);
-                    [[fallthrough]];
+                      "Error ensuring table schema for record {}: {}",
+                      offset,
+                      e);
+                    _error = writer_error::unknown_error;
+                    break;
                 case table_creator::errc::shutting_down:
-                    _error = writer_error::parquet_conversion_error;
+                    _error = writer_error::shutting_down;
                 }
                 co_return ss::stop_iteration::yes;
             }
@@ -226,10 +237,11 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                       _log.warn,
                       "Error getting table info for record {}: {}",
                       offset,
-                      load_res.error());
-                    [[fallthrough]];
+                      e);
+                    _error = writer_error::unknown_error;
+                    break;
                 case schema_manager::errc::shutting_down:
-                    _error = writer_error::parquet_conversion_error;
+                    _error = writer_error::shutting_down;
                 }
                 co_return ss::stop_iteration::yes;
             }
@@ -242,7 +254,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                   _log.warn,
                   "expected to successfully fill field IDs for record {}",
                   offset);
-                _error = writer_error::parquet_conversion_error;
+                _error = writer_error::unknown_error;
                 co_return ss::stop_iteration::yes;
             }
 
@@ -255,7 +267,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                   "at offset {}",
                   load_res.value().location,
                   offset);
-                _error = writer_error::parquet_conversion_error;
+                _error = writer_error::unknown_error;
                 co_return ss::stop_iteration::yes;
             }
 
@@ -416,17 +428,21 @@ record_multiplexer::handle_invalid_record(
 
             if (ensure_res.has_error()) {
                 auto e = ensure_res.error();
+
                 switch (e) {
                 case table_creator::errc::incompatible_schema:
-                    [[fallthrough]];
                 case table_creator::errc::failed:
-                    [[fallthrough]];
-                case table_creator::errc::shutting_down:
                     vlog(
                       _log.warn,
-                      "Error ensuring DLQ table schema for invalid record {}",
-                      offset);
-                    co_return writer_error::parquet_conversion_error;
+                      "Error ensuring DLQ table schema for invalid record {}: "
+                      "{}",
+                      offset,
+                      e);
+                    // Normally this is not possible, so we use blanket error
+                    // code.
+                    co_return writer_error::unknown_error;
+                case table_creator::errc::shutting_down:
+                    co_return writer_error::shutting_down;
                 }
             }
 
@@ -441,10 +457,10 @@ record_multiplexer::handle_invalid_record(
                       _log.warn,
                       "Error getting table info for record {}: {}",
                       offset,
-                      load_res.error());
-                    [[fallthrough]];
+                      e);
+                    co_return writer_error::unknown_error;
                 case schema_manager::errc::shutting_down:
-                    co_return writer_error::parquet_conversion_error;
+                    co_return writer_error::shutting_down;
                 }
             }
 
@@ -457,7 +473,7 @@ record_multiplexer::handle_invalid_record(
                   _log.warn,
                   "expected to successfully fill field IDs for record {}",
                   offset);
-                co_return writer_error::parquet_conversion_error;
+                co_return writer_error::unknown_error;
             }
 
             auto table_remote_path = _location_provider.from_uri(
@@ -469,7 +485,7 @@ record_multiplexer::handle_invalid_record(
                   "at offset {}",
                   load_res.value().location,
                   offset);
-                co_return writer_error::parquet_conversion_error;
+                co_return writer_error::unknown_error;
             }
 
             _invalid_record_writer = std::make_unique<partitioning_writer>(
@@ -497,11 +513,11 @@ record_multiplexer::handle_invalid_record(
           headers);
         if (record_data_res.has_error()) {
             vlog(
-              _log.debug,
+              _log.warn,
               "Error translating DLQ data for record {}: {}",
               offset,
               record_data_res.error());
-            co_return writer_error::parquet_conversion_error;
+            co_return writer_error::unknown_error;
         }
 
         if (!_result.has_value()) {

--- a/src/v/datalake/serde_parquet_writer.cc
+++ b/src/v/datalake/serde_parquet_writer.cc
@@ -15,6 +15,10 @@ ss::future<writer_error> serde_parquet_writer::add_data_struct(
     auto conversion_result = co_await to_parquet_value(
       std::make_unique<iceberg::struct_value>(std::move(value)));
     if (conversion_result.has_error()) {
+        vlog(
+          datalake_log.warn,
+          "Error converting iceberg struct to parquet value - {}",
+          conversion_result.error());
         co_return writer_error::parquet_conversion_error;
     }
 

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -530,43 +530,9 @@ public:
               _invalid_record_action,
               _location_provider,
               *_probe});
-            _discard_translated_state = false;
-        }
-        if (_discard_translated_state) {
-            return std::move(reader).release()->finally().then([] {
-                return ss::make_exception_future(
-                  std::runtime_error("state changed, reset translation"));
-            });
         }
         return _in_progress_translation->translate_once(
           std::move(reader), start_offset, as);
-    }
-
-    void reconcile_properties() final {
-        auto old_invalid_action = _invalid_record_action;
-        auto old_cp_enabled = _cp_enabled;
-
-        // target lag changes will be picked dynamically and does not
-        // need a state reset.
-        _invalid_record_action = compute_invalid_record_action();
-        _cp_enabled = translation_task::custom_partitioning_enabled{
-          _features.is_active(features::feature::datalake_iceberg_ga)};
-
-        auto properties_updated = old_invalid_action != _invalid_record_action
-                                  || old_cp_enabled != _cp_enabled;
-        if (properties_updated) {
-            vlog(
-              datalake_log.info,
-              "[{}] properties updated, new properties: invalid record action: "
-              "{}, custom_partition_enabled: {}",
-              _ntp,
-              _invalid_record_action,
-              _cp_enabled);
-        }
-        if (_in_progress_translation && properties_updated) {
-            // discard any state so far
-            _discard_translated_state = properties_updated;
-        }
     }
 
     size_t flushed_bytes() const final {
@@ -634,10 +600,6 @@ public:
             co_return translation_errc::no_data;
         }
         vlog(datalake_log.debug, "[{}] finishing translation", _ntp);
-        if (_discard_translated_state) {
-            co_await discard().discard_result();
-            co_return translation_errc::discard_error;
-        }
         auto task = std::exchange(_in_progress_translation, std::nullopt);
         auto result = co_await std::move(task.value())
                         .finish(_cp_enabled, _upload_path_prefix, rcn, as);
@@ -711,7 +673,6 @@ private:
     translation_task::custom_partitioning_enabled _cp_enabled;
     translator_mem_tracker _mem_tracker;
     std::optional<translation_task> _in_progress_translation;
-    bool _discard_translated_state{false};
 };
 
 std::unique_ptr<translation_context>

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -48,6 +48,8 @@ map_error_code(datalake::translation_task::errc errc) {
         return translation_errc::shutting_down;
     case datalake::translation_task::errc::out_of_disk:
         return translation_errc::out_of_disk;
+    case datalake::translation_task::errc::type_resolution_error:
+        return translation_errc::type_resolution_error;
     }
 }
 } // namespace
@@ -474,6 +476,8 @@ std::ostream& operator<<(std::ostream& o, translation_errc ec) {
         return o << "translation_errc::shutting_down";
     case out_of_disk:
         return o << "translation_errc::out_of_disk";
+    case type_resolution_error:
+        return o << "translation_errc::type_resolution_error";
     }
 }
 

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -226,6 +226,7 @@ enum translation_errc {
     time_limit_exceeded,
     shutting_down,
     out_of_disk,
+    type_resolution_error,
 };
 
 std::ostream& operator<<(std::ostream&, translation_errc);

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -264,11 +264,6 @@ public:
     virtual std::optional<kafka::offset> last_translated_offset() const = 0;
 
     /**
-     * Reconciles the translator configurations.
-     */
-    virtual void reconcile_properties() = 0;
-
-    /**
      * Cleans up state and uploads data to cloud storage. Should be called in
      * all cases for appropriate cleanup.
      * This is called outside of translation scheduler context so it does not

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -85,13 +85,6 @@ partition_translator::partition_translator(
   , _logger(
       datalake_log, fmt::format("{}-term-{}", _data_source->ntp(), _term)) {}
 
-void partition_translator::reconcile_properties() noexcept {
-    if (_gate.is_closed()) {
-        return;
-    }
-    _translation_ctx->reconcile_properties();
-}
-
 ss::future<coordinator::fetch_latest_translated_offset_reply>
 partition_translator::fetch_latest_translated_offset(retry_chain_node& rcn) {
     auto request = coordinator::fetch_latest_translated_offset_request{};

--- a/src/v/datalake/translation/partition_translator.h
+++ b/src/v/datalake/translation/partition_translator.h
@@ -92,8 +92,6 @@ public:
 
     void stop_translation(stop_reason) final;
 
-    void reconcile_properties() noexcept final;
-
     void set_finish_translation() final;
 
     bool get_finish_translation() final;

--- a/src/v/datalake/translation/scheduling.h
+++ b/src/v/datalake/translation/scheduling.h
@@ -187,11 +187,6 @@ public:
     virtual ss::future<> close() noexcept = 0;
 
     /**
-     * Invoked when any of the translation related properties are altered.
-     */
-    virtual void reconcile_properties() noexcept = 0;
-
-    /**
      * Current status of the translation.
      */
     virtual translation_status status() const = 0;

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -311,8 +311,6 @@ public:
         return ss::make_ready_future();
     }
 
-    void reconcile_properties() final {}
-
     ss::future<
       checked<datalake::coordinator::translated_offset_range, translation_errc>>
     finish(retry_chain_node&, ss::abort_source&) final {

--- a/src/v/datalake/translation/tests/scheduler_fixture.h
+++ b/src/v/datalake/translation/tests/scheduler_fixture.h
@@ -39,7 +39,6 @@ public:
     translation_status status() const override;
     void start_translation(clock::duration translate_for) override;
     void stop_translation(stop_reason) override;
-    void reconcile_properties() noexcept override {}
     std::chrono::milliseconds current_lag_ms() const override {
         return std::chrono::milliseconds{0};
     }

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -56,6 +56,8 @@ translation_task::errc map_error_code(writer_error errc) {
         return translation_task::errc::out_of_disk;
     case writer_error::unknown_error:
         return translation_task::errc::file_io_error;
+    case writer_error::retryable_type_resolution_error:
+        return translation_task::errc::type_resolution_error;
     }
 }
 
@@ -265,7 +267,7 @@ ss::future<checked<void, translation_task::errc>> translation_task::flush() {
     auto result = co_await _multiplexer.flush_writers();
     if (result != writer_error::ok) {
         vlog(_log.debug, "error flushing writers: {}", result);
-        co_return translation_task::errc::flush_error;
+        co_return map_error_code(result);
     }
     co_return outcome::success();
 }
@@ -408,6 +410,8 @@ std::ostream& operator<<(std::ostream& o, translation_task::errc ec) {
         return o << "shutting down";
     case translation_task::errc::out_of_disk:
         return o << "disk exhausted";
+    case translation_task::errc::type_resolution_error:
+        return o << "type resolution error";
     }
 }
 } // namespace datalake

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -60,6 +60,7 @@ translation_task::errc map_error_code(writer_error errc) {
 }
 
 ss::future<checked<remote_path, translation_task::errc>> execute_single_upload(
+  prefix_logger& logger,
   cloud_data_io& _cloud_io,
   const partitioning_writer::partitioned_file& file,
   const remote_path& remote_path_prefix,
@@ -82,7 +83,7 @@ ss::future<checked<remote_path, translation_task::errc>> execute_single_upload(
       file.local_file, file_remote_path, upload_rcn, lazy_as);
     if (result.has_error()) {
         vlog(
-          datalake_log.warn,
+          logger.warn,
           "error uploading file {} to {} - {}",
           file.local_file,
           file_remote_path,
@@ -96,21 +97,22 @@ ss::future<checked<remote_path, translation_task::errc>> execute_single_upload(
 
 ss::future<checked<std::nullopt_t, translation_task::errc>>
 delete_local_data_files(
+  prefix_logger& logger,
   const chunked_vector<partitioning_writer::partitioned_file>& files) {
     using ret_t = checked<std::nullopt_t, translation_task::errc>;
     return ss::max_concurrent_for_each(
              files,
              16,
-             [](const partitioning_writer::partitioned_file& file) {
+             [&logger](const partitioning_writer::partitioned_file& file) {
                  vlog(
-                   datalake_log.trace,
+                   logger.trace,
                    "removing local data file: {}",
                    file.local_file);
                  return ss::remove_file(file.local_file.path().string());
              })
       .then([] { return ret_t(std::nullopt); })
-      .handle_exception([](const std::exception_ptr& e) {
-          vlog(datalake_log.warn, "error deleting local data files - {}", e);
+      .handle_exception([&logger](const std::exception_ptr& e) {
+          vlog(logger.warn, "error deleting local data files - {}", e);
           return ret_t(translation_task::errc::file_io_error);
       });
 }
@@ -118,6 +120,7 @@ delete_local_data_files(
 ss::future<
   checked<chunked_vector<coordinator::data_file>, translation_task::errc>>
 upload_files(
+  prefix_logger& logger,
   cloud_data_io& _cloud_io,
   const chunked_vector<partitioning_writer::partitioned_file>& files,
   translation_task::custom_partitioning_enabled is_custom_partitioning_enabled,
@@ -130,11 +133,11 @@ upload_files(
     std::optional<translation_task::errc> upload_error;
     for (auto& file : files) {
         auto r = co_await execute_single_upload(
-          _cloud_io, file, remote_path_prefix, rcn, lazy_as);
+          logger, _cloud_io, file, remote_path_prefix, rcn, lazy_as);
 
         if (r.has_error()) {
             vlog(
-              datalake_log.warn,
+              logger.warn,
               "error uploading file {} to object store - {}",
               file.local_file,
               r.error());
@@ -177,11 +180,11 @@ upload_files(
         ret.push_back(std::move(uploaded));
     }
 
-    auto delete_result = co_await delete_local_data_files(files);
+    auto delete_result = co_await delete_local_data_files(logger, files);
     // for now we simply ignore the local deletion failures
     if (delete_result.has_error()) {
         vlog(
-          datalake_log.warn,
+          logger.warn,
           "error deleting local data files - {}",
           delete_result.error());
     }
@@ -199,7 +202,7 @@ upload_files(
           std::move(files_to_delete), rcn);
         if (remote_del_result.has_error()) {
             vlog(
-              datalake_log.warn,
+              logger.warn,
               "error deleting remote data files - {}",
               remote_del_result.error());
         }
@@ -222,7 +225,8 @@ translation_task::translation_task(
   model::iceberg_invalid_record_action invalid_record_action,
   location_provider location_provider,
   translation_probe& probe)
-  : _cloud_io(&cloud_io)
+  : _log(datalake_log, fmt::format("{}", ntp))
+  , _cloud_io(&cloud_io)
   , _schema_mgr(&schema_mgr)
   , _type_resolver(&type_resolver)
   , _record_translator(&record_translator)
@@ -260,7 +264,7 @@ size_t translation_task::flushed_bytes() const {
 ss::future<checked<void, translation_task::errc>> translation_task::flush() {
     auto result = co_await _multiplexer.flush_writers();
     if (result != writer_error::ok) {
-        vlog(datalake_log.debug, "error flushing writers: {}", result);
+        vlog(_log.debug, "error flushing writers: {}", result);
         co_return translation_task::errc::flush_error;
     }
     co_return outcome::success();
@@ -280,13 +284,13 @@ translation_task::finish(
     auto mux_result = co_await std::move(_multiplexer).finish();
     if (mux_result.has_error()) {
         auto mux_err = mux_result.error();
-        vlog(datalake_log.warn, "Error writing data files - {}", mux_err);
+        vlog(_log.warn, "Error writing data files - {}", mux_err);
         co_return map_error_code(mux_err);
     }
     auto write_result = std::move(mux_result).value();
     if (datalake_log.is_enabled(seastar::log_level::trace)) {
         vlog(
-          datalake_log.trace,
+          _log.trace,
           "translation result base offset: {}, last offset: {}, data files: "
           "{}, dlq files: {}",
           write_result.start_offset,
@@ -321,6 +325,7 @@ translation_task::finish(
     // Data files.
     {
         auto upload_res = co_await upload_files(
+          _log,
           *_cloud_io,
           write_result.data_files,
           is_custom_partitioning_enabled,
@@ -336,6 +341,7 @@ translation_task::finish(
     // DLQ files.
     {
         auto dlq_upload_res = co_await upload_files(
+          _log,
           *_cloud_io,
           write_result.dlq_files,
           is_custom_partitioning_enabled,
@@ -355,27 +361,24 @@ ss::future<checked<std::nullopt_t, translation_task::errc>>
 translation_task::discard() && {
     auto mux_result = co_await std::move(_multiplexer).finish();
     if (mux_result.has_error()) {
-        vlog(
-          datalake_log.warn,
-          "Error writing data files - {}",
-          mux_result.error());
+        vlog(_log.warn, "Error writing data files - {}", mux_result.error());
         co_return errc::file_io_error;
     }
     auto write_result = std::move(mux_result).value();
     auto [data_result, dlq_result] = co_await ss::when_all_succeed(
-      delete_local_data_files(write_result.data_files),
-      delete_local_data_files(write_result.dlq_files));
+      delete_local_data_files(_log, write_result.data_files),
+      delete_local_data_files(_log, write_result.dlq_files));
 
     if (data_result.has_error()) {
         vlog(
-          datalake_log.warn,
+          _log.warn,
           "error deleting local data files - {}",
           data_result.error());
         co_return data_result.error();
     }
     if (dlq_result.has_error()) {
         vlog(
-          datalake_log.warn,
+          _log.warn,
           "error deleting local dlq files - {}",
           data_result.error());
         co_return dlq_result.error();

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -107,6 +107,7 @@ private:
       chunked_vector<remote_path>, retry_chain_node& parent_rcn);
 
     static constexpr std::chrono::milliseconds _read_timeout{30000};
+    prefix_logger _log;
     cloud_data_io* _cloud_io;
     schema_manager* _schema_mgr;
     type_resolver* _type_resolver;

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -49,6 +49,7 @@ public:
         time_limit_exceeded,
         shutting_down,
         out_of_disk,
+        type_resolution_error,
     };
 
     using custom_partitioning_enabled

--- a/tests/rptest/tests/datalake/iceberg_toggling_test.py
+++ b/tests/rptest/tests/datalake/iceberg_toggling_test.py
@@ -16,12 +16,29 @@ from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import SchemaRegistryConfig, SISettings
+from confluent_kafka import SerializingProducer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroSerializer
+from confluent_kafka.serialization import StringSerializer
 from rptest.tests.datalake.datalake_services import DatalakeServices
 from rptest.tests.datalake.datalake_verifier import DatalakeVerifier
 from rptest.tests.datalake.query_engine_base import QueryEngineType
 from rptest.tests.datalake.utils import supported_storage_types
 from rptest.tests.redpanda_test import RedpandaTest
+import ducktape.errors
+from threading import Thread
+
+AVRO_SCHEMA_STR = """
+{
+    "type": "record",
+    "namespace": "com.redpanda.examples.avro",
+    "name": "Counter",
+    "fields": [
+        {"name": "count", "type": "long"}
+    ]
+}
+"""
 
 
 class IcebergTogglingTest(RedpandaTest):
@@ -37,6 +54,7 @@ class IcebergTogglingTest(RedpandaTest):
                 # Help datalake verifier queries scan less data.
                 "iceberg_default_partition_spec": "redpanda.partition",
             },
+            schema_registry_config=SchemaRegistryConfig(),
             *args,
             **kwargs)
         self.rpk = RpkTool(self.redpanda)
@@ -45,6 +63,39 @@ class IcebergTogglingTest(RedpandaTest):
 
     def setUp(self):
         pass
+
+    def produce_avro_records(self,
+                             schema=AVRO_SCHEMA_STR,
+                             record_count=100,
+                             seed=0):
+        value_serializer = AvroSerializer(
+            SchemaRegistryClient(
+                {"url": self.redpanda.schema_reg().split(",")[0]}), schema)
+        producer = SerializingProducer({
+            'bootstrap.servers':
+            self.redpanda.brokers(),
+            'key.serializer':
+            StringSerializer('utf_8'),
+            'value.serializer':
+            value_serializer,
+        })
+
+        for i in range(record_count):
+            record = {
+                "count": seed + i,
+            }
+            producer.produce(
+                topic=self.topic_name,
+                key=str(seed + i),
+                value=record,
+            )
+        producer.flush()
+
+    def set_iceberg_mode(self, mode: str):
+        self.rpk.alter_topic_config(self.topic_name,
+                                    TopicSpec.PROPERTY_ICEBERG_MODE, mode)
+        self.logger.info(
+            f"Set iceberg mode to {mode} for topic {self.topic_name}")
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=supported_storage_types())
@@ -176,3 +227,86 @@ class IcebergTogglingTest(RedpandaTest):
             # Verify the data.
             DatalakeVerifier.oneshot(self.redpanda, self.topic_name,
                                      dl.spark())
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_iceberg_mode_toggling(self, cloud_storage_type):
+        """
+        Test toggling iceberg mode between disabled, value_schema_latest and value_schema_id_prefix
+        on the same partition leader.
+        """
+        NUM_PARTITIONS = 1
+        RECORD_COUNT = 100
+        produced_records = 0
+
+        with DatalakeServices(self.test_context,
+                              self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
+            # Create the topic with iceberg disabled
+            dl.create_iceberg_enabled_topic(self.topic_name,
+                                            partitions=NUM_PARTITIONS,
+                                            iceberg_mode="disabled")
+
+            # Misconfigure iceberg mode to value_schema_latest
+            self.set_iceberg_mode("value_schema_latest:subject=foo")
+            self.produce_avro_records(record_count=RECORD_COUNT)
+            produced_records += RECORD_COUNT
+
+            try:
+                dl.wait_for_translation(self.topic_name,
+                                        msg_count=produced_records,
+                                        timeout=30)
+                assert False, "Expected translation to fail but it did not"
+            except ducktape.errors.TimeoutError:
+                pass
+
+            self.set_iceberg_mode("value_schema_id_prefix")
+
+            dl.wait_for_translation(self.topic_name,
+                                    msg_count=produced_records,
+                                    timeout=30)
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_concurrent_mode_toggling(self, cloud_storage_type):
+        """
+        Test toggling iceberg mode while producing data and translation is in progress.
+        """
+        NUM_PARTITIONS = 1
+        RECORDS_PER_PRODUCE = 100
+        TOGGLES = 200
+
+        with DatalakeServices(self.test_context,
+                              self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK
+                                                     ]) as dl:
+            # Create the topic with iceberg disabled
+            dl.create_iceberg_enabled_topic(self.topic_name,
+                                            partitions=NUM_PARTITIONS,
+                                            iceberg_mode="disabled")
+            stopped = False
+            total_produced = 0
+
+            def produce_until_stopped():
+                nonlocal total_produced
+                while not stopped:
+                    self.produce_avro_records(record_count=RECORDS_PER_PRODUCE)
+                    total_produced += RECORDS_PER_PRODUCE
+                    time.sleep(0.1)
+
+            produce_t = Thread(target=produce_until_stopped, daemon=True)
+            produce_t.start()
+
+            for i in range(TOGGLES):
+                self.set_iceberg_mode("value_schema_latest:subject=foo")
+                time.sleep(0.1)
+                self.set_iceberg_mode("value_schema_id_prefix")
+
+            stopped = True
+            produce_t.join()
+
+            self.set_iceberg_mode("value_schema_id_prefix")
+            dl.wait_for_translation(self.topic_name,
+                                    msg_count=total_produced,
+                                    timeout=30)


### PR DESCRIPTION
Currently changing `redpanda.iceberg.mode` is a noop as the code inherited this behavior from pre schema evolution days. This PR makes the topic property change dynamic.

Additionally fixes some observability by avoiding a blanket parquet_conversion_error for all schema issues. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
### Improvements
* Allow changing `redpanda.iceberg.mode` dynamically at runtime
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
