### PR TITLE
dt/data_migrations: increase consume timeout

### DIFF
--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -1196,7 +1196,7 @@ class DataMigrationsMultiClusterTest(RedpandaTest, DataMigrationTestMixin):
     def consume(self, topic, redpanda, msg_count) -> None:
         consumer = self.start_consumer(topic, redpanda)
         self.logger.info(f"expecting to consume {msg_count} messages")
-        consumer.wait_total_reads(msg_count, timeout_sec=30, backoff_sec=1)
+        consumer.wait_total_reads(msg_count, timeout_sec=60, backoff_sec=1)
         consumer.stop()
         consumer.free()
 


### PR DESCRIPTION
Sometimes 30s is not enough to consume all required messages.

Fixes https://redpandadata.atlassian.net/browse/CORE-10107

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
