### PR TITLE
utils: crash if close has not been called on fanout ds

### DIFF
--- a/src/v/utils/stream_utils.h
+++ b/src/v/utils/stream_utils.h
@@ -82,6 +82,10 @@ public:
         co_await _in.close();
     }
 
+    bool attached(unsigned index) const {
+        return (_bitmask & (1U << index)) == 0;
+    }
+
     /// Detach client with 'index' from the fanout
     ///
     /// The remaining clients can proceed as usual.
@@ -223,6 +227,16 @@ struct fanout_data_source final : ss::data_source_impl {
       ss::lw_shared_ptr<input_stream_fanout<Ch>> i, size_t source_id)
       : _isf(std::move(i))
       , _id{source_id} {}
+
+    ~fanout_data_source() final {
+        // Close must have been called before the destructor otherwise we get a
+        // deadlock as the ring buffer is full and we're still expecting
+        // consumption from it.
+        vassert(
+          !_isf->attached(_id),
+          "fanout_data_source destructor called while the source is "
+          "still attached to the fanout");
+    }
 
     ss::future<> close() final { co_await _isf->detach(_id); }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
