### PR TITLE
[v24.3.x] tests: make stuck shutdown detection timeout longer

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -354,6 +354,9 @@ class PartitionBalancerTest(PartitionBalancerService):
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_unavailable_nodes(self):
         self.start_redpanda(num_nodes=5)
+        # set partition shutdown watchdog timeout to a large value to prevent spurious detection when Redpanda node is suspended
+        self.redpanda.set_cluster_config(
+            {"partition_manager_shutdown_watchdog_timeout": 90000})
 
         self.topic = TopicSpec(partition_count=random.randint(20, 30))
         self.client().create_topic(self.topic)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26258
