### PR TITLE
k/tests: retry creating topic in topic recreate test

### DIFF
--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -40,22 +40,30 @@ using namespace std::chrono_literals; // NOLINT
 class recreate_test_fixture : public redpanda_thread_fixture {
 public:
     void create_topic(ss::sstring tp, int32_t partitions, int16_t rf) {
-        kafka::creatable_topic topic{
-          .name = model::topic(tp),
-          .num_partitions = partitions,
-          .replication_factor = rf,
-        };
+        for (int current_retry = 0; current_retry < 5; ++current_retry) {
+            kafka::creatable_topic topic{
+              .name = model::topic(tp),
+              .num_partitions = partitions,
+              .replication_factor = rf,
+            };
 
-        auto req = kafka::create_topics_request{.data{
-          .topics = {topic},
-          .timeout_ms = 10s,
-          .validate_only = false,
-        }};
+            auto req = kafka::create_topics_request{.data{
+              .topics = {topic},
+              .timeout_ms = 10s,
+              .validate_only = false,
+            }};
 
-        auto client = make_kafka_client().get();
-        client.connect().get();
-        auto resp
-          = client.dispatch(std::move(req), kafka::api_version(2)).get();
+            auto client = make_kafka_client().get();
+            client.connect().get();
+            auto resp
+              = client.dispatch(std::move(req), kafka::api_version(2)).get();
+            if (
+              resp.data.topics.begin()->error_code == kafka::error_code::none) {
+                return;
+            }
+            // wait before retrying
+            ss::sleep(500ms).get();
+        }
     }
     kafka::delete_topics_request make_delete_topics_request(
       chunked_vector<model::topic> topics, std::chrono::milliseconds timeout) {


### PR DESCRIPTION
Sometimes it may happen that the client will receive not leader controller reply. In this case we must retry creating topic to make sure the rest of the test passes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none