### PR TITLE
tests: update ducktape ref

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@a87a474ed802e46a9e3af879240ac41eeebbc905',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@805139d3e207e2bad0090bf92e25bbb812ee0232',
         'prometheus-client==0.9.0',
         'kafka-python==2.0.6',
         'crc32c==2.2',


### PR DESCRIPTION
Update ducktape ref to HEAD of `0.12.x-redpanda` branch. This version introduces `--allow-test-failures` flag and will be used in CI to improve retries

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
