### PR TITLE
Partition balancer incident followups

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -608,17 +608,17 @@ size_t partition_balancer_backend::get_min_partition_size_threshold() const {
         return _min_partition_size_threshold().value();
     }
 
-    // TODO: replace partition_autobalancing_concurrent_moves after we have it
-    // as a field in balancer backend
-    const auto min_rate
-      = _raft_learner_recovery_rate()
-        / config::shard_local_cfg().partition_autobalancing_concurrent_moves();
+    auto num_concurrent_moves = _max_concurrent_actions();
+    if (num_concurrent_moves == 0) {
+        return 0;
+    }
 
     /**
      * We use a heuristic to calculate the minimum size of of partition, we
      * want that the partition with the threshold size to have enough data that
      * it will move for at least ten seconds.
      */
+    const auto min_rate = _raft_learner_recovery_rate() / num_concurrent_moves;
     return min_rate * 10;
 }
 

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -390,6 +390,11 @@ ss::future<> partition_balancer_backend::do_tick() {
           mode);
     }
 
+    const bool space_management_enabled = config::shard_local_cfg().space_management_enable()
+     && (
+      config::shard_local_cfg().retention_local_target_capacity_percent() > 0
+      || config::shard_local_cfg().retention_local_target_capacity_bytes() > 0);
+
     partition_balancer_planner planner(
       planner_config{
         .mode = mode,
@@ -403,8 +408,7 @@ ss::future<> partition_balancer_backend::do_tick() {
         .min_partition_size_threshold = get_min_partition_size_threshold(),
         .node_responsiveness_timeout = node_responsiveness_timeout,
         .topic_aware = _topic_aware(),
-        .space_management_enabled
-        = config::shard_local_cfg().space_management_enable,
+        .space_management_enabled = space_management_enabled,
       },
       _state,
       _partition_allocator);

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1929,15 +1929,15 @@ partition_balancer_planner::get_full_node_actions(request_context& ctx) {
 
 ss::future<> partition_balancer_planner::get_counts_rebalancing_actions(
   request_context& ctx) {
-    if (!ctx.config().ondemand_rebalance_requested) {
-        if (ctx.state().nodes_to_rebalance().empty()) {
-            co_return;
-        }
+    if (
+      ctx.state().nodes_to_rebalance().empty()
+      && !ctx.config().ondemand_rebalance_requested) {
+        co_return;
+    }
 
-        if (ctx.config().mode < model::partition_autobalancing_mode::node_add) {
-            ctx._counts_rebalancing_finished = true;
-            co_return;
-        }
+    if (ctx.config().mode == model::partition_autobalancing_mode::off) {
+        ctx._counts_rebalancing_finished = true;
+        co_return;
     }
 
     if (!ctx.can_add_reassignment()) {

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -291,15 +291,23 @@ class ScalingUpTest(PreallocNodesTest):
         for n in self.redpanda.nodes[3:]:
             self.redpanda.clean_node(n)
             self.redpanda.start_node(n)
+        self.redpanda.wait_for_membership(first_start=True)
 
         # verify that all new nodes are empty
 
-        per_node = self._replicas_per_node()
+        admin = Admin(self.redpanda, retries_amount=20)
 
+        wait_until(
+            lambda: admin.get_partition_balancer_status()["status"] == "ready",
+            timeout_sec=90,
+            backoff_sec=5)
+
+        per_node = self._replicas_per_node()
         assert len(per_node) == 3
 
         # trigger rebalance
-        admin = Admin(self.redpanda, retries_amount=20)
+        self.redpanda.set_cluster_config(
+            {"partition_autobalancing_mode": "node_add"})
         admin.trigger_rebalance()
 
         self.wait_for_partitions_rebalanced(total_replicas=total_replicas,


### PR DESCRIPTION
* https://redpandadata.atlassian.net/browse/CORE-10078
* https://redpandadata.atlassian.net/browse/CORE-10079
* https://redpandadata.atlassian.net/browse/CORE-10081

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes
### Bug Fixes
* Fix Redpanda crash if `partition_autobalancing_concurrent_moves` was set to 0.
* `partition_autobalancing_mode=off` now stops on-demand partition rebalance as well.
* Allow partition balancing to opearte in case when space management was enabled, but local target capacity was unset.
