### PR TITLE
cs/tests: retry on non leader error when patching config

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -127,6 +127,28 @@ public:
         co_return expected_count == 2;
     }
 
+    ss::future<cluster::config_frontend::patch_result>
+    patch_config(const cluster::config_update_request& req) {
+        for (int i = 0; i < 5; i++) {
+            auto result
+              = co_await app.controller->get_config_frontend().local().patch(
+                req, model::timeout_clock::now() + 5s);
+            if (
+              result.errc == cluster::errc::not_leader_controller
+              || result.errc == raft::errc::not_leader) {
+                vlog(
+                  logger.debug,
+                  "Not leader, retrying config patch: {}",
+                  result.errc);
+                co_await ss::sleep(200ms);
+            } else {
+                co_return result;
+            }
+        }
+        co_return cluster::config_frontend::patch_result{
+          .errc = cluster::errc::timeout};
+    }
+
 protected:
     scoped_config test_local_cfg;
     cluster::consensus_ptr raft0;
@@ -327,12 +349,8 @@ TEST_F(cluster_metadata_uploader_fixture, test_upload_in_term) {
 
     // Now do some action and write a new snapshot.
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
-    auto result = app.controller->get_config_frontend()
-                    .local()
-                    .patch(
-                      cluster::config_update_request{
-                        .upsert = {{"cluster_id", "foo"}}},
-                      model::timeout_clock::now() + 5s)
+    auto result = patch_config(cluster::config_update_request{
+                                 .upsert = {{"cluster_id", "foo"}}})
                     .get();
     ASSERT_TRUE(!result.errc);
     RPTEST_REQUIRE_EVENTUALLY(
@@ -363,14 +381,12 @@ TEST_F(cluster_metadata_uploader_fixture, test_upload_loop_deletes_orphans) {
     RPTEST_REQUIRE_EVENTUALLY(5s, [this, &manifest] {
         return list_contains_manifest_contents(manifest);
     });
+
     // Now do something to trigger another controller snapshot.
-    auto result = app.controller->get_config_frontend()
-                    .local()
-                    .patch(
-                      cluster::config_update_request{
-                        .upsert = {{"cluster_id", "foo"}}},
-                      model::timeout_clock::now() + 5s)
+    auto result = patch_config(cluster::config_update_request{
+                                 .upsert = {{"cluster_id", "foo"}}})
                     .get();
+
     ASSERT_TRUE(!result.errc);
     RPTEST_REQUIRE_EVENTUALLY(
       5s, [this] { return controller_stm.maybe_write_snapshot(); });


### PR DESCRIPTION
When patching configuration the `configuration_frontend` may return non leader error if the controller is in the middle of leader election. Added retries to make the test more robust.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none