### PR TITLE
[CORE-10604] schema_registry/authz: Extend ACL resources

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -911,7 +911,8 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     {
         cluster::delete_acls_cmd_data data;
         for (auto i = 0, mi = random_generators::get_int(5, 25); i < mi; ++i) {
-            data.filters.push_back(tests::random_acl_binding_filter());
+            data.filters.push_back(tests::random_acl_binding_filter(
+              tests::serialization_format::serde));
         }
         roundtrip_test(data);
     }
@@ -1477,8 +1478,8 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
     {
         cluster::delete_acls_cmd_data delete_acls_data{};
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
-            delete_acls_data.filters.push_back(
-              tests::random_acl_binding_filter());
+            delete_acls_data.filters.push_back(tests::random_acl_binding_filter(
+              tests::serialization_format::serde));
         }
         cluster::delete_acls_request data{
           delete_acls_data, random_timeout_clock_duration()};
@@ -2136,7 +2137,7 @@ void adl_roundtrip_cmd(Key key, Value value) {
                           .get();
     auto deserialized_cmd = std::get<Cmd>(deserialized);
 
-    BOOST_REQUIRE(deserialized_cmd.key == cmd.key);
+    BOOST_REQUIRE_EQUAL(deserialized_cmd.key, cmd.key);
 
     if constexpr (std::equality_comparable<Value>) {
         BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
@@ -2199,8 +2200,8 @@ SEASTAR_THREAD_TEST_CASE(commands_serialization_test) {
         cluster::delete_acls_cmd_data delete_acl_data;
 
         for (auto i = 0, mi = random_generators::get_int(1, 20); i < mi; ++i) {
-            delete_acl_data.filters.push_back(
-              tests::random_acl_binding_filter());
+            delete_acl_data.filters.push_back(tests::random_acl_binding_filter(
+              tests::serialization_format::adl));
         }
 
         roundtrip_cmd<cluster::delete_acls_cmd>(std::move(delete_acl_data), 0);

--- a/src/v/compat/acls_generator.h
+++ b/src/v/compat/acls_generator.h
@@ -68,8 +68,10 @@ template<>
 struct instance_generator<cluster::delete_acls_request> {
     static cluster::delete_acls_request random() {
         cluster::delete_acls_cmd_data data;
-        auto rand_filters = tests::random_vector(
-          [] { return tests::random_acl_binding_filter(); });
+        auto rand_filters = tests::random_vector([] {
+            return tests::random_acl_binding_filter(
+              tests::serialization_format::adl);
+        });
         data.filters.insert(
           data.filters.end(), rand_filters.begin(), rand_filters.end());
         return {data, tests::random_duration<model::timeout_clock::duration>()};

--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -270,6 +270,10 @@ inline int8_t to_kafka_resource_type(security::resource_type type) {
         return 4;
     case security::resource_type::transactional_id:
         return 5;
+    case security::resource_type::sr_subject:
+    case security::resource_type::sr_global:
+        vassert(
+          false, "Schema Registry resources are not supported in kafka ACLs");
     }
     __builtin_unreachable();
 }
@@ -408,6 +412,22 @@ const std::vector<security::acl_operation>& get_allowed_operations() {
       security::acl_operation::describe,
     };
 
+    static const std::vector<security::acl_operation> sr_subject_resource_ops{
+      security::acl_operation::read,
+      security::acl_operation::write,
+      security::acl_operation::remove,
+      security::acl_operation::describe,
+      security::acl_operation::alter_configs,
+      security::acl_operation::describe_configs,
+    };
+
+    static const std::vector<security::acl_operation> sr_global_resource_ops{
+      security::acl_operation::read,
+      security::acl_operation::describe,
+      security::acl_operation::alter_configs,
+      security::acl_operation::describe_configs,
+    };
+
     auto resource_type = security::get_resource_type<T>();
 
     switch (resource_type) {
@@ -419,6 +439,10 @@ const std::vector<security::acl_operation>& get_allowed_operations() {
         return topic_resource_ops;
     case security::resource_type::transactional_id:
         return transactional_id_resource_ops;
+    case security::resource_type::sr_subject:
+        return sr_subject_resource_ops;
+    case security::resource_type::sr_global:
+        return sr_global_resource_ops;
     };
 
     __builtin_unreachable();

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -121,6 +121,9 @@ from_string_view<output_format>(std::string_view sv) {
 
 std::ostream& operator<<(std::ostream& os, const output_format& of);
 
+///\brief Type representing a global resource for ACLs.
+using global_resource = named_type<ss::sstring, struct global_resource_tag>;
+
 ///\brief A subject is the name under which a schema is registered.
 ///
 /// Typically it will be "<topic>-key" or "<topic>-value".

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -145,6 +145,7 @@ redpanda_cc_library(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/pandaproxy/schema_registry:types",
         "//src/v/random:generators",
         "//src/v/reflection:adl",
         "//src/v/security/audit:types",

--- a/src/v/security/BUILD
+++ b/src/v/security/BUILD
@@ -151,6 +151,7 @@ redpanda_cc_library(
         "//src/v/serde",
         "//src/v/serde:bytes",
         "//src/v/serde:enum",
+        "//src/v/serde:inet_address",
         "//src/v/serde:optional",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -336,6 +336,10 @@ std::ostream& operator<<(std::ostream& os, resource_type type) {
         return os << "cluster";
     case resource_type::transactional_id:
         return os << "transactional_id";
+    case resource_type::sr_subject:
+        return os << "schema_registry_subject";
+    case resource_type::sr_global:
+        return os << "schema_registry_global";
     }
     __builtin_unreachable();
 }
@@ -523,7 +527,7 @@ bool resource_pattern_filter::matches(const resource_pattern& pattern) const {
         }
         break;
     case resource_subsystem::schema_registry:
-        if (pattern.resource() <= resource_type::transactional_id) {
+        if (pattern.resource() < resource_type::sr_subject) {
             return false;
         }
         break;

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -12,6 +12,11 @@
 
 #include "security/acl_store.h"
 #include "security/logger.h"
+#include "serde/rw/enum.h"
+#include "serde/rw/envelope.h"
+#include "serde/rw/inet_address.h"
+#include "serde/rw/optional.h"
+#include "serde/rw/rw.h"
 #include "utils/to_string.h"
 
 #include <seastar/coroutine/maybe_yield.hh>
@@ -581,6 +586,18 @@ void write(iobuf& out, resource_pattern_filter filter) {
     write(out, filter._resource);
     write(out, filter._name);
     write(out, pattern);
+}
+
+void acl_binding_filter::serde_read(iobuf_parser& in, const serde::header& h) {
+    read_nested(in, _pattern, h._bytes_left_limit);
+    using serde::read_nested;
+    read_nested(in, _acl, h._bytes_left_limit);
+}
+
+void acl_binding_filter::serde_write(iobuf& out) const {
+    using serde::write;
+    write(out, _pattern);
+    write(out, _acl);
 }
 
 } // namespace security

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -412,13 +412,26 @@ operator<<(std::ostream& os, const resource_pattern_filter::pattern_match&) {
     return os;
 }
 
+std::ostream&
+operator<<(std::ostream& os, resource_pattern_filter::resource_subsystem s) {
+    using resource_subsystem = resource_pattern_filter::resource_subsystem;
+    switch (s) {
+    case resource_subsystem::kafka:
+        return os << "kafka";
+    case resource_subsystem::schema_registry:
+        return os << "schema_registry";
+    }
+    __builtin_unreachable();
+}
+
 std::ostream& operator<<(std::ostream& o, const resource_pattern_filter& f) {
     fmt::print(
       o,
-      "{{ resource: {} name: {} pattern: {} }}",
+      "{{ resource: {} name: {} pattern: {} subsystem: {}}}",
       f._resource,
       f._name,
-      f._pattern);
+      f._pattern,
+      f._subsystem);
     return o;
 }
 
@@ -503,6 +516,19 @@ bool resource_pattern_filter::matches(const resource_pattern& pattern) const {
         return false;
     }
 
+    switch (_subsystem) {
+    case resource_subsystem::kafka:
+        if (pattern.resource() > resource_type::transactional_id) {
+            return false;
+        }
+        break;
+    case resource_subsystem::schema_registry:
+        if (pattern.resource() <= resource_type::transactional_id) {
+            return false;
+        }
+        break;
+    }
+
     if (
       _pattern && std::holds_alternative<pattern_type>(*_pattern)
       && std::get<pattern_type>(*_pattern) != pattern.pattern()) {
@@ -534,7 +560,8 @@ bool resource_pattern_filter::matches(const resource_pattern& pattern) const {
 void read_nested(
   iobuf_parser& in,
   resource_pattern_filter& filter,
-  const size_t bytes_left_limit) {
+  const size_t bytes_left_limit,
+  serde::version_t version) {
     using serde::read_nested;
 
     read_nested(in, filter._resource, bytes_left_limit);
@@ -548,20 +575,25 @@ void read_nested(
 
     if (!pattern) {
         filter._pattern = std::nullopt;
-        return;
+    } else {
+        switch (*pattern) {
+        case serialized_pattern_type::literal:
+            filter._pattern = pattern_type::literal;
+            break;
+
+        case serialized_pattern_type::prefixed:
+            filter._pattern = pattern_type::prefixed;
+            break;
+        case serialized_pattern_type::match:
+            filter._pattern = resource_pattern_filter::pattern_match{};
+            break;
+        }
     }
 
-    switch (*pattern) {
-    case serialized_pattern_type::literal:
-        filter._pattern = security::pattern_type::literal;
-        break;
-
-    case serialized_pattern_type::prefixed:
-        filter._pattern = security::pattern_type::prefixed;
-        break;
-    case serialized_pattern_type::match:
-        filter._pattern = security::resource_pattern_filter::pattern_match{};
-        break;
+    if (version >= 1) {
+        filter._subsystem
+          = read_nested<resource_pattern_filter::resource_subsystem>(
+            in, bytes_left_limit);
     }
 }
 
@@ -586,10 +618,11 @@ void write(iobuf& out, resource_pattern_filter filter) {
     write(out, filter._resource);
     write(out, filter._name);
     write(out, pattern);
+    write(out, filter._subsystem);
 }
 
 void acl_binding_filter::serde_read(iobuf_parser& in, const serde::header& h) {
-    read_nested(in, _pattern, h._bytes_left_limit);
+    read_nested(in, _pattern, h._bytes_left_limit, h._version);
     using serde::read_nested;
     read_nested(in, _acl, h._bytes_left_limit);
 }

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -401,19 +401,27 @@ private:
 /*
  * A filter for matching resources.
  *
- * Note: This type does not have a serde::header.
+ * version 1 adds subsystem.
+ *
+ * Note: This type does not have a serde::header, the version must be provided
+ * by the caller of nested_read, which has the wrong signature for serde.
  *
  */
 class resource_pattern_filter
   : public serde::envelope<
       resource_pattern_filter,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
 public:
     enum class serialized_pattern_type {
         literal = 0,
         prefixed = 1,
         match = 2,
+    };
+
+    enum class resource_subsystem : uint8_t {
+        kafka = 0,
+        schema_registry = 1,
     };
 
     static serialized_pattern_type to_pattern(security::pattern_type from) {
@@ -439,10 +447,12 @@ public:
     resource_pattern_filter(
       std::optional<resource_type> type,
       std::optional<ss::sstring> name,
-      std::optional<pattern_filter_type> pattern)
+      std::optional<pattern_filter_type> pattern,
+      resource_subsystem subsystem = resource_subsystem::kafka)
       : _resource(type)
       , _name(std::move(name))
-      , _pattern(pattern) {}
+      , _pattern(pattern)
+      , _subsystem(subsystem) {}
 
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     resource_pattern_filter(const resource_pattern& resource)
@@ -452,10 +462,16 @@ public:
     /*
      * A filter that matches any resource.
      */
-    static const resource_pattern_filter& any() {
-        static const resource_pattern_filter filter(
-          std::nullopt, std::nullopt, std::nullopt);
-        return filter;
+    static const resource_pattern_filter&
+    any(resource_subsystem subsystem = resource_subsystem::kafka) {
+        static const resource_pattern_filter k_filter(
+          std::nullopt, std::nullopt, std::nullopt, resource_subsystem::kafka);
+        static const resource_pattern_filter sr_filter(
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          resource_subsystem::schema_registry);
+        return subsystem == resource_subsystem::kafka ? k_filter : sr_filter;
     }
 
     bool matches(const resource_pattern& pattern) const;
@@ -464,6 +480,7 @@ public:
     std::optional<resource_type> resource() const { return _resource; }
     const std::optional<ss::sstring>& name() const { return _name; }
     std::optional<pattern_filter_type> pattern() const { return _pattern; }
+    resource_subsystem subsystem() const { return _subsystem; }
 
     template<typename H>
     friend H AbslHashValue(H h, const pattern_match&) {
@@ -474,10 +491,22 @@ public:
         return H::combine(std::move(h), f._resource, f._name, f._pattern);
     }
 
+    /*
+     * Reads nested data into a resource_pattern_filter object from an input
+     * stream.
+     *
+     * nested_read intentionally has the wrong signature for serde.
+     *
+     * \param in The input stream to read from
+     * \param filter The filter to read into
+     * \param bytes_left_limit The maximum number of bytes to read
+     * \param version The serde version to use
+     */
     friend void read_nested(
       iobuf_parser& in,
       resource_pattern_filter& filter,
-      const size_t bytes_left_limit);
+      const size_t bytes_left_limit,
+      serde::version_t version);
 
     friend void write(iobuf& out, resource_pattern_filter filter);
 
@@ -492,6 +521,7 @@ private:
     std::optional<resource_type> _resource;
     std::optional<ss::sstring> _name;
     std::optional<pattern_filter_type> _pattern;
+    resource_subsystem _subsystem{resource_subsystem::kafka};
 };
 
 std::ostream&
@@ -563,11 +593,14 @@ private:
 
 /*
  * A filter for matching ACL bindings.
+ *
+ * version 1 adds resource_pattern_filter::subsystem, since
+ * resource_pattern_filter does not have a header for it to be versioned.
  */
 class acl_binding_filter
   : public serde::envelope<
       acl_binding_filter,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
 public:
     acl_binding_filter() = default;
@@ -581,12 +614,23 @@ public:
     }
 
     /*
-     * A filter that matches any ACL binding.
+     * A filter that matches any ACL binding for the given subsystem.
      */
-    static const acl_binding_filter& any() {
-        static const acl_binding_filter filter(
-          resource_pattern_filter::any(), acl_entry_filter::any());
-        return filter;
+    static const acl_binding_filter& any(
+      resource_pattern_filter::resource_subsystem subsystem
+      = resource_pattern_filter::resource_subsystem::kafka) {
+        static const acl_binding_filter k_filter(
+          resource_pattern_filter::any(
+            resource_pattern_filter::resource_subsystem::kafka),
+          acl_entry_filter::any());
+        static const acl_binding_filter sr_filter(
+          resource_pattern_filter::any(
+            resource_pattern_filter::resource_subsystem::schema_registry),
+          acl_entry_filter::any());
+
+        return subsystem == resource_pattern_filter::resource_subsystem::kafka
+                 ? k_filter
+                 : sr_filter;
     }
 
     bool matches(const acl_binding& binding) const {

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -13,6 +13,7 @@
 #include "base/type_traits.h"
 #include "kafka/protocol/types.h"
 #include "model/fundamental.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "serde/envelope.h"
 #include "utils/named_type.h"
 
@@ -47,10 +48,13 @@ enum class resource_type : int8_t {
     group = 1,
     cluster = 2,
     transactional_id = 3,
+    sr_subject = 4,
+    sr_global = 5,
 };
 
 template<typename T>
 consteval resource_type get_resource_type() {
+    namespace ppsr = pandaproxy::schema_registry;
     if constexpr (std::is_same_v<T, model::topic>) {
         return resource_type::topic;
     } else if constexpr (std::is_same_v<T, kafka::group_id>) {
@@ -59,6 +63,10 @@ consteval resource_type get_resource_type() {
         return resource_type::cluster;
     } else if constexpr (std::is_same_v<T, kafka::transactional_id>) {
         return resource_type::transactional_id;
+    } else if constexpr (std::is_same_v<T, ppsr::subject>) {
+        return resource_type::sr_subject;
+    } else if constexpr (std::is_same_v<T, ppsr::global_resource>) {
+        return resource_type::sr_global;
     } else {
         static_assert(base::unsupported_type<T>::value, "Unsupported type");
     }

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -14,9 +14,6 @@
 #include "kafka/protocol/types.h"
 #include "model/fundamental.h"
 #include "serde/envelope.h"
-#include "serde/rw/enum.h"
-#include "serde/rw/optional.h"
-#include "serde/rw/rw.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
@@ -403,6 +400,9 @@ private:
 
 /*
  * A filter for matching resources.
+ *
+ * Note: This type does not have a serde::header.
+ *
  */
 class resource_pattern_filter
   : public serde::envelope<
@@ -602,7 +602,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream&, const acl_binding_filter&);
 
-    auto serde_fields() { return std::tie(_pattern, _acl); }
+    void serde_read(iobuf_parser& in, const serde::header& h);
+    void serde_write(iobuf& out) const;
 
 private:
     resource_pattern_filter _pattern;

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/types.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "security/role.h"
 #include "security/role_store.h"
 
@@ -309,6 +310,18 @@ template auth_result authorizer::authorized(
 
 template auth_result authorizer::authorized(
   const kafka::transactional_id&,
+  acl_operation,
+  const acl_principal&,
+  const acl_host&) const;
+
+template auth_result authorizer::authorized(
+  const pandaproxy::schema_registry::subject&,
+  acl_operation,
+  const acl_principal&,
+  const acl_host&) const;
+
+template auth_result authorizer::authorized(
+  const pandaproxy::schema_registry::global_resource&,
   acl_operation,
   const acl_principal&,
   const acl_host&) const;

--- a/src/v/security/tests/BUILD
+++ b/src/v/security/tests/BUILD
@@ -72,6 +72,7 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/config",
+        "//src/v/pandaproxy/schema_registry:types",
         "//src/v/random:generators",
         "//src/v/security",
         "//src/v/test_utils:seastar_boost",

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 #include "config/mock_property.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "random/generators.h"
+#include "security/acl.h"
 #include "security/authorizer.h"
 #include "security/role.h"
 #include "security/role_store.h"
@@ -70,10 +72,10 @@ static auto get_acls(authorizer& auth, acl_principal principal) {
     return found;
 }
 
-static auto get_acls(authorizer& auth, acl_binding_filter filter) {
+static auto get_acls(authorizer& auth, const acl_binding_filter& filter) {
     absl::flat_hash_set<acl_entry> found;
     auto acls = auth.acls(filter);
-    for (auto acl : acls) {
+    for (const auto& acl : acls) {
         found.emplace(acl.entry());
     }
     return found;
@@ -100,6 +102,12 @@ BOOST_AUTO_TEST_CASE(authz_resource_type_auto) {
     BOOST_REQUIRE(
       get_resource_type<kafka::transactional_id>()
       == security::resource_type::transactional_id);
+    BOOST_REQUIRE(
+      get_resource_type<pandaproxy::schema_registry::subject>()
+      == security::resource_type::sr_subject);
+    BOOST_REQUIRE(
+      get_resource_type<pandaproxy::schema_registry::global_resource>()
+      == security::resource_type::sr_global);
 
     BOOST_REQUIRE(
       get_resource_type<model::topic>() == get_resource_type<model::topic>());
@@ -1591,6 +1599,84 @@ BOOST_AUTO_TEST_CASE(role_authz_remove_binding_multiple_match) {
 
     absl::flat_hash_set<acl_entry> expected{};
     BOOST_REQUIRE(get_acls(auth, wildcard_resource) == expected);
+}
+
+BOOST_AUTO_TEST_CASE(authz_filter_out_non_kafka_resources) {
+    namespace ppsr = pandaproxy::schema_registry;
+    acl_principal user(principal_type::user, "alice");
+    acl_host host("192.168.2.1");
+
+    auto auth = make_test_instance();
+
+    const acl_entry allow_all(
+      acl_wildcard_user,
+      acl_wildcard_host,
+      acl_operation::all,
+      acl_permission::allow);
+
+    const acl_entry allow_read(
+      acl_wildcard_user,
+      acl_wildcard_host,
+      acl_operation::read,
+      acl_permission::allow);
+
+    const acl_entry allow_describe(
+      acl_wildcard_user,
+      acl_wildcard_host,
+      acl_operation::describe,
+      acl_permission::allow);
+
+    std::vector<acl_binding> bindings;
+    resource_pattern subject_resource(
+      resource_type::sr_subject, "model-", pattern_type::prefixed);
+    resource_pattern global_resource(
+      resource_type::sr_global,
+      resource_pattern::wildcard,
+      pattern_type::literal);
+    resource_pattern topic_resource(
+      resource_type::topic, "model", pattern_type::literal);
+    bindings.emplace_back(subject_resource, allow_read);
+    bindings.emplace_back(global_resource, allow_describe);
+    bindings.emplace_back(topic_resource, allow_all);
+    auth.add_bindings(bindings);
+
+    auto result = auth.authorized(
+      model::topic("model"), acl_operation::read, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    auto kafka_acls = get_acls(auth, acl_binding_filter::any());
+    BOOST_REQUIRE_EQUAL(kafka_acls.size(), 1);
+
+    auto sr_acls = get_acls(
+      auth,
+      acl_binding_filter::any(
+        resource_pattern_filter::resource_subsystem::schema_registry));
+    BOOST_REQUIRE_EQUAL(sr_acls.size(), 2);
+
+    // Check prefix match for schema registry subject
+    result = auth.authorized(
+      ppsr::subject("model-value"), acl_operation::read, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    // Check read implies describe
+    result = auth.authorized(
+      ppsr::subject("model-key"), acl_operation::describe, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    // Check read does not imply write
+    result = auth.authorized(
+      ppsr::subject("model-key"), acl_operation::write, user, host);
+    BOOST_REQUIRE(!result.is_authorized());
+
+    // Check global resource
+    result = auth.authorized(
+      ppsr::global_resource(), acl_operation::describe, user, host);
+    BOOST_REQUIRE(result.is_authorized());
+
+    // Check that describe does not imply read
+    result = auth.authorized(
+      ppsr::global_resource(), acl_operation::read, user, host);
+    BOOST_REQUIRE(!result.is_authorized());
 }
 
 } // namespace security

--- a/src/v/security/tests/randoms.h
+++ b/src/v/security/tests/randoms.h
@@ -18,6 +18,11 @@
 
 namespace tests {
 
+enum class serialization_format {
+    adl,
+    serde,
+};
+
 inline security::scram_credential random_credential() {
     return security::scram_credential(
       tests::random_bytes(256),
@@ -44,6 +49,17 @@ inline security::resource_pattern random_resource_pattern() {
       random_resource_type(),
       random_generators::gen_alphanum_string(10),
       random_pattern_type()};
+}
+
+inline security::resource_pattern_filter::resource_subsystem
+random_resource_subsystem(serialization_format fmt) {
+    if (fmt == serialization_format::adl) {
+        return security::resource_pattern_filter::resource_subsystem::kafka;
+    }
+    return random_generators::random_choice<
+      security::resource_pattern_filter::resource_subsystem>(
+      {security::resource_pattern_filter::resource_subsystem::kafka,
+       security::resource_pattern_filter::resource_subsystem::schema_registry});
 }
 
 inline security::acl_principal random_acl_principal() {
@@ -87,7 +103,8 @@ inline security::acl_binding random_acl_binding() {
     return {random_resource_pattern(), random_acl_entry()};
 }
 
-inline security::resource_pattern_filter random_resource_pattern_filter() {
+inline security::resource_pattern_filter
+random_resource_pattern_filter(serialization_format fmt) {
     auto resource = tests::random_optional(
       [] { return random_resource_type(); });
 
@@ -105,7 +122,7 @@ inline security::resource_pattern_filter random_resource_pattern_filter() {
         }
     });
 
-    return {resource, std::move(name), pattern};
+    return {resource, std::move(name), pattern, random_resource_subsystem(fmt)};
 }
 
 inline security::acl_entry_filter random_acl_entry_filter() {
@@ -123,8 +140,9 @@ inline security::acl_entry_filter random_acl_entry_filter() {
     return {std::move(principal), host, operation, permission};
 }
 
-inline security::acl_binding_filter random_acl_binding_filter() {
-    return {random_resource_pattern_filter(), random_acl_entry_filter()};
+inline security::acl_binding_filter
+random_acl_binding_filter(serialization_format fmt) {
+    return {random_resource_pattern_filter(fmt), random_acl_entry_filter()};
 }
 
 } // namespace tests


### PR DESCRIPTION
Introduce the concept of a `subsystem` into ACLs, so that `kafka` resources and `schema_registry` resources can operate independently.

ACLs for `kafka` resources are managed by the Kafka API, and operate on Kafka resources.
ACLs for `schema_registry` resources shall be managed through a separate API.

It is important that the two subsystems do not interact with each other.

Replaces #26388

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

