### PR TITLE
`config`: reduce `max_compacted_log_segment_size` default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1501,7 +1501,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "10737418240",
        .visibility = visibility::tunable},
-      5_GiB)
+      512_MiB)
   , storage_ignore_timestamps_in_future_sec(
       *this,
       "storage_ignore_timestamps_in_future_sec",


### PR DESCRIPTION
This default value of `5_GiB` is quite massive and was chosen long ago. With the [advent of changes resulting in more aggressive adjacent merging during compaction](https://github.com/redpanda-data/redpanda/pull/25953), this default needs revisiting to ensure the new behavior won't cause stability issues in the extreme case where a long running `log` suddenly has its average `segment` size trend towards `max_compacted_log_segment_size` due to compaction.

Our cloud tier config generators have dropped the default down to twice the value of `log_segment_size` [1].

A rational explanation for why twice the value of `log_segment_size` makes sense for this default is that for most `compact` enable topics with a bounded keyset, historical `segment`s existing in the `log` should be reduced to very small sizes as sliding window compaction works over the entirety of the key-offset space. These `segment`s will be ostensibly be reduced in number and increased in size, trending towards `max_compacted_log_size` thanks to adjacent merge compaction. Therefore, capping at `512_MiB` with the new default seems to be a safer bet than the much larger than average (with regards to the statistics we see in current `redpanda` clusters) `segment` size of `5_GiB`.  

In the pathological case that sliding window compaction cannot reduce two adjacent segments, twice the value of `compacted_log_segment_size` still allows for the segments to be adjacently merged, so even in the worst case scenario, the growth rate for the `segment` count in a `log` can be kept somewhat bounded.

[1]: https://github.com/redpanda-data/cloudv2/blob/940cfd4f3560b21df6d763faabf529c88a2546ef/install-pack/generate-tiers.py#L562


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
