### PR TITLE
[v24.2.x] rpk: improve rpk debug bundle assumptions in k8s environments 

### DIFF
--- a/src/go/rpk/Makefile
+++ b/src/go/rpk/Makefile
@@ -11,6 +11,13 @@ GOCMD=go
 GOLANGCILINTCMD=golangci-lint
 GOFUMPTCMD=gofumpt
 BAZELCMD=bazel
+ifeq ($(shell uname),Darwin)
+    BAZELCMD := bazelisk
+    GOFUMPT_OS_CMD := $(shell find . -type f -name '*.go' -print0 | xargs -0 -n 1 $(GOFUMPTCMD) -w)
+else
+	BAZELCMD := bazel
+    GOFUMPT_OS_CMD := 	$(shell find -type f -name '*.go' | xargs -n1 $(GOFUMPTCMD) -w)
+endif
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
+
 package bundle
 
 import (

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -168,7 +168,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVar(&logsSizeLimit, "logs-size-limit", "100MiB", "Read the logs until the given size is reached (e.g. 3MB, 1GiB)")
 	f.StringVar(&controllerLogsSizeLimit, "controller-logs-size-limit", "132MB", "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB)")
 	f.StringVar(&uploadURL, "upload-url", "", "If provided, where to upload the bundle in addition to creating a copy on disk")
-	f.StringVarP(&namespace, "namespace", "n", "redpanda", "The namespace to use to collect the resources from (k8s only)")
+	f.StringVarP(&namespace, "namespace", "n", "", "The namespace to use to collect the resources from (k8s only)")
 	f.StringArrayVarP(&labelSelector, "label-selector", "l", []string{"app.kubernetes.io/name=redpanda"}, "Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only)")
 	f.StringArrayVarP(&partitionFlag, "partition", "p", nil, "Comma-separated partition IDs; when provided, rpk saves extra admin API requests for those partitions. Check help for extended usage")
 	f.DurationVar(&cpuProfilerWait, "cpu-profiler-wait", 30*time.Second, "For how long to collect samples for the CPU profiler (e.g. 30s, 1.5m). Must be higher than 15s")

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_all.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_all.go
@@ -12,21 +12,19 @@
 package bundle
 
 import (
-	"context"
-	"errors"
-
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
 	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
 )
 
-func executeBundle(context.Context, bundleParams) error {
-	return errors.New("rpk debug bundle is unsupported on your operating system")
-}
-
-func executeK8SBundle(context.Context, bundleParams) error {
-	return errors.New("rpk debug bundle is unsupported on your operating system")
-}
-
-func determineFilepath(afero.Fs, *config.RedpandaYaml, string, bool) (string, error) {
-	return "", errors.New("rpk debug bundle is not supported on your operating system")
+func NewCommand(_ afero.Fs, _ *config.Params) *cobra.Command {
+	return &cobra.Command{
+		Use:   "bundle",
+		Short: "Collect environment data and create a bundle file for the Redpanda Data support team to inspect",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			out.Die("rpk debug bundle is not supported on your operating system")
+		},
+	}
 }

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -159,6 +159,9 @@ func k8sClientset() (*kubernetes.Clientset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get kubernetes cluster configuration: %v", err)
 	}
+	// We need to increase the burst size to avoid throttling. We do ~6-8 req
+	// per broker.
+	k8sCfg.Burst = 30
 
 	return kubernetes.NewForConfig(k8sCfg)
 }
