### PR TITLE
`storage`: check for hash key map of capacity 0 in `do_compact()`

### DIFF
--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -39,6 +39,10 @@ struct partitions_memory_reservation {
     size_t reserved_bytes(size_t total_memory) const;
 };
 
+namespace testing {
+class system_memory_groups_accessor;
+}
+
 /**
  * Centralized unit for memory management.
  *
@@ -114,6 +118,8 @@ private:
     size_t _total_system_memory;
     bool _wasm_enabled;
     bool _datalake_enabled;
+
+    friend class testing::system_memory_groups_accessor;
 };
 
 /**
@@ -124,3 +130,15 @@ system_memory_groups& memory_groups();
 // Grabs the actual storage for the above. Useful to reset for tests such that
 // the above will reinit using the latest config
 std::optional<system_memory_groups>& memory_groups_holder();
+
+namespace testing {
+
+class system_memory_groups_accessor {
+public:
+    static size_t&
+    compaction_reserved_memory(system_memory_groups& mem_groups) {
+        return mem_groups._compaction_reserved_memory;
+    }
+};
+
+} // namespace testing

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1369,7 +1369,9 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
 ss::future<> disk_log_impl::do_compact(
   compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
-    if (!config::shard_local_cfg().log_compaction_use_sliding_window()) {
+    if (
+      !config::shard_local_cfg().log_compaction_use_sliding_window()
+      || (compact_cfg.hash_key_map && compact_cfg.hash_key_map->capacity() == 0)) {
         co_return co_await adjacent_merge_compact(
           compact_cfg, new_start_offset);
     }

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -577,6 +577,7 @@ redpanda_cc_btest(
         "//src/v/model/tests:random",
         "//src/v/random:generators",
         "//src/v/reflection:adl",
+        "//src/v/resource_mgmt:memory_groups",
         "//src/v/storage",
         "//src/v/storage:batch_cache",
         "//src/v/storage:record_batch_builder",

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -23,6 +23,7 @@
 #include "model/timestamp.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
+#include "resource_mgmt/memory_groups.h"
 #include "storage/batch_cache.h"
 #include "storage/disk_log_impl.h"
 #include "storage/log_housekeeping_meta.h"
@@ -5997,4 +5998,45 @@ FIXTURE_TEST(prefix_truncate_offset_range_size, storage_test_fixture) {
               ss::default_priority_class())
             .get());
     }
+}
+
+FIXTURE_TEST(log_compaction_enable_sliding_window, storage_test_fixture) {
+    // Simulate enabling sliding window after starting Redpanda with it disabled
+    // by setting the compaction_reserved_memory in the memory group to 0.
+    auto& mem_groups = memory_groups();
+    testing::system_memory_groups_accessor::compaction_reserved_memory(
+      mem_groups)
+      = 0;
+    storage::log_manager mgr = make_log_manager();
+    info("Configuration: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "a", 0);
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    // Add a few segments.
+    auto num_segments = 5;
+    for (int i = 0; i < num_segments; ++i) {
+        add_segment(2_MiB, model::term_id(0));
+        log->force_roll(ss::default_priority_class()).get();
+    }
+
+    // config::shard_local_cfg().log_compaction_use_sliding_window is still
+    // `true` at this point. Assert this call doesn't crash when a map with
+    // capacity 0 is used.
+    storage::testing_details::log_manager_accessor::housekeeping_scan(mgr)
+      .get();
 }

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -514,3 +514,58 @@ class LogCompactionSchedulingTest(LogCompactionTestBase, PreallocNodesTest):
 
         # Perform validation with KgoVerifierSeqConsumer
         self.consume_and_validate_log()
+
+
+class LogCompactionEnableSlidingWindow(RedpandaTest):
+    """
+    Test that enabling log_compaction_use_sliding_window when Redpanda is started with it
+    disabled does not result in any broker crashes.
+    """
+    def __init__(self, test_context):
+        self.test_context = test_context
+        # Start with sliding window compaction disabled.
+        self.extra_rp_conf = {
+            'log_compaction_use_sliding_window': False,
+            'log_compaction_interval_ms': 100,
+            'log_segment_size': 2 * 1024**2,  # 2 MiB
+            'compacted_log_segment_size': 1024**2,  # 1 MiB
+        }
+
+        super().__init__(test_context=test_context,
+                         num_brokers=1,
+                         extra_rp_conf=self.extra_rp_conf)
+
+        self._rpk_client = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=2)
+    def test_enable_sliding_window(self):
+        # Redpanda was started with log_compaction_use_sliding_window=false.
+        # Set it to true, thereby leaving the memory reservation for compaction at 0.
+        self._rpk_client.cluster_config_set(
+            "log_compaction_use_sliding_window", True)
+
+        topic_spec = TopicSpec(cleanup_policy=TopicSpec.CLEANUP_COMPACT,
+                               replication_factor=1)
+        self.client().create_topic(topic_spec)
+
+        # Produce a small amount of segments and wait
+        producer = KgoVerifierProducer(context=self.test_context,
+                                       redpanda=self.redpanda,
+                                       topic=topic_spec.name,
+                                       msg_size=1024,
+                                       msg_count=10000)
+
+        producer.start()
+        producer.wait(timeout_sec=180)
+
+        def seen_compacted_segments():
+            return self.redpanda.metric_sum(
+                metric_name="vectorized_storage_log_compacted_segment_total",
+                metrics_endpoint=MetricsEndpoint.METRICS,
+                topic=topic_spec.name,
+                expect_metric=True) > 0
+
+        wait_until(seen_compacted_segments,
+                   timeout_sec=60,
+                   backoff_sec=1,
+                   err_msg=f"Did not see any compacted segments.")


### PR DESCRIPTION
Allowing a `compaction_config` with a `hash_key_map` of `capacity() == 0` through to sliding window compaction results in a floating point exception core dump.

This means users who:

1. Start with a cluster config of `log_compaction_use_sliding_window=false`
2. Execute `rpk cluster config set log_compaction_use_sliding_window=true`

Can easily run into a crash.

Prevent the crash by adding a new check for the capacity of the `hash_key_map` and fall back to adjacent segment compaction if it is 0 (any capacity value above 0 is safe from my testing)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a broker would crash during sliding window compaction when started with `log_compaction_use_sliding_window=false` and its value was later set to `true` without restarting.
