### PR TITLE
rptest/cluster_restore_test: avoid depending on slow TS

### DIFF
--- a/tests/rptest/tests/datalake/cluster_restore_test.py
+++ b/tests/rptest/tests/datalake/cluster_restore_test.py
@@ -41,6 +41,9 @@ class DatalakeClusterRestoreTest(RedpandaTest):
             "iceberg_enabled": "true",
             "iceberg_catalog_commit_interval_ms": 1000,
             "iceberg_target_lag_ms": 1000,
+
+            # Allow tests to alter _schemas (e.g. to disable uploads).
+            "kafka_nodelete_topics": [],
         }
         si_settings = SISettings(
             test_context,
@@ -411,9 +414,29 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                               redpanda=self.redpanda,
                               include_query_engines=[QueryEngineType.SPARK],
                               catalog_type=catalog_type) as dl:
+            # To make this test more robust, on top of lowering the upload
+            # rate, we'll just avoid uploading the schemas topic to allow us to
+            # reliably check that the schemas topic is not restored below
+            # (otherwise a leadership transfer could trigger an upload).
+            rpk: RpkTool = RpkTool(self.redpanda)
+            rpk.create_topic("_schemas",
+                             partitions=1,
+                             config={"redpanda.remote.write": "false"})
+
             all_topics, all_streams = self.start_all_topic_streams(dl)
             for t in all_topics:
                 dl.wait_for_translation_until_offset(t, 50)
+
+            # To simulate slow tiered storage, disable writes and then
+            # push more data to Iceberg.
+            for t in all_topics:
+                rpk.alter_topic_config(t, "redpanda.remote.write", "false")
+            offsets_snap = self.offsets_per_table(dl, all_topics)
+            wait_until(
+                lambda: self.tables_translated_more(dl, offsets_snap, 50),
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg="Translation not progressing after disabling uploads")
 
             for s in all_streams:
                 self.rpcn.stop_stream(s, should_finish=None)
@@ -447,12 +470,6 @@ class DatalakeClusterRestoreTest(RedpandaTest):
             # and instead should write to their DLQs.
             for t in structured_tables:
                 dl.wait_for_translation_until_offset(f"{t}~dlq", 50)
-                offset_zero_res = dl.spark().run_query_fetch_all(
-                    f"select * from redpanda.`{t}~dlq` where redpanda.offset = 0"
-                )
-                assert len(
-                    offset_zero_res
-                ) == 1, f"Expected exactly one record with offset zero, got: {offset_zero_res}"
 
             structured_offsets_snap_after = self.offsets_per_table(
                 dl, structured_tables)
@@ -478,6 +495,12 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                        backoff_sec=1,
                        err_msg="Translation not progressing after restore")
 
+            # Reenable tiered storage writes to allow for end-of-test
+            # scrubbing.
+            for t in all_topics:
+                rpk.alter_topic_config(t, "redpanda.remote.write", "true")
+            rpk.alter_topic_config("_schemas", "redpanda.remote.write", "true")
+
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
@@ -497,9 +520,29 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                               redpanda=self.redpanda,
                               include_query_engines=[QueryEngineType.SPARK],
                               catalog_type=catalog_type) as dl:
+            # To make this test more robust, on top of lowering the upload
+            # rate, we'll just avoid uploading the schemas topic to allow us to
+            # reliably check that the schemas topic is not restored below
+            # (otherwise a leadership transfer could trigger an upload).
+            rpk: RpkTool = RpkTool(self.redpanda)
+            rpk.create_topic("_schemas",
+                             partitions=1,
+                             config={"redpanda.remote.write": "false"})
+
             all_topics, all_streams = self.start_all_topic_streams(dl)
             for t in all_topics:
                 dl.wait_for_translation_until_offset(t, 50)
+
+            # To simulate slow tiered storage, disable writes and then
+            # push more data to Iceberg.
+            for t in all_topics:
+                rpk.alter_topic_config(t, "redpanda.remote.write", "false")
+            offsets_snap = self.offsets_per_table(dl, all_topics)
+            wait_until(
+                lambda: self.tables_translated_more(dl, offsets_snap, 50),
+                timeout_sec=60,
+                backoff_sec=1,
+                err_msg="Translation not progressing after disabling uploads")
 
             for s in all_streams:
                 self.rpcn.stop_stream(s, should_finish=None)
@@ -516,7 +559,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
             offsets_snap = self.offsets_per_table(dl, all_topics)
 
             # All of our topics should continue to write with no issues since
-            # we have recreated some schemas.
+            # we have recreated our schemas.
             wait_until(
                 lambda: self.tables_translated_more(dl, offsets_snap, 50),
                 timeout_sec=60,
@@ -532,10 +575,12 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                 self.redpanda.logger.debug(f"Duplicate offsets for {t}: {res}")
                 assert len(
                     res) > 0, f"Expected some duplicate offsets for table {t}"
-                zero_offset_count_res = [tup for tup in res if tup[0] == 0]
-                assert [
-                    (0, 2)
-                ] == zero_offset_count_res, f"Expected offset 0 to be duplicated: {zero_offset_count_res}"
             assert dl.num_tables() == len(
                 all_topics
             ), "Expected one table per topic (i.e. no DLQ tables)"
+
+            # Reenable tiered storage writes to allow for end-of-test
+            # scrubbing.
+            for t in all_topics:
+                rpk.alter_topic_config(t, "redpanda.remote.write", "true")
+            rpk.alter_topic_config("_schemas", "redpanda.remote.write", "true")


### PR DESCRIPTION
A couple tests had checks that depended on tiered storage not uploading anything, supposedly guaranteed by slowing down the upload interval. This actually isn't a sufficient condition to ensure tiered storage uploads don't actually happen, since a leadership change will cause uploads to happen immediately.

Rather than relying on slow timing, this changes the test to explicitly disable tiered storage after some time, to simulate slow tiered storage. Conditions in the test are also updated, as before the test would expect no uploads at all, while now the test will have some initial uploads but eventually quiesce.

Fixes CORE-9301
Fixes CORE-9303
Fixes CORE-9442

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
