### PR TITLE
[UX-246] rpk cloud override: set environment variables

### DIFF
--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -1873,6 +1873,11 @@ func (c *Config) loadCloudEnvToOverrides() {
 			case "ppd", CloudEnvironmentPreprod:
 				env = CloudEnvironmentPreprod
 			}
+			setEnvIfUnset := func(env, val string) {
+				if _, ok := os.LookupEnv(env); !ok {
+					os.Setenv(env, val)
+				}
+			}
 			if override, ok := cloudEnvConfig[env]; ok {
 				c.devOverrides.PublicAPIURL = override.PublicAPIURL
 				c.devOverrides.CloudAPIURL = override.CloudAPIURL
@@ -1881,7 +1886,14 @@ func (c *Config) loadCloudEnvToOverrides() {
 				c.devOverrides.CloudAuthAudience = override.CloudAuthAudience
 				// The BYOC plugin uses a different environment var to set the
 				// cloud URL, and it's not part of the overrides.
-				os.Setenv("CLOUD_URL", fmt.Sprintf("%v/api/v1", override.CloudAPIURL))
+				setEnvIfUnset("CLOUD_URL", fmt.Sprintf("%v/api/v1", override.CloudAPIURL))
+				// And we also want to set the environment variable for
+				// the BYOC plugin to pick up.
+				setEnvIfUnset("RPK_PUBLIC_API_URL", override.PublicAPIURL)
+				setEnvIfUnset("RPK_CLOUD_URL", override.CloudAPIURL)
+				setEnvIfUnset("RPK_AUTH_APP_CLIENT_ID", override.CloudAuthAppClientID)
+				setEnvIfUnset("RPK_CLOUD_AUTH_URL", override.CloudAuthURL)
+				setEnvIfUnset("RPK_CLOUD_AUTH_AUDIENCE", override.CloudAuthAudience)
 			}
 		}
 	}


### PR DESCRIPTION
The BYOC plugin now uses the Public API URLs env
vars  like rpk does, so this change helps BYOC
users by letting them set just one flag - rpk will set all the needed env vars for them.

We only set these env vars if they haven't been
set already, so users can still override them if
needed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
