### PR TITLE
dl/iceberg: usage based billing metric

### DIFF
--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -522,3 +522,21 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "datalake_usage_aggregator",
+    srcs = [
+        "datalake_usage_aggregator.cc",
+    ],
+    hdrs = [
+        "datalake_usage_aggregator.h",
+    ],
+    include_prefix = "datalake",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":logger",
+        ":types",
+        "//src/v/cluster",
+        "//src/v/kafka/server:datalake_usage_api",
+    ],
+)

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -536,7 +536,11 @@ redpanda_cc_library(
     deps = [
         ":logger",
         ":types",
+        "//src/v/base",
         "//src/v/cluster",
+        "//src/v/datalake/coordinator:frontend",
         "//src/v/kafka/server:datalake_usage_api",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
     ],
 )

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -829,4 +829,22 @@ coordinator::update_lifecycle_state(
     co_return ss::stop_iteration::no;
 }
 
+ss::future<checked<datalake_usage_stats, coordinator::errc>>
+coordinator::sync_get_usage_stats() {
+    auto gate = maybe_gate();
+    if (gate.has_error()) {
+        co_return gate.error();
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (sync_res.has_error()) {
+        co_return convert_stm_errc(sync_res.error());
+    }
+
+    datalake_usage_stats result;
+    for (const auto& [topic, state] : stm_->state().topic_to_state) {
+        result.topic_usages.emplace_back(
+          topic, state.revision, state.total_kafka_bytes_processed);
+    }
+    co_return result;
+}
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -543,11 +543,13 @@ coordinator::sync_add_files(
     }
     vlog(
       datalake_log.debug,
-      "Sync add files requested {} (topic rev: {}): [{}, {}], {} files",
+      "Sync add files requested {} (topic rev: {}): [{}, {}], kafka_bytes: {} "
+      "files: {}",
       tp,
       topic_revision,
       entries.begin()->start_offset,
       entries.back().last_offset,
+      entries.back().kafka_bytes_processed,
       entries.size());
     auto sync_res = co_await stm_->sync(10s);
     if (sync_res.has_error()) {

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -85,6 +85,8 @@ public:
     ss::future<checked<last_offsets, errc>> sync_get_last_added_offsets(
       model::topic_partition tp, model::revision_id topic_rev);
 
+    ss::future<checked<datalake_usage_stats, errc>> sync_get_usage_stats();
+
     void notify_leadership(std::optional<model::node_id>);
 
     bool leader_loop_running() const { return term_as_.has_value(); }

--- a/src/v/datalake/coordinator/frontend.cc
+++ b/src/v/datalake/coordinator/frontend.cc
@@ -124,7 +124,7 @@ auto frontend::remote_dispatch(req_t request, model::node_id leader_id) {
               ::rpc::client_opts{model::timeout_clock::now() + rpc_timeout});
         })
       .then(&::rpc::get_ctx_data<resp_t>)
