### PR TITLE
Add gradle, go caches

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -319,13 +319,16 @@ COPY --from=kafka-tools /root/.m2 /root/.m2
 COPY --from=spark /root/.m2 /root/.m2
 
 ###################################
-# Not used by the final image, but useful for debugging.
+# Not used by the final image, but useful for debugging the cache mount contents.
 # You can invoke this like:
-# task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=debug-dl-cache --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
-FROM os_base AS debug-dl-cache
+# task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=debug-caches --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
+FROM os_base AS debug-caches
 ARG CACHE_BREAK=0
-COPY --chmod=0755 tests/docker/ducktape-deps/download-utils /
-RUN --mount=type=cache,id=dl-cache,target=/dl-cache bash -c "source /download-utils && debug_cache"
+COPY --chmod=0755 tests/docker/ducktape-deps/download-utils tests/docker/ducktape-deps/debug-cache /
+RUN --mount=type=cache,id=dl-cache,target=/dl-cache \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash -c "source /debug-cache && debug_cache"
 
 ###################################
 # Not used by the final image, but useful to clean the cache mount(s).

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -127,8 +127,8 @@ RUN /kcat && \
 FROM base AS golang
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/golang /
-RUN /golang && \
-    rm /golang
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /golang && rm /golang
 ENV PATH="${PATH}:/usr/local/go/bin"
 
 #################################
@@ -169,8 +169,8 @@ RUN /rp-storage-tool && \
 FROM golang AS sarama-examples
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/sarama-examples /
-RUN /sarama-examples && \
-    rm /sarama-examples
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /sarama-examples && rm /sarama-examples
 
 #################################
 
@@ -178,16 +178,16 @@ FROM golang AS golang-test-clients
 
 COPY --chown=0:0 --chmod=0755 tests/go /opt/redpanda-tests/go
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/golang-test-clients /
-RUN /golang-test-clients && \
-    rm /golang-test-clients
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /golang-test-clients && rm /golang-test-clients
 
 #################################
 
 FROM golang AS franz-bench
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/franz-bench /
-RUN /franz-bench && \
-    rm /franz-bench
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /franz-bench && rm /franz-bench
 
 #################################
 
@@ -202,16 +202,16 @@ RUN --mount=type=cache,id=dl-cache,target=/dl-cache /flink && \
 FROM golang AS kcl
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/kcl /
-RUN /kcl && \
-    rm /kcl
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /kcl && rm /kcl
 
 #################################
 
 FROM golang AS kgo-verifier
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/kgo-verifier /
-RUN /kgo-verifier && \
-    rm /kgo-verifier
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /kgo-verifier && rm /kgo-verifier
 
 #################################
 
@@ -227,7 +227,8 @@ FROM golang AS byoc-mock
 
 COPY --chown=0:0 --chmod=0755 tests/go/byoc-mock /opt/redpanda-tests/go/byoc-mock
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/byoc-mock /
-RUN /byoc-mock && rm /byoc-mock
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /byoc-mock && rm /byoc-mock
 
 #################################
 
@@ -235,7 +236,8 @@ FROM golang AS plugin-mock
 
 COPY --chown=0:0 --chmod=0755 tests/go/plugin-mock /opt/redpanda-tests/go/plugin-mock
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/plugin-mock /
-RUN /plugin-mock && rm /plugin-mock
+RUN --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
+    /plugin-mock && rm /plugin-mock
 
 #################################
 
@@ -334,6 +336,7 @@ RUN --mount=type=cache,id=dl-cache,target=/dl-cache \
     --mount=type=cache,target=/gradle_polaris,id=gradle-polaris \
     --mount=type=cache,target=/gradle_nessie,id=gradle-nessie \
     --mount=type=cache,target=/gradle_iceberg,id=gradle-iceberg \
