### PR TITLE
storage/tests: migrate even more tests to GTest

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -623,7 +623,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "crash_reporter_test",
     timeout = "short",
     srcs = [
@@ -632,10 +632,9 @@ redpanda_cc_btest(
     deps = [
         "//src/v/cluster",
         "//src/v/storage/tests:kvstore_fixture",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/cluster/tests/crash_reporter_test.cc
+++ b/src/v/cluster/tests/crash_reporter_test.cc
@@ -15,13 +15,13 @@
 
 #include <seastar/util/defer.hh>
 
-#include <boost/test/tools/old/interface.hpp>
+#include <gtest/gtest.h>
 
 #include <chrono>
 
 using namespace std::chrono_literals;
 
-FIXTURE_TEST(rate_limiter_test, kvstore_test_fixture) {
+TEST_F(kvstore_test_fixture, rate_limiter_test) {
     auto kvstore = make_kvstore();
     kvstore->start().get();
     auto defer = ss::defer([&] { kvstore->stop().get(); });
@@ -30,12 +30,12 @@ FIXTURE_TEST(rate_limiter_test, kvstore_test_fixture) {
 
     // Initially there is no rate limit
     auto wt = rl.wait_time();
-    BOOST_CHECK_EQUAL(wt, 0s);
+    EXPECT_EQ(wt, 0s);
 
     rl.record().get();
 
     // After calling record, there is a rate limit
     wt = rl.wait_time();
-    BOOST_CHECK_GT(wt, 0s);
-    BOOST_CHECK_LE(wt, cluster::crash_reporter::rate_limiter::upload_rate);
+    EXPECT_GT(wt, 0s);
+    EXPECT_LE(wt, cluster::crash_reporter::rate_limiter::upload_rate);
 }

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -392,7 +392,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "usage_manager_test",
     timeout = "short",
     srcs = [
@@ -402,10 +402,9 @@ redpanda_cc_btest(
         "//src/v/base",
         "//src/v/kafka/server",
         "//src/v/storage/tests:kvstore_fixture",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/kafka/server/tests/usage_manager_test.cc
+++ b/src/v/kafka/server/tests/usage_manager_test.cc
@@ -11,8 +11,9 @@
 #include "kafka/server/usage_aggregator.h"
 #include "storage/tests/kvstore_fixture.h"
 
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/log.hh>
+
+#include <gtest/gtest.h>
 
 static ss::logger af_logger{"test-accounting-fiber"};
 
@@ -102,7 +103,7 @@ ss::sstring print_window_data(const std::vector<kafka::usage_window>& v) {
 }
 } // namespace
 
-FIXTURE_TEST(test_usage, kvstore_test_fixture) {
+TEST_F(kvstore_test_fixture, test_usage) {
     using namespace std::chrono_literals;
     auto kvstore = make_kvstore();
     kvstore->start().get();
@@ -141,7 +142,7 @@ FIXTURE_TEST(test_usage, kvstore_test_fixture) {
     /// an empty window to properly compare
     data.emplace_back(kafka::usage{.bytes_sent = 0, .bytes_received = 0});
     std::reverse(data.begin(), data.end());
-    BOOST_CHECK_EQUAL(result, data);
+    EXPECT_EQ(result, data);
 
     /// Add to open window
     usage_fiber->add_bytes(10, 10);
@@ -154,8 +155,8 @@ FIXTURE_TEST(test_usage, kvstore_test_fixture) {
       "Clock advanced 4s, data: {}",
       print_window_data(open_windows));
     const auto open_window = open_windows[0];
-    BOOST_CHECK_EQUAL(open_window.u.bytes_sent, 20);
-    BOOST_CHECK_EQUAL(open_window.u.bytes_received, 20);
+    EXPECT_EQ(open_window.u.bytes_sent, 20);
+    EXPECT_EQ(open_window.u.bytes_received, 20);
 
     /// Grab most recent result before shutdown
     result = strip_window_data(usage_fiber->get_usage_stats().get());
@@ -173,15 +174,15 @@ FIXTURE_TEST(test_usage, kvstore_test_fixture) {
     auto result_after_restart = strip_window_data(
       usage_fiber->get_usage_stats().get());
     const auto& new_open_window = result_after_restart[0];
-    BOOST_CHECK_EQUAL(new_open_window.bytes_sent, 20);
-    BOOST_CHECK_EQUAL(new_open_window.bytes_received, 20);
-    BOOST_CHECK_EQUAL(result, result_after_restart);
+    EXPECT_EQ(new_open_window.bytes_sent, 20);
+    EXPECT_EQ(new_open_window.bytes_received, 20);
+    EXPECT_EQ(result, result_after_restart);
 
     usage_fiber->stop().get();
     kvstore->stop().get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_round_to_interval_method) {
+TEST(UsageManagerTest, test_round_to_interval_method) {
     using namespace std::chrono_literals;
     /// Aug 3rd, 2023 4PM GMT
     const auto ts = ss::lowres_system_clock::time_point(
@@ -191,17 +192,17 @@ SEASTAR_THREAD_TEST_CASE(test_round_to_interval_method) {
 
     for (const auto& ival : intervals) {
         /// Underneath the 2min threshold the method returns the input rounded
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts));
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts + 10s));
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts - 10s));
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts + 1min));
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts - 1min));
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts + 2min));
-        BOOST_CHECK(ts == kafka::detail::round_to_interval(ival, ts - 2min));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts + 10s));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts - 10s));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts + 1min));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts - 1min));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts + 2min));
+        EXPECT_EQ(ts, kafka::detail::round_to_interval(ival, ts - 2min));
         /// Past the 2min threshold the method returns the input unmodified
