### PR TITLE
iceberg/rest_client: configure client once

### DIFF
--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -118,6 +118,9 @@ catalog_client::maybe_configure(retry_chain_node& rtc) {
     if (!gh.has_value()) {
         co_return tl::unexpected(gh.error());
     }
+    if (_configured) {
+        co_return std::monostate{};
+    }
     vlog(log.debug, "Configuring Iceberg REST catalog client");
     auto http_request = http::request_builder{}
                           .method(boost::beast::http::verb::get)


### PR DESCRIPTION
This[1] commit regressed the REST catalog client to repeatedly configure. Reverts the unintentional change to return early if we've already configured.

[1] https://github.com/redpanda-data/redpanda/commit/279e3ada00a9d24b70f0b73ffc5785b76c11449a

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
