### PR TITLE
CORE-10193 DR: k/client: support multi-topic list_offsets

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -52,6 +52,7 @@ redpanda_cc_library(
         "//src/v/bytes:scattered_message",
         "//src/v/cluster",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/container:fragmented_vector",
         "//src/v/hashing:murmur",
         "//src/v/kafka/protocol",

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -10,6 +10,7 @@
 #include "kafka/client/client.h"
 
 #include "base/seastarx.h"
+#include "container/chunked_hash_map.h"
 #include "container/fragmented_vector.h"
 #include "kafka/client/broker.h"
 #include "kafka/client/configuration.h"
@@ -18,6 +19,7 @@
 #include "kafka/client/logger.h"
 #include "kafka/client/partitioners.h"
 #include "kafka/client/sasl_client.h"
+#include "kafka/client/topic_cache.h"
 #include "kafka/client/utils.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
@@ -39,8 +41,10 @@
 
 #include <absl/container/node_hash_map.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <exception>
+#include <iterator>
 #include <system_error>
 
 namespace kafka::client {
@@ -372,32 +376,80 @@ void throw_on_error(const T& r) {
 } // namespace
 
 ss::future<list_offsets_response>
-client::list_offsets(model::topic_partition tp) {
-    return gated_retry_with_mitigation(
-             [this, tp{std::move(tp)}]() { return do_list_offsets(tp); })
-      .then([](auto res) {
-          throw_on_error<list_offsets_response>(res);
-          return res;
-      });
+client::list_offsets(list_offsets_request req) {
+    co_return co_await gated_retry_with_mitigation([this, &req]() {
+        return do_list_offsets(req);
+    }).then([](auto res) {
+        throw_on_error<list_offsets_response>(res);
+        return res;
+    });
 }
 
 ss::future<list_offsets_response>
-client::do_list_offsets(model::topic_partition tp) {
-    auto node_id = co_await _topic_cache.leader(tp);
-    auto broker = co_await _brokers.find(node_id);
-    chunked_vector<kafka::list_offset_topic> cv;
-    cv.push_back(kafka::list_offset_topic{
-      .name{tp.topic},
-      .partitions{
-        {
-          {.partition_index{tp.partition}, .max_num_offsets = 1},
-        },
-      },
-    });
-    auto res = co_await broker->dispatch(kafka::list_offsets_request{
-      .data = {
-        .topics = std::move(cv),
-      }});
+client::list_offsets(model::topic_partition tp) {
+    kafka::list_offsets_request req;
+    req.data.topics.emplace_back(kafka::list_offset_topic{
+      .name = std::move(tp.topic),
+      .partitions = {kafka::list_offset_partition{
+        .partition_index = tp.partition,
+        .max_num_offsets = 1,
+      }}});
+    return list_offsets(std::move(req));
+}
+
+ss::future<list_offsets_response>
+client::do_list_offsets(const list_offsets_request& unsharded_req) {
+    // Group requests by the broker they are sent to
+    chunked_hash_map<model::node_id, kafka::list_offsets_request> reqs;
+
+    for (const auto& topic : unsharded_req.data.topics) {
+        for (const auto& partition : topic.partitions) {
+            model::topic_partition tp{topic.name, partition.partition_index};
+            auto node_id = co_await _topic_cache.leader(tp);
+
+            auto& topics
+              = reqs.try_emplace(node_id, kafka::list_offsets_request{})
+                  .first->second.data.topics;
+            auto topic_it = std::ranges::find(
+              topics, tp.topic, &list_offset_topic::name);
+            auto& topic = topic_it == topics.end()
+                            ? topics.emplace_back(std::move(tp.topic))
+                            : *topic_it;
+            topic.partitions.emplace_back(partition);
+        }
+    }
+
+    auto mapper = [this](auto kv) {
+        auto node_id = kv.first;
+        return _brokers.find(node_id).then(
+          [req = std::move(kv.second)](shared_broker_t broker) mutable {
+              return broker->dispatch(std::move(req));
+          });
+    };
+
+    auto reducer = [](list_offsets_response result, list_offsets_response val) {
+        result.data.throttle_time_ms += val.data.throttle_time_ms;
+        for (auto& topic : val.data.topics) {
+            auto topic_it = std::ranges::find(
+              result.data.topics,
+              topic.name,
+              &list_offset_topic_response::name);
+            if (topic_it == result.data.topics.end()) {
+                result.data.topics.push_back(std::move(topic));
+            } else {
+                std::ranges::move(
+                  topic.partitions, std::back_inserter(topic_it->partitions));
+            }
+        }
+        return result;
+    };
+
+    auto res = co_await ss::map_reduce(
+      std::make_move_iterator(reqs.begin()),
+      std::make_move_iterator(reqs.end()),
+      mapper,
+      list_offsets_response{},
+      reducer);
 
     // We must always throw and retry if a custom mitigator is
     // configured, as the mitigator may need to handle this error

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -359,15 +359,13 @@ client::do_list_offsets(model::topic_partition tp) {
       }});
 
     const auto& topics = res.data.topics;
-    auto ec = error_code::none;
-    if (topics.size() != 1 || topics[0].partitions.size() != 1) {
-        co_return ss::coroutine::exception(std::make_exception_ptr(
-          broker_error(node_id, error_code::unknown_server_error)));
-    }
-    ec = topics[0].partitions[0].error_code;
-    if (ec != error_code::none) {
-        co_return ss::coroutine::exception(
-          std::make_exception_ptr(partition_error(tp, ec)));
+    for (const auto& topic : topics) {
+        for (const auto& part : topic.partitions) {
+            if (part.error_code != error_code::none) {
+                co_return ss::coroutine::exception(std::make_exception_ptr(
+                  partition_error(tp, part.error_code)));
+            }
+        }
     }
     co_return res;
 }

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -341,10 +341,44 @@ client::create_topic(kafka::creatable_topic req) {
     });
 }
 
+namespace {
+
+template<typename T, typename ErrorPredicate>
+requires(KafkaApi<typename T::api_type>)
+void throw_on_error(const T& r, ErrorPredicate should_throw) {
+    using type = std::remove_cvref_t<T>;
+    if constexpr (std::is_same_v<type, list_offsets_response>) {
+        for (const auto& topic : r.data.topics) {
+            for (const auto& partition : topic.partitions) {
+                if (
+                  partition.error_code != error_code::none
+                  && should_throw(partition.error_code)) {
+                    throw partition_error(
+                      model::topic_partition{
+                        topic.name, partition.partition_index},
+                      partition.error_code);
+                }
+            }
+        }
+    }
+}
+
+template<typename T>
+requires(KafkaApi<typename T::api_type>)
+void throw_on_error(const T& r) {
+    return throw_on_error(r, [](error_code) { return true; });
+}
+
+} // namespace
+
 ss::future<list_offsets_response>
 client::list_offsets(model::topic_partition tp) {
     return gated_retry_with_mitigation(
-      [this, tp{std::move(tp)}]() { return do_list_offsets(tp); });
+             [this, tp{std::move(tp)}]() { return do_list_offsets(tp); })
+      .then([](auto res) {
+          throw_on_error<list_offsets_response>(res);
+          return res;
+      });
 }
 
 ss::future<list_offsets_response>
