### PR TITLE
storage/compaction: Implement min.compaction.lag.ms

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -237,6 +237,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
       1,
       log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
     // NOTE: the storage layer only initially requests eviction; it relies on
@@ -660,6 +661,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
       1, // max_bytes_in_log
       log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
     RPTEST_REQUIRE_EVENTUALLY(
@@ -964,6 +966,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
       0,
       log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     partition->log()->housekeeping(housekeeping_conf).get();
 

--- a/src/v/cluster/archival/tests/async_data_uploader_test.cc
+++ b/src/v/cluster/archival/tests/async_data_uploader_test.cc
@@ -167,6 +167,7 @@ public:
           std::nullopt,
           max_collect_offset,
           std::nullopt,
+          std::chrono::milliseconds{0},
           as);
 
         auto log = get_partition_log();

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -252,6 +252,7 @@ struct reupload_fixture : public archiver_fixture {
             std::nullopt,
             max_removable,
             std::nullopt,
+            std::chrono::milliseconds{0},
             abort_source})
           .get();
 

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -98,6 +98,7 @@ struct manual_deletion_fixture : public raft::raft_fixture {
                 100_MiB,
                 model::offset::max(),
                 std::nullopt,
+                std::chrono::milliseconds{0},
                 as,
                 storage::ntp_sanitizer_config{.sanitize_only = true}));
 

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -108,6 +108,7 @@ public:
                     std::nullopt,
                     log->stm_manager()->max_removable_local_log_offset(),
                     std::nullopt,
+                    std::chrono::milliseconds{0},
                     dummy_as,
                   })
                   .handle_exception_type(
@@ -227,6 +228,7 @@ public:
           std::nullopt,
           model::offset::max(),
           std::nullopt,
+          std::chrono::milliseconds{0},
           as);
         // Compacts until a single sealed segment remains, other than the
         // currently active one.

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -352,6 +352,7 @@ ss::future<> run_workload(
                 std::nullopt,
                 log->stm_manager()->max_removable_local_log_offset(),
                 std::nullopt,
+                std::chrono::milliseconds{0},
                 dummy_as,
               })
               .handle_exception_type(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -530,7 +530,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
             return false;
         }
 
