### PR TITLE
serde/json: add json writer

### DIFF
--- a/src/v/bytes/details/io_byte_iterator.h
+++ b/src/v/bytes/details/io_byte_iterator.h
@@ -72,6 +72,11 @@ public:
         }
         return *this;
     }
+    io_byte_iterator operator++(int) {
+        auto tmp = *this;
+        ++*this;
+        return tmp;
+    }
 
 private:
     void next_fragment() {

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -20,7 +20,9 @@
 
 #include <seastar/core/temporary_buffer.hh>
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iosfwd>
 #include <string_view>
 #include <type_traits>
@@ -75,7 +77,7 @@ public:
 
     static iobuf from(std::string_view view) {
         iobuf i;
-        i.append(view.data(), view.size());
+        i.append_str(view);
         return i;
     }
 
@@ -160,6 +162,24 @@ public:
      * a copy of the source bytes.
      */
     void append(const uint8_t*, size_t);
+
+    /**
+     * A helper to append a container of uint8_t or char to this iobuf. This
+     * always makes a copy of the source bytes.
+     */
+    template<typename T, size_t S>
+    void append(const std::array<T, S>& a) {
+        static_assert(
+          std::is_same_v<std::remove_const_t<T>, uint8_t>
+          || std::is_same_v<std::remove_const_t<T>, char>);
+        append(a.data(), a.size());
+    }
+
+    /**
+     * A helper to append a string_view to this iobuf. This always makes a copy
+     * of the source bytes.
+     */
+    void append_str(std::string_view str) { append(str.data(), str.size()); }
 
     /**
      * Appends the contents of the passed buffer to this one.

--- a/src/v/compat/run.cc
+++ b/src/v/compat/run.cc
@@ -186,7 +186,7 @@ struct corpus_helper {
             w.Key("name");
             w.String(b.name);
             w.Key("data");
-            w.String(iobuf_to_base64(b.data));
+            w.String(iobuf_to_base64_string(b.data, b.data.size_bytes()));
             w.Key("crc32c");
             w.Uint(crc.value());
             w.EndObject();

--- a/src/v/datalake/partition_key_path.cc
+++ b/src/v/datalake/partition_key_path.cc
@@ -156,11 +156,11 @@ struct primitive_formatting_visitor {
     }
     checked<ss::sstring, partition_key_error>
     operator()(const iceberg::fixed_value& v) {
-        return iobuf_to_base64(v.val, limited_size(v.val));
+        return iobuf_to_base64_string(v.val, limited_size(v.val));
     }
     checked<ss::sstring, partition_key_error>
     operator()(const iceberg::binary_value& v) {
-        return iobuf_to_base64(v.val, limited_size(v.val));
+        return iobuf_to_base64_string(v.val, limited_size(v.val));
     }
 };
 

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -84,7 +84,6 @@ public:
         if (buf.empty()) {
             return w.Null();
         }
-        // TODO Ben: Implement custom OutputStream to prevent this linearization
         return w.String(iobuf_to_base64(buf));
     };
 

--- a/src/v/serde/json/BUILD
+++ b/src/v/serde/json/BUILD
@@ -1,0 +1,21 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+redpanda_cc_library(
+    name = "writer",
+    srcs = [
+        "writer.cc",
+    ],
+    hdrs = [
+        "writer.h",
+    ],
+    implementation_deps = [
+        "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/strings",
+    ],
+    include_prefix = "serde/json",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+    ],
+)

--- a/src/v/serde/json/BUILD
+++ b/src/v/serde/json/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_library(
         "writer.h",
     ],
     implementation_deps = [
+        "//src/v/utils:base64",
         "@abseil-cpp//absl/cleanup",
         "@abseil-cpp//absl/strings",
     ],

--- a/src/v/serde/json/tests/BUILD
+++ b/src/v/serde/json/tests/BUILD
@@ -1,0 +1,17 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "writer_test",
+    timeout = "short",
+    srcs = ["writer_test.cc"],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/serde/json:writer",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/cleanup",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/src/v/serde/json/tests/BUILD
+++ b/src/v/serde/json/tests/BUILD
@@ -8,10 +8,14 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/random:generators",
         "//src/v/serde/json:writer",
         "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/strings",
+        "@boost//:locale",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@rapidjson",
     ],
 )

--- a/src/v/serde/json/tests/writer_test.cc
+++ b/src/v/serde/json/tests/writer_test.cc
@@ -31,7 +31,9 @@ class JsonWriterTest : public ::testing::Test {
 protected:
     std::string serialize(const std::function<void(serde::json::writer&)>& fn) {
         serde::json::writer w;
+        w.begin_object();
         fn(w);
+        w.end_object();
         return to_string(std::move(w));
     }
 };

--- a/src/v/serde/json/tests/writer_test.cc
+++ b/src/v/serde/json/tests/writer_test.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/json/writer.h"
+
+#include <absl/cleanup/cleanup.h>
+#include <gtest/gtest.h>
+
+#include <numbers>
+
+namespace {
+
+std::string to_string(serde::json::writer&& w) {
+    iobuf b = std::move(w).finish();
+    std::string output;
+    for (const auto& frag : b) {
+        output.append(frag.get(), frag.size());
+    }
+    return output;
+}
+
+class JsonWriterTest : public ::testing::Test {
+protected:
+    std::string serialize(const std::function<void(serde::json::writer&)>& fn) {
+        serde::json::writer w;
+        fn(w);
+        return to_string(std::move(w));
+    }
+};
+
+TEST_F(JsonWriterTest, EscapedBackslashAndQuotes) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("key");
+        w.string(R"(value with "escaped quote" and backslash\)");
+    });
+    EXPECT_EQ(
+      result, R"({"key":"value with \"escaped quote\" and backslash\\"})");
+}
+
+TEST_F(JsonWriterTest, UnicodeEscapeSequences) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("key");
+        w.string("\u2028\u2029\xF0\x9D\x84\x9E"); // UTF-8 for U+1D11E
+    });
+    EXPECT_EQ(result, R"({"key":"\u2028\u2029\ud834\udd1e"})");
+    result = serialize([](serde::json::writer& w) {
+        w.key("emoji");
+        w.string("\u2028\u2029\xF0\x9D\x84\x9E"); // UTF-8 for U+1D11E
+    });
+}
+
+TEST_F(JsonWriterTest, Utf8CharacterWidths) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("utf8");
+        // 1-byte: A, 2-byte: ©, 3-byte: €, 4-byte: 😀
+        w.string("A\xC2\xA9\xE2\x82\xAC\xF0\x9F\x98\x80");
+    });
+    EXPECT_EQ(result, R"({"utf8":"A\u00a9\u20ac\ud83d\ude00"})");
+}
+
+TEST_F(JsonWriterTest, InvalidUtf8) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("utf8");
+        // Should be an invalid utf8 character, so we get the replacement char
+        w.string("My face was: \xF0\x9F\x98 - can't you see the smile?");
+    });
+    EXPECT_EQ(
+      result, R"({"utf8":"My face was: \ufffd- can't you see the smile?"})");
+}
+
+TEST_F(JsonWriterTest, EmptyKey) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("");
+        w.string("empty key");
+    });
+    EXPECT_EQ(result, "{\"\":\"empty key\"}");
+}
+
+TEST_F(JsonWriterTest, KeyWithEscapedChars) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("ke\ny");
+        w.string(std::string_view{"val\0ue", 6});
+    });
+    EXPECT_EQ(result, R"({"ke\ny":"val\u0000ue"})");
+}
+
+TEST_F(JsonWriterTest, DeeplyNestedObject) {
+    std::string expected = "{";
+    for (char c = 'a'; c <= 'g'; ++c) {
+        expected += std::string("\"") + c + "\":{";
+    }
+    expected.pop_back();
+    expected += R"("too deep?")";
+    for (int i = 0; i <= ('g' - 'a'); ++i) {
+        expected += "}";
+    }
+
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("a");
+        w.begin_object();
+        auto o1 = absl::MakeCleanup([&w] { w.end_object(); });
+        w.key("b");
+        w.begin_object();
+        auto o2 = absl::MakeCleanup([&w] { w.end_object(); });
+        w.key("c");
+        w.begin_object();
+        auto o3 = absl::MakeCleanup([&w] { w.end_object(); });
+        w.key("d");
+        w.begin_object();
+        auto o4 = absl::MakeCleanup([&w] { w.end_object(); });
+        w.key("e");
+        w.begin_object();
+        auto o5 = absl::MakeCleanup([&w] { w.end_object(); });
+        w.key("f");
+        w.begin_object();
+        auto o6 = absl::MakeCleanup([&w] { w.end_object(); });
+        w.key("g");
+        w.string("too deep?");
+    });
+    EXPECT_EQ(result, expected);
+}
+
+TEST_F(JsonWriterTest, Primatives) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("pi");
+        w.number(std::numbers::pi);
+        w.key("null");
+        w.null();
+        w.key("boolean");
+        w.boolean(true);
+        w.key("integer");
+        w.number(42);
+        w.key("array");
+        w.begin_array();
+        w.number(std::numbers::e);
+        w.boolean(false);
+        w.null();
+        w.number(-42);
+        w.end_array();
+    });
+    EXPECT_EQ(
+      result,
+      R"({"pi":3.14159,"null":null,"boolean":true,"integer":42,"array":[2.71828,false,null,-42]})");
+}
+
+TEST_F(JsonWriterTest, EmptyArrayAndObject) {
+    auto result = serialize([](serde::json::writer& w) {
+        w.key("emptyArr");
+        w.begin_array();
+        w.end_array();
+        w.key("emptyObj");
+        w.begin_object();
+        w.end_object();
+    });
+    EXPECT_EQ(result, R"({"emptyArr":[],"emptyObj":{}})");
+}
+
+} // namespace

--- a/src/v/serde/json/tests/writer_test.cc
+++ b/src/v/serde/json/tests/writer_test.cc
@@ -9,12 +9,21 @@
  * by the Apache License, Version 2.0
  */
 
+#include "gtest/gtest.h"
+#include "random/generators.h"
 #include "serde/json/writer.h"
 
 #include <absl/cleanup/cleanup.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
+#include <rapidjson/document.h>
+#include <rapidjson/reader.h>
+#include <rapidjson/writer.h>
 
+#include <cstdlib>
 #include <numbers>
+#include <source_location>
 
 namespace {
 
@@ -29,17 +38,30 @@ std::string to_string(serde::json::writer&& w) {
 
 class JsonWriterTest : public ::testing::Test {
 protected:
-    std::string serialize(const std::function<void(serde::json::writer&)>& fn) {
+    std::string
+    serialize_value(const std::function<void(serde::json::writer&)>& fn) {
         serde::json::writer w;
-        w.begin_object();
         fn(w);
-        w.end_object();
         return to_string(std::move(w));
+    }
+    std::string
+    serialize_object(const std::function<void(serde::json::writer&)>& fn) {
+        return serialize_value([fn](serde::json::writer& w) {
+            w.begin_object();
+            fn(w);
+            w.end_object();
+        });
     }
 };
 
+TEST_F(JsonWriterTest, SingleValue) {
+    auto result = serialize_value(
+      [](serde::json::writer& w) { w.string("testing"); });
+    EXPECT_EQ(result, R"("testing")");
+}
+
 TEST_F(JsonWriterTest, EscapedBackslashAndQuotes) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("key");
         w.string(R"(value with "escaped quote" and backslash\)");
     });
@@ -48,19 +70,19 @@ TEST_F(JsonWriterTest, EscapedBackslashAndQuotes) {
 }
 
 TEST_F(JsonWriterTest, UnicodeEscapeSequences) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("key");
         w.string("\u2028\u2029\xF0\x9D\x84\x9E"); // UTF-8 for U+1D11E
     });
     EXPECT_EQ(result, R"({"key":"\u2028\u2029\ud834\udd1e"})");
