### PR TITLE
kafka/server: Metadata: Do not return new topics before voting

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -92,6 +92,9 @@ std::optional<cluster::leader_term> get_leader_term(
      * cluster::topic_dispatcher before)
      */
     if (!leader_term) {
+        if (!md_cache.get_previous_leader_id(tp_ns, p_id).has_value()) {
+            return std::nullopt;
+        }
         leader_term.emplace(replicas[0], model::term_id(0));
         return leader_term;
     }
@@ -149,6 +152,9 @@ metadata_response::topic make_topic_response_from_topic_metadata(
         p.partition_index = p_as.id;
         p.leader_id = no_leader;
         auto lt = get_leader_term(tp_ns, p_as.id, md_cache, replicas);
+        if (!lt) {
+            continue;
+        }
         if (lt && !is_node_isolated && p.error_code == error_code::none) {
             p.leader_id = lt->leader.value_or(no_leader);
             p.leader_epoch = leader_epoch_from_term(lt->term);
@@ -293,8 +299,11 @@ get_topic_metadata(
                   authz_quiet{true})) {
                 continue;
             }
-            res.push_back(
-              make_topic_response(ctx, request, md.metadata, is_node_isolated));
+            auto ts = make_topic_response(
+              ctx, request, md.metadata, is_node_isolated);
+            if (!ts.partitions.empty()) {
+                res.push_back(std::move(ts));
+            }
         }
 
         return ss::make_ready_future<
@@ -327,8 +336,14 @@ get_topic_metadata(
                 md) {
                 auto src_topic_response = make_topic_response(
                   ctx, request, *md, is_node_isolated);
-                src_topic_response.name = move_topic_name();
-                res.push_back(std::move(src_topic_response));
+                if (src_topic_response.partitions.empty()) {
+                    res.push_back(make_error_topic_response(
+                      move_topic_name(),
+                      error_code::unknown_topic_or_partition));
+                } else {
+                    src_topic_response.name = move_topic_name();
+                    res.push_back(std::move(src_topic_response));
+                }
                 continue;
             }
         }

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -25,6 +25,6 @@ namespace kafka {
 memory_estimate_fn metadata_memory_estimator;
 
 using metadata_handler
-  = single_stage_handler<metadata_api, 0, 8, metadata_memory_estimator>;
+  = single_stage_handler<metadata_api, 0, 9, metadata_memory_estimator>;
 
 } // namespace kafka


### PR DESCRIPTION
NOTE: Do not merge, just running this against the full test suite.

When a topic is created, it is added to metadata_cache prior to having a leader. The leader_epoch is 0, which can conflict with a previous topic of the same name.

After voting, the term_id is set correctly, resulting in a correct leader_epoch, which allows a consumer to detect the change.

This commit detects that a topic is new by not returning partitions that have never had a leader; if there are no partitions, the topic is rejected as unknown.

TODO:
* Write tests

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Features

* kafka/server: Support metadata v9

