### PR TITLE
[v24.3.x] `rptest`: fix race in `compaction_recovery_test.py`

### DIFF
--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -59,10 +59,17 @@ class CompactionRecoveryTest(RedpandaTest):
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_index_recovery(self):
-        partitions = self.produce_until_segments(3)
+        partition_node_list = [p.node for p in self.produce_until_segments(3)]
 
-        for p in partitions:
-            self.redpanda.stop_node(p.node)
+        for node in partition_node_list:
+            self.redpanda.stop_node(node)
+
+        # The segment information returned from produce_until_segments()
+        # could be outdated by the time we stop the redpanda nodes,
+        # e.g due to adjacent segment compaction. Query it here
+        # after stopping the cluster.
+        storage = self.redpanda.storage(all_nodes=True)
+        partitions = storage.partitions("kafka", self.topic)
 
         for p in partitions:
             p.delete_indices(allow_fail=False)
@@ -73,8 +80,8 @@ class CompactionRecoveryTest(RedpandaTest):
                              compaction_ctrl_min_shares=1000,
                              compaction_ctrl_max_shares=1000)
 
-        for p in partitions:
-            self.redpanda.start_node(p.node)
+        for node in partition_node_list:
+            self.redpanda.start_node(node)
 
         self.redpanda.set_cluster_config(extra_rp_conf, True)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/25127