@@ -365,15 +399,12 @@ client::do_list_offsets(model::topic_partition tp) {
         .topics = std::move(cv),
       }});
 
-    const auto& topics = res.data.topics;
-    for (const auto& topic : topics) {
-        for (const auto& part : topic.partitions) {
-            if (part.error_code != error_code::none) {
-                co_return ss::coroutine::exception(std::make_exception_ptr(
-                  partition_error(tp, part.error_code)));
-            }
-        }
-    }
+    // We must always throw and retry if a custom mitigator is
+    // configured, as the mitigator may need to handle this error
+    throw_on_error(res, [&](auto ec) {
+        return kafka::is_retriable(ec) || _external_mitigate.has_value();
+    });
+
     co_return res;
 }
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -45,7 +45,7 @@
 
 namespace kafka::client {
 
-client::client(const YAML::Node& cfg, external_mitigate mitigater)
+client::client(const YAML::Node& cfg, std::optional<external_mitigate> mitigater)
   : _config{cfg}
   , _seeds{_config.brokers()}
   , _topic_cache{}
@@ -81,7 +81,7 @@ ss::future<> client::connect() {
           },
           [this, &retries](std::exception_ptr ex) {
               ++retries;
-              return _external_mitigate(ex);
+              return external_mitigate_error(ex);
           },
           _as);
     });
@@ -155,8 +155,15 @@ ss::future<> client::apply(metadata_response res) {
     }
 }
 
