### PR TITLE
storage: log more info when requesting eviction

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -461,28 +461,36 @@ disk_log_impl::monitor_eviction(ss::abort_source& as) {
 
 model::offset
 disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
-    vlog(
-      gclog.debug,
-      "[{}] requested eviction of segments up to {} offset",
-      config().ntp(),
-      max_offset);
-    // we only notify eviction monitor if there are segments to evict
-    auto have_segments_to_evict
-      = (_segs.size() > 1)
-        && _segs.front()->offsets().get_committed_offset() <= max_offset;
+    const auto min_offset = [this]() -> std::optional<model::offset> {
+        if (_segs.size() > 1) {
+            return _segs.front()->offsets().get_committed_offset();
+        }
+        return std::nullopt;
+    }();
+
+    const auto have_segments_to_evict = min_offset.has_value()
+                                        && min_offset.value() <= max_offset;
 
     if (_eviction_monitor && have_segments_to_evict) {
         _eviction_monitor->promise.set_value(max_offset);
         _eviction_monitor.reset();
 
-        return model::next_offset(max_offset);
-    } else {
         vlog(
           gclog.debug,
-          "[{}] no segments to evict up to {} offset; skipping eviction",
+          "[{}] requested eviction of segments up to {} offset",
           config().ntp(),
           max_offset);
+
+        return model::next_offset(max_offset);
     }
+
+    vlog(
+      gclog.debug,
+      "[{}] skipping eviction: monitor {} min offset {} max offset {}",
+      config().ntp(),
+      _eviction_monitor.has_value(),
+      min_offset,
+      max_offset);
 
     return _start_offset;
 }


### PR DESCRIPTION
Callers that request log eviction log the request, but there are still several conditions that must pass before the request is actually made to the eviction stm. This PR logs additional information to help debug if the request is successfully made.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

