### PR TITLE
[CORE-10125] fixes in describe producers test

### DIFF
--- a/tests/rptest/tests/describe_producers_test.py
+++ b/tests/rptest/tests/describe_producers_test.py
@@ -54,10 +54,6 @@ class DescribeProducersTest(RedpandaTest):
         assert ts == -1 or (ts_epoch >= range_start and ts_epoch <= range_end), \
             f"Producer timestamp must correspond to system clock. Returned timestamp: {ts}, range: [{range_start}, {range_end}]"
 
-    def _random_group_name(self):
-        return ''.join(
-            random.choice(string.ascii_uppercase) for _ in range(16))
-
     @cluster(num_nodes=3)
     @matrix(include_group_tx=[True, False])
     def test_describe_producer_with_tx(self, include_group_tx):
@@ -67,7 +63,7 @@ class DescribeProducersTest(RedpandaTest):
             for _ in range(5):
                 c = ck.Consumer({
                     'bootstrap.servers': self.redpanda.brokers(),
-                    'group.id': self._random_group_name(),
+                    'group.id': f'test-tx-group-{i}',
                     'auto.offset.reset': 'earliest',
                     'enable.auto.commit': False,
                     'max.poll.interval.ms': 10000,

--- a/tests/rptest/tests/describe_producers_test.py
+++ b/tests/rptest/tests/describe_producers_test.py
@@ -60,7 +60,10 @@ class DescribeProducersTest(RedpandaTest):
 
         consumers = []
         if include_group_tx:
-            for _ in range(5):
+            for i in range(5):
+                self.logger.debug(
+                    f"Creating consumer for group transaction: test-tx-group-{i}"
+                )
                 c = ck.Consumer({
                     'bootstrap.servers': self.redpanda.brokers(),
                     'group.id': f'test-tx-group-{i}',
@@ -77,6 +80,8 @@ class DescribeProducersTest(RedpandaTest):
         producer_count = 20
         producers = []
         for idx in range(producer_count):
+            self.logger.debug(
+                f"Creating producer with transactional.id: tx-producer-{idx}")
             producer = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': f'tx-producer-{idx}',

--- a/tests/rptest/tests/describe_producers_test.py
+++ b/tests/rptest/tests/describe_producers_test.py
@@ -85,6 +85,8 @@ class DescribeProducersTest(RedpandaTest):
             producer = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': f'tx-producer-{idx}',
+                # use long transaction timeout to avoid transaction expiration
+                'transaction.timeout.ms': 300000,
             })
             producer.init_transactions()
             producers.append(producer)


### PR DESCRIPTION
tests: use larger transaction timeout in describe producers test

The test was failing as the transactions that were expected to be
present when describing producers were already expired. Made the
transaction timeout larger to make sure the transactions are still
present when the producer list is being validated.

Fixes: CORE-10125

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
