### PR TITLE
[CORE-10602] schema_registry: Add swagger for ACL management

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1226,5 +1226,212 @@
           }
         }
       }
+    },
+    "/security/acls": {
+      "get": {
+        "summary": "List ACLs",
+        "description": "Returns a list of rules that match the specified filters.",
+        "operationId": "get_security_acls",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "principal",
+            "in": "query",
+            "type": "string",
+            "description": "The name of the principal (e.g., user or role). Use \"*\" to represent wildcard."
+          },
+          {
+            "name": "principal_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["USER", "ROLE"],
+            "description": "The type of the principal."
+          },
+          {
+            "name": "resource",
+            "in": "query",
+            "type": "string",
+            "description": "The name of the resource. Use \"*\" to represent wildcard."
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["GLOBAL", "SUBJECT"],
+            "description": "Type of the resource being secured."
+          },
+          {
+            "name": "pattern_type",
+            "in": "query",
+            "type": "string",
+            "enum": ["LITERAL", "PREFIX"],
+            "description": "Pattern match type for the resource. Only applies when resource_type is SUBJECT."
+          },
+          {
+            "name": "host",
+            "in": "query",
+            "type": "string",
+            "description": "Originating host for which this rule applies. Use \"*\" to represent wildcard."
+          },
+          {
+            "name": "operation",
+            "in": "query",
+            "type": "string",
+            "enum": ["ALL", "READ", "WRITE", "REMOVE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER", "ALTER_CONFIGS"],
+            "description": "The operation to allow or deny."
+          },
+          {
+            "name": "permission",
+            "in": "query",
+            "type": "string",
+            "enum": ["ALLOW", "DENY"],
+            "description": "Specifies whether the operation is allowed or denied."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List ACLs",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "principal": "alice",
+                  "principal_type": "USER",
+                  "resource": "model-",
+                  "resource_type": "SUBJECT",
+                  "pattern_type": "PREFIX",
+                  "operation": "READ",
+                  "permission": "ALLOW",
+                  "host": "*"
+                }
+              ]
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create ACLs",
+        "description": "Create new rules.",
+        "operationId": "post_security_acls",
+        "parameters": [
+          {
+            "name": "acls",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "ACLs created"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete ACLs",
+        "description": "Delete ACL rules exactly matching the given definitions.",
+        "operationId": "delete_security_acls",
+        "parameters": [
+          {
+            "name": "acls",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/security_acl"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "ACLs deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
     }
-  

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -116,4 +116,77 @@
           }
         },
       }
+    },
+    "security_acl": {
+      "type": "object",
+      "required": [
+        "principal",
+        "principal_type",
+        "resource",
+        "resource_type",
+        "pattern_type",
+        "host",
+        "operation",
+        "permission"
+      ],
+      "properties": {
+        "principal": {
+          "type": "string",
+          "description": "The name of the principal (e.g., User or RedpandaRole). Use \"*\" to represent wildcard."
+        },
+        "principal_type": {
+          "type": "string",
+          "enum": [
+            "USER",
+            "REDPANDA_ROLE"
+          ],
+          "description": "The type of the principal."
+        },
+        "resource": {
+          "type": "string",
+          "description": "The name of the resource. Use \"*\" to represent wildcard."
+        },
+        "resource_type": {
+          "type": "string",
+          "enum": [
+            "GLOBAL",
+            "SUBJECT"
+          ],
+          "description": "Type of the resource being secured."
+        },
+        "pattern_type": {
+          "type": "string",
+          "enum": [
+            "LITERAL",
+            "PREFIX"
+          ],
+          "description": "Pattern match type for the resource. Only applies when resource_type is SUBJECT."
+        },
+        "host": {
+          "type": "string",
+          "description": "Originating host for which this rule applies. Use \"*\" to represent wildcard."
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "ALL",
+            "READ",
+            "WRITE",
+            "REMOVE",
+            "DESCRIBE",
+            "DESCRIBE_CONFIGS",
+            "ALTER",
+            "ALTER_CONFIGS"
+          ],
+          "description": "The operation to allow or deny."
+        },
+        "permission": {
+          "type": "string",
+          "enum": [
+            "ALLOW",
+            "DENY"
+          ],
+          "description": "Specifies whether the operation is allowed or denied."
+        }
+      }
     }


### PR DESCRIPTION
Add endpoints for managing ACLs for authz.

ACLs can be created and deleted with a POST body.
ACLs can be retrieved with a GET and filters in the query.

An example ACL:
```json
[
  {
    "principal": "Alice",
    "principal_type": "USER",
    "resource": "model-",
    "resource_type": "SUBJECT",
    "pattern_type": "PREFIX",
    "host": "*",
    "operation": "READ",
    "permission": "ALLOW"
  }
]
```

The swagger can be viewed on [SwaggerHub](https://app.swaggerhub.com/apis/BenPope/pandaproxy-schema-registry/1.1.0)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
