### PR TITLE
treewide: Nuke foreign_data_t

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -56,7 +56,6 @@ using namespace std::chrono_literals;
 namespace cloud_storage {
 
 using data_t = model::record_batch_reader::data_t;
-using storage_t = model::record_batch_reader::storage_t;
 
 remote_partition::iterator remote_partition::get_or_materialize_segment(
   const remote_segment_path& path,
@@ -369,7 +368,7 @@ public:
         }
     }
 
-    ss::future<storage_t>
+    ss::future<data_t>
     do_load_slice(model::timeout_clock::time_point deadline) override {
         std::exception_ptr unknown_exception_ptr = nullptr;
         try {
@@ -378,7 +377,7 @@ public:
                   _ctxlog.debug,
                   "partition_record_batch_reader_impl do_load_slice - "
                   "empty");
-                co_return storage_t{};
+                co_return data_t{};
             }
             if (_seg_reader->config().over_budget) {
                 vlog(
@@ -391,12 +390,12 @@ public:
 
                 // The existing state have to be rebuilt
                 dispose_current_reader();
-                co_return storage_t{};
+                co_return data_t{};
             }
             while (co_await maybe_reset_reader()) {
                 if (_partition->_gate.is_closed()) {
                     co_await set_end_of_stream();
-                    co_return storage_t{};
+                    co_return data_t{};
                 }
 
                 throw_on_external_abort();
@@ -438,7 +437,7 @@ public:
                       _first_produced_offset);
                     if (_first_produced_offset != model::offset{}) {
                         co_await set_end_of_stream();
-                        co_return storage_t{};
+                        co_return data_t{};
                     } else {
                         _ot_state->reset();
                     }
@@ -500,7 +499,7 @@ public:
                         co_await set_end_of_stream();
                     }
                 }
-                co_return storage_t{std::move(d)};
+                co_return data_t{std::move(d)};
             }
         } catch (const ss::gate_closed_exception&) {
             vlog(
@@ -534,7 +533,7 @@ public:
           "EOS reached, reader available: {}, is end of stream: {}",
           static_cast<bool>(_seg_reader),
           is_end_of_stream());
-        co_return storage_t{};
+        co_return data_t{};
     }
 
     void print(std::ostream& o) override {

--- a/src/v/cloud_topics/L0_read_path/placeholder_extent_reader.cc
+++ b/src/v/cloud_topics/L0_read_path/placeholder_extent_reader.cc
@@ -107,7 +107,7 @@ public:
         return is_eos;
     }
 
