### PR TITLE
Revert "raft/log_eviction_stm: avoid unnecessary wait on visible offset"

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -167,10 +167,8 @@ log_eviction_stm::do_write_raft_snapshot(model::offset truncation_point) {
     if (truncation_point <= _raft->last_snapshot_index()) {
         co_return;
     }
-    // Waiting for the snapshot at truncation_point ensures that the state
-    // machine has applied all entries up to that point. Since the state machine
-    // only applies Raft-committed entries (check state_machine_manager/apply),
-    // we can safely assume truncation_point is committed.
+    co_await _raft->visible_offset_monitor().wait(
+      truncation_point, model::no_timeout, _as);
     co_await _raft->refresh_commit_index();
     co_await _raft->log()->stm_manager()->ensure_snapshot_exists(
       truncation_point);


### PR DESCRIPTION
Reverts redpanda-data/redpanda#26314

> An stm snapshot at truncation_point guarantees truncation_point is raft committed (since only raft committed entries are applied) which also guarantees that truncation_point is raft visible.

The original PR's assumption doesn't hold when a replica boots from snapshots. In this scenario, all STMs may have snapshot offsets significantly greater than the Raft committed_offset, since snapshot offsets are loaded directly from the snapshot, while the Raft offsets are caught up via append_entries from the leader. During this gap, the assumption is violated.

## Release notes
* none