### PR TITLE
c/archival: wakeup upload loop after flush

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -878,8 +878,8 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
             // grow very large disabling the archival storage
             vlog(
               _rtclog.trace, "Nothing to upload, applying backoff algorithm");
-            co_await ss::sleep_abortable(
-              backoff + _backoff_jitter.next_jitter_duration(), _as);
+            co_await _wakeup_event.wait(
+              backoff + _backoff_jitter.next_jitter_duration());
             backoff = std::min(backoff * 2, _conf->upload_loop_max_backoff());
         } else {
             backoff = _conf->upload_loop_initial_backoff();
@@ -1017,6 +1017,7 @@ ss::future<> ntp_archiver::stop() {
     _uploads_active.broken();
     _leader_cond.broken();
     _flush_cond.broken();
+    _wakeup_event.broken();
     co_await _gate.close();
 }
 
@@ -2956,6 +2957,7 @@ flush_result ntp_archiver::flush() {
 
     _flush_uploads_offset = model::prev_offset(
       max_uploadable_offset_exclusive());
+    _wakeup_event.set();
     vlog(
       _rtclog.debug,
       "Accepted flush, flush offset is {}",

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -784,7 +784,7 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
         auto fence
           = _parent.archival_meta_stm()->manifest().get_applied_offset();
         vlog(
-          archival_log.debug,
+          _rtclog.debug,
           "fence value is: {}, in-sync offset: {}",
           fence,
           _parent.archival_meta_stm()->get_insync_offset());

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "ssx/event.h"
 #include "storage/fwd.h"
 #include "utils/retry_chain_node.h"
 
@@ -766,6 +767,10 @@ private:
     // Used by clients wait()'ing on flush. Will be signalled by a complete
     // flush(), or by a change in leadership.
     ss::condition_variable _flush_cond;
+
+    // Used to wakeup the upload loop if it has to run immediately (e.g. after a
+    // flush)
+    ssx::event _wakeup_event{"ntp_archiver"};
 
     // Indicates that a request to flush all local data up to and including
     // offset() (inclusive) has been made when has_value() is true.


### PR DESCRIPTION
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes
* none