### PR TITLE
k/generator: do not use standard vectors for offset commit protocol

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -526,11 +526,11 @@ ss::future<offset_fetch_response> client::consumer_offset_fetch(
 ss::future<offset_commit_response> client::consumer_offset_commit(
   const group_id& g_id,
   const member_id& name,
-  std::vector<offset_commit_request_topic> topics) {
+  chunked_vector<offset_commit_request_topic> topics) {
     return get_consumer(g_id, name)
       .then([this, topics{std::move(topics)}](shared_consumer_t c) mutable {
           return gated_retry_with_mitigation([c, topics{std::move(topics)}]() {
-              return c->offset_commit(topics);
+              return c->offset_commit(make_copy(topics));
           });
       });
 }

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -155,7 +155,7 @@ public:
     ss::future<offset_commit_response> consumer_offset_commit(
       const group_id& g_id,
       const member_id& m_id,
-      std::vector<offset_commit_request_topic> topics);
+      chunked_vector<offset_commit_request_topic> topics);
 
     ss::future<fetch_response> consumer_fetch(
       const group_id& g_id,

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -375,7 +375,7 @@ consumer::offset_fetch(std::vector<offset_fetch_request_topic> topics) {
 }
 
 ss::future<offset_commit_response>
-consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
+consumer::offset_commit(chunked_vector<offset_commit_request_topic> topics) {
     refresh_inactivity_timer();
     if (topics.empty()) { // commit all offsets
         for (const auto& s : _fetch_sessions) {
@@ -394,7 +394,7 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
           .group_id = me->_group_id,
           .generation_id = me->_generation_id,
           .member_id = me->_member_id,
-          .topics = topics}};
+          .topics = make_copy(topics)}};
     };
 
     co_return co_await req_res(std::move(req_builder));

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -74,7 +74,7 @@ public:
     ss::future<offset_fetch_response>
     offset_fetch(std::vector<offset_fetch_request_topic> topics);
     ss::future<offset_commit_response>
