### PR TITLE
kafka/debug: add a debug end point for offset_for_leader_epoch

### DIFF
--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -227,6 +227,7 @@ redpanda_cc_library(
         "//src/v/features:enterprise_features",
         "//src/v/finjector",
         "//src/v/json",
+        "//src/v/kafka/data:partition_proxy",
         "//src/v/kafka/server",
         "//src/v/metrics",
         "//src/v/model",

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -464,6 +464,40 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/partitions/{topic}/{partition}/offset_for_leader_epoch",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Perform offset_for_leader_epoch on the given Kafka partition and epoch",
+                    "nickname": "offset_for_leader_epoch",
+                    "type": "epoch_and_offset",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "epoch",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -798,6 +832,30 @@
                     "description:": "List of nodes that are dead and contributing to majority loss of partitions."
                 }
             }
+        },
+        "epoch_and_offset": {
+            "id": "epoch_and_offset",
+            "description": "Result of the offset for leader epoch request",
+            "type": "object",
+            "properties": {
+                "epoch": {
+                    "type": "int",
+                    "description": "The epoch requested"
+                },
+                "current_leader_epoch": {
+                    "type": "int",
+                    "description": "The current leader epoch of the partition"
+                },
+                "end_offset": {
+                    "type": "long",
+                    "description": "The end offset of the partition for the requested epoch"
+                }
+            },
+            "required": [
+                "epoch",
+                "current_leader_epoch",
+                "end_offset"
+            ]
         }
     }
 }

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -19,6 +19,7 @@
 #include "cluster/topics_frontend.h"
 #include "container/fragmented_vector.h"
 #include "container/lw_shared_container.h"
+#include "kafka/data/partition_proxy.h"
 #include "model/record.h"
 #include "redpanda/admin/api-doc/debug.json.hh"
 #include "redpanda/admin/api-doc/partition.json.hh"
@@ -681,6 +682,62 @@ admin_server::set_partition_replica_core_handler(
     co_return ss::json::json_void();
 }
 
