### PR TITLE
gha: expand list of shfmt-linted scripts

### DIFF
--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -4,15 +4,22 @@ on:
   push:
     branches: [dev]
     paths:
+      - '**.bash'
       - '**.sh'
       - '.github/workflows/lint-sh.yml'
+      - '.buildkite/hooks/*'
+      - 'tests/docker/ducktape-deps/*'
+      - 'tools/*'
     tags-ignore:
       - '**'
   pull_request:
     paths:
+      - '**.bash'
       - '**.sh'
-      - tests/docker/ducktape-deps/tinygo-wasi-transforms
       - '.github/workflows/lint-sh.yml'
+      - '.buildkite/hooks/*'
+      - 'tests/docker/ducktape-deps/*'
+      - 'tools/*'
 jobs:
   sh:
     name: Lint shell scripts


### PR DESCRIPTION
Avoid missing lint checks on files whose name is not suffixed with `.sh`. The list is obtained with:

```bash
find . -type f ! -name '*.sh' -exec grep -Il '^#!.*bash' {} \;
```

so only those scripts that have the shebang are included.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
