### PR TITLE
gdb: fix absl_flat_hash_map wrapper

### DIFF
--- a/tools/redpanda-gdb.py
+++ b/tools/redpanda-gdb.py
@@ -221,7 +221,6 @@ class std_unique_ptr:
         self.obj = obj
 
     def get(self):
-        # return self.obj['_M_t']['_M_t']['_M_head_impl']
         return self.obj['__ptr_']['__value_']
 
     def dereference(self):
@@ -611,7 +610,8 @@ class absl_flat_hash_map:
         return self.settings["compressed_tuple_"]["value"]
 
     def __iter__(self):
-        slot_type = lookup_type(f"{self.container_type}::slot_type").strip_typedefs()
+        slot_type = lookup_type(
+            f"{self.container_type}::slot_type").strip_typedefs()
         control = self.settings["control_"]
         slots = self.settings["slots_"].cast(slot_type.pointer())
 
@@ -620,6 +620,7 @@ class absl_flat_hash_map:
                 continue
             slot = slots[i]
             yield slot["value"]["first"], slot["value"]["second"]
+
 
 def has_enable_lw_shared_from_this(type):
     for f in type.fields():
@@ -1334,12 +1335,23 @@ class disk_log_impl:
         return readers_cache(std_unique_ptr(self.ref["_readers_cache"]).get())
 
 
+class log_housekeeping_meta:
+    log_housekeeping_meta_t = gdb.lookup_type("storage::log_housekeeping_meta")
+
+    def __init__(self, ref):
+        self.ref = ref.cast(self.log_housekeeping_meta_t.pointer())
+
+    def handle(self):
+        h = self.ref["handle"]
+        return seastar_shared_ptr(h).get()
+
+
 def find_logs(shard=None):
     storage = find_storage_api(shard)
     log_mgr = std_unique_ptr(storage["_log_mgr"]).dereference()
     for ntp, log in absl_flat_hash_map(log_mgr["_logs"]):
-        log_meta_ptr = std_unique_ptr(log)
-        impl = seastar_shared_ptr(log_meta_ptr["handle"]["_impl"]).get()
+        meta = log_housekeeping_meta(std_unique_ptr(log).get())
+        impl = meta.handle()
         yield ntp, disk_log_impl(impl)
 
 

--- a/tools/redpanda-gdb.py
+++ b/tools/redpanda-gdb.py
@@ -1148,26 +1148,25 @@ class offset_tracker:
 
     @property
     def base_offset(self):
-        return model_offset(self.ref['base_offset'])
+        return model_offset(self.ref['_base_offset'])
 
     @property
     def dirty_offset(self):
-        return model_offset(self.ref['dirty_offset'])
+        return model_offset(self.ref['_dirty_offset'])
 
     @property
     def term(self):
-        return model_offset(self.ref['term'])
+        return model_offset(self.ref['_term'])
 
     @property
     def committed_offset(self):
-        return model_offset(self.ref['committed_offset'])
+        return model_offset(self.ref['_committed_offset'])
 
     @property
     def stable_offset(self):
-        return model_offset(self.ref['stable_offset'])
+        return model_offset(self.ref['_stable_offset'])
 
     def __str__(self):
-
         return f"[base_offset: {self.base_offset}, dirty_offset: {self.dirty_offset}, term: {self.term} committed_offset: {self.committed_offset}, stable_offset: {self.stable_offset}]"
 
 
@@ -1336,6 +1335,11 @@ class disk_log_impl:
 
 
 class log_housekeeping_meta:
+    """
+    This is based on the v24.2.x implementation. When implementing decoding for
+    newer versions it is often sufficient to use a try/catch block to
+    incrementally fall back when field names and types change.
+    """
     log_housekeeping_meta_t = gdb.lookup_type("storage::log_housekeeping_meta")
 
     def __init__(self, ref):

--- a/tools/redpanda-gdb.py
+++ b/tools/redpanda-gdb.py
@@ -591,42 +591,35 @@ def absl_get_nodes(val):
 
 
 class absl_flat_hash_map:
-    signed_byte_t = gdb.lookup_type('int8_t')
-
+    """
+    This is based off of absl::lts_20230802. This can be inspected dynamically
+    by looking at the container type derived in the constructor and then we can
+    use that to dynamically select different implementations when it comes time
+    to revise this implementation for a newer version of abseil.
+    """
     def __init__(self, p):
         self.map = p
-        container_type = self.map.type.strip_typedefs()
-        self.kt = container_type.template_argument(0)
-        self.vt = container_type.template_argument(1)
-        self._begin()
+        self.container_type = self.map.type.strip_typedefs()
+        self.kt = self.container_type.template_argument(0)
+        self.vt = self.container_type.template_argument(1)
+        self.settings = self.map["settings_"]["value"]
 
     def capacity(self):
-        return self.map["capacity_"]
+        return self.settings["capacity_"]
 
     def __len__(self):
-        return self.map["size_"]
-
-    def _begin(self):
-        self.it_ctrl = self.map["settings_"]
-        self.it_slot = self.map["slots_"]
-        self._skip_empty_or_deleted()
+        return self.settings["compressed_tuple_"]["value"]
 
     def __iter__(self):
-        while self.it_ctrl != (self.map["ctrl_"] + self.map["capacity_"]):
-            value = self.it_slot["value"]
-            yield value["first"], value["second"]
-            self.it_ctrl += 1
-            self.it_slot += 1
-            self._skip_empty_or_deleted()
+        slot_type = lookup_type(f"{self.container_type}::slot_type").strip_typedefs()
+        control = self.settings["control_"]
+        slots = self.settings["slots_"].cast(slot_type.pointer())
 
-    def _skip_empty_or_deleted(self):
-        while self._ctrl_value() < -1:
-            self.it_ctrl += 1
-            self.it_slot += 1
-
-    def _ctrl_value(self):
-        return self.it_ctrl.cast(self.signed_byte_t.pointer()).dereference()
-
+        for i in range(self.capacity()):
+            if int(control[i]) < 0:
+                continue
+            slot = slots[i]
+            yield slot["value"]["first"], slot["value"]["second"]
 
 def has_enable_lw_shared_from_this(type):
     for f in type.fields():


### PR DESCRIPTION
making it further. can now print segment counts for partitions

```
{"kafka"}.{"prod_observations"}.{83} segment count 2
{"kafka"}.{"prod_observations"}.{82} segment count 2
{"kafka"}.{"prod_observations"}.{60} segment count 2
{"kafka"}.{"prod_observations_axes"}.{50} segment count 129
{"kafka"}.{"prod_observations_axes"}.{98} segment count 142
{"kafka"}.{"prod_observations"}.{17} segment count 2
{"kafka"}.{"prod_observations_sqs_redrive_dlq"}.{5} segment count 1
{"kafka"}.{"prod_postoffice_egress_dlt"}.{4} segment count 1
{"kafka"}.{"prod_observations_dlq"}.{5} segment count 2
{"kafka"}.{"prod_observations_axes"}.{43} segment count 137
{"kafka"}.{"prod_bronze_axes_dlq"}.{24} segment count 1
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
