### PR TITLE
Adding logs for missing critical topics

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -868,6 +868,12 @@ class CloudCluster():
 
         _intersect = list(set(_topics) & set(_critical))
         if len(_intersect) < required_critical_topic_count:
+            missing_topics = [
+                topic for topic in _critical if topic not in _intersect
+            ]
+            self._logger.error(f"Missing critical topics: {missing_topics}")
+            self._logger.error(f"Expected critical topics: {_critical}")
+            self._logger.error(f"Actual topics found: {_topics}")
             return warn_and_return("Cluster missing critical topics")
         else:
             _t = ', '.join(_intersect)


### PR DESCRIPTION
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

This pull request adds enhanced logging to the `warn_and_return` function in the `tests/rptest/services/redpanda_cloud.py` file. The changes aim to provide more detailed error messages when critical topics are missing.

**Logging improvements:**

* [`tests/rptest/services/redpanda_cloud.py`](diffhunk://#diff-a18352c0aff7b7dbf69f7b5d6a1cea78aeedc6e5bdb90229b77d1325d26af3b6R871-R874): Added detailed logging to display the missing critical topics, the expected critical topics, and the actual topics found when the required critical topic count is not met.