### PR TITLE
Fix oversized allocations in `kafka::fetch_session_cache`

### DIFF
--- a/src/v/container/chunked_hash_map.h
+++ b/src/v/container/chunked_hash_map.h
@@ -105,3 +105,19 @@ std::ostream& operator<<(std::ostream& o, const chunked_hash_map<K, V>& r) {
     o << "}";
     return o;
 }
+
+/// Returns a lower bound on the memory currently being held by `m`.
+template<
+  typename K,
+  typename V,
+  typename Hash = std::conditional_t<
+    detail::has_absl_hash<K>,
+    detail::avalanching_absl_hash<K>,
+    ankerl::unordered_dense::hash<K>>,
+  typename EqualTo = std::equal_to<K>>
+size_t
+memory_usage_lower_bound(const chunked_hash_map<K, V, Hash, EqualTo>& m) {
+    return m.bucket_count()
+             * sizeof(typename chunked_hash_map<K, V>::bucket_type)
+           + m.values().capacity() * sizeof(m.values()[0]);
+}

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "container/chunked_hash_map.h"
 #include "container/intrusive_list_helpers.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
@@ -46,7 +47,7 @@ struct fetch_session_partition {
  * list to allow interation with preserved insertion order. We require such
  * semantics as partitions order in fetch request/response have to be the same.
  *
- * Internally the map is based on absl::flat_hash_map containing entries that
+ * Internally the map is based on chunked_hash_map containing entries that
  * are additionally linked by being elements of an intrusive list. The intrusive
  * list provides the insertion order traversal across the partitions.
  */
@@ -100,7 +101,7 @@ private:
         }
     };
 
-    using underlying_t = absl::flat_hash_map<
+    using underlying_t = chunked_hash_map<
       model::topic_partition_view,
       std::unique_ptr<entry>,
       topic_partition_hash,
@@ -162,9 +163,7 @@ public:
     }
 
     size_t mem_usage() {
-        using debug = absl::container_internal::hashtable_debug_internal::
-          HashtableDebugAccess<underlying_t>;
-        return debug::AllocatedByteSize(partitions)
+        return memory_usage_lower_bound(partitions)
                + partitions.size() * sizeof(fetch_session_partition);
     }
 

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -164,7 +164,7 @@ void fetch_session_cache::gc_sessions() {
         } else {
             vlog(klog.debug, "evicting session {}", it->second->id());
             _sessions_mem_usage -= it->second->mem_usage();
-            _sessions.erase(it++);
+            it = _sessions.erase(it);
         }
     }
 }

--- a/src/v/kafka/server/fetch_session_cache.h
+++ b/src/v/kafka/server/fetch_session_cache.h
@@ -11,13 +11,12 @@
 #pragma once
 
 #include "base/units.h"
+#include "container/chunked_hash_map.h"
 #include "kafka/server/fetch_session.h"
 #include "metrics/metrics.h"
 
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/smp.hh>
-
-#include <absl/container/flat_hash_map.h>
 
 #include <chrono>
 
@@ -40,8 +39,7 @@ public:
     size_t size() const { return _sessions.size(); }
 
 private:
-    using underlying_t
-      = absl::flat_hash_map<fetch_session_id, fetch_session_ptr>;
+    using underlying_t = chunked_hash_map<fetch_session_id, fetch_session_ptr>;
 
     static constexpr size_t max_mem_usage = 10_MiB;
 
@@ -58,9 +56,7 @@ private:
     void gc_sessions();
 
     size_t mem_usage() const {
-        using debug = absl::container_internal::hashtable_debug_internal::
-          HashtableDebugAccess<underlying_t>;
-        return debug::AllocatedByteSize(_sessions) + _sessions_mem_usage;
+        return memory_usage_lower_bound(_sessions) + _sessions_mem_usage;
     }
 
     void register_metrics();


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds the `memory_usage_lower_bound` function for `chunked_hash_map`s to get a lower bound estimate the memory being allocated by the map. It also switches from `absl::flat_hash_map` to `chunked_hash_map` in fetch sessions to avoid an oversized allocation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->