### PR TITLE
`rptest`: partially deflake `test_stress_consumer_group_commits`

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1686,8 +1686,9 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
             assert tp.offset == expected, f"Offset mismatch for partition {tp.topic}{tp.partition}, expected: {expected} got: {tp.offset}"
 
         olv = OfflineLogViewer(self.redpanda)
-        for n in self.redpanda.nodes:
-            summary = olv.consumer_offsets_summary(n)
+
+        def get_summary(node):
+            summary = olv.consumer_offsets_summary(node)
             for _, cg_partition_summary in summary.items():
                 assert len(
                     cg_partition_summary['raft_configurations']
@@ -1700,3 +1701,14 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
                         'committed_offset']
                     assert committed == self.consumers[p].get_last_committed(
                     ), f"On disk state mismatch, expected: {expected}, got: {expected}"
+            return True
+
+        for n in self.redpanda.nodes:
+            wait_until(
+                lambda: get_summary(n),
+                timeout_sec=60,
+                backoff_sec=1,
+                retry_on_exc=True,
+                err_msg=
+                f"Failed to get consumer offsets summary for node {n.account.hostname}"
+            )

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -17,6 +17,7 @@ from typing import Dict, List
 
 from rptest.clients.default import DefaultClient
 from rptest.clients.offline_log_viewer import OfflineLogViewer
+from rptest.services.redpanda import LoggingConfig
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 
@@ -1584,9 +1585,9 @@ class OffsetCommitter:
 
 class ConsumerGroupOffsetResetTest(RedpandaTest):
     """
-    This tests simulates a large number of consumers trying to commit consumer 
-    group offsets. The test doesn't produce or fetch any messages, 
-    it just stress tests OffsetCommit requests and validates the final 
+    This tests simulates a large number of consumers trying to commit consumer
+    group offsets. The test doesn't produce or fetch any messages,
+    it just stress tests OffsetCommit requests and validates the final
     state of the consumer group.
     """
     def __init__(self, test_context):
@@ -1598,7 +1599,15 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
                                  "compacted_log_segment_size": 1024 * 1024,
                                  "log_compaction_interval_ms": 1000,
                                  "group_offset_retention_sec": 20,
-                             })
+                             },
+                             log_config=LoggingConfig(
+                                 'info', {
+                                     'storage': 'warn',
+                                     'storage-resources': 'warn',
+                                     'storage-gc': 'warn',
+                                     'raft': 'debug',
+                                     'cluster': 'debug',
+                                 }))
 
     def get_group_description(self):
         description = self.admin_client.describe_consumer_groups(


### PR DESCRIPTION
This test can race with adjacent segment compaction while collecting a node's consumer offsets summary, with a backtrace like

```
File "/root/tests/rptest/tests/consumer_group_test.py", line 1690, in test_stress_consumer_group_commits
    summary = olv.consumer_offsets_summary(n)
  File "/root/tests/rptest/clients/offline_log_viewer.py", line 59, in consumer_offsets_summary
    return self._json_cmd(node, "--type consumer_offsets_summary")
  File "/root/tests/rptest/clients/offline_log_viewer.py", line 34, in _json_cmd
    json_out = node.account.ssh_output(cmd, combine_stderr=False)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/cluster/remoteaccount.py", line 41, in wrapper
    return method(self, *args, **kwargs)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/cluster/remoteaccount.py", line 421, in ssh_output
    raise RemoteCommandError(self, cmd, exit_status, stderr.read())
  FileNotFoundError: [Errno 2] No such file or directory: \'/var/lib/redpanda/data/kafka/__consumer_offsets/0_22/2239422-4-v1.log\'\n'
```

Use a `wait_until()` wrapper instead to retry this exceptional case.

The second commit also adds a `LoggingConfig` argument to pass to the `RedpandaService` base class for this test, since it generates large enough logs to fill up the CI agent node's disks.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