-        if (s.has_compactible_offsets(cfg)) {
+        if (s.is_compactible(cfg)) {
             vlog(
               gclog.debug,
               "[{}] segment {} stable offs {}, max compactible {}, "
@@ -633,11 +633,11 @@ segment_set disk_log_impl::find_sliding_range(
         _last_compaction_window_start_offset.reset();
     }
 
-    // Collect all segments that have stable data.
+    // Collect all segments that are compactible.
     segment_set::underlying_t buf;
     for (const auto& seg : _segs) {
-        if (seg->has_appender() || !seg->has_compactible_offsets(cfg)) {
-            // Stop once we get to an unstable segment.
+        if (seg->has_appender() || !seg->is_compactible(cfg)) {
+            // Stop once we get to an uncompactible segment.
             break;
         }
         if (
@@ -962,7 +962,7 @@ disk_log_impl::find_adjacent_compaction_range(const compaction_config& cfg) {
     const auto unstable = std::any_of(
       range.first, range.second, [&cfg](ss::lw_shared_ptr<segment>& seg) {
           return !seg->finished_self_compaction() || seg->has_appender()
-                 || !seg->has_compactible_offsets(cfg);
+                 || !seg->is_compactible(cfg);
       });
     if (unstable) {
         return std::nullopt;
@@ -1341,7 +1341,7 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
     auto new_start_offset = co_await do_gc(cfg.gc);
 
     /*
-     * comapction. could factor out into a public interface like gc/retention if
+     * Compaction. Could factor out into a public interface like gc/retention if
      * there is a need to run it separately.
      */
     if (config().is_compacted() && !_segs.empty()) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -461,6 +461,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           _config.retention_bytes(),
           max_compactible_offset,
           current_log.handle->config().tombstone_retention_ms(),
+          current_log.handle->config().min_compaction_lag_ms(),
           _abort_source,
           std::move(ntp_sanitizer_cfg),
           _compaction_hash_key_map.get()));

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -501,6 +501,7 @@ struct compact_op final : opfuzz::op {
           std::nullopt,
           model::offset::max(),
           std::nullopt,
+          std::chrono::milliseconds{0},
           *(ctx._as),
           storage::ntp_sanitizer_config{.sanitize_only = true});
         if (random_generators::get_int(0, 100) > 70) {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -218,7 +218,7 @@ public:
     const compacted_index_writer& compaction_index() const;
     // We currently use `max_removable_local_log_offset` to control both
     // deletion/eviction, and compaction.
-    bool has_compactible_offsets(const compaction_config& cfg) const;
+    bool is_compactible(const compaction_config& cfg) const;
 
     // Calls `_cache->reset()`, iff the optional `_cache` has a value. This
     // leaves the object in a re-usable state. If there is no contained object
@@ -436,10 +436,16 @@ inline bool segment::has_compaction_index() const {
     return _compaction_index != std::nullopt;
 }
 
-inline bool
-segment::has_compactible_offsets(const compaction_config& cfg) const {
-    // since we don't support partially-compacted segments, a segment must
-    // end before the max compactible offset to be eligible for compaction.
+inline bool segment::is_compactible(const compaction_config& cfg) const {
+    // Because we don't support partially-compacted segments, to be eligible for
+    // compaction a segment must both
+    // 1. have latest batch timestamp longer ago than min.compaction.lag.ms, and
+    // 2. end before the max compactible offset.
+    const auto now = to_time_point(model::timestamp::now());
+    const auto max_batch_ts = to_time_point(index().retention_timestamp());
+    if (now - max_batch_ts < cfg.min_lag_ms) {
+        return false;
+    }
     return _tracker.get_stable_offset() <= cfg.max_removable_local_log_offset;
 }
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -193,6 +193,12 @@ public:
           _state.broker_timestamp, _state.max_timestamp, _retention_timestamp);
     }
 
+    model::timestamp retention_timestamp() const {
+        const auto cfg = time_based_retention_cfg::make(
+          _feature_table.get().local());
+        return retention_timestamp(cfg);
+    }
+
     // Check if compacted timestamp has a value.
     bool has_clean_compact_timestamp() const {
         return _state.clean_compact_timestamp.has_value();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -743,7 +743,7 @@ ss::future<compaction_result> self_compact_segment(
 
     const bool may_remove_tombstones = may_have_removable_tombstones(s, cfg);
     if (
-      !s->has_compactible_offsets(cfg)
+      !s->is_compactible(cfg)
       || (s->finished_self_compaction() && !may_remove_tombstones)) {
         co_return compaction_result{s->size_bytes()};
     }

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -76,6 +76,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       std::nullopt,
       first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     first_log->housekeeping(conf).get();
 
@@ -124,6 +125,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       std::nullopt,
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     new_log->housekeeping(conf2).get();
 
@@ -196,6 +198,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       std::nullopt,
       first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     first_log->housekeeping(conf).get();
 
@@ -224,6 +227,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       std::nullopt,
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
+      std::chrono::milliseconds{0},
       as);
     new_log->housekeeping(conf2).get();
     exec.validate(new_log, 2).get();

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -243,6 +243,7 @@ public:
           never_abort,
           std::nullopt,
           max_keys,
+          std::chrono::milliseconds{0},
           nullptr,
           nullptr);
         auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
@@ -263,6 +264,7 @@ public:
           never_abort,
           std::nullopt,
           max_keys,
+          std::chrono::milliseconds{0},
           nullptr,
           nullptr);
         auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -256,7 +256,12 @@ TEST_F(log_builder_fixture, test_skipping_compaction_below_start_offset) {
     ASSERT_EQ(log.segment_count(), 2);
 
     housekeeping_config cfg{
-      model::timestamp::max(), 1, model::offset::max(), std::nullopt, abs};
+      model::timestamp::max(),
+      1,
+      model::offset::max(),
+      std::nullopt,
+      std::chrono::milliseconds{0},
+      abs};
 
     // Call into `disk_log_impl::gc` and listen for the eviction
     // notification being created.

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -335,7 +335,12 @@ TEST_F(
     ss::abort_source as;
     log
       ->housekeeping(housekeeping_config(
-        ts, std::nullopt, model::offset::max(), std::nullopt, as))
+        ts,
+        std::nullopt,
+        model::offset::max(),
+        std::nullopt,
+        std::chrono::milliseconds{0},
+        as))
       .get();
     // truncate at 0, offset earlier then the one present in log
     log->truncate(storage::truncate_config(model::offset(0))).get();
@@ -501,7 +506,12 @@ TEST_F(storage_test_fixture, test_concurrent_prefix_truncate_and_gc) {
     // to evict. The test does not listen for the notification,
     // so this call is basically a no-op.
     auto f1 = log->housekeeping(housekeeping_config(
-      ts, std::nullopt, model::offset::max(), std::nullopt, as));
+      ts,
+      std::nullopt,
+      model::offset::max(),
+      std::nullopt,
+      std::chrono::milliseconds{0},
+      as));
 
     auto f2 = log->truncate_prefix(
       storage::truncate_prefix_config(model::next_offset(lstats.dirty_offset)));
@@ -562,7 +572,12 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
     auto ts = now();
     auto sleep_ms1 = random_generators::get_int(0, 100);
     housekeeping_config housekeeping_cfg(
-      ts, std::nullopt, model::offset::max(), std::nullopt, as);
+      ts,
+      std::nullopt,
+      model::offset::max(),
+      std::nullopt,
+      std::chrono::milliseconds{0},
+      as);
     auto f1 = ss::sleep(sleep_ms1 * 1ms).then([&] {
         return log->housekeeping(housekeeping_cfg);
     });

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -99,6 +99,7 @@ FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
       /*max_bytes_in_log=*/1,
       /*max_collect_offset=*/model::offset::min(),
       /*tombstone_retention_ms=*/std::nullopt,
+      /*min_lag_ms=*/std::chrono::milliseconds{0},
       as);
 
     const auto num_records = 100;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5607,6 +5607,68 @@ TEST_F(storage_test_fixture, max_compaction_lag) {
     read_and_validate_all_batches(log);
 }
 
+TEST_F(storage_test_fixture, min_compaction_lag) {
+    using log_manager_accessor = storage::testing_details::log_manager_accessor;
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    // Surely, no test could run this slow...
+    ov.min_compaction_lag_ms = 100000s;
+
+    auto ntp = model::ntp("kafka", "tapioca", 0);
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    using bflags = storage::log_housekeeping_meta::bitflags;
+    static constexpr auto is_set = [](bflags var, auto flag) {
+        return (var & flag) == flag;
+    };
+
+    auto append_and_force_roll = [this, &log]() {
+        auto headers = append_random_batches<linear_int_kv_batch_generator>(
+          log, 10);
+        log->force_roll().get();
+    };
+
+    // Append and close one segment, then compact.
+    // Because of min lag, no segments should be compacted.
+    append_and_force_roll();
+    log_manager_accessor::housekeeping_scan(mgr).get();
+
+    auto& meta = log_manager_accessor::logs_list(mgr).front();
+    ASSERT_TRUE(is_set(meta.flags, bflags::lifetime_checked));
+    ASSERT_TRUE(is_set(meta.flags, bflags::compaction_checked));
+    // The log was compacted, but no segments were eligible due to min lag.
+    ASSERT_TRUE(is_set(meta.flags, bflags::compacted));
+    for (const auto& batch : read_and_validate_all_batches(log)) {
+        // The batches should not have been compacted.
+        ASSERT_EQ(
+          batch.record_count(),
+          linear_int_kv_batch_generator::records_per_batch);
+    }
+
+    // Roll to reset compaction checks. Appending more batches breaks
+    // the batch generator's expectation after compacting.
+    log->force_roll().get();
+    overrides_t ov2;
+    ov2.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    ov2.min_compaction_lag_ms = 0s; // The default.
+    log->set_overrides(ov2);
+
+    log_manager_accessor::housekeeping_scan(mgr).get();
+    ASSERT_TRUE(is_set(meta.flags, bflags::lifetime_checked));
+    ASSERT_TRUE(is_set(meta.flags, bflags::compaction_checked));
+    ASSERT_TRUE(is_set(meta.flags, bflags::compacted));
+    auto batches = read_and_validate_all_batches(log);
+    linear_int_kv_batch_generator::validate_post_compaction(std::move(batches));
+}
+
 // Ensures that the log_housekeeping_meta level locking/concurrency in
 // the log_manager is race free during ntp removal, addition, and housekeeping.
 // By allowing regular housekeeping to run on a quick interval and also

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -667,6 +667,7 @@ TEST_F(storage_test_fixture, test_time_based_eviction) {
       std::nullopt,
       model::offset::min(), // should prevent compaction
       std::nullopt,
+      0ms,
       as);
     auto before = disk_log->offsets();
     disk_log->housekeeping(ccfg_no_compact).get();
@@ -681,6 +682,7 @@ TEST_F(storage_test_fixture, test_time_based_eviction) {
             std::nullopt,
             model::offset::max(),
             std::nullopt,
+            0ms,
             as);
       };
 
