### PR TITLE
Add an apt cache in the DT docker image build

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -21,22 +21,27 @@ ARG DL_USE_CACHE=1
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive
 
-RUN mkdir -p /opt/redpanda-tests
+# removing docker-clean to ensure the downloaded packages remain: we use a cache mount
+# for apt, so apt downloads and repo lists do not appear in the final image
+RUN rm /etc/apt/apt.conf.d/docker-clean && mkdir -p /opt/redpanda-tests
 COPY --chown=0:0 tests/protobuf /opt/redpanda-tests/protobuf
 
 COPY --chmod=0755 tests/docker/ducktape-deps/download-utils /
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/java-dev-tools /
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/protobuf /
-RUN --mount=type=cache,id=dl-cache,target=/dl-cache /java-dev-tools && \
-    rm /java-dev-tools && \
-    rm -rf /var/lib/apt/lists/*
+# these /running/<name> mounts exist solely to appear first in the command such
+# that you can tell what's running when the first part of a command would otherwise
+# just be a long series of common mount options
+RUN --mount=target=/running/java-dev-tools,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked --mount=type=cache,id=dl-cache,target=/dl-cache \
+    /java-dev-tools && \
+    rm /java-dev-tools
 
 # - install distro-packaged depedencies
 # - install dependencies of 'rpk debug' system scan
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/tool-pkgs /
-RUN /tool-pkgs && \
-    rm /tool-pkgs && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=target=/running/tool-pkgs,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /tool-pkgs && \
+    rm /tool-pkgs
 
 #################################
 
@@ -45,7 +50,9 @@ FROM base AS maven_base
 ARG USE_MAVEN_SEED=1
 # Used to seed the maven cache for the java base image, see script for details
 COPY --chmod=0755 tests/docker/ducktape-deps/seed-maven-cache /
-RUN --mount=type=cache,id=dl-cache,target=/dl-cache /seed-maven-cache && rm -rf /seed-maven-cache /var/lib/apt/lists/*
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache \
+    /seed-maven-cache && \
+    rm /seed-maven-cache
 
 
 #################################
@@ -247,7 +254,8 @@ RUN /tinygo-wasi-transforms && \
 
 FROM base AS ocsf
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/ocsf-server /
-RUN /ocsf-server && rm /ocsf-server
+RUN --mount=target=/running/ocsf-server,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked,id=ocsf-cache-apt --mount=type=cache,target=/var/lib/apt,sharing=locked,id=ocsf-lib-apt \
+    /ocsf-server && rm /ocsf-server
 
 #################################
 
@@ -325,9 +333,9 @@ RUN /python-deps
 ENV PATH="/opt/.ducktape-venv/bin:$PATH"
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/teleport /
-RUN /teleport && \
-    rm /teleport && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=target=/running/teleport,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /teleport && \
+    rm /teleport
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/arroyo /
 RUN /arroyo && \

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -347,10 +347,6 @@ COPY --chown=0:0 --chmod=0755 tests/setup.py /root/tests/
 RUN python3 -m pip install --upgrade --force pip && \
     python3 -m pip install --force --no-cache-dir --no-binary confluent-kafka -e /root/tests/
 
-# seastar addrress to line utility depends on 'file' pkg
-RUN apt update && \
-    apt install -y file && \
-    rm -rf /var/lib/apt/lists/*
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/addr2line /
 RUN /addr2line && \
     rm /addr2line

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -14,6 +14,8 @@
 # limitations under the License.
 FROM public.ecr.aws/docker/library/ubuntu:jammy-20240911.1 AS os_base
 FROM os_base AS base
+# set to any random value to rebuild all layers from the base on down
+ARG BASE_CACHE_BREAK=0
 # 1 to use the download-utils caching, 0 to disable
 ARG DL_USE_CACHE=1
 ENV TZ="UTC" \

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -36,8 +36,11 @@ Type:           exec.cachemount
 
 This shows the "dl-cache" and "gradle" cache mounts.
 
-You can also examine the specific contents of the cache mounts using:
+You can also examine the specific contents of the download cache mount using:
 
+```
+task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=debug-dl-cache --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
+```
 
 
 #### Cleanup

--- a/tests/docker/ducktape-deps/java-dev-tools
+++ b/tests/docker/ducktape-deps/java-dev-tools
@@ -6,12 +6,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
 apt update
 apt install -y \
   build-essential \
-  openjdk-17-jdk \
-  openjdk-21-jdk \
-  git \
-  maven \
   cmake \
   curl \
+  git \
+  maven \
+  openjdk-17-jdk \
+  openjdk-21-jdk \
   wget
 
 SCRIPTPATH="$(

--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -7,6 +7,7 @@ apt-get install -qq \
   bsdmainutils \
   dmidecode \
   faketime \
+  file \
   gnuplot-nox \
   iproute2 \
   iptables \

--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -2,32 +2,32 @@
 set -e
 apt-get update
 apt-get install -qq \
-  bind9-utils \
   bind9-dnsutils \
+  bind9-utils \
   bsdmainutils \
   dmidecode \
+  faketime \
   gnuplot-nox \
+  iproute2 \
+  iptables \
   krb5-admin-server \
   krb5-kdc \
   krb5-user \
-  iproute2 \
-  iptables \
   libatomic1 \
-  libyajl-dev \
   libsasl2-dev \
   libsasl2-modules-gssapi-mit \
   libssl-dev \
-  net-tools \
+  libyajl-dev \
+  libzstd-dev \
+  llvm \
   lsof \
-  pciutils \
+  net-tools \
+  netcat-openbsd \
   nodejs \
   npm \
   openssh-server \
-  netcat-openbsd \
-  sudo \
-  llvm \
+  pciutils \
+  pkg-config \
   python3-pip \
   python3-venv \
-  libzstd-dev \
-  pkg-config \
-  faketime
+  sudo \


### PR DESCRIPTION
This PR has a few housekeeping/minor changes to the dockerfile, then the key change: introducing
a cache mount (--mount=type=cache) for apt downloaded package and lists, which
speeds up the image build by a significant amount. The apt install
process works as normal, but using the cache allows it to carry over
downloaded packages both from one stage to another in the same build,
and also between builds.

The list files in /var/lib/apt/lists are also cached, which means that
apt update is also much faster on subsequent builds, as it does not need
to redownload package index files unless they have changed.

This shaves 20-30% off the full rebuild time for me (e.g., 10 minutes
to 7 minutes), when the apt cache is populated. The image size is
unchanged at 13.1 GB.

The packer build is unaffected.

This pull request updates the `tests/docker/Dockerfile` and related files to improve caching, optimize package installations, and simplify Docker image builds. The changes include modifications to cache mounts, package installation order, and cleanup steps to enhance efficiency and maintainability.

AI says:

### Dockerfile improvements:

* **Cache optimization**: Updated `RUN` commands to use cache mounts (`target=/var/cache/apt` and `target=/var/lib/apt`) for package installations, ensuring better caching and reducing redundant downloads. Removed unnecessary cleanup steps like `rm -rf /var/lib/apt/lists/*` to retain cached data. (`[[1]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aR18-R42)`, `[[2]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL46-R53)`, `[[3]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aR254-R257)`, `[[4]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL326-R337)`)
* **Temporary mounts for running tools**: Introduced `tmpfs` mounts (`target=/running/<name>`) for tools like `java-dev-tools`, `tool-pkgs`, and others to improve clarity during execution and streamline debugging. (`[[1]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aR18-R42)`, `[[2]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aR254-R257)`, `[[3]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL326-R337)`)

### Package installation adjustments:

* **Reordered dependencies**: Adjusted the order of package installations in `tests/docker/ducktape-deps/java-dev-tools` for better readability and consistency. (`[tests/docker/ducktape-deps/java-dev-toolsL9-R14](diffhunk://#diff-e615edad3da65c788d086ce7330218d794147dbc50ed20927bca70b1e23fa19cL9-R14)`)
* **Added missing packages**: Included additional dependencies like `faketime`, `file`, `iproute2`, `iptables`, and `libzstd-dev` in `tests/docker/ducktape-deps/tool-pkgs` to ensure all required tools are installed. (`[tests/docker/ducktape-deps/tool-pkgsL5-R34](diffhunk://#diff-7c64aec9acaed2535205bc7490fbf423ec8f08858f51e99af8df5a683ae83be2L5-R34)`)

### Documentation update:

* **Improved README instructions**: Updated `tests/docker/README.md` to clarify cache mount usage and added an example command for building the test Docker image with cache-breaking arguments. (`[tests/docker/README.mdL39-R43](diffhunk://#diff-ab07866f6431945aab2745bc62a52b89f799d71143b678a137ccc28f3b282353L39-R43)`)
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

