### PR TITLE
storage/tests: extract batch generators

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -93,6 +93,7 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/cluster",
+        "//src/v/storage/tests:batch_generators",
         "//src/v/storage/tests:storage_test_fixture_gtest",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:random",
@@ -1216,6 +1217,7 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/cluster",
+        "//src/v/storage/tests:batch_generators",
         "//src/v/storage/tests:storage_test_fixture",
         "//src/v/test_utils:seastar_boost",
     ],

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -10,6 +10,7 @@
 #include "cluster/rm_stm.h"
 #include "cluster/tests/rm_stm_test_fixture.h"
 #include "cluster/tests/tx_compaction_utils.h"
+#include "test_utils/fixture.h"
 #include "test_utils/scoped_config.h"
 
 #include <seastar/util/defer.hh>

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -11,7 +11,8 @@
 
 #include "cluster/logger.h"
 #include "cluster/rm_stm.h"
-#include "storage/tests/storage_test_fixture.h"
+#include "storage/segment.h"
+#include "storage/tests/batch_generators.h"
 #include "test_utils/async.h"
 #include "test_utils/randoms.h"
 #include "test_utils/test_macros.h"

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -103,6 +103,27 @@ redpanda_test_cc_library(
 )
 
 redpanda_test_cc_library(
+    name = "batch_generators",
+    hdrs = [
+        "batch_generators.h",
+    ],
+    include_prefix = "storage/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/compression",
+        "//src/v/hashing:crc32c",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/random:generators",
+        "//src/v/reflection:adl",
+        "//src/v/test_utils:fixture",
+        "//src/v/utils:vint",
+        "@seastar",
+    ],
+)
+
+redpanda_test_cc_library(
     name = "storage_test_fixture_gtest",
     hdrs = [
         "storage_test_fixture.h",
@@ -110,10 +131,9 @@ redpanda_test_cc_library(
     include_prefix = "storage/tests",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/v/compression",
+        ":batch_generators",
         "//src/v/config",
         "//src/v/features",
-        "//src/v/model/tests:random",
         "//src/v/storage",
         "//src/v/test_utils:gtest",
     ],
@@ -127,10 +147,9 @@ redpanda_test_cc_library(
     include_prefix = "storage/tests",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/v/compression",
+        ":batch_generators",
         "//src/v/config",
         "//src/v/features",
-        "//src/v/model/tests:random",
         "//src/v/storage",
         "//src/v/test_utils:fixture",
     ],
@@ -562,6 +581,7 @@ redpanda_cc_btest(
     ],
     cpu = 1,
     deps = [
+        ":batch_generators",
         ":common",
         ":disk_log_builder",
         ":disk_log_builder_fixture",
@@ -795,6 +815,7 @@ redpanda_cc_gtest(
         "//src/v/model",
         "//src/v/storage",
         "//src/v/storage:key_offset_map",
+        "//src/v/storage/tests:batch_generators",
         "//src/v/storage/tests:storage_test_fixture",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/storage/tests/batch_generators.h
+++ b/src/v/storage/tests/batch_generators.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "compression/compression.h"
+#include "hashing/crc32c.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_utils.h"
+#include "model/tests/random_batch.h"
+#include "random/generators.h"
+#include "reflection/adl.h"
+#include "test_utils/test_macros.h"
+#include "utils/vint.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/reactor.hh>
+
+#include <optional>
+
+struct random_batches_generator {
+    ss::circular_buffer<model::record_batch>
+    operator()(std::optional<model::timestamp> base_ts = std::nullopt) {
+        return model::test::make_random_batches(
+                 model::offset(0),
+                 random_generators::get_int(1, 10),
+                 true,
+                 base_ts)
+          .get();
+    }
+};
+
+struct key_limited_random_batch_generator {
+    static constexpr int cardinality = 10;
+
+    ss::circular_buffer<model::record_batch>
+    operator()(std::optional<model::timestamp> ts = std::nullopt) {
+        return model::test::make_random_batches(
+                 model::test::record_batch_spec{
+                   .allow_compression = true,
+                   .count = random_generators::get_int(1, 10),
+                   .max_key_cardinality = cardinality,
+                   .bt = model::record_batch_type::raft_data,
+                   .timestamp = ts})
+          .get();
+    }
+};
+
+// Deterministic data generator that generates integer keys linearly with
+// duplicates in each batch. Each batch contains a new integer key. With small
+// enough batch sizes (not exceeding compaction budget), compaction should
+// dedupe all the keys within a batch and the resulting log file should contain
+// a single key per batch forming a sequence of integers. A handy validate()
+// method is provided that validates the the batch state after compaction.
+struct linear_int_kv_batch_generator {
+    int _idx = 0;
+
+    static constexpr int batches_per_call = 5;
+    static constexpr int records_per_batch = 5;
+
+    model::record_batch
+    make_batch(model::test::record_batch_spec spec, int idx) {
+        auto ts = spec.timestamp.value_or(
+          model::timestamp(model::timestamp::now()() - (spec.count - 1)));
+        auto max_ts = spec.timestamp.value_or(
+          model::timestamp(ts.value() + spec.count - 1));
+        auto header = model::record_batch_header{
+          .size_bytes = 0, // computed later
+          .base_offset = spec.offset,
+          .type = spec.bt,
+          .crc = 0, // we-reassign later
+          .attrs = model::record_batch_attributes(
+            random_generators::get_int<int16_t>(
+              0, spec.allow_compression ? 4 : 0)),
+          .last_offset_delta = spec.count - 1,
+          .first_timestamp = ts,
+          .max_timestamp = max_ts,
+          .producer_id = spec.producer_id,
+          .producer_epoch = spec.producer_epoch,
+          .base_sequence = 0,
+          .record_count = spec.count};
+
+        if (spec.is_transactional) {
+            header.attrs.set_transactional_type();
+        }
+
+        if (spec.enable_idempotence) {
+            header.base_sequence = spec.base_sequence;
+        }
+
+        auto size = model::packed_record_batch_header_size;
+        model::record_batch::records_type records;
+        auto rs = model::record_batch::uncompressed_records();
+        rs.reserve(spec.count);
+
+        for (int i = 0; i < spec.count; i++) {
+            rs.emplace_back(
+              model::test::make_random_record(i, reflection::to_iobuf(idx)));
+        }
+
+        if (header.attrs.compression() != model::compression::none) {
+            iobuf body;
+            for (auto& r : rs) {
+                model::append_record_to_buffer(body, r);
+            }
+            rs.clear();
+            records = ::compression::compressor::compress(
+              body, header.attrs.compression());
+            size += std::get<iobuf>(records).size_bytes();
+        } else {
+            for (auto& r : rs) {
+                size += r.size_bytes();
+                size += vint::vint_size(r.size_bytes());
+            }
+            records = std::move(rs);
+        }
+        // TODO: expose term setting
+        header.ctx = model::record_batch_header::context(
+          model::term_id(0), ss::this_shard_id());
+        header.size_bytes = size;
+        auto batch = model::record_batch(header, std::move(records));
+        batch.header().crc = model::crc_record_batch(batch);
+        batch.header().header_crc = model::internal_header_only_crc(
+          batch.header());
+        return batch;
+    }
+
+    ss::circular_buffer<model::record_batch>
+    operator()(std::optional<model::timestamp> ts = std::nullopt) {
+        ss::circular_buffer<model::record_batch> ret;
+        ret.reserve(batches_per_call);
+        auto batch_spec = model::test::record_batch_spec{
+          .allow_compression = false,
+          .count = records_per_batch,
+          .bt = model::record_batch_type::raft_data,
+          .timestamp = ts,
+        };
+        return operator()(batch_spec, batches_per_call);
+    }
+
+    ss::circular_buffer<model::record_batch>
+    operator()(model::test::record_batch_spec spec, int num_batches) {
+        ss::circular_buffer<model::record_batch> ret;
+        ret.reserve(num_batches);
+        for (int i = 0; i < num_batches; i++) {
+            ret.push_back(make_batch(spec, _idx++));
+        }
+        return ret;
+    }
+
+    // Batches generated by this generator should all have 1 record
+    // and the record should match the index of the batch if compaction
+    // ran correctly.
+    static void validate_post_compaction(
+      ss::circular_buffer<model::record_batch>&& batches) {
+        int idx = 0;
+        for (const auto& batch : batches) {
+            RPTEST_EXPECT_EQ(batch.record_count(), 1);
+            batch.for_each_record([&idx](model::record rec) {
+                RPTEST_EXPECT_EQ(
+                  reflection::from_iobuf<int>(rec.release_key()), idx++);
+            });
+        }
+    }
+};

--- a/src/v/storage/tests/compaction_reducer_fixture_test.cc
+++ b/src/v/storage/tests/compaction_reducer_fixture_test.cc
@@ -19,6 +19,7 @@
 #include "storage/segment_deduplication_utils.h"
 #include "storage/segment_set.h"
 #include "storage/segment_utils.h"
+#include "storage/tests/batch_generators.h"
 #include "storage/tests/storage_test_fixture.h"
 #include "storage/types.h"
 #include "test_utils/test.h"

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -32,6 +32,7 @@
 #include "storage/ntp_config.h"
 #include "storage/record_batch_builder.h"
 #include "storage/segment_utils.h"
+#include "storage/tests/batch_generators.h"
 #include "storage/tests/common.h"
 #include "storage/tests/disk_log_builder_fixture.h"
 #include "storage/tests/storage_test_fixture.h"

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -13,21 +13,13 @@
 
 #include "base/seastarx.h"
 #include "base/units.h"
-#include "compression/compression.h"
 #include "config/configuration.h"
 #include "features/feature_table.h"
-#include "hashing/crc32c.h"
-#include "model/fundamental.h"
-#include "model/record.h"
-#include "model/record_utils.h"
-#include "model/tests/random_batch.h"
-#include "random/generators.h"
-#include "reflection/adl.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
+#include "storage/tests/batch_generators.h"
 #include "storage/types.h"
 #include "test_utils/fixture.h"
-#include "test_utils/test_macros.h"
 
 #include <seastar/core/file.hh>
 #include <seastar/core/reactor.hh>
@@ -42,152 +34,6 @@
 using namespace std::chrono_literals; // NOLINT
 
 inline ss::logger tlog{"test_log"};
-
-struct random_batches_generator {
-    ss::circular_buffer<model::record_batch>
-    operator()(std::optional<model::timestamp> base_ts = std::nullopt) {
-        return model::test::make_random_batches(
-                 model::offset(0),
-                 random_generators::get_int(1, 10),
-                 true,
-                 base_ts)
-          .get();
-    }
-};
-
-struct key_limited_random_batch_generator {
-    static constexpr int cardinality = 10;
-
-    ss::circular_buffer<model::record_batch>
-    operator()(std::optional<model::timestamp> ts = std::nullopt) {
-        return model::test::make_random_batches(
-                 model::test::record_batch_spec{
-                   .allow_compression = true,
-                   .count = random_generators::get_int(1, 10),
-                   .max_key_cardinality = cardinality,
-                   .bt = model::record_batch_type::raft_data,
-                   .timestamp = ts})
-          .get();
-    }
-};
-
-// Deterministic data generator that generates integer keys linearly with
-// duplicates in each batch. Each batch contains a new integer key. With small
-// enough batch sizes (not exceeding compaction budget), compaction should
-// dedupe all the keys within a batch and the resulting log file should contain
-// a single key per batch forming a sequence of integers. A handy validate()
-// method is provided that validates the the batch state after compaction.
-struct linear_int_kv_batch_generator {
-    int _idx = 0;
-
-    static constexpr int batches_per_call = 5;
-    static constexpr int records_per_batch = 5;
-
-    model::record_batch
-    make_batch(model::test::record_batch_spec spec, int idx) {
-        auto ts = spec.timestamp.value_or(
-          model::timestamp(model::timestamp::now()() - (spec.count - 1)));
-        auto max_ts = spec.timestamp.value_or(
-          model::timestamp(ts.value() + spec.count - 1));
-        auto header = model::record_batch_header{
-          .size_bytes = 0, // computed later
-          .base_offset = spec.offset,
-          .type = spec.bt,
-          .crc = 0, // we-reassign later
-          .attrs = model::record_batch_attributes(
-            random_generators::get_int<int16_t>(
-              0, spec.allow_compression ? 4 : 0)),
-          .last_offset_delta = spec.count - 1,
-          .first_timestamp = ts,
-          .max_timestamp = max_ts,
-          .producer_id = spec.producer_id,
-          .producer_epoch = spec.producer_epoch,
-          .base_sequence = 0,
-          .record_count = spec.count};
-
-        if (spec.is_transactional) {
-            header.attrs.set_transactional_type();
-        }
-
-        if (spec.enable_idempotence) {
-            header.base_sequence = spec.base_sequence;
-        }
-
-        auto size = model::packed_record_batch_header_size;
-        model::record_batch::records_type records;
-        auto rs = model::record_batch::uncompressed_records();
-        rs.reserve(spec.count);
-
-        for (int i = 0; i < spec.count; i++) {
-            rs.emplace_back(
-              model::test::make_random_record(i, reflection::to_iobuf(idx)));
-        }
-
-        if (header.attrs.compression() != model::compression::none) {
-            iobuf body;
-            for (auto& r : rs) {
-                model::append_record_to_buffer(body, r);
-            }
-            rs.clear();
-            records = ::compression::compressor::compress(
-              body, header.attrs.compression());
-            size += std::get<iobuf>(records).size_bytes();
-        } else {
-            for (auto& r : rs) {
-                size += r.size_bytes();
-                size += vint::vint_size(r.size_bytes());
-            }
-            records = std::move(rs);
-        }
-        // TODO: expose term setting
-        header.ctx = model::record_batch_header::context(
-          model::term_id(0), ss::this_shard_id());
-        header.size_bytes = size;
-        auto batch = model::record_batch(header, std::move(records));
-        batch.header().crc = model::crc_record_batch(batch);
-        batch.header().header_crc = model::internal_header_only_crc(
-          batch.header());
-        return batch;
-    }
-
-    ss::circular_buffer<model::record_batch>
-    operator()(std::optional<model::timestamp> ts = std::nullopt) {
-        ss::circular_buffer<model::record_batch> ret;
-        ret.reserve(batches_per_call);
-        auto batch_spec = model::test::record_batch_spec{
-          .allow_compression = false,
-          .count = records_per_batch,
-          .bt = model::record_batch_type::raft_data,
-          .timestamp = ts,
-        };
-        return operator()(batch_spec, batches_per_call);
-    }
-
-    ss::circular_buffer<model::record_batch>
-    operator()(model::test::record_batch_spec spec, int num_batches) {
-        ss::circular_buffer<model::record_batch> ret;
-        ret.reserve(num_batches);
-        for (int i = 0; i < num_batches; i++) {
-            ret.push_back(make_batch(spec, _idx++));
-        }
-        return ret;
-    }
-
-    // Batches generated by this generator should all have 1 record
-    // and the record should match the index of the batch if compaction
-    // ran correctly.
-    static void validate_post_compaction(
-      ss::circular_buffer<model::record_batch>&& batches) {
-        int idx = 0;
-        for (const auto& batch : batches) {
-            RPTEST_EXPECT_EQ(batch.record_count(), 1);
-            batch.for_each_record([&idx](model::record rec) {
-                RPTEST_EXPECT_EQ(
-                  reflection::from_iobuf<int>(rec.release_key()), idx++);
-            });
-        }
-    }
-};
 
 class storage_test_fixture {
 public:


### PR DESCRIPTION
Factored out three generator classes (random_batches_generator, key_limited_random_batch_generator, linear_int_kv_batch_generator) from storage_test_fixture.h into a new batch_generators.h header file.

This is just nice to do, plus it will also be helpful when incrementally migrating tests from Boost to Google Test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