-    result = serialize([](serde::json::writer& w) {
+    result = serialize_object([](serde::json::writer& w) {
         w.key("emoji");
         w.string("\u2028\u2029\xF0\x9D\x84\x9E"); // UTF-8 for U+1D11E
     });
 }
 
 TEST_F(JsonWriterTest, Utf8CharacterWidths) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("utf8");
         // 1-byte: A, 2-byte: ©, 3-byte: €, 4-byte: 😀
         w.string("A\xC2\xA9\xE2\x82\xAC\xF0\x9F\x98\x80");
@@ -69,7 +91,7 @@ TEST_F(JsonWriterTest, Utf8CharacterWidths) {
 }
 
 TEST_F(JsonWriterTest, InvalidUtf8) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("utf8");
         // Should be an invalid utf8 character, so we get the replacement char
         w.string("My face was: \xF0\x9F\x98 - can't you see the smile?");
@@ -79,7 +101,7 @@ TEST_F(JsonWriterTest, InvalidUtf8) {
 }
 
 TEST_F(JsonWriterTest, EmptyKey) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("");
         w.string("empty key");
     });
@@ -87,7 +109,7 @@ TEST_F(JsonWriterTest, EmptyKey) {
 }
 
 TEST_F(JsonWriterTest, KeyWithEscapedChars) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("ke\ny");
         w.string(std::string_view{"val\0ue", 6});
     });
