### PR TITLE
remove podman from README.md

### DIFF
--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -1,6 +1,6 @@
 ## tests/docker
 
-This Dockerfile is used to back the ducktape cluster nodes when running ducktape in docker/podman mode. It relies heavily on multi-root builds to build the relatively heavy dependencies (mostly large Java projects) in parallel and to limit layer rebuilds when only a subset change.
+This Dockerfile is used to back the ducktape cluster nodes when running ducktape in docker mode. It relies heavily on multi-root builds to build the relatively heavy dependencies (mostly large Java projects) in parallel and to limit layer rebuilds when only a subset change.
 
 ## Caching
 


### PR DESCRIPTION
A final podman mention, deleted.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
