### PR TITLE
[v24.3.x] `storage`: add `_num_adjacent_segments_compacted` to `probe` (Manual backport)

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1132,6 +1132,8 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
           segments.back(), "compact_adjacent_segments");
     }
 
+    _probe->add_adjacent_segments_compacted(segments.size() - 1);
+
     co_return ret;
 }
 

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -201,6 +201,12 @@ void probe::setup_metrics(const model::ntp& ntp) {
           sm::description("Number of tombstone records removed by compaction "
                           "due to the delete.retention.ms setting."),
           labels),
+        sm::make_counter(
+          "adjacent_segments_compacted",
+          [this] { return _num_adjacent_segments_compacted; },
+          sm::description("Number of segments that have been compacted away "
+                          "during adjacent merge compaction."),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -90,6 +90,10 @@ public:
         _compaction_removed_bytes += bytes;
     }
 
+    void add_adjacent_segments_compacted(uint64_t num_segments_compacted) {
+        _num_adjacent_segments_compacted += num_segments_compacted;
+    }
+
     void batch_write_error(const std::exception_ptr& e);
 
     void add_batches_read(uint32_t batches) { _batches_read += batches; }
@@ -140,6 +144,7 @@ private:
     uint32_t _batch_write_errors = 0;
     double _compaction_ratio = 1.0;
     uint64_t _tombstones_removed = 0;
+    uint64_t _num_adjacent_segments_compacted = 0;
 
     ssize_t _compaction_removed_bytes = 0;
 


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26180. `cherry-pick` conflict due to other added metrics in `storage/probe.h` not present in previous versions.

Backporting to improve compaction observability for adjacent segment compaction in `v24.3.x`.

Fixes https://github.com/redpanda-data/redpanda/issues/26202

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Adds the `storage_log_adjacent_segments_compacted` metric for better observability into adjacent segment compaction.