-      .then([leader_id, self = _self](result<resp_t> r) {
+      .then([leader_id, self = _self](result<resp_t> r) mutable {
           if (r.has_error()) {
               vlog(
                 datalake::datalake_log.warn,
@@ -134,7 +134,7 @@ auto frontend::remote_dispatch(req_t request, model::node_id leader_id) {
                 self);
               return resp_t{errc::timeout};
           }
-          return r.value();
+          return std::move(r.value());
       });
 }
 
@@ -142,6 +142,7 @@ template<auto LocalFunc, auto RemoteFunc, typename req_t>
 requires requires(
   datalake::coordinator::frontend f, const model::ntp& ntp, req_t req) {
     (f.*LocalFunc)(std::move(req), ntp, ss::shard_id{0});
+    request_has_topic<req_t> || request_has_coordinator_partition<req_t>;
 }
 auto frontend::process(req_t req, bool local_only) {
     using resp_t = req_t::resp_t;
@@ -151,15 +152,23 @@ auto frontend::process(req_t req, bool local_only) {
             return ss::make_ready_future<resp_t>(
               resp_t{errc::coordinator_topic_not_exists});
         }
-        auto cp = coordinator_partition(req.get_topic());
-        if (!cp) {
-            return ss::make_ready_future<resp_t>(
-              resp_t{errc::coordinator_topic_not_exists});
+        model::partition_id cp_result;
+        if constexpr (request_has_topic<req_t>) {
+            // If the request has a topic, we can use it to find the coordinator
+            // partition.
+            auto cp = coordinator_partition(req.get_topic());
+            if (!cp) {
+                return ss::make_ready_future<resp_t>(
+                  resp_t{errc::coordinator_topic_not_exists});
+            }
+            cp_result = cp.value();
+        } else {
+            cp_result = req.get_coordinator_partition();
         }
         model::ntp c_ntp{
           model::datalake_coordinator_nt.ns,
           model::datalake_coordinator_nt.tp,
-          cp.value()};
+          cp_result};
         auto leader = _leaders->local().get_leader(c_ntp);
         if (leader == _self) {
             auto shard = _shard_table->local().shard_for(c_ntp);
@@ -192,6 +201,13 @@ template auto frontend::process<
   &frontend::fetch_latest_translated_offset_locally,
   &frontend::client::fetch_latest_translated_offset>(
   fetch_latest_translated_offset_request, bool);
+
+template auto frontend::remote_dispatch<&frontend::client::get_usage_stats>(
+  usage_stats_request, model::node_id);
+
+template auto frontend::process<
+  &frontend::get_usage_stats_locally,
+  &frontend::client::get_usage_stats>(usage_stats_request, bool);
 
 // -- explicit instantiations ---
 
@@ -394,6 +410,38 @@ frontend::fetch_latest_translated_offset(
       &frontend::fetch_latest_translated_offset_locally,
       &client::fetch_latest_translated_offset>(
       std::move(request), bool(local_only_exec));
+}
+
+ss::future<usage_stats_reply> frontend::get_usage_stats_locally(
+  usage_stats_request,
+  const model::ntp& coordinator_partition,
+  ss::shard_id shard) {
+    auto holder = _gate.hold();
+    co_return co_await _coordinator_mgr->invoke_on(
+      shard, [coordinator_partition](coordinator_manager& mgr) mutable {
+          auto partition = mgr.get(coordinator_partition);
+          if (!partition) {
+              return ssx::now(usage_stats_reply{errc::not_leader});
+          }
+          return partition->sync_get_usage_stats().then([](auto result) {
+              usage_stats_reply resp;
+              if (result.has_error()) {
+                  resp.errc = to_rpc_errc(result.error());
+              } else {
+                  resp.errc = errc::ok;
+                  resp.stats = std::move(result.value());
+              }
+              return ssx::now(std::move(resp));
+          });
+      });
+}
+
+ss::future<usage_stats_reply> frontend::get_usage_stats(
+  usage_stats_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &frontend::get_usage_stats_locally,
+      &client::get_usage_stats>(std::move(request), bool(local_only_exec));
 }
 
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/frontend.h
+++ b/src/v/datalake/coordinator/frontend.h
@@ -25,6 +25,16 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 
+template<typename T>
+concept request_has_topic = requires(T t) {
+    { t.get_topic() } -> std::same_as<const model::topic&>;
+};
+
+template<typename T>
+concept request_has_coordinator_partition = requires(T t) {
+    { t.get_coordinator_partition() } -> std::same_as<model::partition_id>;
+};
+
 namespace datalake::coordinator {
 
 /*
@@ -61,6 +71,9 @@ public:
       fetch_latest_translated_offset(
         fetch_latest_translated_offset_request, local_only = local_only::no);
 
+    ss::future<usage_stats_reply>
+      get_usage_stats(usage_stats_request, local_only = local_only::no);
+
 private:
     using proto_t = datalake::coordinator::rpc::impl::
       datalake_coordinator_rpc_client_protocol;
@@ -81,6 +94,7 @@ private:
     requires requires(
       datalake::coordinator::frontend f, const model::ntp& ntp, req_t req) {
         (f.*LocalFunc)(std::move(req), ntp, ss::shard_id{0});
+        request_has_topic<req_t> || request_has_coordinator_partition<req_t>;
     }
     auto process(req_t req, bool local_only);
 
@@ -112,6 +126,11 @@ private:
     ss::future<fetch_latest_translated_offset_reply>
     fetch_latest_translated_offset_locally(
       fetch_latest_translated_offset_request,
+      const model::ntp& coordinator_partition,
+      ss::shard_id);
+
+    ss::future<usage_stats_reply> get_usage_stats_locally(
+      usage_stats_request,
       const model::ntp& coordinator_partition,
       ss::shard_id);
 

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -505,10 +505,17 @@ iceberg_file_committer::commit_topic_files_to_catalog(
           dlq_table_commit_builder_res.value());
     }
 
-    chunked_hash_map<model::partition_id, kafka::offset> pending_commits;
+    struct offset_and_bytes {
+        kafka::offset last_offset{};
+        size_t kafka_bytes_processed{0};
+    };
+
+    chunked_hash_map<model::partition_id, offset_and_bytes> pending_commits;
     for (const auto& [pid, p_state] : tp_state.pid_to_pending_files) {
         for (const auto& e : p_state.pending_entries) {
-            pending_commits[pid] = e.data.last_offset;
+            pending_commits[pid].last_offset = e.data.last_offset;
+            pending_commits[pid].kafka_bytes_processed
+              += e.data.kafka_bytes_processed;
 
             if (!e.data.files.empty()) {
                 vassert(
@@ -546,10 +553,14 @@ iceberg_file_committer::commit_topic_files_to_catalog(
         co_return chunked_vector<mark_files_committed_update>{};
     }
     chunked_vector<mark_files_committed_update> updates;
-    for (const auto& [pid, committed_offset] : pending_commits) {
+    for (const auto& [pid, entry] : pending_commits) {
         auto tp = model::topic_partition(topic, pid);
         auto update_res = mark_files_committed_update::build(
-          state, tp, topic_revision, committed_offset);
+          state,
+          tp,
+          topic_revision,
+          entry.last_offset,
+          entry.kafka_bytes_processed);
         if (update_res.has_error()) {
             vlog(
               datalake_log.warn,

--- a/src/v/datalake/coordinator/rpc.json
+++ b/src/v/datalake/coordinator/rpc.json
@@ -24,6 +24,11 @@
             "name": "fetch_latest_translated_offset",
             "input_type": "fetch_latest_translated_offset_request",
             "output_type": "fetch_latest_translated_offset_reply"
+        },
+        {
+            "name": "get_usage_stats",
+            "input_type": "usage_stats_request",
+            "output_type": "usage_stats_reply"
         }
     ]
 }

--- a/src/v/datalake/coordinator/service.cc
+++ b/src/v/datalake/coordinator/service.cc
@@ -46,4 +46,10 @@ service::fetch_latest_translated_offset(
       std::move(request), frontend::local_only::yes);
 }
 
+ss::future<usage_stats_reply> service::get_usage_stats(
+  usage_stats_request request, ::rpc::streaming_context&) {
+    return _frontend->local().get_usage_stats(
+      std::move(request), frontend::local_only::yes);
+}
+
 }; // namespace datalake::coordinator::rpc

--- a/src/v/datalake/coordinator/service.h
+++ b/src/v/datalake/coordinator/service.h
@@ -33,6 +33,9 @@ public:
       fetch_latest_translated_offset_request,
       ::rpc::streaming_context&) override;
 
+    ss::future<usage_stats_reply>
+    get_usage_stats(usage_stats_request, ::rpc::streaming_context&) override;
+
 private:
     ss::sharded<frontend>* _frontend;
 };

--- a/src/v/datalake/coordinator/state.cc
+++ b/src/v/datalake/coordinator/state.cc
@@ -43,6 +43,7 @@ topic_state topic_state::copy() const {
         result.pid_to_pending_files[id] = state.copy();
     }
     result.lifecycle_state = lifecycle_state;
+    result.total_kafka_bytes_processed = total_kafka_bytes_processed;
     return result;
 }
 

--- a/src/v/datalake/coordinator/state.h
+++ b/src/v/datalake/coordinator/state.h
@@ -80,9 +80,13 @@ struct partition_state
 // worker.
 struct topic_state
   : public serde::
-      envelope<topic_state, serde::version<0>, serde::compat_version<0>> {
+      envelope<topic_state, serde::version<1>, serde::compat_version<0>> {
     auto serde_fields() {
-        return std::tie(revision, pid_to_pending_files, lifecycle_state);
+        return std::tie(
+          revision,
+          pid_to_pending_files,
+          lifecycle_state,
+          total_kafka_bytes_processed);
     }
 
     enum class lifecycle_state_t {
@@ -102,12 +106,19 @@ struct topic_state
     bool has_pending_entries() const;
     bool has_pending_main_entries() const;
     bool has_pending_dlq_entries() const;
+    void add_kafka_bytes_processed(uint64_t bytes) {
+        total_kafka_bytes_processed += bytes;
+    }
 
     // Topic revision
     model::revision_id revision;
     // Map from Redpanda partition id to the files pending per partition.
     chunked_hash_map<model::partition_id, partition_state> pid_to_pending_files;
     lifecycle_state_t lifecycle_state = lifecycle_state_t::live;
+
+    // Total number of kafka bytes processed so far that have been successfully
+    // committed to iceberg. Includes bytes from DLQ table as well.
+    uint64_t total_kafka_bytes_processed{0};
 
     topic_state copy() const;
 

--- a/src/v/datalake/coordinator/state_update.cc
+++ b/src/v/datalake/coordinator/state_update.cc
@@ -131,11 +131,13 @@ mark_files_committed_update::build(
   const topics_state& state,
   const model::topic_partition& tp,
   model::revision_id topic_revision,
-  kafka::offset o) {
+  kafka::offset o,
+  uint64_t kafka_bytes_processed) {
     mark_files_committed_update update{
       .tp = tp,
       .topic_revision = topic_revision,
       .new_committed = o,
+      .kafka_bytes_processed = kafka_bytes_processed,
     };
     auto allowed = update.can_apply(state);
     if (allowed.has_error()) {
@@ -304,10 +306,11 @@ std::ostream&
 operator<<(std::ostream& o, const mark_files_committed_update& u) {
     fmt::print(
       o,
-      "{{tp: {}, revision: {}, new_committed: {}}}",
+      "{{tp: {}, revision: {}, new_committed: {}, kafka_bytes_processed: {}}}",
       u.tp,
       u.topic_revision,
-      u.new_committed);
+      u.new_committed,
+      u.kafka_bytes_processed);
     return o;
 }
 

--- a/src/v/datalake/coordinator/state_update.cc
+++ b/src/v/datalake/coordinator/state_update.cc
@@ -199,14 +199,17 @@ mark_files_committed_update::apply(topics_state& state) {
     const auto& topic = tp.topic;
     const auto& pid = tp.partition;
 
+    auto& tp_state = state.topic_to_state[topic];
+
     // Mark all files that fall entirely below `new_committed` as committed.
-    auto& files_state = state.topic_to_state[topic].pid_to_pending_files[pid];
+    auto& files_state = tp_state.pid_to_pending_files[pid];
     while (!files_state.pending_entries.empty()
            && files_state.pending_entries.front().data.last_offset
                 <= new_committed) {
         files_state.pending_entries.pop_front();
     }
     files_state.last_committed = new_committed;
+    tp_state.add_kafka_bytes_processed(kafka_bytes_processed);
     return std::nullopt;
 }
 

--- a/src/v/datalake/coordinator/state_update.h
+++ b/src/v/datalake/coordinator/state_update.h
@@ -57,15 +57,19 @@ struct add_files_update
 struct mark_files_committed_update
   : public serde::envelope<
       mark_files_committed_update,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     static constexpr auto key{update_key::mark_files_committed};
     static checked<mark_files_committed_update, stm_update_error> build(
       const topics_state&,
       const model::topic_partition&,
       model::revision_id topic_revision,
-      kafka::offset);
-    auto serde_fields() { return std::tie(tp, topic_revision, new_committed); }
+      kafka::offset,
+      uint64_t kafka_bytes_processed);
+    auto serde_fields() {
+        return std::tie(
+          tp, topic_revision, new_committed, kafka_bytes_processed);
+    }
 
     checked<std::nullopt_t, stm_update_error> can_apply(const topics_state&);
     checked<std::nullopt_t, stm_update_error> apply(topics_state&);
@@ -78,6 +82,10 @@ struct mark_files_committed_update
     // All pending entries whose offset range falls entirely below this offset
     // (inclusive) should be removed.
     kafka::offset new_committed;
+
+    // Number of Kafka bytes processed to translate the files included in this
+    // update.
+    uint64_t kafka_bytes_processed{0};
 };
 
 // An update to change topic lifecycle state after it has been deleted.

--- a/src/v/datalake/coordinator/tests/BUILD
+++ b/src/v/datalake/coordinator/tests/BUILD
@@ -16,6 +16,7 @@ redpanda_test_cc_library(
         "//src/v/datalake/coordinator:translated_offset_range",
         "//src/v/iceberg:table_identifier",
         "//src/v/model",
+        "//src/v/random:generators",
         "@googletest//:gtest",
     ],
 )

--- a/src/v/datalake/coordinator/tests/state_machine_test.cc
+++ b/src/v/datalake/coordinator/tests/state_machine_test.cc
@@ -30,7 +30,7 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
     }
 
     config::binding<std::chrono::milliseconds> commit_interval() const {
-        return config::mock_binding(500ms);
+        return config::mock_binding(1ms);
     }
 
     config::binding<std::chrono::seconds> snapshot_interval() const {
@@ -91,7 +91,8 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
           model::timeout_clock::now() + 5s,
           [this, func = std::forward<Func>(func)](
             raft_node_instance& leader) mutable {
-              return func(coordinators[leader.get_vnode()]);
+              return func(
+                coordinators[leader.get_vnode()], leader.get_vnode().id());
           });
     }
 
@@ -104,6 +105,10 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
         return result;
     }
 
+    /**
+     * Returns the last committed offset for a given topic partition
+     * from each coordinator replica (stm).
+     */
     std::vector<std::optional<kafka::offset>>
     last_committed_offsets(model::topic_partition tp) {
         std::vector<std::optional<kafka::offset>> result;
@@ -127,6 +132,26 @@ struct coordinator_stm_fixture : stm_raft_fixture<stm> {
             } else {
                 result.push_back(p_it->second.last_committed);
             }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the  kafka bytes processed for a given topic
+     * from each coordinator replica (stm).
+     */
+    std::vector<std::optional<uint64_t>>
+    total_bytes_processed(model::topic topic) {
+        std::vector<std::optional<uint64_t>> result;
+        result.reserve(node_stms.size());
+        for (auto& [_, stms] : node_stms) {
+            const auto& topic_state = std::get<0>(stms)->state();
+            auto it = topic_state.topic_to_state.find(topic);
+            if (it == topic_state.topic_to_state.end()) {
+                result.emplace_back(std::nullopt);
+                continue;
+            }
+            result.emplace_back(it->second.total_kafka_bytes_processed);
         }
         return result;
     }
@@ -179,8 +204,12 @@ TEST_F_CORO(coordinator_stm_fixture, test_snapshots) {
     while (completed_snapshots != max_snapshots) {
         // mock a translator
         auto add_files_result = co_await retry_with_leader_coordinator(
-          [&, this](coordinator& coordinator) mutable {
+          [&, this](coordinator& coordinator, model::node_id node_id) mutable {
               auto tp = random_tp();
+              // manually notify leadership to ensure coordinator processing
+              // loop starts. Here the test runs without a coordinator manager
+              // that is supposed to notify leadership.
+              coordinator->notify_leadership(node_id);
               return coordinator->sync_get_last_added_offsets(tp, rev).then(
                 [&, tp](auto result) {
                     if (!result) {
@@ -256,4 +285,13 @@ TEST_F_CORO(coordinator_stm_fixture, test_snapshots) {
           << "Topic state mismatch across replicas for partition: " << pid
           << ", offsets: " << committed_offsets;
     }
+
+    auto bytes_processed = total_bytes_processed(tp_ns.tp);
+    vlog(logger().info, "bytes processed: {}", bytes_processed);
+    ASSERT_TRUE_CORO(std::equal(
+      bytes_processed.begin() + 1,
+      bytes_processed.end(),
+      bytes_processed.begin()))
+      << "Topic state mismatch across replicas for partition: " << tp_ns.tp
+      << ", bytes processed: " << bytes_processed;
 }

--- a/src/v/datalake/coordinator/tests/state_test_utils.cc
+++ b/src/v/datalake/coordinator/tests/state_test_utils.cc
@@ -9,6 +9,8 @@
  */
 #include "datalake/coordinator/tests/state_test_utils.h"
 
+#include "random/generators.h"
+
 namespace datalake::coordinator {
 
 chunked_vector<translated_offset_range> make_pending_files(
@@ -29,11 +31,15 @@ chunked_vector<translated_offset_range> make_pending_files(
                 std::nullopt),
             });
         }
+        auto total_bytes = (end - begin + 1)
+                           * random_generators::get_int<uint64_t>(
+                             100, 1000); // Simulate some bytes processed.
         if (dlq) {
             files.emplace_back(translated_offset_range{
               .start_offset = kafka::offset{begin},
               .last_offset = kafka::offset{end},
               .dlq_files = std::move(fs),
+              .kafka_bytes_processed = total_bytes,
               // Other args irrelevant.
             });
         } else {
@@ -41,6 +47,7 @@ chunked_vector<translated_offset_range> make_pending_files(
               .start_offset = kafka::offset{begin},
               .last_offset = kafka::offset{end},
               .files = std::move(fs),
+              .kafka_bytes_processed = total_bytes,
               // Other args irrelevant.
             });
         }

--- a/src/v/datalake/coordinator/tests/state_test_utils.h
+++ b/src/v/datalake/coordinator/tests/state_test_utils.h
@@ -47,7 +47,8 @@ public:
               state,
               tp,
               t_state.revision,
-              files.pending_entries.back().data.last_offset);
+              files.pending_entries.back().data.last_offset,
+              files.pending_entries.back().data.kafka_bytes_processed);
             EXPECT_FALSE(build_res.has_error());
             ret.emplace_back(std::move(build_res.value()));
         }

--- a/src/v/datalake/coordinator/tests/state_update_test.cc
+++ b/src/v/datalake/coordinator/tests/state_update_test.cc
@@ -62,7 +62,7 @@ void check_commit_doesnt_apply(
   int64_t commit_offset) {
     // We should fail to build the update in the first place.
     auto update = mark_files_committed_update::build(
-      state, tp, rev, kafka::offset{commit_offset});
+      state, tp, rev, kafka::offset{commit_offset}, 0UL);
     EXPECT_TRUE(update.has_error());
 
     // Also explicitly build the bad update and make sure it doesn't apply.
@@ -186,7 +186,8 @@ TEST(StateUpdateTest, TestMarkCommitted) {
     ASSERT_NO_FATAL_FAILURE(check_commit_doesnt_apply(state, tp, 201));
     ASSERT_NO_FATAL_FAILURE(check_partition(state, tp, 100, {{101, 200}}));
 
-    res = mark_files_committed_update::build(state, tp, rev, kafka::offset{200})
+    res = mark_files_committed_update::build(
+            state, tp, rev, kafka::offset{200}, 0UL)
             .value()
             .apply(state);
     EXPECT_FALSE(res.has_error());
@@ -214,7 +215,8 @@ TEST(StateUpdateTest, TestMarkCommitted) {
       check_partition(state, tp, 200, {{201, 205}, {206, 210}, {211, 220}}));
 
     // But it should work with one of the inner files.
-    res = mark_files_committed_update::build(state, tp, rev, kafka::offset{205})
+    res = mark_files_committed_update::build(
+            state, tp, rev, kafka::offset{205}, 0UL)
             .value()
             .apply(state);
     EXPECT_FALSE(res.has_error());
@@ -222,7 +224,8 @@ TEST(StateUpdateTest, TestMarkCommitted) {
       check_partition(state, tp, 205, {{206, 210}, {211, 220}}));
 
     // And it should work with the last file.
-    res = mark_files_committed_update::build(state, tp, rev, kafka::offset{220})
+    res = mark_files_committed_update::build(
+            state, tp, rev, kafka::offset{220}, 0UL)
             .value()
             .apply(state);
     EXPECT_FALSE(res.has_error());
@@ -295,7 +298,7 @@ TEST(StateUpdateTest, TestLifecycle) {
 
     {
         auto upd = mark_files_committed_update::build(
-          state, tp, rev2, kafka::offset{100});
+          state, tp, rev2, kafka::offset{100}, 0UL);
         ASSERT_TRUE(upd.has_value());
         ASSERT_TRUE(upd.value().apply(state).has_value());
     }

--- a/src/v/datalake/coordinator/translated_offset_range.cc
+++ b/src/v/datalake/coordinator/translated_offset_range.cc
@@ -13,11 +13,13 @@ namespace datalake::coordinator {
 
 std::ostream& operator<<(std::ostream& o, const translated_offset_range& r) {
     o << fmt::format(
-      "{{start_offset: {}, last_offset: {}, files: {}, dlq_files: {}}}",
+      "{{start_offset: {}, last_offset: {}, files: {}, dlq_files: {}, "
+      "kafka_bytes_processed: {}}}",
       r.start_offset,
       r.last_offset,
       r.files,
-      r.dlq_files);
+      r.dlq_files,
+      r.kafka_bytes_processed);
     return o;
 }
 

--- a/src/v/datalake/coordinator/translated_offset_range.h
+++ b/src/v/datalake/coordinator/translated_offset_range.h
@@ -22,10 +22,11 @@ namespace datalake::coordinator {
 struct translated_offset_range
   : serde::envelope<
       translated_offset_range,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     auto serde_fields() {
-        return std::tie(start_offset, last_offset, files, dlq_files);
+        return std::tie(
+          start_offset, last_offset, files, dlq_files, kafka_bytes_processed);
     }
     // First Kafka offset (inclusive) represented in this range.
     kafka::offset start_offset;
@@ -36,10 +37,15 @@ struct translated_offset_range
     // Files for dead-letter queue table.
     chunked_vector<data_file> dlq_files;
 
+    // Total number of raw Kafka bytes processed to generate this
+    // translated range.
+    uint64_t kafka_bytes_processed{0};
+
     translated_offset_range copy() const {
         translated_offset_range range;
         range.start_offset = start_offset;
         range.last_offset = last_offset;
+        range.kafka_bytes_processed = kafka_bytes_processed;
         range.files.reserve(files.size());
         for (const auto& f : files) {
             range.files.push_back(f.copy());

--- a/src/v/datalake/coordinator/types.cc
+++ b/src/v/datalake/coordinator/types.cc
@@ -96,4 +96,29 @@ std::ostream& operator<<(
       request.topic_revision);
     return o;
 }
+
+std::ostream& operator<<(std::ostream& o, const per_topic_usage_stats& stats) {
+    fmt::print(
+      o,
+      "{{topic: {}, revision: {}, total_kafka_bytes_processed: {}}}",
+      stats.topic,
+      stats.revision,
+      stats.total_kafka_bytes_processed);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const datalake_usage_stats& stats) {
+    fmt::print(o, "{{topic_usages: {} }}", stats.topic_usages);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const usage_stats_reply& resp) {
+    fmt::print(o, "{{errc: {}, stats: {}}}", resp.errc, resp.stats);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const usage_stats_request& req) {
+    fmt::print(o, "{{coordinator_partition: {}}}", req.coordinator_partition);
+    return o;
+}
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -266,4 +266,88 @@ struct stm_snapshot
     auto serde_fields() { return std::tie(topics); }
 };
 
+struct per_topic_usage_stats
+  : serde::envelope<
+      per_topic_usage_stats,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    per_topic_usage_stats() = default;
+    explicit per_topic_usage_stats(
+      model::topic topic,
+      model::revision_id revision,
+      uint64_t kafka_bytes_processed)
+      : topic(std::move(topic))
+      , revision(revision)
+      , total_kafka_bytes_processed(kafka_bytes_processed) {}
+
+    model::topic topic;
+    model::revision_id revision;
+    uint64_t total_kafka_bytes_processed{0};
+
+    friend std::ostream&
+    operator<<(std::ostream&, const per_topic_usage_stats&);
+
+    auto serde_fields() {
+        return std::tie(topic, revision, total_kafka_bytes_processed);
+    }
+};
+
+struct datalake_usage_stats
+  : serde::envelope<
+      datalake_usage_stats,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    friend std::ostream& operator<<(std::ostream&, const datalake_usage_stats&);
+
+    chunked_vector<per_topic_usage_stats> topic_usages;
+
+    auto serde_fields() { return std::tie(topic_usages); }
+};
+
+struct usage_stats_reply
+  : serde::
+      envelope<usage_stats_reply, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    usage_stats_reply() = default;
+    explicit usage_stats_reply(errc err)
+      : errc(err) {}
+
+    friend std::ostream& operator<<(std::ostream&, const usage_stats_reply&);
+
+    errc errc;
+    // only valid if errc == errc::ok
+    datalake_usage_stats stats;
+
+    auto serde_fields() { return std::tie(errc, stats); }
+};
+
+// Request to fetch usage stats for all topics coordinated by a given
+// coordinator topic partition.
+struct usage_stats_request
+  : serde::envelope<
+      usage_stats_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    using resp_t = usage_stats_reply;
+
+    model::partition_id coordinator_partition;
+
+    usage_stats_request() = default;
+    explicit usage_stats_request(model::partition_id coordinator_partition)
+      : coordinator_partition(coordinator_partition) {}
+    friend std::ostream& operator<<(std::ostream&, const usage_stats_request&);
+
+    model::partition_id get_coordinator_partition() {
+        return coordinator_partition;
+    }
+
+    auto serde_fields() { return std::tie(coordinator_partition); }
+};
+
 } // namespace datalake::coordinator

--- a/src/v/datalake/datalake_usage_aggregator.cc
+++ b/src/v/datalake/datalake_usage_aggregator.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/datalake_usage_aggregator.h"
+
+#include "cluster/controller.h"
+#include "datalake/logger.h"
+
+namespace datalake {
+
+disabled_datalake_usage_api_impl::disabled_datalake_usage_api_impl(
+  cluster::controller* controller)
+  : _controller(controller) {
+    vassert(
+      _controller,
+      "Controller must not be null for disabled datalake usage API");
+}
+
+ss::future<kafka::datalake_usage_api::usage_stats>
+disabled_datalake_usage_api_impl::compute_usage(ss::abort_source&) {
+    usage_stats stats;
+    if (!_controller->is_raft0_leader()) {
+        stats.missing_reason = kafka::datalake_usage_api::stats_missing_reason::
+          not_controller_leader;
+    } else {
+        stats.missing_reason
+          = kafka::datalake_usage_api::stats_missing_reason::feature_disabled;
+        vlog(
+          datalake_log.debug,
+          "Datalake usage API is disabled, returning empty stats");
+    }
+    return ss::make_ready_future<usage_stats>(std::move(stats));
+}
+
+} // namespace datalake

--- a/src/v/datalake/datalake_usage_aggregator.cc
+++ b/src/v/datalake/datalake_usage_aggregator.cc
@@ -11,7 +11,27 @@
 #include "datalake/datalake_usage_aggregator.h"
 
 #include "cluster/controller.h"
+#include "cluster/topic_table.h"
+#include "datalake/coordinator/frontend.h"
 #include "datalake/logger.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+namespace {
+ss::future<chunked_vector<datalake::coordinator::usage_stats_reply>>
+dispatch_requests(
+  datalake::coordinator::frontend& frontend, int partition_count) {
+    chunked_vector<ss::future<datalake::coordinator::usage_stats_reply>>
+      replies;
+    for (auto i = 0; i < partition_count; ++i) {
+        datalake::coordinator::usage_stats_request request{
+          model::partition_id(i)};
+        replies.push_back(frontend.get_usage_stats(request));
+    }
+    co_return co_await ss::when_all_succeed(replies.begin(), replies.end());
+}
+} // namespace
 
 namespace datalake {
 
@@ -37,6 +57,115 @@ disabled_datalake_usage_api_impl::compute_usage(ss::abort_source&) {
           "Datalake usage API is disabled, returning empty stats");
     }
     return ss::make_ready_future<usage_stats>(std::move(stats));
+}
+
+static constexpr ss::lowres_clock::duration usage_aggregation_timeout = 5s;
+static constexpr ss::lowres_clock::duration usage_aggregation_backoff = 100ms;
+
+default_datalake_usage_api_impl::default_datalake_usage_api_impl(
+  cluster::controller* controller,
+  ss::sharded<cluster::topic_table>* topic_table,
+  ss::sharded<datalake::coordinator::frontend>* coordinator_fe)
+  : _controller(controller)
+  , _topics(topic_table)
+  , _frontend(coordinator_fe) {
+    vassert(_controller, "Controller must not be null");
+}
+
+ss::future<kafka::datalake_usage_api::usage_stats>
+default_datalake_usage_api_impl::compute_usage(ss::abort_source& as) {
+    if (!_controller->is_raft0_leader()) {
+        kafka::datalake_usage_api::usage_stats stats;
+        stats.missing_reason = kafka::datalake_usage_api::stats_missing_reason::
+          not_controller_leader;
+        co_return stats;
+    }
+    const auto& topics = _topics->local();
+    auto topic = topics.get_topic_metadata(model::datalake_coordinator_nt);
+    if (!topic) {
+        vlog(
+          datalake_log.debug,
+          "Datalake coordinator topic {} not found, nothing to report",
+          model::datalake_coordinator_nt);
+        // The absence of the coordinator topic suggests the datalake feature
+        // was never used, as any coordinator operation would have created it
+        // initially. Hence nothing to report.
+        kafka::datalake_usage_api::usage_stats stats;
+        stats.missing_reason
+          = kafka::datalake_usage_api::stats_missing_reason::none;
+        stats.topic_stats.emplace();
+        co_return stats;
+    }
+
+    retry_chain_node rcn(
+      as,
+      usage_aggregation_timeout,
+      usage_aggregation_backoff,
+      retry_strategy::polling);
+    std::exception_ptr last_exception = nullptr;
+    while (true) {
+        auto coordinator_partitions
+          = topic->get_configuration().partition_count;
+        auto usage_results_f = co_await ss::coroutine::as_future(
+          dispatch_requests(_frontend->local(), coordinator_partitions));
+
+        bool succeeded = true;
+        chunked_vector<kafka::datalake_usage_api::topic_usage> topic_stats;
+        if (usage_results_f.failed()) {
+            last_exception = usage_results_f.get_exception();
+            vlog(
+              datalake_log.warn,
+              "Failed to collect datalake usage stats: {}",
+              last_exception);
+            succeeded = false;
+        } else {
+            for (const auto& result : usage_results_f.get()) {
+                if (result.errc != coordinator::errc::ok) {
+                    vlog(
+                      datalake_log.warn,
+                      "Failed to collect datalake usage stats: {}",
+                      result.errc);
+                    succeeded = false;
+                    break;
+                }
+                for (const auto& topic_usage : result.stats.topic_usages) {
+                    kafka::datalake_usage_api::topic_usage usage;
+                    usage.topic = topic_usage.topic,
+                    usage.revision = topic_usage.revision,
+                    usage.kafka_bytes_processed
+                      = topic_usage.total_kafka_bytes_processed;
+                    topic_stats.push_back(std::move(usage));
+                }
+                co_await ss::maybe_yield();
+            }
+        }
+        if (succeeded) {
+            // If we succeeded, we can return the stats
+            usage_stats stats;
+            stats.missing_reason
+              = kafka::datalake_usage_api::stats_missing_reason::none;
+            stats.topic_stats = std::move(topic_stats);
+            vlog(
+              datalake_log.debug, "Collected datalake usage stats: {}", stats);
+            co_return stats;
+        }
+        // check if we should retry
+        auto retry = rcn.retry();
+        if (!retry.is_allowed) {
+            break;
+        }
+        last_exception = nullptr;
+        co_await ss::sleep_abortable(retry.delay, as);
+    }
+    rcn.check_abort();
+    if (last_exception) {
+        // last retry resulted in an exception, let the caller handle it
+        std::rethrow_exception(last_exception);
+    }
+    usage_stats stats;
+    stats.missing_reason
+      = kafka::datalake_usage_api::stats_missing_reason::collection_error;
+    co_return stats;
 }
 
 } // namespace datalake

--- a/src/v/datalake/datalake_usage_aggregator.h
+++ b/src/v/datalake/datalake_usage_aggregator.h
@@ -10,11 +10,15 @@
 
 #pragma once
 
+#include "base/seastarx.h"
+#include "cluster/fwd.h"
+#include "datalake/fwd.h"
 #include "kafka/server/datalake_usage_api.h"
 
 namespace cluster {
 class controller;
 }
+#include <seastar/core/sharded.hh>
 
 namespace datalake {
 
@@ -27,5 +31,19 @@ public:
 
 private:
     cluster::controller* _controller{nullptr};
+};
+
+class default_datalake_usage_api_impl final : public kafka::datalake_usage_api {
+public:
+    explicit default_datalake_usage_api_impl(
+      cluster::controller*,
+      ss::sharded<cluster::topic_table>*,
+      ss::sharded<datalake::coordinator::frontend>*);
+    ss::future<usage_stats> compute_usage(ss::abort_source&) final;
+
+private:
+    cluster::controller* _controller;
+    ss::sharded<cluster::topic_table>* _topics;
+    ss::sharded<coordinator::frontend>* _frontend;
 };
 } // namespace datalake

--- a/src/v/datalake/datalake_usage_aggregator.h
+++ b/src/v/datalake/datalake_usage_aggregator.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "kafka/server/datalake_usage_api.h"
+
+namespace cluster {
+class controller;
+}
+
+namespace datalake {
+
+class disabled_datalake_usage_api_impl final
+  : public kafka::datalake_usage_api {
+public:
+    disabled_datalake_usage_api_impl(cluster::controller*);
+
+    ss::future<usage_stats> compute_usage(ss::abort_source&) final;
+
+private:
+    cluster::controller* _controller{nullptr};
+};
+} // namespace datalake

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -54,11 +54,17 @@ public:
       : _func(std::move(f)) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch b) {
-        return _func(std::move(b));
+        auto batch_raw_size = b.size_bytes();
+        return _func(std::move(b))
+          .then([this, batch_raw_size](ss::stop_iteration si) {
+              _total_read_bytes += batch_raw_size;
+              return si;
+          });
     }
