### PR TITLE
[v25.1.x] `storage`: output full `segment` in `WARN` log in `offset_to_filepos.cc`

### DIFF
--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -129,10 +129,9 @@ ss::future<result<offset_to_file_pos_result>> convert_begin_offset_to_file_pos(
     if (!offset_found && fail_on_missing_offset) {
         vlog(
           stlog.warn,
-          "Segment does not contain searched for offset: {}, segment offsets: "
-          "{}",
-          sto,
-          segment->offsets());
+          "Segment {} does not contain searched for offset: {}",
+          segment,
+          sto);
         co_return std::make_error_code(std::errc::invalid_seek);
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26224
