### PR TITLE
CORE-10195 k/client: Added support for `describe_topics`

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -58,6 +58,7 @@ redpanda_cc_library(
         "//src/v/kafka/protocol:api_versions",
         "//src/v/kafka/protocol:create_topics",
         "//src/v/kafka/protocol:delete_records",
+        "//src/v/kafka/protocol:describe_configs",
         "//src/v/kafka/protocol:describe_groups",
         "//src/v/kafka/protocol:fetch",
         "//src/v/kafka/protocol:find_coordinator",

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -10,6 +10,7 @@
 #include "kafka/client/client.h"
 
 #include "base/seastarx.h"
+#include "container/fragmented_vector.h"
 #include "kafka/client/broker.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/consumer.h"
@@ -575,6 +576,38 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
                   [res{std::move(res)}]() mutable { return std::move(res); });
           });
     });
+}
+
+ss::future<kafka::describe_configs_response> client::describe_topics(
+  chunked_vector<model::topic> topics,
+  std::optional<chunked_vector<ss::sstring>> configuration_keys) {
+    co_return co_await gated_retry_with_mitigation(
+      [this, &topics, &configuration_keys]() {
+          // Copy here to ensure retries can call the lambda again
+          return do_describe_topics(
+            topics.copy(),
+            configuration_keys.transform(&chunked_vector<ss::sstring>::copy));
+      });
+}
+
+ss::future<kafka::describe_configs_response> client::do_describe_topics(
+  chunked_vector<model::topic> topics,
+  std::optional<chunked_vector<ss::sstring>> configuration_keys) {
+    auto broker = co_await _brokers.any();
+
+    chunked_vector<describe_configs_resource> dcr;
+    dcr.reserve(topics.size());
+    for (const auto& topic : topics) {
+        dcr.push_back(describe_configs_resource{
+          .resource_type = config_resource_type::topic,
+          .resource_name = topic(),
+          .configuration_keys = configuration_keys.transform(
+            &chunked_vector<ss::sstring>::copy),
+        });
+    }
+
+    co_return co_await broker->dispatch(
+      describe_configs_request{.data = {.resources = std::move(dcr)}});
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -24,6 +24,7 @@
 #include "kafka/client/types.h"
 #include "kafka/client/utils.h"
 #include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/describe_configs.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/list_offset.h"
 #include "ssx/semaphore.h"
@@ -162,6 +163,20 @@ public:
       std::optional<std::chrono::milliseconds> timeout,
       std::optional<int32_t> max_bytes);
 