@@ -524,7 +527,6 @@ func saveK8SLogs(ctx context.Context, ps *stepParams, namespace, since string, l
 		limitBytes := int64(logsLimitBytes)
 		logOpts := &k8score.PodLogOptions{
 			LimitBytes: &limitBytes,
-			Container:  "redpanda",
 		}
 
 		if len(since) > 0 {
@@ -538,12 +540,22 @@ func saveK8SLogs(ctx context.Context, ps *stepParams, namespace, since string, l
 
 		var grp multierror.Group
 		for _, p := range pods.Items {
-			p := p
-			cb := func(ctx context.Context) ([]byte, error) {
-				return podsInterface.GetLogs(p.Name, logOpts).Do(ctx).Raw()
+			for _, c := range p.Spec.Containers {
+				opts := logOpts.DeepCopy()
+				opts.Container = c.Name
+				cb := func(ctx context.Context) ([]byte, error) {
+					return podsInterface.GetLogs(p.Name, opts).Do(ctx).Raw()
+				}
+				grp.Go(func() error { return requestAndSave(ctx, ps, fmt.Sprintf("logs/%v-%v.txt", p.Name, c.Name), cb) })
 			}
-
-			grp.Go(func() error { return requestAndSave(ctx, ps, fmt.Sprintf("logs/%v.txt", p.Name), cb) })
+			for _, c := range p.Spec.InitContainers {
+				opts := logOpts.DeepCopy()
+				opts.Container = c.Name
+				cb := func(ctx context.Context) ([]byte, error) {
+					return podsInterface.GetLogs(p.Name, opts).Do(ctx).Raw()
+				}
+				grp.Go(func() error { return requestAndSave(ctx, ps, fmt.Sprintf("logs/%v-init-%v.txt", p.Name, c.Name), cb) })
+			}
 		}
 
 		errs := grp.Wait()

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -130,6 +130,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
+		errs.ErrorFormat = errorFormat
 		fmt.Println(errs.Error())
 	}
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -65,7 +65,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		fileRoot: strings.TrimSuffix(filepath.Base(bp.path), ".zip"),
 	}
 	var errs *multierror.Error
-
+	bp.namespace = resolveNamespace(bp.namespace)
 	steps := []step{
 		saveCPUInfo(ps),
 		saveCmdLine(ps),
@@ -263,6 +263,29 @@ func getClusterDomain() string {
 	clusterDomain := strings.TrimPrefix(cname, apiSvc+".")
 
 	return clusterDomain
+}
+
+// resolveNamespace determines the Kubernetes namespace to use based on the
+// following priority order:
+//  1. The `--namespace` flag, if provided.
+//  2. The `NAMESPACE` environment variable, if set.
+//  3. The contents of the file
+//     `/var/run/secrets/kubernetes.io/serviceaccount/namespace`, if it exists.
+//  4. A default fallback value of "redpanda".
+func resolveNamespace(ns string) string {
+	if ns != "" {
+		return ns
+	}
+	zap.L().Sugar().Warn("flag '--namespace' not set; reading from $NAMESPACE")
+	if envNamespace := os.Getenv("NAMESPACE"); envNamespace != "" {
+		return envNamespace
+	}
+	zap.L().Sugar().Warn("$NAMESPACE not set; reading /var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	zap.L().Sugar().Warn("could not identify namespace; using default 'redpanda'")
+	return "redpanda"
 }
 
 // saveClusterAdminAPICalls saves per-cluster Admin API requests in the 'admin/'

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -101,19 +101,21 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 
 		adminAddresses, err = adminAddressesFromK8S(ctx, bp.namespace)
 		if err != nil {
-			zap.L().Sugar().Debugf("unable to get admin API addresses from the k8s API: %v", err)
+			zap.L().Sugar().Warnf("unable to get admin API addresses from the k8s API: %v", err)
 		}
+	}
+	// It's always safe to use the admin API addresses from the profile, even if
+	// we already have the addresses from the k8s API.
+	if len(bp.p.AdminAPI.Addresses) > 0 {
+		adminAddresses = adminAddressesUnion(bp.p.AdminAPI.Addresses, adminAddresses)
+	} else {
+		zap.L().Sugar().Warnf("no admin API addresses found in the current rpk profile")
 	}
 	if len(adminAddresses) == 0 {
-		if len(bp.p.AdminAPI.Addresses) > 0 {
-			zap.L().Sugar().Debugf("using admin API addresses from profile: %v", bp.p.AdminAPI.Addresses)
-			adminAddresses = bp.p.AdminAPI.Addresses
-		} else {
-			defaultAddress := fmt.Sprintf("127.0.0.1:%v", config.DefaultAdminPort)
-			zap.L().Sugar().Debugf("profile empty, using %v for the Admin API address", defaultAddress)
-			adminAddresses = []string{defaultAddress}
-		}
+		defaultAddress := fmt.Sprintf("127.0.0.1:%v", config.DefaultAdminPort)
+		adminAddresses = []string{defaultAddress}
 	}
+	zap.L().Debug("using admin API addresses", zap.Strings("addresses", adminAddresses))
 	steps = append(steps, []step{
 		saveClusterAdminAPICalls(ctx, ps, bp.fs, bp.p, adminAddresses, bp.partitions),
 		saveSingleAdminAPICalls(ctx, ps, bp.fs, bp.p, adminAddresses, bp.metricsInterval, bp.cpuProfilerWait),
@@ -136,6 +138,20 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 
 	fmt.Printf("Debug bundle saved to %q\n", f.Name())
 	return nil
+}
+
+// adminAddressesUnion returns the union of two slices of adminAddresses.
+func adminAddressesUnion(a, b []string) []string {
+	m := make(map[string]struct{}) // track unique addresses.
+	for _, v := range a {
+		m[v] = struct{}{}
+	}
+	for _, v := range b {
+		if _, ok := m[v]; !ok {
+			a = append(a, v)
+		}
+	}
+	return a
 }
 
 func k8sClientset() (*kubernetes.Clientset, error) {

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -169,11 +169,27 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
+		errs.ErrorFormat = errorFormat
 		fmt.Println(errs.Error())
 	}
 
 	fmt.Printf("Debug bundle saved to '%s'\n", bp.path)
 	return nil
+}
+
+func errorFormat(errs []error) string {
+	if len(errs) == 1 {
+		return fmt.Sprintf("Debug bundle successfully generated. 1 diagnostic failed:\n\t* %s\n\n", errs[0])
+	}
+
+	points := make([]string, len(errs))
+	for i, err := range errs {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"Debug bundle successfully generated. %d diagnostics failed:\n\t%s\n\n",
+		len(errs), strings.Join(points, "\n\t"))
 }
 
 type step func() error


### PR DESCRIPTION
Backport of #26091


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* rpk debug bundle: improve reliability of debug bundle collection in k8s environments.