@@ -754,6 +756,7 @@ TEST_F(storage_test_fixture, test_size_based_eviction) {
       total_size + first_size,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     compact_and_prefix_truncate(*disk_log, ccfg_no_compact);
 
@@ -783,6 +786,7 @@ TEST_F(storage_test_fixture, test_size_based_eviction) {
       max_size,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     compact_and_prefix_truncate(*disk_log, ccfg);
 
@@ -848,7 +852,7 @@ TEST_F(storage_test_fixture, test_eviction_notification) {
       model::term_id(0),
       custom_ts_batch_generator(model::timestamp(gc_ts() + 10)));
     storage::housekeeping_config ccfg(
-      gc_ts, std::nullopt, model::offset::max(), std::nullopt, as);
+      gc_ts, std::nullopt, model::offset::max(), std::nullopt, 0ms, as);
 
     log->housekeeping(ccfg).get();
 
@@ -960,6 +964,7 @@ TEST_F(storage_test_fixture, write_concurrently_with_gc) {
           1000,
           model::offset::max(),
           std::nullopt,
+          0ms,
           as);
         return log->housekeeping(ccfg);
     };
@@ -1245,7 +1250,7 @@ TEST_F(storage_test_fixture, test_compaction_preserve_state) {
       ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov));
 
     storage::housekeeping_config compaction_cfg(
-      model::timestamp::min(), 1, model::offset::max(), std::nullopt, as);
+      model::timestamp::min(), 1, model::offset::max(), std::nullopt, 0ms, as);
     auto log = mgr.manage(std::move(ntp_cfg)).get();
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
     auto offsets_after_recovery = log->offsets();
