### PR TITLE
rpk: show user friendly warning when a protected topic is altered/deleted

### DIFF
--- a/src/go/rpk/pkg/cli/topic/config.go
+++ b/src/go/rpk/pkg/cli/topic/config.go
@@ -11,6 +11,7 @@ package topic
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -55,6 +56,25 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 		Run: func(_ *cobra.Command, topics []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			nodeleteTopics := []string{"_redpanda.audit_log", "__consumer_offsets", "_schemas"}
+			// Check if any of the topics to be altered are protected.
+			// By looping from the end toward zero, removals don’t affect the yet-to-be-visited indexes:
+			before := len(topics)
+			for i := len(topics) - 1; i >= 0; i-- {
+				if protected(topics[i], nodeleteTopics) {
+					fmt.Printf("%s is protected and cannot be altered\n", topics[i])
+					topics = append(topics[:i], topics[i+1:]...)
+				}
+			}
+			after := len(topics)
+			if before != after {
+				fmt.Println("See the full protected topics with 'rpk cluster config get kafka_nodelete_topics'")
+				fmt.Println()
+			}
+			if len(topics) == 0 {
+				out.Die("No topics to alter")
+			}
 
 			cl, err := kafka.NewFranzClient(fs, p)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)

--- a/src/go/rpk/pkg/cli/topic/delete.go
+++ b/src/go/rpk/pkg/cli/topic/delete.go
@@ -12,6 +12,7 @@ package topic
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
@@ -58,6 +59,25 @@ For example,
 			adm, err := kafka.NewAdmin(fs, p)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer adm.Close()
+
+			nodeleteTopics := []string{"_redpanda.audit_log", "__consumer_offsets", "_schemas"}
+			// Check if any of the topics to be deleted are protected.
+			// By looping from the end toward zero, removals don’t affect the yet-to-be-visited indexes:
+			before := len(topics)
+			for i := len(topics) - 1; i >= 0; i-- {
+				if protected(topics[i], nodeleteTopics) {
+					fmt.Printf("%s is protected and cannot be deleted\n", topics[i])
+					topics = append(topics[:i], topics[i+1:]...)
+				}
+			}
+			after := len(topics)
+			if before != after {
+				fmt.Println("See the full protected topics with 'rpk cluster config get kafka_nodelete_topics'")
+			}
+			fmt.Println()
+			if len(topics) == 0 {
+				out.Die("No topics to delete")
+			}
 
 			if re {
 				topics, err = regexTopics(adm, topics)

--- a/src/go/rpk/pkg/cli/topic/utils.go
+++ b/src/go/rpk/pkg/cli/topic/utils.go
@@ -79,3 +79,12 @@ func regexTopicDetails(adm *kadm.Client, expressions []string) (kadm.TopicDetail
 	}
 	return result, nil
 }
+
+func protected(topic string, protectedTopics []string) bool {
+	for _, protectedTopic := range protectedTopics {
+		if topic == protectedTopic {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
There are protected topics being defined in `kafka_nodelete_topics`, which cannot be altered / deleted. When we try to alter a config of the topic, the following error returns.

```
$ rpk topic alter-config __consumer_offsets -s cleanup.policy=delete
TOPIC               STATUS
__consumer_offsets  TOPIC_AUTHORIZATION_FAILED
```

This commit makes the message more user friendly and actionable if that's the case. For the protected topics, the command doesn't send the request to brokers any more.

```
$ rpk topic alter-config __consumer_offsets foo _schemas -s cleanup.policy=delete
_schemas is protected and cannot be altered
__consumer_offsets is protected and cannot be altered
See the full protected topics with 'rpk cluster config get kafka_nodelete_topics'

TOPIC  STATUS
foo    OK
```

Also the commit makes a change to the `topic delete` command as follows.

```
$ rpk topic delete __consumer_offsets _schemas foo
_schemas is protected and cannot be deleted
__consumer_offsets is protected and cannot be deleted
See the full protected topics with 'rpk cluster config get kafka_nodelete_topics'

TOPIC  STATUS
foo    UNKNOWN_TOPIC_OR_PARTITION: This server does not host this topic-partition.
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* rpk: topic alter-config and delete show user friendly messages when nodelete topics are specified