-        BOOST_CHECK(ts != kafka::detail::round_to_interval(ival, ts + 3min));
-        BOOST_CHECK(ts != kafka::detail::round_to_interval(ival, ts - 3min));
-        BOOST_CHECK(ts != kafka::detail::round_to_interval(ival, ts + 10min));
-        BOOST_CHECK(ts != kafka::detail::round_to_interval(ival, ts - 10min));
+        EXPECT_NE(ts, kafka::detail::round_to_interval(ival, ts + 3min));
+        EXPECT_NE(ts, kafka::detail::round_to_interval(ival, ts - 3min));
+        EXPECT_NE(ts, kafka::detail::round_to_interval(ival, ts + 10min));
+        EXPECT_NE(ts, kafka::detail::round_to_interval(ival, ts - 10min));
     }
 }

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -777,7 +777,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "file_sanitizer_test",
     timeout = "short",
     srcs = [
@@ -788,10 +788,9 @@ redpanda_cc_btest(
         "//src/v/bytes:iostream",
         "//src/v/storage",
         "//src/v/test_utils:fixture",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -359,7 +359,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "concat_segment_reader_test",
     timeout = "short",
     srcs = [
@@ -370,9 +370,9 @@ redpanda_cc_btest(
         "//src/v/bytes:iostream",
         "//src/v/model/tests:random",
         "//src/v/storage",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -66,6 +66,7 @@ redpanda_test_cc_library(
     include_prefix = "storage/tests",
     deps = [
         ":disk_log_builder",
+        "@googletest//:gtest",
     ],
 )
 
@@ -377,7 +378,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "timequery_test",
     timeout = "short",
     srcs = [
@@ -388,8 +389,8 @@ redpanda_cc_btest(
         "//src/v/config",
         "//src/v/model",
         "//src/v/model/tests:random",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
     ],
 )
@@ -723,7 +724,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "disk_log_builder_test",
     timeout = "short",
     srcs = [
@@ -736,10 +737,9 @@ redpanda_cc_btest(
         "//src/v/storage",
         "//src/v/storage/tests:disk_log_builder_fixture",
         "//src/v/test_utils:fixture",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -40,7 +40,7 @@ redpanda_test_cc_library(
         "//src/v/features",
         "//src/v/random:generators",
         "//src/v/storage",
-        "//src/v/test_utils:seastar_boost",
+        "@googletest//:gtest",
     ],
 )
 
@@ -310,7 +310,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "kvstore_test",
     timeout = "short",
     srcs = [
@@ -322,10 +322,10 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/reflection:adl",
         "//src/v/storage",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
+        "@googletest//:gtest",
         "@seastar",
-        "@seastar//:testing",
     ],
 )
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -345,7 +345,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "backlog_controller_test",
     timeout = "short",
     srcs = [
@@ -354,7 +354,8 @@ redpanda_cc_btest(
     deps = [
         "//src/v/base",
         "//src/v/storage",
-        "//src/v/test_utils:seastar_boost",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
     ],
 )

--- a/src/v/storage/tests/backlog_controller_test.cc
+++ b/src/v/storage/tests/backlog_controller_test.cc
@@ -10,7 +10,6 @@
 #include "base/seastarx.h"
 #include "storage/backlog_controller.h"
 #include "test_utils/async.h"
-#include "test_utils/fixture.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/io_priority_class.hh>
@@ -20,6 +19,8 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/log.hh>
+
+#include <gtest/gtest.h>
 
 #include <cstdint>
 
@@ -34,7 +35,8 @@ struct simple_backlog_sampler : storage::backlog_controller::sampler {
     int64_t& current_backlog;
 };
 
-struct backlog_controller_fixture {
+class backlog_controller_fixture : public ::testing::Test {
+public:
     const std::map<ss::sstring, ss::sstring> sch_group_label = {
       {"group", "sch_control_gr"}, {"shard", "0"}};
     backlog_controller_fixture()
@@ -62,6 +64,7 @@ struct backlog_controller_fixture {
 
     ~backlog_controller_fixture() { ctrl->stop().get(); }
 
+protected:
     ss::io_priority_class iopc;
     ss::scheduling_group sg;
     std::unique_ptr<storage::backlog_controller> ctrl;
@@ -81,7 +84,7 @@ struct backlog_controller_fixture {
     }
 };
 
-FIXTURE_TEST(test_feedback_loop, backlog_controller_fixture) {
+TEST_F(backlog_controller_fixture, test_feedback_loop) {
     ctrl->start().get();
     /**
      * current backlog is equal to 0, setpoint is set to 20, error = 20.0

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -15,8 +15,9 @@
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/tmp_dir.h"
 
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
 
 constexpr size_t segment_size{32_MiB};
 
@@ -40,7 +41,8 @@ size_t copy_stream(concat_segment_reader_view& cv) {
     return sz;
 }
 
-SEASTAR_THREAD_TEST_CASE(
+TEST(
+  ConcatSegmentReaderTest,
   test_multiple_segments_read_with_content_verification) {
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
@@ -119,24 +121,23 @@ SEASTAR_THREAD_TEST_CASE(
       segments, start_pos, end_pos, ss::default_priority_class()};
 
     iobuf buf;
-    auto result = transform_stream(
-                    cv.take_stream(),
-                    make_iobuf_ref_output_stream(buf),
-                    [](model::record_batch_header h) {
-                        BOOST_REQUIRE_EQUAL(
-                          h.type,
-                          model::record_batch_type::user_management_cmd);
-                        return batch_consumer::consume_result::accept_batch;
-                    })
-                    .get();
-    BOOST_REQUIRE(!result.has_error());
-    BOOST_REQUIRE_EQUAL(
+    auto result
+      = transform_stream(
+          cv.take_stream(),
+          make_iobuf_ref_output_stream(buf),
+          [](model::record_batch_header h) {
+              EXPECT_EQ(h.type, model::record_batch_type::user_management_cmd);
+              return batch_consumer::consume_result::accept_batch;
+          })
+          .get();
+    EXPECT_FALSE(result.has_error());
+    EXPECT_EQ(
       result.value(),
       b.get_disk_log_impl().size_bytes()
         - (start_pos + final_segment->file_size() - end_pos));
 }
 
-SEASTAR_THREAD_TEST_CASE(test_single_segment_read_with_bounds) {
+TEST(ConcatSegmentReaderTest, test_single_segment_read_with_bounds) {
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
 
@@ -161,11 +162,10 @@ SEASTAR_THREAD_TEST_CASE(test_single_segment_read_with_bounds) {
 
     concat_segment_reader_view cv{
       segments, start_pos, end_pos, ss::default_priority_class()};
-    BOOST_REQUIRE_EQUAL(
-      b.get_disk_log_impl().size_bytes() - 40, copy_stream(cv));
+    EXPECT_EQ(b.get_disk_log_impl().size_bytes() - 40, copy_stream(cv));
 }
 
-SEASTAR_THREAD_TEST_CASE(test_single_segment_read_full) {
+TEST(ConcatSegmentReaderTest, test_single_segment_read_full) {
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -188,10 +188,10 @@ SEASTAR_THREAD_TEST_CASE(test_single_segment_read_full) {
     size_t end_pos = log_segments.back()->file_size();
     concat_segment_reader_view cv{
       segments, start_pos, end_pos, ss::default_priority_class()};
-    BOOST_REQUIRE_EQUAL(b.get_disk_log_impl().size_bytes(), copy_stream(cv));
+    EXPECT_EQ(b.get_disk_log_impl().size_bytes(), copy_stream(cv));
 }
 
-SEASTAR_THREAD_TEST_CASE(test_multiple_segments_read_full) {
+TEST(ConcatSegmentReaderTest, test_multiple_segments_read_full) {
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -220,5 +220,5 @@ SEASTAR_THREAD_TEST_CASE(test_multiple_segments_read_full) {
     size_t end_pos = log_segments.back()->file_size();
     concat_segment_reader_view cv{
       segments, start_pos, end_pos, ss::default_priority_class()};
-    BOOST_REQUIRE_EQUAL(b.get_disk_log_impl().size_bytes(), copy_stream(cv));
+    EXPECT_EQ(b.get_disk_log_impl().size_bytes(), copy_stream(cv));
 }

--- a/src/v/storage/tests/disk_log_builder_fixture.h
+++ b/src/v/storage/tests/disk_log_builder_fixture.h
@@ -12,7 +12,9 @@
 #pragma once
 #include "storage/tests/utils/disk_log_builder.h"
 
-class log_builder_fixture {
+#include <gtest/gtest.h>
+
+class log_builder_fixture : public ::testing::Test {
 public:
     struct log_stats {
         size_t seg_count{0};

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -20,11 +20,11 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/defer.hh>
 
-#include <boost/test/unit_test.hpp>
+#include <gtest/gtest.h>
 
 #include <optional>
 
-FIXTURE_TEST(kitchen_sink, log_builder_fixture) {
+TEST_F(log_builder_fixture, kitchen_sink) {
     using namespace storage; // NOLINT
 
     auto batch = model::test::make_random_batch(model::offset(104), 1, false);
@@ -38,64 +38,68 @@ FIXTURE_TEST(kitchen_sink, log_builder_fixture) {
     auto stats = get_stats().get();
 
     b | stop();
-    BOOST_TEST(stats.seg_count == 3);
-    BOOST_TEST(stats.batch_count == 7);
-    BOOST_TEST(stats.record_count >= 105);
+    EXPECT_EQ(stats.seg_count, 3);
+    EXPECT_EQ(stats.batch_count, 7);
+    EXPECT_GE(stats.record_count, 105);
 }
 
-FIXTURE_TEST(size_bytes_after_offset, log_builder_fixture) {
+TEST_F(log_builder_fixture, size_bytes_after_offset) {
     using namespace storage;
     // see issues/15417, this test segfaults on the first block and returns
     // wrong results on the rest
 
-    BOOST_TEST_CONTEXT("empty log (sanity check)") {
+    {
+        SCOPED_TRACE("empty log (sanity check)");
         b | start();
         auto _ = ss::defer([&] { b | stop(); });
-        BOOST_CHECK_EQUAL(get_stats().get().seg_count, 0);
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(get_stats().get().seg_count, 0);
+        EXPECT_EQ(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset::min()),
           0);
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset{0}), 0);
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset::max()),
           0);
     }
 
-    BOOST_TEST_CONTEXT("one segment") {
+    {
+        SCOPED_TRACE("one segment");
         b | start() | add_segment(0) | add_random_batch(0, 100);
         auto _ = ss::defer([&] { b | stop(); });
 
-        BOOST_CHECK_EQUAL(get_stats().get().seg_count, 1);
-        BOOST_CHECK_GT(
+        EXPECT_EQ(get_stats().get().seg_count, 1);
+        EXPECT_GT(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset::min()),
           0);
-        BOOST_CHECK_GT(
+        EXPECT_GT(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset{0}), 0);
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset::max()),
           0);
     }
 
-    BOOST_TEST_CONTEXT("more than one segment") {
+    {
+        SCOPED_TRACE("more than one segment");
         b | start() | add_segment(0) | add_random_batch(0, 100)
           | add_segment(100) | add_random_batch(100, 100);
         auto _ = ss::defer([&] { b | stop(); });
 
-        BOOST_CHECK_EQUAL(get_stats().get().seg_count, 2);
-        BOOST_CHECK_GT(
+        EXPECT_EQ(get_stats().get().seg_count, 2);
+        EXPECT_GT(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset::min()),
           0);
-        BOOST_CHECK_GT(
+        EXPECT_GT(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset{0}), 0);
-        BOOST_CHECK_GT(
+        EXPECT_GT(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset{100}), 0);
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(
           b.get_disk_log_impl().size_bytes_after_offset(model::offset::max()),
           0);
     }
 
-    BOOST_TEST_CONTEXT("In the middle of the segment") {
+    {
+        SCOPED_TRACE("In the middle of the segment");
         b | start() | add_segment(0)
           | add_random_batches(
             model::offset(0), 2000, maybe_compress_batches::no);
@@ -106,27 +110,26 @@ FIXTURE_TEST(size_bytes_after_offset, log_builder_fixture) {
 
         auto _ = ss::defer([&] { b | stop(); });
         disk_log_impl& d_log = b.get_disk_log_impl();
-        BOOST_CHECK_EQUAL(get_stats().get().seg_count, 2);
+        EXPECT_EQ(get_stats().get().seg_count, 2);
         auto& s0 = d_log.segments()[0];
         auto& s1 = d_log.segments()[1];
         // all data
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(
           d_log.size_bytes_after_offset(model::offset(0)),
           s0->size_bytes() + s1->size_bytes());
         // somewhere in the middle of the first segment
         auto offset = model::offset(s0->offsets().get_committed_offset()() / 2);
-        BOOST_CHECK_GT(d_log.size_bytes_after_offset(offset), s1->size_bytes());
+        EXPECT_GT(d_log.size_bytes_after_offset(offset), s1->size_bytes());
 
         // somewhere in the middle of the second segment
         auto offset_2 = s1->offsets().get_base_offset()
                         + model::offset(
                           s1->offsets().get_committed_offset()
                           - s1->offsets().get_base_offset() / 2);
-        BOOST_CHECK_LT(
-          d_log.size_bytes_after_offset(offset_2), s1->size_bytes());
+        EXPECT_LT(d_log.size_bytes_after_offset(offset_2), s1->size_bytes());
 
         // only the second segment
-        BOOST_CHECK_EQUAL(
+        EXPECT_EQ(
           d_log.size_bytes_after_offset(s0->offsets().get_committed_offset()),
           s1->size_bytes());
     }
@@ -155,7 +158,7 @@ static void do_write_garbage(ss::sstring name) {
     out.close().get();
 }
 
-FIXTURE_TEST(test_valid_segment_name_with_zeroes_data, log_builder_fixture) {
+TEST_F(log_builder_fixture, test_valid_segment_name_with_zeroes_data) {
     using namespace storage; // NOLINT
     auto ntp = model::ntp(
       model::ns("test.ns"), model::topic("zeroes"), model::partition_id(66));
@@ -172,14 +175,14 @@ FIXTURE_TEST(test_valid_segment_name_with_zeroes_data, log_builder_fixture) {
     auto stats = get_stats().get();
     b | stop();
 
-    BOOST_REQUIRE(
-      !ss::file_exists(ssx::sformat("{}/270-1850-v1.log", dir)).get());
-    BOOST_TEST(stats.seg_count == 0);
-    BOOST_TEST(stats.batch_count == 0);
-    BOOST_TEST(stats.record_count >= 0);
+    ASSERT_FALSE(
+      ss::file_exists(ssx::sformat("{}/270-1850-v1.log", dir)).get());
+    EXPECT_EQ(stats.seg_count, 0);
+    EXPECT_EQ(stats.batch_count, 0);
+    EXPECT_GE(stats.record_count, 0);
 }
 
-FIXTURE_TEST(iterator_invalidation, log_builder_fixture) {
+TEST_F(log_builder_fixture, iterator_invalidation) {
     using namespace storage; // NOLINT
     constexpr const model::record_batch_type configuration
       = model::record_batch_type::raft_configuration;
@@ -217,12 +220,12 @@ FIXTURE_TEST(iterator_invalidation, log_builder_fixture) {
                             .get();
     auto all_batches = b.consume().get();
     b | stop();
-    BOOST_REQUIRE_EQUAL(data_batches.size(), 2);
-    BOOST_REQUIRE_EQUAL(config_batches.size(), 2);
-    BOOST_REQUIRE_EQUAL(all_batches.size(), 4);
+    ASSERT_EQ(data_batches.size(), 2);
+    ASSERT_EQ(config_batches.size(), 2);
+    ASSERT_EQ(all_batches.size(), 4);
 }
 
-FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
+TEST_F(log_builder_fixture, test_skipping_compaction_below_start_offset) {
     using namespace storage;
 
     ss::abort_source abs;
@@ -252,7 +255,7 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
 
     b | add_segment(100) | add_random_batch(100, 100);
 
-    RPTEST_REQUIRE_EQ(log.segment_count(), 2);
+    ASSERT_EQ(log.segment_count(), 2);
 
     housekeeping_config cfg{
       model::timestamp::max(),
@@ -266,24 +269,24 @@ FIXTURE_TEST(test_skipping_compaction_below_start_offset, log_builder_fixture) {
     // notification being created.
     auto eviction_future = log.monitor_eviction(abs);
     auto new_start_offset = b.apply_retention(cfg.gc).get();
-    RPTEST_REQUIRE(new_start_offset);
+    ASSERT_TRUE(new_start_offset);
 
-    RPTEST_REQUIRE_EQ(log.segment_count(), 2);
+    ASSERT_EQ(log.segment_count(), 2);
 
     // Grab the new start offset from the notification and
     // update the removable offset and start offsets.
     auto evict_at_offset = eviction_future.get();
-    RPTEST_REQUIRE_EQ(*new_start_offset, model::next_offset(evict_at_offset));
-    RPTEST_REQUIRE(b.update_start_offset(*new_start_offset).get());
+    ASSERT_EQ(*new_start_offset, model::next_offset(evict_at_offset));
+    ASSERT_TRUE(b.update_start_offset(*new_start_offset).get());
 
     // Call into `disk_log_impl::compact`. The only segment eligible for
     // compaction is the below the start offset and it should be ignored.
     auto& first_seg = log.segments().front();
-    RPTEST_REQUIRE_EQ(first_seg->finished_self_compaction(), false);
+    ASSERT_EQ(first_seg->finished_self_compaction(), false);
 
     b.apply_adjacent_merge_compaction(cfg.compact, *new_start_offset).get();
 
-    RPTEST_REQUIRE_EQ(first_seg->finished_self_compaction(), false);
+    ASSERT_EQ(first_seg->finished_self_compaction(), false);
 
     b.stop().get();
 }

--- a/src/v/storage/tests/file_sanitizer_test.cc
+++ b/src/v/storage/tests/file_sanitizer_test.cc
@@ -16,7 +16,8 @@
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
-#include <seastar/testing/thread_test_case.hh>
+
+#include <gtest/gtest.h>
 
 const ss::sstring valid_schema = R"(
 {
@@ -136,7 +137,7 @@ void write_to_file(ss::file& f, const ss::sstring& cfg) {
     out.close().get();
 }
 
-SEASTAR_THREAD_TEST_CASE(file_sanitizer_config_parse_test) {
+TEST(FileSanitizerTest, file_sanitizer_config_parse_test) {
     temporary_dir tmp_dir("file_sanitizer_test");
     auto path = tmp_dir.get_path();
 
@@ -170,33 +171,32 @@ SEASTAR_THREAD_TEST_CASE(file_sanitizer_config_parse_test) {
           invalid_batch_path,
           missing_path}) {
         auto res = storage::make_finjector_file_config(path).get();
-        BOOST_REQUIRE(!res.has_value());
+        EXPECT_FALSE(res.has_value());
     }
 
     // Create a configuration from the valid input and validate its contents.
     auto cfg = storage::make_finjector_file_config(valid_path).get();
-    BOOST_REQUIRE(cfg.has_value());
+    EXPECT_TRUE(cfg.has_value());
 
     model::ntp ntp{"kafka", "test", 1};
     const auto& ntp_cfg = cfg->get_config_for_ntp(ntp);
-    BOOST_REQUIRE(ntp_cfg.has_value());
+    EXPECT_TRUE(ntp_cfg.has_value());
 
-    BOOST_REQUIRE_EQUAL(ntp_cfg->sanitize_only, false);
-    BOOST_REQUIRE_EQUAL(ntp_cfg->finjection_cfg.has_value(), true);
+    EXPECT_EQ(ntp_cfg->sanitize_only, false);
+    EXPECT_EQ(ntp_cfg->finjection_cfg.has_value(), true);
 
     const auto& finject_cfg = ntp_cfg->finjection_cfg.value();
 
-    BOOST_REQUIRE_EQUAL(finject_cfg.ntp, ntp);
-    BOOST_REQUIRE_EQUAL(finject_cfg.op_configs.size(), 1);
+    EXPECT_EQ(finject_cfg.ntp, ntp);
+    EXPECT_EQ(finject_cfg.op_configs.size(), 1);
 
     const auto& write_failure_cfg = finject_cfg.op_configs[0];
-    BOOST_REQUIRE_EQUAL(
-      write_failure_cfg.op_type, storage::failable_op_type::write);
-    BOOST_REQUIRE_EQUAL(
+    EXPECT_EQ(write_failure_cfg.op_type, storage::failable_op_type::write);
+    EXPECT_EQ(
       write_failure_cfg.batch_type.value(),
       model::record_batch_type::raft_data);
-    BOOST_REQUIRE_EQUAL(write_failure_cfg.failure_probability.value(), 0.1);
-    BOOST_REQUIRE_EQUAL(write_failure_cfg.delay_probability.value(), 100);
-    BOOST_REQUIRE_EQUAL(write_failure_cfg.min_delay_ms.value(), 0);
-    BOOST_REQUIRE_EQUAL(write_failure_cfg.max_delay_ms.value(), 100);
+    EXPECT_EQ(write_failure_cfg.failure_probability.value(), 0.1);
+    EXPECT_EQ(write_failure_cfg.delay_probability.value(), 100);
+    EXPECT_EQ(write_failure_cfg.min_delay_ms.value(), 0);
+    EXPECT_EQ(write_failure_cfg.max_delay_ms.value(), 100);
 }

--- a/src/v/storage/tests/kvstore_fixture.h
+++ b/src/v/storage/tests/kvstore_fixture.h
@@ -12,14 +12,15 @@
 #include "random/generators.h"
 #include "storage/kvstore.h"
 #include "storage/storage_resources.h"
-#include "test_utils/fixture.h"
 
 #include <seastar/util/file.hh>
+
+#include <gtest/gtest.h>
 
 // This fixture manages the dependencies needed to create kvstore instance.
 // It's the responsiblity of the test to stop the kvstore instances created
 // by the fixture.
-class kvstore_test_fixture {
+class kvstore_test_fixture : public ::testing::Test {
 public:
     kvstore_test_fixture()
       : _test_dir(

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -12,12 +12,12 @@
 #include "reflection/adl.h"
 #include "storage/kvstore.h"
 #include "storage/tests/kvstore_fixture.h"
-#include "test_utils/fixture.h"
 #include "test_utils/random_bytes.h"
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/file.hh>
+
+#include <gtest/gtest.h>
 
 template<typename T>
 static void set_configuration(ss::sstring p_name, T v) {
@@ -26,7 +26,7 @@ static void set_configuration(ss::sstring p_name, T v) {
     }).get();
 }
 
-FIXTURE_TEST(key_space, kvstore_test_fixture) {
+TEST_F(kvstore_test_fixture, key_space) {
     set_configuration("disable_metrics", true);
 
     auto kvs = make_kvstore();
@@ -48,28 +48,28 @@ FIXTURE_TEST(key_space, kvstore_test_fixture) {
     kvs->put(storage::kvstore::key_space::consensus, empty_key, value_d.copy())
       .get();
 
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::testing, key).value() == value_a);
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::consensus, key).value() == value_b);
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::testing, empty_key).value()
-      == value_c);
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::consensus, empty_key).value()
-      == value_d);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), value_a);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::consensus, key).value(), value_b);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, empty_key).value(),
+      value_c);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::consensus, empty_key).value(),
+      value_d);
 
     std::map<bytes, iobuf> testing_kvs;
     kvs
       ->for_each(
         storage::kvstore::key_space::testing,
         [&](bytes_view key, const iobuf& val) {
-            BOOST_REQUIRE(testing_kvs.emplace(key, val.copy()).second);
+            EXPECT_TRUE(testing_kvs.emplace(key, val.copy()).second);
         })
       .get();
-    BOOST_REQUIRE_EQUAL(testing_kvs.size(), 2);
-    BOOST_REQUIRE(testing_kvs.at(key) == value_a);
-    BOOST_REQUIRE(testing_kvs.at(empty_key) == value_c);
+    EXPECT_EQ(testing_kvs.size(), 2);
+    EXPECT_EQ(testing_kvs.at(key), value_a);
+    EXPECT_EQ(testing_kvs.at(empty_key), value_c);
 
     kvs->stop().get();
 
@@ -77,21 +77,21 @@ FIXTURE_TEST(key_space, kvstore_test_fixture) {
     kvs = make_kvstore();
     kvs->start().get();
 
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::testing, key).value() == value_a);
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::consensus, key).value() == value_b);
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::testing, empty_key).value()
-      == value_c);
-    BOOST_REQUIRE(
-      kvs->get(storage::kvstore::key_space::consensus, empty_key).value()
-      == value_d);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, key).value(), value_a);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::consensus, key).value(), value_b);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::testing, empty_key).value(),
+      value_c);
+    EXPECT_EQ(
+      kvs->get(storage::kvstore::key_space::consensus, empty_key).value(),
+      value_d);
 
     kvs->stop().get();
 }
 
-FIXTURE_TEST(kvstore_empty, kvstore_test_fixture) {
+TEST_F(kvstore_test_fixture, kvstore_empty) {
     set_configuration("disable_metrics", true);
 
     // empty started then stopped
@@ -130,11 +130,11 @@ FIXTURE_TEST(kvstore_empty, kvstore_test_fixture) {
     }
 
     // equal
-    BOOST_REQUIRE(!truth.empty());
+    EXPECT_FALSE(truth.empty());
     for (auto& e : truth) {
-        BOOST_REQUIRE(
-          kvs->get(storage::kvstore::key_space::testing, e.first).value()
-          == e.second);
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
     }
 
     // now remove all of the keys
@@ -144,17 +144,17 @@ FIXTURE_TEST(kvstore_empty, kvstore_test_fixture) {
     truth.clear();
 
     // the db should be empty now
-    BOOST_REQUIRE(kvs->empty());
+    EXPECT_TRUE(kvs->empty());
     kvs->stop().get();
 
     // now restart the db and ensure still empty
     kvs = make_kvstore();
     kvs->start().get();
-    BOOST_REQUIRE(kvs->empty());
+    EXPECT_TRUE(kvs->empty());
     kvs->stop().get();
 }
 
-FIXTURE_TEST(kvstore, kvstore_test_fixture) {
+TEST_F(kvstore_test_fixture, kvstore) {
     set_configuration("disable_metrics", true);
 
     std::unordered_map<bytes, iobuf> truth;
@@ -169,9 +169,9 @@ FIXTURE_TEST(kvstore, kvstore_test_fixture) {
         truth[key] = value.copy();
         kvs->put(storage::kvstore::key_space::testing, key, std::move(value))
           .get();
-        BOOST_REQUIRE(
-          kvs->get(storage::kvstore::key_space::testing, key).value()
-          == truth[key]);
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, key).value(),
+          truth[key]);
 
         // maybe delete something
         auto coin = random_generators::get_int(1000);
@@ -182,9 +182,9 @@ FIXTURE_TEST(kvstore, kvstore_test_fixture) {
         }
 
         for (auto& e : truth) {
-            BOOST_REQUIRE(
-              kvs->get(storage::kvstore::key_space::testing, e.first).value()
-              == e.second);
+            EXPECT_EQ(
+              kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+              e.second);
         }
     }
     kvs->stop().get();
@@ -194,9 +194,9 @@ FIXTURE_TEST(kvstore, kvstore_test_fixture) {
     kvs = make_kvstore();
     kvs->start().get();
     for (auto& e : truth) {
-        BOOST_REQUIRE(
-          kvs->get(storage::kvstore::key_space::testing, e.first).value()
-          == e.second);
+        EXPECT_EQ(
+          kvs->get(storage::kvstore::key_space::testing, e.first).value(),
+          e.second);
     }
     kvs->stop().get();
 }

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -12,11 +12,10 @@
 #include "model/tests/random_batch.h"
 #include "model/timestamp.h"
 #include "storage/tests/disk_log_builder_fixture.h"
-#include "test_utils/fixture.h"
 
 #include <seastar/core/file.hh>
 
-#include <boost/test/tools/context.hpp>
+#include <gtest/gtest.h>
 
 namespace {
 
@@ -42,7 +41,7 @@ model::record_batch make_random_batch(
 
 } // namespace
 
-FIXTURE_TEST(timequery, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery) {
     using namespace storage; // NOLINT
 
     b | start();
@@ -68,17 +67,17 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
     }
 
     for (const auto& seg : b.get_log_segments()) {
-        BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
+        EXPECT_TRUE(seg->index().batch_timestamps_are_monotonic());
     }
 
-    BOOST_TEST_CONTEXT(
-      "undershoot the timestamp but keep increasing the start offset") {
+    {
+        SCOPED_TRACE(
+          "undershoot the timestamp but keep increasing the start offset");
         auto log = b.get_log();
         for (auto start_offset = log->offsets().start_offset;
              start_offset < model::offset(10);
              start_offset++) {
-            BOOST_TEST_INFO_SCOPE(
-              fmt::format("start_offset: {}", start_offset));
+            SCOPED_TRACE(fmt::format("start_offset: {}", start_offset));
 
             storage::timequery_config config(
               start_offset,
@@ -88,9 +87,9 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
               std::nullopt);
 
             auto res = log->timequery(config).get();
-            BOOST_TEST(res);
-            BOOST_TEST(res->time == model::timestamp(start_offset));
-            BOOST_TEST(res->offset == start_offset);
+            EXPECT_TRUE(res);
+            EXPECT_EQ(res->time, model::timestamp(start_offset));
+            EXPECT_EQ(res->offset, start_offset);
         }
     }
 
@@ -106,9 +105,9 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
           std::nullopt);
 
         auto res = log->timequery(config).get();
-        BOOST_TEST(res);
-        BOOST_TEST(res->time == model::timestamp(ts));
-        BOOST_TEST(res->offset == model::offset(ts));
+        EXPECT_TRUE(res);
+        EXPECT_EQ(res->time, model::timestamp(ts));
+        EXPECT_EQ(res->offset, model::offset(ts));
     }
 
     // in the second segment
@@ -131,15 +130,15 @@ FIXTURE_TEST(timequery, log_builder_fixture) {
         auto offset = (ts - 100) * 5 + 100;
 
         auto res = log->timequery(config).get();
-        BOOST_TEST(res);
-        BOOST_TEST(res->time == model::timestamp(ts));
-        BOOST_TEST(res->offset == model::offset(offset));
+        EXPECT_TRUE(res);
+        EXPECT_EQ(res->time, model::timestamp(ts));
+        EXPECT_EQ(res->offset, model::offset(offset));
     }
 
     b | stop();
 }
 
-FIXTURE_TEST(timequery_multiple_messages_per_batch, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery_multiple_messages_per_batch) {
     using namespace storage; // NOLINT
 
     b | start();
@@ -175,7 +174,7 @@ FIXTURE_TEST(timequery_multiple_messages_per_batch, log_builder_fixture) {
     }
 
     for (const auto& seg : b.get_log_segments()) {
-        BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
+        EXPECT_TRUE(seg->index().batch_timestamps_are_monotonic());
     }
 
     auto log = b.get_log();
@@ -183,7 +182,7 @@ FIXTURE_TEST(timequery_multiple_messages_per_batch, log_builder_fixture) {
     for (auto start_offset = log->offsets().start_offset;
          start_offset < model::offset(num_batches * records_per_batch);
          start_offset++) {
-        BOOST_TEST_INFO_SCOPE(fmt::format("start_offset: {}", start_offset));
+        SCOPED_TRACE(fmt::format("start_offset: {}", start_offset));
 
         storage::timequery_config config(
           start_offset,
@@ -193,15 +192,15 @@ FIXTURE_TEST(timequery_multiple_messages_per_batch, log_builder_fixture) {
           std::nullopt);
 
         auto res = log->timequery(config).get();
-        BOOST_TEST(res);
-        BOOST_TEST(res->time == model::timestamp(start_offset));
-        BOOST_TEST(res->offset == start_offset);
+        EXPECT_TRUE(res);
+        EXPECT_EQ(res->time, model::timestamp(start_offset));
+        EXPECT_EQ(res->offset, start_offset);
     }
 
     b | stop();
 }
 
-FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery_single_value) {
     using namespace storage; // NOLINT
 
     b | start();
@@ -224,19 +223,19 @@ FIXTURE_TEST(timequery_single_value, log_builder_fixture) {
       std::nullopt);
 
     auto empty_res = log->timequery(config).get();
-    BOOST_TEST(!empty_res);
+    EXPECT_FALSE(empty_res);
 
     // ask for 999 it should return first segment
     config.time = model::timestamp(999);
 
     auto res = log->timequery(config).get();
-    BOOST_TEST(res);
-    BOOST_TEST(res->time == model::timestamp(1000));
-    BOOST_TEST(res->offset == model::offset(0));
+    EXPECT_TRUE(res);
+    EXPECT_EQ(res->time, model::timestamp(1000));
+    EXPECT_EQ(res->offset, model::offset(0));
     b | stop();
 }
 
-FIXTURE_TEST(timequery_sparse_index, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery_sparse_index) {
     using namespace storage;
 
     b | start();
@@ -254,8 +253,8 @@ FIXTURE_TEST(timequery_sparse_index, log_builder_fixture) {
     b | add_batch(std::move(batch3));
 
     const auto& seg = b.get_log_segments().front();
-    BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
-    BOOST_TEST(seg->index().size() == 2);
+    EXPECT_TRUE(seg->index().batch_timestamps_are_monotonic());
+    EXPECT_EQ(seg->index().size(), 2);
 
     auto log = b.get_log();
     storage::timequery_config config(
@@ -266,14 +265,14 @@ FIXTURE_TEST(timequery_sparse_index, log_builder_fixture) {
       std::nullopt);
 
     auto res = log->timequery(config).get();
-    BOOST_TEST(res);
-    BOOST_TEST(res->time == model::timestamp(1600));
-    BOOST_TEST(res->offset == model::offset(1));
+    EXPECT_TRUE(res);
+    EXPECT_EQ(res->time, model::timestamp(1600));
+    EXPECT_EQ(res->offset, model::offset(1));
 
     b | stop();
 }
 
-FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery_one_element_index) {
     using namespace storage;
 
     b | start();
@@ -287,8 +286,8 @@ FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
     b | add_batch(std::move(batch));
 
     const auto& seg = b.get_log_segments().front();
-    BOOST_TEST(seg->index().batch_timestamps_are_monotonic());
-    BOOST_TEST(seg->index().size() == 1);
+    EXPECT_TRUE(seg->index().batch_timestamps_are_monotonic());
+    EXPECT_EQ(seg->index().size(), 1);
 
     auto log = b.get_log();
     storage::timequery_config config(
@@ -299,14 +298,14 @@ FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
       std::nullopt);
 
     auto res = log->timequery(config).get();
-    BOOST_TEST(res);
-    BOOST_TEST(res->time == model::timestamp(1000));
-    BOOST_TEST(res->offset == model::offset(0));
+    EXPECT_TRUE(res);
+    EXPECT_EQ(res->time, model::timestamp(1000));
+    EXPECT_EQ(res->offset, model::offset(0));
 
     b | stop();
 }
 
-FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery_non_monotonic_log) {
     using namespace storage; // NOLINT
 
     b | start();
@@ -334,8 +333,8 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
     }
 
     const auto& segs = b.get_log_segments();
-    BOOST_TEST(segs.size() == 1);
-    BOOST_TEST(segs.front()->index().batch_timestamps_are_monotonic() == false);
+    EXPECT_EQ(segs.size(), 1);
+    EXPECT_FALSE(segs.front()->index().batch_timestamps_are_monotonic());
 
     auto log = b.get_log();
     for (const auto& [offset, ts] : batch_spec) {
@@ -353,13 +352,13 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
             // first batch that satifies: `batch_max_timestamp >= needle`.
             // So, in this case we pick the first batch with timestamp
             // greater or equal to 1002.
-            BOOST_TEST(res);
-            BOOST_TEST(res->time == model::timestamp(1002));
-            BOOST_TEST(res->offset == model::offset(2));
+            EXPECT_TRUE(res);
+            EXPECT_EQ(res->time, model::timestamp(1002));
+            EXPECT_EQ(res->offset, model::offset(2));
         } else {
-            BOOST_TEST(res);
-            BOOST_TEST(res->time == ts);
-            BOOST_TEST(res->offset == offset);
+            EXPECT_TRUE(res);
+            EXPECT_EQ(res->time, ts);
+            EXPECT_EQ(res->offset, offset);
         }
     }
 
@@ -374,13 +373,13 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
 
     auto res = log->timequery(config).get();
 
-    BOOST_TEST(res);
-    BOOST_TEST(res->offset == model::offset(0));
+    EXPECT_TRUE(res);
+    EXPECT_EQ(res->offset, model::offset(0));
 
     b | stop();
 }
 
-FIXTURE_TEST(timequery_clamp, log_builder_fixture) {
+TEST_F(log_builder_fixture, timequery_clamp) {
     using namespace storage; // NOLINT
 
     b | start();
@@ -402,8 +401,8 @@ FIXTURE_TEST(timequery_clamp, log_builder_fixture) {
     }
 
     const auto& segs = b.get_log_segments();
-    BOOST_TEST(segs.size() == 1);
-    BOOST_TEST(segs.front()->index().batch_timestamps_are_monotonic() == true);
+    EXPECT_EQ(segs.size(), 1);
+    EXPECT_TRUE(segs.front()->index().batch_timestamps_are_monotonic());
 
     auto log = b.get_log();
     storage::timequery_config config(
@@ -415,9 +414,9 @@ FIXTURE_TEST(timequery_clamp, log_builder_fixture) {
 
     const auto& [expected_offset, expected_ts] = batch_spec.back();
     auto res = log->timequery(config).get();
-    BOOST_TEST(res);
-    BOOST_TEST(res->time == expected_ts);
-    BOOST_TEST(res->offset == expected_offset);
+    EXPECT_TRUE(res);
+    EXPECT_EQ(res->time, expected_ts);
+    EXPECT_EQ(res->offset, expected_offset);
 
     b | stop();
 }


### PR DESCRIPTION
Robot is pretty good at this.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
