### PR TITLE
rptest/kcat: improve error handling

### DIFF
--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -11,6 +11,7 @@ import subprocess
 import time
 import json
 from typing import Any, cast
+import rptest.utils.process_utils as process_utils
 
 from rptest.services.redpanda_types import RedpandaServiceForClients
 from rptest.util import wait_until_result
@@ -84,12 +85,15 @@ class KafkaCat:
                 res = subprocess.check_output(
                     ["kcat", "-b", self._redpanda.brokers()] + cmd,
                     text=True,
-                    input=input)
+                    input=input,
+                    stderr=subprocess.PIPE)
                 self._redpanda.logger.debug(res)
                 return res
             except subprocess.CalledProcessError as e:
                 if retry == 0:
-                    raise
+                    self._redpanda.logger.info(
+                        f"kcat failed: stderr:\n{e.stderr}")
+                    raise process_utils.CalledProcessError(e) from e
                 self._redpanda.logger.debug(
                     "kcat retrying after exit code {}: {}".format(
                         e.returncode, e.output))

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -135,7 +135,7 @@ class InternalTopicProtectionTest(RedpandaTest):
         try:
             produce_fn(test_topic, "test_msg")
         except Exception as e:
-            assert type(e) == failure_exception_type
+            assert isinstance(e, failure_exception_type)
         else:
             assert False, "Call to delete topic returned sucess"
         post_produce_hw = get_hw(test_topic, partition_id)

--- a/tests/rptest/utils/process_utils.py
+++ b/tests/rptest/utils/process_utils.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+class CalledProcessError(subprocess.CalledProcessError):
+    """An extension of subprocess.CalledProcessError which includes the last line of stderr
+    in the __str__ method."""
+    def __init__(self, orignal: subprocess.CalledProcessError):
+        super().__init__(orignal.returncode, orignal.cmd, orignal.output,
+                         orignal.stderr)
+
+    def __str__(self):
+        last_line = self.stderr.splitlines()[-1] if self.stderr else ""
+        return f"{super().__str__()} last line of stderr: {last_line}"


### PR DESCRIPTION
When an error occurs in kcat, we didn't capture the stderr, so it goes to the console and is lost to the captured logs entirely.

Instead, capture it, and output it on failure, and include the last line of the error in the exception message.



## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
