### PR TITLE
`storage`: output full `segment` in `WARN` log in `offset_to_filepos.cc`

### DIFF
--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -129,10 +129,9 @@ ss::future<result<offset_to_file_pos_result>> convert_begin_offset_to_file_pos(
     if (!offset_found && fail_on_missing_offset) {
         vlog(
           stlog.warn,
-          "Segment does not contain searched for offset: {}, segment offsets: "
-          "{}",
-          sto,
-          segment->offsets());
+          "Segment {} does not contain searched for offset: {}",
+          segment,
+          sto);
         co_return std::make_error_code(std::errc::invalid_seek);
     }
 


### PR DESCRIPTION
Knowing all of the details about the segment in question would be helpful when trying to debug issues related to this log line.


Backporting for observability in previous versions.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
