### PR TITLE
`test_utils`: set `--gtest_output` for `gtest_listener_test`

### DIFF
--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -44,6 +44,9 @@ redpanda_cc_gtest(
     srcs = [
         "gtest_listener_test.cc",
     ],
+    args = [
+        "--gtest_output=xml:/dev/null",
+    ],
     deps = [
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",


### PR DESCRIPTION
This test is expected to fail, but the `ASSERT_FALSE(true)` call will result in `gtest` & `bazel` writing a "true" failure to `test.xml`.

To avoid this, redirect the `xml` output to `/dev/null` so the test appears as a pass when the `test.xml` file is read by our CI scripts.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
