### PR TITLE
tests: make stuck shutdown detection timeout longer

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -365,6 +365,9 @@ class PartitionBalancerTest(PartitionBalancerService):
              log_allow_list=CHAOS_LOG_ALLOW_LIST + RECONCILIATION_TIMEOUT_LOG)
     def test_unavailable_nodes(self):
         self.start_redpanda(num_nodes=5)
+        # set partition shutdown watchdog timeout to a large value to prevent spurious detection when Redpanda node is suspended
+        self.redpanda.set_cluster_config(
+            {"partition_manager_shutdown_watchdog_timeout": 90000})
 
         self.topic = TopicSpec(partition_count=random.randint(20, 30))
         self.client().create_topic(self.topic)


### PR DESCRIPTION
Partition balancer test when node is unavailable uses SIG_STOP to simulate node being stuck. When Redpanda process is paused during the partition shutdown sequence, watchdog may detect stuck shutdown. Changed the watchdog detection threshold to account for the time when redpanda process is paused.

Fixes: CORE-10053

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none