### PR TITLE
`storage`: add `_num_adjacent_segments_compacted` to `probe`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1160,6 +1160,8 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
           segment_to_remove, "compact_adjacent_segments");
     }
 
+    _probe->add_adjacent_segments_compacted(segments.size() - 1);
+
     add_dirty_segment_bytes(clean_turning_dirty_bytes);
     const ssize_t removed_bytes = ssize_t(ret.size_before)
                                   - ssize_t(ret.size_after);

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -239,6 +239,12 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _closed_segment_bytes; },
           sm::description("Number of bytes within closed segments of the log"),
           labels),
+        sm::make_counter(
+          "adjacent_segments_compacted",
+          [this] { return _num_adjacent_segments_compacted; },
+          sm::description("Number of segments that have been compacted away "
+                          "during adjacent merge compaction."),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -90,6 +90,10 @@ public:
         _compaction_removed_bytes += bytes;
     }
 
+    void add_adjacent_segments_compacted(uint64_t num_segments_compacted) {
+        _num_adjacent_segments_compacted += num_segments_compacted;
+    }
+
     void batch_write_error(const std::exception_ptr& e);
 
     void add_batches_read(uint32_t batches) { _batches_read += batches; }
@@ -165,6 +169,7 @@ private:
     uint64_t _segments_marked_tombstone_free = 0;
     uint64_t _num_rounds_window_compaction = 0;
     uint64_t _num_chunked_compaction_runs = 0;
+    uint64_t _num_adjacent_segments_compacted = 0;
 
     ssize_t _dirty_segment_bytes = 0;
     ssize_t _closed_segment_bytes = 0;


### PR DESCRIPTION
To improve observability of adjacent segment compaction. This counter represents the total number of segments that have been compacted away via adjacent segment compaction.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes


### Improvements

* Adds the `storage_log_adjacent_segments_compacted` metric for better observability into adjacent segment compaction.
