### PR TITLE
storage/tests: yet more Boost to Google Test migrations

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -192,7 +192,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "log_segment_appender_test",
     timeout = "short",
     srcs = [
@@ -208,10 +208,10 @@ redpanda_cc_btest(
         "//src/v/storage:chunk_cache",
         "//src/v/storage:resources",
         "//src/v/storage:segment_appender",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
         "@fmt",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -256,7 +256,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "batch_cache_test",
     timeout = "short",
     srcs = [
@@ -267,9 +267,10 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/storage:batch_cache",
         "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "@fmt",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -847,7 +847,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "log_replayer_test",
     timeout = "short",
     srcs = [
@@ -864,8 +864,8 @@ redpanda_cc_btest(
         "//src/v/storage:logger",
         "//src/v/storage:record_batch_utils",
         "//src/v/storage:resources",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -499,7 +499,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "offset_translator_tests",
     timeout = "moderate",
     srcs = [
@@ -513,10 +513,10 @@ redpanda_cc_btest(
         "//src/v/random:generators",
         "//src/v/storage",
         "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
         "//src/v/test_utils:random_bytes",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:range",
-        "@boost//:test",
+        "@fmt",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -738,18 +738,17 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_btest(
-    name = "log_retention_tests",
+redpanda_cc_gtest(
+    name = "log_retention_test",
     timeout = "short",
     srcs = [
-        "log_retention_tests.cc",
+        "log_retention_test.cc",
     ],
     deps = [
         "//src/v/model",
         "//src/v/storage/tests:disk_log_builder",
-        "//src/v/test_utils:fixture",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/storage/tests/batch_cache_test.cc
+++ b/src/v/storage/tests/batch_cache_test.cc
@@ -19,7 +19,9 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
-#include <boost/test/tools/old/interface.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <gtest/gtest.h>
 
 static storage::batch_cache::reclaim_options opts = {
   .growth_window = std::chrono::milliseconds(3000),
@@ -47,7 +49,7 @@ static model::record_batch make_random_batch(
     return std::move(b).build();
 }
 
-class batch_cache_test_fixture {
+class batch_cache_test_fixture : public ::testing::Test {
 public:
     batch_cache_test_fixture()
       : cache(opts) {}
@@ -58,36 +60,36 @@ public:
     storage::batch_cache cache;
 };
 
-FIXTURE_TEST(initially_empty, batch_cache_test_fixture) {
-    BOOST_CHECK(cache.empty());
+TEST_F(batch_cache_test_fixture, initially_empty) {
+    EXPECT_TRUE(cache.empty());
 }
 
-FIXTURE_TEST(evict, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, evict) {
     storage::batch_cache_index index(cache);
 
     auto b = make_batch(100);
     auto w = cache.put(index, std::move(b), is_dirty_entry::no);
-    BOOST_CHECK(!cache.empty());
+    EXPECT_FALSE(cache.empty());
     cache.evict(std::move(w.range()));
-    BOOST_CHECK(cache.empty());
+    EXPECT_TRUE(cache.empty());
 }
 
-FIXTURE_TEST(reclaim_rounds_up, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, reclaim_rounds_up) {
     storage::batch_cache_index index(cache);
 
     auto b = make_batch(5);
     auto b_size = b.memory_usage();
-    std::cout << b_size << std::endl;
+    SCOPED_TRACE(fmt::format("batch size: {}", b_size));
     cache.put(index, std::move(b), is_dirty_entry::no);
-    BOOST_CHECK(!cache.empty());
+    EXPECT_FALSE(cache.empty());
 
     auto size = cache.reclaim(1);
     // reclaims rounds up to the range size for small batches
-    BOOST_REQUIRE_EQUAL(size, storage::batch_cache::range::range_size);
-    BOOST_CHECK(cache.empty());
+    EXPECT_EQ(size, storage::batch_cache::range::range_size);
+    EXPECT_TRUE(cache.empty());
 }
 
-FIXTURE_TEST(reclaim_removes_multiple, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, reclaim_removes_multiple) {
     storage::batch_cache_index index(cache);
 
     auto b = make_batch(100);
@@ -99,33 +101,33 @@ FIXTURE_TEST(reclaim_removes_multiple, batch_cache_test_fixture) {
     cache.put(index, b.share(), is_dirty_entry::no);
     cache.put(index, b.share(), is_dirty_entry::no);
     cache.put(index, b.share(), is_dirty_entry::no);
-    BOOST_CHECK(!cache.empty());
+    EXPECT_FALSE(cache.empty());
 
     auto size = cache.reclaim(b_size + 1);
-    BOOST_CHECK(size > (2 * b_size));
-    BOOST_CHECK(cache.empty());
+    EXPECT_GT(size, (2 * b_size));
+    EXPECT_TRUE(cache.empty());
 }
 
-FIXTURE_TEST(weakness, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, weakness) {
     storage::batch_cache_index index(cache);
 
     auto b0 = cache.put(index, make_batch(10), is_dirty_entry::no);
     auto b1 = cache.put(index, make_batch(10), is_dirty_entry::no);
     auto b2 = cache.put(index, make_batch(10), is_dirty_entry::no);
 
-    BOOST_CHECK(!cache.empty());
+    EXPECT_FALSE(cache.empty());
 
-    BOOST_CHECK(b0.range());
-    BOOST_CHECK(b1.range());
-    BOOST_CHECK(b2.range());
+    EXPECT_TRUE(b0.range());
+    EXPECT_TRUE(b1.range());
+    EXPECT_TRUE(b2.range());
 
     cache.reclaim(1);
-    BOOST_CHECK(!b0.range());
-    BOOST_CHECK(!b1.range());
-    BOOST_CHECK(!b2.range());
+    EXPECT_FALSE(b0.range());
+    EXPECT_FALSE(b1.range());
+    EXPECT_FALSE(b2.range());
 }
 
-SEASTAR_THREAD_TEST_CASE(touch) {
+TEST(batch_cache_test, touch) {
     static storage::batch_cache::reclaim_options opts = {
       .growth_window = std::chrono::milliseconds(3000),
       .stable_window = std::chrono::milliseconds(10000),
@@ -145,8 +147,8 @@ SEASTAR_THREAD_TEST_CASE(touch) {
 
         // first one is invalid, second one still valid
         cache.reclaim(1);
-        BOOST_CHECK(!b0.range());
-        BOOST_CHECK(b1.range());
+        EXPECT_FALSE(b0.range());
+        EXPECT_TRUE(b1.range());
         cache.stop().get();
     }
 
@@ -165,22 +167,22 @@ SEASTAR_THREAD_TEST_CASE(touch) {
         cache.touch(b0.range());
         // so reclaiming now frees the second
         cache.reclaim(1);
-        BOOST_CHECK(b0.range());
-        BOOST_CHECK(!b1.range());
+        EXPECT_TRUE(b0.range());
+        EXPECT_FALSE(b1.range());
         cache.stop().get();
     }
 }
 
-FIXTURE_TEST(index_get_empty, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, index_get_empty) {
     storage::batch_cache_index index(cache);
 
-    BOOST_CHECK(index.empty());
-    BOOST_CHECK(!index.get(model::offset(0)));
-    BOOST_CHECK(!index.get(model::offset(10)));
-    BOOST_CHECK(index.empty());
+    EXPECT_TRUE(index.empty());
+    EXPECT_FALSE(index.get(model::offset(0)));
+    EXPECT_FALSE(index.get(model::offset(10)));
+    EXPECT_TRUE(index.empty());
 }
 
-FIXTURE_TEST(index_get, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, index_get) {
     storage::batch_cache_index index(cache);
     storage::batch_cache_index index2(cache);
 
@@ -190,16 +192,16 @@ FIXTURE_TEST(index_get, batch_cache_test_fixture) {
     index.put(make_batch(10, model::offset(21)), is_dirty_entry::no);
 
     // before first
-    BOOST_CHECK(!index.get(model::offset(0)));
-    BOOST_CHECK(!index.get(model::offset(9)));
+    EXPECT_FALSE(index.get(model::offset(0)));
+    EXPECT_FALSE(index.get(model::offset(9)));
 
     // macro makes line numbers and printed values work for error messages
 #define checker(o, base, last)                                                 \
     do {                                                                       \
-        BOOST_REQUIRE(index.get(model::offset(o)));                            \
-        BOOST_CHECK(                                                           \
+        ASSERT_TRUE(index.get(model::offset(o)));                              \
+        EXPECT_TRUE(                                                           \
           index.get(model::offset(o))->base_offset() == model::offset(base));  \
-        BOOST_CHECK(                                                           \
+        EXPECT_TRUE(                                                           \
           index.get(model::offset(o))->last_offset() == model::offset(last));  \
     } while (0)
 
@@ -218,20 +220,20 @@ FIXTURE_TEST(index_get, batch_cache_test_fixture) {
 #undef checker
 
     // after last
-    BOOST_CHECK(!index.get(model::offset(31)));
-    BOOST_CHECK(!index.get(model::offset(40)));
+    EXPECT_FALSE(index.get(model::offset(31)));
+    EXPECT_FALSE(index.get(model::offset(40)));
 
     // [11:20]   [41:50]
     index2.put(make_batch(10, model::offset(11)), is_dirty_entry::no);
     index2.put(make_batch(10, model::offset(41)), is_dirty_entry::no);
 
     // in the gap
-    BOOST_CHECK(!index2.get(model::offset(21)));
-    BOOST_CHECK(!index2.get(model::offset(25)));
-    BOOST_CHECK(!index2.get(model::offset(40)));
+    EXPECT_FALSE(index2.get(model::offset(21)));
+    EXPECT_FALSE(index2.get(model::offset(25)));
+    EXPECT_FALSE(index2.get(model::offset(40)));
 }
 
-FIXTURE_TEST(index_truncate_smoke, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, index_truncate_smoke) {
     storage::batch_cache_index index(cache);
 
     // add batches of increasing size
@@ -242,19 +244,19 @@ FIXTURE_TEST(index_truncate_smoke, batch_cache_test_fixture) {
     }
 
     for (auto i = 0; i < base(); i++) {
-        BOOST_CHECK(index.get(model::offset(i)));
+        EXPECT_TRUE(index.get(model::offset(i)));
     }
 
     base += model::offset(10);
     for (auto trunc_at = base(); trunc_at-- > 0;) {
         index.truncate(model::offset(trunc_at));
         for (auto i = trunc_at; i < base(); i++) {
-            BOOST_CHECK(!index.get(model::offset(i)));
+            EXPECT_FALSE(index.get(model::offset(i)));
         }
     }
 }
 
-FIXTURE_TEST(index_truncate_hole, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, index_truncate_hole) {
     storage::batch_cache_index index(cache);
 
     // [10][11:20]  [41:50]
@@ -264,12 +266,12 @@ FIXTURE_TEST(index_truncate_hole, batch_cache_test_fixture) {
 
     index.truncate(model::offset(25));
     // all batches belong to the same range, all of them will be evicted
-    BOOST_CHECK(!index.get(model::offset(10)));
-    BOOST_CHECK(!index.get(model::offset(11)));
-    BOOST_CHECK(!index.get(model::offset(41)));
+    EXPECT_FALSE(index.get(model::offset(10)));
+    EXPECT_FALSE(index.get(model::offset(11)));
+    EXPECT_FALSE(index.get(model::offset(41)));
 }
 
-FIXTURE_TEST(index_truncate_hole_missing_prev, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, index_truncate_hole_missing_prev) {
     storage::batch_cache_index index(cache);
 
     // [10][11:20]  [41:50]
@@ -278,17 +280,17 @@ FIXTURE_TEST(index_truncate_hole_missing_prev, batch_cache_test_fixture) {
     index.put(make_batch(10, model::offset(41)), is_dirty_entry::no);
 
     index.testing_evict_from_cache(model::offset(11));
-    BOOST_CHECK(index.testing_exists_in_index(model::offset(11)));
-    BOOST_CHECK(!index.get(model::offset(10)));
+    EXPECT_TRUE(index.testing_exists_in_index(model::offset(11)));
+    EXPECT_FALSE(index.get(model::offset(10)));
 
     index.truncate(model::offset(25));
-    BOOST_CHECK(!index.get(model::offset(10)));
-    BOOST_CHECK(!index.testing_exists_in_index(model::offset(11)));
-    BOOST_CHECK(!index.get(model::offset(11)));
-    BOOST_CHECK(!index.get(model::offset(41)));
+    EXPECT_FALSE(index.get(model::offset(10)));
+    EXPECT_FALSE(index.testing_exists_in_index(model::offset(11)));
+    EXPECT_FALSE(index.get(model::offset(11)));
+    EXPECT_FALSE(index.get(model::offset(41)));
 }
 
-FIXTURE_TEST(test_random_batch_sizes, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, test_random_batch_sizes) {
     storage::batch_cache_index index(cache);
     std::vector<model::record_batch> batches;
     for (int i = 0; i < 1000; ++i) {
@@ -300,9 +302,9 @@ FIXTURE_TEST(test_random_batch_sizes, batch_cache_test_fixture) {
 
     for (auto& b : batches) {
         auto from_cache = index.get(b.base_offset());
-        BOOST_REQUIRE(from_cache.has_value());
-        BOOST_REQUIRE_EQUAL(from_cache->header(), b.header());
-        BOOST_REQUIRE_EQUAL(from_cache->data(), b.data());
+        ASSERT_TRUE(from_cache.has_value());
+        EXPECT_EQ(from_cache->header(), b.header());
+        EXPECT_EQ(from_cache->data(), b.data());
     }
     double max_waste = ((double)storage::batch_cache::range::max_waste_bytes
                         / storage::batch_cache::range::range_size)
@@ -311,29 +313,29 @@ FIXTURE_TEST(test_random_batch_sizes, batch_cache_test_fixture) {
     // assert waste, we have to skip last range
     for (auto& r :
          std::ranges::subrange(get_lru().begin(), std::prev(get_lru().end()))) {
-        BOOST_REQUIRE_LE(r.waste(), max_waste);
+        EXPECT_LE(r.waste(), max_waste);
     }
 }
 
-FIXTURE_TEST(test_mark_clean_empty, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, test_mark_clean_empty) {
     storage::batch_cache_index index(cache);
     index.mark_clean(model::offset(1000));
 }
 
 /// Test marking a single batch as clean to catch any potential off-by-one
 /// errors or incorrect use of `<=` vs `<` comparison operators.
-FIXTURE_TEST(test_mark_clean_min_edge, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, test_mark_clean_min_edge) {
     storage::batch_cache_index index(cache);
 
     index.put(make_batch(1, model::offset(10)), is_dirty_entry::yes);
     index.mark_clean(model::offset(10));
 
     cache.clear();
-    BOOST_CHECK(index.empty());
-    BOOST_CHECK(cache.empty());
+    EXPECT_TRUE(index.empty());
+    EXPECT_TRUE(cache.empty());
 }
 
-FIXTURE_TEST(test_mark_clean_edge, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, test_mark_clean_edge) {
     storage::batch_cache_index index(cache);
 
     // Small batches which will go in the same range.
@@ -344,25 +346,25 @@ FIXTURE_TEST(test_mark_clean_edge, batch_cache_test_fixture) {
 
     // Reclaim will not happen due to a dirty batch in the range.
     cache.clear();
-    BOOST_CHECK(index.get(model::offset(20)).has_value());
-    BOOST_CHECK(index.get(model::offset(30)).has_value());
-    BOOST_CHECK(index.get(model::offset(40)).has_value());
-    BOOST_CHECK(index.get(model::offset(10)).has_value());
+    EXPECT_TRUE(index.get(model::offset(20)).has_value());
+    EXPECT_TRUE(index.get(model::offset(30)).has_value());
+    EXPECT_TRUE(index.get(model::offset(40)).has_value());
+    EXPECT_TRUE(index.get(model::offset(10)).has_value());
 
     // No reclaim as there is a dirty batch with a higher offset.
     index.mark_clean(model::offset(43));
-    BOOST_CHECK(index.get(model::offset(20)).has_value());
-    BOOST_CHECK(index.get(model::offset(30)).has_value());
-    BOOST_CHECK(index.get(model::offset(40)).has_value());
-    BOOST_CHECK(index.get(model::offset(10)).has_value());
+    EXPECT_TRUE(index.get(model::offset(20)).has_value());
+    EXPECT_TRUE(index.get(model::offset(30)).has_value());
+    EXPECT_TRUE(index.get(model::offset(40)).has_value());
+    EXPECT_TRUE(index.get(model::offset(10)).has_value());
 
     // Reclaim will happen here and evict the whole range.
     index.mark_clean(model::offset(44));
     cache.clear();
-    BOOST_CHECK(!index.get(model::offset(20)));
-    BOOST_CHECK(!index.get(model::offset(30)));
-    BOOST_CHECK(!index.get(model::offset(40)));
-    BOOST_CHECK(!index.get(model::offset(10)));
+    EXPECT_FALSE(index.get(model::offset(20)));
+    EXPECT_FALSE(index.get(model::offset(30)));
+    EXPECT_FALSE(index.get(model::offset(40)));
+    EXPECT_FALSE(index.get(model::offset(10)));
 }
 
 /// Regression test for a buggy iteration order after the introduction of the
@@ -370,7 +372,7 @@ FIXTURE_TEST(test_mark_clean_edge, batch_cache_test_fixture) {
 /// from the "min dirty offset=10" to the "mark clean up_to=1".
 /// The assertions are implicit: not hitting any assertions in implementation
 /// and not crashing.
-FIXTURE_TEST(test_mark_clean_valid_iterating, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, test_mark_clean_valid_iterating) {
     storage::batch_cache_index index(cache);
 
     index.put(make_batch(1, model::offset(1)), is_dirty_entry::no);
@@ -381,7 +383,7 @@ FIXTURE_TEST(test_mark_clean_valid_iterating, batch_cache_test_fixture) {
     index.mark_clean(model::offset(19));
 }
 
-FIXTURE_TEST(test_add_dirty_seq, batch_cache_test_fixture) {
+TEST_F(batch_cache_test_fixture, test_add_dirty_seq) {
     storage::batch_cache_index index(cache);
 
     index.put(make_batch(10, model::offset(10)), is_dirty_entry::yes);

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -27,6 +27,8 @@
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>
 
+#include <gtest/gtest.h>
+
 #include <memory>
 
 using namespace storage; // NOLINT
@@ -135,18 +137,18 @@ public:
 };
 } // namespace storage
 
-SEASTAR_THREAD_TEST_CASE(test_can_recover_single_batch) {
+TEST(log_replayer_test, test_can_recover_single_batch) {
     log_replayer_fixture ctx;
     auto batches = model::test::make_random_batches(model::offset(1), 1).get();
     auto last_offset = batches.back().last_offset();
     ctx.write(batches);
     storage::log_replayer::checkpoint recovered
       = ctx.replayer().recover_in_thread(ss::default_priority_class());
-    BOOST_REQUIRE(bool(recovered));
-    BOOST_CHECK_EQUAL(recovered.last_offset.value(), last_offset);
+    ASSERT_TRUE(bool(recovered));
+    EXPECT_EQ(recovered.last_offset.value(), last_offset);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_unrecovered_single_batch) {
+TEST(log_replayer_test, test_unrecovered_single_batch) {
     {
         log_replayer_fixture ctx;
         auto batches
@@ -155,7 +157,7 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_single_batch) {
         ctx.write(batches);
         auto recovered = ctx.replayer().recover_in_thread(
           ss::default_priority_class());
-        BOOST_CHECK(!bool(recovered));
+        EXPECT_FALSE(bool(recovered));
     }
     {
         log_replayer_fixture ctx;
@@ -165,31 +167,31 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_single_batch) {
         ctx.write(batches);
         auto recovered = ctx.replayer().recover_in_thread(
           ss::default_priority_class());
-        BOOST_CHECK(!bool(recovered));
+        EXPECT_FALSE(bool(recovered));
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(test_malformed_segment) {
+TEST(log_replayer_test, test_malformed_segment) {
     log_replayer_fixture ctx;
     ctx.write_garbage();
     ctx.initialize(model::offset(0));
     auto recovered = ctx.replayer().recover_in_thread(
       ss::default_priority_class());
-    BOOST_CHECK(!bool(recovered));
+    EXPECT_FALSE(bool(recovered));
 }
 
-SEASTAR_THREAD_TEST_CASE(test_can_recover_multiple_batches) {
+TEST(log_replayer_test, test_can_recover_multiple_batches) {
     log_replayer_fixture ctx;
     auto batches = model::test::make_random_batches(model::offset(1), 10).get();
     auto last_offset = batches.back().last_offset();
     ctx.write(batches);
     auto recovered = ctx.replayer().recover_in_thread(
       ss::default_priority_class());
-    BOOST_CHECK(bool(recovered));
-    BOOST_CHECK_EQUAL(recovered.last_offset.value(), last_offset);
+    EXPECT_TRUE(bool(recovered));
+    EXPECT_EQ(recovered.last_offset.value(), last_offset);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_unrecovered_multiple_batches) {
+TEST(log_replayer_test, test_unrecovered_multiple_batches) {
     {
         // bad crc test
         log_replayer_fixture ctx;
@@ -200,8 +202,8 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_multiple_batches) {
         ctx.write(batches);
         auto recovered = ctx.replayer().recover_in_thread(
           ss::default_priority_class());
-        BOOST_CHECK(bool(recovered));
-        BOOST_CHECK_EQUAL(recovered.last_offset.value(), last_offset);
+        EXPECT_TRUE(bool(recovered));
+        EXPECT_EQ(recovered.last_offset.value(), last_offset);
     }
     {
         // timestamp test
@@ -213,11 +215,11 @@ SEASTAR_THREAD_TEST_CASE(test_unrecovered_multiple_batches) {
         ctx.write(batches);
         auto recovered = ctx.replayer().recover_in_thread(
           ss::default_priority_class());
-        BOOST_CHECK(bool(recovered));
-        BOOST_CHECK_EQUAL(recovered.last_offset.value(), last_offset);
+        EXPECT_TRUE(bool(recovered));
+        EXPECT_EQ(recovered.last_offset.value(), last_offset);
     }
 }
-SEASTAR_THREAD_TEST_CASE(test_reset_index) {
+TEST(log_replayer_test, test_reset_index) {
     // bad crc test
     log_replayer_fixture ctx;
     ctx.write_garbage_index(); // key
@@ -226,8 +228,8 @@ SEASTAR_THREAD_TEST_CASE(test_reset_index) {
     ctx.write(batches);
     auto recovered = ctx.replayer().recover_in_thread(
       ss::default_priority_class());
-    BOOST_CHECK(bool(recovered));
-    BOOST_CHECK_EQUAL(recovered.last_offset.value(), last_offset);
+    EXPECT_TRUE(bool(recovered));
+    EXPECT_EQ(recovered.last_offset.value(), last_offset);
     storage::stlog.info("Recovered segment:{}", ctx._seg);
-    BOOST_CHECK(ctx._seg->index().needs_persistence());
+    EXPECT_TRUE(ctx._seg->index().needs_persistence());
 }

--- a/src/v/storage/tests/log_retention_test.cc
+++ b/src/v/storage/tests/log_retention_test.cc
@@ -14,22 +14,25 @@
 
 #include <seastar/util/defer.hh>
 
+#include <gtest/gtest.h>
+
 #include <optional>
 
 using namespace std::literals;
 
-struct gc_fixture {
+class gc_fixture : public ::testing::Test {
+public:
     storage::disk_log_builder builder;
 };
 
-FIXTURE_TEST(empty_log_garbage_collect, gc_fixture) {
+TEST_F(gc_fixture, empty_log_garbage_collect) {
     builder | storage::start()
       | storage::garbage_collect(
         model::timestamp::now(), std::make_optional<size_t>(1024))
       | storage::stop();
 }
 
-FIXTURE_TEST(retention_test_time, gc_fixture) {
+TEST_F(gc_fixture, retention_test_time) {
     auto base_ts = model::timestamp::now();
     ss::sleep(5s).get();
     builder.set_time(base_ts);
@@ -44,72 +47,70 @@ FIXTURE_TEST(retention_test_time, gc_fixture) {
 
     ss::sleep(5s).get();
     builder | storage::add_segment(104) | storage::add_random_batches(104, 3);
-    BOOST_TEST_MESSAGE(
-      "Should not collect segments with timestamp older than 1");
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
+    // Should not collect segments with timestamp older than 1
+    EXPECT_EQ(builder.get_log()->segment_count(), 3);
 
     builder | storage::garbage_collect(base_ts, std::nullopt);
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
+    EXPECT_EQ(builder.get_log()->segment_count(), 3);
 
-    BOOST_TEST_MESSAGE("Should not collect segments because size is infinity");
+    // Should not collect segments because size is infinity
     builder
       | storage::garbage_collect(
         base_ts,
         std::make_optional<size_t>(std::numeric_limits<size_t>::max()));
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
+    EXPECT_EQ(builder.get_log()->segment_count(), 3);
 
-    BOOST_TEST_MESSAGE("Should leave one active segment");
+    // Should leave one active segment
     builder
       | storage::garbage_collect(
         model::timestamp{base_ts() + 15'000}, std::nullopt)
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 1);
+    EXPECT_EQ(builder.get_log()->segment_count(), 1);
 }
 
-FIXTURE_TEST(retention_test_size, gc_fixture) {
+TEST_F(gc_fixture, retention_test_size) {
     builder | storage::start() | storage::add_segment(0)
       | storage::add_random_batch(0, 100, storage::maybe_compress_batches::yes)
       | storage::add_random_batch(100, 2, storage::maybe_compress_batches::yes)
       | storage::add_segment(102)
       | storage::add_random_batch(102, 2, storage::maybe_compress_batches::yes)
       | storage::add_segment(104) | storage::add_random_batches(104, 3);
-    BOOST_TEST_MESSAGE("Should not collect segments because size equal to "
-                       "current partition size");
+    // Should not collect segments because size equal to current partition size
     builder
       | storage::garbage_collect(
         model::timestamp(1),
         std::make_optional(
           builder.get_disk_log_impl().get_probe().partition_size()));
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 3);
+    EXPECT_EQ(builder.get_log()->segment_count(), 3);
 
-    BOOST_TEST_MESSAGE("Should collect all segments");
+    // Should collect all segments
     builder
       | storage::garbage_collect(model::timestamp(1), std::optional<size_t>(0))
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
+    EXPECT_EQ(builder.get_log()->segment_count(), 0);
 }
 
-FIXTURE_TEST(retention_test_size_with_one_segment, gc_fixture) {
+TEST_F(gc_fixture, retention_test_size_with_one_segment) {
     builder | storage::start() | storage::add_segment(0)
       | storage::add_random_batch(0, 100, storage::maybe_compress_batches::yes)
       | storage::add_random_batch(100, 2, storage::maybe_compress_batches::yes);
-    BOOST_TEST_MESSAGE("Should not collect the segment because size equal to "
-                       "current partition size");
+    // Should not collect the segment because size equal to current partition
+    // size
     builder
       | storage::garbage_collect(
         model::timestamp(1),
         std::make_optional(
           builder.get_disk_log_impl().get_probe().partition_size()));
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 1);
+    EXPECT_EQ(builder.get_log()->segment_count(), 1);
 
-    BOOST_TEST_MESSAGE("Should not collect the segment");
+    // Should not collect the segment
     builder
       | storage::garbage_collect(model::timestamp(1), std::optional<size_t>(0))
       | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 1);
+    EXPECT_EQ(builder.get_log()->segment_count(), 1);
 }
 
 /*
@@ -128,7 +129,7 @@ FIXTURE_TEST(retention_test_size_with_one_segment, gc_fixture) {
  * for all batches. so we expect that all segments except the active segment to
  * be removed.
  */
-FIXTURE_TEST(retention_test_size_time, gc_fixture) {
+TEST_F(gc_fixture, retention_test_size_time) {
     const auto last_week = model::to_timestamp(
       model::timestamp_clock::now() - std::chrono::days(7));
 
@@ -154,12 +155,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
         offset += model::offset(num_records);
     }
 
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 2_MiB),
       builder.storage().resources().get_falloc_step({})
         * builder.get_disk_log_impl().segments().size());
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 2_MiB),
       builder.storage().resources().get_falloc_step({})
@@ -182,12 +183,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     // the first segment is now eligible for reclaim
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 3_MiB),
       builder.storage().resources().get_falloc_step({})
         * builder.get_disk_log_impl().segments().size());
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 3_MiB),
       builder.storage().resources().get_falloc_step({})
@@ -210,12 +211,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     // the first,second segment is now eligible for reclaim
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 4_MiB),
       builder.storage().resources().get_falloc_step({})
         * builder.get_disk_log_impl().segments().size());
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 4_MiB),
       builder.storage().resources().get_falloc_step({})
@@ -238,12 +239,12 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     // the first,second segment is now eligible for reclaim
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 5_MiB),
       builder.storage().resources().get_falloc_step({})
         * builder.get_disk_log_impl().segments().size());
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 5_MiB),
       builder.storage().resources().get_falloc_step({})
@@ -252,29 +253,28 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     builder | storage::garbage_collect(model::timestamp::now(), 4_MiB);
 
     // right after gc runs there shouldn't be anything reclaimable
-    BOOST_CHECK_EQUAL(
+    EXPECT_EQ(
       builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention,
       0);
-    BOOST_CHECK_EQUAL(
+    EXPECT_EQ(
       builder.disk_usage(model::timestamp::now(), 0).get().usage.total(), 0);
 
     builder | storage::stop();
 
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
+    EXPECT_EQ(builder.get_log()->segment_count(), 0);
 }
-FIXTURE_TEST(retention_test_after_truncation, gc_fixture) {
-    BOOST_TEST_MESSAGE("Should be safe to garbage collect after truncation");
+TEST_F(gc_fixture, retention_test_after_truncation) {
+    // Should be safe to garbage collect after truncation
     builder | storage::start() | storage::add_segment(0)
       | storage::add_random_batch(0, 100, storage::maybe_compress_batches::yes)
       | storage::truncate_log(model::offset(0))
       | storage::garbage_collect(model::timestamp::now(), std::nullopt)
       | storage::stop();
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
-    BOOST_CHECK_EQUAL(
-      builder.get_disk_log_impl().get_probe().partition_size(), 0);
+    EXPECT_EQ(builder.get_log()->segment_count(), 0);
+    EXPECT_EQ(builder.get_disk_log_impl().get_probe().partition_size(), 0);
 }
 
-FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
+TEST_F(gc_fixture, retention_by_size_with_remote_write) {
     /*
      * This test sets the size retention limit on a cloud storage topic
      * via the rention.local.target.bytes topic configuration option.
@@ -328,21 +328,21 @@ FIXTURE_TEST(retention_by_size_with_remote_write, gc_fixture) {
         auto segment_count_after_gc = builder.get_log()->segment_count();
 
         if (partition_size > size_limit) {
-            BOOST_CHECK_GE(segment_count_before_gc, segment_count_after_gc);
+            EXPECT_GE(segment_count_before_gc, segment_count_after_gc);
         } else {
-            BOOST_CHECK_EQUAL(segment_count_before_gc, segment_count_after_gc);
+            EXPECT_EQ(segment_count_before_gc, segment_count_after_gc);
         }
     }
 
     auto final_partition_size
       = builder.get_disk_log_impl().get_probe().partition_size();
 
-    BOOST_CHECK_LE(size_limit, final_partition_size);
+    EXPECT_LE(size_limit, final_partition_size);
 
     builder.stop().get();
 }
 
-FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
+TEST_F(gc_fixture, retention_by_time_with_remote_write) {
     /*
      * This test sets the time retention limit on a cloud storage topic
      * via the rention.local.target.ms topic configuration option.
@@ -394,7 +394,7 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
     // Try to garbage collet the segments. None should get collected
     // because we are currently using the default local target retention.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt);
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 2);
+    EXPECT_EQ(builder.get_log()->segment_count(), 2);
 
     // Override the local target retention.
     storage::ntp_config::default_overrides time_override;
@@ -406,10 +406,10 @@ FIXTURE_TEST(retention_by_time_with_remote_write, gc_fixture) {
     // Collect again. All segments should be removed this time.
     builder | storage::garbage_collect(model::timestamp{1}, std::nullopt)
       | storage::stop();
-    BOOST_CHECK_EQUAL(builder.get_log()->segment_count(), 0);
+    EXPECT_EQ(builder.get_log()->segment_count(), 0);
 }
 
-FIXTURE_TEST(non_collectible_disk_usage_test, gc_fixture) {
+TEST_F(gc_fixture, non_collectible_disk_usage_test) {
     // a few helpers
     const auto last_week = model::to_timestamp(
       model::timestamp_clock::now() - std::chrono::days(7));
@@ -459,13 +459,12 @@ FIXTURE_TEST(non_collectible_disk_usage_test, gc_fixture) {
         offset += model::offset(num_records);
     }
 
-    BOOST_REQUIRE_EQUAL(
-      builder.get_disk_log_impl().config().is_collectable(), false);
+    ASSERT_EQ(builder.get_disk_log_impl().config().is_collectable(), false);
 
-    BOOST_CHECK_EQUAL(
+    EXPECT_EQ(
       builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention,
       0);
-    BOOST_CHECK_LE(
+    EXPECT_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 3_MiB),
       builder.storage().resources().get_falloc_step({})

--- a/src/v/storage/tests/log_segment_appender_test.cc
+++ b/src/v/storage/tests/log_segment_appender_test.cc
@@ -28,10 +28,8 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
-#include <boost/test/results_collector.hpp>
-#include <boost/test/tools/interface.hpp>
-#include <boost/test/tools/old/interface.hpp>
 #include <fmt/format.h>
+#include <gtest/gtest.h>
 
 #include <algorithm>
 #include <chrono>
@@ -154,13 +152,13 @@ static void run_test_can_append_multiple_flushes(size_t fallocate_size) {
 
         auto in = make_file_input_stream(f, 0);
         iobuf result = read_iobuf_exactly(in, expected.size_bytes()).get();
-        BOOST_REQUIRE_EQUAL(result.size_bytes(), expected.size_bytes());
-        BOOST_REQUIRE_EQUAL(result, expected);
+        ASSERT_EQ(result.size_bytes(), expected.size_bytes());
+        ASSERT_EQ(result, expected);
         in.close().get();
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(test_can_append_multiple_flushes) {
+TEST(log_segment_appender_test, test_can_append_multiple_flushes) {
     run_test_can_append_multiple_flushes(16_KiB);
     run_test_can_append_multiple_flushes(32_MiB);
 }
@@ -182,45 +180,47 @@ static void run_test_can_append_mixed(size_t fallocate_size) {
             original.append(data.data(), data.size());
             original.append("\n", 1);
         }
-        BOOST_REQUIRE_EQUAL(step, original.size_bytes());
+        ASSERT_EQ(step, original.size_bytes());
         appender.append(original).get();
         appender.flush().get();
-        BOOST_REQUIRE_EQUAL(acc + step, appender.file_byte_offset());
+        ASSERT_EQ(acc + step, appender.file_byte_offset());
         // now there should be nothing in-flight
-        BOOST_CHECK_EQUAL(access(appender).inflight_dispatched(), 0);
-        BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
+        EXPECT_EQ(access(appender).inflight_dispatched(), 0);
+        EXPECT_EQ(access(appender).inflight().size(), 0);
         auto in = make_file_input_stream(f, acc);
         iobuf result = read_iobuf_exactly(in, step).get();
-        fmt::print(
-          "==> i:{}, step:{}, acc:{}, og.size:{}, expected.size{}\n",
-          i,
-          step,
-          acc,
-          original.size_bytes(),
-          result.size_bytes());
         if (original != result) {
+            SCOPED_TRACE(fmt::format(
+              "==> i:{}, step:{}, acc:{}, og.size:{}, expected.size{}\n",
+              i,
+              step,
+              acc,
+              original.size_bytes(),
+              result.size_bytes()));
             auto in = iobuf::iterator_consumer(
               original.cbegin(), original.cend());
-            in.consume(original.size_bytes(), [](const char* src, size_t n) {
-                fmt::print("\nOriginal\n");
+            fmt::memory_buffer comp_str;
+            auto w = std::back_inserter(comp_str);
+            in.consume(original.size_bytes(), [&w](const char* src, size_t n) {
+                fmt::format_to(w, "\nOriginal\n");
                 while (n-- > 0) {
-                    fmt::print("{}", *src++);
+                    fmt::format_to(w, "{}", *src++);
                 }
-                fmt::print("\n");
+                fmt::format_to(w, "\n");
                 return ss::stop_iteration::no;
             });
             in = iobuf::iterator_consumer(result.cbegin(), result.cend());
-            in.consume(original.size_bytes(), [](const char* src, size_t n) {
-                fmt::print("\nResult\n");
+            in.consume(original.size_bytes(), [&w](const char* src, size_t n) {
+                fmt::format_to(w, "\nResult\n");
                 while (n-- > 0) {
-                    fmt::print("{}", *src++);
+                    fmt::format_to(w, "{}", *src++);
                 }
-                fmt::print("\n");
+                fmt::format_to(w, "\n");
                 return ss::stop_iteration::no;
             });
 
             // fail the test
-            BOOST_REQUIRE_EQUAL(original, result);
+            ASSERT_EQ(original, result) << fmt::to_string(comp_str);
         }
         acc += step;
         in.close().get();
@@ -230,14 +230,14 @@ static void run_test_can_append_mixed(size_t fallocate_size) {
     // many writes as iterations, but actually somewhat more because about 1 of
     // every 4 appends gets split across a chunk which means 2 writes
     auto write_count = access(appender).total_dispatched();
-    BOOST_CHECK_GE(write_count, iterations);
-    BOOST_CHECK_LT(write_count, 2 * iterations);
+    EXPECT_GE(write_count, iterations);
+    EXPECT_LT(write_count, 2 * iterations);
 
     // we expect 0 merges with the A+F pattern
-    BOOST_CHECK_EQUAL(access(appender).total_merged(), 0);
+    EXPECT_EQ(access(appender).total_merged(), 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_can_append_mixed) {
+TEST(log_segment_appender_test, test_can_append_mixed) {
     run_test_can_append_mixed(16_KiB);
     run_test_can_append_mixed(32_MiB);
 }
@@ -258,12 +258,12 @@ static void run_test_can_append_10MB(size_t fallocate_size) {
         appender.flush().get();
 
         // now there should be nothing in-flight
-        BOOST_CHECK_EQUAL(access(appender).inflight_dispatched(), 0);
-        BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
+        EXPECT_EQ(access(appender).inflight_dispatched(), 0);
+        EXPECT_EQ(access(appender).inflight().size(), 0);
 
         auto in = make_file_input_stream(f, i * one_meg);
         iobuf result = read_iobuf_exactly(in, one_meg).get();
-        BOOST_CHECK_EQUAL(original, result);
+        EXPECT_EQ(original, result);
         in.close().get();
     }
 
@@ -274,13 +274,13 @@ static void run_test_can_append_10MB(size_t fallocate_size) {
       = iterations
         * (one_meg / default_chunk_size() + !!(one_meg % default_chunk_size()));
     auto write_count = access(appender).total_dispatched();
-    BOOST_CHECK_EQUAL(write_count, expected_writes);
+    EXPECT_EQ(write_count, expected_writes);
 
     // we expect 0 merges with the A+F pattern
-    BOOST_CHECK_EQUAL(access(appender).total_merged(), 0);
+    EXPECT_EQ(access(appender).total_merged(), 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_can_append_10MB) {
+TEST(log_segment_appender_test, test_can_append_10MB) {
     run_test_can_append_10MB(16_KiB);
     run_test_can_append_10MB(32_MiB);
 }
@@ -306,13 +306,14 @@ static void run_test_can_append_10MB_sequential_write_sequential_read(
         iobuf tmp_o = original.share(i * one_meg, one_meg);
         // read_iobuf_exactly can return a short read, but we do not expect that
         // here.
-        BOOST_REQUIRE_EQUAL(one_meg, result.size_bytes());
-        BOOST_REQUIRE_EQUAL(tmp_o, result);
+        ASSERT_EQ(one_meg, result.size_bytes());
+        ASSERT_EQ(tmp_o, result);
         in.close().get();
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(
+TEST(
+  log_segment_appender_test,
   test_can_append_10MB_sequential_write_sequential_read) {
     run_test_can_append_10MB_sequential_write_sequential_read(16_KiB);
     run_test_can_append_10MB_sequential_write_sequential_read(32_MiB);
@@ -320,15 +321,12 @@ SEASTAR_THREAD_TEST_CASE(
 
 /**
  * @brief Returns true iff the current test is currently passing.
- *
- * From https://stackoverflow.com/a/22102899
- * https://creativecommons.org/licenses/by-sa/3.0/
  */
 bool current_test_passing() {
-    using namespace boost::unit_test;
-    test_case::id_t id = framework::current_test_case().p_id;
-    test_results rez = results_collector.results(id);
-    return rez.passed();
+    // In gtest, we don't have an equivalent of checking if test is passing
+    // during execution. We'll assume it's passing unless we have evidence
+    // otherwise. This is used for debug output on test failure.
+    return !::testing::Test::HasFailure();
 }
 
 static void run_concurrent_append_flush(
@@ -343,180 +341,181 @@ static void run_concurrent_append_flush(
     auto seed = random_generators::get_int<size_t>();
     std::default_random_engine rng(seed);
 
-    BOOST_TEST_CONTEXT(
-      "run_concurrent_append_flush, seed: "
-      << seed << ", fallocate_size: " << fallocate_size
-      << ", max_buf_size: " << max_buf_size << ", buf_count :" << buf_count) {
-        // the basic idea is we create a bunch of random buffers, then randomly
-        // perform actions on the segment appedner, like appending one of the
-        // random buffers, flushing the appender, yeilding, etc.
+    SCOPED_TRACE(fmt::format(
+      "run_concurrent_append_flush, seed: {}, fallocate_size: {}, "
+      "max_buf_size: {}, buf_count: {}",
+      seed,
+      fallocate_size,
+      max_buf_size,
+      buf_count));
+    // the basic idea is we create a bunch of random buffers, then randomly
+    // perform actions on the segment appedner, like appending one of the
+    // random buffers, flushing the appender, yeilding, etc.
 
-        std::vector<iobuf> bufs(buf_count);
-        unsigned char v = 1;
-        std::uniform_int_distribution<size_t> bufdist(0, max_buf_size);
-        for (auto& buf : bufs) {
-            buf = make_iobuf_with_char(bufdist(rng), v);
-            if (++v == 0) {
-                v = 1;
-            }
+    std::vector<iobuf> bufs(buf_count);
+    unsigned char v = 1;
+    std::uniform_int_distribution<size_t> bufdist(0, max_buf_size);
+    for (auto& buf : bufs) {
+        buf = make_iobuf_with_char(bufdist(rng), v);
+        if (++v == 0) {
+            v = 1;
         }
+    }
 
-        // At each iteration we chose an action to perform with equal
-        // probability, respecting the rules of the appender, e.g., that any
-        // previous append must have resolved before a new one is invoked.
-        struct action {
-            enum kind_enum { APPEND, FLUSH, WAIT_APPEND, SLEEP, LAST = SLEEP };
+    // At each iteration we chose an action to perform with equal
+    // probability, respecting the rules of the appender, e.g., that any
+    // previous append must have resolved before a new one is invoked.
+    struct action {
+        enum kind_enum { APPEND, FLUSH, WAIT_APPEND, SLEEP, LAST = SLEEP };
 
-            action(int kind)
-              : kind{(kind_enum)kind} {}
+        action(int kind)
+          : kind{(kind_enum)kind} {}
 
-            kind_enum kind;
-            segment_appender_info info{};
-            ss::sstring extra;
-            ss::future<> flush_future
-              = ss::make_ready_future<>(); // if kind == FLUSH
+        kind_enum kind;
+        segment_appender_info info{};
+        ss::sstring extra;
+        ss::future<> flush_future
+          = ss::make_ready_future<>(); // if kind == FLUSH
 
-            ss::sstring to_string() const {
-                ss::sstring astr = [this]() {
-                    switch (kind) {
-                    case APPEND:
-                        return "APPEND";
-                    case FLUSH:
-                        return "FLUSH";
-                    case WAIT_APPEND:
-                        return "WAIT_APPEND";
-                    case SLEEP:
-                        return "SLEEP";
-                    }
-                    vassert(false, "bad kind");
-                }();
+        ss::sstring to_string() const {
+            ss::sstring astr = [this]() {
+                switch (kind) {
+                case APPEND:
+                    return "APPEND";
+                case FLUSH:
+                    return "FLUSH";
+                case WAIT_APPEND:
+                    return "WAIT_APPEND";
+                case SLEEP:
+                    return "SLEEP";
+                }
+                vassert(false, "bad kind");
+            }();
 
-                return fmt::format("{:12}: {}", astr + extra, info.to_string());
-            };
+            return fmt::format("{:12}: {}", astr + extra, info.to_string());
         };
+    };
 
-        std::optional<ss::future<>> last_append;
-        std::vector<ss::future<>> futs;
+    std::optional<ss::future<>> last_append;
+    std::vector<ss::future<>> futs;
 
-        size_t max_inflight = 0, max_dispatched = 0;
+    size_t max_inflight = 0, max_dispatched = 0;
 
-        std::uniform_int_distribution<int> dist(0, action::LAST);
+    std::uniform_int_distribution<int> dist(0, action::LAST);
 
-        std::vector<action> all_actions;
+    std::vector<action> all_actions;
 
-        for (size_t buf_index = 0; buf_index < bufs.size();) {
-            auto& current_action = all_actions.emplace_back(dist(rng));
+    for (size_t buf_index = 0; buf_index < bufs.size();) {
+        auto& current_action = all_actions.emplace_back(dist(rng));
 
-            max_inflight = std::max(
-              max_inflight, access(appender).inflight().size());
-            max_dispatched = std::max(
-              max_dispatched, access(appender).inflight_dispatched());
+        max_inflight = std::max(
+          max_inflight, access(appender).inflight().size());
+        max_dispatched = std::max(
+          max_dispatched, access(appender).inflight_dispatched());
 
-            switch (current_action.kind) {
-            case action::APPEND:
-                if (last_append) {
-                    // skip, as we already have an unawaited append in progress
-                    all_actions.pop_back(); // delete action
-                    continue;
-                }
-                last_append = appender.append(bufs[buf_index++]);
-                break;
-            case action::FLUSH:
-                futs.push_back(appender.flush());
-                break;
-            case action::WAIT_APPEND:
-                if (!last_append) {
-                    // no append to wait for, skip
-                    all_actions.pop_back();
-                    continue;
-                }
-                last_append->get();
-                last_append.reset();
-                break;
-            case action::SLEEP: {
-                // yield 99% of the time, sleep for 0-10 us the other 1%
-                auto sleep_us = std::uniform_int_distribution<int>(0, 1000)(rng)
-                                * 1us;
-                (sleep_us > 10us ? ss::yield() : ss::sleep(sleep_us)).get();
-                current_action.extra += fmt::format(" ({} ms)", sleep_us);
-                break;
+        switch (current_action.kind) {
+        case action::APPEND:
+            if (last_append) {
+                // skip, as we already have an unawaited append in progress
+                all_actions.pop_back(); // delete action
+                continue;
             }
-            default:
-                BOOST_TEST_FAIL("bad action");
+            last_append = appender.append(bufs[buf_index++]);
+            break;
+        case action::FLUSH:
+            futs.push_back(appender.flush());
+            break;
+        case action::WAIT_APPEND:
+            if (!last_append) {
+                // no append to wait for, skip
+                all_actions.pop_back();
+                continue;
             }
-            current_action.info = access(appender).info();
-        }
-
-        // check that we got some visible inflight and dispatched IOs
-        BOOST_CHECK_GT(max_inflight, 0);
-        BOOST_CHECK_GT(max_dispatched, 0);
-
-        // now we need to wait for the last append, if any
-        if (last_append) {
             last_append->get();
+            last_append.reset();
+            break;
+        case action::SLEEP: {
+            // yield 99% of the time, sleep for 0-10 us the other 1%
+            auto sleep_us = std::uniform_int_distribution<int>(0, 1000)(rng)
+                            * 1us;
+            (sleep_us > 10us ? ss::yield() : ss::sleep(sleep_us)).get();
+            current_action.extra += fmt::format(" ({} ms)", sleep_us);
+            break;
         }
-
-        // append a final flush, so we are in a known flushed state for the
-        // following checks
-        futs.emplace_back(appender.flush());
-
-        for (auto& f : futs) {
-            // get all the flush futures
-            // whp these are all available except possibly the last one
-            // (appended above) but this is not actually guaranteed, see
-            // redpanda#13035
-            f.get();
+        default:
+            FAIL() << "bad action";
         }
-        auto sa_state = fmt::format("{}", appender);
+        current_action.info = access(appender).info();
+    }
 
-        // now there should be nothing in-flight
-        BOOST_CHECK_EQUAL(access(appender).inflight_dispatched(), 0);
+    // check that we got some visible inflight and dispatched IOs
+    EXPECT_GT(max_inflight, 0);
+    EXPECT_GT(max_dispatched, 0);
 
-        BOOST_TEST_INFO(fmt::format(
-          "appender inflight operations (should be empty): {}",
-          access(appender).inflight_str()));
-        BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
+    // now we need to wait for the last append, if any
+    if (last_append) {
+        last_append->get();
+    }
 
-        // check that we got some writes and merges (we don't know how many)
-        BOOST_CHECK_GT(access(appender).total_dispatched(), 0);
-        BOOST_CHECK_GT(access(appender).total_merged(), 0);
+    // append a final flush, so we are in a known flushed state for the
+    // following checks
+    futs.emplace_back(appender.flush());
 
-        // now we expect all the prior flush futures to be available
-        // we don't guarantee this is in the API currently but it is how it
-        // works currently and we might as well assert it
+    for (auto& f : futs) {
+        // get all the flush futures
+        // whp these are all available except possibly the last one
+        // (appended above) but this is not actually guaranteed, see
+        // redpanda#13035
+        f.get();
+    }
+    auto sa_state = fmt::format("{}", appender);
 
-        // verify the output
-        auto in = make_file_input_stream(seg_file);
-        auto closefile = ss::defer([&] { in.close().get(); });
-        for (auto& buf : bufs) {
-            size_t sz = buf.size_bytes();
-            iobuf result = read_iobuf_exactly(in, sz).get();
-            BOOST_CHECK_EQUAL(buf, result);
+    // now there should be nothing in-flight
+    EXPECT_EQ(access(appender).inflight_dispatched(), 0);
+
+    EXPECT_EQ(access(appender).inflight().size(), 0) << fmt::format(
+      "appender inflight operations (should be empty): {}",
+      access(appender).inflight_str());
+
+    // check that we got some writes and merges (we don't know how many)
+    EXPECT_GT(access(appender).total_dispatched(), 0);
+    EXPECT_GT(access(appender).total_merged(), 0);
+
+    // now we expect all the prior flush futures to be available
+    // we don't guarantee this is in the API currently but it is how it
+    // works currently and we might as well assert it
+
+    // verify the output
+    auto in = make_file_input_stream(seg_file);
+    auto closefile = ss::defer([&] { in.close().get(); });
+    for (auto& buf : bufs) {
+        size_t sz = buf.size_bytes();
+        iobuf result = read_iobuf_exactly(in, sz).get();
+        EXPECT_EQ(buf, result);
+    }
+
+    if (!current_test_passing()) {
+        // test is about to fail, print details
+        // we jump through these hoops because I can't find a better way
+        // to defer generating the entire diagnosis string (which may be
+        // very large) until a test actually fails
+        std::string astr;
+        for (size_t aid = std::max(0, (int)all_actions.size() - 50);
+             aid < all_actions.size();
+             aid++) {
+            auto& ar = all_actions.at(aid);
+            astr += fmt::format("action[{}]: {}\n", aid, ar.to_string());
         }
+        SCOPED_TRACE("actions: \n" + astr);
 
-        if (!current_test_passing()) {
-            // test is about to fail, print details
-            // we jump through these hoops because I can't find a better way
-            // to defer generating the entire diagnosis string (which may be
-            // very large) until a test actually fails
-            std::string astr;
-            for (size_t aid = std::max(0, (int)all_actions.size() - 50);
-                 aid < all_actions.size();
-                 aid++) {
-                auto& ar = all_actions.at(aid);
-                astr += fmt::format("action[{}]: {}\n", aid, ar.to_string());
-            }
-            BOOST_TEST_INFO("actions: \n" << astr);
-
-            BOOST_TEST_INFO("last_append: " << last_append.has_value());
-            BOOST_TEST_INFO("fsize: " << futs.size());
-            BOOST_TEST_INFO("segment_appender: " << sa_state);
-            BOOST_TEST_FAIL("failed see above");
-        }
+        SCOPED_TRACE(fmt::format("last_append: {}", last_append.has_value()));
+        SCOPED_TRACE(fmt::format("fsize: {}", futs.size()));
+        SCOPED_TRACE("segment_appender: " + sa_state);
+        FAIL() << "failed see above";
     }
 }
 
-SEASTAR_THREAD_TEST_CASE(test_concurrent_append_flush) {
+TEST(log_segment_appender_test, test_concurrent_append_flush) {
     // we use smaller buffer counts for the large buffer size tests
     // to keep the runtime manageable (less than ~2 seconds for this test)
 
@@ -556,16 +555,16 @@ static void run_test_can_append_little_data(size_t fallocate_size) {
               data.begin() + std::min<size_t>(data.size(), i + 3),
               std::back_inserter(tmp));
             tmp.push_back('\0');
-            fmt::print("\nINPUT AROUND:{}, i:{}\n", tmp.data(), i);
             // make it fail
-            BOOST_REQUIRE_EQUAL(c, result[0]);
+            ASSERT_EQ(c, result[0])
+              << fmt::format("INPUT AROUND:{}, i:{}", tmp.data(), i);
         }
         in.close().get();
     }
-    BOOST_REQUIRE_EQUAL(appender.file_byte_offset(), data.size());
+    ASSERT_EQ(appender.file_byte_offset(), data.size());
 }
 
-SEASTAR_THREAD_TEST_CASE(test_can_append_little_data) {
+TEST(log_segment_appender_test, test_can_append_little_data) {
     run_test_can_append_little_data(16_KiB);
     run_test_can_append_little_data(32_MiB);
 }
@@ -590,25 +589,25 @@ static void run_test_fallocate_size(size_t fallocate_size) {
                 original.append(data.data(), data.size());
             }
         }
-        BOOST_CHECK_EQUAL(one_meg, original.size_bytes());
+        EXPECT_EQ(one_meg, original.size_bytes());
         appender.append(original).get();
         appender.flush().get();
 
         // now there should be nothing in-flight
-        BOOST_CHECK_EQUAL(access(appender).inflight_dispatched(), 0);
-        BOOST_CHECK_EQUAL(access(appender).inflight().size(), 0);
+        EXPECT_EQ(access(appender).inflight_dispatched(), 0);
+        EXPECT_EQ(access(appender).inflight().size(), 0);
 
         auto in = make_file_input_stream(f, i * one_meg);
         iobuf result = read_iobuf_exactly(in, one_meg).get();
-        BOOST_CHECK_EQUAL(original, result);
+        EXPECT_EQ(original, result);
         in.close().get();
     }
 
     // test that logical file size got updated as well (truncate called)
-    BOOST_CHECK_EQUAL(ss::file_size(filename).get() % fallocate_size, 0);
+    EXPECT_EQ(ss::file_size(filename).get() % fallocate_size, 0);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_fallocate_size) {
+TEST(log_segment_appender_test, test_fallocate_size) {
     for (const size_t fallocate_size : {4096ul, 16_KiB, 32_MiB}) {
         run_test_fallocate_size(fallocate_size);
     }

--- a/src/v/storage/tests/offset_translator_tests.cc
+++ b/src/v/storage/tests/offset_translator_tests.cc
@@ -24,8 +24,8 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 
-#include <boost/range/irange.hpp>
-#include <boost/test/tools/old/interface.hpp>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
 
 #include <utility>
 
@@ -47,7 +47,7 @@ static model::record_batch create_batch(
     return std::move(b).build();
 }
 
-struct base_fixture {
+struct base_fixture : public ::testing::Test {
     base_fixture()
       : _test_dir(
           fmt::format("test_{}", random_generators::gen_alphanum_string(6))) {
@@ -107,11 +107,11 @@ void validate_translation(
   storage::offset_translator& tr,
   model::offset log_offset,
   model::offset kafka_offset) {
-    BOOST_REQUIRE_EQUAL(tr.state()->from_log_offset(log_offset), kafka_offset);
-    BOOST_REQUIRE_EQUAL(tr.state()->to_log_offset(kafka_offset), log_offset);
+    EXPECT_EQ(tr.state()->from_log_offset(log_offset), kafka_offset);
+    EXPECT_EQ(tr.state()->to_log_offset(kafka_offset), log_offset);
 }
 
-struct offset_translator_fixture : base_fixture {
+struct offset_translator_fixture : public base_fixture {
     offset_translator_fixture()
       : tr(make_offset_translator()) {
         tr.start(storage::offset_translator::must_reset::yes).get();
@@ -125,7 +125,7 @@ struct offset_translator_fixture : base_fixture {
     storage::offset_translator tr;
 };
 
-FIXTURE_TEST(test_translating_to_kafka_offsets, offset_translator_fixture) {
+TEST_F(offset_translator_fixture, test_translating_to_kafka_offsets) {
     std::set<model::offset> batch_offsets{
       model::offset(0),
       model::offset(1),
@@ -151,8 +151,7 @@ FIXTURE_TEST(test_translating_to_kafka_offsets, offset_translator_fixture) {
     validate_offset_translation(model::offset(12), model::offset(4));
 }
 
-FIXTURE_TEST(
-  test_translating_to_kafka_offsets_first, offset_translator_fixture) {
+TEST_F(offset_translator_fixture, test_translating_to_kafka_offsets_first) {
     std::set<model::offset> batch_offsets{// data batch @ 0 -> kafka 0
                                           // data batch @ 1 -> kafka 1
                                           model::offset(2),
@@ -177,7 +176,7 @@ FIXTURE_TEST(
     validate_offset_translation(model::offset(11), model::offset(4));
 }
 
-FIXTURE_TEST(random_translation_test, offset_translator_fixture) {
+TEST_F(offset_translator_fixture, random_translation_test) {
     auto batches_count = 1000;
     std::set<model::offset> batch_offsets;
     /**
@@ -201,11 +200,11 @@ FIXTURE_TEST(random_translation_test, offset_translator_fixture) {
         }
         auto kafka_offset = tr.state()->from_log_offset(log_offset);
         auto reverse_log_offset = tr.state()->to_log_offset(kafka_offset);
-        BOOST_REQUIRE_EQUAL(log_offset, reverse_log_offset);
+        EXPECT_EQ(log_offset, reverse_log_offset);
     }
 }
 
-FIXTURE_TEST(random_translation_test_with_hint, offset_translator_fixture) {
+TEST_F(offset_translator_fixture, random_translation_test_with_hint) {
     auto batches_count = 1000;
     std::set<model::offset> batch_offsets;
     /**
@@ -232,11 +231,11 @@ FIXTURE_TEST(random_translation_test_with_hint, offset_translator_fixture) {
         auto reverse_log_offset = tr.state()->to_log_offset(
           kafka_offset, prev_log_offset);
         prev_log_offset = reverse_log_offset;
-        BOOST_REQUIRE_EQUAL(log_offset, reverse_log_offset);
+        EXPECT_EQ(log_offset, reverse_log_offset);
     }
 }
 
-FIXTURE_TEST(immutability_test, offset_translator_fixture) {
+TEST_F(offset_translator_fixture, immutability_test) {
     auto batches_count = 100;
     auto end_offset = 1100; // exclusive
     std::set<model::offset> batch_offsets;
@@ -268,7 +267,7 @@ FIXTURE_TEST(immutability_test, offset_translator_fixture) {
         auto kafka_offset = tr.state()->from_log_offset(log_offset);
         auto reverse_log_offset = tr.state()->to_log_offset(kafka_offset);
 
-        BOOST_REQUIRE_EQUAL(log_offset, reverse_log_offset);
+        EXPECT_EQ(log_offset, reverse_log_offset);
         offsets_mapping.emplace(log_offset, kafka_offset);
     }
 
@@ -280,7 +279,7 @@ FIXTURE_TEST(immutability_test, offset_translator_fixture) {
             }
             model::offset k_offset = tr.state()->from_log_offset(log_offset);
             // validate that offset havent changed
-            BOOST_REQUIRE_EQUAL(offsets_mapping[log_offset], k_offset);
+            EXPECT_EQ(offsets_mapping[log_offset], k_offset);
         }
     };
 
@@ -442,7 +441,7 @@ struct fuzz_checker {
 
         co_await _log->truncate_prefix(storage::truncate_prefix_config(
           new_start_offset, ss::default_priority_class()));
-        BOOST_REQUIRE_EQUAL(new_start_offset, _log->offsets().start_offset);
+        EXPECT_EQ(new_start_offset, _log->offsets().start_offset);
 
         _snapshot_offset = new_start_offset;
         if (_snapshot_offset() > 0) {
@@ -493,12 +492,10 @@ struct fuzz_checker {
         // check translation for high watermark (first unoccupied offset)
         model::offset hwm_lo(_kafka_offsets.size());
         model::offset hwm_ko(_log_offsets.size());
-        BOOST_TEST_CONTEXT("With log offset: " << hwm_lo) {
-            BOOST_REQUIRE_EQUAL(hwm_ko, _tr->state()->from_log_offset(hwm_lo));
-        }
-        BOOST_TEST_CONTEXT("With kafka offset: " << hwm_ko) {
-            BOOST_REQUIRE_EQUAL(hwm_lo, _tr->state()->to_log_offset(hwm_ko));
-        }
+        EXPECT_EQ(hwm_ko, _tr->state()->from_log_offset(hwm_lo))
+          << fmt::format("With log offset: {}", hwm_lo);
+        EXPECT_EQ(hwm_lo, _tr->state()->to_log_offset(hwm_ko))
+          << fmt::format("With kafka offset: {}", hwm_ko);
 
         const auto n_kafka_offsets = static_cast<int64_t>(
           _kafka_offsets.size());
@@ -509,21 +506,18 @@ struct fuzz_checker {
         }
 
         for (int64_t lo = start_log_offset; lo < n_kafka_offsets; ++lo) {
-            BOOST_TEST_CONTEXT("With log offset: " << lo) {
-                BOOST_REQUIRE_EQUAL(
-                  _kafka_offsets[lo],
-                  _tr->state()->from_log_offset(model::offset{lo}));
-            }
+            EXPECT_EQ(
+              _kafka_offsets[lo],
+              _tr->state()->from_log_offset(model::offset{lo}))
+              << fmt::format("With log offset: {}", lo);
         }
 
         const auto n_log_offsets = static_cast<int64_t>(_log_offsets.size());
         int64_t start_kafka_offset = _kafka_offsets[start_log_offset];
         for (int64_t ko = start_kafka_offset; ko < n_log_offsets; ++ko) {
-            BOOST_TEST_CONTEXT("With kafka offset: " << ko) {
-                BOOST_REQUIRE_EQUAL(
-                  _log_offsets[ko],
-                  _tr->state()->to_log_offset(model::offset{ko}));
-            }
+            EXPECT_EQ(
+              _log_offsets[ko], _tr->state()->to_log_offset(model::offset{ko}))
+              << fmt::format("With kafka offset: {}", ko);
         }
     }
 
@@ -551,7 +545,7 @@ const std::vector<model::record_batch_type> fuzz_checker::all_batch_types{
   model::record_batch_type::checkpoint,
 };
 
-FIXTURE_TEST(fuzz_operations_test, base_fixture) {
+TEST_F(base_fixture, fuzz_operations_test) {
     constexpr int number_of_ops = 100;
     constexpr int number_of_runs = 10;
 
@@ -608,7 +602,7 @@ FIXTURE_TEST(fuzz_operations_test, base_fixture) {
     }
 }
 
-FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
+TEST_F(base_fixture, test_moving_persistent_state) {
     std::set<model::offset> batch_offsets{
       // data batch @ 0 -> kafka 0
       // data batch @ 1 -> kafka 1
@@ -693,6 +687,6 @@ FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
       storage::kvstore::key_space::offset_translator,
       local_ot.highest_known_offset_key());
 
-    BOOST_REQUIRE_EQUAL(map.has_value(), false);
-    BOOST_REQUIRE_EQUAL(highest_known_offset.has_value(), false);
+    EXPECT_EQ(map.has_value(), false);
+    EXPECT_EQ(highest_known_offset.has_value(), false);
 }


### PR DESCRIPTION
The robot isn't good at translating Boost logging into GTest logging so I had to help a bit.

I'm finding `<<` into GTest assertions plus `SCOPED_TRACE` is sufficient for logging. We
shouldn't need the output if the test doesn't fail.

Otherwise, it does the migration OK.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
