### PR TITLE
tests/Dockerfile: improve image build

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -32,20 +32,24 @@ COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/protobuf /
 # these /running/<name> mounts exist solely to appear first in the command such
 # that you can tell what's running when the first part of a command would otherwise
 # just be a long series of common mount options
+COPY --chmod=0755 tests/docker/ducktape-deps/base-tools /
+RUN --mount=target=/running/base-tools,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /base-tools && rm /base-tools
+
+COPY --chmod=0755 tests/docker/ducktape-deps/protobuf /
+RUN --mount=target=/running/protobuf,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /protobuf && rm /protobuf
+
+##########################################
+FROM base AS java-base
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/java-dev-tools /
 RUN --mount=target=/running/java-dev-tools,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked --mount=type=cache,id=dl-cache,target=/dl-cache \
     /java-dev-tools && \
     rm /java-dev-tools
 
-# - install distro-packaged depedencies
-# - install dependencies of 'rpk debug' system scan
-COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/tool-pkgs /
-RUN --mount=target=/running/tool-pkgs,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    /tool-pkgs && \
-    rm /tool-pkgs
-
 #################################
 
-FROM base AS maven_base
+FROM java-base AS maven-base
 # maven_base is used for all maven-using java stages below
 ARG USE_MAVEN_SEED=1
 # Used to seed the maven cache for the java base image, see script for details
@@ -57,7 +61,7 @@ RUN --mount=type=cache,id=dl-cache,target=/dl-cache \
 
 #################################
 
-FROM maven_base AS kafka-streams-examples
+FROM maven-base AS kafka-streams-examples
 
 # Install kafka streams examples.  This is a very slow step (tens of minutes), doing
 # many maven dependency downloads without any parallelism.  To avoid re-running it
@@ -68,7 +72,7 @@ RUN /kafka-streams-examples && \
 
 #################################
 
-FROM maven_base AS omb
+FROM maven-base AS omb
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/omb /
 RUN /omb && \
@@ -76,7 +80,7 @@ RUN /omb && \
 
 #################################
 
-FROM maven_base AS java-verifiers
+FROM maven-base AS java-verifiers
 
 COPY --chown=0:0 tests/java/e2e-verifiers /opt/redpanda-tests/java/e2e-verifiers
 COPY --chown=0:0 tests/java/verifiers /opt/redpanda-tests/java/verifiers
@@ -87,7 +91,7 @@ RUN /java-verifiers && \
 
 #################################
 
-FROM maven_base AS kafka-tools
+FROM maven-base AS kafka-tools
 
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/kafka-tools /
@@ -96,7 +100,15 @@ RUN --mount=type=cache,id=dl-cache,target=/dl-cache /kafka-tools && \
 
 #################################
 
-FROM base AS librdkafka
+FROM java-base AS base-with-tools
+
+COPY --chmod=0755 tests/docker/ducktape-deps/tool-pkgs /
+RUN --mount=target=/running/tool-pkgs,type=tmpfs --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /tool-pkgs && rm /tool-pkgs
+
+#################################
+
+FROM base-with-tools AS librdkafka
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/librdkafka /
 RUN /librdkafka && \
@@ -179,7 +191,7 @@ RUN /franz-bench && \
 
 #################################
 
-FROM base AS flink
+FROM java-base AS flink
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/flink /
 RUN --mount=type=cache,id=dl-cache,target=/dl-cache /flink && \
@@ -259,19 +271,19 @@ RUN --mount=target=/running/ocsf-server,type=tmpfs --mount=type=cache,target=/va
 
 #################################
 
-FROM base AS polaris
+FROM java-base AS polaris
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/polaris /
 RUN /polaris && rm /polaris
 
 #################################
 
-FROM base AS nessie
+FROM java-base AS nessie
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/nessie /
 RUN /nessie && rm /nessie
 
 #################################
 
-FROM base AS iceberg-rest
+FROM java-base AS iceberg-rest
 COPY --chown=0:0 tests/java/iceberg-rest-catalog /opt/redpanda-tests/java/iceberg-rest-catalog
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/iceberg-rest-catalog /
 RUN /iceberg-rest-catalog && rm /iceberg-rest-catalog
@@ -284,7 +296,7 @@ RUN --mount=type=cache,id=dl-cache,target=/dl-cache /trino && rm /trino
 
 #################################
 
-FROM maven_base AS spark
+FROM maven-base AS spark
 COPY --chown=0:0 tests/java/spark-iceberg-dependencies /opt/redpanda-tests/java/spark-iceberg-dependencies
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/spark /
 RUN --mount=type=cache,id=dl-cache,target=/dl-cache /spark && rm /spark

--- a/tests/docker/ducktape-deps/base-tools
+++ b/tests/docker/ducktape-deps/base-tools
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+########################################################
+#                                                      #
+# ONLY ADD NEEDED TOOLS HERE:                          #
+# "Base" packages are those needed by multiple         #
+# subsequent sibling stages.                           #
+# Tools which are just needed by ducktape at runtime   #
+# should be added to runtime-tools, while tools needed #
+# by a single stage should be added to/before that     #
+# stage.                                               #
+#                                                      #
+########################################################
+
+set -euo pipefail
+apt-get update
+apt-get install -y \
+  build-essential \
+  ca-certificates \
+  cmake \
+  curl \
+  git \
+  libsasl2-dev \
+  libsasl2-modules-gssapi-mit \
+  libssl-dev \
+  libzstd-dev \
+  pkg-config \
+  python3 \
+  python3-pip \
+  python3-venv \
+  wget

--- a/tests/docker/ducktape-deps/java-dev-tools
+++ b/tests/docker/ducktape-deps/java-dev-tools
@@ -4,21 +4,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
 
 apt update
-apt install -y \
-  build-essential \
-  cmake \
-  curl \
-  git \
-  maven \
+apt-get install -y \
   openjdk-17-jdk \
   openjdk-21-jdk \
-  wget
+  maven
 
-SCRIPTPATH="$(
-  cd -- "$(dirname "$0")" >/dev/null 2>&1
-  pwd -P
-)"
-$SCRIPTPATH/protobuf
 ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH)
 
 architecture=""

--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# "tool packages" are generally those which are needed for running ducktape
+# tests, but not for building the early layers of the image themselves. They
+# are installed relatively late in the Dockerfile, after most of the heavy
+# "non mainline" layers have forked off.
 set -e
 apt-get update
 apt-get install -qq \
@@ -15,11 +20,7 @@ apt-get install -qq \
   krb5-kdc \
   krb5-user \
   libatomic1 \
-  libsasl2-dev \
-  libsasl2-modules-gssapi-mit \
-  libssl-dev \
   libyajl-dev \
-  libzstd-dev \
   llvm \
   lsof \
   net-tools \
@@ -28,7 +29,4 @@ apt-get install -qq \
   npm \
   openssh-server \
   pciutils \
-  pkg-config \
-  python3-pip \
-  python3-venv \
   sudo


### PR DESCRIPTION
Split main apt packages list into two base-tools, and tool-pkg, with the former being tools needed for the remainder of the image build, and the latter being the (more numerous) tools needed to run DT but not for the image build. This lets us get to the fan-out part of the build more quickly and reduce the critical path.

Call protobuf install explicitly instead of inside java-dev-tools, for faster rebuilds when protobuf is unchanged (this changes very rarely).

This shaves a minute or so off the DT build for me.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
