### PR TITLE
[v24.3.x] `storage`: check for hash key map of capacity 0 in `do_compact()` (Manual backport)

### DIFF
--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -31,6 +31,10 @@ struct compaction_memory_reservation {
     double max_limit_pct{100.0};
 };
 
+namespace testing {
+class system_memory_groups_accessor;
+}
+
 /**
  * Centralized unit for memory management.
  *
@@ -96,9 +100,23 @@ private:
     size_t _total_system_memory;
     bool _wasm_enabled;
     bool _datalake_enabled;
+
+    friend class testing::system_memory_groups_accessor;
 };
 
 /**
  * Grab the shard local, lazily initialized, system memory groups.
  */
 system_memory_groups& memory_groups();
+
+namespace testing {
+
+class system_memory_groups_accessor {
+public:
+    static size_t&
+    compaction_reserved_memory(system_memory_groups& mem_groups) {
+        return mem_groups._compaction_reserved_memory;
+    }
+};
+
+} // namespace testing

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1336,7 +1336,9 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
 ss::future<> disk_log_impl::do_compact(
   compaction_config compact_cfg,
   std::optional<model::offset> new_start_offset) {
-    if (!config::shard_local_cfg().log_compaction_use_sliding_window()) {
+    if (
+      !config::shard_local_cfg().log_compaction_use_sliding_window()
+      || (compact_cfg.hash_key_map && compact_cfg.hash_key_map->capacity() == 0)) {
         co_return co_await adjacent_merge_compact(
           compact_cfg, new_start_offset);
     }

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ rp_test(
         BINARY_NAME storage_e2e_single_thread
         SOURCES
         storage_e2e_test.cc
-        LIBRARIES v::seastar_testing_main v::storage_test_utils v::model_test_utils
+        LIBRARIES v::seastar_testing_main v::storage_test_utils v::model_test_utils v::resource_mgmt
         LABELS storage
         ARGS "-- -c 1"
 )

--- a/src/v/storage/tests/common.h
+++ b/src/v/storage/tests/common.h
@@ -19,5 +19,9 @@ public:
     static batch_cache& batch_cache(storage::log_manager& m) {
         return m._batch_cache;
     }
+
+    static ss::future<> housekeeping_scan(storage::log_manager& m) {
+        return m.housekeeping_scan(m.lowest_ts_to_retain());
+    }
 };
 } // namespace storage::testing_details

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -23,6 +23,7 @@
 #include "model/timestamp.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
+#include "resource_mgmt/memory_groups.h"
 #include "storage/batch_cache.h"
 #include "storage/log_manager.h"
 #include "storage/log_reader.h"
@@ -5319,4 +5320,45 @@ FIXTURE_TEST(disk_usage_with_log_throwing_exception, storage_test_fixture) {
 
     // Reassign the gate so there is no double close().
     disk_log->gate() = ss::gate{};
+}
+
+FIXTURE_TEST(log_compaction_enable_sliding_window, storage_test_fixture) {
+    // Simulate enabling sliding window after starting Redpanda with it disabled
+    // by setting the compaction_reserved_memory in the memory group to 0.
+    auto& mem_groups = memory_groups();
+    testing::system_memory_groups_accessor::compaction_reserved_memory(
+      mem_groups)
+      = 0;
+    storage::log_manager mgr = make_log_manager();
+    info("Configuration: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "a", 0);
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    // Add a few segments.
+    auto num_segments = 5;
+    for (int i = 0; i < num_segments; ++i) {
+        add_segment(2_MiB, model::term_id(0));
+        log->force_roll(ss::default_priority_class()).get();
+    }
+
+    // config::shard_local_cfg().log_compaction_use_sliding_window is still
+    // `true` at this point. Assert this call doesn't crash when a map with
+    // capacity 0 is used.
+    storage::testing_details::log_manager_accessor::housekeeping_scan(mgr)
+      .get();
 }


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26182. `cherry-pick` conflict due to changes in `memory_groups.h` not present in previous branches. 

Fixes https://github.com/redpanda-data/redpanda/issues/26190.

## Backports Required


- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a broker would crash during sliding window compaction when started with `log_compaction_use_sliding_window=false` and its value was later set to `true` without restarting.
