### PR TITLE
`rptest`: correct exception handling in `test_stress_consumer_group_commits`

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1697,7 +1697,14 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
         olv = OfflineLogViewer(self.redpanda)
 
         def get_summary(node):
-            summary = olv.consumer_offsets_summary(node)
+            try:
+                summary = olv.consumer_offsets_summary(node)
+            except Exception as e:
+                self.logger.debug(
+                    f"Caught exception {e} while collecting consumer offsets summary, retrying"
+                )
+                return False
+
             for _, cg_partition_summary in summary.items():
                 assert len(
                     cg_partition_summary['raft_configurations']
@@ -1717,7 +1724,6 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
                 lambda: get_summary(n),
                 timeout_sec=60,
                 backoff_sec=1,
-                retry_on_exc=True,
                 err_msg=
                 f"Failed to get consumer offsets summary for node {n.account.hostname}"
             )


### PR DESCRIPTION
As pointed out in https://github.com/redpanda-data/redpanda/pull/26185#discussion_r2100249786, `retry_on_exc` will retry any exception, even `AssertionError`s raised by failed `assert` statements within `get_summary()`.

While the conditions which would cause the `assert` statements to fail likely aren't transient errors, we should fail the test upon first sighting of one of these failed `assert`s per test expectations.

Alter the error handling to retry the collection of the consumer offsets summary from the `OfflineLogViewer` should an exception be raised, but do not allow any of the `assert`s to be retriable failures.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
