### PR TITLE
[v24.3.x] `storage`: add `_segment_cleanly_compacted` to `probe` (Manual backport)

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -626,7 +626,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         // compacted.
         auto seg = segs.front();
         co_await internal::mark_segment_as_finished_window_compaction(
-          seg, true);
+          seg, true, *_probe);
         segs.pop_front();
     }
     if (segs.empty()) {
@@ -721,7 +721,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             // entirely comprised of non-data batches. Mark it as compacted so
             // we can progress through compactions.
             co_await internal::mark_segment_as_finished_window_compaction(
-              seg, is_clean_compacted);
+              seg, is_clean_compacted, *_probe);
 
             vlog(
               gclog.debug,
@@ -736,7 +736,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             // All data records are already compacted away. Skip to avoid a
             // needless rewrite.
             co_await internal::mark_segment_as_finished_window_compaction(
-              seg, is_clean_compacted);
+              seg, is_clean_compacted, *_probe);
 
             vlog(
               gclog.trace,
@@ -836,7 +836,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         // Mark the segment as completed window compaction, and possibly set the
         // clean_compact_timestamp in it's index.
         co_await internal::mark_segment_as_finished_window_compaction(
-          seg, is_clean_compacted);
+          seg, is_clean_compacted, *_probe);
 
         co_await seg->index().flush();
         co_await ss::rename_file(

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -207,6 +207,14 @@ void probe::setup_metrics(const model::ntp& ntp) {
           sm::description("Number of segments that have been compacted away "
                           "during adjacent merge compaction."),
           labels),
+        sm::make_counter(
+          "cleanly_compacted_segment",
+          [this] { return _segment_cleanly_compacted; },
+          sm::description(
+            "Number of segments cleanly compacted (i.e, had their "
+            "keys de-duplicated with all previous segments "
+            "before them to the front of the log)"),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -102,6 +102,7 @@ public:
     }
 
     void add_removed_tombstone() { ++_tombstones_removed; }
+    void add_cleanly_compacted_segment() { ++_segment_cleanly_compacted; }
 
     void batch_parse_error() { ++_batch_parse_errors; }
 
@@ -145,6 +146,7 @@ private:
     double _compaction_ratio = 1.0;
     uint64_t _tombstones_removed = 0;
     uint64_t _num_adjacent_segments_compacted = 0;
+    uint64_t _segment_cleanly_compacted = 0;
 
     ssize_t _compaction_removed_bytes = 0;
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1160,12 +1160,13 @@ offset_delta_time should_apply_delta_time_offset(
 }
 
 ss::future<> mark_segment_as_finished_window_compaction(
-  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp) {
+  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp, probe& pb) {
     seg->mark_as_finished_windowed_compaction();
     if (set_clean_compact_timestamp) {
         bool did_set = seg->index().maybe_set_clean_compact_timestamp(
           model::timestamp::now());
         if (did_set) {
+            pb.add_cleanly_compacted_segment();
             return seg->index().flush();
         }
     }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -299,7 +299,7 @@ bool may_have_removable_tombstones(
 // Also potentially issues a call to seg->index()->flush(), if the
 // `clean_compact_timestamp` was set in the index.
 ss::future<> mark_segment_as_finished_window_compaction(
-  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp);
+  ss::lw_shared_ptr<segment> seg, bool set_clean_compact_timestamp, probe& pb);
 
 template<typename Func>
 auto with_segment_reader_handle(segment_reader_handle handle, Func func) {


### PR DESCRIPTION
A metric that measures the number of segments that have been cleanly compacted (i.e, had their keys de-duplicated with all previous segments before them to the front of the log).

Backporting to improve observability of compaction in `v24.3.x`.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
