### PR TITLE
tests: adjusted default partition shutdown timeout

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1428,6 +1428,9 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
         'kafka_connections_max': 2048,
         'kafka_connections_max_per_ip': 1024,
         'kafka_connections_max_overrides': ["1.2.3.4:5"],
+        # configure shutdown watchdog timeout to 20 seconds to give it a chance
+        # to fire before Redpanda node that doesn't stopped is killed
+        "partition_manager_shutdown_watchdog_timeout": 20000,
     }
 
     logs = {
@@ -4510,7 +4513,10 @@ class RedpandaService(RedpandaServiceBase):
             # this configuration property was introduced in 22.2, ensure
             # it doesn't appear in older configurations
             del conf['log_segment_size_jitter_percent']
-
+        if cur_ver != RedpandaInstaller.HEAD and cur_ver < (23, 2, 1):
+            # versions prior to 23.2.1 does not support
+            # partition_manager_shutdown_watchdog_timeout property
+            del conf['partition_manager_shutdown_watchdog_timeout']
         if self._extra_rp_conf:
             self.logger.debug(
                 "Setting custom cluster configuration options: {}".format(


### PR DESCRIPTION
Almost all ducktape tests use default 30 seconds shutdown timeout. Adjusted the default value of partition shutdown watchdog to 20 seconds to give it a chance to fire before Redpanda node is killed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none