### PR TITLE
[v24.3.x] r/consensus: stop consumable offset monitor

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -270,6 +270,7 @@ void consensus::shutdown_input() {
         _as.request_abort();
         _commit_index_updated.broken();
         _follower_reply.broken();
+        _consumable_offset_monitor.stop();
     }
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26260