+ss::future<ss::json::json_return_type>
+admin_server::offset_for_leader_epoch_handler(
+  std::unique_ptr<ss::http::request> request) {
+    auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*request, ntp);
+    }
+    vlog(
+      adminlog.debug,
+      "Requesting offset for leader epoch for partition {}",
+      ntp);
+    auto epoch_str = request->get_query_param("epoch");
+    kafka::leader_epoch epoch{};
+    try {
+        epoch = boost::lexical_cast<kafka::leader_epoch>(epoch_str);
+    } catch (const boost::bad_lexical_cast&) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("epoch parameter must be an integer: {}", epoch_str));
+    }
+    auto shard = _shard_table.local().shard_for(ntp);
+    if (!shard) {
+        throw ss::httpd::not_found_exception(fmt_with_ctx(
+          fmt::format, "Partition {} not found on this node", ntp));
+    }
+    auto [offset, current_epoch] = co_await _partition_manager.invoke_on(
+      *shard,
+      [ntp = std::move(ntp), epoch](cluster::partition_manager& pm) mutable {
+          return ss::do_with(
+            kafka::make_partition_proxy(ntp, pm),
+            std::move(ntp),
+            [epoch](
+              std::optional<kafka::partition_proxy>& proxy, model::ntp& ntp) {
+                if (!proxy) {
+                    return ss::make_exception_future<std::pair<
+                      std::optional<model::offset>,
+                      kafka::leader_epoch>>(
+                      ss::httpd::not_found_exception(fmt_with_ctx(
+                        fmt::format,
+                        "Partition {} not found on this node",
+                        ntp)));
+                }
+                auto current_epoch = proxy->leader_epoch();
+                return proxy->get_leader_epoch_last_offset(epoch).then(
+                  [current_epoch](std::optional<model::offset> offset) {
+                      return std::make_pair(offset, current_epoch);
+                  });
+            });
+      });
+
+    ss::httpd::partition_json::epoch_and_offset result;
+    result.epoch = epoch;
+    result.current_leader_epoch = current_epoch();
+    result.end_offset = offset ? offset.value()() : -1;
+    co_return result;
+}
+
 void admin_server::register_partition_routes() {
     /*
      * Get a list of partition summaries.
@@ -838,6 +895,12 @@ void admin_server::register_partition_routes() {
       ss::httpd::debug_json::disable_append_entries_error_injection,
       [this](std::unique_ptr<ss::http::request> req) {
           return toggle_append_entries_error_injection(std::move(req), false);
+      });
+
+    register_route<superuser>(
+      ss::httpd::partition_json::offset_for_leader_epoch,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return offset_for_leader_epoch_handler(std::move(req));
       });
 
     register_route<superuser>(

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -551,6 +551,8 @@ private:
       std::unique_ptr<ss::http::request>, bool inject);
     ss::future<ss::json::json_return_type>
       set_partition_replica_core_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      offset_for_leader_epoch_handler(std::unique_ptr<ss::http::request>);
 
     ss::future<ss::json::json_return_type>
       trigger_on_demand_rebalance_handler(std::unique_ptr<ss::http::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1656,6 +1656,10 @@ class Admin:
         path = f"debug/partition/{namespace}/{topic}/{partition}"
         return self._request("GET", path, node=node).json()
 
+    def get_offset_for_leader_epoch(self, topic, partition, epoch, node=None):
+        path = f"debug/partitions/{topic}/{partition}/offset_for_leader_epoch?epoch={epoch}"
+        return self._request("GET", path, node=node).json()
+
     def get_partitions_local_summary(self, node: ClusterNode):
         path = f"partitions/local_summary"
         return self._request("GET", path, node=node).json()

--- a/tests/rptest/tests/partition_state_api_test.py
+++ b/tests/rptest/tests/partition_state_api_test.py
@@ -12,6 +12,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
+from requests.exceptions import HTTPError
 
 from collections import Counter
 import time
@@ -199,3 +200,80 @@ class PartitionStateAPItest(RedpandaTest):
         sumsum_eventually(count=2 * n_topics,
                           leaderless=2 * n_topics,
                           under_replicated=0)
+
+    @cluster(num_nodes=5)
+    def test_offset_for_leader_epoch(self):
+        self.topics = [
+            TopicSpec(partition_count=1,
+                      replication_factor=len(self.redpanda.nodes))
+        ]
+        topic = self.topics[0]
+        self._create_initial_topics()
+        kafka_tools = KafkaCliTools(self.redpanda)
+
+        # Invalid request
+        try:
+            self.redpanda._admin.get_offset_for_leader_epoch(
+                topic.name, 0, "unparseable_epoch")
+            assert False, "Expected request to fail with invalid epoch"
+        except HTTPError as e:
+            assert e.response.status_code == 400, \
+                f"Expected 400 Bad Request, got {e.response.status_code}"
+
+        def produce_one_record():
+            kafka_tools.produce(topic.name, 1, 1, acks=-1)
+
+        def get_current_leader_epoch():
+            try:
+                return self.redpanda._admin.get_offset_for_leader_epoch(
+                    topic.name, 0, 1)["current_leader_epoch"]
+            except:
+                self.logger.debug(f"Failed to get current leader epoch",
+                                  exc_info=True)
+                return -1
+
+        def do_validate_offset_for_leader_epoch(epoch: int,
+                                                expected_offset: int):
+            node_results = []
+            for node in self.redpanda.started_nodes():
+                try:
+                    output = self.redpanda._admin.get_offset_for_leader_epoch(
+                        topic.name, 0, epoch, node)
+                    node_results.append(
+                        output["end_offset"] == expected_offset
+                        and output["current_leader_epoch"] == epoch)
+                except:
+                    self.logger.debug(
+                        f"Failed to get offset for leader epoch for node {node}",
+                        exc_info=True)
+                    node_results.append(False)
+            return all(node_results)
+
+        def validate_offset_for_leader_epoch(epoch: int, expected_offset: int):
+            self.redpanda.wait_until(
+                lambda: do_validate_offset_for_leader_epoch(
+                    epoch, expected_offset),
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg=
+                f"Offset for leader epoch {epoch} not consistent across nodes")
+
+        current_epoch = get_current_leader_epoch()
+        validate_offset_for_leader_epoch(current_epoch, 0)
+        produce_one_record()
+        validate_offset_for_leader_epoch(current_epoch, 1)
+        produce_one_record()
+        validate_offset_for_leader_epoch(current_epoch, 2)
+
+        # Bump epoch
+        while True:
+            epoch = get_current_leader_epoch()
+            if epoch > current_epoch:
+                current_epoch = epoch
+                break
+            self.redpanda._admin.partition_transfer_leadership(
+                "kafka", topic.name, 0)
+
+        validate_offset_for_leader_epoch(current_epoch, 2)
+        produce_one_record()
+        validate_offset_for_leader_epoch(current_epoch, 3)


### PR DESCRIPTION
There have been more than one incident in the past few months where something like this would've simplified debugging. 

Example:

Sample request

```
http://any-broker:9644/v1/debug/offset_for_leader_epoch/<topic_name>/<partition_id>/<epoch_to_query>
```

Sample response

```
{
  "epoch": 1,  # Input epoch
  "current_leader_epoch": 1, # current epoch of the leader processing this request
  "end_offset": 0 # max offset for this leader epoch
}
```

Fixes https://redpandadata.atlassian.net/browse/CORE-9935

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
