### PR TITLE
Reliably end txes on migrations

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -397,9 +397,10 @@ public:
     bool started() const noexcept { return _started; }
     void mark_started() noexcept { _started = true; }
 
-private:
+    // Acquire a shared lock for producing to the partition.
     ss::future<result<ssx::rwlock_unit>> hold_writes_enabled();
 
+private:
     ss::future<>
     replicate_unsafe_reset(cloud_storage::partition_manifest manifest);
 

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -211,54 +211,60 @@ ss::future<begin_tx_reply> rm_partition_frontend::do_begin_tx(
   std::chrono::milliseconds transaction_timeout_ms,
   model::partition_id tm) {
     if (!is_leader_of(ntp)) {
-        return ss::make_ready_future<begin_tx_reply>(
-          begin_tx_reply{ntp, tx::errc::leader_not_found});
+        return ssx::now(
+          begin_tx_reply{std::move(ntp), tx::errc::leader_not_found});
     }
 
     auto shard = _shard_table.local().shard_for(ntp);
-
     if (!shard) {
-        return ss::make_ready_future<begin_tx_reply>(
-          begin_tx_reply{ntp, tx::errc::shard_not_found});
+        return ssx::now(
+          begin_tx_reply{std::move(ntp), tx::errc::shard_not_found});
     }
 
     return _partition_manager.invoke_on(
       *shard,
       _ssg,
-      [ntp, pid, tx_seq, transaction_timeout_ms, tm, this](
+      [ntp = std::move(ntp), pid, tx_seq, transaction_timeout_ms, tm, this](
         cluster::partition_manager& mgr) mutable {
-          auto partition = mgr.get(ntp);
-          if (!partition) {
-              return ss::make_ready_future<begin_tx_reply>(
-                begin_tx_reply{ntp, tx::errc::partition_not_found});
-          }
-
-          auto stm = partition->rm_stm();
-
-          if (!stm) {
-              vlog(txlog.warn, "partition {} doesn't have rm_stm", ntp);
-              return ss::make_ready_future<begin_tx_reply>(
-                begin_tx_reply{ntp, tx::errc::stm_not_found});
-          }
-
-          auto topic_md = _metadata_cache.local().get_topic_metadata(
-            model::topic_namespace_view(ntp));
-          if (!topic_md) {
-              return ss::make_ready_future<begin_tx_reply>(
-                begin_tx_reply{ntp, tx::errc::partition_not_exists});
-          }
-          auto topic_revision = topic_md->get_revision();
-
-          return stm->begin_tx(pid, tx_seq, transaction_timeout_ms, tm)
-            .then(
-              [ntp, topic_revision](checked<model::term_id, tx::errc> etag) {
-                  if (!etag.has_value()) {
-                      return begin_tx_reply{ntp, etag.error()};
-                  }
-                  return begin_tx_reply{
-                    ntp, etag.value(), tx::errc::none, topic_revision};
-              });
+          return do_begin_tx_on_partition_shard(
+            std::move(ntp), pid, tx_seq, transaction_timeout_ms, tm, mgr);
       });
+}
+
+ss::future<begin_tx_reply>
+rm_partition_frontend::do_begin_tx_on_partition_shard(
+  model::ntp ntp,
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  std::chrono::milliseconds transaction_timeout_ms,
+  model::partition_id tm,
+  cluster::partition_manager& mgr) {
+    auto partition = mgr.get(ntp);
+    if (!partition) {
+        co_return begin_tx_reply{std::move(ntp), tx::errc::partition_not_found};
+    }
+
+
+    auto stm = partition->rm_stm();
+    if (!stm) {
+        vlog(txlog.warn, "partition {} doesn't have rm_stm", ntp);
+        co_return begin_tx_reply{std::move(ntp), tx::errc::stm_not_found};
+    }
+
+    auto topic_md = _metadata_cache.local().get_topic_metadata(
+      model::topic_namespace_view(ntp));
+    if (!topic_md) {
+        co_return begin_tx_reply{
+          std::move(ntp), tx::errc::partition_not_exists};
+    }
+    auto topic_revision = topic_md->get_revision();
+
+    auto etag = co_await stm->begin_tx(pid, tx_seq, transaction_timeout_ms, tm);
+    if (!etag.has_value()) {
+        co_return begin_tx_reply{std::move(ntp), etag.error()};
+    }
+    co_return begin_tx_reply{
+      std::move(ntp), etag.value(), tx::errc::none, topic_revision};
 }
 
 ss::future<commit_tx_reply> rm_partition_frontend::commit_tx(

--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -244,6 +244,16 @@ rm_partition_frontend::do_begin_tx_on_partition_shard(
         co_return begin_tx_reply{std::move(ntp), tx::errc::partition_not_found};
     }
 
+    auto maybe_partition_units = co_await partition->hold_writes_enabled();
+    if (!maybe_partition_units.has_value()) {
+        vlog(
+          txlog.warn,
+          "partition {} is not writable, errc: {}",
+          ntp,
+          maybe_partition_units.error());
+        co_return begin_tx_reply{
+          std::move(ntp), tx::errc::partition_writes_locked};
+    }
 
     auto stm = partition->rm_stm();
     if (!stm) {

--- a/src/v/cluster/rm_partition_frontend.h
+++ b/src/v/cluster/rm_partition_frontend.h
@@ -90,6 +90,13 @@ private:
       model::tx_seq,
       std::chrono::milliseconds,
       model::partition_id);
+    ss::future<begin_tx_reply> do_begin_tx_on_partition_shard(
+      model::ntp ntp,
+      model::producer_identity pid,
+      model::tx_seq tx_seq,
+      std::chrono::milliseconds transaction_timeout_ms,
+      model::partition_id tm,
+      cluster::partition_manager& mgr);
     ss::future<commit_tx_reply> dispatch_commit_tx(
       model::node_id,
       model::ntp,

--- a/src/v/cluster/tx_errc.cc
+++ b/src/v/cluster/tx_errc.cc
@@ -74,6 +74,8 @@ std::ostream& operator<<(std::ostream& o, errc err) {
         return o << "tx::errc::invalid_timeout";
     case errc::producer_creation_error:
         return o << "tx::errc::producer_creation_error";
+    case errc::partition_writes_locked:
+        return o << "tx::errc::partition_writes_locked";
     }
     return o;
 }

--- a/src/v/cluster/tx_errc.h
+++ b/src/v/cluster/tx_errc.h
@@ -53,7 +53,8 @@ enum class errc {
     // internal error when the state machine cannot create a working producer.
     // used in cases when the cache is full which does not permit new producers
     // or the producer has been evicted but has not yet been removed.
-    producer_creation_error
+    producer_creation_error,
+    partition_writes_locked
 };
 
 std::ostream& operator<<(std::ostream& o, errc err);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1454,10 +1454,19 @@ ss::future<add_partitions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
         add_partitions_tx_reply::partition_result res_partition;
         res_partition.partition_index = reply.ntp.tp.partition;
         res_partition.error_code = reply.ec;
+
+        auto level_for = [](tx::errc ec) {
+            if (ec == tx::errc::none) {
+                return ss::log_level::trace;
+            }
+            if (ec == tx::errc::partition_writes_locked) {
+                return ss::log_level::warn;
+            }
+            return ss::log_level::error;
+        };
         vlogl(
           txlog,
-          reply.ec == tx::errc::none ? ss::log_level::trace
-                                     : ss::log_level::error,
+          level_for(reply.ec),
           "[tx_id={}] begin_tx request for pid: {} at ntp: {} result: {}",
           request.transactional_id,
           pid,

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -168,6 +168,9 @@ constexpr error_code map_tx_errc(cluster::tx::errc ec) {
         return error_code::unknown_server_error;
     case cluster::tx::errc::invalid_timeout:
         return error_code::invalid_transaction_timeout;
+    // should be consistent with cluster::errc::resource_is_being_migrated
+    case cluster::tx::errc::partition_writes_locked:
+        return error_code::policy_violation;
     }
 }
 

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -885,8 +885,7 @@ admin_server::get_producers_state_handler(
     auto result = co_await _tx_gateway_frontend.local().get_producers(
       cluster::get_producers_request{ntp, timeout, limit});
     if (result.error_code != cluster::tx::errc::none) {
-        throw ss::httpd::server_error_exception(fmt::format(
-          "Error {} getting producers for ntp: {}", result.error_code, ntp));
+        co_await throw_on_error(*req, result.error_code, ntp);
     }
     vlog(
       adminlog.debug,

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -828,6 +828,49 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
         self.cancel(migration_id, topic_name)
         self.assert_no_topics()
 
+    @bg_thread_cm
+    def transaction_producer_thread(self, topic: str):
+        producer = self.get_ck_producer(use_transactional=True)
+        producer.init_transactions()
+        while (yield):
+            try:
+                producer.begin_transaction()
+                producer.produce(topic, key="key1", value="value1")
+                producer.commit_transaction()
+            except Exception as e:
+                self.logger.info(f"error producing with a transaction: {e}")
+
+    def ensure_no_inflight_transactions(self, topic_name, partition):
+        producers = self.admin.get_producers_state(namespace="kafka",
+                                                   topic=topic_name,
+                                                   partition=partition)
+        self.redpanda.logger.debug(f"{producers=}")
+        for producer in producers.get('producers', []):
+            assert 'transaction_begin_offset' not in producer, \
+                "unexpected transaction in progress"
+
+    @cluster(num_nodes=3, log_allow_list=MIGRATION_LOG_ALLOW_LIST)
+    @matrix(transfer_leadership=[True])
+    def test_transactions(self, transfer_leadership: bool):
+        workload_topic = TopicSpec(partition_count=1)
+        self.client().create_topic(workload_topic)
+        tl_topic_name = workload_topic.name if transfer_leadership else None
+        with self.tl_thread(tl_topic_name):
+            with self.transaction_producer_thread(workload_topic.name):
+                out_migration = OutboundDataMigration(
+                    topics=[make_namespaced_topic(workload_topic.name)],
+                    consumer_groups=[])
+                out_migration_id = self.create_and_wait(out_migration)
+
+                self.admin.execute_data_migration_action(
+                    out_migration_id, MigrationAction.prepare)
+                self.wait_for_migration_states(out_migration_id, ['prepared'])
+                self.admin.execute_data_migration_action(
+                    out_migration_id, MigrationAction.execute)
+                self.wait_for_migration_states(out_migration_id, ['executed'])
+
+                self.ensure_no_inflight_transactions(workload_topic.name, 0)
+
     @cluster(
         num_nodes=4,
         log_allow_list=MIGRATION_LOG_ALLOW_LIST + [

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0
 
 import random
-import threading
 import time
 from enum import Enum
 from typing import Callable, Literal, List, TypedDict, get_type_hints
@@ -31,6 +30,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.tests.e2e_finjector import Finjector
 from rptest.clients.rpk import RpkTool, RpkException
+from rptest.util import bg_thread_cm
 from rptest.utils.data_migrations import DataMigrationTestMixin
 import requests
 import re
@@ -48,39 +48,23 @@ def now():
     return int(time.time() * 1000)
 
 
-class TransferLeadersBackgroundThread:
-    def __init__(self, redpanda: RedpandaServiceBase, topic: str):
-        self.redpanda = redpanda
-        self.logger = redpanda.logger
-        self.stop_ev = threading.Event()
-        self.topic = topic
-        self.admin = Admin(self.redpanda, retry_codes=[503, 504])
-        self.thread = threading.Thread(target=lambda: self._loop())
-        self.thread.daemon = True
-
-    def __enter__(self):
-        self.thread.start()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.stop_ev.set()
-
-    def _loop(self):
-        while not self.stop_ev.is_set():
-            p_id = None
-            try:
-                partitions = self.admin.get_partitions(namespace="kafka",
-                                                       topic=self.topic)
-                partition = random.choice(partitions)
-                p_id = partition['partition_id']
-                self.logger.info(
-                    f"Transferring leadership of {self.topic}/{p_id}")
-                self.admin.partition_transfer_leadership(namespace="kafka",
-                                                         topic=self.topic,
-                                                         partition=p_id)
-            except Exception as e:
-                self.logger.info(
-                    f"error transferring leadership of {self.topic}/{p_id} - {e}"
-                )
+@bg_thread_cm
+def TransferLeadersBackgroundThread(redpanda: RedpandaServiceBase, topic: str):
+    logger = redpanda.logger
+    admin = Admin(redpanda, retry_codes=[503, 504])
+    while (yield):
+        p_id = None
+        try:
+            partitions = admin.get_partitions(namespace="kafka", topic=topic)
+            partition = random.choice(partitions)
+            p_id = partition['partition_id']
+            logger.info(f"Transferring leadership of {topic}/{p_id}")
+            admin.partition_transfer_leadership(namespace="kafka",
+                                                topic=topic,
+                                                partition=p_id)
+        except Exception as e:
+            logger.info(
+                f"error transferring leadership of {topic}/{p_id} - {e}")
 
 
 class CancellationStage(TypedDict):

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -9,8 +9,9 @@
 
 import os
 import pprint
+import threading
 from contextlib import contextmanager
-from typing import Callable, Optional, Any
+from typing import Callable, Optional, Any, ContextManager
 
 from ducktape.utils.util import wait_until
 from requests.exceptions import HTTPError
@@ -488,3 +489,49 @@ def ssh_output_stderr(source_service,
     source_service.logger.debug(
         f"Returning ssh command output:\n{stdoutdata}\n")
     return stdoutdata, stderrdata
+
+
+def bg_thread_cm(func) -> Callable[..., ContextManager]:
+    """
+    Decorator for a context manager repeating an action in a background thread
+
+    Usage:
+    @bg_thread_cm
+    def some_action_repeater(parameters_if_needed):  # can be a method too
+        # Some preparations if needed
+        while (yield):
+            try:
+                # Some action we'd like to repeat
+            catch Exception as e:
+                # Handle exception, typically just log it.
+                # If we (re-)throw an exception, the background thread stops
+        # Some cleanup if needed
+
+    with some_action_repeater():
+        # do some checks while the background thread repeats the action
+    """
+    def ctx(*args, **kwargs):
+        stop_ev = threading.Event()
+
+        def loop():
+            gen = func(*args, **kwargs)
+            gen.send(None)  # prime the generator
+            while not stop_ev.is_set():
+                gen.send(True)  # tell gen loop to carry on
+            try:
+                gen.send(False)  # tell gen loop to stop
+            except StopIteration:
+                pass  # expected, gen loop stopped cleanly
+            else:
+                assert False, "Background thread function did not stop cleanly"
+
+        thread = threading.Thread(target=loop)
+        thread.daemon = True
+        thread.start()
+        try:
+            yield
+        finally:
+            stop_ev.set()
+            thread.join()
+
+    return contextmanager(ctx)


### PR DESCRIPTION
Outbound migration execution expires existing transactions on migrated topics but does not prevent creating more of them. This is to disallow new transactions while and after a partition writes are getting blocked.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
