### PR TITLE
rpk: decommission-status reports reallocation failure details

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.62.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829
-	github.com/redpanda-data/common-go/rpadmin v0.1.13
+	github.com/redpanda-data/common-go/rpadmin v0.1.14
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.5.10
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -222,8 +222,8 @@ github.com/redpanda-data/common-go/net v0.1.0 h1:JnJioRJuL961r1QXiJQ1tW9+yEaJfu8
 github.com/redpanda-data/common-go/net v0.1.0/go.mod h1:iOdNkjxM7a1T8F3cYHTaKIPFCHzzp/ia6TN+Z+7Tt5w=
 github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829 h1:fx1Z+t/fa0vd7kAblgCrdYRW3QHc3svYiVnO1DadS94=
 github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829/go.mod h1:6WXvgZCZIkbQCNsvU5zTx/+ub5eXTuCcl90i5xkhMw0=
-github.com/redpanda-data/common-go/rpadmin v0.1.13 h1:0H0rUIU0y7BnWs26Ep+iHgKZ7gk6Ol+4OXBu/FMr6OI=
-github.com/redpanda-data/common-go/rpadmin v0.1.13/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
+github.com/redpanda-data/common-go/rpadmin v0.1.14 h1:G/rlh9cHsGhTsNpkwrISdpGA8fPZ7ul57rzxbPiJhs0=
+github.com/redpanda-data/common-go/rpadmin v0.1.14/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -35,34 +35,35 @@ partition size in a human-readable format.
 $ rpk redpanda admin brokers decommission-status 4
 DECOMMISSION PROGRESS
 =====================
-NAMESPACE-TOPIC              PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE
-kafka/test                   0          3          9             1699470920
-kafka/test                   4          3          0             1614258779
-kafka/test2                  3          3          3             2722706514
-kafka/test2                  4          3          4             2945518089
-kafka_internal/id_allocator  0          3          0             3562
+PARTITION                      MOVING-TO  COMPLETION-%  PARTITION-SIZE
+kafka/test/0                   3          9             1699470920
+kafka/test/4                   3          0             1614258779
+kafka/test2/3                  3          3             2722706514
+kafka/test2/4                  3          4             2945518089
+kafka_internal/id_allocator/0  3          0             3562
 
 Using --detailed / -d, it additionally prints granular reports.
 
 $ rpk redpanda admin brokers decommission-status 4 -d
 DECOMMISSION PROGRESS
 =====================
-NAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING
-kafka/test       0          3          13            1731773243      228114727    1503658516
-kafka/test       4          3          1             1645952961      18752660     1627200301
-kafka/test2      3          3          5             2752632301      140975805    2611656496
-kafka/test2      4          3          6             2975443783      181581219    2793862564
+PARTITION      MOVING-TO  COMPLETION-%  PARTITION-SIZE  BYTES-MOVED  BYTES-REMAINING
+kafka/test/0   3          13            1731773243      228114727    1503658516
+kafka/test/4   3          1             1645952961      18752660     1627200301
+kafka/test2/3  3          5             2752632301      140975805    2611656496
+kafka/test2/4  3          6             2975443783      181581219    2793862564
 
-If a partition cannot be moved with some reason, the command reports the
-problematic partition in the 'ALLOCATION FAILURES' section and decommission
-never succeeds. Typical scenarios the failure occurs are; there's no node
-that has enough space to allocate a partition or that can satisfy rack
-constraints, etc.
+If a partition cannot be moved for some reason, the command reports the
+problematic partition in the 'REALLOCATION FAILURE DETAILS' or 'ALLOCATION FAILURES'
+section and decommission fails. Typical scenarios for failure include:
+there are no brokers that have enough space to allocate a partition, or that can satisfy
+rack constraints, etc.
 
-ALLOCATION FAILURES
-==================
-kafka/foo/2
-kafka/test/0
+REALLOCATION FAILURE DETAILS
+============================
+PARTITION    REASON
+kafka/foo/1  Missing partition size information, all replicas may be offline
+kafka/foo/7  Missing partition size information, all replicas may be offline
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -95,7 +96,22 @@ kafka/test/0
 				}
 			}
 
-			if dbs.AllocationFailures != nil {
+			if dbs.ReallocationFailureDetails != nil {
+				out.Section("reallocation failure details")
+				tw := out.NewTable("Partition", "Reason")
+				for _, f := range dbs.ReallocationFailureDetails {
+					ntp := f.NS + "/" + f.Topic + "/" + strconv.Itoa(f.Partition)
+					tw.PrintStructFields(struct {
+						NTP    string
+						Reason string
+					}{
+						NTP:    ntp,
+						Reason: f.Error,
+					})
+				}
+				tw.Flush()
+				fmt.Println()
+			} else if dbs.AllocationFailures != nil {
 				sort.Strings(dbs.AllocationFailures)
 				out.Section("allocation failures")
 				for _, f := range dbs.AllocationFailures {
@@ -105,7 +121,7 @@ kafka/test/0
 			}
 
 			out.Section("decommission progress")
-			headers := []string{"Namespace-Topic", "Partition", "Moving-to", "Completion-%", "Partition-size"}
+			headers := []string{"Partition", "Moving-to", "Completion-%", "Partition-size"}
 			if detailed {
 				headers = append(headers, "Bytes-moved", "Bytes-remaining")
 			}
@@ -118,22 +134,20 @@ kafka/test/0
 			}
 
 			f := func(p *rpadmin.DecommissionPartitions) interface{} {
-				nt := p.Ns + "/" + p.Topic
+				ntp := p.Ns + "/" + p.Topic + "/" + strconv.Itoa(p.Partition)
 				if p.PartitionSize > 0 {
 					completion = p.BytesMoved * 100 / p.PartitionSize
 				}
 				if detailed {
 					return struct {
-						NT             string
-						Partition      int
+						NTP            string
 						MovingTo       int
 						Completion     int
 						PartitionSize  string
 						BytesMoved     string
 						BytesRemaining string
 					}{
-						nt,
-						p.Partition,
+						ntp,
 						p.MovingTo.NodeID,
 						completion,
 						sizeFn(p.PartitionSize),
@@ -142,14 +156,12 @@ kafka/test/0
 					}
 				} else {
 					return struct {
-						NT            string
-						Partition     int
+						NTP           string
 						MovingTo      int
 						Completion    int
 						PartitionSize string
 					}{
-						nt,
-						p.Partition,
+						ntp,
 						p.MovingTo.NodeID,
 						completion,
 						sizeFn(p.PartitionSize),


### PR DESCRIPTION
Since https://github.com/redpanda-data/redpanda/pull/26054, redpanda core reports "reallocation failure details" if something goes wrong during decommissioning. This commit handles the response and reports it accordingly.

```
REALLOCATION FAILURE DETAILS
============================
PARTITION    REASON
kafka/foo/1  Missing partition size information, all replicas may be offline
kafka/foo/7  Missing partition size information, all replicas may be offline
```

Also changed how the existing `DECOMMISSION PROGRESS` table reports NTP because it doesn't make any sense to report NT and P separately. 

Before:
```
DECOMMISSION PROGRESS
=====================
NAMESPACE-TOPIC  PARTITION  MOVING-TO  COMPLETION-%  PARTITION-SIZE
kafka/bar        0          3          0             0
kafka/bar        1          3          0             375079035
```
After:
```
DECOMMISSION PROGRESS
=====================
PARTITION    MOVING-TO  COMPLETION-%  PARTITION-SIZE
kafka/bar/0  3          0             0
kafka/bar/1  3          2             375079414
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* rpk: `decommission-status` reports reallocation failure details