-    offset_commit(std::vector<offset_commit_request_topic> topics);
+    offset_commit(chunked_vector<offset_commit_request_topic> topics);
     ss::future<fetch_response>
     fetch(std::chrono::milliseconds timeout, std::optional<int32_t> max_bytes);
 

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "fixture",
@@ -294,5 +294,22 @@ redpanda_cc_btest(
         "@seastar",
         "@seastar//:testing",
         "@yaml-cpp",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "utils_test",
+    timeout = "short",
+    srcs = [
+        "utils_test.cc",
+    ],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/kafka/client",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:offset_commit",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
     ],
 )

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -304,7 +304,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
     // Commit 5 offsets, with metadata of the member id.
     for (size_t i = 0; i < sorted_members.size(); ++i) {
         auto m_id = sorted_members[i];
-        auto t = std::vector<kafka::offset_commit_request_topic>{};
+        auto t = chunked_vector<kafka::offset_commit_request_topic>{};
         t.reserve(3);
         std::transform(
           topics.begin(),
@@ -361,7 +361,7 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
     // empty list means commit all offsets
     for (size_t i = 0; i < sorted_members.size(); ++i) {
         auto m_id = sorted_members[i];
-        auto t = std::vector<kafka::offset_commit_request_topic>{};
+        auto t = chunked_vector<kafka::offset_commit_request_topic>{};
         auto res
           = client.consumer_offset_commit(group_id, m_id, std::move(t)).get();
         BOOST_REQUIRE_EQUAL(res.data.topics.size(), 3);

--- a/src/v/kafka/client/test/utils_test.cc
+++ b/src/v/kafka/client/test/utils_test.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/utils.h"
+#include "kafka/protocol/offset_commit.h"
+
+#include <gtest/gtest.h>
+
+TEST(utils_test, test_copying_offset_commit_request) {
+    chunked_vector<kafka::offset_commit_request_topic> topics;
+    absl::btree_map<kafka::tag_id, bytes> tags;
+    tags.emplace(kafka::tag_id(1), bytes::from_string("unknown-tag-data"));
+
+    for (int i = 0; i < 10; ++i) {
+        topics.emplace_back(kafka::offset_commit_request_topic{
+          .name = model::topic(ssx::sformat("topic-{}", i)),
+          .partitions = {
+            kafka::offset_commit_request_partition{
+              .partition_index = model::partition_id(i),
+              .committed_offset = model::offset(i),
+              .committed_metadata = ssx::sformat("metadata-{}", i),
+            },
+          },    
+          .unknown_tags = kafka::tagged_fields{tags},
+        });
+    }
+
+    ASSERT_EQ(topics, kafka::client::make_copy(topics));
+}

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -16,6 +16,7 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/exceptions.h"
 #include "kafka/protocol/find_coordinator.h"
+#include "kafka/protocol/offset_commit.h"
 #include "utils/retry.h"
 
 namespace kafka::client {
@@ -144,6 +145,25 @@ ss::future<shared_broker_t> find_coordinator_with_retry_and_mitigation(
             net::unresolved_address(res.data.host, res.data.port),
             client_config);
       });
+}
+
+inline chunked_vector<kafka::offset_commit_request_topic>
+make_copy(const chunked_vector<kafka::offset_commit_request_topic>& topics) {
+    static_assert(
+      reflection::arity<kafka::offset_commit_request_topic>() == 3,
+      "kafka::offset_commit_request_topic must have 3 fields, otherwise this "
+      "function must be updated");
+
+    chunked_vector<kafka::offset_commit_request_topic> res;
+    res.reserve(topics.size());
+    for (const auto& topic : topics) {
+        res.push_back({
+          .name = topic.name,
+          .partitions = topic.partitions.copy(),
+          .unknown_tags = topic.unknown_tags,
+        });
+    }
+    return res;
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -68,8 +68,8 @@ auto retry_with_mitigation(
                   "\t    auto _ = consume(std::move(movable_state));\n"
                   "\t};");
 
-                return fut.then(func).handle_exception(
-                  [&eptr](std::exception_ptr ex) mutable {
+                return fut.then([&func] { return func(); })
+                  .handle_exception([&eptr](std::exception_ptr ex) mutable {
                       eptr = ex;
                       return Futurator::make_exception_future(eptr);
                   });
@@ -95,7 +95,7 @@ std::invoke_result_t<Func> gated_retry_with_mitigation_impl(
        &retry_gate,
        func{std::move(func)},
        errFunc{std::move(errFunc)},
-       as]() {
+       as]() mutable {
           return retry_with_mitigation(
             retries,
             retry_base_backoff,

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -541,18 +541,12 @@ override_member_container = {
     'createable_topic_config': 'std::vector',
     'creatable_topic_configs': 'std::vector',
     'creatable_replica_assignment': 'std::vector',
-    'offset_commit_request_partition': 'std::vector',
-    'offset_commit_response_partition': 'std::vector',
-    'offset_commit_request_topic': 'std::vector',
     'offset_fetch_request_topic': 'std::vector',
     'partition_produce_response': 'std::vector',
     'creatable_acl_result': 'std::vector',
     'offset_delete_request_partition': 'std::vector',
     'deletable_group_result': 'std::vector',
     'delete_acls_matching_acl': 'std::vector',
-    'txn_offset_commit_request_partition': 'std::vector',
-    'txn_offset_commit_request_topic': 'std::vector',
-    'txn_offset_commit_response_partition': 'std::vector',
 }
 
 

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -27,16 +27,16 @@ struct txn_offset_commit_ctx {
     txn_offset_commit_request request;
     ss::smp_service_group ssg;
 
-    absl::flat_hash_map<
+    chunked_hash_map<
       model::topic,
-      std::vector<txn_offset_commit_response_partition>>
+      chunked_vector<txn_offset_commit_response_partition>>
       unauthorized_tps;
 
     // topic partitions found not to existent prior to processing. responses for
     // these are patched back into the final response after processing.
-    absl::flat_hash_map<
+    chunked_hash_map<
       model::topic,
-      std::vector<txn_offset_commit_response_partition>>
+      chunked_vector<txn_offset_commit_response_partition>>
       nonexistent_tps;
 
     txn_offset_commit_ctx(
@@ -66,10 +66,10 @@ ss::future<response_ptr> txn_offset_commit(txn_offset_commit_ctx& octx) {
               for (auto& topic : resp.data.topics) {
                   auto it = octx.nonexistent_tps.find(topic.name);
                   if (it != octx.nonexistent_tps.end()) {
-                      topic.partitions.insert(
-                        topic.partitions.end(),
+                      std::copy(
                         it->second.begin(),
-                        it->second.end());
+                        it->second.end(),
+                        std::back_inserter(topic.partitions));
                       octx.nonexistent_tps.erase(it);
                   }
               }
@@ -129,63 +129,60 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
      * flag to mark topic-partitions to be ignored by the group membership
      * subsystem.
      */
-    for (auto it = octx.request.data.topics.begin();
-         it != octx.request.data.topics.end();) {
-        /*
-         * check if topic exists
-         */
-        const auto topic_name = model::topic(it->name);
-        model::topic_namespace_view tn(model::kafka_namespace, topic_name);
+    chunked_vector<txn_offset_commit_request_topic> valid_topics;
+    valid_topics.reserve(octx.request.data.topics.size());
+    for (auto& topic : octx.request.data.topics) {
+        model::topic_namespace_view tn(model::kafka_namespace, topic.name);
 
-        if (!octx.rctx.authorized(security::acl_operation::read, topic_name)) {
-            auto& parts = octx.unauthorized_tps[it->name];
-            parts.reserve(it->partitions.size());
+        if (!octx.rctx.authorized(security::acl_operation::read, topic.name)) {
+            auto& parts = octx.unauthorized_tps[topic.name];
+            parts.reserve(topic.partitions.size());
             absl::c_transform(
-              it->partitions, parts.begin(), [](const auto& part) {
+              topic.partitions, parts.begin(), [](const auto& part) {
                   return txn_offset_commit_response_partition{
                     .partition_index = part.partition_index,
                     .error_code = error_code::topic_authorization_failed};
               });
-            it->partitions.clear();
-        } else if (octx.rctx.metadata_cache().contains(tn)) {
-            /*
-             * check if each partition exists
-             */
-            auto split = std::partition(
-              it->partitions.begin(),
-              it->partitions.end(),
-              [&octx, &tn](const txn_offset_commit_request_partition& p) {
-                  return octx.rctx.metadata_cache().contains(
-                    tn, p.partition_index);
-              });
-            /*
-             * build responses for nonexistent topic partitions
-             */
-            if (split != it->partitions.end()) {
-                auto& parts = octx.nonexistent_tps[it->name];
-                for (auto part = split; part != it->partitions.end(); part++) {
-                    parts.push_back(txn_offset_commit_response_partition{
-                      .partition_index = part->partition_index,
-                      .error_code = error_code::unknown_topic_or_partition,
-                    });
-                }
-                it->partitions.erase(split, it->partitions.end());
-            }
-            ++it;
-        } else {
+            continue;
+        }
+        if (!octx.rctx.metadata_cache().contains(tn)) {
             /*
              * the topic doesn't exist. build all partition responses.
              */
-            auto& parts = octx.nonexistent_tps[it->name];
-            for (const auto& part : it->partitions) {
+            auto& parts = octx.nonexistent_tps[topic.name];
+            for (const auto& part : topic.partitions) {
                 parts.push_back(txn_offset_commit_response_partition{
                   .partition_index = part.partition_index,
                   .error_code = error_code::unknown_topic_or_partition,
                 });
             }
-            it = octx.request.data.topics.erase(it);
+            continue;
         }
+
+        /*
+         * check if each partition exists
+         */
+        chunked_vector<txn_offset_commit_request_partition> valid_partitions;
+        valid_partitions.reserve(topic.partitions.size());
+        for (auto& part : topic.partitions) {
+            auto& parts = octx.nonexistent_tps[topic.name];
+            if (!octx.rctx.metadata_cache().contains(
+                  tn, part.partition_index)) {
+                parts.push_back(txn_offset_commit_response_partition{
+                  .partition_index = part.partition_index,
+                  .error_code = error_code::unknown_topic_or_partition,
+                });
+                continue;
+            }
+            valid_partitions.push_back(std::move(part));
+        }
+        valid_topics.push_back(txn_offset_commit_request_topic{
+          .name = topic.name,
+          .partitions = std::move(valid_partitions),
+          .unknown_tags = std::move(topic.unknown_tags),
+        });
     }
+    octx.request.data.topics = std::move(valid_topics);
 
     if (!octx.rctx.audit()) {
         return octx.rctx.respond(txn_offset_commit_response{

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1680,13 +1680,13 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
         // for these are patched back into the final response after processing.
         absl::flat_hash_map<
           model::topic,
-          std::vector<offset_commit_response_partition>>
+          chunked_vector<offset_commit_response_partition>>
           nonexistent_tps;
 
         // topic partitions that principal is not authorized to read
         absl::flat_hash_map<
           model::topic,
-          std::vector<offset_commit_response_partition>>
+          chunked_vector<offset_commit_response_partition>>
           unauthorized_tps;
 
         offset_commit_ctx(
@@ -1714,86 +1714,81 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
      * flag to mark topic-partitions to be ignored by the group membership
      * subsystem.
      */
-    for (auto it = octx.request.data.topics.begin();
-         it != octx.request.data.topics.end();) {
+    chunked_vector<offset_commit_request_topic> valid_topics;
+    valid_topics.reserve(octx.request.data.topics.size());
+    for (auto& topic : octx.request.data.topics) {
         /*
          * not authorized for this group. all topics in the request are
          * responded to with a group authorization failed error code.
          */
         if (!group_authorized) {
-            auto& parts = octx.unauthorized_tps[it->name];
-            parts.reserve(it->partitions.size());
-            for (const auto& part : it->partitions) {
+            auto& parts = octx.unauthorized_tps[topic.name];
+            parts.reserve(topic.partitions.size());
+            for (const auto& part : topic.partitions) {
                 parts.push_back(offset_commit_response_partition{
                   .partition_index = part.partition_index,
                   .error_code = error_code::group_authorization_failed,
                 });
             }
-            it = octx.request.data.topics.erase(it);
             continue;
         }
 
         /*
          * check topic authorization
          */
-        if (!octx.rctx.authorized(security::acl_operation::read, it->name)) {
-            auto& parts = octx.unauthorized_tps[it->name];
-            parts.reserve(it->partitions.size());
-            for (const auto& part : it->partitions) {
+        if (!octx.rctx.authorized(security::acl_operation::read, topic.name)) {
+            auto& parts = octx.unauthorized_tps[topic.name];
+            parts.reserve(topic.partitions.size());
+            for (const auto& part : topic.partitions) {
                 parts.push_back(offset_commit_response_partition{
                   .partition_index = part.partition_index,
                   .error_code = error_code::topic_authorization_failed,
                 });
             }
-            it = octx.request.data.topics.erase(it);
             continue;
         }
 
         /*
          * check if topic exists
          */
-        const auto topic_name = model::topic(it->name);
-        model::topic_namespace_view tn(model::kafka_namespace, topic_name);
+        model::topic_namespace_view tn(model::kafka_namespace, topic.name);
 
-        if (octx.rctx.metadata_cache().contains(tn)) {
-            /*
-             * check if each partition exists
-             */
-            auto split = std::partition(
-              it->partitions.begin(),
-              it->partitions.end(),
-              [&octx, &tn](const offset_commit_request_partition& p) {
-                  return octx.rctx.metadata_cache().contains(
-                    tn, p.partition_index);
-              });
-            /*
-             * build responses for nonexistent topic partitions
-             */
-            if (split != it->partitions.end()) {
-                auto& parts = octx.nonexistent_tps[it->name];
-                for (auto part = split; part != it->partitions.end(); part++) {
-                    parts.push_back(offset_commit_response_partition{
-                      .partition_index = part->partition_index,
-                      .error_code = error_code::unknown_topic_or_partition,
-                    });
-                }
-                it->partitions.erase(split, it->partitions.end());
-            }
-            ++it;
-        } else {
+        if (!octx.rctx.metadata_cache().contains(tn)) {
             /*
              * the topic doesn't exist. build all partition responses.
              */
-            auto& parts = octx.nonexistent_tps[it->name];
-            for (const auto& part : it->partitions) {
+            auto& parts = octx.nonexistent_tps[topic.name];
+            for (const auto& part : topic.partitions) {
                 parts.push_back(offset_commit_response_partition{
                   .partition_index = part.partition_index,
                   .error_code = error_code::unknown_topic_or_partition,
                 });
             }
-            it = octx.request.data.topics.erase(it);
+            continue;
         }
+        chunked_vector<offset_commit_request_partition> valid_partitions;
+        valid_partitions.reserve(topic.partitions.size());
+        for (auto& p : topic.partitions) {
+            // non existing partition, build a response
+            if (octx.rctx.metadata_cache().contains(tn, p.partition_index)) {
+                valid_partitions.push_back(std::move(p));
+                continue;
+            }
+
+            auto& parts = octx.nonexistent_tps[topic.name];
+            parts.push_back(offset_commit_response_partition{
+              .partition_index = p.partition_index,
+              .error_code = error_code::unknown_topic_or_partition,
+            });
+        }
+
+        valid_topics.push_back({
+          .name = std::move(topic.name),
+          .partitions = std::move(valid_partitions),
+          .unknown_tags = std::move(topic.unknown_tags),
+        });
     }
+    octx.request.data.topics = std::move(valid_topics);
 
     if (!octx.rctx.audit()) {
         offset_commit_response resp(
@@ -1851,10 +1846,11 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
                   for (auto& topic : resp.data.topics) {
                       auto it = octx.nonexistent_tps.find(topic.name);
                       if (it != octx.nonexistent_tps.end()) {
-                          topic.partitions.insert(
-                            topic.partitions.end(),
+                          std::copy(
                             it->second.begin(),
-                            it->second.end());
+                            it->second.end(),
+                            std::back_inserter(topic.partitions));
+
                           octx.nonexistent_tps.erase(it);
                       }
                   }

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -127,10 +127,13 @@ FIXTURE_TEST(empty_offset_commit_request, consumer_offsets_fixture) {
         BOOST_REQUIRE(!resp.data.errored());
     }
     {
-        auto req = offset_commit_request{.data{
+        offset_commit_request req;
+        req.data = offset_commit_request_data{
           .group_id = kafka::group_id{"foo-partitions"},
-          .topics = {offset_commit_request_topic{
-            .name = model::topic{"foo"}, .partitions = {}}}}};
+          .topics = chunked_vector<offset_commit_request_topic>::single(
+            offset_commit_request_topic{
+              .name = model::topic{"foo"}, .partitions = {}})};
+
         req.data.group_instance_id = gr;
         auto resp = client.dispatch(std::move(req)).get();
         BOOST_REQUIRE(!resp.data.errored());
@@ -164,7 +167,8 @@ FIXTURE_TEST(conditional_retention_test, consumer_offsets_fixture) {
 
         return offset_commit_request{.data{
           .group_id = kafka::group_id{fmt::format("foo-{}", offset)},
-          .topics = {std::move(topic)}}};
+          .topics = chunked_vector<offset_commit_request_topic>::single(
+            std::move(topic))}};
     };
     for (int i = 0; i < 10; i++) {
         auto req = rand_offset_commit();

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -209,7 +209,7 @@ struct offset_commit_op : executable_op {
 
     ss::future<> execute(group_manager_fixture* fixture) override {
         vlog(logger.trace, "Executing offset_commit_op: {}", req);
-        auto result = co_await fixture->tx_offset_commit(req);
+        auto result = co_await fixture->tx_offset_commit(std::move(req));
         ASSERT_FALSE_CORO(result.data.errored());
     }
     kafka::txn_offset_commit_request req;
@@ -285,7 +285,8 @@ random_ops generate_workload(workload_parameters params) {
               {.partition_index = model::partition_id{0},
                .committed_offset = model::offset{j}});
             offset_req.data.topics.push_back(std::move(topic_data));
-            group_ops.emplace(ss::make_shared<offset_commit_op>(offset_req));
+            group_ops.emplace(
+              ss::make_shared<offset_commit_op>(std::move(offset_req)));
 
             auto commit_group_tx
               = params.tx_workload_type == workload_parameters::commit_only

--- a/src/v/pandaproxy/json/requests/offset_commit.h
+++ b/src/v/pandaproxy/json/requests/offset_commit.h
@@ -22,10 +22,10 @@
 
 namespace pandaproxy::json {
 
-inline std::vector<kafka::offset_commit_request_topic>
+inline chunked_vector<kafka::offset_commit_request_topic>
 partition_offsets_request_to_offset_commit_request(
   std::vector<topic_partition_offset> tps) {
-    std::vector<kafka::offset_commit_request_topic> res;
+    chunked_vector<kafka::offset_commit_request_topic> res;
     if (tps.empty()) {
         return res;
     }

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -461,7 +461,7 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
     // If the request is empty, commit all offsets
     auto req_data = rq.req->content_length == 0
-                      ? std::vector<kafka::offset_commit_request_topic>()
+                      ? chunked_vector<kafka::offset_commit_request_topic>()
                       : ppj::partition_offsets_request_to_offset_commit_request(
                           co_await rjson_parse(
                             *rq.req, ppj::partition_offsets_request_handler()));


### PR DESCRIPTION
In transactional and standard offset commit request and replies topic partition offsets are stored as a vectors. The number of partitions/topics in a single request may grow large, therefore we should use a fragmented vector when handling those requests.

Changed the Kafka protocol generator overrides for offset commit requests and responses to use default `chunked_vector`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Fixed large allocation issues when handling OffsetCommits