### PR TITLE
[CORE-9879] kafka: Support for metadata v12

### DIFF
--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -101,6 +101,11 @@ public:
 
     const topic_table::underlying_t& all_topics_metadata() const;
 
+    std::optional<model::topic_namespace>
+    get_name_by_id(model::topic_id tp_id) const {
+        return _topics_state.local().get_name_by_id(tp_id);
+    }
+
     /// Returns all brokers, returns copy as the content of broker can change
     const members_table::cache_t& nodes() const;
 

--- a/src/v/kafka/client/errors.h
+++ b/src/v/kafka/client/errors.h
@@ -40,6 +40,7 @@ inline bool is_retriable_error(kafka::error_code ec) {
     case error_code::preferred_leader_not_available:
     case error_code::unstable_offset_commit:
     case error_code::throttling_quota_exceeded:
+    case error_code::unknown_topic_id:
         return true;
     case error_code::unknown_server_error:
     case error_code::invalid_fetch_size:

--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -199,6 +199,8 @@ std::string_view error_code_to_str(error_code error) {
         return "duplicate_resource";
     case error_code::unacceptable_credential:
         return "unacceptable_credential";
+    case error_code::unknown_topic_id:
+        return "unknown_topic_id";
     case error_code::transactional_id_not_found:
         return "transactional_id_not_found";
     default:
@@ -244,6 +246,7 @@ bool is_retriable(error_code error) {
     case error_code::kafka_storage_error:
     case error_code::fetch_session_id_not_found:
     case error_code::invalid_fetch_session_epoch:
+    case error_code::unknown_topic_id:
         return true;
     case error_code::unknown_server_error:
     case error_code::none:

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -235,6 +235,8 @@ enum class error_code : int16_t {
     duplicate_resource = 92,
     // Requested credential would not meet criteria for acceptability
     unacceptable_credential = 93,
+    // This server does not host this topic ID.
+    unknown_topic_id = 100,
     // The transactional_id could not be found for describe tx request.
     transactional_id_not_found = 105,
 };

--- a/src/v/kafka/protocol/types.cc
+++ b/src/v/kafka/protocol/types.cc
@@ -30,7 +30,7 @@ uuid uuid::from_string(std::string_view encoded) {
           decoded.size());
     }
     underlying_t ul;
-    std::copy_n(decoded.begin(), length, ul.begin());
+    std::copy_n(decoded.begin(), length, ul.mutable_uuid().begin());
     return uuid(ul);
 }
 

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -99,7 +99,7 @@ enum class describe_configs_source : int8_t {
 class uuid {
 public:
     static constexpr auto length = 16;
-    using underlying_t = std::array<uint8_t, length>;
+    using underlying_t = uuid_t;
 
     uuid() = default;
 
@@ -108,7 +108,11 @@ public:
     explicit uuid(const underlying_t& uuid)
       : _uuid(uuid) {}
 
-    bytes_view view() const { return {_uuid.data(), _uuid.size()}; }
+    explicit operator uuid_t() { return _uuid; }
+
+    bytes_view view() const {
+        return {_uuid.uuid().begin(), _uuid.uuid().size()};
+    }
 
     ss::sstring to_string() const;
 

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -37,6 +37,7 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <fmt/ostream.h>
 
+#include <algorithm>
 #include <iterator>
 #include <type_traits>
 
@@ -124,6 +125,9 @@ metadata_response::topic make_topic_response_from_topic_metadata(
     tp.error_code = error_code::none;
     model::topic_namespace_view tp_ns = tp_md.get_configuration().tp_ns;
     tp.name = tp_md.get_configuration().tp_ns.tp;
+    if (tp_md.get_configuration().tp_id) {
+        tp.topic_id = uuid{tp_md.get_configuration().tp_id.value()()};
+    }
 
     tp.is_internal = is_internal(tp_ns);
 
@@ -304,23 +308,44 @@ get_topic_metadata(
     std::vector<model::topic> topics_to_be_created;
     std::vector<ss::future<metadata_response::topic>> new_topics;
 
+    bool use_topic_ids = std::ranges::any_of(
+      *request.data.topics,
+      [](const auto& topic) { return topic.topic_id != uuid{}; });
+
     for (auto& topic : *request.data.topics) {
         const auto move_topic_name = [&topic]() {
             return std::move(topic.name).value_or(model::topic{});
         };
 
-        /**
-         * Authorize source topic in case if we deal with materialized one
-         */
-        if (!ctx.authorized(
-              security::acl_operation::describe,
-              topic.name.value_or(model::topic{}))) {
-            // not authorized, return authorization error
-            res.push_back(make_error_topic_response(
-              move_topic_name(), error_code::topic_authorization_failed));
-            continue;
+        const bool should_describe
+          = (!use_topic_ids && topic.name.has_value())
+            || (use_topic_ids && topic.topic_id != uuid{});
+
+        if (use_topic_ids && topic.topic_id != uuid{}) {
+            // Check if topic is not found by ID
+            auto name = ctx.metadata_cache().get_name_by_id(
+              model::topic_id{topic.topic_id});
+            if (!name.has_value()) {
+                res.push_back(metadata_response::topic{
+                  .error_code = kafka::error_code::unknown_topic_id,
+                  .topic_id = topic.topic_id});
+                continue;
+            }
+            topic.name = std::move(name)->tp;
         }
-        if (topic.name.has_value()) {
+
+        if (should_describe) {
+            /**
+             * Authorize source topic in case if we deal with materialized one
+             */
+            if (!ctx.authorized(
+                  security::acl_operation::describe,
+                  topic.name.value_or(model::topic{}))) {
+                // not authorized, return authorization error
+                res.push_back(make_error_topic_response(
+                  move_topic_name(), error_code::topic_authorization_failed));
+                continue;
+            }
             if (auto md = ctx.metadata_cache().get_topic_metadata(
                   model::topic_namespace_view(
                     model::kafka_namespace, *topic.name));
@@ -336,13 +361,15 @@ get_topic_metadata(
         if (
           !config::shard_local_cfg().auto_create_topics_enabled
           || !request.data.allow_auto_topic_creation) {
-            bool valid = topic.name.has_value()
-                         && validate_kafka_topic_name(*topic.name)
-                              == model::errc::success;
-            res.push_back(make_error_topic_response(
-              move_topic_name(),
-              valid ? error_code::unknown_topic_or_partition
-                    : error_code::invalid_topic_exception));
+            if (!use_topic_ids) {
+                bool valid = topic.name.has_value()
+                             && validate_kafka_topic_name(*topic.name)
+                                  == model::errc::success;
+                res.push_back(make_error_topic_response(
+                  move_topic_name(),
+                  valid ? error_code::unknown_topic_or_partition
+                        : error_code::invalid_topic_exception));
+            }
             continue;
         }
         /**

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -25,6 +25,6 @@ namespace kafka {
 memory_estimate_fn metadata_memory_estimator;
 
 using metadata_handler
-  = single_stage_handler<metadata_api, 0, 8, metadata_memory_estimator>;
+  = single_stage_handler<metadata_api, 0, 12, metadata_memory_estimator>;
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -9,8 +9,10 @@
 
 #include "absl/algorithm/container.h"
 #include "cluster/security_frontend.h"
+#include "cluster/topic_configuration.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/metadata.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
@@ -79,6 +81,30 @@ protected:
                        user, credential, model::timeout_clock::now() + 5s)
                      .get();
         BOOST_REQUIRE_EQUAL(err, cluster::errc::success);
+    }
+
+    std::optional<model::topic_id>
+    get_topic_id(const model::topic& topic_name) {
+        return app.controller->get_topics_state()
+          .local()
+          .get_topic_cfg({model::kafka_namespace, topic_name})
+          .and_then(&cluster::topic_configuration::tp_id);
+    }
+
+    [[nodiscard]] auto set_auto_create_topics(bool value) {
+        auto current = config::shard_local_cfg().auto_create_topics_enabled();
+        auto apply = [this](bool value) {
+            cluster::config_update_request r{
+              .upsert = {
+                {"auto_create_topics_enabled", ssx::sformat("{}", value)}}};
+            auto res = app.controller->get_config_frontend()
+                         .local()
+                         .patch(r, model::timeout_clock::now() + 1s)
+                         .get();
+            BOOST_REQUIRE(!res.errc);
+        };
+        apply(value);
+        return ss::defer([current, apply] { apply(current); });
     }
 };
 
@@ -359,5 +385,48 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
               ? cluster_ops
               : default_response.cluster_authorized_operations;
         BOOST_REQUIRE_EQUAL(resp.data.cluster_authorized_operations, expected);
+    }
+}
+
+FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
+    using kafka::api_version;
+    constexpr auto max_supported = kafka::metadata_handler::max_supported;
+    const model::topic test_topic_query{"metadata_autocreate_query"};
+    const model::topic test_topic_create{"metadata_autocreate_create"};
+
+    auto undo = set_auto_create_topics(true);
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto close = ss::defer([&client] { client.stop().get(); });
+
+    auto create_resp = client
+                         .dispatch(
+                           kafka::create_topics_request{.data{
+                             .topics{
+                               {.name{test_topic_query},
+                                .num_partitions = 1,
+                                .replication_factor = 1}},
+                             .timeout_ms = 10s,
+                             .validate_only = false}},
+                           kafka::api_version{2})
+                         .get();
+    BOOST_REQUIRE(!create_resp.data.errored());
+
+    const kafka::metadata_response_data default_response;
+    for (api_version ver{8}; ver < max_supported; ++ver) {
+        auto req = kafka::metadata_request{.data{
+          .topics
+          = {{{.name{ssx::sformat("{}_{}_{}", test_topic_create, "by_name", ver)}}, {.name{test_topic_query}}}},
+          .allow_auto_topic_creation = true,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+        auto resp = client.dispatch(std::move(req), ver).get();
+
+        BOOST_REQUIRE(!resp.data.errored());
+        const auto& topics = resp.data.topics;
+        BOOST_REQUIRE_EQUAL(topics.size(), 2);
+        BOOST_REQUIRE_EQUAL(topics[0].error_code, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(topics[1].error_code, kafka::error_code::none);
     }
 }

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -280,9 +280,6 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
 
 FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
     using kafka::api_version;
-    if (kafka::metadata_handler::max_supported < api_version{12}) {
-        return;
-    }
 
     auto client = make_kafka_client().get();
     auto deferred_close = ss::defer([&client] { client.stop().get(); });
@@ -319,10 +316,8 @@ FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
 
 FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
     using kafka::api_version;
-    if (kafka::metadata_handler::max_supported < api_version{12}) {
-        return;
-    }
-    ss::sstring test_topic_name = "metadata_non_empty_topic_id";
+    constexpr auto max_supported = kafka::metadata_handler::max_supported;
+    const model::topic test_topic_name{"metadata_non_empty_topic_id"};
 
     create_topic(test_topic_name, 1, 1);
 
@@ -353,6 +348,24 @@ FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
         BOOST_REQUIRE_EQUAL(resp.data.cluster_id, default_response.cluster_id);
         BOOST_REQUIRE_EQUAL(
           resp.data.controller_id, default_response.controller_id);
+    }
+
+    for (api_version ver{12}; ver <= max_supported; ++ver) {
+        auto topic_id = get_topic_id(test_topic_name);
+        BOOST_REQUIRE(topic_id.has_value());
+        BOOST_REQUIRE_NE(topic_id.value(), model::topic_id{});
+
+        auto resp = client
+                      .dispatch(
+                        kafka::metadata_request{
+                          .data{.topics{{{.name{test_topic_name}}}}}},
+                        ver)
+                      .get();
+
+        BOOST_REQUIRE(!resp.data.errored());
+        BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(
+          resp.data.topics.front().topic_id, kafka::uuid{*topic_id});
     }
 }
 
@@ -388,6 +401,53 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
     }
 }
 
+FIXTURE_TEST(metadata_v12_mixed, metadata_fixture) {
+    // Test specifying a topic name and a topic id in the same request
+    // If any topic is is present, only topic ids are used.
+    using namespace kafka;
+    const model::topic test_topic_name_0{"metadata_v12_mixed_0"};
+    const model::topic test_topic_name_1{"metadata_v12_mixed_1"};
+
+    auto undo = set_auto_create_topics(false);
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+
+    client
+      .dispatch(
+        kafka::create_topics_request{.data{
+          .topics{
+            {.name{test_topic_name_0},
+             .num_partitions = 1,
+             .replication_factor = 1},
+            {.name{test_topic_name_1},
+             .num_partitions = 1,
+             .replication_factor = 1}},
+          .timeout_ms = 10s,
+          .validate_only = false}},
+        kafka::api_version{2})
+      .get();
+
+    auto topic_1_id = get_topic_id(model::topic(test_topic_name_1));
+    BOOST_REQUIRE(topic_1_id.has_value());
+
+    // Request topic 0 by name and topic 1 by id (expect only topic 1)
+    auto resp
+      = client
+          .dispatch(
+            kafka::metadata_request{
+              .data{.topics{
+                {{.name{test_topic_name_0}}, {.topic_id{uuid{*topic_1_id}}}}}},
+            },
+            api_version{12})
+          .get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+    BOOST_REQUIRE(!resp.data.errored());
+    BOOST_REQUIRE(resp.data.topics[0].name == test_topic_name_1);
+    BOOST_REQUIRE(resp.data.topics[0].error_code == kafka::error_code::none);
+}
+
 FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
     using kafka::api_version;
     constexpr auto max_supported = kafka::metadata_handler::max_supported;
@@ -418,6 +478,25 @@ FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
         auto req = kafka::metadata_request{.data{
           .topics
           = {{{.name{ssx::sformat("{}_{}_{}", test_topic_create, "by_name", ver)}}, {.name{test_topic_query}}}},
+          .allow_auto_topic_creation = true,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+        auto resp = client.dispatch(std::move(req), ver).get();
+
+        BOOST_REQUIRE(!resp.data.errored());
+        const auto& topics = resp.data.topics;
+        BOOST_REQUIRE_EQUAL(topics.size(), 2);
+        BOOST_REQUIRE_EQUAL(topics[0].error_code, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(topics[1].error_code, kafka::error_code::none);
+    }
+
+    auto query_topic_id = get_topic_id(model::topic(test_topic_query));
+    BOOST_REQUIRE(query_topic_id.has_value());
+
+    for (api_version ver{12}; ver <= max_supported; ++ver) {
+        auto req = kafka::metadata_request{.data{
+          .topics
+          = {{{.name{ssx::sformat("{}_{}_{}", test_topic_create, "by_id", ver)}}, {.topic_id{kafka::uuid{*query_topic_id}}}}},
           .allow_auto_topic_creation = true,
           .include_cluster_authorized_operations = false,
           .include_topic_authorized_operations = false}};

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -278,6 +278,7 @@ std::error_condition make_error_condition(std::error_code ec) {
         case kec::reassignment_in_progress:
             return rec::kafka_retriable_error;
         case kec::unknown_topic_or_partition:
+        case kec::unknown_topic_id:
             return rec::partition_not_found;
         case kec::unknown_member_id:
             return rec::consumer_instance_not_found;

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -40,7 +40,7 @@ class SaramaProduceTest(RedpandaTest):
                                                 extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_produce(self, version):
         verifier_bin = "/opt/redpanda-tests/go/sarama/produce_test/produce_test"
 

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -41,7 +41,7 @@ class SaramaTest(RedpandaTest):
         self._timeout = 30 if self.scale.local else 1200
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_interceptors(self, version):
         sarama_example = SaramaExamples.SaramaInterceptors(
             self.redpanda, version, self.topic)
@@ -57,7 +57,7 @@ class SaramaTest(RedpandaTest):
                    backoff_sec=1)
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_http_server(self, version):
         sarama_example = SaramaExamples.SaramaHttpServer(
             self.redpanda, version)
@@ -95,7 +95,7 @@ class SaramaTest(RedpandaTest):
                    err_msg="sarama http_server test failed")
 
     @cluster(num_nodes=5)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_consumergroup(self, version):
         count = 10 if self.scale.local else 5000
 
@@ -152,7 +152,7 @@ class SaramaScramTest(RedpandaTest):
         super(SaramaScramTest, self).__init__(test_context, security=security)
 
     @cluster(num_nodes=3)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_sasl_scram(self, version):
         # Get the SASL SCRAM command and a ducktape node
         cmd = SaramaExamples.sarama_sasl_scram(self.redpanda, version,


### PR DESCRIPTION
Add support for metadata v12

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
