### PR TITLE
utils: Tracing using the retry-chain-node

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -740,6 +740,7 @@ redpanda_cc_library(
         "//src/v/utils:available_promise",
         "//src/v/utils:directory_walker",
         "//src/v/utils:exceptions",
+        "//src/v/utils:execution_monitor",
         "//src/v/utils:expiring_promise",
         "//src/v/utils:file_io",
         "//src/v/utils:fixed_string",

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -396,6 +396,9 @@ void ntp_archiver::log_collected_traces() noexcept {
             _rtclog.error("Diagnostic dump start");
 
             _rtclog.info("[repeat] start");
+            if (_rtctx.truncation_warning()) {
+                _rtclog.info("[truncated]");
+            }
             for (const auto& trace : _rtctx.traces()) {
                 _rtclog.info("[repeat] {}", trace);
             }

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -40,6 +40,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "model/timeout_clock.h"
 #include "net/connection.h"
 #include "raft/fundamental.h"
 #include "ssx/checkpoint_mutex.h"
@@ -48,13 +49,16 @@
 #include "storage/fs_utils.h"
 #include "storage/ntp_config.h"
 #include "storage/parser.h"
+#include "utils/execution_monitor.h"
 #include "utils/human.h"
 #include "utils/lazy_abort_source.h"
+#include "utils/prefix_logger.h"
 #include "utils/retry_chain_node.h"
 #include "utils/stream_provider.h"
 #include "utils/stream_utils.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
@@ -81,7 +85,9 @@
 
 namespace {
 constexpr auto housekeeping_jit = 5ms;
-}
+constexpr size_t max_bytes_rtc_node = 0x1000;
+constexpr auto liveness_check_interval = 900s;
+} // namespace
 
 namespace archival {
 
@@ -336,7 +342,8 @@ ntp_archiver::ntp_archiver(
   , _parent(parent)
   , _policy(_ntp, conf->time_limit)
   , _gate()
-  , _rtcnode(_as)
+  , _rtctx("ntp_archiver", _as, max_bytes_rtc_node)
+  , _rtcnode(_rtctx)
   , _rtclog(archival_log, _rtcnode, _ntp.path())
   , _conf(conf)
   , _sync_manifest_timeout(
@@ -360,8 +367,9 @@ ntp_archiver::ntp_archiver(
   , _manifest_view(std::move(amv))
   , _initial_backoff(config::shard_local_cfg()
                        .cloud_storage_upload_loop_initial_backoff_ms.bind())
-  , _max_backoff(config::shard_local_cfg()
-                   .cloud_storage_upload_loop_max_backoff_ms.bind()) {
+  , _max_backoff(
+      config::shard_local_cfg().cloud_storage_upload_loop_max_backoff_ms.bind())
+  , _execution_monitor("ntp_archiver", liveness_check_interval) {
     _housekeeping_interval.watch([this] {
         _housekeeping_jitter = simple_time_jitter<ss::lowres_clock>{
           _housekeeping_interval(), housekeeping_jit};
@@ -379,6 +387,87 @@ ntp_archiver::ntp_archiver(
     // Override bucket for read-replica
     if (_parent.is_read_replica_mode_enabled()) {
         _bucket_override = _parent.get_read_replica_bucket();
+    }
+}
+
+void ntp_archiver::log_collected_traces() noexcept {
+    try {
+        _rtclog.bypass_tracing([this] {
+            _rtclog.error("Diagnostic dump start");
+
+            _rtclog.info("[repeat] start");
+            for (const auto& trace : _rtctx.traces()) {
+                _rtclog.info("[repeat] {}", trace);
+            }
+            _rtclog.info("[repeat] end");
+
+            // Log timestamps of operations
+            _rtclog.info(
+              "last manifest upload time: {}, last_segment_upload_time: {}, "
+              "last_marked_clean_time: {}, last_upload_time: {}, "
+              "last_sync_time: "
+              "{}",
+              _last_manifest_upload_time.time_since_epoch(),
+              _last_segment_upload_time.time_since_epoch(),
+              _last_marked_clean_time.time_since_epoch(),
+              _last_upload_time.time_since_epoch(),
+              _last_sync_time.has_value() ? _last_sync_time->time_since_epoch()
+                                          : ss::lowres_clock::duration{});
+
+            // Log mutexes
+            auto mutex_cp = _mutex.get_blocking_checkpoint();
+            if (mutex_cp) {
+                auto delta = std::chrono::steady_clock::now()
+                             - mutex_cp.value().time;
+                _rtclog.info(
+                  "mutex units: {}, {}ms",
+                  mutex_cp.value().line,
+                  std::chrono::duration_cast<std::chrono::milliseconds>(delta));
+            }
+            auto uploads_active_cp = _uploads_active.get_blocking_checkpoint();
+            if (uploads_active_cp) {
+                auto delta = std::chrono::steady_clock::now()
+                             - uploads_active_cp.value().time;
+                _rtclog.info(
+                  "uploads_active units: {}, {}ms",
+                  uploads_active_cp.value().line,
+                  std::chrono::duration_cast<std::chrono::milliseconds>(delta));
+            }
+
+            // Log raft state
+            _rtclog.info(
+              "raft term: {}, is_leader: {}, offsets: {}",
+              _parent.term(),
+              _parent.is_leader(),
+              _parent.raft()->log()->offsets());
+
+            // Log manifest state
+            _rtclog.info(
+              "manifest, last uploaded offset {}, last uploaded compacted "
+              "offset "
+              "{}, applied offset {}, insync offset {}, last scrubbed offset "
+              "{}, "
+              "archive start offset {}, archive start delta {}, archive clean "
+              "offset "
+              "{}, last segment {}",
+              manifest().get_last_offset(),
+              manifest().get_last_uploaded_compacted_offset(),
+              manifest().get_applied_offset(),
+              manifest().get_insync_offset(),
+              manifest().last_scrubbed_offset().value_or(model::offset()),
+              manifest().get_archive_start_offset(),
+              manifest().get_archive_start_offset_delta(),
+              manifest().get_archive_clean_offset(),
+              manifest().empty()
+                ? "N/A"
+                : ssx::sformat("{}", manifest().last_segment()));
+            _rtclog.info("Diagnostic dump end");
+        });
+    } catch (...) {
+        vlog(
+          _rtclog.error,
+          "Failed to log diagnostic information: {}",
+          std::current_exception());
     }
 }
 
@@ -418,6 +507,28 @@ ss::future<> ntp_archiver::start() {
         });
     }
 
+    ssx::execution_monitor::stall_detector_config sdc{
+      .cb =
+        [this](const retry_chain_context&) {
+            vlog(
+              _rtclog.error, "stall detected, logging diagnostic information");
+            log_collected_traces();
+        },
+      .contexts = {&_rtctx}};
+
+    ssx::execution_monitor::unexpected_shutdown_detector_config udc{
+      .cb =
+        [this] {
+            vlog(
+              _rtclog.error,
+              "unexpected shutdown detected, logging diagnostic information");
+            log_collected_traces();
+        },
+      .gate = &_gate,
+    };
+
+    _execution_monitor.start(sdc, udc);
+
     co_return;
 }
 
@@ -451,7 +562,12 @@ ss::future<> ntp_archiver::upload_until_abort() {
             try {
                 vlog(
                   _rtclog.debug, "upload loop waiting for leadership/unpause");
-                co_await _leader_cond.wait();
+                constexpr auto leader_cond_timeout = 30s;
+                _rtctx.suspend_to(
+                  ss::lowres_clock::now() + leader_cond_timeout + 1s);
+                co_await _leader_cond.wait(leader_cond_timeout);
+            } catch (const ss::condition_variable_timed_out&) {
+                continue;
             } catch (const ss::broken_condition_variable&) {
                 // stop() was called
                 shutdown = true;
@@ -631,7 +747,12 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
                 vlog(
                   _rtclog.debug,
                   "sync manifest loop waiting for leadership/unpause");
-                co_await _leader_cond.wait();
+                constexpr auto leader_cond_timeout = 30s;
+                _rtctx.suspend_to(
+                  ss::lowres_clock::now() + leader_cond_timeout + 1s);
+                co_await _leader_cond.wait(leader_cond_timeout);
+            } catch (const ss::condition_variable_timed_out&) {
+                continue;
             } catch (const ss::broken_condition_variable&) {
                 shutdown = true;
             }
@@ -669,6 +790,7 @@ ss::future<> ntp_archiver::sync_manifest_until_abort() {
               "restart.",
               e);
         } catch (...) {
+            log_collected_traces();
             vlog(
               _rtclog.error,
               "sync manifest loop error: {}",
@@ -871,6 +993,8 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
     }
 
     while (may_begin_uploads()) {
+        // Reset trace logging in the beginning of the upload round
+        _rtctx.reset();
         // Hold sempahore units to enable other code to know that we are in
         // the process of doing uploads + wait for us to drop out if they
         // e.g. set _paused.
@@ -1005,8 +1129,15 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
             // grow very large disabling the archival storage
             vlog(
               _rtclog.trace, "Nothing to upload, applying backoff algorithm");
-            co_await _wakeup_event.wait(
-              backoff + _backoff_jitter.next_jitter_duration());
+            auto timeout = backoff + _backoff_jitter.next_jitter_duration();
+            // Reset the context before sleeping to avoid holding to the memory.
+            // Most of the time the archiver spends in the following 'wait'
+            // call. It's not possible for it to get stalled there so it's safe
+            // to reset the context here. This guarantees that we only consuming
+            // additional memory for traces for the duration of the upload.
+            _rtctx.reset();
+            _rtctx.suspend_to(ss::lowres_clock::now() + timeout + 1s);
+            co_await _wakeup_event.wait(timeout);
             backoff = std::min(backoff * 2, _conf->upload_loop_max_backoff());
         } else {
             backoff = _conf->upload_loop_initial_backoff();
@@ -1022,6 +1153,8 @@ struct segment_size_limits {
 
 ss::future<> ntp_archiver::sync_manifest_until_term_change() {
     while (can_update_archival_metadata()) {
+        _rtctx.reset();
+
         if (!_feature_table.local().is_active(
               features::feature::cloud_storage_manifest_format_v2)) {
             vlog(
@@ -1055,6 +1188,8 @@ ss::future<> ntp_archiver::sync_manifest_until_term_change() {
               "Successfuly downloaded manifest {}",
               manifest().get_manifest_path(remote_path_provider()));
         }
+        _rtctx.suspend_to(
+          ss::lowres_clock::now() + _sync_manifest_timeout() + 1s);
         co_await ss::sleep_abortable(_sync_manifest_timeout(), _as);
     }
 }
@@ -1139,6 +1274,8 @@ ss::future<> ntp_archiver::stop() {
         }
         co_await _scrubber->stop();
     }
+
+    _execution_monitor.stop();
 
     _as.request_abort();
     _uploads_active.broken();

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -29,6 +29,7 @@
 #include "ssx/checkpoint_mutex.h"
 #include "ssx/event.h"
 #include "storage/fwd.h"
+#include "utils/execution_monitor.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
@@ -377,6 +378,8 @@ public:
     /// Return reference to partition manifest from archival STM
     const cloud_storage::partition_manifest& manifest() const;
 
+    void log_collected_traces() noexcept;
+
     /// Get segment size for the partition
     size_t get_local_segment_size() const;
 
@@ -695,6 +698,7 @@ private:
     std::optional<cloud_storage_clients::bucket_name> _bucket_override;
     ss::gate _gate;
     ss::abort_source _as;
+    retry_chain_context _rtctx;
     retry_chain_node _rtcnode;
     retry_chain_logger _rtclog;
 
@@ -789,6 +793,8 @@ private:
 
     config::binding<std::chrono::milliseconds> _initial_backoff;
     config::binding<std::chrono::milliseconds> _max_backoff;
+
+    ssx::execution_monitor _execution_monitor;
 
     friend class archiver_fixture;
 };

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -720,3 +720,17 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "execution_monitor",
+    hdrs = [
+        "execution_monitor.h",
+    ],
+    include_prefix = "utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/execution_monitor.h
+++ b/src/v/utils/execution_monitor.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/vassert.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/timer.hh>
+
+#include <cstdint>
+#include <optional>
+
+namespace ssx {
+
+template<typename Clock = seastar::lowres_clock>
+using execution_monitor_stall_callback
+  = std::function<void(basic_retry_chain_context<Clock>&)>;
+
+using execution_monitor_unexpected_shutdown_callback = std::function<void()>;
+
+/// The execution monitor detects stalls in a process's execution.
+/// It monitors a collection of `retry_chain_context` instances,
+/// each with a deadline that should not be reached under normal conditions.
+/// A stall is detected if all monitored contexts reach their deadlines.
+template<typename Clock = seastar::lowres_clock>
+class basic_execution_monitor {
+public:
+    using time_point = typename Clock::time_point;
+    using duration = typename Clock::duration;
+
+    /// Create a new execution monitor with a specified stall timeout.
+    basic_execution_monitor(
+      seastar::sstring name, duration stall_timeout) noexcept
+      : _name(std::move(name))
+      , _stall_timeout(stall_timeout) {}
+
+    basic_execution_monitor(const basic_execution_monitor&) = delete;
+    basic_execution_monitor(basic_execution_monitor&&) = delete;
+    basic_execution_monitor& operator=(const basic_execution_monitor&) = delete;
+    basic_execution_monitor& operator=(basic_execution_monitor&&) = delete;
+
+    /// Configuration structure for the stall detector.
+    /// It is used to pass a set of monitored contexts and a callback.
+    struct stall_detector_config {
+        /// The callback which is invoked when the stall is detected
+        execution_monitor_stall_callback<Clock> cb;
+        /// List of contexts to monitor for stalls
+        std::vector<retry_chain_context*> contexts;
+    };
+
+    /// Configuration structure for the shutdown detector.
+    struct unexpected_shutdown_detector_config {
+        /// The callback which is invoked when the unexpected shutdown is
+        /// detected
+        execution_monitor_unexpected_shutdown_callback cb;
+        /// The callback is invoked when the gate doesn't have any holders
+        seastar::gate* gate{nullptr};
+    };
+
+    /// Start the execution monitor with the given configs.
+    /// The algorithm of the execution monitor is as follows:
+    /// 1. The monitor is started with a timer that checks the contexts
+    ///    periodically (every stall_timeout).
+    /// 2. Each context can be checkpointed, which updates the last check time.
+    /// 3. The stall is detected if the last check time of all contexts
+    ///    is older than the stall timeout.
+    /// 4. The unexpected shutdown is detected if the gate count is zero
+    ///    and the shutdown is not announced.
+    void start(
+      std::optional<stall_detector_config> stall_cfg,
+      std::optional<unexpected_shutdown_detector_config> exit_cfg) {
+        if (!exit_cfg.has_value() && !stall_cfg.has_value()) {
+            return;
+        }
+        vassert(!_timer.armed(), "Execution monitor already started");
+        _timer.set_callback([this,
+                             stall_cfg = std::move(stall_cfg),
+                             exit_cfg = std::move(exit_cfg)]() mutable {
+            // Check all contexts for stalls. At least one context
+            // should have the access time within the stall timeout.
+            if (stall_cfg.has_value()) {
+                bool has_stall = true;
+                basic_retry_chain_context<Clock>* last_ctx = nullptr;
+                for (auto* ctx : stall_cfg.value().contexts) {
+                    auto deadline = ctx->get_deadline(_stall_timeout);
+                    if (deadline > Clock::now()) {
+                        // If at least one context has been checked
+                        // within the stall timeout, we don't have a stall.
+                        // No need to check the rest of them.
+                        has_stall = false;
+                        break;
+                    }
+                    if (last_ctx != nullptr) {
+                        // Save the last callsite
+                        if (
+                          ctx->get_last_trace_time()
+                          > last_ctx->get_last_trace_time()) {
+                            last_ctx = ctx;
+                        }
+                    } else {
+                        last_ctx = ctx;
+                    }
+                }
+                if (has_stall && last_ctx != nullptr) {
+                    stall_cfg.value().cb(*last_ctx);
+                }
+            }
+            // The inverse logic is used for shutdown callsites.
+            if (
+              exit_cfg.has_value() && !_expect_shutdown
+              && exit_cfg.value().gate->get_count() == 0) {
+                exit_cfg.value().cb();
+            }
+        });
+        _timer.arm_periodic(_stall_timeout);
+    }
+
+    void stop() {
+        expect_shutdown();
+        _timer.cancel();
+    }
+
+    void expect_shutdown() { _expect_shutdown = true; }
+
+private:
+    seastar::sstring _name;
+    duration _stall_timeout;
+    bool _expect_shutdown{false};
+    seastar::timer<Clock> _timer;
+};
+
+using execution_monitor = basic_execution_monitor<>;
+
+} // namespace ssx

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -33,6 +33,153 @@ thread_local static uint32_t fiber_count = 0;
 static constexpr size_t max_retry_chain_depth = 8;
 static constexpr uint16_t max_retry_count = std::numeric_limits<uint16_t>::max()
                                             - 1;
+namespace detail {
+rtc_circular_buffer::rtc_circular_buffer(size_t capacity)
+  : _data()
+  , _capacity(capacity) {}
+
+void rtc_circular_buffer::push_back(char value) {
+    if (_size < _capacity) {
+        _data.push_back(value);
+        ++_size;
+    } else {
+        _data[_start] = value;
+        _start = (_start + 1) % _capacity;
+    }
+    _total_added++;
+}
+
+void rtc_circular_buffer::push_back(std::string_view sv) {
+    if (sv.empty()) {
+        return;
+    }
+
+    if (sv.size() >= _capacity) {
+        // String is larger than or equal to capacity, only keep the last
+        // part
+        auto offset = sv.size() - _capacity;
+        _data.assign(sv.begin() + offset, sv.end());
+        _size = _capacity;
+        _start = 0;
+        _total_added += sv.size();
+        return;
+    }
+
+    // String fits within capacity
+    size_t bytes_to_copy = sv.size();
+
+    if (_size < _capacity) {
+        // Buffer not full, append normally
+        size_t space_available = _capacity - _size;
+        size_t n = std::min(space_available, bytes_to_copy);
+        std::copy(
+          sv.begin(), std::next(sv.begin(), n), std::back_inserter(_data));
+        std::copy(std::next(sv.begin(), n), sv.end(), _data.begin());
+        _size += n;
+        _start = (bytes_to_copy - n) % _capacity;
+    } else {
+        // Buffer is full, overwrite using circular logic
+        size_t space_to_end = _capacity - _start;
+        if (bytes_to_copy <= space_to_end) {
+            // Case one: enough space from _start to end of buffer
+            std::memcpy(_data.data() + _start, sv.data(), bytes_to_copy);
+            _start = (_start + bytes_to_copy) % _capacity;
+        } else {
+            // Case two: not enough space, need two memcpy calls
+            std::memcpy(_data.data() + _start, sv.data(), space_to_end);
+            size_t remaining = bytes_to_copy - space_to_end;
+            std::memcpy(_data.data(), sv.data() + space_to_end, remaining);
+            _start = remaining;
+        }
+    }
+
+    _total_added += bytes_to_copy;
+}
+
+/// Access element at logical index (0 is the oldest element)
+rtc_circular_buffer::reference rtc_circular_buffer::operator[](size_t index) {
+    return _data[(_start + index) % _capacity];
+}
+
+/// Access element at logical index (0 is the oldest element)
+rtc_circular_buffer::const_reference
+rtc_circular_buffer::operator[](size_t index) const {
+    return _data[(_start + index) % _capacity];
+}
+
+/// Access element at logical index with bounds checking
+rtc_circular_buffer::reference rtc_circular_buffer::at(size_t index) {
+    if (index >= _size) {
+        throw std::out_of_range("circular_buffer::at");
+    }
+    return _data[(_start + index) % _capacity];
+}
+
+/// Access element at logical index with bounds checking
+rtc_circular_buffer::const_reference
+rtc_circular_buffer::at(size_t index) const {
+    if (index >= _size) {
+        throw std::out_of_range("circular_buffer::at");
+    }
+    return _data[(_start + index) % _capacity];
+}
+
+/// Get the first (oldest) element
+rtc_circular_buffer::reference rtc_circular_buffer::front() {
+    return _data[_start];
+}
+
+/// Get the first (oldest) element
+rtc_circular_buffer::const_reference rtc_circular_buffer::front() const {
+    return _data[_start];
+}
+
+/// Get the last (newest) element
+rtc_circular_buffer::reference rtc_circular_buffer::back() {
+    if (_size < _capacity) {
+        return _data[_size - 1];
+    } else {
+        return _data[(_start + _size - 1) % _capacity];
+    }
+}
+
+/// Get the last (newest) element
+rtc_circular_buffer::const_reference rtc_circular_buffer::back() const {
+    if (_size < _capacity) {
+        return _data[_size - 1];
+    } else {
+        return _data[(_start + _size - 1) % _capacity];
+    }
+}
+
+/// Number of elements currently in the buffer
+size_t rtc_circular_buffer::size() const noexcept { return _size; }
+
+/// Maximum capacity of the buffer
+size_t rtc_circular_buffer::capacity() const noexcept { return _capacity; }
+
+/// Check if the buffer is empty
+bool rtc_circular_buffer::empty() const noexcept { return _size == 0; }
+
+/// Check if the buffer is at full capacity
+bool rtc_circular_buffer::full() const noexcept { return _size == _capacity; }
+
+/// Get the number of elements that were added to the buffer and
+/// then overwritten and lost. The count is reset if 'clear' is
+/// called.
+size_t rtc_circular_buffer::overwritten() const noexcept {
+    return _total_added > _capacity ? _total_added - _capacity : 0;
+}
+
+/// Clear all elements from the buffer
+void rtc_circular_buffer::clear() noexcept {
+    _size = 0;
+    _start = 0;
+    _total_added = 0;
+    _data.clear();
+    _data.shrink_to_fit();
+}
+} // namespace detail
 
 template<class Clock>
 basic_retry_chain_node<Clock>::basic_retry_chain_node(

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -35,6 +35,54 @@ static constexpr uint16_t max_retry_count = std::numeric_limits<uint16_t>::max()
                                             - 1;
 
 template<class Clock>
+basic_retry_chain_node<Clock>::basic_retry_chain_node(
+  basic_retry_chain_context<Clock>& ctx)
+  : _id(fiber_count++) // generate new head id
+  , _backoff{0}
+  , _deadline{time_point::min()}
+  , _parent(&ctx) {}
+
+template<class Clock>
+basic_retry_chain_node<Clock>::basic_retry_chain_node(
+  basic_retry_chain_context<Clock>& ctx,
+  time_point deadline,
+  duration backoff)
+  : _id(fiber_count++) // generate new head id
+  , _backoff{std::chrono::duration_cast<std::chrono::milliseconds>(backoff)}
+  , _deadline{deadline}
+  , _parent(&ctx) {
+    vassert(
+      backoff <= milliseconds_uint16_t::max(),
+      "Initial backoff {} is too large",
+      backoff);
+}
+
+template<class Clock>
+basic_retry_chain_node<Clock>::basic_retry_chain_node(
+  basic_retry_chain_context<Clock>& ctx,
+  time_point deadline,
+  duration backoff,
+  retry_strategy retry_strategy)
+  : basic_retry_chain_node(ctx, deadline, backoff) {
+    _retry_strategy = retry_strategy;
+}
+
+template<class Clock>
+basic_retry_chain_node<Clock>::basic_retry_chain_node(
+  basic_retry_chain_context<Clock>& ctx, duration timeout, duration backoff)
+  : basic_retry_chain_node(ctx, Clock::now() + timeout, backoff) {}
+
+template<class Clock>
+basic_retry_chain_node<Clock>::basic_retry_chain_node(
+  basic_retry_chain_context<Clock>& ctx,
+  duration timeout,
+  duration backoff,
+  retry_strategy retry_strategy)
+  : basic_retry_chain_node(ctx, timeout, backoff) {
+    _retry_strategy = retry_strategy;
+}
+
+template<class Clock>
 basic_retry_chain_node<Clock>::basic_retry_chain_node(ss::abort_source& as)
   : _id(fiber_count++) // generate new head id
   , _backoff{0}
@@ -195,6 +243,8 @@ template<class Clock>
 ss::abort_source* basic_retry_chain_node<Clock>::get_abort_source() {
     if (std::holds_alternative<ss::abort_source*>(_parent)) {
         return std::get<ss::abort_source*>(_parent);
+    } else if (std::holds_alternative<context_t*>(_parent)) {
+        return &std::get<context_t*>(_parent)->as();
     }
     return nullptr;
 }
@@ -204,6 +254,8 @@ const ss::abort_source*
 basic_retry_chain_node<Clock>::get_abort_source() const {
     if (std::holds_alternative<ss::abort_source*>(_parent)) {
         return std::get<ss::abort_source*>(_parent);
+    } else if (std::holds_alternative<context_t*>(_parent)) {
+        return &std::get<context_t*>(_parent)->as();
     }
     return nullptr;
 }
@@ -296,6 +348,13 @@ typename Clock::duration
 basic_retry_chain_node<Clock>::get_poll_interval() const {
     duration jitter(fast_prng_source() % _backoff.count());
     return _backoff + jitter;
+}
+
+template<class Clock>
+bool basic_retry_chain_node<Clock>::has_retry_chain_context() const {
+    auto root = get_root();
+    return std::holds_alternative<basic_retry_chain_context<Clock>*>(
+      root->_parent);
 }
 
 template<class Clock>
@@ -395,6 +454,16 @@ void basic_retry_chain_node<Clock>::check_abort() const {
     if (as) {
         as->check();
     }
+}
+
+template<class Clock>
+void basic_retry_chain_node<Clock>::maybe_add_trace(
+  const ss::sstring& s) const {
+    auto root = get_root();
+    if (!root->has_retry_chain_context()) {
+        return;
+    }
+    std::get<context_t*>(root->_parent)->add_trace(s);
 }
 
 template<class Clock>

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -154,6 +154,95 @@
 #include <ranges>
 #include <variant>
 
+namespace detail {
+/// A fixed-size circular buffer that behaves like std::vector for basic
+/// operations. When the buffer reaches its maximum capacity, new elements
+/// overwrite the oldest elements in FIFO order.
+class rtc_circular_buffer {
+public:
+    using value_type = char;
+    using reference = char&;
+    using const_reference = const char&;
+
+    /// Create a circular buffer with the specified maximum capacity
+    explicit rtc_circular_buffer(size_t capacity);
+
+    /// Add an element to the buffer. When the buffer is full, the oldest
+    /// element is overwritten.
+    void push_back(value_type value);
+
+    void push_back(std::string_view sv);
+
+    /// Access element at logical index (0 is the oldest element)
+    reference operator[](size_t index);
+
+    /// Access element at logical index (0 is the oldest element)
+    const_reference operator[](size_t index) const;
+
+    /// Access element at logical index with bounds checking
+    reference at(size_t index);
+
+    /// Access element at logical index with bounds checking
+    const_reference at(size_t index) const;
+
+    /// Get the first (oldest) element
+    reference front();
+
+    /// Get the first (oldest) element
+    const_reference front() const;
+
+    /// Get the last (newest) element
+    reference back();
+
+    /// Get the last (newest) element
+    const_reference back() const;
+
+    /// Number of elements currently in the buffer
+    size_t size() const noexcept;
+
+    /// Maximum capacity of the buffer
+    size_t capacity() const noexcept;
+
+    /// Check if the buffer is empty
+    bool empty() const noexcept;
+
+    /// Check if the buffer is at full capacity
+    bool full() const noexcept;
+
+    /// Get the number of elements that were added to the buffer and
+    /// then overwritten and lost. The count is reset if 'clear' is
+    /// called.
+    size_t overwritten() const noexcept;
+
+    /// Clear all elements from the buffer
+    void clear() noexcept;
+
+    /// Return a view of the entire buffer (const version)
+    auto view() const {
+        return std::views::join(std::views::all(std::array{
+          std::span(_data).subspan(
+            _start, _size < _capacity ? _size - _start : _capacity - _start),
+          std::span(_data).subspan(0, _size < _capacity ? 0 : _start)}));
+    }
+
+    /// Return a view of the entire buffer
+    auto view() {
+        return std::views::join(std::views::all(std::array{
+          std::span(_data).subspan(
+            _start, _size < _capacity ? _size - _start : _capacity - _start),
+          std::span(_data).subspan(0, _size < _capacity ? 0 : _start)}));
+    }
+
+private:
+    std::vector<value_type> _data;
+    size_t _capacity;
+    size_t _size{0};
+    size_t _start{0};
+    size_t _total_added{0};
+};
+
+} // namespace detail
+
 /// Represents the context for a retry chain node, capable of collecting trace
 /// messages in memory.
 ///
@@ -184,29 +273,19 @@ public:
       ss::sstring name, ss::abort_source& as, size_t size)
       : _name(std::move(name))
       , _as(as)
-      , _size_limit(size) {}
+      , _size_limit(size)
+      , _buf(size) {}
 
     /// Add a trace to the buffer.
     void add_trace(const ss::sstring& msg) const {
         _last_trace_ts = Clock::now();
-        if (_buf.size() >= _size_limit) {
-            if (!_is_truncated) {
-                // If the buffer is full, we're adding ''truncated''
-                // to the end but only once.
-                _is_truncated = true;
-                fmt::format_to(std::back_inserter(_buf), "[truncated]");
-            }
-            return;
-        }
-        auto bii = std::back_inserter(_buf);
-        std::copy(msg.begin(), msg.end(), bii);
-        bii = '\n';
+        _buf.push_back(std::string_view{msg.data(), msg.size()});
+        _buf.push_back('\n');
     }
 
     /// Returns a view of trace strings that can be iterated
     auto traces() const {
-        auto view = std::string_view(_buf.data(), _buf.size());
-        return std::ranges::split_view(view, '\n')
+        return std::ranges::split_view(_buf.view(), '\n')
                | std::views::transform([](auto&& r) {
                      auto begin = std::ranges::begin(r);
                      auto end = std::ranges::end(r);
@@ -216,18 +295,23 @@ public:
                  [](const ss::sstring& s) { return !s.empty(); });
     }
 
+    bool truncation_warning() const { return _buf.overwritten() > 0; }
+
     /// Get the entire trace log as a string (added for testing).
-    std::string_view get_trace_log() const {
-        return {_buf.data(), _buf.size()};
+    ss::sstring get_trace_log() const {
+        ss::sstring res;
+        for (const auto& trace : traces()) {
+            res += trace;
+            res += "\n";
+        }
+        return res;
     }
 
     auto get_last_trace_time() const noexcept { return _last_trace_ts; }
 
     /// Reset the state of the context and empties the buffer
     void reset() {
-        // Clear the buffer,
-        // 'clear' doesn't free memory.
-        _buf = fmt::memory_buffer();
+        _buf.clear();
         _last_trace_ts = Clock::now();
         _suspended_to = Clock::time_point::min();
     }
@@ -256,10 +340,8 @@ private:
     ss::abort_source& _as;
     /// Trace buffer size limit
     size_t _size_limit;
-    /// Indicates if the buffer is full and traces are truncated.
-    mutable bool _is_truncated{false};
     /// Buffer to store traces
-    mutable fmt::memory_buffer _buf;
+    mutable detail::rtc_circular_buffer _buf;
     /// Last trace timestamp
     mutable Clock::time_point _last_trace_ts;
     Clock::time_point _suspended_to;

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -139,7 +139,9 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/core/weak_ptr.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/noncopyable_function.hh>
 
@@ -147,7 +149,121 @@
 #include <fmt/ostream.h>
 
 #include <chrono>
+#include <exception>
+#include <iterator>
+#include <ranges>
 #include <variant>
+
+/// Represents the context for a retry chain node, capable of collecting trace
+/// messages in memory.
+///
+/// This context is intended for logging repeated or periodic processes—
+/// for example, a background fiber that wakes up at intervals to perform work.
+/// It works in conjunction with `retry_chain_node` and `retry_chain_logger`
+/// to provide structured logging.
+///
+/// The context maintains an in-memory buffer for trace messages, with a
+/// configurable memory limit. This limit should be set based on the number of
+/// trace messages expected per iteration of the process.
+///
+/// When the buffer reaches its capacity, additional trace messages are
+/// discarded. In such cases, the buffer will end with a "[truncated]" message
+/// to indicate overflow. As such, this class is not intended for logging
+/// unbounded traces between resets.
+///
+/// Additionally, the context can provide an abort source, allowing external
+/// control to stop the associated fiber.
+template<typename Clock = ss::lowres_clock>
+class basic_retry_chain_context {
+public:
+    /// Create a trace memory buffer with the specified size.
+    /// \name is a name of the context
+    /// \as is an abort source
+    /// \size is a size limit for the in-memory buffer
+    explicit basic_retry_chain_context(
+      ss::sstring name, ss::abort_source& as, size_t size)
+      : _name(std::move(name))
+      , _as(as)
+      , _size_limit(size) {}
+
+    /// Add a trace to the buffer.
+    void add_trace(const ss::sstring& msg) const {
+        _last_trace_ts = Clock::now();
+        if (_buf.size() >= _size_limit) {
+            if (!_is_truncated) {
+                // If the buffer is full, we're adding ''truncated''
+                // to the end but only once.
+                _is_truncated = true;
+                fmt::format_to(std::back_inserter(_buf), "[truncated]");
+            }
+            return;
+        }
+        auto bii = std::back_inserter(_buf);
+        std::copy(msg.begin(), msg.end(), bii);
+        bii = '\n';
+    }
+
+    /// Returns a view of trace strings that can be iterated
+    auto traces() const {
+        auto view = std::string_view(_buf.data(), _buf.size());
+        return std::ranges::split_view(view, '\n')
+               | std::views::transform([](auto&& r) {
+                     auto begin = std::ranges::begin(r);
+                     auto end = std::ranges::end(r);
+                     return ss::sstring(begin, end);
+                 })
+               | std::views::filter(
+                 [](const ss::sstring& s) { return !s.empty(); });
+    }
+
+    /// Get the entire trace log as a string (added for testing).
+    std::string_view get_trace_log() const {
+        return {_buf.data(), _buf.size()};
+    }
+
+    auto get_last_trace_time() const noexcept { return _last_trace_ts; }
+
+    /// Reset the state of the context and empties the buffer
+    void reset() {
+        // Clear the buffer,
+        // 'clear' doesn't free memory.
+        _buf = fmt::memory_buffer();
+        _last_trace_ts = Clock::now();
+        _suspended_to = Clock::time_point::min();
+    }
+
+    /// Get shared abort source of the context
+    ss::abort_source& as() noexcept { return _as; }
+
+    /// This method informs the context about the stall.
+    /// This will push the deadline into the future. The idea is that this
+    /// method should be invoked before the 'seastar::sleep' or similar method
+    /// is invoked to avoid triggering the stall detection logic.
+    void suspend_to(Clock::time_point sp) noexcept { _suspended_to = sp; }
+
+    /// Get the deadline value.
+    /// The deadline is computed as the timestamp of the last message logged +
+    /// stall timeout. The 'suspend_to' can override this value.
+    Clock::time_point get_deadline(Clock::duration stall_timeout) const {
+        return std::max(_last_trace_ts + stall_timeout, _suspended_to);
+    }
+
+    const ss::sstring& name() const noexcept { return _name; }
+
+private:
+    ss::sstring _name;
+    /// Root abort source
+    ss::abort_source& _as;
+    /// Trace buffer size limit
+    size_t _size_limit;
+    /// Indicates if the buffer is full and traces are truncated.
+    mutable bool _is_truncated{false};
+    /// Buffer to store traces
+    mutable fmt::memory_buffer _buf;
+    /// Last trace timestamp
+    mutable Clock::time_point _last_trace_ts;
+    Clock::time_point _suspended_to;
+};
 
 /// Retry strategy
 enum class retry_strategy : uint8_t {
@@ -199,6 +315,8 @@ struct retry_permit {
 /// timeout value have to be smaller that the one of the parent node.
 template<class Clock = ss::lowres_clock>
 class [[gnu::warn_unused]] basic_retry_chain_node {
+    using context_t = basic_retry_chain_context<Clock>;
+
 public:
     using clock = Clock;
     using duration = typename clock::duration;
@@ -224,6 +342,29 @@ public:
       ss::abort_source& as, duration timeout, duration initial_backoff);
     basic_retry_chain_node(
       ss::abort_source& as,
+      duration timeout,
+      duration initial_backoff,
+      retry_strategy retry_strategy);
+
+    /// Create a head of the chain without backoff but with context.
+    explicit basic_retry_chain_node(basic_retry_chain_context<Clock>& ctx);
+    /// Creates a head with the provided context, deadline, and
+    /// backoff granularity.
+    basic_retry_chain_node(
+      basic_retry_chain_context<Clock>& ctx,
+      time_point deadline,
+      duration initial_backoff);
+    basic_retry_chain_node(
+      basic_retry_chain_context<Clock>& ctx,
+      time_point deadline,
+      duration initial_backoff,
+      retry_strategy retry_strategy);
+    basic_retry_chain_node(
+      basic_retry_chain_context<Clock>& ctx,
+      duration timeout,
+      duration initial_backoff);
+    basic_retry_chain_node(
+      basic_retry_chain_context<Clock>& ctx,
       duration timeout,
       duration initial_backoff,
       retry_strategy retry_strategy);
@@ -325,6 +466,8 @@ public:
     /// Checks if the abort_source was provided and abort was requested.
     void check_abort() const;
 
+    void maybe_add_trace(const ss::sstring&) const;
+
     /// Return backoff duration that should be used before the next retry
     duration get_backoff() const;
 
@@ -339,6 +482,8 @@ public:
 
     /// Return root node of the retry chain
     const basic_retry_chain_node* get_root() const;
+
+    bool has_retry_chain_context() const;
 
 private:
     void format(std::back_insert_iterator<fmt::memory_buffer>& bii) const;
@@ -373,8 +518,9 @@ private:
     milliseconds_uint16_t _backoff;
     /// Deadline for retry attempts
     time_point _deadline;
-    /// optional parent node or (if root) abort source for all fibers
-    std::variant<basic_retry_chain_node*, ss::abort_source*> _parent;
+    /// optional parent node or (if root) abort source or the context object
+    std::variant<basic_retry_chain_node*, ss::abort_source*, context_t*>
+      _parent;
 };
 
 using retry_chain_node = basic_retry_chain_node<ss::lowres_clock>;
@@ -387,21 +533,29 @@ public:
     basic_retry_chain_logger(
       ss::logger& log, basic_retry_chain_node<Clock>& node)
       : _log(log)
-      , _node(node) {}
+      , _node(node)
+      , _has_tracing(node.has_retry_chain_context()) {}
     /// Make logger that adds retry_chain_node id and custom string
     /// to every message
     basic_retry_chain_logger(
       ss::logger& log, basic_retry_chain_node<Clock>& node, ss::sstring context)
       : _log(log)
       , _node(node)
-      , _ctx(std::move(context)) {}
+      , _ctx(std::move(context))
+      , _has_tracing(node.has_retry_chain_context()) {}
     template<typename... Args>
     void
     log(ss::log_level lvl, fmt::format_string<Args...> format, Args&&... args)
       const {
+        std::optional<ss::sstring> trace;
+        if (_has_tracing) {
+            trace = ssx::sformat(format, std::forward<Args>(args)...);
+            _node.maybe_add_trace(trace.value());
+        }
         if (_log.is_enabled(lvl)) {
             auto lambda = [&](ss::logger& logger, ss::log_level lvl) {
-                auto msg = ssx::sformat(format, std::forward<Args>(args)...);
+                auto msg = trace.value_or(
+                  ssx::sformat(format, std::forward<Args>(args)...));
                 if (_ctx) {
                     logger.log(
                       lvl,
@@ -435,6 +589,24 @@ public:
     void trace(fmt::format_string<Args...> format, Args&&... args) const {
         log(ss::log_level::trace, format, std::forward<Args>(args)...);
     }
+    /// Invoke the lambda function but disable tracing while the function is
+    /// running.
+    template<class Fn>
+    void bypass_tracing(Fn&& fn) {
+        auto d = ss::defer([this, t = _has_tracing] { _has_tracing = t; });
+        std::exception_ptr err;
+        auto tmp = _has_tracing;
+        _has_tracing = false;
+        try {
+            std::invoke(std::forward<Fn>(fn));
+        } catch (...) {
+            err = std::current_exception();
+        }
+        _has_tracing = tmp;
+        if (err) {
+            std::rethrow_exception(err);
+        }
+    }
 
 private:
     void __attribute__((noinline)) do_log(
@@ -444,6 +616,8 @@ private:
     ss::logger& _log;
     const basic_retry_chain_node<Clock>& _node;
     std::optional<ss::sstring> _ctx;
+    bool _has_tracing;
 };
 
 using retry_chain_logger = basic_retry_chain_logger<ss::lowres_clock>;
+using retry_chain_context = basic_retry_chain_context<ss::lowres_clock>;

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -576,3 +576,19 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "execution_monitor_test",
+    timeout = "short",
+    srcs = [
+        "execution_monitor_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/test_utils:seastar_boost",
+        "//src/v/utils:execution_monitor",
+        "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/utils/tests/execution_monitor_test.cc
+++ b/src/v/utils/tests/execution_monitor_test.cc
@@ -1,0 +1,227 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "utils/execution_monitor.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+namespace ss = seastar;
+
+SEASTAR_THREAD_TEST_CASE(execution_monitor_happy_path) {
+    // This test verifies that the execution monitor doesn't
+    // detect stalls when the callsites are checked properly.
+    ssx::execution_monitor monitor("test_monitor", 50ms);
+
+    ss::abort_source as;
+    retry_chain_context callsite1("test_callsite1", as, 0x100);
+    retry_chain_context callsite2("test_callsite2", as, 0x100);
+    retry_chain_context callsite3("test_callsite3", as, 0x100);
+    ss::gate gate;
+
+    auto stall_cfg = ssx::execution_monitor::stall_detector_config{
+      .cb =
+        [](retry_chain_context& ctx) {
+            // Stall callback
+            BOOST_FAIL("Stall detected at callsite: " + ctx.name());
+        },
+      .contexts = {&callsite1, &callsite2, &callsite3}};
+    auto exit_cfg = ssx::execution_monitor::unexpected_shutdown_detector_config{
+      .cb =
+        []() {
+            // Stall callback
+            BOOST_FAIL("Unexpected exit");
+        },
+      .gate = &gate,
+    };
+
+    auto h = gate.hold();
+    // Start the monitor with a stall interval of 10ms
+    monitor.start(stall_cfg, exit_cfg);
+
+    // Run for two stall intervals (100ms)
+    for (int i = 0; i < 10; i++) {
+        // Single callsite should be able to prevent the stall from
+        // being detected.
+        callsite1.reset();
+        ss::sleep(10ms).get();
+    }
+
+    // Stop the monitor
+    monitor.stop();
+}
+
+SEASTAR_THREAD_TEST_CASE(execution_monitor_triggered_stall) {
+    // This test verifies that the execution monitor detects stalls
+    // when they happen.
+    ssx::execution_monitor monitor("test_monitor", 50ms);
+
+    ss::abort_source as;
+    retry_chain_context callsite1("test_callsite1", as, 0x100);
+    retry_chain_context callsite2("test_callsite2", as, 0x100);
+    retry_chain_context callsite3("test_callsite3", as, 0x100);
+    ss::gate gate;
+
+    bool stall_detected = true;
+    auto stall_cfg = ssx::execution_monitor::stall_detector_config{
+      .cb =
+        [&](retry_chain_context& ctx) {
+            // Stall callback
+            stall_detected = true;
+            BOOST_REQUIRE(ctx.name() == "test_callsite2");
+        },
+      .contexts = {&callsite1, &callsite2, &callsite3}};
+    auto exit_cfg = ssx::execution_monitor::unexpected_shutdown_detector_config{
+      .cb =
+        []() {
+            // Stall callback
+            BOOST_FAIL("Unexpected exit");
+        },
+      .gate = &gate,
+    };
+
+    auto h = gate.hold();
+    monitor.start(stall_cfg, exit_cfg);
+
+    // Checkpoint callsite2 and then check that it is passed into the stall
+    // callback.
+    callsite2.reset();
+    ss::sleep(120ms).get();
+
+    BOOST_REQUIRE(stall_detected);
+
+    // Stop the monitor
+    monitor.stop();
+}
+
+SEASTAR_THREAD_TEST_CASE(execution_monitor_trigger_unexpected_shutdown) {
+    // This test verifies that the execution monitor can detect unexpected
+    // shutdown. The shutdown is represented by a callsite. But the difference
+    // is that the shutdown callsite shouldn't be reached unless the shutdown
+    // was announced by to monitor.
+
+    ssx::execution_monitor monitor("test_monitor", 50ms);
+
+    ss::abort_source as;
+    ss::gate gate;
+
+    auto stall_cfg = ssx::execution_monitor::stall_detector_config{
+      .cb =
+        [](retry_chain_context& ctx) {
+            // Stall callback
+            BOOST_FAIL("Stall detected at callsite: " + ctx.name());
+        },
+      .contexts = {}};
+    bool shutdown_detected = false;
+    auto exit_cfg = ssx::execution_monitor::unexpected_shutdown_detector_config{
+      .cb = [&]() { shutdown_detected = true; },
+      .gate = &gate,
+    };
+
+    monitor.start(stall_cfg, exit_cfg);
+
+    // The gate is not held
+    ss::sleep(90ms).get();
+
+    BOOST_REQUIRE(shutdown_detected);
+
+    // Stop the monitor
+    monitor.stop();
+}
+
+SEASTAR_THREAD_TEST_CASE(execution_monitor_suspend_no_detection) {
+    // This test verifies that the execution monitor does not
+    // detect stalls when the callsites are suspended.
+    ssx::execution_monitor monitor("test_monitor", 50ms);
+
+    ss::abort_source as;
+    retry_chain_context callsite1("test_callsite1", as, 0x100);
+    retry_chain_context callsite2("test_callsite2", as, 0x100);
+    retry_chain_context callsite3("test_callsite3", as, 0x100);
+
+    auto stall_cfg = ssx::execution_monitor::stall_detector_config{
+      .cb =
+        [](retry_chain_context& ctx) {
+            // Stall callback
+            BOOST_FAIL("Stall detected at callsite: " + ctx.name());
+        },
+      .contexts = {&callsite1, &callsite2, &callsite3}};
+
+    monitor.start(stall_cfg, std::nullopt);
+
+    callsite2.reset();
+    callsite2.suspend_to(ss::lowres_clock::now() + 200ms);
+    ss::sleep(100ms).get();
+
+    // Stop the monitor
+    monitor.stop();
+}
+
+SEASTAR_THREAD_TEST_CASE(execution_monitor_suspend_detection) {
+    // This test verifies that the execution monitor detects
+    // stalls when the callsites are suspended.
+    ssx::execution_monitor monitor("test_monitor", 50ms);
+
+    ss::abort_source as;
+    retry_chain_context callsite1("test_callsite1", as, 0x100);
+    retry_chain_context callsite2("test_callsite2", as, 0x100);
+
+    bool stall_detected = false;
+    auto stall_cfg = ssx::execution_monitor::stall_detector_config{
+      .cb =
+        [&](retry_chain_context& ctx) {
+            stall_detected = true;
+            BOOST_REQUIRE(ctx.name() == "test_callsite2");
+        },
+      .contexts = {&callsite1, &callsite2}};
+
+    monitor.start(stall_cfg, std::nullopt);
+
+    callsite1.reset();
+    ss::sleep(10ms).get();
+    callsite2.reset();
+    callsite2.suspend_to(ss::lowres_clock::now() + 30ms);
+    ss::sleep(100ms).get();
+
+    // Stop the monitor
+    monitor.stop();
+}
+
+SEASTAR_THREAD_TEST_CASE(execution_monitor_expected_shutdown) {
+    // This test verifies that the execution monitor can tolerate
+    // shutdown if it was properly announced.
+    ssx::execution_monitor monitor("test_monitor", 50ms);
+
+    ss::abort_source as;
+    ss::gate gate;
+
+    auto exit_cfg = ssx::execution_monitor::unexpected_shutdown_detector_config{
+      .cb = [&]() { BOOST_FAIL("Shutdown detected"); },
+      .gate = &gate,
+    };
+
+    monitor.start(std::nullopt, exit_cfg);
+
+    monitor.expect_shutdown();
+    // The gate is not held
+    ss::sleep(90ms).get();
+
+    // Stop the monitor
+    monitor.stop();
+}

--- a/src/v/utils/tests/retry_chain_node_test.cc
+++ b/src/v/utils/tests/retry_chain_node_test.cc
@@ -187,7 +187,6 @@ SEASTAR_THREAD_TEST_CASE(check_node_comparison) {
 
 SEASTAR_THREAD_TEST_CASE(check_tracing) {
     ss::logger test_log("rtc_test_log");
-
     ss::abort_source as;
     retry_chain_context ctx1("test", as, 0x100);
 
@@ -200,7 +199,7 @@ SEASTAR_THREAD_TEST_CASE(check_tracing) {
     rtc_log1.trace("first message");
 
     auto found = ctx1.get_trace_log().find("first message")
-                 != std::string_view::npos;
+                 != ss::sstring::npos;
     BOOST_REQUIRE(found);
 
     // check that the message is printed even if the logger is
@@ -208,8 +207,7 @@ SEASTAR_THREAD_TEST_CASE(check_tracing) {
     test_log.set_level(ss::log_level::info);
     rtc_log1.trace("second message");
 
-    found = ctx1.get_trace_log().find("second message")
-            != std::string_view::npos;
+    found = ctx1.get_trace_log().find("second message") != ss::sstring::npos;
     BOOST_REQUIRE(found);
 
     std::vector<ss::sstring> actual;
@@ -230,12 +228,12 @@ SEASTAR_THREAD_TEST_CASE(check_tracing) {
     });
 
     found = ctx1.get_trace_log().find("unexpected message")
-            != std::string_view::npos;
+            != ss::sstring::npos;
     BOOST_REQUIRE(!found);
 
     // check that reset works
     ctx1.reset();
-    found = ctx1.get_trace_log().find("message") != std::string_view::npos;
+    found = ctx1.get_trace_log().find("message") != ss::sstring::npos;
     BOOST_REQUIRE(!found);
 
     // check nested rtc
@@ -245,18 +243,188 @@ SEASTAR_THREAD_TEST_CASE(check_tracing) {
 
         rtc_log2.trace("third message");
     }
-    found = ctx1.get_trace_log().find("third message")
-            != std::string_view::npos;
+    found = ctx1.get_trace_log().find("third message") != ss::sstring::npos;
     BOOST_REQUIRE(found);
 
     // check truncation
     for (int i = 0; i < 20; i++) {
         rtc_log1.trace("long message");
     }
-    found = ctx1.get_trace_log().find("truncated") != std::string_view::npos;
-    BOOST_REQUIRE(found);
+    BOOST_REQUIRE(ctx1.truncation_warning());
 
     // check abort source functionality
     ctx1.as().request_abort();
     BOOST_REQUIRE_THROW(rtc1.check_abort(), ss::abort_requested_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_basic_operations) {
+    detail::rtc_circular_buffer buf(3);
+
+    // Test initial state
+    BOOST_REQUIRE(buf.empty());
+    BOOST_REQUIRE_EQUAL(buf.size(), 0);
+    BOOST_REQUIRE_EQUAL(buf.capacity(), 3);
+    BOOST_REQUIRE(!buf.full());
+    BOOST_REQUIRE_EQUAL(buf.overwritten(), 0);
+
+    // Test push_back and access
+    buf.push_back(1);
+    BOOST_REQUIRE_EQUAL(buf.size(), 1);
+    BOOST_REQUIRE_EQUAL(buf[0], 1);
+    BOOST_REQUIRE_EQUAL(buf.front(), 1);
+    BOOST_REQUIRE_EQUAL(buf.back(), 1);
+
+    buf.push_back(2);
+    buf.push_back(3);
+    BOOST_REQUIRE(buf.full());
+    BOOST_REQUIRE_EQUAL(buf.size(), 3);
+    BOOST_REQUIRE_EQUAL(buf[0], 1);
+    BOOST_REQUIRE_EQUAL(buf[1], 2);
+    BOOST_REQUIRE_EQUAL(buf[2], 3);
+    BOOST_REQUIRE_EQUAL(buf.front(), 1);
+    BOOST_REQUIRE_EQUAL(buf.back(), 3);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_wraparound) {
+    detail::rtc_circular_buffer buf(3);
+
+    // Fill buffer
+    buf.push_back(1);
+    buf.push_back(2);
+    buf.push_back(3);
+
+    // Test wraparound - should overwrite oldest element
+    buf.push_back(4);
+    BOOST_REQUIRE_EQUAL(buf.size(), 3);
+    BOOST_REQUIRE_EQUAL(buf.overwritten(), 1);
+    BOOST_REQUIRE_EQUAL(buf[0], 2); // oldest is now 2
+    BOOST_REQUIRE_EQUAL(buf[1], 3);
+    BOOST_REQUIRE_EQUAL(buf[2], 4); // newest is 4
+    BOOST_REQUIRE_EQUAL(buf.front(), 2);
+    BOOST_REQUIRE_EQUAL(buf.back(), 4);
+
+    // Continue wraparound
+    buf.push_back(5);
+    buf.push_back(6);
+    BOOST_REQUIRE_EQUAL(buf.overwritten(), 3);
+    BOOST_REQUIRE_EQUAL(buf[0], 4);
+    BOOST_REQUIRE_EQUAL(buf[1], 5);
+    BOOST_REQUIRE_EQUAL(buf[2], 6);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_bounds_checking) {
+    detail::rtc_circular_buffer buf(2);
+    buf.push_back(1);
+
+    // Valid access
+    BOOST_REQUIRE_EQUAL(buf.at(0), 1);
+
+    // Invalid access should throw
+    BOOST_REQUIRE_THROW(buf.at(1), std::out_of_range);
+    BOOST_REQUIRE_THROW(buf.at(2), std::out_of_range);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_string_view_specialization) {
+    detail::rtc_circular_buffer buf(10);
+
+    // Test empty string view
+    buf.push_back(std::string_view{});
+    BOOST_REQUIRE_EQUAL(buf.size(), 0);
+
+    // Test normal string view
+    ss::sstring test_str = "hello";
+    buf.push_back(std::string_view{test_str});
+    BOOST_REQUIRE_EQUAL(buf.size(), 5);
+
+    // Check iteration
+    std::string result;
+    for (size_t i = 0; i < buf.size(); ++i) {
+        result.push_back(buf[i]);
+    }
+    BOOST_REQUIRE_EQUAL(result, test_str);
+
+    // Test string larger than capacity
+    buf.clear();
+    std::string large_str = "this_is_a_very_long_string";
+    buf.push_back(std::string_view{large_str});
+    BOOST_REQUIRE_EQUAL(buf.size(), buf.capacity());
+
+    // Should contain only the last 'capacity' characters
+    result.clear();
+    for (size_t i = 0; i < buf.size(); ++i) {
+        result.push_back(buf[i]);
+    }
+    BOOST_REQUIRE_EQUAL(
+      result, large_str.substr(large_str.size() - buf.capacity()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_string_view_wraparound) {
+    detail::rtc_circular_buffer buf(8);
+
+    // Fill buffer partially
+    buf.push_back(std::string_view{"abc"});
+    BOOST_REQUIRE_EQUAL(buf.size(), 3);
+
+    // Add string that causes wraparound
+    buf.push_back(std::string_view{"redpanda"});
+    BOOST_REQUIRE_EQUAL(buf.size(), 8);
+    BOOST_REQUIRE(buf.overwritten() > 0);
+
+    std::string result;
+    for (size_t i = 0; i < buf.size(); ++i) {
+        result.push_back(buf[i]);
+    }
+    BOOST_REQUIRE_EQUAL(result, "redpanda");
+
+    buf.push_back(std::string_view{"head"});
+    // this is supposed to hit case two: not enough space, need two memcpy calls
+    buf.push_back(std::string_view{"1234567"});
+
+    result.clear();
+    for (size_t i = 0; i < buf.size(); ++i) {
+        result.push_back(buf[i]);
+    }
+    BOOST_REQUIRE_EQUAL(result, "d1234567");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_clear) {
+    detail::rtc_circular_buffer buf(3);
+
+    buf.push_back(1);
+    buf.push_back(2);
+    buf.push_back(3);
+    buf.push_back(4); // causes overwrite
+
+    BOOST_REQUIRE(!buf.empty());
+    BOOST_REQUIRE(buf.overwritten() > 0);
+
+    buf.clear();
+
+    BOOST_REQUIRE(buf.empty());
+    BOOST_REQUIRE_EQUAL(buf.size(), 0);
+    BOOST_REQUIRE_EQUAL(buf.overwritten(), 0);
+    BOOST_REQUIRE(!buf.full());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_circular_buffer_view) {
+    detail::rtc_circular_buffer buf(5);
+
+    buf.push_back('a');
+    buf.push_back('b');
+    buf.push_back('c');
+
+    auto view = buf.view();
+
+    // Check that view contains correct data
+    std::string result(view.begin(), view.end());
+    BOOST_REQUIRE_EQUAL(result, "abc");
+
+    // Test with wraparound
+    buf.push_back('d');
+    buf.push_back('e');
+    buf.push_back('f'); // should overwrite 'a'
+
+    view = buf.view();
+    result = std::string(view.begin(), view.end());
+    BOOST_REQUIRE_EQUAL(result, "bcdef");
 }

--- a/src/v/utils/tests/retry_chain_node_test.cc
+++ b/src/v/utils/tests/retry_chain_node_test.cc
@@ -184,3 +184,79 @@ SEASTAR_THREAD_TEST_CASE(check_node_comparison) {
     BOOST_REQUIRE(!r1.same_root(c21));
     BOOST_REQUIRE(!c11.same_root(c21));
 }
+
+SEASTAR_THREAD_TEST_CASE(check_tracing) {
+    ss::logger test_log("rtc_test_log");
+
+    ss::abort_source as;
+    retry_chain_context ctx1("test", as, 0x100);
+
+    retry_chain_node rtc1(ctx1);
+    retry_chain_logger rtc_log1(test_log, rtc1);
+
+    // check that the message is printed if logger is
+    // on trace
+    test_log.set_level(ss::log_level::trace);
+    rtc_log1.trace("first message");
+
+    auto found = ctx1.get_trace_log().find("first message")
+                 != std::string_view::npos;
+    BOOST_REQUIRE(found);
+
+    // check that the message is printed even if the logger is
+    // on info but the message is printed on trace
+    test_log.set_level(ss::log_level::info);
+    rtc_log1.trace("second message");
+
+    found = ctx1.get_trace_log().find("second message")
+            != std::string_view::npos;
+    BOOST_REQUIRE(found);
+
+    std::vector<ss::sstring> actual;
+    std::vector<ss::sstring> expected = {
+      "first message",
+      "second message",
+    };
+    for (const auto& trace : ctx1.traces()) {
+        actual.push_back(trace);
+    }
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      actual.begin(), actual.end(), expected.begin(), expected.end());
+
+    // check that bypass_tracing method works correctly
+    rtc_log1.bypass_tracing([&] {
+        // this shouldn't be added to the trace
+        rtc_log1.trace("unexpected message");
+    });
+
+    found = ctx1.get_trace_log().find("unexpected message")
+            != std::string_view::npos;
+    BOOST_REQUIRE(!found);
+
+    // check that reset works
+    ctx1.reset();
+    found = ctx1.get_trace_log().find("message") != std::string_view::npos;
+    BOOST_REQUIRE(!found);
+
+    // check nested rtc
+    {
+        retry_chain_node rtc2(&rtc1);
+        retry_chain_logger rtc_log2(test_log, rtc2);
+
+        rtc_log2.trace("third message");
+    }
+    found = ctx1.get_trace_log().find("third message")
+            != std::string_view::npos;
+    BOOST_REQUIRE(found);
+
+    // check truncation
+    for (int i = 0; i < 20; i++) {
+        rtc_log1.trace("long message");
+    }
+    found = ctx1.get_trace_log().find("truncated") != std::string_view::npos;
+    BOOST_REQUIRE(found);
+
+    // check abort source functionality
+    ctx1.as().request_abort();
+    BOOST_REQUIRE_THROW(rtc1.check_abort(), ss::abort_requested_exception);
+}


### PR DESCRIPTION
This PR adds few things:
- `execution_monitor` class which implements a periodic liveness check;
- `retry_chain_context` is a mechanism that can be used to collect trace logs;

We have the following problem. In case of any liveness issue (deadlock) it's difficult to debug the `ntp_archiver` because the system runs on info level so the trace logs from the moment when the issue occurred are gone. 

The proposed solution to this is to improve observability of the system. Instead of collecting trace logs all the time we can collect them in memory. When something interesting happens we can dump the diagnostic information and include all trace logs that we collected. This guarantees that the traces will be visible.

The `retry_chain_context` solves this issue. The `retry_chain_node` is modified to take the context as a parameter. When any information is logged using the `retry_chain_logger` the data is written into the context. These traces are stored in memory using limited amount of memory (configurable). The code can iterate through traces or discard them.

The last but not least is the `execution_monitor`. The monitor is a simple tool that takes a list of pointers to `retry_chain_context` objects and a pointer to `seastar::gate` and two callbacks. It checks the contexts periodically. If the contexts were not accessed long enough it detects a stall and invokes a corresponding callback. It also checks the gate. If the gate is closed before the execution monitor is stopped it detects an unexpected exits and invokes a corresponding callback.

The code in the `ntp_archiver` is modified to use all these mechanisms to detect stalls and log the diagnostics.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none