### PR TITLE
r/stm_manager: added watchdog logging an error when stm did not stop

### DIFF
--- a/src/v/raft/BUILD
+++ b/src/v/raft/BUILD
@@ -157,6 +157,7 @@ redpanda_cc_library(
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",
+        "//src/v/ssx:watchdog",
         "//src/v/storage",
         "//src/v/storage:record_batch_builder",
         "//src/v/storage:record_batch_utils",

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -23,6 +23,7 @@
 #include "serde/rw/rw.h"
 #include "ssx/future-util.h"
 #include "ssx/semaphore.h"
+#include "ssx/watchdog.h"
 #include "storage/snapshot.h"
 #include "storage/types.h"
 #include "utils/mutex.h"
@@ -159,13 +160,17 @@ state_machine_manager::named_stm::named_stm(ss::sstring name, stm_ptr stm)
   , stm(std::move(stm)) {}
 
 state_machine_manager::state_machine_manager(
-  consensus* raft, std::vector<named_stm> stms, ss::scheduling_group apply_sg)
+  consensus* raft,
+  std::vector<named_stm> stms,
+  ss::scheduling_group apply_sg,
+  config::binding<std::chrono::milliseconds> stm_shutdown_timeout)
   : _raft(raft)
   , _log(ctx_log(_raft->group(), _raft->ntp()))
   , _apply_sg(apply_sg)
   , _initial_recovery_snapshot_mgr(
       std::filesystem::path(_raft->log_config().work_directory()),
-      "stm_manager.snapshot") {
+      "stm_manager.snapshot")
+  , _stm_shutdown_timeout(std::move(stm_shutdown_timeout)) {
     for (auto& n_stm : stms) {
         _supports_snapshot_at_offset
           = _supports_snapshot_at_offset
@@ -230,6 +235,19 @@ ss::future<> state_machine_manager::start() {
     });
 }
 
+ss::future<> state_machine_manager::do_stop_stm(entry_ptr entry) {
+    ssx::watchdog wd(
+      _stm_shutdown_timeout(), [ntp = _raft->ntp(), name = entry->name] {
+          vlog(
+            raftlog.error,
+            "[{}] Timedout waiting for {} state machine to stop",
+            ntp,
+            name);
+      });
+    // stop the state machine
+    co_await entry->stm->stop();
+}
+
 ss::future<> state_machine_manager::stop() {
     vlog(
       _log.debug,
@@ -240,7 +258,7 @@ ss::future<> state_machine_manager::stop() {
 
     auto gate_f = _gate.close();
     co_await ss::coroutine::parallel_for_each(
-      _machines, [](auto p) { return p.second->stm->stop(); });
+      _machines, [this](auto p) { return do_stop_stm(p.second); });
     co_await std::move(gate_f);
 }
 

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "raft/fwd.h"
 #include "raft/logger.h"
@@ -171,7 +172,8 @@ private:
     state_machine_manager(
       consensus* raft,
       std::vector<named_stm> stms_to_manage,
-      ss::scheduling_group apply_sg);
+      ss::scheduling_group apply_sg,
+      config::binding<std::chrono::milliseconds> stm_shutdown_timeout);
 
     friend class batch_applicator;
     friend class state_machine_manager_builder;
@@ -219,7 +221,7 @@ private:
     model::offset last_applied() const { return model::prev_offset(_next); }
 
     ss::future<> apply_initial_recovery_policy();
-
+    ss::future<> do_stop_stm(entry_ptr entry);
     /**
      * Methods to access/write the local state machine manager snapshot. The
      * snapshot is currently used to maintain the state of initial recovery for
@@ -260,6 +262,7 @@ private:
     ss::scheduling_group _apply_sg;
     snapshot_at_offset_supported _supports_snapshot_at_offset{true};
     storage::simple_snapshot_manager _initial_recovery_snapshot_mgr;
+    config::binding<std::chrono::milliseconds> _stm_shutdown_timeout;
 };
 
 /**
@@ -278,12 +281,20 @@ public:
     void with_scheduing_group(ss::scheduling_group sg) { _sg = sg; }
 
     state_machine_manager build(raft::consensus* raft) && {
-        return {raft, std::move(_stms), _sg};
+        return {
+          raft,
+          std::move(_stms),
+          _sg,
+          std::move(_stm_shutdown_timeout),
+        };
     }
 
 private:
     std::vector<state_machine_manager::named_stm> _stms;
     ss::scheduling_group _sg = ss::default_scheduling_group();
+    config::binding<std::chrono::milliseconds> _stm_shutdown_timeout
+      = config::shard_local_cfg()
+          .partition_manager_shutdown_watchdog_timeout.bind();
 };
 
 } // namespace raft


### PR DESCRIPTION
State machines should be able to stop timely as any issue with stopping a state machine may lead to a situation in which the whole partition fails to stop. Added watchdog reporting an error when STM fails to stop.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- better observability of state machines shutdown issues