+    ss::future<describe_configs_response> describe_topics(
+      chunked_vector<model::topic> topics,
+      std::optional<chunked_vector<ss::sstring>> configuration_keys
+      = std::nullopt);
+
+    ss::future<describe_configs_response> describe_topics(
+      model::topic topic,
+      std::optional<chunked_vector<ss::sstring>> configuration_keys
+      = std::nullopt) {
+        return describe_topics(
+          chunked_vector<model::topic>{std::move(topic)},
+          std::move(configuration_keys));
+    }
+
     ss::future<> update_metadata() { return _wait_or_start_update_metadata(); }
 
     ss::future<bool> is_connected() const {
@@ -173,6 +188,10 @@ public:
 private:
     ss::future<list_offsets_response>
     do_list_offsets(model::topic_partition tp);
+
+    ss::future<describe_configs_response> do_describe_topics(
+      chunked_vector<model::topic> topics,
+      std::optional<chunked_vector<ss::sstring>> configuration_keys);
 
     /// \brief Connect and update metdata.
     ss::future<> do_connect(net::unresolved_address addr);

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -250,3 +250,26 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "describe_topics",
+    timeout = "short",
+    srcs = [
+        "describe_topics.cc",
+    ],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/kafka/client",
+        "//src/v/kafka/client/test:fixture",
+        "//src/v/kafka/client/test:utils",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:create_topics",
+        "//src/v/kafka/protocol:describe_configs",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/kafka/client/test/describe_topics.cc
+++ b/src/v/kafka/client/test/describe_topics.cc
@@ -1,0 +1,140 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "container/fragmented_vector.h"
+#include "kafka/client/client.h"
+#include "kafka/client/test/fixture.h"
+#include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/describe_configs.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/types.h"
+#include "model/fundamental.h"
+
+#include <boost/test/tools/old/interface.hpp>
+
+class describe_topic_fixture : public kafka_client_fixture {};
+
+FIXTURE_TEST(test_describe_topic, describe_topic_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    info("Describe an unknown topic");
+    const auto unknown_tp = model::topic("non-existent");
+    const auto unknown_tp_resp = client.describe_topics(unknown_tp).get();
+    BOOST_REQUIRE_EQUAL(unknown_tp_resp.data.results.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      unknown_tp_resp.data.results[0].error_code,
+      kafka::error_code::unknown_topic_or_partition);
+
+    info("Create and describe an existing topic");
+    const auto topic = create_topic();
+    const auto resp = client.describe_topics(topic.tp).get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.results.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.results[0].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.results[0].resource_type, kafka::config_resource_type::topic);
+    BOOST_REQUIRE_EQUAL(resp.data.results[0].resource_name, topic.tp());
+    BOOST_REQUIRE_GE(resp.data.results[0].configs.size(), 0);
+}
+
+namespace {
+
+std::optional<kafka::describe_configs_resource_result> find_config(
+  const chunked_vector<kafka::describe_configs_resource_result>& configs,
+  std::string_view target) {
+    auto it = std::ranges::find(
+      configs, target, &kafka::describe_configs_resource_result::name);
+    return it != configs.end() ? std::optional{*it} : std::nullopt;
+}
+
+} // namespace
+
+FIXTURE_TEST(test_describe_with_configuration_keys, describe_topic_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    const auto topic = model::topic("topic-with-custom-configs");
+    const auto custom_config = kafka::createable_topic_config{
+      .name = "cleanup.policy", .value = "compact"};
+
+    info("Create a topic with custom topics");
+    kafka::creatable_topic req{
+      .name = topic,
+      .num_partitions = 1,
+      .replication_factor = 1,
+      .configs = {custom_config},
+    };
+    const auto created_topic = client.create_topic(std::move(req));
+
+    {
+        info("Checking if describing the topic returns the custom config");
+        const auto resp = client.describe_topics(topic).get();
+        BOOST_REQUIRE_EQUAL(resp.data.results.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.results[0].error_code, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.results[0].resource_type,
+          kafka::config_resource_type::topic);
+        BOOST_REQUIRE_EQUAL(resp.data.results[0].resource_name, topic);
+        BOOST_REQUIRE_GE(resp.data.results[0].configs.size(), 0);
+        const auto found = find_config(
+          resp.data.results[0].configs, custom_config.name);
+        BOOST_REQUIRE(found);
+        BOOST_REQUIRE(found->value == custom_config.value);
+    }
+
+    {
+        info("Checking if requesting to describe the custom config returns it");
+        const auto req_confs = chunked_vector<ss::sstring>{custom_config.name};
+        const auto resp = client.describe_topics(topic, req_confs.copy()).get();
+        BOOST_REQUIRE_EQUAL(resp.data.results.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.results[0].error_code, kafka::error_code::none);
+        BOOST_REQUIRE_GE(resp.data.results[0].configs.size(), req_confs.size());
+        BOOST_REQUIRE(
+          find_config(resp.data.results[0].configs, custom_config.name));
+    }
+
+    {
+        info("Checking if requesting multiple configs works");
+        const auto req_confs = chunked_vector<ss::sstring>{
+          custom_config.name, "max.message.bytes"};
+        auto resp = client.describe_topics(topic, req_confs.copy()).get();
+        BOOST_REQUIRE_EQUAL(resp.data.results.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.results[0].error_code, kafka::error_code::none);
+        BOOST_REQUIRE_GE(resp.data.results[0].configs.size(), req_confs.size());
+        for (const auto& conf : req_confs) {
+            BOOST_REQUIRE(find_config(resp.data.results[0].configs, conf));
+        }
+    }
+}
+
+FIXTURE_TEST(test_describe_topic_multiple, describe_topic_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    const auto t1 = create_topic(1, 1);
+    const auto t2 = create_topic(1, 2);
+
+    info("Describe two topics at the same time");
+    const auto resp
+      = client.describe_topics(chunked_vector<model::topic>{t1.tp, t2.tp})
+          .get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.results.size(), 2);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.results[0].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.results[0].resource_name, t1.tp());
+    BOOST_REQUIRE_EQUAL(
+      resp.data.results[1].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.results[1].resource_name, t2.tp());
+}

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -216,6 +216,8 @@ public:
             return dispatch(std::move(r), api_version(2));
         } else if constexpr (std::is_same_v<type, sasl_authenticate_request>) {
             return dispatch(std::move(r), api_version(1));
+        } else if constexpr (std::is_same_v<type, describe_configs_request>) {
+            return dispatch(std::move(r), api_version(4));
         }
     }
 

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -56,6 +56,18 @@ auto retry_with_mitigation(
                           // ignore failed mitigation
                       });
                 }
+
+                static_assert(
+                  std::is_invocable_v<const Func&>,
+                  "Func must have a const operator(), i.e., it must not be a "
+                  "mutable lambda or functor with non-const call operator. "
+                  "This is to prevent problematic usage patterns where state "
+                  "is moved-from on retries. For example, the following is "
+                  "problematic:\n"
+                  "\tauto bad_func = [movable_state]() mutable {\n"
+                  "\t    auto _ = consume(std::move(movable_state));\n"
+                  "\t};");
+
                 return fut.then(func).handle_exception(
                   [&eptr](std::exception_ptr ex) mutable {
                       eptr = ex;


### PR DESCRIPTION
This introduces a new API on the internal kafka client to describe the topic configs of a topic using the DescribeConfigs Kafka API.

This is going to be used later for topic config syncing for Disaster Recovery.

Fixes https://redpandadata.atlassian.net/browse/CORE-10195

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
