### PR TITLE
`storage`: remove unused variable in `write_concatenated_compacted_index()`

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1063,8 +1063,6 @@ ss::future<> write_concatenated_compacted_index(
     if (segments.empty()) {
         return ss::now();
     }
-    std::vector<compacted_index_reader> readers;
-    readers.reserve(segments.size());
     return ss::do_with(
       std::move(segments),
       [cfg, target_path = std::move(target_path), &resources](


### PR DESCRIPTION
This `vector` is declared, has its capacity reserved, and is never used afterwards.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
