### PR TITLE
[CORE-10604] schema_registry/authz: Extend ACL resources

### DIFF
--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -270,6 +270,10 @@ inline int8_t to_kafka_resource_type(security::resource_type type) {
         return 4;
     case security::resource_type::transactional_id:
         return 5;
+    case security::resource_type::sr_subject:
+    case security::resource_type::sr_global:
+        vassert(
+          false, "Schema Registry resources are not supported in kafka ACLs");
     }
     __builtin_unreachable();
 }
@@ -408,6 +412,22 @@ const std::vector<security::acl_operation>& get_allowed_operations() {
       security::acl_operation::describe,
     };
 
+    static const std::vector<security::acl_operation> sr_subject_resource_ops{
+      security::acl_operation::read,
+      security::acl_operation::write,
+      security::acl_operation::remove,
+      security::acl_operation::describe,
+      security::acl_operation::alter_configs,
+      security::acl_operation::describe_configs,
+    };
+
+    static const std::vector<security::acl_operation> sr_global_resource_ops{
+      security::acl_operation::read,
+      security::acl_operation::describe,
+      security::acl_operation::alter_configs,
+      security::acl_operation::describe_configs,
+    };
+
     auto resource_type = security::get_resource_type<T>();
 
     switch (resource_type) {
@@ -419,6 +439,10 @@ const std::vector<security::acl_operation>& get_allowed_operations() {
         return topic_resource_ops;
     case security::resource_type::transactional_id:
         return transactional_id_resource_ops;
+    case security::resource_type::sr_subject:
+        return sr_subject_resource_ops;
+    case security::resource_type::sr_global:
+        return sr_global_resource_ops;
     };
 
     __builtin_unreachable();

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -121,6 +121,9 @@ from_string_view<output_format>(std::string_view sv) {
 
 std::ostream& operator<<(std::ostream& os, const output_format& of);
 
+///\brief Type representing a global resource for ACLs.
+using global_resource = named_type<ss::sstring, struct global_resource_tag>;
+
 ///\brief A subject is the name under which a schema is registered.
 ///
 /// Typically it will be "<topic>-key" or "<topic>-value".

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -145,6 +145,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/pandaproxy/schema_registry:types",
         "//src/v/random:generators",
         "//src/v/reflection:adl",
         "//src/v/security/audit:types",

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -331,6 +331,10 @@ std::ostream& operator<<(std::ostream& os, resource_type type) {
         return os << "cluster";
     case resource_type::transactional_id:
         return os << "transactional_id";
+    case resource_type::sr_subject:
+        return os << "schema_registry_subject";
+    case resource_type::sr_global:
+        return os << "schema_registry_global";
     }
     __builtin_unreachable();
 }
@@ -407,13 +411,26 @@ operator<<(std::ostream& os, const resource_pattern_filter::pattern_match&) {
     return os;
 }
 
+std::ostream&
+operator<<(std::ostream& os, resource_pattern_filter::resource_subsystem s) {
+    using resource_subsystem = resource_pattern_filter::resource_subsystem;
+    switch (s) {
+    case resource_subsystem::kafka:
+        return os << "kafka";
+    case resource_subsystem::schema_registry:
+        return os << "schema_registry";
+    }
+    __builtin_unreachable();
+}
+
 std::ostream& operator<<(std::ostream& o, const resource_pattern_filter& f) {
     fmt::print(
       o,
-      "{{ resource: {} name: {} pattern: {} }}",
+      "{{ resource: {} name: {} pattern: {} subsystem: {}}}",
       f._resource,
       f._name,
-      f._pattern);
+      f._pattern,
+      f._subsystem);
     return o;
 }
 
@@ -498,6 +515,19 @@ bool resource_pattern_filter::matches(const resource_pattern& pattern) const {
         return false;
     }
 
+    switch (_subsystem) {
+    case resource_subsystem::kafka:
+        if (pattern.resource() > resource_type::transactional_id) {
+            return false;
+        }
+        break;
+    case resource_subsystem::schema_registry:
+        if (pattern.resource() < resource_type::sr_subject) {
+            return false;
+        }
+        break;
+    }
+
     if (
       _pattern && std::holds_alternative<pattern_type>(*_pattern)
       && std::get<pattern_type>(*_pattern) != pattern.pattern()) {
@@ -558,6 +588,11 @@ void read_nested(
         filter._pattern = security::resource_pattern_filter::pattern_match{};
         break;
     }
+    if (in.bytes_left() > 0) {
+        filter._subsystem
+          = read_nested<resource_pattern_filter::resource_subsystem>(
+            in, bytes_left_limit);
+    }
 }
 
 void write(iobuf& out, resource_pattern_filter filter) {
@@ -581,6 +616,7 @@ void write(iobuf& out, resource_pattern_filter filter) {
     write(out, filter._resource);
     write(out, filter._name);
     write(out, pattern);
+    write(out, filter._subsystem);
 }
 
 } // namespace security

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -13,6 +13,7 @@
 #include "base/type_traits.h"
 #include "kafka/protocol/types.h"
 #include "model/fundamental.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "serde/envelope.h"
 #include "serde/rw/enum.h"
 #include "serde/rw/optional.h"