+    --mount=type=cache,target=/root/go/pkg/mod,id=go-mod-cache \
     bash -c "source /debug-cache && debug_cache"
 
 ###################################

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -273,20 +273,23 @@ RUN --mount=target=/running/ocsf-server,type=tmpfs --mount=type=cache,target=/va
 
 FROM java-base AS polaris
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/polaris /
-RUN /polaris && rm /polaris
+RUN --mount=type=cache,target=/root/.gradle/caches/modules-2,id=gradle-polaris \
+    /polaris && rm /polaris
 
 #################################
 
 FROM java-base AS nessie
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/nessie /
-RUN /nessie && rm /nessie
+RUN --mount=type=cache,target=/root/.gradle/caches/modules-2,id=gradle-nessie \
+    /nessie && rm /nessie
 
 #################################
 
 FROM java-base AS iceberg-rest
 COPY --chown=0:0 tests/java/iceberg-rest-catalog /opt/redpanda-tests/java/iceberg-rest-catalog
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/iceberg-rest-catalog /
-RUN /iceberg-rest-catalog && rm /iceberg-rest-catalog
+RUN --mount=type=cache,target=/root/.gradle/caches/modules-2,id=gradle-iceberg \
+    /iceberg-rest-catalog && rm /iceberg-rest-catalog
 
 #################################
 
@@ -328,6 +331,9 @@ COPY --chmod=0755 tests/docker/ducktape-deps/download-utils tests/docker/ducktap
 RUN --mount=type=cache,id=dl-cache,target=/dl-cache \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/gradle_polaris,id=gradle-polaris \
+    --mount=type=cache,target=/gradle_nessie,id=gradle-nessie \
+    --mount=type=cache,target=/gradle_iceberg,id=gradle-iceberg \
     bash -c "source /debug-cache && debug_cache"
 
 ###################################

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -36,10 +36,10 @@ Type:           exec.cachemount
 
 This shows the "dl-cache" and "gradle" cache mounts.
 
-You can also examine the specific contents of the download cache mount using:
+You can also examine the contents and summary statistics for all cache mounts using:
 
 ```
-task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=debug-dl-cache --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
+task rp:build-test-docker-image EXTRA_BUILD_ARGS="--target=debug-caches --progress=plain --build-arg=CACHE_BREAK=$RANDOM"
 ```
 
 