@@ -1405,6 +1410,7 @@ TEST_F(storage_test_fixture, compacted_log_truncation) {
           std::nullopt,
           model::offset::max(),
           std::nullopt,
+          0ms,
           as);
         log->flush().get();
         check_dirty_and_closed_segment_bytes(log);
@@ -1470,6 +1476,7 @@ TEST_F(storage_test_fixture, check_segment_roll_after_compacted_log_truncate) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     log->flush().get();
     check_dirty_and_closed_segment_bytes(log);
@@ -1652,7 +1659,12 @@ TEST_F(storage_test_fixture, partition_size_while_cleanup) {
     ASSERT_EQ(lstats_before.start_offset, model::offset{0});
 
     storage::housekeeping_config ccfg(
-      model::timestamp::min(), 50_KiB, model::offset::max(), std::nullopt, as);
+      model::timestamp::min(),
+      50_KiB,
+      model::offset::max(),
+      std::nullopt,
+      0ms,
+      as);
 
     // Compact 10 times, with a configuration calling for 60kiB max log size.
     // This results in prefix truncating at offset 50.
@@ -1771,6 +1783,7 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
 
     // There are 4 segments, and the last is the active segments. The first two
@@ -1838,6 +1851,7 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction_terms) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
 
     // compact all the individual segments
@@ -1908,6 +1922,7 @@ TEST_F(storage_test_fixture, max_adjacent_segment_compaction) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
 
     // self compaction steps
