### PR TITLE
k/tests: always use non 0 offset to create snapshot

### DIFF
--- a/src/v/kafka/server/tests/write_at_offset_stm_test.cc
+++ b/src/v/kafka/server/tests/write_at_offset_stm_test.cc
@@ -392,10 +392,12 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
     enable_offset_translation();
     initialize_state_machines(3).get();
-    wait_for_leader(10s).get();
+    auto leader_id = wait_for_leader(10s).get();
     auto stm = get_leader_stm();
     kafka::offset expected_offset{0};
-
+    // store the truncation point, it is the base offset of second replicated
+    // batch.
+    model::offset snapshot_offset{};
     for (int i = 0; i < 10; ++i) {
         auto batches = generate_batches(
           expected_offset,
@@ -411,13 +413,15 @@ TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
             ASSERT_FALSE(result.has_error());
             expected_offset += bsz;
         }
+        if (snapshot_offset == model::offset{}) {
+            snapshot_offset = node(leader_id).raft()->dirty_offset();
+        }
     }
 
     ASSERT_TRUE(logs_content_is_valid().get());
-    auto leader_id = wait_for_leader(10s).get();
+    leader_id = wait_for_leader(10s).get();
     auto& leader = node(leader_id);
     auto dirty_offset = leader.raft()->dirty_offset();
-    auto first_left = leader.random_batch_base_offset(dirty_offset).get();
 
     auto to_restart = random_follower_id();
     for (auto& [id, node] : nodes()) {
@@ -426,8 +430,7 @@ TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
             continue;
         }
         node->raft()
-          ->write_snapshot(
-            raft::write_snapshot_cfg(model::prev_offset(first_left), iobuf{}))
+          ->write_snapshot(raft::write_snapshot_cfg(snapshot_offset, iobuf{}))
           .get();
     }
 
@@ -435,7 +438,9 @@ TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
     auto& follower = node(*to_restart);
     // wait for recovery
     wait_for_committed_offset(dirty_offset, 10s).get();
-    ASSERT_THAT(follower.raft()->log()->offsets().start_offset, Eq(first_left));
+    ASSERT_THAT(
+      follower.raft()->log()->offsets().start_offset,
+      Eq(model::next_offset(snapshot_offset)));
     ASSERT_TRUE(logs_content_is_valid().get());
 }
 


### PR DESCRIPTION
Previously the code sometimes selected offset `0` to take the snapshot at which lead to a situation in which snapshot was not taken. That lead to a test failure as the test expects snapshot to be present. Changed the logic to snapshot at offset greater than `0`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none