### PR TITLE
iceberg: Set SNI hostname for REST catalog TLS connections

### DIFF
--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -192,6 +192,7 @@ rest_catalog_factory::create_catalog() {
       .server_addr = endpoint_information.address,
     };
     if (endpoint_information.needs_tls) {
+        transport_config.tls_sni_hostname = endpoint_information.address.host();
         try {
             transport_config.credentials = co_await build_tls_credentials(
               *config_);


### PR DESCRIPTION
The catalog factory is not setting TLS SNI information.

Fixes CORE-10512

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Properly set TLS SNI information for Iceberg REST catalog connections.