@@ -2163,6 +2178,7 @@ TEST_F(storage_test_fixture, compaction_backlog_calculation) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     /**
      * Initially all compaction rations are equal to 1.0 so it is easy to
@@ -2493,6 +2509,7 @@ TEST_F(storage_test_fixture, changing_cleanup_policy_back_and_forth) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
 
     // self compaction steps
@@ -2729,6 +2746,7 @@ TEST_F(storage_test_fixture, test_compacting_batches_of_different_types) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     auto before_compaction = compact_in_memory(log);
 
@@ -2964,6 +2982,7 @@ TEST_F(storage_test_fixture, write_truncate_compact) {
                              std::nullopt,
                              model::offset::max(),
                              std::nullopt,
+                             0ms,
                              as))
                            .handle_exception_type(
                              [](const storage::segment_closed_exception&) {
@@ -3128,6 +3147,7 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     log->housekeeping(compaction_cfg).get();
 
@@ -3212,6 +3232,7 @@ TEST_F(storage_test_fixture, compaction_truncation_corner_cases) {
               std::nullopt,
               model::offset::max(),
               std::nullopt,
+              0ms,
               as))
             .get();
       };
@@ -3338,6 +3359,7 @@ TEST_F(storage_test_fixture, test_max_compact_offset) {
       std::nullopt,
       max_compact_offset,
       std::nullopt,
+      0ms,
       as);
     log->housekeeping(ccfg).get();
     auto final_stats = log->offsets();
@@ -3401,6 +3423,7 @@ TEST_F(storage_test_fixture, test_self_compaction_while_reader_is_open) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
     auto& segment = *(disk_log->segments().begin());
     auto stream = segment->offset_data_stream(model::offset(0)).get();
@@ -3452,6 +3475,7 @@ TEST_F(storage_test_fixture, test_simple_compaction_rebuild_index) {
       std::nullopt,
       model::offset::max(),
       std::nullopt,
+      0ms,
       as);
 
     log->housekeeping(ccfg).get();
@@ -3546,6 +3570,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
       std::nullopt,
       model::offset(args.max_compact_offs),
       std::nullopt,
+      0ms,
       as);
     log->housekeeping(ccfg).get();
     auto final_stats = log->offsets();
@@ -3816,6 +3841,7 @@ TEST_F(storage_test_fixture, test_bytes_eviction_overrides) {
             cfg.retention_bytes(),
             model::offset::max(),
             std::nullopt,
+            0ms,
             as));
 
         // retention won't violate the target
@@ -4530,6 +4556,7 @@ TEST_F(storage_test_fixture, test_offset_range_size_compacted) {
       std::nullopt,
       log->offsets().committed_offset,
       std::nullopt,
+      0ms,
       as);
     log->housekeeping(h_cfg).get();
 
@@ -4720,6 +4747,7 @@ TEST_F(storage_test_fixture, test_offset_range_size2_compacted) {
       std::nullopt,
       log->offsets().committed_offset,
       std::nullopt,
+      0ms,
       as);
     log->housekeeping(h_cfg).get();
 
@@ -5250,7 +5278,7 @@ TEST_F(storage_test_fixture, dirty_and_closed_bytes_bookkeeping) {
     auto* disk_log = static_cast<disk_log_impl*>(log.get());
 
     housekeeping_config cfg{
-      model::timestamp::max(), 1, model::offset::max(), std::nullopt, abs};
+      model::timestamp::max(), 1, model::offset::max(), std::nullopt, 0ms, abs};
 
     // add a segment with random keys until a certain size
     auto add_segment = [&](size_t size, model::term_id term) {

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -129,6 +129,7 @@ ss::future<> disk_log_builder::gc(
         max_partition_retention_size,
         model::offset::max(),
         tombstone_retention_ms,
+        std::chrono::milliseconds{0},
         _abort_source))
       .get();
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -479,12 +479,14 @@ struct compaction_config {
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
       std::optional<size_t> max_keys = std::nullopt,
+      std::chrono::milliseconds min_lag_ms = std::chrono::milliseconds{0},
       hash_key_offset_map* key_map = nullptr,
       scoped_file_tracker::set_t* to_clean = nullptr)
       : max_removable_local_log_offset(max_collect_offset)
       , tombstone_retention_ms(tombstone_ret_ms)
       , sanitizer_config(std::move(san_cfg))
       , key_offset_map_max_keys(max_keys)
+      , min_lag_ms(min_lag_ms)
       , hash_key_map(key_map)
       , files_to_cleanup(to_clean)
       , asrc(&as) {}
@@ -511,6 +513,9 @@ struct compaction_config {
     // Limit the number of keys stored by a compaction's key-offset map.
     std::optional<size_t> key_offset_map_max_keys;
 
+    // The value of min.compaction.lag.ms for this compaction.
+    std::chrono::milliseconds min_lag_ms;
+
     // Hash key-offset map to reuse across compactions.
     hash_key_offset_map* hash_key_map;
 
@@ -536,6 +541,7 @@ struct housekeeping_config {
       std::optional<size_t> max_bytes_in_log,
       model::offset max_collect_offset,
       std::optional<std::chrono::milliseconds> tombstone_retention_ms,
+      std::chrono::milliseconds min_lag_ms,
       ss::abort_source& as,
       std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
       hash_key_offset_map* key_map = nullptr)
@@ -545,6 +551,7 @@ struct housekeeping_config {
           as,
           std::move(san_cfg),
           std::nullopt,
+          min_lag_ms,
           key_map)
       , gc(upper, max_bytes_in_log) {}
 


### PR DESCRIPTION
Most file changes are updating cfg constructors. The meat of the implementation is very small.

This is a follow-up to #26112, which implemented `max.compaction.lag.ms`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Features

* Add support for `min.compaction.lag.ms`. In a compacted topic, this property sets the minimum time for which a message will remain ineligible for compaction. This can be used to reduce the frequency of compactions in some cases.
* Add support for `max.compaction.lag.ms which sets the maximum time before a message becomes eligible for compaction. This can be used to induce periodic compaction of a topic in some cases.

