### PR TITLE
Fixed test not stopping KgoVerifierService before freeing it

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -361,6 +361,7 @@ class KgoVerifierService(Service):
         )
 
         self._release_port()
+        self._stopped = True
 
         return True
 
@@ -375,6 +376,7 @@ class KgoVerifierService(Service):
             return super(KgoVerifierService, self).allocate_nodes()
 
     def free(self):
+        assert self._stopped, "Cannot free KgoVerifierService before stopping it"
         if self.use_custom_node:
             return
         else:

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -1197,6 +1197,7 @@ class DataMigrationsMultiClusterTest(RedpandaTest, DataMigrationTestMixin):
         consumer = self.start_consumer(topic, redpanda)
         self.logger.info(f"expecting to consume {msg_count} messages")
         consumer.wait_total_reads(msg_count, timeout_sec=30, backoff_sec=1)
+        consumer.stop()
         consumer.free()
 
     def start_extra_cluster(self, num_brokers=3):

--- a/tests/rptest/tests/tiered_storage_pause_test.py
+++ b/tests/rptest/tests/tiered_storage_pause_test.py
@@ -286,6 +286,7 @@ class TestTieredStoragePause(PreallocNodesTest):
         # Pre-populate the topic
         self.start_producer()
         self.producer.wait_for_acks(self._msg_count, 120, 1)
+        self.producer.stop()
         self.producer.free()
 
         # Check that pre-populated data is uploaded to the cloud storage.


### PR DESCRIPTION
When calling `KgoVerifierService::free` a caller indicates that the node is ready to be reused by other tests. If the verifier process is not stopped it may leak and influence other tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
