### PR TITLE
datalake: hold gate when interacting with catalog in schema manager

### DIFF
--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -172,6 +172,10 @@ catalog_schema_manager::ensure_table_schema(
   const iceberg::table_identifier& table_id,
   const iceberg::struct_type& desired_type,
   const iceberg::unresolved_partition_spec& partition_spec) {
+    auto gh = maybe_gate();
+    if (gh.has_error()) {
+        co_return gh.error();
+    }
     auto load_res = co_await catalog_.load_or_create_table(
       table_id, desired_type, partition_spec);
     if (load_res.has_error()) {
@@ -236,6 +240,10 @@ ss::future<checked<schema_manager::table_info, schema_manager::errc>>
 catalog_schema_manager::get_table_info(
   const iceberg::table_identifier& table_id,
   std::optional<std::reference_wrapper<iceberg::struct_type>> desired_type) {
+    auto gh = maybe_gate();
+    if (gh.has_error()) {
+        co_return gh.error();
+    }
     auto load_res = co_await catalog_.load_table(table_id);
     if (load_res.has_error()) {
         co_return log_and_convert_catalog_err(
@@ -323,5 +331,16 @@ catalog_schema_manager::get_ids_from_table_meta(
     }
     return true;
 }
+
+checked<ss::gate::holder, catalog_schema_manager::errc>
+catalog_schema_manager::maybe_gate() {
+    auto holder = gate_.try_hold();
+    if (!holder) {
+        return errc::shutting_down;
+    }
+    return std::move(holder.value());
+}
+
+ss::future<> catalog_schema_manager::stop() { return gate_.close(); }
 
 } // namespace datalake

--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -52,6 +52,7 @@ public:
       = std::nullopt)
       = 0;
 
+    virtual ss::future<> stop() = 0;
     virtual ~schema_manager() = default;
 };
 
@@ -72,6 +73,7 @@ public:
       const iceberg::table_identifier&,
       std::optional<std::reference_wrapper<iceberg::struct_type>> desired_type
       = std::nullopt) override;
+    ss::future<> stop() final { return ss::now(); }
 
 private:
     iceberg::uri table_location_prefix_;
@@ -102,6 +104,10 @@ public:
       std::optional<std::reference_wrapper<iceberg::struct_type>> desired_type
       = std::nullopt) override;
 
+    // Stops the schema manager, waiting for any ongoing operations to
+    // complete.
+    ss::future<> stop() override;
+
 private:
     // Attempts to fill the field ids in the given type with those from the
     // current schema of the given table metadata.
@@ -113,8 +119,9 @@ private:
       const iceberg::table_identifier&,
       const iceberg::table_metadata&,
       iceberg::struct_type&);
-
+    checked<ss::gate::holder, errc> maybe_gate();
     iceberg::catalog& catalog_;
+    ss::gate gate_;
 };
 
 } // namespace datalake

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -617,6 +617,9 @@ ss::future<> datalake_manager::shutdown() {
     if (_backlog_controller) {
         co_await _backlog_controller->stop();
     }
+    if (_schema_mgr) {
+        co_await _schema_mgr->stop();
+    }
     if (_catalog) {
         co_await _catalog->stop();
     }


### PR DESCRIPTION
Schema manager holds reference to `iceber::catalog` the catalog may be closed and removed before the request finishes. This may lead to accessing dangling client pointer.

Added a gate to the schema manger and waiting for it to finish any pending operations before destroying the catalog.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none