### PR TITLE
config: mark that Iceberg REST props need restart

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3926,7 +3926,7 @@ configuration::configuration()
       "iceberg_rest_catalog_trust_file",
       "Path to a file containing a certificate chain to trust for the REST "
       "Iceberg catalog",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_trust(
@@ -3935,7 +3935,9 @@ configuration::configuration()
       "The contents of a certificate chain to trust for the REST "
       "Iceberg catalog. Takes precedence over "
       "`iceberg_rest_catalog_trust_file`.",
-      {.visibility = visibility::user, .secret = is_secret::yes},
+      {.needs_restart = needs_restart::yes,
+       .visibility = visibility::user,
+       .secret = is_secret::yes},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_crl_file(
@@ -3943,7 +3945,7 @@ configuration::configuration()
       "iceberg_rest_catalog_crl_file",
       "Path to certificate revocation list for "
       "`iceberg_rest_catalog_trust_file`.",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_crl(
@@ -3952,7 +3954,9 @@ configuration::configuration()
       "The contents of a certificate revocation list for "
       "`iceberg_rest_catalog_trust`. Takes precedence over "
       "`iceberg_rest_catalog_crl_file`.",
-      {.visibility = visibility::user, .secret = is_secret::yes},
+      {.needs_restart = needs_restart::yes,
+       .visibility = visibility::user,
+       .secret = is_secret::yes},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_warehouse(
@@ -3961,7 +3965,8 @@ configuration::configuration()
       "Warehouse to use for the Iceberg REST catalog. Redpanda will query the "
       "catalog for configurations specific to the warehouse, for example, "
       "using it to automatically configure the appropriate prefix.",
-      {.visibility = visibility::user,
+      {.needs_restart = needs_restart::yes,
+       .visibility = visibility::user,
        .aliases = {"iceberg_rest_catalog_prefix"}},
       std::nullopt,
       &validate_non_empty_string_opt)
@@ -3971,7 +3976,7 @@ configuration::configuration()
       "The OAuth URI used to retrieve access tokens for Iceberg catalog "
       "authentication. If left undefined, the deprecated Iceberg catalog "
       "endpoint `/v1/oauth/tokens` is used instead.",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_oauth2_scope(
@@ -3980,7 +3985,7 @@ configuration::configuration()
       "The OAuth scope used to retrieve access tokens for Iceberg catalog "
       "authentication. Only meaningful when "
       "`iceberg_rest_catalog_authentication_mode` is set to `oauth2`",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       "PRINCIPAL_ROLE:ALL")
   , iceberg_rest_catalog_authentication_mode(
       *this,


### PR DESCRIPTION
The catalog factory is invoked when the broker starts up, so the updated properties don't take effect until a restart.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Several Iceberg REST catalog configurations are now correctly marked as needing restart.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