--- a/tests/docker/ducktape-deps/debug-cache
+++ b/tests/docker/ducktape-deps/debug-cache
@@ -34,10 +34,13 @@ debug_cache() {
   all_caches=("$DL_CACHE_DIR" /var/cache/apt /var/lib/apt)
   local logdir=/debug-cache-logs
 
+  mkdir -p $logdir
+
   for cache_dir in "${all_caches[@]}"; do
     if [[ -d $cache_dir ]]; then
-      echo "DEBUG CACHE: contents for $cache_dir:"
-      find $cache_dir -ls
+      name=$(echo "${cache_dir#/}" | tr '/' '_')
+      echo "DEBUG CACHE: writing contents of $cache_dir to $logdir/$name.txt"
+      find $cache_dir -ls >"$logdir/$name.txt"
     else
       echo "CACHE_DIR does not exist: $cache_dir"
     fi

--- a/tests/docker/ducktape-deps/debug-cache
+++ b/tests/docker/ducktape-deps/debug-cache
@@ -31,7 +31,7 @@ dir_stats() {
 debug_cache() {
   set_vars
   local all_caches
-  all_caches=("$DL_CACHE_DIR" /var/cache/apt /var/lib/apt /gradle_polaris /gradle_nessie /gradle_iceberg)
+  all_caches=("$DL_CACHE_DIR" /var/cache/apt /var/lib/apt /gradle_polaris /gradle_nessie /gradle_iceberg /root/go/pkg/mod)
   local logdir=/debug-cache-logs
 
   mkdir -p $logdir

--- a/tests/docker/ducktape-deps/debug-cache
+++ b/tests/docker/ducktape-deps/debug-cache
@@ -31,7 +31,7 @@ dir_stats() {
 debug_cache() {
   set_vars
   local all_caches
-  all_caches=("$DL_CACHE_DIR" /var/cache/apt /var/lib/apt)
+  all_caches=("$DL_CACHE_DIR" /var/cache/apt /var/lib/apt /gradle_polaris /gradle_nessie /gradle_iceberg)
   local logdir=/debug-cache-logs
 
   mkdir -p $logdir

--- a/tests/docker/ducktape-deps/debug-cache
+++ b/tests/docker/ducktape-deps/debug-cache
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
+
+sep() {
+  echo "-------------------------------------"
+}
+
+dir_stats() {
+  local target_dir="${1:-.}" # Default to current directory if no argument is provided
+  local file_count
+  local total_size
+
+  # Check if the target directory exists
+  if [ ! -d "$target_dir" ]; then
+    echo "DEBUG_CACHE: ERROR: directory '$target_dir' not found."
+    return
+  fi
+
+  file_count=$(find "$target_dir" -type f | wc -l)
+  total_size=$(du -sh "$target_dir" | cut -f1)
+
+  sep
+  echo "Cache directory : $target_dir"
+  echo "Number of Files : $file_count"
+  echo "Total Size      : $total_size"
+}
+
+debug_cache() {
+  set_vars
+  local all_caches
+  all_caches=("$DL_CACHE_DIR" /var/cache/apt /var/lib/apt)
+  local logdir=/debug-cache-logs
+
+  for cache_dir in "${all_caches[@]}"; do
+    if [[ -d $cache_dir ]]; then
+      echo "DEBUG CACHE: contents for $cache_dir:"
+      find $cache_dir -ls
+    else
+      echo "CACHE_DIR does not exist: $cache_dir"
+    fi
+  done
+
+  for cache_dir in "${all_caches[@]}"; do
+    dir_stats "$cache_dir"
+  done
+  sep
+}

--- a/tests/docker/ducktape-deps/download-utils
+++ b/tests/docker/ducktape-deps/download-utils
@@ -61,13 +61,3 @@ download_extract() {
 download() {
   (_download "$@")
 }
-
-debug_cache() {
-  set_vars
-  echo "DEBUG DL-CACHE:"
-  if [[ -d $DL_CACHE_DIR ]]; then
-    find $DL_CACHE_DIR -ls
-  else
-    echo "DL_CACHE_DIR does not exist: $DL_CACHE_DIR"
-  fi
-}


### PR DESCRIPTION
The main thing is a --mount=type=cache for gradle and go module directories, two of the main slow download sources in the DT image.

This pull request introduces improvements to caching mechanisms in the Dockerfile used for testing, as well as debugging utilities to inspect cache contents. The changes optimize build performance by leveraging cache mounts and enhance debugging capabilities by logging all files in the cache mounts and also providing a summary of cache mount file count and size.

### Dockerfile caching improvements:
* Updated `RUN` commands across multiple stages in `tests/docker/Dockerfile` to use `--mount=type=cache` for Go module directories (`/root/go/pkg/mod`) and Gradle caches (`/root/.gradle/caches/modules-2`). This ensures that dependencies are cached efficiently, reducing build times. [[1]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL130-R131) [[2]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL172-R190) [[3]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL205-R214) [[4]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL230-R240) [[5]](diffhunk://#diff-69679cf19b9e6a7a57703807f503d32f680101ffe6862958eb60f88eace6868aL276-R294)
* Enhanced the debug target in `tests/docker/Dockerfile` to include cache mounts for Gradle, Go modules, and system directories (`/var/cache/apt`, `/var/lib/apt`). This helps in debugging cache contents more comprehensively.

### Debugging utilities:
* Added a new script `tests/docker/ducktape-deps/debug-cache` to analyze cache directories. The script provides statistics such as file count and total size for each cache and logs detailed contents to files for debugging purposes.

### Documentation updates:
* Updated `tests/docker/README.md` to reflect changes in debugging commands, replacing the old `debug-dl-cache` target with the new `debug-caches` target for inspecting all cache mounts.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
