### PR TITLE
storage/tests: migrate more tests to Google Test

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -429,7 +429,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "produce_consume_test",
     timeout = "short",
     srcs = [
@@ -439,9 +439,9 @@ redpanda_cc_btest(
     deps = [
         ":disk_log_builder",
         "//src/v/model",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
         "@boost//:range",
-        "@seastar//:testing",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -754,21 +754,21 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
-    name = "half_page_concurrent_dispatch",
+redpanda_cc_gtest(
+    name = "half_page_concurrent_dispatch_test",
     timeout = "short",
     srcs = [
-        "half_page_concurrent_dispatch.cc",
+        "half_page_concurrent_dispatch_test.cc",
     ],
     deps = [
         "//src/v/storage",
         "//src/v/storage:record_batch_builder",
         "//src/v/storage/tests:disk_log_builder",
         "//src/v/test_utils:fixture",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -821,7 +821,6 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -328,19 +328,19 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "appender_chunk_manipulations_test",
     timeout = "short",
     srcs = [
-        "appender_chunk_manipulations.cc",
+        "appender_chunk_manipulations_test.cc",
     ],
     deps = [
         "//src/v/config",
         "//src/v/random:generators",
         "//src/v/storage:segment_appender",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
-        "@seastar//:testing",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -789,7 +789,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "compaction_reducer_test",
     timeout = "short",
     srcs = [
@@ -799,11 +799,9 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/storage",
         "//src/v/storage:logger",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
-        "@seastar",
-        "@seastar//:testing",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/storage/tests/appender_chunk_manipulations_test.cc
+++ b/src/v/storage/tests/appender_chunk_manipulations_test.cc
@@ -11,17 +11,15 @@
 #include "random/generators.h"
 #include "storage/segment_appender.h"
 
-#include <seastar/testing/thread_test_case.hh>
-
-#include <boost/test/tools/old/interface.hpp>
-#include <boost/test/unit_test_log.hpp>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
 
 #include <cstring>
 
 using chunk = storage::segment_appender::chunk;
 static constexpr storage::alignment alignment{4096};
 
-SEASTAR_THREAD_TEST_CASE(chunk_manipulation) {
+TEST(AppenderChunkManipulationsTest, chunk_manipulation) {
     const auto b = random_generators::gen_alphanum_string(1024 * 1024);
     const auto chunk_size = config::shard_local_cfg().append_chunk_size();
     chunk c(chunk_size, alignment);
@@ -31,35 +29,34 @@ SEASTAR_THREAD_TEST_CASE(chunk_manipulation) {
 
     {
         c.append(b.data(), c.space_left());
-        BOOST_REQUIRE(c.is_full());
-        BOOST_REQUIRE_EQUAL(c.size(), chunk_size);
+        ASSERT_TRUE(c.is_full());
+        ASSERT_EQ(c.size(), chunk_size);
         c.reset();
     }
     {
         c.append(b.data(), alignment - 2);
         c.append(b.data(), 4);
-        BOOST_REQUIRE_EQUAL(c.dma_size(), 8192);
+        ASSERT_EQ(c.dma_size(), 8192);
         c.reset();
     }
     {
         size_t i = (alignment * 3) + 10;
         c.append(b.data(), i);
-        BOOST_REQUIRE_EQUAL(c.dma_size(), alignment * 4);
+        ASSERT_EQ(c.dma_size(), alignment * 4);
         const char* dptr = c.dma_ptr();
         const char* eptr = b.data();
-        BOOST_REQUIRE(std::memcmp(dptr, eptr, i) == 0);
+        ASSERT_EQ(std::memcmp(dptr, eptr, i), 0);
         c.flush();
         // same after flush
-        BOOST_REQUIRE_EQUAL(c.dma_size(), alignment);
+        ASSERT_EQ(c.dma_size(), alignment);
         // 10 bytes on the next page
-        BOOST_REQUIRE_EQUAL(c.flushed_pos() % alignment, 10);
-        BOOST_TEST_MESSAGE("10 bytes spill over: " << c);
+        ASSERT_EQ(c.flushed_pos() % alignment, 10)
+          << "10 bytes spill over: " << c;
         c.append(b.data() + i, alignment() + 10);
-        BOOST_TEST_MESSAGE("Should be full: " << c.is_full() << ", " << c);
-        BOOST_REQUIRE(c.is_full());
+        ASSERT_TRUE(c.is_full()) << "Should be full: " << c;
         // we flushed after 3 pages. so the dma_size() should be 1 page left
-        BOOST_REQUIRE_EQUAL(c.dma_size(), alignment);
+        ASSERT_EQ(c.dma_size(), alignment);
         c.reset();
-        BOOST_REQUIRE_EQUAL(c.dma_size(), 0);
+        ASSERT_EQ(c.dma_size(), 0);
     }
 }

--- a/src/v/storage/tests/compaction_reducer_fixture_test.cc
+++ b/src/v/storage/tests/compaction_reducer_fixture_test.cc
@@ -8,7 +8,6 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-#include "gtest/gtest.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "storage/compaction_reducers.h"
@@ -27,6 +26,8 @@
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
 
 class MapBuildingReducerFixtureTest : public storage_test_fixture {};
 

--- a/src/v/storage/tests/compaction_reducer_test.cc
+++ b/src/v/storage/tests/compaction_reducer_test.cc
@@ -13,9 +13,9 @@
 #include "storage/compaction_reducers.h"
 #include "test_utils/random_bytes.h"
 
-#include <seastar/testing/thread_test_case.hh>
+#include <gtest/gtest.h>
 
-SEASTAR_THREAD_TEST_CASE(compaction_reducer_key_clash_test) {
+TEST(CompactionReducerTest, compaction_reducer_key_clash_test) {
     // Insert three elements with the same key in the reducer
     // and validate that the one with the largest offset wins.
 
@@ -49,11 +49,11 @@ SEASTAR_THREAD_TEST_CASE(compaction_reducer_key_clash_test) {
     reducer(std::move(entry_at_1)).get();
 
     auto bitmap = reducer.end_of_stream();
-    BOOST_REQUIRE_EQUAL(bitmap.minimum(), 1);
-    BOOST_REQUIRE_EQUAL(bitmap.maximum(), 1);
+    ASSERT_EQ(bitmap.minimum(), 1);
+    ASSERT_EQ(bitmap.maximum(), 1);
 }
 
-SEASTAR_THREAD_TEST_CASE(compaction_reducer_max_mem_usage_test) {
+TEST(CompactionReducerTest, compaction_reducer_max_mem_usage_test) {
     storage::internal::compaction_key_reducer reducer{16_KiB};
 
     // Empirically, 200 of the entries below use 16KiB of memory.
@@ -67,6 +67,6 @@ SEASTAR_THREAD_TEST_CASE(compaction_reducer_max_mem_usage_test) {
           0);
 
         reducer(std::move(entry)).get();
-        BOOST_REQUIRE_LE(reducer.idx_mem_usage(), 16_KiB);
+        ASSERT_LE(reducer.idx_mem_usage(), 16_KiB);
     }
 }

--- a/src/v/storage/tests/half_page_concurrent_dispatch_test.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch_test.cc
@@ -15,7 +15,10 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/temporary_buffer.hh>
 
-struct fixture {
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+struct fixture : public testing::Test {
     storage::disk_log_builder b{storage::log_config(
       storage::random_dir(),
       1_GiB,
@@ -25,7 +28,7 @@ struct fixture {
     ~fixture() { b.stop().get(); }
 };
 
-FIXTURE_TEST(half_next_page, fixture) {
+TEST_F(fixture, half_next_page) {
     using namespace storage; // NOLINT
     // gurantee next half page on 4096 segments(default)
     const size_t data_size = (config::shard_local_cfg().append_chunk_size() / 2)
@@ -42,14 +45,13 @@ FIXTURE_TEST(half_next_page, fixture) {
                    .build();
     b | start() | add_segment(0);
     auto& seg = b.get_segment(0);
-    info("About to append batch: {}", batch);
     seg.append(std::move(batch)).get();
-    info("Segment: {}", seg);
+    SCOPED_TRACE(fmt::format("Segment: {}", seg));
     seg.flush().get();
     b | add_random_batch(1, 1, maybe_compress_batches::yes);
     auto recs = b.consume().get();
-    BOOST_REQUIRE_EQUAL(recs.size(), 2);
+    ASSERT_EQ(recs.size(), 2);
     for (auto& rec : recs) {
-        BOOST_REQUIRE_EQUAL(rec.header().crc, model::crc_record_batch(rec));
+        ASSERT_EQ(rec.header().crc, model::crc_record_batch(rec));
     }
 }

--- a/src/v/storage/tests/produce_consume_test.cc
+++ b/src/v/storage/tests/produce_consume_test.cc
@@ -11,13 +11,12 @@
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/fixture.h"
 
-#include <seastar/testing/thread_test_case.hh>
-
 #include <boost/range/irange.hpp>
+#include <gtest/gtest.h>
 
 using namespace storage; // NOLINT
 
-SEASTAR_THREAD_TEST_CASE(produce_consume_concurrency) {
+TEST(ProduceConsumeTest, produce_consume_concurrency) {
     auto cfg = log_builder_config();
     cfg.cache = storage::with_cache::no;
     storage::disk_log_builder builder(std::move(cfg));


### PR DESCRIPTION
Migrates 5 more tests. This time the robot used `fmt::print` for `info()` instead of `SUCCEED() <<`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
