### PR TITLE
Fix archival STM shutdown race

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1193,7 +1193,6 @@ partition::replicate_unsafe_reset(cloud_storage::partition_manifest manifest) {
     auto sync_timeout = config::shard_local_cfg()
                           .cloud_storage_metadata_sync_timeout_ms.value();
     auto replication_deadline = ss::lowres_clock::now() + sync_timeout;
-    std::vector<cluster::command_batch_builder> builders;
 
     // TODO: move this logic to the ntp_archiver
     // currently, the 'batch_start' method will work even if there is an

--- a/src/v/raft/offset_monitor.h
+++ b/src/v/raft/offset_monitor.h
@@ -43,6 +43,7 @@ public:
             waiter.second->done.set_exception(ss::abort_requested_exception());
         }
         _waiters.clear();
+        stopped = true;
     }
 
     /**
@@ -56,6 +57,9 @@ public:
         // the offset has already been applied
         if (offset <= _last_applied) {
             return ss::now();
+        }
+        if (unlikely(stopped)) {
+            return ss::make_exception_future<>(ss::abort_requested_exception());
         }
         auto w = std::make_unique<waiter>(this, deadline, as);
         auto f = w->done.get_future();
@@ -148,6 +152,7 @@ private:
 
     waiters_type _waiters;
     Offset _last_applied;
+    bool stopped{false};
 };
 
 } // namespace raft

--- a/src/v/raft/tests/offset_monitor_test.cc
+++ b/src/v/raft/tests/offset_monitor_test.cc
@@ -97,6 +97,19 @@ SEASTAR_THREAD_TEST_CASE(stop) {
     for (auto& f : fs) {
         BOOST_CHECK_THROW(f.get(), ss::abort_requested_exception);
     }
+
+    fs.clear();
+
+    // already reached offset is still regarded as reached by monitor
+    auto already_reached = mon.wait(
+      model::offset{}, model::no_timeout, std::nullopt);
+    BOOST_REQUIRE(already_reached.available());
+    BOOST_REQUIRE_NO_THROW(already_reached.get());
+
+    // but nothing beyond it is going to be waited for
+    auto never_happening = mon.wait(
+      model::offset(0), model::no_timeout, std::nullopt);
+    BOOST_CHECK_THROW(never_happening.get(), ss::abort_requested_exception);
 }
 
 SEASTAR_THREAD_TEST_CASE(notify_abort) {


### PR DESCRIPTION
Sometimes archival_metadata_stm fails to stop on cluster shutdown.
Scenario:
- a replication request is in progress
- the majority of partition nodes is already down
- replication request never completes or times out
- it is never applied, so waiting for offsets hangs forever
- it holds the gate
- in stop(), waiting for the gate to close never ends.

The solution is to make offset monitor fail with an exception straight away if it has been stopped.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
