### PR TITLE
`storage`: migrate `IndexOverflowTruncate` to `gtest`

### DIFF
--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -411,7 +411,7 @@ TEST(IndexState, NonDataTimestampsWithOverflow) {
       0);
 }
 
-BOOST_AUTO_TEST_CASE(index_overflow_truncate) {
+TEST(IndexState, IndexOverflowTruncate) {
     storage::index_state state;
 
     // Previous versions of Redpanda can have an index with offsets spanning
@@ -428,18 +428,18 @@ BOOST_AUTO_TEST_CASE(index_overflow_truncate) {
     state.add_entry(static_cast<uint32_t>(uint32_max + 1), time_idx, 3);
     state.add_entry(static_cast<uint32_t>(uint32_max + 10), time_idx, 4);
     state.max_offset = model::offset{uint32_max + 10};
-    BOOST_CHECK_EQUAL(4, state.size());
+    EXPECT_EQ(4, state.size());
 
     // The truncation shouldn't remove index entries, given the overflow.
     auto needs_flush = state.truncate(
       model::offset(uint32_max + 1), model::timestamp::now());
-    BOOST_CHECK(needs_flush);
-    BOOST_CHECK_EQUAL(4, state.size());
-    BOOST_CHECK_EQUAL(state.max_offset, model::offset{uint32_max + 1});
+    EXPECT_TRUE(needs_flush);
+    EXPECT_EQ(4, state.size());
+    EXPECT_EQ(state.max_offset, model::offset{uint32_max + 1});
 
     // Queries for the offset should start from the beginning of the segment.
     auto res = state.find_nearest(model::offset(uint32_max + 1));
-    BOOST_REQUIRE(res.has_value());
-    BOOST_CHECK_EQUAL(res->offset, model::offset{0});
-    BOOST_CHECK_EQUAL(res->filepos, 1);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->offset, model::offset{0});
+    EXPECT_EQ(res->filepos, 1);
 }


### PR DESCRIPTION
Looks like this was a merge race between porting `index_state_test.cc` to `gtest` and adding a new `Boost.Test` in a different commit/PR.

Migrate the test to `gtest` to fix CI.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