+ss::future<> client::external_mitigate_error(std::exception_ptr ex) const {
+    if (_external_mitigate) {
+        return (*_external_mitigate)(ex);
+    }
+    return ss::make_exception_future(ex);
+}
+
 ss::future<> client::mitigate_error(std::exception_ptr ex) {
-    return _external_mitigate(ex).handle_exception(
+    return external_mitigate_error(ex).handle_exception(
       [this](std::exception_ptr ex) {
           _gate.check();
           try {

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -27,6 +27,7 @@
 #include "kafka/protocol/describe_configs.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/list_offset.h"
+#include "model/timestamp.h"
 #include "ssx/semaphore.h"
 #include "utils/retry.h"
 #include "utils/unresolved_address.h"
@@ -112,6 +113,8 @@ public:
     ss::future<produce_response>
     produce_records(model::topic topic, chunked_vector<record_essence> batch);
 
+    ss::future<list_offsets_response> list_offsets(list_offsets_request req);
+
     ss::future<list_offsets_response> list_offsets(model::topic_partition tp);
 
     ss::future<fetch_response> fetch_partition(
@@ -179,7 +182,7 @@ public:
 
 private:
     ss::future<list_offsets_response>
-    do_list_offsets(model::topic_partition tp);
+    do_list_offsets(const list_offsets_request&);
 
     ss::future<describe_configs_response> do_describe_topics(
       chunked_vector<model::topic> topics,

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -65,21 +65,13 @@ private:
     ssx::semaphore _lock{1, "k/client"};
 };
 
-namespace impl {
-
-constexpr auto default_external_mitigate = [](std::exception_ptr ex) {
-    return ss::make_exception_future(ex);
-};
-
-} // namespace impl
-
 class client {
 public:
     using external_mitigate
       = ss::noncopyable_function<ss::future<>(std::exception_ptr)>;
     explicit client(
       const YAML::Node& cfg,
-      external_mitigate mitigater = impl::default_external_mitigate);
+      std::optional<external_mitigate> mitigater = std::nullopt);
 
     /// \brief Connect to all brokers.
     ss::future<> connect();
@@ -208,6 +200,10 @@ private:
     /// the error
     ss::future<> mitigate_error(std::exception_ptr ex);
 
+    /// \brief Handle errors by performing the optionally-configurable external
+    /// mitigation action that may fix the cause of the error
+    ss::future<> external_mitigate_error(std::exception_ptr ex) const;
+
     /// \brief Apply metadata update
     ss::future<> apply(metadata_response res);
 
@@ -244,8 +240,7 @@ private:
     /// \brief Wait for retries.
     ss::gate _gate;
 
-    ss::noncopyable_function<ss::future<>(std::exception_ptr)>
-      _external_mitigate;
+    std::optional<external_mitigate> _external_mitigate;
     ss::abort_source _as;
 };
 

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -313,3 +313,26 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_btest(
+    name = "list_offsets",
+    timeout = "short",
+    srcs = [
+        "list_offsets.cc",
+    ],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/kafka/client",
+        "//src/v/kafka/client/test:fixture",
+        "//src/v/kafka/client/test:utils",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:create_topics",
+        "//src/v/kafka/protocol:describe_configs",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:seastar_boost",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/kafka/client/test/list_offsets.cc
+++ b/src/v/kafka/client/test/list_offsets.cc
@@ -33,3 +33,43 @@ FIXTURE_TEST(test_unknown_topic, list_offsets_fixture) {
           return ex.error == kafka::error_code::unknown_topic_or_partition;
       });
 }
+
+FIXTURE_TEST(test_list_multiple_ntps, list_offsets_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    const auto t1 = create_topic(1, 1);
+    const auto t2 = create_topic(2, 2);
+
+    auto req = kafka::list_offsets_request{};
+    auto add_tp = [&](auto topic, auto n_partitions) {
+        auto& elem = req.data.topics.emplace_back(
+          kafka::list_offset_topic{.name = topic.tp});
+        for (int i = 0; i < n_partitions; ++i) {
+            elem.partitions.emplace_back(kafka::list_offset_partition{
+              .partition_index = model::partition_id{i}});
+        }
+    };
+    add_tp(t1, 1);
+    add_tp(t2, 2);
+
+    const auto resp = client.list_offsets(std::move(req)).get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 2);
+
+    auto t1_res = std::ranges::find_if(
+      resp.data.topics, [&](auto& tp_data) { return tp_data.name == t1.tp; });
+    BOOST_REQUIRE(t1_res != resp.data.topics.end());
+    BOOST_REQUIRE_EQUAL(t1_res->partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      t1_res->partitions[0].error_code, kafka::error_code::none);
+
+    auto t2_res = std::ranges::find_if(
+      resp.data.topics, [&](auto& tp_data) { return tp_data.name == t2.tp; });
+    BOOST_REQUIRE(t2_res != resp.data.topics.end());
+    BOOST_REQUIRE_EQUAL(t2_res->partitions.size(), 2);
+    BOOST_REQUIRE_EQUAL(
+      t2_res->partitions[0].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(
+      t2_res->partitions[1].error_code, kafka::error_code::none);
+}

--- a/src/v/kafka/client/test/list_offsets.cc
+++ b/src/v/kafka/client/test/list_offsets.cc
@@ -1,0 +1,35 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/client/client.h"
+#include "kafka/client/test/fixture.h"
+#include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
+
+#include <boost/test/tools/old/interface.hpp>
+
+inline const model::topic_partition unknown_tp{
+  model::topic{"unknown"}, model::partition_id{0}};
+
+class list_offsets_fixture : public kafka_client_fixture {};
+
+FIXTURE_TEST(test_unknown_topic, list_offsets_fixture) {
+    auto client = make_connected_client();
+    auto stop_client = ss::defer([&client]() { client.stop().get(); });
+
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(5));
+
+    BOOST_REQUIRE_EXCEPTION(
+      client.list_offsets(unknown_tp).get(),
+      kafka::exception_base,
+      [](kafka::exception_base ex) {
+          return ex.error == kafka::error_code::unknown_topic_or_partition;
+      });
+}

--- a/src/v/kafka/client/test/retry.cc
+++ b/src/v/kafka/client/test/retry.cc
@@ -20,21 +20,6 @@
 inline const model::topic_partition unknown_tp{
   model::topic{"unknown"}, model::partition_id{0}};
 
-FIXTURE_TEST(test_retry_list_offsets, kafka_client_fixture) {
-    auto client = make_connected_client();
-    auto stop_client = ss::defer([&client]() { client.stop().get(); });
-
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(5));
-
-    BOOST_REQUIRE_EXCEPTION(
-      client.list_offsets(unknown_tp).get(),
-      kafka::exception_base,
-      [](kafka::exception_base ex) {
-          return ex.error == kafka::error_code::unknown_topic_or_partition;
-      });
-}
-
 FIXTURE_TEST(test_retry_produce, kafka_client_fixture) {
     auto client = make_connected_client();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });

--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -226,4 +226,106 @@ const std::error_category& error_category() noexcept {
     static error_category e;
     return e;
 }
+
+bool is_retriable(error_code error) {
+    switch (error) {
+    case error_code::corrupt_message:
+    case error_code::unknown_topic_or_partition:
+    case error_code::leader_not_available:
+    case error_code::not_leader_for_partition:
+    case error_code::request_timed_out:
+    case error_code::network_exception:
+    case error_code::coordinator_load_in_progress:
+    case error_code::coordinator_not_available:
+    case error_code::not_coordinator:
+    case error_code::not_enough_replicas:
+    case error_code::not_enough_replicas_after_append:
+    case error_code::not_controller:
+    case error_code::kafka_storage_error:
+    case error_code::fetch_session_id_not_found:
+    case error_code::invalid_fetch_session_epoch:
+        return true;
+    case error_code::unknown_server_error:
+    case error_code::none:
+    case error_code::offset_out_of_range:
+    case error_code::invalid_fetch_size:
+    case error_code::broker_not_available:
+    case error_code::replica_not_available:
+    case error_code::message_too_large:
+    case error_code::stale_controller_epoch:
+    case error_code::offset_metadata_too_large:
+    case error_code::invalid_topic_exception:
+    case error_code::record_list_too_large:
+    case error_code::invalid_required_acks:
+    case error_code::illegal_generation:
+    case error_code::inconsistent_group_protocol:
+    case error_code::invalid_group_id:
+    case error_code::unknown_member_id:
+    case error_code::invalid_session_timeout:
+    case error_code::rebalance_in_progress:
+    case error_code::invalid_commit_offset_size:
+    case error_code::topic_authorization_failed:
+    case error_code::group_authorization_failed:
+    case error_code::cluster_authorization_failed:
+    case error_code::invalid_timestamp:
+    case error_code::unsupported_sasl_mechanism:
+    case error_code::illegal_sasl_state:
+    case error_code::unsupported_version:
+    case error_code::topic_already_exists:
+    case error_code::invalid_partitions:
+    case error_code::invalid_replication_factor:
+    case error_code::invalid_replica_assignment:
+    case error_code::invalid_config:
+    case error_code::invalid_request:
+    case error_code::unsupported_for_message_format:
+    case error_code::policy_violation:
+    case error_code::out_of_order_sequence_number:
+    case error_code::duplicate_sequence_number:
+    case error_code::invalid_producer_epoch:
+    case error_code::invalid_txn_state:
+    case error_code::invalid_producer_id_mapping:
+    case error_code::invalid_transaction_timeout:
+    case error_code::concurrent_transactions:
+    case error_code::transaction_coordinator_fenced:
+    case error_code::transactional_id_authorization_failed:
+    case error_code::security_disabled:
+    case error_code::operation_not_attempted:
+    case error_code::log_dir_not_found:
+    case error_code::sasl_authentication_failed:
+    case error_code::unknown_producer_id:
+    case error_code::reassignment_in_progress:
+    case error_code::delegation_token_auth_disabled:
+    case error_code::delegation_token_not_found:
+    case error_code::delegation_token_owner_mismatch:
+    case error_code::delegation_token_request_not_allowed:
+    case error_code::delegation_token_authorization_failed:
+    case error_code::delegation_token_expired:
+    case error_code::invalid_principal_type:
+    case error_code::non_empty_group:
+    case error_code::group_id_not_found:
+    case error_code::listener_not_found:
+    case error_code::topic_deletion_disabled:
+    case error_code::fenced_leader_epoch:
+    case error_code::unknown_leader_epoch:
+    case error_code::unsupported_compression_type:
+    case error_code::stale_broker_epoch:
+    case error_code::offset_not_available:
+    case error_code::member_id_required:
+    case error_code::preferred_leader_not_available:
+    case error_code::group_max_size_reached:
+    case error_code::no_reassignment_in_progress:
+    case error_code::fenced_instance_id:
+    case error_code::group_subscribed_to_topic:
+    case error_code::invalid_record:
+    case error_code::unstable_offset_commit:
+    case error_code::throttling_quota_exceeded:
+    case error_code::resource_not_found:
+    case error_code::duplicate_resource:
+    case error_code::unacceptable_credential:
+    case error_code::transactional_id_not_found:
+        break;
+    }
+    return false;
+}
+
 } // namespace kafka

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -243,6 +243,7 @@ std::ostream& operator<<(std::ostream&, error_code);
 std::string_view error_code_to_str(error_code error);
 std::error_code make_error_code(error_code);
 const std::error_category& error_category() noexcept;