-    void end_of_stream() {}
+    uint64_t end_of_stream() { return _total_read_bytes; }
 
 private:
+    uint64_t _total_read_bytes{0};
     Func _func;
 };
 } // namespace
@@ -91,7 +97,7 @@ ss::future<> record_multiplexer::multiplex(
   kafka::offset start_offset,
   model::timeout_clock::time_point deadline,
   ss::abort_source& as) {
-    co_await std::move(reader).consume(
+    _reader_bytes_processed += co_await std::move(reader).consume(
       relaying_consumer{
         [this, start_offset, &as](model::record_batch b) mutable {
             return do_multiplex(std::move(b), start_offset, as);
@@ -379,6 +385,7 @@ record_multiplexer::finish() && {
         // no batches were processed.
         co_return writer_error::no_data;
     }
+    _result->kafka_bytes_processed = _reader_bytes_processed;
     co_return std::move(*_result);
 }
 

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -61,6 +61,8 @@ public:
         chunked_vector<partitioning_writer::partitioned_file> data_files;
         // files with invalid records
         chunked_vector<partitioning_writer::partitioned_file> dlq_files;
+        // Total number of kafka bytes processed by the multiplexer
+        uint64_t kafka_bytes_processed{0};
     };
     explicit record_multiplexer(
       const model::ntp& ntp,
@@ -146,6 +148,8 @@ private:
 
     std::optional<writer_error> _error;
     std::optional<write_result> _result;
+    // Total number of kafka bytes processed by the multiplexer
+    uint64_t _reader_bytes_processed = 0;
 };
 
 } // namespace datalake

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -73,6 +73,11 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     chunked_circular_buffer<model::record_batch> batches
       = model::test::make_random_batches(batch_spec).get();
 
+    uint64_t total_bytes = 0;
+    for (const auto& batch : batches) {
+        total_bytes += batch.size_bytes();
+    }
+
     auto reader = model::make_generating_record_batch_reader(
       [batches = std::move(batches)]() mutable {
           return ss::make_ready_future<model::record_batch_reader::data_t>(
@@ -95,7 +100,9 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
     EXPECT_EQ(
       result.value().last_offset(),
       start_offset + record_count * batch_count - 1);
+    EXPECT_EQ(result.value().kafka_bytes_processed, total_bytes);
 }
+
 TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     int record_count = 10;
     int batch_count = 10;
@@ -250,6 +257,7 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
     const size_t records_per_batch = 4;
     auto start_ts = model::timestamp::now();
     constexpr auto ms_per_hr = 1000 * 3600;
+    uint64_t total_bytes = 0;
     for (size_t h = 0; h < num_hrs; ++h) {
         // Split batches across the hours.
         auto h_ts = model::timestamp{
@@ -268,7 +276,9 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
                 ASSERT_FALSE(add_res.has_error());
                 ++o;
             }
-            batches.emplace_back(std::move(batch_builder).build());
+            auto batch = std::move(batch_builder).build();
+            total_bytes += batch.size_bytes();
+            batches.emplace_back(std::move(batch));
         }
     }
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
@@ -302,4 +312,5 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
 
     const auto num_records = num_hrs * batches_per_hr * records_per_batch;
     EXPECT_EQ(res.value().last_offset(), start_offset() + num_records - 1);
+    EXPECT_EQ(res.value().kafka_bytes_processed, total_bytes);
 }

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -313,6 +313,7 @@ translation_task::finish(
     coordinator::translated_offset_range ret{
       .start_offset = write_result.start_offset,
       .last_offset = write_result.last_offset,
+      .kafka_bytes_processed = write_result.kafka_bytes_processed,
     };
 
     lazy_abort_source lazy_as{[&as]() {

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -364,6 +364,24 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "datalake_usage_api",
+    srcs = [
+        "datalake_usage_api.cc",
+    ],
+    hdrs = [
+        "datalake_usage_api.h",
+    ],
+    include_prefix = "kafka/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/container:fragmented_vector",
+        "//src/v/model",
+        "//src/v/utils:to_string",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "datalake_throttle_manager",
     srcs = [
         "datalake_throttle_manager.cc",

--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -195,6 +195,7 @@ redpanda_cc_library(
     deps = [
         ":consumer_group_lag_metrics_rpc",
         ":datalake_throttle_manager",
+        ":datalake_usage_api",
         ":logger",
         ":qdc_monitor_config",
         "//src/v/base",

--- a/src/v/kafka/server/datalake_usage_api.cc
+++ b/src/v/kafka/server/datalake_usage_api.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "kafka/server/datalake_usage_api.h"
+
+#include "utils/to_string.h"
+
+namespace kafka {
+
+datalake_usage_api::usage_stats::usage_stats(const usage_stats& other) {
+    if (other.topic_stats) {
+        topic_stats = other.topic_stats->copy();
+    } else {
+        topic_stats.reset();
+    }
+    missing_reason = other.missing_reason;
+}
+
+datalake_usage_api::usage_stats& datalake_usage_api::usage_stats::operator=(
+  const datalake_usage_api::usage_stats& other) {
+    if (this != &other) {
+        if (other.topic_stats) {
+            topic_stats = other.topic_stats->copy();
+        } else {
+            topic_stats.reset();
+        }
+        missing_reason = other.missing_reason;
+    }
+    return *this;
+}
+
+std::ostream& operator<<(
+  std::ostream& os, const datalake_usage_api::stats_missing_reason& r) {
+    switch (r) {
+    case datalake_usage_api::stats_missing_reason::none:
+        return os << "none";
+    case datalake_usage_api::stats_missing_reason::feature_disabled:
+        return os << "feature_disabled";
+    case datalake_usage_api::stats_missing_reason::collection_error:
+        return os << "collection_error";
+    case datalake_usage_api::stats_missing_reason::not_controller_leader:
+        return os << "not_controller_leader";
+    }
+}
+
+std::ostream&
+operator<<(std::ostream& os, const datalake_usage_api::topic_usage& u) {
+    fmt::print(
+      os,
+      "{{ topic: {} revision: {} kafka_bytes_processed: {} }}",
+      u.topic,
+      u.revision,
+      u.kafka_bytes_processed);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const datalake_usage_api::usage_stats& u) {
+    fmt::print(
+      os,
+      "{{ topic_stats: {}, missing_stats_reason: {} }}",
+      u.topic_stats,
+      u.missing_reason);
+    return os;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/datalake_usage_api.h
+++ b/src/v/kafka/server/datalake_usage_api.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "container/fragmented_vector.h"
+#include "model/fundamental.h"
+
+#include <cstdint>
+
+namespace kafka {
+
+/**
+ * Interface for computing and reporting datalake usage statistics
+ */
+class datalake_usage_api {
+public:
+    /**
+     * Per-topic usage information
+     */
+    struct topic_usage
+      : serde::
+          envelope<topic_usage, serde::version<0>, serde::compat_version<0>> {
+        model::topic topic{};
+        /// Current revision number
+        /// Each time a topic is recreated, the revision is updated.
+        model::revision_id revision{};
+        /// Total kafka bytes processed so far
+        /// that resulted in data conversion into iceberg format
+        /// Persisted across restarts.
+        uint64_t kafka_bytes_processed{0};
+
+        friend bool operator==(const topic_usage&, const topic_usage&)
+          = default;
+        friend std::ostream& operator<<(std::ostream& os, const topic_usage& u);
+
+        auto serde_fields() {
+            return std::tie(topic, revision, kafka_bytes_processed);
+        }
+    };
+
+    enum class stats_missing_reason : uint8_t {
+        /// No error, stats are available
+        none = 0,
+        /// Disabled by configuration
+        feature_disabled = 1,
+        /// Error collecting usage stats
+        collection_error = 2,
+        /// not controller leader
+        not_controller_leader = 3,
+    };
+
+    friend std::ostream& operator<<(std::ostream&, const stats_missing_reason&);
+
+    /**
+     * Usage statistics for a datalake
+     */
+    struct usage_stats
+      : serde::
+          envelope<usage_stats, serde::version<0>, serde::compat_version<0>> {
+        /// Per-topic usage information
+        /// If unset, check `stats_missing_reason`
+        std::optional<chunked_vector<topic_usage>> topic_stats;
+
+        stats_missing_reason missing_reason
+          = stats_missing_reason::feature_disabled;
+
+        usage_stats() = default;
+        usage_stats(const usage_stats&);
+        usage_stats(usage_stats&&) = default;
+        usage_stats& operator=(const usage_stats&);
+        usage_stats& operator=(usage_stats&&) = default;
+
+        friend bool operator==(const usage_stats&, const usage_stats&)
+          = default;
+        friend std::ostream& operator<<(std::ostream& os, const usage_stats& u);
+
+        auto serde_fields() { return std::tie(topic_stats, missing_reason); }
+    };
+
+    virtual ~datalake_usage_api() = default;
+
+    /**
+     * Compute current usage statistics for the datalake
+     *
+     * @return Current datalake usage statistics for all topics
+     */
+    virtual ss::future<usage_stats> compute_usage(ss::abort_source&) = 0;
+};
+} // namespace kafka

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -32,5 +32,6 @@ class snc_quota_context;
 class snc_quota_manager;
 class usage_manager;
 class datalake_throttle_manager;
+class datalake_usage_api;
 
 } // namespace kafka

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -118,6 +118,7 @@ void usage_window::reset(uint64_t now) {
     u.bytes_sent = 0;
     u.bytes_received = 0;
     u.bytes_cloud_storage = std::nullopt;
+    u.datalake_usage = {};
 }
 
 template<typename clock_type>
@@ -320,6 +321,8 @@ ss::future<> usage_aggregator<clock_type>::grab_data(size_t idx) {
             _buckets[idx].u += usage_data;
             _buckets[idx].u.bytes_cloud_storage
               = usage_data.bytes_cloud_storage;
+            _buckets[idx].u.datalake_usage = std::move(
+              usage_data.datalake_usage);
         }
     } catch (const std::exception& e) {
         vlog(

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "base/vlog.h"
 #include "container/fragmented_vector.h"
+#include "kafka/server/datalake_usage_api.h"
 #include "kafka/server/logger.h"
 #include "serde/rw/envelope.h"
 #include "serde/rw/optional.h"
@@ -58,24 +59,28 @@ std::chrono::time_point<clock_type, duration> round_to_interval(
 /// periodically serialized to disk, hence why the struct inherits from the
 /// serde::envelope
 struct usage
-  : serde::envelope<usage, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<usage, serde::version<1>, serde::compat_version<0>> {
     uint64_t bytes_sent{0};
     uint64_t bytes_received{0};
     std::optional<uint64_t> bytes_cloud_storage;
+    datalake_usage_api::usage_stats datalake_usage;
     usage operator+(const usage&) const;
     usage& operator+=(const usage&);
     auto serde_fields() {
-        return std::tie(bytes_sent, bytes_received, bytes_cloud_storage);
+        return std::tie(
+          bytes_sent, bytes_received, bytes_cloud_storage, datalake_usage);
     }
     friend bool operator==(const usage&, const usage&) = default;
     friend std::ostream& operator<<(std::ostream& os, const usage& u) {
         fmt::print(
           os,
-          "{{ bytes_sent: {} bytes_received: {} bytes_cloud_storage: {} }}",
+          "{{ bytes_sent: {} bytes_received: {} bytes_cloud_storage: {} "
+          "datalake_usage: {} }}",
           u.bytes_sent,
           u.bytes_received,
           u.bytes_cloud_storage ? std::to_string(*u.bytes_cloud_storage)
-                                : "n/a");
+                                : "n/a",
+          u.datalake_usage);
         return os;
     }
 };

--- a/src/v/kafka/server/usage_manager.cc
+++ b/src/v/kafka/server/usage_manager.cc
@@ -19,6 +19,8 @@
 #include "ssx/future-util.h"
 #include "storage/api.h"
 
+#include <utility>
+
 namespace kafka {
 
 usage_manager::usage_accounting_fiber::usage_accounting_fiber(
@@ -26,6 +28,8 @@ usage_manager::usage_accounting_fiber::usage_accounting_fiber(
   ss::sharded<usage_manager>& um,
   ss::sharded<cluster::health_monitor_frontend>& health_monitor,
   ss::sharded<storage::api>& storage,
+  ss::shared_ptr<datalake_usage_api> datalake_usage_api,
+  ss::abort_source& as,
   size_t usage_num_windows,
   std::chrono::seconds usage_window_width_interval,
   std::chrono::seconds usage_disk_persistance_interval)
@@ -36,7 +40,9 @@ usage_manager::usage_accounting_fiber::usage_accounting_fiber(
       usage_disk_persistance_interval)
   , _controller(controller)
   , _health_monitor(health_monitor.local())
-  , _um(um) {}
+  , _um(um)
+  , _datalake_usage_api(std::move(datalake_usage_api))
+  , _as(as) {}
 
 /// The fiber running on the timer has a mutable effect when sample() is
 /// called, to prevent issues when open bucket is querying all shards for
@@ -46,6 +52,7 @@ usage_manager::usage_accounting_fiber::close_current_window() {
     auto u = co_await _um.map_reduce0(
       [](usage_manager& um) { return um.sample(); }, usage{}, std::plus<>());
     u.bytes_cloud_storage = co_await get_cloud_usage_data();
+    u.datalake_usage = co_await _datalake_usage_api->compute_usage(_as);
     co_return u;
 }
 
@@ -69,7 +76,8 @@ usage_manager::usage_accounting_fiber::get_cloud_usage_data() {
 usage_manager::usage_manager(
   cluster::controller* controller,
   ss::sharded<cluster::health_monitor_frontend>& health_monitor,
-  ss::sharded<storage::api>& storage)
+  ss::sharded<storage::api>& storage,
+  ss::shared_ptr<datalake_usage_api> datalake_usage_api)
   : _usage_enabled(config::shard_local_cfg().enable_usage.bind())
   , _usage_num_windows(config::shard_local_cfg().usage_num_windows.bind())
   , _usage_window_width_interval(
@@ -78,7 +86,8 @@ usage_manager::usage_manager(
       config::shard_local_cfg().usage_disk_persistance_interval_sec.bind())
   , _controller(controller)
   , _health_monitor(health_monitor)
-  , _storage(storage) {}
+  , _storage(storage)
+  , _datalake_usage_api(std::move(datalake_usage_api)) {}
 
 ss::future<> usage_manager::reset() {
     oncore_debug_verify(_verify_shard);
@@ -110,6 +119,8 @@ ss::future<> usage_manager::start_accounting_fiber() {
       this->container(),
       _health_monitor,
       _storage,
+      _datalake_usage_api,
+      _as,
       _usage_num_windows(),
       _usage_window_width_interval(),
       _usage_disk_persistance_interval());
@@ -134,6 +145,7 @@ ss::future<> usage_manager::start() {
 }
 
 ss::future<> usage_manager::stop() {
+    _as.request_abort();
     co_await _background_gate.close();
     if (!_accounting_fiber) {
         co_return;

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -13,6 +13,7 @@
 #include "base/oncore.h"
 #include "cluster/fwd.h"
 #include "config/property.h"
+#include "kafka/server/datalake_usage_api.h"
 #include "kafka/server/usage_aggregator.h"
 #include "model/namespace.h"
 #include "storage/fwd.h"
@@ -42,6 +43,8 @@ public:
           ss::sharded<usage_manager>& um,
           ss::sharded<cluster::health_monitor_frontend>& health_monitor,
           ss::sharded<storage::api>& storage,
+          ss::shared_ptr<datalake_usage_api> datalake_usage_api,
+          ss::abort_source& as,
           size_t usage_num_windows,
           std::chrono::seconds usage_window_width_interval,
           std::chrono::seconds usage_disk_persistance_interval);
@@ -56,6 +59,8 @@ public:
         cluster::controller* _controller;
         cluster::health_monitor_frontend& _health_monitor;
         ss::sharded<usage_manager>& _um;
+        ss::shared_ptr<datalake_usage_api> _datalake_usage_api;
+        ss::abort_source& _as;
     };
 
     /// Class constructor
@@ -65,7 +70,8 @@ public:
     explicit usage_manager(
       cluster::controller* controller,
       ss::sharded<cluster::health_monitor_frontend>& health_monitor,
-      ss::sharded<storage::api>& storage);
+      ss::sharded<storage::api>& storage,
+      ss::shared_ptr<datalake_usage_api> datalake_usage_api);
 
     /// Allocates and starts the accounting fiber
     ss::future<> start();
@@ -115,11 +121,13 @@ private:
     cluster::controller* _controller;
     ss::sharded<cluster::health_monitor_frontend>& _health_monitor;
     ss::sharded<storage::api>& _storage;
+    ss::shared_ptr<datalake_usage_api> _datalake_usage_api;
 
     /// Per-core metric, shard-0 aggregates these values across shards
     usage _current_bucket;
     mutex _background_mutex{"usage_monitor::_background_mutex"};
     ss::gate _background_gate;
+    ss::abort_source _as;
 
     /// Valid on core-0 when usage_enabled() == true
     std::unique_ptr<usage_aggregator<>> _accounting_fiber;

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -33,6 +33,7 @@ redpanda_cc_library(
         "//src/v/datalake:types",
         "//src/v/datalake:cloud_data_io",
         "//src/v/datalake:manager",
+        "//src/v/datalake:datalake_usage_aggregator",
         "//src/v/datalake/coordinator:coordinator_manager",
         "//src/v/datalake/coordinator:frontend",
         "//src/v/datalake/coordinator:stm",

--- a/src/v/redpanda/admin/api-doc/usage.json
+++ b/src/v/redpanda/admin/api-doc/usage.json
@@ -24,6 +24,40 @@
         }
     ],
     "models": {
+        "datalake_topic_usage": {
+            "type": "object",
+            "description": "Datalake feature usage metrics of a single topic with datalake enabled.",
+            "properties": {
+                "topic_name": {
+                    "type": "string",
+                    "description": "Name of the topic."
+                },
+                "topic_revision": {
+                    "type": "long",
+                    "description": "Revision of the topic, used to detect delete and re-create scenarios."
+                },
+                "kafka_bytes_processed": {
+                    "type": "long",
+                    "description": "Total number of topic bytes successfully converted to Iceberg format. This is a counter that persists across restarts."
+                }
+            }
+        },
+        "datalake_usage": {
+            "description": "Datalake feature usage metrics.",
+            "type": "object",
+            "properties": {
+                "missing_reason": {
+                    "type": "string",
+                    "description": "Indicates the reason for missing datalake usage. This field is set only when usage data is unavailable. Possible values: 'feature_disabled', 'collection_error', 'not_controller_leader'."
+                },
+                "topics": {
+                    "type": "array",
+                    "items": {
+                        "type": "datalake_topic_usage"
+                    }
+                }
+            }
+        },
         "usage_response": {
             "id": "usage_response",
             "description": "Kafka & cloud storage usage metrics for this node",
@@ -51,6 +85,10 @@
                 "cloud_storage_bytes_gauge": {
                     "type": "long",
                     "description": "Number of bytes resting in cloud storage at window close"
+                },
+                "datalake_usage": {
+                    "type": "datalake_usage",
+                    "description": "Datalake feature usage metrics."
                 }
             }
         }

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -30,6 +30,21 @@ ss::json::json_return_type raw_data_to_usage_response(
         } else {
             resp.back().cloud_storage_bytes_gauge = -1;
         }
+        auto& dl_usage = e.u.datalake_usage;
+        ss::httpd::usage_json::datalake_usage dl_usage_response;
+        if (dl_usage.topic_stats) {
+            for (auto& entry : dl_usage.topic_stats.value()) {
+                ss::httpd::usage_json::datalake_topic_usage topic_usage;
+                topic_usage.topic_name = entry.topic;
+                topic_usage.topic_revision = entry.revision();
+                topic_usage.kafka_bytes_processed = entry.kafka_bytes_processed;
+                dl_usage_response.topics.push(std::move(topic_usage));
+            }
+        } else {
+            dl_usage_response.missing_reason = fmt::format(
+              "{}", dl_usage.missing_reason);
+        }
+        resp.back().datalake_usage = std::move(dl_usage_response);
     }
     if (include_open && !resp.empty()) {
         /// Handle case where client does not want to observe

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1440,6 +1440,17 @@ void application::wire_up_runtime_services(
           .invoke_on_all(&kafka::datalake_throttle_manager::start)
           .get();
     }
+
+    syschecks::systemd_message("Creating kafka usage manager frontend").get();
+    construct_service(
+      usage_manager,
+      controller.get(),
+      std::ref(controller->get_health_monitor()),
+      std::ref(storage),
+      ss::sharded_parameter(
+        [this] { return make_datalake_usage_aggregator(); }))
+      .get();
+
     construct_single_service(_monitor_unsafe, std::ref(feature_table));
 
     construct_service(_debug_bundle_service, &storage.local().kvs()).get();
@@ -2177,16 +2188,6 @@ void application::wire_up_redpanda_services(
       controller.get())
       .get();
 
-    syschecks::systemd_message("Creating kafka usage manager frontend").get();
-    construct_service(
-      usage_manager,
-      controller.get(),
-      std::ref(controller->get_health_monitor()),
-      std::ref(storage),
-      ss::sharded_parameter(
-        [this] { return make_datalake_usage_aggregator(); }))
-      .get();
-
     syschecks::systemd_message("Creating tx coordinator frontend").get();
     construct_single_service_sharded(
       tx_topic_manager,
@@ -2418,6 +2419,12 @@ bool application::datalake_enabled() {
 
 ss::shared_ptr<kafka::datalake_usage_api>
 application::make_datalake_usage_aggregator() {
+    if (datalake_enabled()) {
+        return ss::make_shared<datalake::default_datalake_usage_api_impl>(
+          controller.get(),
+          &controller->get_topics_state(),
+          &_datalake_coordinator_fe);
+    }
     return ss::make_shared<datalake::disabled_datalake_usage_api_impl>(
       controller.get());
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -95,6 +95,7 @@
 #include "datalake/coordinator/service.h"
 #include "datalake/coordinator/state_machine.h"
 #include "datalake/datalake_manager.h"
+#include "datalake/datalake_usage_aggregator.h"
 #include "datalake/translation/state_machine.h"
 #include "debug_bundle/debug_bundle_service.h"
 #include "features/feature_table_snapshot.h"
@@ -2181,7 +2182,9 @@ void application::wire_up_redpanda_services(
       usage_manager,
       controller.get(),
       std::ref(controller->get_health_monitor()),
-      std::ref(storage))
+      std::ref(storage),
+      ss::sharded_parameter(
+        [this] { return make_datalake_usage_aggregator(); }))
       .get();
 
     syschecks::systemd_message("Creating tx coordinator frontend").get();
@@ -2411,6 +2414,12 @@ bool application::wasm_data_transforms_enabled() {
 bool application::datalake_enabled() {
     return config::shard_local_cfg().iceberg_enabled()
            && !config::node().recovery_mode_enabled();
+}
+
+ss::shared_ptr<kafka::datalake_usage_api>
+application::make_datalake_usage_aggregator() {
+    return ss::make_shared<datalake::disabled_datalake_usage_api_impl>(
+      controller.get());
 }
 
 bool application::kafka_data_rpc_enabled() {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -265,6 +265,8 @@ private:
 
     bool kafka_data_rpc_enabled();
 
+    ss::shared_ptr<kafka::datalake_usage_api> make_datalake_usage_aggregator();
+
     // Stop the service.
     // The method should be invoked in the ss::thread context.
     template<class Service>

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -322,7 +322,8 @@ class DatalakeServices():
             translation_done,
             timeout_sec=timeout,
             backoff_sec=backoff_sec,
-            err_msg=f"Timed out waiting for events to appear in datalake")
+            err_msg=
+            f"Timed out waiting for events from {topic} to appear in datalake")
 
     def produce_to_topic(self,
                          topic,

--- a/tests/rptest/tests/datalake/datalake_usage_test.py
+++ b/tests/rptest/tests/datalake/datalake_usage_test.py
@@ -1,0 +1,223 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import os
+import time
+import random
+import json
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings
+from rptest.services.cluster import cluster
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.catalog_service_factory import supported_catalog_types, filesystem_catalog_type
+from rptest.utils.functional import flat_map
+from typing import Optional, Dict
+from collections import namedtuple
+from rptest.clients.rpk import RpkTool
+
+TopicUsage = namedtuple("TopicUsage", [
+    "begin_timestamp", "end_timestamp", "open", "revision",
+    "kafka_bytes_processed", "missing_reason"
+])
+
+
+class IcebergUsageTest(RedpandaTest):
+    """
+    Test to check iceberg usage with multiple topics having iceberg enabled.
+    """
+    def __init__(self, test_ctx, *args, **kwargs):
+        extra_rp_conf = dict(iceberg_enabled=True,
+                             iceberg_catalog_commit_interval_ms=1000,
+                             enable_usage=True,
+                             usage_num_windows=30,
+                             usage_window_width_interval_sec=1)
+        self.test_ctx = test_ctx
+        super(IcebergUsageTest,
+              self).__init__(test_context=test_ctx,
+                             si_settings=SISettings(test_context=test_ctx),
+                             extra_rp_conf=extra_rp_conf,
+                             *args,
+                             **kwargs)
+
+    def setUp(self):
+        pass
+
+    def usage_by_topic(self):
+        """
+        Get iceberg usage from the datalake /usage end point.
+        """
+        usage_by_topic = {}
+        for node in self.redpanda.nodes:
+            reported_usages = flat_map(
+                lambda node: self.redpanda._admin.get_usage(node),
+                self.redpanda.nodes)
+            for window in reported_usages:
+                dl_usage = window['datalake_usage']
+                ts = window["begin_timestamp"]
+                if "missing_reason" in dl_usage and dl_usage[
+                        'missing_reason'] != "not_controller_leader":
+                    continue
+                if 'topics' not in dl_usage.keys():
+                    continue
+                for topic in dl_usage['topics']:
+                    existing = usage_by_topic.get(topic['topic_name'], None)
+                    if not existing or existing.begin_timestamp < int(
+                            window['begin_timestamp']):
+                        usage_by_topic[topic['topic_name']] = TopicUsage(
+                            begin_timestamp=int(window['begin_timestamp']),
+                            end_timestamp=int(window['end_timestamp']),
+                            open=bool(window['open']),
+                            revision=int(topic['topic_revision']),
+                            kafka_bytes_processed=int(
+                                topic['kafka_bytes_processed']),
+                            missing_reason="none")
+
+        self.logger.debug(
+            f"Usage by topic: {json.dumps(usage_by_topic, indent=2)}")
+        return usage_by_topic
+
+    @cluster(num_nodes=6)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            query_engine=[QueryEngineType.SPARK],
+            catalog_type=[filesystem_catalog_type()])
+    def test_iceberg_usage(self, cloud_storage_type, query_engine,
+                           catalog_type):
+        """
+        Test that verifies basic iceberg usage with multiple topics having iceberg enabled.
+        """
+        ib_topics = [f"iceberg_topic_{i}" for i in range(random.randint(1, 5))]
+
+        message_size = random.randint(50, 100)
+        total_messages = random.randint(500, 1000)
+        total_bytes = total_messages * message_size
+
+        def produce_data(iteration: int):
+            for topic in ib_topics:
+                dl.produce_to_topic(topic, message_size, total_messages)
+                dl.wait_for_translation(topic, iteration * total_messages)
+
+        self.logger.debug(
+            f"Iceberg topics: {ib_topics}, total messages per round: {total_messages}, message size: {message_size}, total bytes: {total_bytes}"
+        )
+
+        def check_no_usage():
+            """
+            Check if all usages are empty or have no kafka bytes processed.
+            """
+            def do_check():
+                usages = self.usage_by_topic()
+                return len(usages) == 0
+
+            wait_until(do_check,
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       err_msg=f"Timed out waiting for all usages to be empty")
+
+        def check_all_usages_atleast(
+                expected_topics: list[str],
+                min_bytes: int,
+                prev_usages: Optional[dict[str, TopicUsage]] = None):
+            """
+            Check if all usages have kafka bytes processed greater than or equal to min_bytes.
+            """
+            def do_check():
+                usages = self.usage_by_topic()
+
+                all_topics_present = all(topic in usages.keys()
+                                         for topic in expected_topics)
+
+                usages_increased = True
+                if prev_usages is not None:
+                    usages_increased = all([
+                        (topic not in prev_usages.keys())
+                        or usage.kafka_bytes_processed
+                        > prev_usages[topic].kafka_bytes_processed
+                        for topic, usage in usages.items()
+                    ])
+
+                return all_topics_present and usages_increased and all(
+                    usage.kafka_bytes_processed >= min_bytes
+                    for usage in usages.values())
+
+            wait_until(
+                do_check,
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg=
+                f"Timed out waiting for all usages to be at least {min_bytes} bytes"
+            )
+
+        def check_usage(usage: dict[str, TopicUsage]):
+            def do_check():
+                current_usages = self.usage_by_topic()
+                if len(current_usages) != len(usage):
+                    return False
+                for topic, expected_usage in usage.items():
+                    if topic not in current_usages:
+                        return False
+                    current_usage = current_usages[topic]
+                    if current_usage.revision != expected_usage.revision or current_usage.kafka_bytes_processed != expected_usage.kafka_bytes_processed:
+                        return False
+                return True
+
+            wait_until(do_check,
+                       timeout_sec=30,
+                       backoff_sec=2,
+                       err_msg=f"Timed out waiting for usage to match {usage}")
+
+        with DatalakeServices(self.test_ctx,
+                              redpanda=self.redpanda,
+                              include_query_engines=[query_engine],
+                              catalog_type=catalog_type) as dl:
+
+            # No usage before producing messages
+            check_no_usage()
+            for topic in ib_topics:
+                dl.create_iceberg_enabled_topic(topic,
+                                                partitions=3,
+                                                replicas=3,
+                                                target_lag_ms=10000)
+            # Produce some data and check usage.
+            produce_data(iteration=1)
+            check_all_usages_atleast(ib_topics, total_bytes)
+            current_usages = self.usage_by_topic()
+            # Produce more data and check usage again.
+            produce_data(iteration=2)
+            check_all_usages_atleast(ib_topics,
+                                     total_bytes,
+                                     prev_usages=current_usages)
+            current_usages = self.usage_by_topic()
+            # Restart the cluster and ensure usage is still tracked as expected.
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+            check_usage(current_usages)
+
+            usages = self.usage_by_topic()
+            # Delete and recreate topics
+
+            rpk = RpkTool(self.redpanda)
+            for topic in ib_topics:
+                rpk.delete_topic(topic)
+
+            for topic in ib_topics:
+                dl.create_iceberg_enabled_topic(topic,
+                                                partitions=3,
+                                                replicas=3,
+                                                target_lag_ms=10000)
+            produce_data(iteration=1)
+            check_all_usages_atleast(ib_topics, total_bytes)
+            current_usages = self.usage_by_topic()
+            # Check the new revisions are strictly grreater than the previous ones.
+            assert all(
+                current_usages[topic].revision > usages[topic].revision
+                for topic in ib_topics
+            ), "Topic revisions did not increase after topic recreation"


### PR DESCRIPTION
Fixes: https://redpandadata.atlassian.net/browse/ENG-493

Adds a byte metric counter per topic that tracks the number of uncompressed Kafka (raw batch) bytes consumed by translation to produce iceberg committed files. Requirements

* Post decompression byte count (since translation cost is proportional to decompressed size)
* Bytes accounted only once and only those attempts that resulted in successful Iceberg commits
* Persisted across restarts for accurate downstream billing.
* Wired up with /usage end point 

Example output on a valid controller.

```
[
    {
        "begin_timestamp": 1749656093,
        "end_timestamp": 1749656094,
        "open": true,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": 0,
        "datalake_usage": {
            "topics": [
                {
                    "topic_name": "iceberg_topic_0",
                    "topic_revision": 22,
                    "kafka_bytes_processed": 81862
                },
                {
                    "topic_name": "iceberg_topic_1",
                    "topic_revision": 25,
                    "kafka_bytes_processed": 81862
                }
            ]
        }
    },
    {
        "begin_timestamp": 1749656092,
        "end_timestamp": 1749656093,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": 0,
        "datalake_usage": {
            "topics": [
                {
                    "topic_name": "iceberg_topic_0",
                    "topic_revision": 22,
                    "kafka_bytes_processed": 81862
                },
                {
                    "topic_name": "iceberg_topic_1",
                    "topic_revision": 25,
                    "kafka_bytes_processed": 81862
                }
            ]
        }
    },
    {
        "begin_timestamp": 1749656091,
        "end_timestamp": 1749656092,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": 0,
        "datalake_usage": {
            "topics": [
                {
                    "topic_name": "iceberg_topic_0",
                    "topic_revision": 22,
                    "kafka_bytes_processed": 81862
                },
                {
                    "topic_name": "iceberg_topic_1",
                    "topic_revision": 25,
                    "kafka_bytes_processed": 81862
                }
            ]
        }
    },
    {
        "begin_timestamp": 1749656090,
        "end_timestamp": 1749656091,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": 0,
        "datalake_usage": {
            "topics": [
                {
                    "topic_name": "iceberg_topic_0",
                    "topic_revision": 22,
                    "kafka_bytes_processed": 81862
                },
                {
                    "topic_name": "iceberg_topic_1",
                    "topic_revision": 25,
                    "kafka_bytes_processed": 81862
                }
            ]
        }
    },
    {
        "begin_timestamp": 1749656089,
        "end_timestamp": 1749656090,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": 0,
        "datalake_usage": {
            "topics": [
                {
                    "topic_name": "iceberg_topic_0",
                    "topic_revision": 22,
                    "kafka_bytes_processed": 81862
                },
                {
                    "topic_name": "iceberg_topic_1",
                    "topic_revision": 25,
                    "kafka_bytes_processed": 0
                }
            ]
        }
    }
]
```

On a broker that is not controller leader / is controller leader but ran into an error collecting usage stats, the output would look something like this..

A field `missing_reason` is only populated if stats were not collected, otherwise `topics` array exists as seen in the above output.

```
[
    {
        "begin_timestamp": 1749656093,
        "end_timestamp": 1749656094,
        "open": true,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": -1,
        "datalake_usage": {
            "missing_reason": "not_controller_leader"
        }
    },
    {
        "begin_timestamp": 1749656092,
        "end_timestamp": 1749656093,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": -1,
        "datalake_usage": {
            "missing_reason": "not_controller_leader"
        }
    },
    {
        "begin_timestamp": 1749656091,
        "end_timestamp": 1749656092,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": -1,
        "datalake_usage": {
            "missing_reason": "not_controller_leader"
        }
    },
    {
        "begin_timestamp": 1749656090,
        "end_timestamp": 1749656091,
        "open": false,
        "kafka_bytes_sent_count": 0,
        "kafka_bytes_received_count": 0,
        "cloud_storage_bytes_gauge": -1,
        "datalake_usage": {
            "missing_reason": "not_controller_leader"
        }
    }

]
```


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
