### PR TITLE
c/partition_manager: added log entries when partition is being shutdown

### DIFF
--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -391,13 +391,18 @@ partition_manager::do_shutdown(ss::lw_shared_ptr<partition> partition) {
     try {
         auto ntp = partition->ntp();
         shutdown_state.update(partition_shutdown_stage::stopping_raft);
+        vlog(clusterlog.debug, "shutdown partition {} - stopping raft", ntp);
         xst_state.raft = co_await _raft_manager.local().shutdown(
           partition->raft());
         _unmanage_watchers.notify(ntp, model::topic_partition_view(ntp.tp));
         shutdown_state.update(partition_shutdown_stage::stopping_partition);
+        vlog(
+          clusterlog.debug, "shutdown partition {} - stopping partition", ntp);
         co_await partition->stop();
         shutdown_state.update(partition_shutdown_stage::stopping_storage);
+        vlog(clusterlog.debug, "shutdown partition {} - stopping log", ntp);
         co_await _storage.log_mgr().shutdown(partition->ntp());
+        vlog(clusterlog.debug, "shutdown partition {} - stopped", ntp);
     } catch (...) {
         vassert(
           false,
@@ -407,7 +412,6 @@ partition_manager::do_shutdown(ss::lw_shared_ptr<partition> partition) {
           *this,
           std::current_exception());
     }
-
     co_return xst_state;
 }
 


### PR DESCRIPTION
It is very helpful to know where partition shutdown sequence stuck. Added additional logs to make it easier to debug such issues.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none