@@ -50,10 +51,13 @@ enum class resource_type : int8_t {
     group = 1,
     cluster = 2,
     transactional_id = 3,
+    sr_subject = 4,
+    sr_global = 5,
 };
 
 template<typename T>
 consteval resource_type get_resource_type() {
+    namespace ppsr = pandaproxy::schema_registry;
     if constexpr (std::is_same_v<T, model::topic>) {
         return resource_type::topic;
     } else if constexpr (std::is_same_v<T, kafka::group_id>) {
@@ -62,6 +66,10 @@ consteval resource_type get_resource_type() {
         return resource_type::cluster;
     } else if constexpr (std::is_same_v<T, kafka::transactional_id>) {
         return resource_type::transactional_id;
+    } else if constexpr (std::is_same_v<T, ppsr::subject>) {
+        return resource_type::sr_subject;
+    } else if constexpr (std::is_same_v<T, ppsr::global_resource>) {
+        return resource_type::sr_global;
     } else {
         static_assert(base::unsupported_type<T>::value, "Unsupported type");
     }
@@ -416,6 +424,11 @@ public:
         match = 2,
     };
 
+    enum class resource_subsystem : uint8_t {
+        kafka = 0,
+        schema_registry = 1,
+    };
+
     static serialized_pattern_type to_pattern(security::pattern_type from) {
         switch (from) {
         case security::pattern_type::literal:
@@ -439,10 +452,12 @@ public:
     resource_pattern_filter(
       std::optional<resource_type> type,
       std::optional<ss::sstring> name,
-      std::optional<pattern_filter_type> pattern)
+      std::optional<pattern_filter_type> pattern,
+      resource_subsystem subsystem = resource_subsystem::kafka)
       : _resource(type)
       , _name(std::move(name))
-      , _pattern(pattern) {}
+      , _pattern(pattern)
+      , _subsystem(subsystem) {}
 
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     resource_pattern_filter(const resource_pattern& resource)
@@ -452,10 +467,16 @@ public:
     /*
      * A filter that matches any resource.
      */
-    static const resource_pattern_filter& any() {
-        static const resource_pattern_filter filter(
-          std::nullopt, std::nullopt, std::nullopt);
-        return filter;
+    static const resource_pattern_filter&
+    any(resource_subsystem subsystem = resource_subsystem::kafka) {
+        static const resource_pattern_filter k_filter(
+          std::nullopt, std::nullopt, std::nullopt, resource_subsystem::kafka);
+        static const resource_pattern_filter sr_filter(
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          resource_subsystem::schema_registry);
+        return subsystem == resource_subsystem::kafka ? k_filter : sr_filter;
     }
 
     bool matches(const resource_pattern& pattern) const;
@@ -464,6 +485,7 @@ public:
     std::optional<resource_type> resource() const { return _resource; }
     const std::optional<ss::sstring>& name() const { return _name; }
     std::optional<pattern_filter_type> pattern() const { return _pattern; }
+    resource_subsystem subsystem() const { return _subsystem; }
 
     template<typename H>
     friend H AbslHashValue(H h, const pattern_match&) {
@@ -492,6 +514,7 @@ private:
     std::optional<resource_type> _resource;
     std::optional<ss::sstring> _name;
     std::optional<pattern_filter_type> _pattern;
+    resource_subsystem _subsystem{resource_subsystem::kafka};
 };
 
 std::ostream&
@@ -581,12 +604,23 @@ public:
     }
 
     /*
-     * A filter that matches any ACL binding.
+     * A filter that matches any ACL binding for the given subsystem.
      */
-    static const acl_binding_filter& any() {
-        static const acl_binding_filter filter(
-          resource_pattern_filter::any(), acl_entry_filter::any());
-        return filter;
+    static const acl_binding_filter& any(
+      resource_pattern_filter::resource_subsystem subsystem
+      = resource_pattern_filter::resource_subsystem::kafka) {
+        static const acl_binding_filter k_filter(
+          resource_pattern_filter::any(
+            resource_pattern_filter::resource_subsystem::kafka),
+          acl_entry_filter::any());
+        static const acl_binding_filter sr_filter(
+          resource_pattern_filter::any(
+            resource_pattern_filter::resource_subsystem::schema_registry),
+          acl_entry_filter::any());
+
+        return subsystem == resource_pattern_filter::resource_subsystem::kafka
+                 ? k_filter
+                 : sr_filter;
     }
 
     bool matches(const acl_binding& binding) const {

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/types.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "security/role.h"
 #include "security/role_store.h"
 
@@ -309,6 +310,18 @@ template auth_result authorizer::authorized(
 
 template auth_result authorizer::authorized(
   const kafka::transactional_id&,
+  acl_operation,
+  const acl_principal&,
+  const acl_host&) const;
+
+template auth_result authorizer::authorized(
+  const pandaproxy::schema_registry::subject&,
+  acl_operation,
+  const acl_principal&,
+  const acl_host&) const;
+
+template auth_result authorizer::authorized(
+  const pandaproxy::schema_registry::global_resource&,
   acl_operation,
   const acl_principal&,
   const acl_host&) const;

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -72,6 +72,7 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/config",
+        "//src/v/pandaproxy/schema_registry:types",
         "//src/v/random:generators",
         "//src/v/security",
         "//src/v/test_utils:seastar_boost",

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 #include "config/mock_property.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "random/generators.h"
+#include "security/acl.h"
 #include "security/authorizer.h"
 #include "security/role.h"
 #include "security/role_store.h"
@@ -70,10 +72,10 @@ static auto get_acls(authorizer& auth, acl_principal principal) {
     return found;
 }
 
-static auto get_acls(authorizer& auth, acl_binding_filter filter) {
+static auto get_acls(authorizer& auth, const acl_binding_filter& filter) {
     absl::flat_hash_set<acl_entry> found;
     auto acls = auth.acls(filter);
-    for (auto acl : acls) {
+    for (const auto& acl : acls) {
         found.emplace(acl.entry());
     }
     return found;
@@ -100,6 +102,12 @@ BOOST_AUTO_TEST_CASE(authz_resource_type_auto) {
     BOOST_REQUIRE(
       get_resource_type<kafka::transactional_id>()
       == security::resource_type::transactional_id);
+    BOOST_REQUIRE(
+      get_resource_type<pandaproxy::schema_registry::subject>()
+      == security::resource_type::sr_subject);
+    BOOST_REQUIRE(
+      get_resource_type<pandaproxy::schema_registry::global_resource>()
+      == security::resource_type::sr_global);
 
     BOOST_REQUIRE(
       get_resource_type<model::topic>() == get_resource_type<model::topic>());
@@ -1591,6 +1599,84 @@ BOOST_AUTO_TEST_CASE(role_authz_remove_binding_multiple_match) {
 
     absl::flat_hash_set<acl_entry> expected{};
     BOOST_REQUIRE(get_acls(auth, wildcard_resource) == expected);
+}
+
+BOOST_AUTO_TEST_CASE(authz_filter_out_non_kafka_resources) {
+    namespace ppsr = pandaproxy::schema_registry;
+    acl_principal user(principal_type::user, "alice");
+    acl_host host("192.168.2.1");
+
+    auto auth = make_test_instance();
+
+    const acl_entry allow_all(
+      acl_wildcard_user,
+      acl_wildcard_host,
+      acl_operation::all,
+      acl_permission::allow);
+
+    const acl_entry allow_read(
+      acl_wildcard_user,
+      acl_wildcard_host,
+      acl_operation::read,
+      acl_permission::allow);
+
+    const acl_entry allow_describe(
+      acl_wildcard_user,
+      acl_wildcard_host,
+      acl_operation::describe,
+      acl_permission::allow);
+
+    std::vector<acl_binding> bindings;
+    resource_pattern subject_resource(
+      resource_type::sr_subject, "model-", pattern_type::prefixed);
+    resource_pattern global_resource(
+      resource_type::sr_global,
+      resource_pattern::wildcard,
+      pattern_type::literal);
+    resource_pattern topic_resource(
+      resource_type::topic, "model", pattern_type::literal);
+    bindings.emplace_back(subject_resource, allow_read);
+    bindings.emplace_back(global_resource, allow_describe);
+    bindings.emplace_back(topic_resource, allow_all);
+    auth.add_bindings(bindings);
+
+    auto result = auth.authorized(
+      model::topic("model"), acl_operation::read, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    auto kafka_acls = get_acls(auth, acl_binding_filter::any());
+    BOOST_REQUIRE_EQUAL(kafka_acls.size(), 1);
+
+    auto sr_acls = get_acls(
+      auth,
+      acl_binding_filter::any(
+        resource_pattern_filter::resource_subsystem::schema_registry));
+    BOOST_REQUIRE_EQUAL(sr_acls.size(), 2);
+
+    // Check prefix match for schema registry subject
+    result = auth.authorized(
+      ppsr::subject("model-value"), acl_operation::read, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    // Check read implies describe
+    result = auth.authorized(
+      ppsr::subject("model-key"), acl_operation::describe, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    // Check read does not imply write
+    result = auth.authorized(
+      ppsr::subject("model-key"), acl_operation::write, user, host);
+    BOOST_REQUIRE(!result.is_authorized());
+
+    // Check global resource
+    result = auth.authorized(
+      ppsr::global_resource(), acl_operation::describe, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    // Check that describe does not imply read
+    result = auth.authorized(
+      ppsr::global_resource(), acl_operation::read, user, host);
+    BOOST_REQUIRE(!result.is_authorized());
 }
 
 } // namespace security


### PR DESCRIPTION
Introduce the concept of a `subsystem` into ACLs, so that `kafka` resources and `schema_registry` resources can operate independently.

ACLs for `kafka` resources are managed by the Kafka API, and operate on Kafka resources.
ACLs for `schema_registry` resources shall be managed through a separate API.

It is important that the two subsystems do not interact with each other.

Replaces #26388

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

