### PR TITLE
Tests: KCL to retry reassignment request when clashing with partition balancer

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -879,6 +879,14 @@ bulk_force_reconfiguration_cmd_data::bulk_force_reconfiguration_cmd_data(
     user_approved_force_recovery_partitions
       = other.user_approved_force_recovery_partitions.copy();
 }
+
+std::ostream&
+operator<<(std::ostream& o, const cluster::feature_update_cmd_data& r) {
+    fmt::print(
+      o, "{{logical_version: {}, actions: {}}}", r.logical_version, r.actions);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -52,6 +52,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::invalid_request;
     case cluster::errc::throttling_quota_exceeded:
         return error_code::throttling_quota_exceeded;
+    case cluster::errc::update_in_progress:
+        return error_code::reassignment_in_progress;
     case cluster::errc::no_update_in_progress:
         return error_code::no_reassignment_in_progress;
     case cluster::errc::topic_disabled:
@@ -68,7 +70,6 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::partition_already_exists:
     case cluster::errc::waiting_for_recovery:
     case cluster::errc::waiting_for_reconfiguration_finish:
-    case cluster::errc::update_in_progress:
     case cluster::errc::user_exists:
     case cluster::errc::user_does_not_exist:
     case cluster::errc::invalid_producer_epoch:

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -324,6 +324,10 @@ class KCL:
                 if has_partition_err(l, "UNKNOWN_TOPIC_OR_PARTITION"):
                     return False
 
+                # A concurrent reassignment may be triggered by partition_balancer
+                if has_partition_err(l, "REASSIGNMENT_IN_PROGRESS"):
+                    return False
+
             return True
 
         wait_until(do_alter_partitions,

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 import itertools
 from typing import Optional
+from functools import cache
 from ducktape.utils.util import wait_until
 from rptest.utils.functional import flat_map
 
@@ -284,15 +285,15 @@ class KCL:
             reassignment_str += join_partitions
             cmd.append(reassignment_str)
 
-        no_broker_re = re.compile(
-            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +BROKER_NOT_AVAILABLE.*$"
-        )
-        bad_rep_factor_re = re.compile(
-            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +INVALID_REPLICATION_FACTOR.*$"
-        )
-        unknown_tp_re = re.compile(
-            r"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +UNKNOWN_TOPIC_OR_PARTITION:.*$"
-        )
+        @cache
+        def make_partition_err_re(err_str):
+            return re.compile(
+                rf"^(?P<topic>[a-z\-]+?) +(?P<partition>[0-9]+?) +{re.escape(err_str)}.*$"
+            )
+
+        def has_partition_err(line, err):
+            re = make_partition_err_re(err)
+            return re.match(line) is not None
 
         lines = None
 
@@ -306,24 +307,21 @@ class KCL:
                 l = l.strip()
                 self._redpanda.logger.debug(l)
 
-                m = no_broker_re.match(l)
                 # No broker available means the partition did not find any eligible allocation nodes.
                 # See the map from cluster errors to kafka errors in kafka::map_topic_error_code()
-                if m is not None:
+                if has_partition_err(l, "BROKER_NOT_AVAILABLE"):
                     raise RuntimeError('No eligible allocation nodes')
 
                 # Invalid replication factor means the number of replicas for one (or more) partitions
                 # in a request does not match the replication factor for the topic.
-                m = bad_rep_factor_re.match(l)
-                if m is not None:
+                if has_partition_err(l, "INVALID_REPLICATION_FACTOR"):
                     raise RuntimeError(
                         'Number of replicas != topic replication factor')
 
                 # RP may report that the topic does not exist, this can
                 # happen when the recieving broker has out-of-date metadata. So
                 # retry the request.
-                m = unknown_tp_re.match(l)
-                if m is not None:
+                if has_partition_err(l, "UNKNOWN_TOPIC_OR_PARTITION"):
                     return False
 
             return True


### PR DESCRIPTION
Sometimes explicitly requested partition reassignment will clash with a reassignment triggered by Partition Balancer. Retry in this case.

No backport as behaviour changes (more specific error code).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
### Improvements
* In AlterPartitionReassignmentsResponse per-partition response REASSIGNMENT_IN_PROGRESS error code is used if a reassignment is requested while Partition Balancer is moving partition replicas.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
