### PR TITLE
tests: ignore error logged when failed to download the manifest

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -41,7 +41,12 @@ TS_LOG_ALLOW_LIST = [
     # topic deletion may happen before data were uploaded
     re.compile(".*cloud_storage.*Failed to fetch manifest during finalize().*"
                ),
-    re.compile(".*archival -.* System error during SSL read:.*")
+    re.compile(".*archival -.* System error during SSL read:.*"),
+    # When Redpanda is suspended manifest download may fail with timeout
+    # ERROR 2025-06-03 09:48:14,461 [shard 0:main] raft - [group_id:316, {kafka/tp-workload-fast/27}] state_machine_manager.cc:385 - error applying raft snapshot - std::runtime_error (couldn't download manifest: cloud_storage::error_outcome:2)
+    re.compile(
+        """state_machine_manager.* error applying raft snapshot - std::runtime_error (couldn't download manifest: cloud_storage::error_outcome:2)"""
+    )
 ]
 
 


### PR DESCRIPTION
When Redpanda node is suspended in `RandomNodeOpeartions` test the retry chain node responsible for manifest download may fail with timeout as suspension may be longer than the rtc backoff budget. Added the log line to ignore list to prevent the test to be reported as failed. The manifest download will be retried.
Fixes: CORE-11386
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.



Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none