### PR TITLE
admin/server: make admin_server::redirect_to_leader a non-coroutine

### DIFF
--- a/src/v/redpanda/admin/kafka.cc
+++ b/src/v/redpanda/admin/kafka.cc
@@ -50,7 +50,7 @@ admin_server::kafka_transfer_leadership_handler(
     auto shard = _shard_table.local().shard_for(ntp);
     if (!shard) {
         // This node is not a member of the raft group, redirect.
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     co_return co_await _partition_manager.invoke_on(

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -40,7 +40,7 @@ admin_server::get_transactions_handler(std::unique_ptr<ss::http::request> req) {
     const model::ntp ntp = parse_ntp_from_request(req->param);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     auto shard = _shard_table.local().shard_for(ntp);
@@ -155,7 +155,7 @@ admin_server::mark_transaction_expired_handler(
       pid);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     auto shard = _shard_table.local().shard_for(ntp);
@@ -463,7 +463,7 @@ admin_server::force_set_partition_replicas_handler(
     }
 
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     auto ntp = parse_ntp_from_request(req->param);
@@ -687,7 +687,7 @@ admin_server::offset_for_leader_epoch_handler(
   std::unique_ptr<ss::http::request> request) {
     auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*request, ntp);
+        throw redirect_to_leader(*request, ntp);
     }
     vlog(
       adminlog.debug,
@@ -1100,7 +1100,7 @@ ss::future<ss::json::json_return_type>
 admin_server::get_majority_lost_partitions(
   std::unique_ptr<ss::http::request> request) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
+        throw redirect_to_leader(*request, model::controller_ntp);
     }
 
     auto input = request->get_query_param("dead_nodes");
@@ -1379,7 +1379,7 @@ admin_server::force_recover_partitions_from_nodes(
     }
 
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
+        throw redirect_to_leader(*request, model::controller_ntp);
     }
 
     static thread_local json::validator validator(

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -37,7 +37,7 @@ using admin::apply_validator;
 
 ss::future<ss::json::json_return_type>
 admin_server::get_transactions_handler(std::unique_ptr<ss::http::request> req) {
-    const model::ntp ntp = parse_ntp_from_request(req->param);
+    model::ntp ntp = parse_ntp_from_request(req->param);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
         throw redirect_to_leader(*req, ntp);
@@ -169,7 +169,7 @@ admin_server::mark_transaction_expired_handler(
       *shard,
       [_ntp = std::move(ntp), pid, _req = std::move(req), this](
         cluster::partition_manager& pm) mutable
-        -> ss::future<ss::json::json_return_type> {
+      -> ss::future<ss::json::json_return_type> {
           auto ntp = std::move(_ntp);
           auto req = std::move(_req);
           auto partition = pm.get(ntp);
@@ -550,7 +550,7 @@ admin_server::toggle_append_entries_error_injection(
     co_return co_await _partition_manager.invoke_on(
       *shard,
       [ntp = std::move(ntp), inject](cluster::partition_manager& pm) mutable
-        -> ss::future<ss::json::json_return_type> {
+      -> ss::future<ss::json::json_return_type> {
           auto partition = pm.get(ntp);
           if (!partition) {
               return ss::make_exception_future<ss::json::json_return_type>(

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -447,7 +447,7 @@ admin_server::create_user_handler(std::unique_ptr<ss::http::request> req) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     auto doc = co_await parse_json_body(req.get());
@@ -503,7 +503,7 @@ admin_server::delete_user_handler(std::unique_ptr<ss::http::request> req) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     ss::sstring user_v = req->get_path_param("user");
@@ -535,7 +535,7 @@ admin_server::update_user_handler(std::unique_ptr<ss::http::request> req) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     ss::sstring user_v = req->get_path_param("user");
@@ -649,7 +649,7 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::create_role_handler(
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
     auto doc = co_await parse_json_body(req.get());
     auto role_name = parse_role_definition(doc);
@@ -683,7 +683,7 @@ admin_server::update_role_members_handler(
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     ss::sstring role_v = req->get_path_param("role");
@@ -828,7 +828,7 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::delete_role_handler(
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     auto role_name = parse_role_name(*req);

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -708,7 +708,7 @@ void admin_server::log_level_timer_handler() {
     rearm_log_level_timer();
 }
 
-ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
+ss::httpd::redirect_exception admin_server::redirect_to_leader(
   ss::http::request& req, const model::ntp& ntp) const {
     auto leader_id_opt = _metadata_cache.local().get_leader_id(ntp);
 
@@ -859,8 +859,7 @@ ss::future<ss::httpd::redirect_exception> admin_server::redirect_to_leader(
     vlog(
       adminlog.info, "Redirecting admin API call to {} leader at {}", ntp, url);
 
-    co_return ss::httpd::redirect_exception(
-      url, ss::http::reply::status_type::temporary_redirect, retry_after);
+    return {url, ss::http::reply::status_type::temporary_redirect, retry_after};
 }
 
 bool admin_server::need_redirect_to_leader(
@@ -1066,9 +1065,9 @@ ss::future<> admin_server::throw_on_error(
               fmt::format("Service unavailable ({})", ec.message()),
               ss::http::reply::status_type::service_unavailable);
         case cluster::errc::not_leader:
-            throw co_await redirect_to_leader(req, ntp);
+            throw redirect_to_leader(req, ntp);
         case cluster::errc::not_leader_controller:
-            throw co_await redirect_to_leader(req, model::controller_ntp);
+            throw redirect_to_leader(req, model::controller_ntp);
         case cluster::errc::no_update_in_progress:
             throw ss::httpd::bad_request_exception(
               "Cannot cancel partition move operation as there is no move "
@@ -1134,7 +1133,7 @@ ss::future<> admin_server::throw_on_error(
         case raft::errc::transfer_to_current_leader:
             co_return;
         case raft::errc::not_leader:
-            throw co_await redirect_to_leader(req, ntp);
+            throw redirect_to_leader(req, ntp);
         case raft::errc::node_does_not_exists:
         case raft::errc::not_voter:
             // node_does_not_exist is a 400 rather than a 404, because it
@@ -1149,7 +1148,7 @@ ss::future<> admin_server::throw_on_error(
     } else if (ec.category() == cluster::tx::error_category()) {
         switch (cluster::tx::errc(ec.value())) {
         case cluster::tx::errc::leader_not_found:
-            throw co_await redirect_to_leader(req, ntp);
+            throw redirect_to_leader(req, ntp);
         case cluster::tx::errc::pid_not_found:
             throw ss::httpd::not_found_exception(
               fmt_with_ctx(fmt::format, "Can not find pid for ntp:{}", ntp));
@@ -2270,7 +2269,7 @@ admin_server::put_feature_handler(std::unique_ptr<ss::http::request> req) {
     }
 
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     auto& fm = _controller->get_feature_manager();
@@ -3011,7 +3010,7 @@ admin_server::self_test_start_handler(std::unique_ptr<ss::http::request> req) {
       make_self_test_start_validator());
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         vlog(adminlog.debug, "Need to redirect self_test_start request");
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
     auto doc = co_await parse_json_body(req.get());
     apply_validator(self_test_start_validator, doc);
@@ -3068,7 +3067,7 @@ ss::future<ss::json::json_return_type>
 admin_server::self_test_stop_handler(std::unique_ptr<ss::http::request> req) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         vlog(adminlog.info, "Need to redirect self_test_stop request");
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
     auto r = co_await _self_test_frontend.invoke_on(
       cluster::self_test_frontend::shard,
@@ -3394,7 +3393,7 @@ admin_server::post_cluster_partitions_topic_handler(
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     auto ns_tp = model::topic_namespace{
@@ -3425,7 +3424,7 @@ admin_server::post_cluster_partitions_topic_partition_handler(
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         // In order that we can do a reliably ordered validation of
         // the request (and drop no-op requests), run on controller leader;
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
 
     auto ntp = parse_ntp_from_request(req->param);
@@ -3859,7 +3858,7 @@ ss::future<ss::json::json_return_type> admin_server::sync_local_state_handler(
     auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
         vlog(adminlog.info, "Need to redirect bucket syncup request");
-        throw co_await redirect_to_leader(*request, ntp);
+        throw redirect_to_leader(*request, ntp);
     } else {
         auto result = co_await _partition_manager.map_reduce(
           manifest_reducer(), [ntp](cluster::partition_manager& p) {
@@ -3894,7 +3893,7 @@ admin_server::unsafe_reset_metadata(
     auto ntp = parse_ntp_from_request(request->param, model::kafka_namespace);
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
         vlog(adminlog.info, "Need to redirect unsafe reset metadata request");
-        throw co_await redirect_to_leader(*request, ntp);
+        throw redirect_to_leader(*request, ntp);
     }
     if (request->content_length <= 0) {
         throw ss::httpd::bad_request_exception("Empty request content");
@@ -3945,7 +3944,7 @@ admin_server::initiate_topic_scan_and_recovery(
     reply->set_content_type("json");
 
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
+        throw redirect_to_leader(*request, model::controller_ntp);
     }
 
     if (!_topic_recovery_service.local_is_initialized()) {
@@ -4019,7 +4018,7 @@ admin_server::initialize_cluster_recovery(
           "Cluster restore is not available, recovery mode enabled");
     }
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
+        throw redirect_to_leader(*request, model::controller_ntp);
     }
     auto& bucket_property = cloud_storage::configuration::get_bucket_config();
     if (!bucket_property.is_overriden() || !bucket_property().has_value()) {
@@ -4040,7 +4039,7 @@ admin_server::initialize_cluster_recovery(
     }
     auto err = error_res.value();
     if (err == cluster::errc::not_leader_controller) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
+        throw redirect_to_leader(*request, model::controller_ntp);
     }
     if (err == cluster::errc::cluster_already_exists) {
         throw ss::httpd::base_exception{
@@ -4065,7 +4064,7 @@ admin_server::initialize_cluster_recovery(
 ss::future<ss::json::json_return_type>
 admin_server::get_cluster_recovery(std::unique_ptr<ss::http::request> req) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
+        throw redirect_to_leader(*req, model::controller_ntp);
     }
     ss::httpd::shadow_indexing_json::cluster_recovery_status ret;
     ret.state = "inactive";
@@ -4372,7 +4371,7 @@ admin_server::get_partition_cloud_storage_status(
       req->param, model::kafka_namespace);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     const auto shard = _shard_table.local().shard_for(ntp);
@@ -4495,7 +4494,7 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::get_manifest(
     }
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     const auto shard = _shard_table.local().shard_for(ntp);
@@ -4552,7 +4551,7 @@ admin_server::get_cloud_storage_anomalies(
     const model::ntp ntp = parse_ntp_from_request(req->param);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     const auto& topic_table = _controller->get_topics_state().local();
@@ -4606,7 +4605,7 @@ admin_server::unsafe_reset_metadata_from_cloud(
         vlog(
           adminlog.info,
           "Need to redirect unsafe reset metadata from cloud request");
-        throw co_await redirect_to_leader(*request, ntp);
+        throw redirect_to_leader(*request, ntp);
     }
 
     const auto shard = _shard_table.local().shard_for(ntp);
@@ -4645,7 +4644,7 @@ admin_server::reset_scrubbing_metadata(std::unique_ptr<ss::http::request> req) {
       req->param, model::kafka_namespace);
 
     if (need_redirect_to_leader(ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, ntp);
+        throw redirect_to_leader(*req, ntp);
     }
 
     const auto shard = _shard_table.local().shard_for(ntp);

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -723,7 +723,7 @@ private:
       std::error_code ec,
       const model::ntp& ntp,
       model::node_id id = model::node_id{-1}) const;
-    ss::future<ss::httpd::redirect_exception>
+    ss::httpd::redirect_exception
     redirect_to_leader(ss::http::request& req, const model::ntp& ntp) const;
 
     ss::future<ss::json::json_return_type> cancel_node_partition_moves(

--- a/src/v/redpanda/admin/transaction.cc
+++ b/src/v/redpanda/admin/transaction.cc
@@ -74,7 +74,7 @@ admin_server::get_all_transactions_handler(
       model::partition_id(coordinator_partition));
 
     if (need_redirect_to_leader(tx_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, tx_ntp);
+        throw redirect_to_leader(*req, tx_ntp);
     }
 
     if (!_tx_gateway_frontend.local_is_initialized()) {
@@ -182,7 +182,7 @@ admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
         throw ss::httpd::bad_request_exception("Coordinator not available");
     }
     if (need_redirect_to_leader(*r.ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, *r.ntp);
+        throw redirect_to_leader(*req, *r.ntp);
     }
 
     auto tx_ntp = _tx_gateway_frontend.local().ntp_for_tx_id(tid);


### PR DESCRIPTION
There seems to be no reason for it to be a coroutine, it does not co_await anything and did not 4 years ago when it was created.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
* 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