+bool is_retriable(error_code);
 
 } // namespace kafka
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -111,6 +111,13 @@ struct batch_builder : public storage::record_batch_builder {
 ss::future<> seq_writer::read_sync() {
     auto offsets = co_await _client.local().list_offsets(
       model::schema_registry_internal_tp);
+    if (
+      offsets.data.topics.size() != 1
+      || offsets.data.topics[0].partitions.size() != 1) {
+        throw kafka::exception(
+          kafka::error_code::unknown_server_error,
+          "Malformed ListOffsets Kafka response for internal topic");
+    }
 
     auto max_offset = offsets.data.topics[0].partitions[0].offset;
     co_await wait_for(max_offset - model::offset{1});

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -595,6 +595,14 @@ ss::future<> service::fetch_internal_topic() {
 
     auto offset_res = co_await _client.local().list_offsets(
       model::schema_registry_internal_tp);
+    if (
+      offset_res.data.topics.size() != 1
+      || offset_res.data.topics[0].partitions.size() != 1) {
+        throw kafka::exception(
+          kafka::error_code::unknown_server_error,
+          "Malformed ListOffsets Kafka response for internal topic");
+    }
+
     auto max_offset = offset_res.data.topics[0].partitions[0].offset;
     vlog(srlog.debug, "Schema registry: _schemas max_offset: {}", max_offset);
 


### PR DESCRIPTION
This implements list_offset that can be issued across multiple brokers
for multiple topic partitions at the same time.

The request is sharded into separate requests per-topic-leader-broker.
The per-broker requests are sent in parallel, and then the response is
reconstructed by merging the invidual responses.

Fixes https://redpandadata.atlassian.net/browse/CORE-10193

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
