### PR TITLE
storage/tests: Migrate 5 more Boost tests to Google Test

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -221,6 +221,7 @@ def redpanda_cc_gtest(
         env = {},
         cpu = None,
         memory = None,
+        target_compatible_with = [],
         data = [],
         tags = []):
     _redpanda_cc_unit_test(
@@ -234,6 +235,7 @@ def redpanda_cc_gtest(
         deps = deps,
         custom_args = args,
         env = env,
+        target_compatible_with = target_compatible_with,
         data = data,
         local_defines = ["IS_GTEST"],
         tags = tags,

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -473,7 +473,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "offset_index_utils_tests",
     timeout = "short",
     srcs = [
@@ -484,12 +484,11 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/storage",
         "//src/v/test_utils:fixture",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:tmpbuf_file",
         "//src/v/utils:file_io",
-        "@boost//:test",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -271,7 +271,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "batch_cache_reclaim_test",
     timeout = "short",
     srcs = [
@@ -285,10 +285,9 @@ redpanda_cc_btest(
         "//src/v/model",
         "//src/v/storage:batch_cache",
         "//src/v/storage:record_batch_builder",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -614,7 +614,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "segment_size_jitter_test",
     timeout = "short",
     srcs = [
@@ -622,10 +622,8 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/storage",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
-        "@seastar",
-        "@seastar//:testing",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -405,7 +405,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "record_batch_builder_test",
     timeout = "short",
     srcs = [
@@ -418,10 +418,9 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/reflection:adl",
         "//src/v/storage:record_batch_builder",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/container:btree",
-        "@boost//:test",
-        "@seastar//:testing",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -212,7 +212,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "log_manager_test",
     timeout = "short",
     srcs = [
@@ -227,11 +227,10 @@ redpanda_cc_btest(
         "//src/v/storage:logger",
         "//src/v/storage:record_batch_utils",
         "//src/v/storage:segment_appender",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/batch_cache_reclaim_test.cc
+++ b/src/v/storage/tests/batch_cache_reclaim_test.cc
@@ -14,9 +14,8 @@
 
 #include <seastar/core/memory.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/testing/thread_test_case.hh>
 
-#include <boost/test/unit_test.hpp>
+#include <gtest/gtest.h>
 
 #include <algorithm>
 
@@ -41,9 +40,7 @@ model::record_batch make_batch(size_t size) {
     return batch;
 }
 
-class fixture {};
-
-FIXTURE_TEST(reclaim, fixture) {
+TEST(BatchCacheReclaimTest, reclaim) {
     using namespace std::chrono_literals;
 
     storage::batch_cache cache(opts);
@@ -53,25 +50,21 @@ FIXTURE_TEST(reclaim, fixture) {
 
     auto stats = ss::memory::stats();
 
-    BOOST_TEST(stats.reclaims() == 0);
-    BOOST_REQUIRE(stats.free_memory() > ss::memory::min_free_memory());
+    EXPECT_EQ(stats.reclaims(), 0);
+    ASSERT_GT(stats.free_memory(), ss::memory::min_free_memory());
     size_t bytes_until_reclaim = stats.free_memory()
                                  - ss::memory::min_free_memory();
 
-    info(
-      "memory stats (kb) total {} free {} min_free {} until_reclaim {} "
-      "reclaims {}",
-      stats.total_memory() / 1024,
-      stats.free_memory() / 1024,
-      ss::memory::min_free_memory() / 1024,
-      bytes_until_reclaim / 1024,
-      stats.reclaims());
+    SUCCEED() << "memory stats (kb) total " << stats.total_memory() / 1024
+              << " free " << stats.free_memory() / 1024 << " min_free "
+              << ss::memory::min_free_memory() / 1024 << " until_reclaim "
+              << bytes_until_reclaim / 1024 << " reclaims " << stats.reclaims();
 
     size_t pages_until_reclaim = bytes_until_reclaim / ss::memory::page_size;
 
     // ensure there is some wiggle room. otherwise the test might be a bit
     // unreliable operating on the edge of reclaim
-    BOOST_TEST_REQUIRE(pages_until_reclaim > 20, "please run with more memory");
+    ASSERT_GT(pages_until_reclaim, 20) << "please run with more memory";
 
     // insert batches into the cache up to roughly have the amount needed to
     // trigger reclaim
@@ -85,20 +78,20 @@ FIXTURE_TEST(reclaim, fixture) {
     ss::thread::yield();
 
     // all of the cache entries should be valid
-    BOOST_CHECK(std::all_of(
+    EXPECT_TRUE(std::all_of(
       cache_entries.begin(),
       cache_entries.end(),
       [](storage::batch_cache::entry& e) { return (bool)e.range(); }));
 
     stats = ss::memory::stats();
-    BOOST_TEST(stats.reclaims() == 0);
+    EXPECT_EQ(stats.reclaims(), 0);
 
     // now allocate past what should cause relcaims to trigger
     for (size_t i = 0; i < pages_until_reclaim; i++) {
         size_t buf_size = ss::memory::page_size - sizeof(model::record_batch);
         auto batch = make_batch(buf_size);
         auto e = cache.put(index, std::move(batch), is_dirty_entry::no);
-        BOOST_REQUIRE((bool)e.range());
+        ASSERT_TRUE((bool)e.range());
         cache_entries.emplace_back(std::move(e));
     }
 
@@ -106,21 +99,17 @@ FIXTURE_TEST(reclaim, fixture) {
     ss::thread::yield();
 
     // now some of the cache entries should have been reclaimed
-    BOOST_CHECK(std::any_of(
+    EXPECT_TRUE(std::any_of(
       cache_entries.begin(),
       cache_entries.end(),
       [](storage::batch_cache::entry& e) { return !e.range(); }));
 
     stats = ss::memory::stats();
-    BOOST_TEST(stats.reclaims() > 0);
+    EXPECT_GT(stats.reclaims(), 0);
 
-    info(
-      "memory stats (kb) total {} free {} min_free {} until_reclaim {} "
-      "reclaims {}",
-      stats.total_memory() / 1024,
-      stats.free_memory() / 1024,
-      ss::memory::min_free_memory() / 1024,
-      bytes_until_reclaim / 1024,
-      stats.reclaims());
+    SUCCEED() << "memory stats (kb) total " << stats.total_memory() / 1024
+              << " free " << stats.free_memory() / 1024 << " min_free "
+              << ss::memory::min_free_memory() / 1024 << " until_reclaim "
+              << bytes_until_reclaim / 1024 << " reclaims " << stats.reclaims();
     cache.stop().get();
 }

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -22,8 +22,9 @@
 #include "test_utils/random_bytes.h"
 
 #include <seastar/core/thread.hh>
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
 
 using namespace std::chrono_literals; // NOLINT
 using namespace storage;              // NOLINT
@@ -69,7 +70,7 @@ ntp_config config_from_ntp(const model::ntp& ntp) {
 constexpr size_t default_segment_readahead_size = 128 * 1024;
 constexpr unsigned default_segment_readahead_count = 10;
 
-SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
+TEST(LogManagerTest, test_can_load_logs) {
     auto conf = make_config();
 
     ss::logger test_logger("test-logger");
@@ -144,14 +145,14 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     m.manage(config_from_ntp(ntps[1].ntp())).get();
     m.manage(config_from_ntp(ntps[2].ntp())).get();
     m.manage(config_from_ntp(ntps[3].ntp())).get();
-    BOOST_CHECK_EQUAL(4, m.size());
-    BOOST_CHECK_EQUAL(m.get(ntps[0].ntp())->segment_count(), 0);
-    BOOST_CHECK_EQUAL(m.get(ntps[1].ntp())->segment_count(), 0);
-    BOOST_CHECK_EQUAL(m.get(ntps[2].ntp())->segment_count(), 1);
-    BOOST_CHECK_EQUAL(m.get(ntps[3].ntp())->segment_count(), 0);
-    BOOST_CHECK(!file_exists(seg->reader().filename()).get());
-    BOOST_CHECK(file_exists(seg3->reader().filename()).get());
-    BOOST_CHECK(!file_exists(seg4->reader().filename()).get());
-    BOOST_CHECK(
+    EXPECT_EQ(4, m.size());
+    EXPECT_EQ(m.get(ntps[0].ntp())->segment_count(), 0);
+    EXPECT_EQ(m.get(ntps[1].ntp())->segment_count(), 0);
+    EXPECT_EQ(m.get(ntps[2].ntp())->segment_count(), 1);
+    EXPECT_EQ(m.get(ntps[3].ntp())->segment_count(), 0);
+    EXPECT_FALSE(file_exists(seg->reader().filename()).get());
+    EXPECT_TRUE(file_exists(seg3->reader().filename()).get());
+    EXPECT_FALSE(file_exists(seg4->reader().filename()).get());
+    EXPECT_TRUE(
       file_exists(seg4->reader().filename() + ".cannotrecover").get());
 }

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -15,12 +15,12 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>
 
-#include <boost/test/tools/old/interface.hpp>
+#include <gtest/gtest.h>
 
 using namespace storage;
 
 namespace storage {
-class offset_index_utils_fixture {
+class offset_index_utils_fixture : public testing::Test {
 public:
     offset_index_utils_fixture(model::offset base = model::offset(0)) {
         _base_offset = base;
@@ -52,9 +52,9 @@ public:
     void index_entry_expect(uint32_t offset, size_t filepos) {
         auto o = model::offset(offset);
         auto p = _idx->find_nearest(o);
-        BOOST_REQUIRE(bool(p));
-        BOOST_REQUIRE_EQUAL(p->offset, o);
-        BOOST_REQUIRE_EQUAL(p->filepos, filepos);
+        ASSERT_TRUE(bool(p));
+        ASSERT_EQ(p->offset, o);
+        ASSERT_EQ(p->filepos, filepos);
     }
 
     model::offset _base_offset;
@@ -65,11 +65,11 @@ public:
 };
 } // namespace storage
 
-FIXTURE_TEST(index_round_trip, offset_index_utils_fixture) {
+TEST_F(offset_index_utils_fixture, index_round_trip) {
     start().get();
 
-    BOOST_CHECK(true);
-    info("index: {}", _idx);
+    EXPECT_TRUE(true);
+    SUCCEED() << "index: " << _idx;
     for (uint32_t i = 0; i < 1024; ++i) {
         model::offset o = _base_offset + model::offset(i);
         _idx->maybe_track(
@@ -77,22 +77,22 @@ FIXTURE_TEST(index_round_trip, offset_index_utils_fixture) {
           std::nullopt,
           i);
     }
-    info("About to flush index");
+    SUCCEED() << "About to flush index";
     _idx->flush().get();
     auto data = _data.share_iobuf();
-    info("{} - serializing from bytes into mem: buffer{}", _idx, data);
+    SUCCEED() << _idx << " - serializing from bytes into mem: buffer" << data;
     auto raw_idx = serde::from_iobuf<storage::index_state>(
       data.share(0, data.size_bytes()));
-    info("verifying tracking info: {}", raw_idx);
-    BOOST_REQUIRE_EQUAL(raw_idx.max_offset(), 1023);
-    BOOST_REQUIRE_EQUAL(raw_idx.index.size(), 1024);
+    SUCCEED() << "verifying tracking info: " << raw_idx;
+    ASSERT_EQ(raw_idx.max_offset(), 1023);
+    ASSERT_EQ(raw_idx.index.size(), 1024);
 }
 
-FIXTURE_TEST(bucket_bug1, offset_index_utils_fixture) {
+TEST_F(offset_index_utils_fixture, bucket_bug1) {
     start().get();
 
-    info("index: {}", _idx);
-    info("Testing bucket find");
+    SUCCEED() << "index: " << _idx;
+    SUCCEED() << "Testing bucket find";
     _idx->maybe_track(
       modify_get(model::offset{824}, 155103), std::nullopt, 0); // indexed
     _idx->maybe_track(
@@ -115,16 +115,16 @@ FIXTURE_TEST(bucket_bug1, offset_index_utils_fixture) {
     index_entry_expect(926, 600121);
     {
         auto p = _idx->find_nearest(model::offset(947));
-        BOOST_REQUIRE(bool(p));
-        BOOST_REQUIRE_EQUAL(p->offset, model::offset(926));
-        BOOST_REQUIRE_EQUAL(p->filepos, 600121);
+        ASSERT_TRUE(bool(p));
+        ASSERT_EQ(p->offset, model::offset(926));
+        ASSERT_EQ(p->filepos, 600121);
     }
 }
-FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
+TEST_F(offset_index_utils_fixture, bucket_truncate) {
     start().get();
 
-    info("index: {}", _idx);
-    info("Testing bucket truncate");
+    SUCCEED() << "index: " << _idx;
+    SUCCEED() << "Testing bucket truncate";
     _idx->maybe_track(
       modify_get(model::offset{824}, 155103), std::nullopt, 0); // indexed
     _idx->maybe_track(
@@ -139,39 +139,39 @@ FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
       modify_get(model::offset{948}, 1667),
       std::nullopt,
       727007); // not indexed
-    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
+    ASSERT_EQ(_idx->num_compactible_records_appended(), 0);
 
     // test range truncation next
     _idx->truncate(model::offset(926), model::timestamp{100}).get();
     index_entry_expect(879, 323968);
     index_entry_expect(901, 458048);
-    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
+    ASSERT_EQ(_idx->num_compactible_records_appended(), 0);
     {
         auto p = _idx->find_nearest(model::offset(926));
-        BOOST_REQUIRE(bool(p));
-        BOOST_REQUIRE_EQUAL(p->offset, model::offset(901));
-        BOOST_REQUIRE_EQUAL(p->filepos, 458048);
+        ASSERT_TRUE(bool(p));
+        ASSERT_EQ(p->offset, model::offset(901));
+        ASSERT_EQ(p->filepos, 458048);
     }
     {
         auto p = _idx->find_nearest(model::offset(947));
-        BOOST_REQUIRE(bool(p));
-        BOOST_REQUIRE_EQUAL(p->offset, model::offset(901));
-        BOOST_REQUIRE_EQUAL(p->filepos, 458048);
+        ASSERT_TRUE(bool(p));
+        ASSERT_EQ(p->offset, model::offset(901));
+        ASSERT_EQ(p->filepos, 458048);
     }
 
-    BOOST_REQUIRE(_idx->max_timestamp() == model::timestamp{100});
+    ASSERT_TRUE(_idx->max_timestamp() == model::timestamp{100});
 
     _idx->truncate(model::offset(824), model::timestamp{100}).get();
-    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
+    ASSERT_EQ(_idx->num_compactible_records_appended(), 0);
     {
         auto p = _idx->find_nearest(model::offset(824));
-        BOOST_REQUIRE(bool(!p));
+        ASSERT_FALSE(bool(p));
     }
 
     _idx->truncate(model::offset(823), model::timestamp{100}).get();
-    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
+    ASSERT_EQ(_idx->num_compactible_records_appended(), 0);
     {
         auto p = _idx->find_nearest(model::offset(824));
-        BOOST_REQUIRE(bool(!p));
+        ASSERT_FALSE(bool(p));
     }
 }

--- a/src/v/storage/tests/record_batch_builder_test.cc
+++ b/src/v/storage/tests/record_batch_builder_test.cc
@@ -16,10 +16,8 @@
 #include "reflection/adl.h"
 #include "storage/record_batch_builder.h"
 
-#include <seastar/testing/thread_test_case.hh>
-
 #include <absl/container/btree_map.h>
-#include <boost/test/tools/old/interface.hpp>
+#include <gtest/gtest.h>
 
 namespace detail {
 
@@ -84,16 +82,16 @@ sample_type deserialize_sample_type(model::record& r) {
 
 } // namespace detail
 
-SEASTAR_THREAD_TEST_CASE(empty_builder) {
+TEST(RecordBatchBuilderTest, empty_builder) {
     // positive case
     {
         storage::record_batch_builder rbb(
           model::record_batch_type::raft_data, model::offset(0));
 
-        BOOST_REQUIRE(rbb.empty());
+        ASSERT_TRUE(rbb.empty());
         auto rb = std::move(rbb).build();
-        BOOST_CHECK(rb.empty());
-        BOOST_CHECK_EQUAL(rb.record_count(), 0);
+        EXPECT_TRUE(rb.empty());
+        EXPECT_EQ(rb.record_count(), 0);
     }
 
     // negative case
@@ -103,14 +101,14 @@ SEASTAR_THREAD_TEST_CASE(empty_builder) {
 
         rbb.add_raw_kv(std::nullopt, std::nullopt);
 
-        BOOST_REQUIRE(!rbb.empty());
+        ASSERT_FALSE(rbb.empty());
         auto rb = std::move(rbb).build();
-        BOOST_CHECK(!rb.empty());
-        BOOST_CHECK_EQUAL(rb.record_count(), 1);
+        EXPECT_FALSE(rb.empty());
+        EXPECT_EQ(rb.record_count(), 1);
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(serialize_deserialize_then_cmp) {
+TEST(RecordBatchBuilderTest, serialize_deserialize_then_cmp) {
     /// 1. Build working set for test
     const std::size_t total = random_generators::get_int(50, 100);
     std::vector<detail::sample_type> sample_data;
@@ -142,5 +140,5 @@ SEASTAR_THREAD_TEST_CASE(serialize_deserialize_then_cmp) {
     record_batch.for_each_record([&sample_output](model::record record) {
         sample_output.push_back(detail::deserialize_sample_type(record));
     });
-    BOOST_CHECK_EQUAL(sample_data, sample_output);
+    EXPECT_EQ(sample_data, sample_output);
 }

--- a/src/v/storage/tests/segment_size_jitter_test.cc
+++ b/src/v/storage/tests/segment_size_jitter_test.cc
@@ -10,17 +10,17 @@
 #include "storage/log_manager.h"
 #include "storage/segment_utils.h"
 
-#include <seastar/testing/thread_test_case.hh>
+#include <gtest/gtest.h>
 
-SEASTAR_THREAD_TEST_CASE(test_segment_size_jitter_calculation) {
+TEST(SegmentSizeJitterTest, test_segment_size_jitter_calculation) {
     constexpr auto jitter = storage::jitter_percents(5);
     std::array<size_t, 5> sizes = {1_GiB, 2_GiB, 100_MiB, 300_MiB, 10_GiB};
     for (auto original_size : sizes) {
         for (int i = 0; i < 100; ++i) {
             auto new_sz = original_size
                           * (1 + storage::internal::random_jitter(jitter));
-            BOOST_REQUIRE_GE(new_sz, 0.95f * original_size);
-            BOOST_REQUIRE_LE(new_sz, 1.05f * original_size);
+            EXPECT_GE(new_sz, 0.95f * original_size);
+            EXPECT_LE(new_sz, 1.05f * original_size);
         }
     }
-};
+}


### PR DESCRIPTION
Migrates five more tests from Boost to Google Test.

The robot was able to do most of this on its own. I had to help a bit with the second commit.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