@@ -105,7 +127,7 @@ TEST_F(JsonWriterTest, DeeplyNestedObject) {
         expected += "}";
     }
 
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("a");
         w.begin_object();
         auto o1 = absl::MakeCleanup([&w] { w.end_object(); });
@@ -131,7 +153,7 @@ TEST_F(JsonWriterTest, DeeplyNestedObject) {
 }
 
 TEST_F(JsonWriterTest, Primatives) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("pi");
         w.number(std::numbers::pi);
         w.key("null");
@@ -154,7 +176,7 @@ TEST_F(JsonWriterTest, Primatives) {
 }
 
 TEST_F(JsonWriterTest, EmptyArrayAndObject) {
-    auto result = serialize([](serde::json::writer& w) {
+    auto result = serialize_object([](serde::json::writer& w) {
         w.key("emptyArr");
         w.begin_array();
         w.end_array();
@@ -163,6 +185,212 @@ TEST_F(JsonWriterTest, EmptyArrayAndObject) {
         w.end_object();
     });
     EXPECT_EQ(result, R"({"emptyArr":[],"emptyObj":{}})");
+}
+
+std::string generate_random_utf8(size_t approx_length) {
+    // Collection of interesting UTF-8 substrings, otherwise
+    // trying to randomly generate utf8 is too complicated
+    static const std::vector<std::string> utf8_parts = {
+      // ASCII
+      "Hello",
+      "World",
+      "Test",
+      "Code",
+      "Data",
+
+      // Latin with diacritics
+      "café",
+      "naïve",
+      "résumé",
+      "Åse",
+      "Björk",
+
+      // Greek letters
+      "α",
+      "β",
+      "ω",
+      "Α",
+      "Β",
+      "Σ",
+      "Ω",
+
+      // Cyrillic
+      "привет",
+      "мир",
+      "Санкт",
+      "Петербург",
+
+      // Chinese characters
+      "你好",
+      "中国",
+      "汉字",
+
+      // Japanese Hiragana
+      "こんにちは",
+      "ひらがな",
+      "かたかな",
+
+      // Japanese Katakana
+      "コンニチハ",
+      "セカイ",
+      "コード",
+      "カタカナ",
+      "データ",
+
+      // Korean
+      "안녕",
+      "세계",
+      "한국어",
+      "서울",
+
+      // Arabic (RTL text)
+      "مرحبا",
+      "عالم",
+      "بيانات",
+
+      // Emojis and symbols
+      "😀",
+      "😂",
+      "🔥",
+      "💻",
+      "🚀",
+      "⚡",
+
+      // Mathematical symbols
+      "∑",
+      "∏",
+      "∫",
+      "∪",
+      "∩",
+    };
+
+    std::string result;
+    // Keep adding random parts until we reach approximate desired length
+    while (result.length() < approx_length) {
+        // Add a random UTF-8 substring
+        result += random_generators::random_choice(utf8_parts);
+    }
+    return result;
+}
+
+rapidjson::Value generate_random_json(
+  rapidjson::Value::AllocatorType& a, int max_depth, int current_depth) {
+    auto generate_str = [&a](size_t size) {
+        auto str = generate_random_utf8(size);
+        rapidjson::Value v(rapidjson::kStringType);
+        v.SetString(str.data(), str.size(), a);
+        return v;
+    };
+
+    switch (random_generators::get_int(0, current_depth < max_depth ? 5 : 3)) {
+    case 0:
+        return {};
+    case 1:
+        return rapidjson::Value(bool(random_generators::get_int(0, 1)));
+    case 2: {
+        auto v = random_generators::get_real<double>();
+        // We only support the precision that absl supports, so truncate to that
+        // precision immediately.
+        vassert(absl::SimpleAtod(absl::StrCat(v), &v), "impossible");
+        return rapidjson::Value(v);
+    }
+    case 3: {
+        return generate_str(random_generators::get_int(4, 1024));
+    }
+    case 4: {
+        if (++current_depth > max_depth) {
+            break;
+        }
+        rapidjson::Value v(rapidjson::kObjectType);
+        size_t count = random_generators::get_int(0, 5);
+        std::set<std::string> keys;
+        for (size_t i = 0; i < count; ++i) {
+            auto key = generate_random_utf8(random_generators::get_int(2, 16));
+            while (keys.contains(key)) {
+                key = generate_random_utf8(random_generators::get_int(2, 16));
+            }
+            keys.insert(key);
+            rapidjson::Value name(rapidjson::kStringType);
+            name.SetString(key.data(), key.size(), a);
+            v.AddMember(
+              name, generate_random_json(a, max_depth, current_depth), a);
+        }
+        return v;
+    }
+    case 5: {
+        if (++current_depth > max_depth) {
+            break;
+        }
+        rapidjson::Value v(rapidjson::kArrayType);
+        size_t count = random_generators::get_int(0, 5);
+        for (size_t i = 0; i < count; ++i) {
+            v.PushBack(generate_random_json(a, max_depth, current_depth), a);
+        }
+        return v;
+    }
+    default:
+        // fallthrough
+    }
+    // Otherwise return `null`
+    return {};
+}
+
+void serialize_rapidjson(const rapidjson::Value& v, serde::json::writer& w) {
+    switch (v.GetType()) {
+    case rapidjson::kNullType:
+        w.null();
+        break;
+    case rapidjson::kFalseType:
+        w.boolean(false);
+        break;
+    case rapidjson::kTrueType:
+        w.boolean(true);
+        break;
+    case rapidjson::kObjectType: {
+        w.begin_object();
+        for (const auto& member : v.GetObject()) {
+            w.key({member.name.GetString(), member.name.GetStringLength()});
+            serialize_rapidjson(member.value, w);
+        }
+        w.end_object();
+        break;
+    }
+    case rapidjson::kArrayType: {
+        w.begin_array();
+        for (const auto& elem : v.GetArray()) {
+            serialize_rapidjson(elem, w);
+        }
+        w.end_array();
+        break;
+    }
+    case rapidjson::kStringType:
+        w.string({v.GetString(), v.GetStringLength()});
+        break;
+    case rapidjson::kNumberType:
+        w.number(v.GetDouble());
+        break;
+    }
+}
+
+std::string rapidjson_to_string(const rapidjson::Value& v) {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    v.Accept(writer);
+    writer.Flush();
+    return buffer.GetString();
+}
+
+TEST(RandomizedJsonWriterTest, RapidJSONRoundtrip) {
+    for (int i = 0; i < 1024; ++i) {
+        rapidjson::Document doc;
+        auto value = generate_random_json(doc.GetAllocator(), 4, 0);
+        serde::json::writer w;
+        serialize_rapidjson(value, w);
+        rapidjson::Document got;
+        EXPECT_NO_THROW(got.Parse(to_string(std::move(w))));
+        EXPECT_EQ(value, got)
+          << rapidjson_to_string(value) << " vs " << rapidjson_to_string(got);
+    }
 }
 
 } // namespace

--- a/src/v/serde/json/writer.cc
+++ b/src/v/serde/json/writer.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/json/writer.h"
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/strings/str_cat.h"
+
+namespace serde::json {
+
+namespace {
+template<typename Iter>
+void serialize_json_string(Iter it, Iter end, iobuf* buf) {
+    // Compile-time initialized escape lookup table for ASCII characters
+    // 0 = no escape, otherwise the character to follow '\'
+    constexpr size_t ascii_size = 128;
+    static constinit const auto escape_table = []() consteval {
+        std::array<char, ascii_size> table{};
+        // Set escape characters for special cases
+        table['"'] = '"';
+        table['\\'] = '\\';
+        table['/'] = '/';
+        table['\b'] = 'b';
+        table['\f'] = 'f';
+        table['\n'] = 'n';
+        table['\r'] = 'r';
+        table['\t'] = 't';
+        // All other entries default to 0 (no escaping needed)
+        return table;
+    }();
+    buf->append_str("\"");
+    auto finish_str = absl::Cleanup([&buf]() { buf->append_str("\""); });
+
+    auto next_char = [&it]() -> char { return *it++; };
+    // Process string character by character
+    while (it != end) {
+        auto c = static_cast<unsigned char>(next_char());
+        constexpr unsigned char max_ascii_control_char = 31;
+        if (c < ascii_size) {
+            // NOLINTNEXTLINE(*-constant-array-index)
+            char escape = escape_table[static_cast<unsigned char>(c)];
+            if (escape) {
+                buf->append(std::to_array({'\\', escape}));
+            } else if (c <= max_ascii_control_char) {
+                buf->append_str(
+                  absl::StrCat(
+                    "\\u",
+                    absl::Hex(static_cast<int32_t>(c), absl::kZeroPad4)));
+            } else {
+                // Normal ASCII character, no escaping needed
+                buf->append(std::to_array({c}));
+            }
+            continue;
+        }
+        // UTF-8 character handling
+        uint32_t codepoint = 0;
+        bool valid = false;
+
+        auto next_char_or_invalid_utf8 = [&it, end]() -> unsigned char {
+            if (it == end) {
+                return '\0'; // Invalid UTF-8 sequence
+            }
+            return static_cast<unsigned char>(*it++);
+        };
+        // NOLINTBEGIN(*-magic-numbers)
+        // 2-byte sequence (110xxxxx 10xxxxxx)
+        if ((c & 0xE0u) == 0xC0) {
+            unsigned char c1 = next_char_or_invalid_utf8();
+            if ((c1 & 0xC0u) == 0x80) {
+                codepoint = ((c & 0x1Fu) << 6u) | (c1 & 0x3Fu);
+                // Check for overlong encoding
+                valid = codepoint >= 0x80;
+            }
+            // 3-byte sequence (1110xxxx 10xxxxxx 10xxxxxx)
+        } else if ((c & 0xF0u) == 0xE0) {
+            unsigned char c1 = next_char_or_invalid_utf8();
+            unsigned char c2 = next_char_or_invalid_utf8();
+            if ((c1 & 0xC0u) == 0x80 && (c2 & 0xC0u) == 0x80) {
+                codepoint = ((c & 0x0Fu) << 12u) | ((c1 & 0x3Fu) << 6u)
+                            | (c2 & 0x3Fu);
+                // Check for uTF-16 surrogates or overlong encoding
+                valid = codepoint >= 0x800
+                        && (codepoint < 0xD800 || codepoint > 0xDFFF);
+            }
+            // 4-byte sequence (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+        } else if ((c & 0xF8u) == 0xF0) {
+            unsigned char c1 = next_char_or_invalid_utf8();
+            unsigned char c2 = next_char_or_invalid_utf8();
+            unsigned char c3 = next_char_or_invalid_utf8();
+            if (
+              (c1 & 0xC0u) == 0x80 && (c2 & 0xC0u) == 0x80
+              && (c3 & 0xC0u) == 0x80) {
+                codepoint = ((c & 0x07u) << 18u) | ((c1 & 0x3Fu) << 12u)
+                            | ((c2 & 0x3Fu) << 6u) | (c3 & 0x3Fu);
+                // Check for valid range (u+10000 through u+10FFFF)
+                valid = codepoint >= 0x10000 && codepoint <= 0x10FFFF;
+            }
+        }
+
+        if (!valid) {
+            // Invalid uTF-8 sequence, use replacement character
+            buf->append_str("\\ufffd");
+            continue;
+        }
+        // For codepoints outside the BMP (> u+FFFF), encode as a
+        // surrogate pair
+        if (codepoint > 0xFFFF) {
+            // Encode as surrogate pair
+            uint32_t hi = 0xD800 + ((codepoint - 0x10000) >> 10u);
+            uint32_t lo = 0xDC00 + ((codepoint - 0x10000) & 0x3FFu);
+            buf->append_str(
+              absl::StrCat(
+                "\\u",
+                absl::Hex(static_cast<int32_t>(hi), absl::kZeroPad4),
+                "\\u",
+                absl::Hex(static_cast<int32_t>(lo), absl::kZeroPad4)));
+        } else {
+            // BMP character, encode directly
+            buf->append_str(
+              absl::StrCat(
+                "\\u",
+                absl::Hex(static_cast<int32_t>(codepoint), absl::kZeroPad4)));
+        }
+        // NOLINTEND(*-magic-numbers)
+    }
+}
+} // namespace
+
+void writer::append_string(const iobuf& b) {
+    iobuf::byte_iterator begin = {b.begin(), b.end()};
+    iobuf::byte_iterator end = {b.end(), b.end()};
+    serialize_json_string(begin, end, &_buf);
+}
+
+void writer::append_string(std::string_view s) {
+    serialize_json_string(s.begin(), s.end(), &_buf);
+}
+
+void writer::number(double d) {
+    append_delimiter();
+    _buf.append_str(absl::StrCat(absl::SixDigits(d)));
+    _next_delimiter = ',';
+}
+void writer::number(int32_t i) {
+    append_delimiter();
+    _buf.append_str(absl::StrCat(absl::AlphaNum(i)));
+    _next_delimiter = ',';
+}
+void writer::number(uint32_t i) {
+    append_delimiter();
+    _buf.append_str(absl::StrCat(absl::AlphaNum(i)));
+    _next_delimiter = ',';
+}
+} // namespace serde::json

--- a/src/v/serde/json/writer.cc
+++ b/src/v/serde/json/writer.cc
@@ -70,10 +70,14 @@ void serialize_json_string(Iter it, Iter end, iobuf* buf) {
             return static_cast<unsigned char>(*it++);
         };
         // NOLINTBEGIN(*-magic-numbers)
+        auto is_utf8_continuation = [](unsigned char c) {
+            // Check that the byte follows the pattern (10xxxxxx)
+            return (c & 0xC0u) == 0x80;
+        };
         // 2-byte sequence (110xxxxx 10xxxxxx)
         if ((c & 0xE0u) == 0xC0) {
             unsigned char c1 = next_char_or_invalid_utf8();
-            if ((c1 & 0xC0u) == 0x80) {
+            if (is_utf8_continuation(c1)) {
                 codepoint = ((c & 0x1Fu) << 6u) | (c1 & 0x3Fu);
                 // Check for overlong encoding
                 valid = codepoint >= 0x80;
@@ -82,7 +86,7 @@ void serialize_json_string(Iter it, Iter end, iobuf* buf) {
         } else if ((c & 0xF0u) == 0xE0) {
             unsigned char c1 = next_char_or_invalid_utf8();
             unsigned char c2 = next_char_or_invalid_utf8();
-            if ((c1 & 0xC0u) == 0x80 && (c2 & 0xC0u) == 0x80) {
+            if (is_utf8_continuation(c1) && is_utf8_continuation(c2)) {
                 codepoint = ((c & 0x0Fu) << 12u) | ((c1 & 0x3Fu) << 6u)
                             | (c2 & 0x3Fu);
                 // Check for UTF-16 surrogates or overlong encoding
@@ -95,8 +99,8 @@ void serialize_json_string(Iter it, Iter end, iobuf* buf) {
             unsigned char c2 = next_char_or_invalid_utf8();
             unsigned char c3 = next_char_or_invalid_utf8();
             if (
-              (c1 & 0xC0u) == 0x80 && (c2 & 0xC0u) == 0x80
-              && (c3 & 0xC0u) == 0x80) {
+              is_utf8_continuation(c1) && is_utf8_continuation(c2)
+              && is_utf8_continuation(c3)) {
                 codepoint = ((c & 0x07u) << 18u) | ((c1 & 0x3Fu) << 12u)
                             | ((c2 & 0x3Fu) << 6u) | (c3 & 0x3Fu);
                 // Check for valid range (u+10000 through u+10FFFF)

--- a/src/v/serde/json/writer.cc
+++ b/src/v/serde/json/writer.cc
@@ -13,6 +13,7 @@
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/strings/str_cat.h"
+#include "utils/base64.h"
 
 namespace serde::json {
 
@@ -46,14 +47,12 @@ void serialize_json_string(Iter it, Iter end, iobuf* buf) {
         constexpr unsigned char max_ascii_control_char = 31;
         if (c < ascii_size) {
             // NOLINTNEXTLINE(*-constant-array-index)
-            char escape = escape_table[static_cast<unsigned char>(c)];
+            char escape = escape_table[c];
             if (escape) {
                 buf->append(std::to_array({'\\', escape}));
             } else if (c <= max_ascii_control_char) {
-                buf->append_str(
-                  absl::StrCat(
-                    "\\u",
-                    absl::Hex(static_cast<int32_t>(c), absl::kZeroPad4)));
+                buf->append_str(absl::StrCat(
+                  "\\u", absl::Hex(static_cast<uint32_t>(c), absl::kZeroPad4)));
             } else {
                 // Normal ASCII character, no escaping needed
                 buf->append(std::to_array({c}));
@@ -86,7 +85,7 @@ void serialize_json_string(Iter it, Iter end, iobuf* buf) {
             if ((c1 & 0xC0u) == 0x80 && (c2 & 0xC0u) == 0x80) {
                 codepoint = ((c & 0x0Fu) << 12u) | ((c1 & 0x3Fu) << 6u)
                             | (c2 & 0x3Fu);
-                // Check for uTF-16 surrogates or overlong encoding
+                // Check for UTF-16 surrogates or overlong encoding
                 valid = codepoint >= 0x800
                         && (codepoint < 0xD800 || codepoint > 0xDFFF);
             }
@@ -106,28 +105,25 @@ void serialize_json_string(Iter it, Iter end, iobuf* buf) {
         }
 
         if (!valid) {
-            // Invalid uTF-8 sequence, use replacement character
+            // Invalid UTF-8 sequence, use replacement character
             buf->append_str("\\ufffd");
             continue;
         }
-        // For codepoints outside the BMP (> u+FFFF), encode as a
+        // For codepoints outside the BMP (> \uffff), encode as a
         // surrogate pair
         if (codepoint > 0xFFFF) {
             // Encode as surrogate pair
             uint32_t hi = 0xD800 + ((codepoint - 0x10000) >> 10u);
             uint32_t lo = 0xDC00 + ((codepoint - 0x10000) & 0x3FFu);
-            buf->append_str(
-              absl::StrCat(
-                "\\u",
-                absl::Hex(static_cast<int32_t>(hi), absl::kZeroPad4),
-                "\\u",
-                absl::Hex(static_cast<int32_t>(lo), absl::kZeroPad4)));
+            buf->append_str(absl::StrCat(
+              "\\u",
+              absl::Hex(hi, absl::kZeroPad4),
+              "\\u",
+              absl::Hex(lo, absl::kZeroPad4)));
         } else {
             // BMP character, encode directly
             buf->append_str(
-              absl::StrCat(
-                "\\u",
-                absl::Hex(static_cast<int32_t>(codepoint), absl::kZeroPad4)));
+              absl::StrCat("\\u", absl::Hex(codepoint, absl::kZeroPad4)));
         }
         // NOLINTEND(*-magic-numbers)
     }
@@ -149,14 +145,29 @@ void writer::number(double d) {
     _buf.append_str(absl::StrCat(absl::SixDigits(d)));
     _next_delimiter = ',';
 }
-void writer::number(int32_t i) {
+void writer::integer(int32_t i) {
     append_delimiter();
     _buf.append_str(absl::StrCat(absl::AlphaNum(i)));
     _next_delimiter = ',';
 }
-void writer::number(uint32_t i) {
+void writer::integer(uint32_t i) {
     append_delimiter();
     _buf.append_str(absl::StrCat(absl::AlphaNum(i)));
+    _next_delimiter = ',';
+}
+void writer::integer_string(int64_t i) {
+    append_delimiter();
+    _buf.append_str(absl::StrCat("\"", absl::AlphaNum(i), "\""));
+    _next_delimiter = ',';
+}
+void writer::integer_string(uint64_t i) {
+    append_delimiter();
+    _buf.append_str(absl::StrCat("\"", absl::AlphaNum(i), "\""));
+    _next_delimiter = ',';
+}
+void writer::base64_string(const iobuf& b) {
+    append_delimiter();
+    append_string(base64_to_iobuf(b));
     _next_delimiter = ',';
 }
 } // namespace serde::json

--- a/src/v/serde/json/writer.h
+++ b/src/v/serde/json/writer.h
@@ -17,9 +17,6 @@ namespace serde::json {
 
 // The writer class is responsible for serializing data into JSON format.
 //
-// This writer can only create JSON objects, so top level objects that are
-// arrays or leaf values are not supported.
-//
 // NOTE: This class is easily misused, it's recommended to use a DOM version
 // (not yet written) or have good tests.
 class writer {
@@ -81,10 +78,7 @@ public:
     void integer_string(int64_t i);
     void integer_string(uint64_t i);
 
-    iobuf&& finish() && {
-        end_object();
-        return std::move(_buf);
-    }
+    iobuf&& finish() && { return std::move(_buf); }
 
 private:
     void append_string(std::string_view);
@@ -97,7 +91,7 @@ private:
     }
 
     char _next_delimiter = '\0';
-    iobuf _buf = iobuf::from("{");
+    iobuf _buf;
 };
 
 } // namespace serde::json

--- a/src/v/serde/json/writer.h
+++ b/src/v/serde/json/writer.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+namespace serde::json {
+
+// The writer class is responsible for serializing data into JSON format.
+//
+// This writer can only create JSON objects, so top level objects that are
+// arrays or leaf values are not supported.
+//
+// NOTE: This class is easily misused, it's recommended to use a DOM version
+// (not yet written) or have good tests.
+class writer {
+public:
+    void begin_object() {
+        append_delimiter();
+        _buf.append_str("{");
+        _next_delimiter = '\0';
+    }
+    void end_object() {
+        _buf.append_str("}");
+        _next_delimiter = ',';
+    }
+    void key(std::string_view k) {
+        append_delimiter();
+        append_string(k);
+        _next_delimiter = ':';
+    }
+    void key(const iobuf& k) {
+        append_delimiter();
+        append_string(k);
+        _next_delimiter = ':';
+    }
+    void begin_array() {
+        append_delimiter();
+        _buf.append_str("[");
+        _next_delimiter = '\0';
+    }
+    void end_array() {
+        _buf.append_str("]");
+        _next_delimiter = ',';
+    }
+    void null() {
+        append_delimiter();
+        _buf.append_str("null");
+        _next_delimiter = ',';
+    }
+    void boolean(bool b) {
+        append_delimiter();
+        _buf.append_str(b ? "true" : "false");
+        _next_delimiter = ',';
+    }
+    void string(const iobuf& b) {
+        append_delimiter();
+        append_string(b);
+        _next_delimiter = ',';
+    }
+    void string(std::string_view b) {
+        append_delimiter();
+        append_string(b);
+        _next_delimiter = ',';
+    }
+    void number(double d);
+    void number(int32_t i);
+    void number(uint32_t i);
+    // NOTE: We intentionally do not support int64_t and uint64_t
+    // It's not clear all JSON parsers will properly preserve those
+    // types, so we force the caller to wrap that as a string like
+    // proto3 json.
+
+    iobuf&& finish() && {
+        end_object();
+        return std::move(_buf);
+    }
+
+private:
+    void append_string(std::string_view);
+    void append_string(const iobuf&);
+
+    void append_delimiter() {
+        if (_next_delimiter) {
+            _buf.append_str({&_next_delimiter, 1});
+        }
+    }
+
+    char _next_delimiter = '\0';
+    iobuf _buf = iobuf::from("{");
+};
+
+} // namespace serde::json

--- a/src/v/serde/json/writer.h
+++ b/src/v/serde/json/writer.h
@@ -72,13 +72,14 @@ public:
         append_string(b);
         _next_delimiter = ',';
     }
+    void base64_string(const iobuf& b);
     void number(double d);
-    void number(int32_t i);
-    void number(uint32_t i);
-    // NOTE: We intentionally do not support int64_t and uint64_t
-    // It's not clear all JSON parsers will properly preserve those
-    // types, so we force the caller to wrap that as a string like
-    // proto3 json.
+    void integer(int32_t i);
+    void integer(uint32_t i);
+    // Because JSON doesn't have a great story around numbers larger than 2^53
+    // we encode larger numbers as strings, similar to proto3 json.
+    void integer_string(int64_t i);
+    void integer_string(uint64_t i);
 
     iobuf&& finish() && {
         end_object();

--- a/src/v/serde/parquet/tests/generate_file.cc
+++ b/src/v/serde/parquet/tests/generate_file.cc
@@ -49,9 +49,11 @@ void json(json_writer& w, const schema_element& schema, const value& v) {
           auto str = fmt::format("{:.8f}", v.val);
           w.RawValue(str.data(), str.size(), rapidjson::kNumberType);
       },
-      [&w](const byte_array_value& v) { w.String(iobuf_to_base64(v.val)); },
+      [&w](const byte_array_value& v) {
+          w.String(iobuf_to_base64_string(v.val, v.val.size_bytes()));
+      },
       [&w](const fixed_byte_array_value& v) {
-          w.String(iobuf_to_base64(v.val));
+          w.String(iobuf_to_base64_string(v.val, v.val.size_bytes()));
       },
       [&w, &schema](const group_value& v) {
           w.StartObject();

--- a/src/v/utils/base64.cc
+++ b/src/v/utils/base64.cc
@@ -10,6 +10,7 @@
  */
 #include "utils/base64.h"
 
+#include "base/units.h"
 #include "base/vassert.h"
 #include "thirdparty/base64/libbase64.h"
 
@@ -17,10 +18,15 @@
 
 #include <absl/strings/escaping.h>
 
+#include <ranges>
+
+namespace {
 // Required length is ceil(4n/3) rounded up to 4 bytes
-static inline size_t encode_capacity(size_t input_size) {
+inline size_t encode_capacity(size_t input_size) {
     return (((4 * input_size) / 3) + 3) & ~0x3U;
 }
+
+size_t decode_capacity(size_t input_size) { return (input_size * 3 + 3) / 4; }
 
 template<typename S>
 S base64_to_string_impl(std::string_view input) {
@@ -44,6 +50,7 @@ S base64_to_string_impl(std::string_view input) {
     output.resize(output_len);
     return output;
 }
+} // namespace
 
 bytes base64_to_bytes(std::string_view input) {
     return base64_to_string_impl<bytes>(input);
@@ -72,8 +79,35 @@ ss::sstring bytes_to_base64(bytes_view input) {
     return output;
 }
 
-ss::sstring iobuf_to_base64(const iobuf& input, std::optional<size_t> limit) {
-    auto sz_bytes = limit.value_or(input.size_bytes());
+iobuf iobuf_to_base64(const iobuf& input) {
+    size_t max_size = encode_capacity(input.size_bytes());
+    constexpr size_t max_alloc = 128_KiB;
+    constexpr size_t max_padding = 4;
+    iobuf output;
+    ss::sstring tmp(
+      ss::sstring::initialized_later{},
+      std::max(std::min(max_size, max_alloc), max_padding));
+    base64_state state; // NOLINT
+    base64_stream_encode_init(&state, 0);
+    for (const auto& frag : input) {
+        std::span<const char> frag_view{frag.get(), frag.size()};
+        while (!frag_view.empty()) {
+            size_t consume_amt = std::min(
+              decode_capacity(tmp.size()), frag_view.size());
+            size_t written = 0;
+            base64_stream_encode(
+              &state, frag_view.data(), consume_amt, tmp.data(), &written);
+            frag_view = frag_view.subspan(consume_amt);
+            output.append(tmp.data(), written);
+        }
+    }
+    size_t output_len = 0;
+    base64_stream_encode_final(&state, tmp.data(), &output_len);
+    output.append(tmp.data(), output_len);
+    return output;
+}
+
+ss::sstring iobuf_to_base64_string(const iobuf& input, size_t sz_bytes) {
     const size_t output_capacity = encode_capacity(sz_bytes);
     ss::sstring output(ss::sstring::initialized_later{}, output_capacity);
     size_t written = 0;

--- a/src/v/utils/base64.h
+++ b/src/v/utils/base64.h
@@ -39,8 +39,9 @@ ss::sstring base64_to_string(std::string_view);
 // base64 -> iobuf
 iobuf base64_to_iobuf(const iobuf&);
 
-// base64 <-> iobuf
-ss::sstring iobuf_to_base64(const iobuf&, std::optional<size_t> = std::nullopt);
+// iobuf -> base64
+iobuf iobuf_to_base64(const iobuf&);
+ss::sstring iobuf_to_base64_string(const iobuf&, size_t max_size);
 
 /// \brief Used to decode URL encoded base64 values
 ///

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -154,12 +154,14 @@ redpanda_cc_btest(
         "base64_test.cc",
     ],
     deps = [
+        "//src/v/base",
         "//src/v/bytes:iobuf_parser",
         "//src/v/random:generators",
         "//src/v/test_utils:random_bytes",
         "//src/v/test_utils:seastar_boost",
         "//src/v/utils:base64",
         "@boost//:test",
+        "@seastar",
     ],
 )
 

--- a/src/v/utils/tests/base64_test.cc
+++ b/src/v/utils/tests/base64_test.cc
@@ -29,10 +29,12 @@ BOOST_AUTO_TEST_CASE(bytes_type) {
 
 BOOST_AUTO_TEST_CASE(iobuf_type) {
     auto encdec = [](const iobuf& input, const auto expected) {
-        auto encoded = iobuf_to_base64(input);
+        auto encoded = iobuf_to_base64_string(input, input.size_bytes());
         BOOST_REQUIRE_EQUAL(encoded, expected);
         auto decoded = base64_to_bytes(encoded);
         BOOST_REQUIRE_EQUAL(decoded, iobuf_to_bytes(input));
+        auto encoded_buf = iobuf_to_base64(input);
+        BOOST_REQUIRE_EQUAL(encoded_buf, iobuf::from(encoded));
     };
 
     encdec(iobuf::from(""), "");
@@ -46,12 +48,14 @@ BOOST_AUTO_TEST_CASE(iobuf_type) {
         buf.append(data.data(), data.size());
     }
 
-    auto encoded = iobuf_to_base64(buf);
+    auto encoded = iobuf_to_base64_string(buf, buf.size_bytes());
     auto decoded = base64_to_bytes(encoded);
     BOOST_REQUIRE_EQUAL(decoded, iobuf_to_bytes(buf));
+    auto encoded_buf = iobuf_to_base64(buf);
+    BOOST_REQUIRE_EQUAL(iobuf::from(encoded), encoded_buf);
 
     auto encdec_limit = [](iobuf input, const auto expected, size_t sz_bytes) {
-        auto encoded = iobuf_to_base64(input, sz_bytes);
+        auto encoded = iobuf_to_base64_string(input, sz_bytes);
         BOOST_REQUIRE_EQUAL(encoded, expected);
         auto decoded = base64_to_bytes(encoded);
         BOOST_REQUIRE_EQUAL(decoded, iobuf_to_bytes(input.share(0, sz_bytes)));

--- a/src/v/utils/tests/base64_test.cc
+++ b/src/v/utils/tests/base64_test.cc
@@ -7,12 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "base/units.h"
 #include "bytes/iobuf_parser.h"
 #include "random/generators.h"
 #include "test_utils/random_bytes.h"
 #include "utils/base64.h"
 
+#include <seastar/core/memory.hh>
+
 #include <boost/test/unit_test.hpp>
+
+#include <iterator>
 
 BOOST_AUTO_TEST_CASE(bytes_type) {
     auto encdec = [](std::string_view input, std::string_view expected) {
@@ -77,6 +82,27 @@ BOOST_AUTO_TEST_CASE(test_base64_to_iobuf) {
     iobuf_parser p{std::move(decoded)};
     auto decoded_str = p.read_string(p.bytes_left());
     BOOST_REQUIRE_EQUAL(decoded_str, "this is a string");
+}
+
+BOOST_AUTO_TEST_CASE(test_iobuf_to_base64_allocations) {
+    iobuf buf;
+    for (size_t size : {512_KiB, 512_KiB - 1, 512_KiB + 1}) {
+        std::string large_string = random_generators::gen_alphanum_string(size);
+        auto large_frag = std::make_unique<iobuf::fragment>(
+          large_string.size());
+        large_frag->append(large_string.data(), large_string.size());
+        BOOST_REQUIRE_EQUAL(large_frag->size(), size);
+        buf.append(std::move(large_frag));
+    }
+    BOOST_REQUIRE_EQUAL(std::distance(buf.begin(), buf.end()), 3);
+    auto baseline = ss::memory::stats();
+    ss::memory::scoped_large_allocation_warning_threshold threshold(128_KiB);
+    auto encoded = iobuf_to_base64(buf);
+    auto decoded = base64_to_iobuf(encoded);
+    BOOST_REQUIRE_EQUAL(decoded, buf);
+    auto updated = ss::memory::stats();
+    BOOST_REQUIRE_EQUAL(
+      baseline.large_allocations(), updated.large_allocations());
 }
 
 BOOST_AUTO_TEST_CASE(base64_url_decode_test_basic) {


### PR DESCRIPTION
Add a minimal JSON writer that is seastar/redpanda friendly.

The API is pretty low level, but there might be a couple of cases where
it's useful. Nicolae is working on a JSON parser, but this is the otherside
of the story.

- **iobuf/byte_iter: support post increment operator**
- **iobuf: add append helpers**
- **serde/json: add a json writer**
- **util/base64: add a direct to iobut base64 encode function**
- **serde/json/writer: add support for proto3 json**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