-    ss::future<model::record_batch_reader::storage_t>
+    ss::future<model::record_batch_reader::data_t>
     do_load_slice(model::timeout_clock::time_point tm) override {
         struct consumer {
             consumer(

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -21,7 +21,7 @@
 namespace kafka::client {
 
 class client_fetcher final : public model::record_batch_reader::impl {
-    using storage_t = model::record_batch_reader::storage_t;
+    using data_t = model::record_batch_reader::data_t;
 
 public:
     client_fetcher(
@@ -39,8 +39,7 @@ public:
     bool is_end_of_stream() const final { return _next_offset >= _last_offset; }
 
     // Implements model::record_batch_reader::impl
-    ss::future<storage_t>
-    do_load_slice(model::timeout_clock::time_point t) final {
+    ss::future<data_t> do_load_slice(model::timeout_clock::time_point t) final {
         if (!_batch_reader || _batch_reader->is_end_of_stream()) {
             vlog(
               kclog.debug,

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -67,13 +67,7 @@ public:
             }
             _batch_reader = std::move(res.begin()->partition_response->records);
         }
-        auto ret = co_await _batch_reader->do_load_slice(t);
-        using data_t = model::record_batch_reader::data_t;
-        vassert(
-          std::holds_alternative<data_t>(ret),
-          "Expected kafka::batch_reader to hold "
-          "model::record_batch_reader::data_t");
-        auto& data = std::get<data_t>(ret);
+        auto data = co_await _batch_reader->do_load_slice(t);
         if (data.empty()) {
             throw kafka::exception(
               kafka::error_code::unknown_server_error, "No records returned");
@@ -84,7 +78,7 @@ public:
           "{}fetch_batch_reader: next_offset: {}",
           _client,
           _next_offset);
-        co_return ret;
+        co_return data;
     }
 
     // Implements model::record_batch_reader::impl

--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -122,7 +122,7 @@ kafka_batch_adapter batch_reader::consume_batch() {
     return kba;
 }
 
-ss::future<batch_reader::storage_t>
+ss::future<batch_reader::data_t>
 batch_reader::do_load_slice(model::timeout_clock::time_point tp) {
     using data_t = model::record_batch_reader::data_t;
     return ss::do_with(data_t{}, [this, tp](data_t& batches) {
@@ -155,7 +155,7 @@ batch_reader::do_load_slice(model::timeout_clock::time_point tp) {
             }
         };
         return ss::do_until(resources_exceeded, consume_one).then([&batches]() {
-            return storage_t(std::move(batches));
+            return data_t(std::move(batches));
         });
     });
 }

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -24,7 +24,7 @@ namespace kafka {
 ///
 /// The array bound is not serialized, c.f. array<kafka::thing>
 class batch_reader final : public model::record_batch_reader::impl {
-    using storage_t = model::record_batch_reader::storage_t;
+    using data_t = model::record_batch_reader::data_t;
 
 public:
     batch_reader() = default;
@@ -50,7 +50,7 @@ public:
     }
 
     // Implements model::record_batch_reader::impl
-    ss::future<storage_t> do_load_slice(model::timeout_clock::time_point) final;
+    ss::future<data_t> do_load_slice(model::timeout_clock::time_point) final;
 
     // Implements model::record_batch_reader::impl
     // NOTE: this stream is intentially devoid of user data.

--- a/src/v/kafka/utils/tests/txn_reader_test.cc
+++ b/src/v/kafka/utils/tests/txn_reader_test.cc
@@ -384,12 +384,12 @@ TEST_F_CORO(seastar_test, UncleanDestroy) {
 
         bool is_end_of_stream() const final { return false; };
 
-        ss::future<model::record_batch_reader::storage_t>
+        ss::future<model::record_batch_reader::data_t>
         do_load_slice(model::timeout_clock::time_point) final {
             auto result = model::record_batch_reader::data_t{};
             result.push_back(
               model::test::make_random_batch(model::test::record_batch_spec{}));
-            return ss::make_ready_future<model::record_batch_reader::storage_t>(
+            return ss::make_ready_future<model::record_batch_reader::data_t>(
               std::move(result));
         }
 

--- a/src/v/kafka/utils/txn_reader.cc
+++ b/src/v/kafka/utils/txn_reader.cc
@@ -66,14 +66,7 @@ namespace {
 
 const model::record_batch_reader::data_t&
 readonly_data_view(const model::record_batch_reader::storage_t& batches) {
-    using data_t = model::record_batch_reader::data_t;
-    using foreign_data_t = model::record_batch_reader::foreign_data_t;
-    return ss::visit(
-      batches,
-      [](const data_t& data) { return std::ref(data); },
-      [](const foreign_data_t& data) -> std::reference_wrapper<const data_t> {
-          return std::ref(*data.buffer);
-      });
+    return std::ref(batches);
 }
 
 bool contains_control_or_txn_batch(
@@ -103,18 +96,9 @@ public:
         // through of the originally loaded slices if there are no control/txn
         // batches does not copy the batches over to a new buffer if it's not
         // needed.
-        ss::visit(
-          initial,
-          [this](model::record_batch_reader::data_t& d) {
-              for (auto& batch : d) {
-                  process(std::move(batch));
-              }
-          },
-          [this](model::record_batch_reader::foreign_data_t& d) {
-              for (const auto& batch : *d.buffer) {
-                  process(batch.copy());
-              }
-          });
+        for (auto& batch : initial) {
+            process(std::move(batch));
+        }
     }
 
     ss::future<ss::stop_iteration> operator()(model::record_batch batch) {

--- a/src/v/kafka/utils/txn_reader.cc
+++ b/src/v/kafka/utils/txn_reader.cc
@@ -65,12 +65,12 @@ aborted_transaction_tracker::create_default(
 namespace {
 
 const model::record_batch_reader::data_t&
-readonly_data_view(const model::record_batch_reader::storage_t& batches) {
+readonly_data_view(const model::record_batch_reader::data_t& batches) {
     return std::ref(batches);
 }
 
 bool contains_control_or_txn_batch(
-  const model::record_batch_reader::storage_t& batches) {
+  const model::record_batch_reader::data_t& batches) {
     for (const model::record_batch& batch : readonly_data_view(batches)) {
         model::record_batch_attributes attrs = batch.header().attrs;
         if (attrs.is_control() || attrs.is_transactional()) {
@@ -87,7 +87,7 @@ struct drain_result {
 
 class drainer {
 public:
-    explicit drainer(model::record_batch_reader::storage_t initial) {
+    explicit drainer(model::record_batch_reader::data_t initial) {
         // TODO(perf): This initial slice is iterated over twice, once to look
         // for control/transactional batches, and another time here.
         //
@@ -183,10 +183,10 @@ ss::future<> read_committed_reader::finally() noexcept {
     return _underlying->finally();
 }
 
-ss::future<model::record_batch_reader::storage_t>
+ss::future<model::record_batch_reader::data_t>
 read_committed_reader::do_load_slice(
   model::timeout_clock::time_point deadline) {
-    model::record_batch_reader::storage_t loaded
+    model::record_batch_reader::data_t loaded
       = co_await _underlying->do_load_slice(deadline);
     // We delete the tracker when we've filtered the stream already.
     if (!_tracker || !contains_control_or_txn_batch(loaded)) {

--- a/src/v/kafka/utils/txn_reader.h
+++ b/src/v/kafka/utils/txn_reader.h
@@ -68,7 +68,7 @@ public:
 
     bool is_end_of_stream() const override;
 
-    ss::future<model::record_batch_reader::storage_t>
+    ss::future<model::record_batch_reader::data_t>
     do_load_slice(model::timeout_clock::time_point deadline) override;
 
     void print(std::ostream& os) override;

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -25,7 +25,6 @@
 
 namespace model {
 using data_t = record_batch_reader::data_t;
-using storage_t = record_batch_reader::storage_t;
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>
 record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
@@ -52,7 +51,7 @@ record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
             _ptr->print(os);
         }
 
-        ss::future<storage_t> do_load_slice(timeout_clock::time_point t) final {
+        ss::future<data_t> do_load_slice(timeout_clock::time_point t) final {
             auto shard = _ptr.get_owner_shard();
             if (shard == ss::this_shard_id()) {
                 return _ptr->do_load_slice(t);
@@ -60,7 +59,7 @@ record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
             // TODO: this function should take an SMP group
             return ss::smp::submit_to(shard, [this, t] {
                 return _ptr->do_load_slice(t).then(
-                  [](storage_t recs) { return recs; });
+                  [](data_t recs) { return recs; });
             });
         }
 
@@ -71,10 +70,10 @@ record_batch_reader make_foreign_record_batch_reader(record_batch_reader&& r) {
     return record_batch_reader(std::move(frn));
 }
 
-record_batch_reader make_memory_record_batch_reader(storage_t batches) {
+record_batch_reader make_memory_record_batch_reader(data_t batches) {
     class reader final : public record_batch_reader::impl {
     public:
-        explicit reader(storage_t batches)
+        explicit reader(data_t batches)
           : _batches(std::move(batches)) {}
 
         bool is_end_of_stream() const final { return _batches.empty(); }
@@ -85,14 +84,14 @@ record_batch_reader make_memory_record_batch_reader(storage_t batches) {
         }
 
     protected:
-        ss::future<record_batch_reader::storage_t>
+        ss::future<record_batch_reader::data_t>
         do_load_slice(timeout_clock::time_point) final {
-            return ss::make_ready_future<record_batch_reader::storage_t>(
+            return ss::make_ready_future<record_batch_reader::data_t>(
               std::exchange(_batches, {}));
         }
 
     private:
-        storage_t _batches;
+        data_t _batches;
     };
 
     return make_record_batch_reader<reader>(std::move(batches));
@@ -114,7 +113,7 @@ record_batch_reader make_empty_record_batch_reader() {
     public:
         bool is_end_of_stream() const final { return true; }
 
-        ss::future<storage_t> do_load_slice(timeout_clock::time_point) final {
+        ss::future<data_t> do_load_slice(timeout_clock::time_point) final {
             co_return data_t{};
         }
 
@@ -141,14 +140,14 @@ record_batch_reader make_generating_record_batch_reader(
         }
 
     protected:
-        ss::future<record_batch_reader::storage_t>
+        ss::future<record_batch_reader::data_t>
         do_load_slice(timeout_clock::time_point) final {
             return _gen().then([this](record_batch_reader::data_t data) {
                 if (data.empty()) {
                     _end_of_stream = true;
-                    return storage_t();
+                    return data_t();
                 }
-                return storage_t(std::move(data));
+                return data_t(std::move(data));
             });
         }
 
@@ -163,10 +162,10 @@ record_batch_reader make_generating_record_batch_reader(
 
 namespace {
 record_batch_reader make_fragmented_memory_record_batch_reader(
-  std::vector<record_batch_reader::storage_t> data) {
+  std::vector<record_batch_reader::data_t> data) {
     class reader final : public record_batch_reader::impl {
     public:
-        explicit reader(std::vector<storage_t> data)
+        explicit reader(std::vector<data_t> data)
           : _data(std::move(data)) {}
 
         bool is_end_of_stream() const final { return _index >= _data.size(); }
@@ -179,24 +178,24 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
         }
 
     protected:
-        ss::future<storage_t> do_load_slice(timeout_clock::time_point) final {
+        ss::future<data_t> do_load_slice(timeout_clock::time_point) final {
             if (is_end_of_stream()) {
-                return ss::make_ready_future<storage_t>(storage_t(data_t{}));
+                return ss::make_ready_future<data_t>();
             }
-            return ss::make_ready_future<storage_t>(std::move(_data[_index++]));
+            return ss::make_ready_future<data_t>(std::move(_data[_index++]));
         }
 
     private:
-        std::vector<storage_t> _data;
+        std::vector<data_t> _data;
         size_t _index = 0;
     };
     return make_record_batch_reader<reader>(std::move(data));
 }
 
 template<typename Container>
-std::vector<record_batch_reader::storage_t>
+std::vector<record_batch_reader::data_t>
 make_fragmented_memory_storage_batches(Container batches) {
-    std::vector<record_batch_reader::storage_t> data;
+    std::vector<record_batch_reader::data_t> data;
     size_t elements_per_fragment
       = fragmented_vector<model::record_batch>::elements_per_fragment();
     data.reserve(batches.size() / elements_per_fragment);

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -25,7 +25,6 @@
 
 namespace model {
 using data_t = record_batch_reader::data_t;
-using foreign_data_t = record_batch_reader::foreign_data_t;
 using storage_t = record_batch_reader::storage_t;
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>
@@ -78,20 +77,10 @@ record_batch_reader make_memory_record_batch_reader(storage_t batches) {
         explicit reader(storage_t batches)
           : _batches(std::move(batches)) {}
 
-        bool is_end_of_stream() const final {
-            return ss::visit(
-              _batches,
-              [](const data_t& d) { return d.empty(); },
-              [](const foreign_data_t& d) {
-                  return d.index >= d.buffer->size();
-              });
-        }
+        bool is_end_of_stream() const final { return _batches.empty(); }
 
         void print(std::ostream& os) final {
-            auto size = ss::visit(
-              _batches,
-              [](const data_t& d) { return d.size(); },
-              [](const foreign_data_t& d) { return d.buffer->size(); });
+            auto size = _batches.size();
             fmt::print(os, "memory reader {} batches", size);
         }
 

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -47,7 +47,6 @@ concept ReferenceBatchReaderConsumer = requires(
 class record_batch_reader final {
 public:
     using data_t = chunked_circular_buffer<model::record_batch>;
-    using storage_t = data_t;
 
     struct private_flags;
 
@@ -64,8 +63,7 @@ public:
 
         virtual bool is_end_of_stream() const = 0;
 
-        virtual ss::future<storage_t>
-          do_load_slice(timeout_clock::time_point) = 0;
+        virtual ss::future<data_t> do_load_slice(timeout_clock::time_point) = 0;
 
         virtual void print(std::ostream&) = 0;
 
@@ -104,7 +102,7 @@ public:
             return batch;
         }
         ss::future<> load_slice(timeout_clock::time_point timeout) {
-            return do_load_slice(timeout).then([this](storage_t s) {
+            return do_load_slice(timeout).then([this](data_t s) {
                 // reassign the local cache
                 _slice = std::move(s);
             });
@@ -157,7 +155,7 @@ public:
                    })
               .then([&consumer] { return consumer.end_of_stream(); });
         }
-        storage_t _slice;
+        data_t _slice;
     };
 
 public:
@@ -293,7 +291,7 @@ record_batch_reader make_record_batch_reader(Args&&... args) {
 }
 
 record_batch_reader
-  make_memory_record_batch_reader(record_batch_reader::storage_t);
+  make_memory_record_batch_reader(record_batch_reader::data_t);
 
 record_batch_reader make_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch>);

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -47,11 +47,7 @@ concept ReferenceBatchReaderConsumer = requires(
 class record_batch_reader final {
 public:
     using data_t = chunked_circular_buffer<model::record_batch>;
-    struct foreign_data_t {
-        ss::foreign_ptr<std::unique_ptr<data_t>> buffer;
-        size_t index{0};
-    };
-    using storage_t = std::variant<data_t, foreign_data_t>;
+    using storage_t = data_t;
 
     struct private_flags;
 
@@ -75,17 +71,7 @@ public:
 
         virtual std::optional<private_flags> get_flags() const { return {}; }
 
-        bool is_slice_empty() const {
-            return ss::visit(
-              _slice,
-              [](const data_t& d) {
-                  // circular buffer is the default
-                  return d.empty();
-              },
-              [](const foreign_data_t& d) {
-                  return d.index >= d.buffer->size();
-              });
-        }
+        bool is_slice_empty() const { return _slice.empty(); }
 
         virtual ss::future<> finally() noexcept { return ss::now(); }
 
@@ -113,18 +99,9 @@ public:
 
     private:
         record_batch pop_batch() {
-            return ss::visit(
-              _slice,
-              [](data_t& d) {
-                  record_batch batch = std::move(d.front());
-                  d.pop_front();
-                  return batch;
-              },
-              [](foreign_data_t& d) {
-                  // cannot have a move-only type from a remote core
-                  // we must make a copy. for iteration use for_each_ref
-                  return (*d.buffer)[d.index++].copy();
-              });
+            record_batch batch = std::move(_slice.front());
+            _slice.pop_front();
+            return batch;
         }
         ss::future<> load_slice(timeout_clock::time_point timeout) {
             return do_load_slice(timeout).then([this](storage_t s) {
@@ -136,16 +113,9 @@ public:
         auto do_for_each_ref(
           ReferenceConsumer& refc, timeout_clock::time_point timeout) {
             return do_action(refc, timeout, [this](ReferenceConsumer& c) {
-                return ss::visit(
-                  _slice,
-                  [&c](data_t& d) {
-                      return c(d.front()).finally([&d] { d.pop_front(); });
-                  },
-                  [&c](foreign_data_t& d) {
-                      // for remote core, next simply means advancing the
-                      // pointer, we need to release the batches wholesale
-                      return c((*d.buffer)[d.index++]);
-                  });
+                return c(_slice.front()).finally([this] {
+                    _slice.pop_front();
+                });
             });
         }
         template<typename Consumer>
@@ -158,25 +128,12 @@ public:
         auto do_peek_each_ref(
           ReferenceConsumer& refc, timeout_clock::time_point timeout) {
             return do_action(refc, timeout, [this](ReferenceConsumer& c) {
-                return ss::visit(
-                  _slice,
-                  [&c](data_t& d) {
-                      return c(d.front()).then([&](ss::stop_iteration stop) {
-                          if (!stop) {
-                              d.pop_front();
-                          }
-                          return stop;
-                      });
-                  },
-                  [&c](foreign_data_t& d) {
-                      return c((*d.buffer)[d.index])
-                        .then([&](ss::stop_iteration stop) {
-                            if (!stop) {
-                                ++d.index;
-                            }
-                            return stop;
-                        });
-                  });
+                return c(_slice.front()).then([&](ss::stop_iteration stop) {
+                    if (!stop) {
+                        _slice.pop_front();
+                    }
+                    return stop;
+                });
             });
         }
         template<typename ConsumerType, typename ActionFn>

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -69,8 +69,6 @@ Iterator find_machine(Iterator begin, Iterator end, model::node_id id) {
 
 class term_assigning_reader : public model::record_batch_reader::impl {
 public:
-    using data_t = model::record_batch_reader::data_t;
-    using foreign_data_t = model::record_batch_reader::foreign_data_t;
     using storage_t = model::record_batch_reader::storage_t;
 
     term_assigning_reader(model::record_batch_reader r, model::term_id term)
@@ -82,18 +80,8 @@ public:
     ss::future<storage_t>
     do_load_slice(model::timeout_clock::time_point tout) final {
         return _source->do_load_slice(tout).then([t = _term](storage_t ret) {
-            if (likely(std::holds_alternative<data_t>(ret))) {
-                auto& d = std::get<data_t>(ret);
-                for (auto& r : d) {
-                    r.set_term(t);
-                }
-            } else {
-                // NOTE: Ok to modify header here. since we are not
-                // touching the underlying IOBUF's
-                auto& d = std::get<foreign_data_t>(ret);
-                for (auto& r : *d.buffer) {
-                    r.set_term(t);
-                }
+            for (auto& r : ret) {
+                r.set_term(t);
             }
             return ret;
         });

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -69,7 +69,7 @@ Iterator find_machine(Iterator begin, Iterator end, model::node_id id) {
 
 class term_assigning_reader : public model::record_batch_reader::impl {
 public:
-    using storage_t = model::record_batch_reader::storage_t;
+    using data_t = model::record_batch_reader::data_t;
 
     term_assigning_reader(model::record_batch_reader r, model::term_id term)
       : _source(std::move(r).release())
@@ -77,9 +77,9 @@ public:
 
     bool is_end_of_stream() const final { return _source->is_end_of_stream(); }
 
-    ss::future<storage_t>
+    ss::future<data_t>
     do_load_slice(model::timeout_clock::time_point tout) final {
-        return _source->do_load_slice(tout).then([t = _term](storage_t ret) {
+        return _source->do_load_slice(tout).then([t = _term](data_t ret) {
             for (auto& r : ret) {
                 r.set_term(t);
             }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -125,7 +125,7 @@ bool deletion_exempt(const model::ntp& ntp) {
 // calculations. For all other applications, the `log_reader` should be used.
 class single_segment_reader final : public model::record_batch_reader::impl {
 public:
-    using storage_t = model::record_batch_reader::storage_t;
+    using data_t = model::record_batch_reader::data_t;
     single_segment_reader(
       ss::lw_shared_ptr<segment> seg,
       ss::rwlock::holder seg_read_lock,
@@ -140,12 +140,12 @@ public:
 
     bool is_end_of_stream() const final { return _is_end_of_stream; }
 
-    ss::future<storage_t>
+    ss::future<data_t>
     do_load_slice(model::timeout_clock::time_point timeout) final {
         auto recs = co_await _rdr.read_some(timeout);
         if (!recs.has_value() || recs.value().empty()) {
             _is_end_of_stream = true;
-            co_return storage_t{};
+            co_return data_t{};
         }
 
         auto& batches = recs.value();

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -357,7 +357,7 @@ void log_reader::maybe_log_load_slice_depth_warning(
     }
 }
 
-ss::future<log_reader::storage_t>
+ss::future<log_reader::data_t>
 log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
     _load_slice_depth = 0;
     while (true) {
@@ -367,7 +367,7 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
             // but offsets might have exceeded the read
             set_end_of_stream();
             co_await _iterator.close();
-            co_return log_reader::storage_t{};
+            co_return log_reader::data_t{};
         }
 
         // We do not want to close the reader if we stopped because requested
@@ -379,13 +379,13 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
           || _config.bytes_consumed > _config.max_bytes
           || _config.over_budget) {
             set_end_of_stream();
-            co_return log_reader::storage_t{};
+            co_return log_reader::data_t{};
         }
 
         if (_last_base == _config.start_offset) {
             set_end_of_stream();
             co_await _iterator.close();
-            co_return log_reader::storage_t{};
+            co_return log_reader::data_t{};
         }
 
         maybe_log_load_slice_depth_warning("reading more");
@@ -393,7 +393,7 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
         ss::future<> fut = find_next_valid_iterator();
         if (is_end_of_stream()) {
             co_await std::move(fut);
-            co_return log_reader::storage_t{};
+            co_return log_reader::data_t{};
         }
         std::exception_ptr e;
         try {
@@ -430,7 +430,7 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
                     _probe.batch_parse_error();
                 }
                 co_await _iterator.close();
-                co_return log_reader::storage_t{};
+                co_return log_reader::data_t{};
             }
             if (recs.value().empty()) {
                 /*

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -132,7 +132,7 @@ class log_reader final : public model::record_batch_reader::impl {
     friend struct fmt::formatter<log_reader>;
 
 public:
-    using storage_t = model::record_batch_reader::storage_t;
+    using data_t = model::record_batch_reader::data_t;
     static std::vector<model::record_batch> make_ghost_batches(
       model::offset start_offset,
       model::offset end_offset,
@@ -152,7 +152,7 @@ public:
         return _iterator.next_seg == _lease->range.end();
     }
 
-    ss::future<storage_t> do_load_slice(model::timeout_clock::time_point) final;
+    ss::future<data_t> do_load_slice(model::timeout_clock::time_point) final;
 
     virtual std::optional<private_flags> get_flags() const final;
 
@@ -239,7 +239,7 @@ private:
         const auto& offsets() const { return (*next_seg)->offsets(); }
     };
 
-    ss::future<storage_t> load_slice(model::timeout_clock::time_point);
+    ss::future<data_t> load_slice(model::timeout_clock::time_point);
     unsigned _load_slice_depth{0};
     bool log_load_slice_depth_warning() const;
     void maybe_log_load_slice_depth_warning(std::string_view) const;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -132,8 +132,6 @@ class log_reader final : public model::record_batch_reader::impl {
     friend struct fmt::formatter<log_reader>;
 
 public:
-    using data_t = model::record_batch_reader::data_t;
-    using foreign_data_t = model::record_batch_reader::foreign_data_t;
     using storage_t = model::record_batch_reader::storage_t;
     static std::vector<model::record_batch> make_ghost_batches(
       model::offset start_offset,

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -266,7 +266,7 @@ readers_cache::entry::make_cached_reader(readers_cache* cache) {
             return _underlying->is_end_of_stream();
         };
 
-        ss::future<model::record_batch_reader::storage_t>
+        ss::future<model::record_batch_reader::data_t>
         do_load_slice(model::timeout_clock::time_point tout) final {
             return _underlying->do_load_slice(tout);
         }

--- a/src/v/storage/utils/transforming_reader.h
+++ b/src/v/storage/utils/transforming_reader.h
@@ -31,7 +31,6 @@ template<typename Transformation>
 requires batch_transformation<Transformation>
 model::record_batch_reader make_transforming_reader(
   model::record_batch_reader&& source, Transformation&& t) {
-    using storage_t = model::record_batch_reader::storage_t;
     using data_t = model::record_batch_reader::data_t;
 
     class transforming_reader final : public model::record_batch_reader::impl {
@@ -52,15 +51,15 @@ model::record_batch_reader make_transforming_reader(
 
         void print(std::ostream& os) final { _ptr->print(os); }
 
-        ss::future<storage_t>
+        ss::future<data_t>
         do_load_slice(model::timeout_clock::time_point t) final {
-            return _ptr->do_load_slice(t).then([this](storage_t source_slice) {
+            return _ptr->do_load_slice(t).then([this](data_t source_slice) {
                 return transform_slice(std::move(source_slice));
             });
         }
 
     private:
-        ss::future<storage_t> transform_slice(storage_t source_slice) {
+        ss::future<data_t> transform_slice(data_t source_slice) {
             data_t result;
             for (auto& batch : get_batches(source_slice)) {
                 auto opt_batch = co_await transform(std::move(batch));
@@ -72,9 +71,9 @@ model::record_batch_reader make_transforming_reader(
             co_return make_slice(source_slice, std::move(result));
         }
 
-        data_t& get_batches(storage_t& st) { return st; }
+        data_t& get_batches(data_t& st) { return st; }
 
-        storage_t make_slice(const storage_t& source, data_t new_data) {
+        data_t make_slice(const data_t& source, data_t new_data) {
             return new_data;
         }
 

--- a/src/v/storage/utils/transforming_reader.h
+++ b/src/v/storage/utils/transforming_reader.h
@@ -33,7 +33,6 @@ model::record_batch_reader make_transforming_reader(
   model::record_batch_reader&& source, Transformation&& t) {
     using storage_t = model::record_batch_reader::storage_t;
     using data_t = model::record_batch_reader::data_t;
-    using foreign_t = model::record_batch_reader::foreign_data_t;
 
     class transforming_reader final : public model::record_batch_reader::impl {
     public:
@@ -73,22 +72,10 @@ model::record_batch_reader make_transforming_reader(
             co_return make_slice(source_slice, std::move(result));
         }
 
-        data_t& get_batches(storage_t& st) {
-            if (std::holds_alternative<data_t>(st)) {
-                return std::get<data_t>(st);
-            } else {
-                return *std::get<foreign_t>(st).buffer;
-            }
-        }
+        data_t& get_batches(storage_t& st) { return st; }
 
         storage_t make_slice(const storage_t& source, data_t new_data) {
-            if (std::holds_alternative<data_t>(source)) {
-                return new_data;
-            } else {
-                return foreign_t{
-                  .buffer = ss::make_foreign(
-                    std::make_unique<data_t>(std::move(new_data)))};
-            }
+            return new_data;
         }
 
         ss::future<std::optional<model::record_batch>>


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

No longer used or needed.

The purpose of `foreign_data_t` was to avoid unsafe/undefined behavior when sharing a `record_batch_reader` between shards. This is no longer necessary since sharing an iobuf was made thread safe in https://github.com/redpanda-data/seastar/pull/149.

https://github.com/redpanda-data/redpanda/pull/24047 removed all uses of `foreign_data_t` but left behind the variant type in `record_batch_reader`. This PR removes all reference to `foreign_data_t` from the tree.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
