### PR TITLE
r/tests/raft_fixture: fix raft_node_instance::random_batch_base_offset

### DIFF
--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -575,20 +575,28 @@ raft_node_instance::read_batches_in_range(
 
 ss::future<model::offset> raft_node_instance::random_batch_base_offset(
   model::offset max, std::optional<model::offset> min) {
-    model::offset read_start(random_generators::get_int<int64_t>(
-      min.value_or(_raft->start_offset()), max));
+    model::offset req_min = min.value_or(_raft->start_offset());
+    // max is exclusive, but read_batches_in_range accepts inclusive
+    model::offset req_max = model::prev_offset(max);
 
-    model::offset last = model::next_offset(read_start);
+    model::offset read_start(
+      random_generators::get_int<int64_t>(req_min, req_max));
+
+    model::offset first = read_start;
+    model::offset last = read_start;
 
     ss::circular_buffer<model::record_batch> batches;
-    while (batches.empty() && last <= _raft->dirty_offset()) {
-        vlog(
-          test_log.info, "Reading batches in range: [{},{}]", read_start, last);
-        batches = co_await read_batches_in_range(read_start, last);
-        last++;
-    }
-    if (batches.empty()) {
-        co_return model::offset{};
+    while (batches.empty()) {
+        vlog(test_log.info, "Reading batches in range: [{},{}]", first, last);
+        batches = co_await read_batches_in_range(first, last);
+        if (last < req_max) {
+            last = model::next_offset(last);
+        } else if (first > req_min) {
+            first = model::prev_offset(first);
+        } else {
+            // cannot widen the search, already requesting full interval
+            co_return model::offset{};
+        }
     }
     co_return batches.front().base_offset();
 }

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -265,6 +265,9 @@ public:
     ss::future<ss::circular_buffer<model::record_batch>>
     read_batches_in_range(model::offset min, model::offset max);
 
+    // Returns the base offset of a random record in the range [min, max)
+    // May therefore return an offset less than min, but may not return an
+    // offset greater than max. Min defaults to start_offset.
     ss::future<model::offset> random_batch_base_offset(
       model::offset max, std::optional<model::offset> min = std::nullopt);
 


### PR DESCRIPTION
Previously it would misbehave if max is in a configuration or ghost batch.
1) It expanded its search up to dirty_offset and returned a batch lying entirely above max.
2) If it nevertheless failed to find a (non-ghost non-configuration) batch it returned model::offset{} even though there could be some valid batch before where it started to search.

The workaround is to expand search towards smaller offsets if we reached the high end of the range.

This fixes `write_at_offset_stm_test`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
