### PR TITLE
http: Set TCP keepalive

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/util/defer.hh>
 
@@ -43,6 +44,10 @@
 #include <stdexcept>
 
 namespace http {
+
+constexpr std::chrono::seconds tcp_keepalive_idle = 360s;
+constexpr std::chrono::seconds tcp_keepalive_interval = 120s;
+constexpr unsigned int tcp_keepalive_probes = 10;
 
 std::string_view content_type_string(content_type type) {
     switch (type) {
@@ -141,7 +146,7 @@ ss::future<client::request_response_t> client::make_request(
         }
     }
     return get_connected(timeout, ctxlog)
-      .then([req, res, target, ctxlog](reconnect_result_t r) {
+      .then([this, req, res, target, ctxlog](reconnect_result_t r) {
           if (r == reconnect_result_t::timed_out) {
               vlog(
                 ctxlog.warn,
@@ -150,6 +155,14 @@ ss::future<client::request_response_t> client::make_request(
               ss::timed_out_error err;
               return ss::make_exception_future<client::request_response_t>(err);
           }
+          // Set keepalive after connection is established and we have a
+          // connected socket.
+          set_keepalive_parameters(ss::net::tcp_keepalive_params{
+            .idle = tcp_keepalive_idle,
+            .interval = tcp_keepalive_interval,
+            .count = tcp_keepalive_probes,
+          });
+          set_keepalive(true);
           return ss::make_ready_future<request_response_t>(
             std::make_tuple(req, res));
       })

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -80,6 +80,13 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
     co_return;
 }
 
+void base_transport::set_keepalive_parameters(
+  const ss::net::keepalive_params& params) {
+    if (_fd) {
+        _fd->set_keepalive_parameters(params);
+    }
+}
+
 ss::future<>
 base_transport::connect(clock_type::time_point connection_timeout) {
     // in order to hold concurrency correctness invariants we must guarantee 3

--- a/src/v/net/transport.cc
+++ b/src/v/net/transport.cc
@@ -87,6 +87,12 @@ void base_transport::set_keepalive_parameters(
     }
 }
 
+void base_transport::set_keepalive(bool keepalive) {
+    if (_fd) {
+        _fd->set_keepalive(keepalive);
+    }
+}
+
 ss::future<>
 base_transport::connect(clock_type::time_point connection_timeout) {
     // in order to hold concurrency correctness invariants we must guarantee 3

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -79,6 +79,8 @@ public:
     void shutdown() noexcept;
     ss::future<> wait_input_shutdown();
 
+    void set_keepalive_parameters(const ss::net::keepalive_params& params);
+
     [[gnu::always_inline]] bool is_valid() const {
         return _fd && !_shutdown && !_in.eof();
     }

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -80,6 +80,7 @@ public:
     ss::future<> wait_input_shutdown();
 
     void set_keepalive_parameters(const ss::net::keepalive_params& params);
+    void set_keepalive(bool);
 
     [[gnu::always_inline]] bool is_valid() const {
         return _fd && !_shutdown && !_in.eof();


### PR DESCRIPTION
Set keepalive on HTTP sockets.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Enable TCP keepalive for cloud storage connections.