### PR TITLE
partition_balancer: removed typo in reallocation_failure_details init

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -71,7 +71,7 @@ reallocation_failure_details map_result_to_failure_details(
     reallocation_failure_details details{
       .replica_to_move = replica_to_move,
       .reason = reason,
-      .error = details.error = reallocation_error::unknown_error};
+      .error = reallocation_error::unknown_error};
     if (ec.category() == cluster::error_category()) {
         switch (static_cast<cluster::errc>(ec.value())) {
         case cluster::errc::no_eligible_allocation_nodes:
@@ -856,7 +856,7 @@ public:
         reallocation_failure_details details{
           .replica_to_move = replica_to_move,
           .reason = reason,
-          .error = details.error = reallocation_error::unknown_error};
+          .error = reallocation_error::unknown_error};
 
         switch (_reason) {
         case immutability_reason::no_quorum:


### PR DESCRIPTION
The typo didn't change the semantics but it was weird and executed assignment twice.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none