### PR TITLE
`storage`: minor tweaks

### DIFF
--- a/src/v/base/type_traits.h
+++ b/src/v/base/type_traits.h
@@ -78,3 +78,8 @@ template<typename T>
 concept is_std_optional = ::detail::is_specialization_of_v<T, std::optional>;
 
 }
+
+template<typename T>
+concept CanReserve = requires(T c, size_t s) {
+    { c.reserve(s) };
+};

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -795,14 +795,15 @@ ss::future<std::error_code> health_monitor_backend::collect_cluster_health() {
     vlog(clusterlog.debug, "collecting cluster health statistics");
     // collect all reports
     auto ids = _members.local().node_ids();
-    auto collected_reports = co_await ssx::async_transform(
-      ids.begin(), ids.end(), [this](model::node_id id) {
-          if (id == _self) {
-              return _report_collection_mutex.with(
-                [this] { return collect_current_node_health(); });
-          }
-          return collect_remote_node_health(id);
-      });
+    auto collected_reports
+      = co_await ssx::async_transform<std::vector<result<node_health_report>>>(
+        ids.begin(), ids.end(), [this](model::node_id id) {
+            if (id == _self) {
+                return _report_collection_mutex.with(
+                  [this] { return collect_current_node_health(); });
+            }
+            return collect_remote_node_health(id);
+        });
     auto new_reports = ss::make_lw_shared<report_cache_t>();
 
     // update nodes reports and cache cluster-level data disk health

--- a/src/v/cluster/self_test/netcheck.cc
+++ b/src/v/cluster/self_test/netcheck.cc
@@ -91,7 +91,7 @@ ss::future<std::vector<self_test_result>> netcheck::run(netcheck_opts opts) {
           "Starting redpanda self-test network benchmark, with options: {}",
           opts);
         co_return co_await ss::with_scheduling_group(opts.sg, [this]() {
-            return ssx::async_transform(
+            return ssx::async_transform<std::vector<self_test_result>>(
               _opts.peers, [this](model::node_id peer) {
                   return run_individual_benchmark(peer);
               });

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -296,7 +296,7 @@ ss::future<reassignable_topic_response> do_handle_topic(
       std::move(alive_nodes),
       tp_metadata_ref);
 
-    return ssx::async_transform(
+    return ssx::async_transform<std::vector<reassignable_partition_response>>(
              topic.partitions.begin(),
              valid_partitions_end,
              [&octx,

--- a/src/v/reflection/test/BUILD
+++ b/src/v/reflection/test/BUILD
@@ -21,6 +21,7 @@ redpanda_cc_btest(
         "async_adl_test.cc",
     ],
     deps = [
+        "//src/v/base",
         "//src/v/bytes:hash",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iobuf_parser",

--- a/src/v/reflection/test/async_adl_test.cc
+++ b/src/v/reflection/test/async_adl_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "base/type_traits.h"
 #include "bytes/hash.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
@@ -75,11 +76,6 @@ struct random_type<model::ntp> {
         auto partition_id = rand_gen::get_int(0, 20);
         return model::ntp(ns, topic, partition_id);
     }
-};
-
-template<typename T>
-concept CanReserve = requires(T c, size_t s) {
-    { c.reserve(s) };
 };
 
 template<typename T>

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "base/seastarx.h"
+#include "base/type_traits.h"
 #include "base/vassert.h"
 #include "utils/functional.h"
 
@@ -31,17 +32,19 @@ namespace ssx {
 
 namespace detail {
 
-template<typename ResultType, typename Iterator, typename Func>
-inline seastar::future<std::vector<ResultType>>
+template<typename ContainerType, typename Iterator, typename Func>
+inline seastar::future<ContainerType>
 async_transform(Iterator begin, Iterator end, Func&& func) {
-    std::vector<ResultType> res;
-    res.reserve(std::distance(begin, end));
+    ContainerType res;
+    if constexpr (CanReserve<ContainerType>) {
+        res.reserve(std::distance(begin, end));
+    }
     return seastar::do_with(
       std::move(res),
       std::move(begin),
       std::move(end),
       [func = std::forward<Func>(func)](
-        std::vector<ResultType>& res, Iterator& begin, Iterator& end) mutable {
+        ContainerType& res, Iterator& begin, Iterator& end) mutable {
           /// Since its not known what type of iterator 'Iterator' is, a
           /// universal ref must be used. For example an rval-ref to a temporary
           /// (when Iterator is a boost::range::iterator_range) or an l-val ref
@@ -75,20 +78,18 @@ async_transform(Iterator begin, Iterator end, Func&& func) {
 /// function invocations that resolves when all the function invocations
 /// complete.  If one or more return an exception, the return value contains one
 /// of the exceptions.
-template<typename Iterator, typename Func>
+template<typename ContainerType, typename Iterator, typename Func>
 requires requires(Func f, Iterator i) {
     *(++i);
     { i != i } -> std::convertible_to<bool>;
     seastar::futurize_invoke(f, *i).get();
 }
 inline auto async_transform(Iterator begin, Iterator end, Func&& func) {
-    using result_type = std::remove_reference_t<
-      decltype(seastar::futurize_invoke(func, *begin).get())>;
-    return detail::async_transform<result_type>(
+    using result_type = ContainerType::value_type;
+    return detail::async_transform<ContainerType>(
       std::move(begin),
       std::move(end),
-      [func = std::forward<Func>(func)](
-        std::vector<result_type>& acc, auto&& x) {
+      [func = std::forward<Func>(func)](ContainerType& acc, auto&& x) {
           return seastar::futurize_invoke(func, std::forward<decltype(x)>(x))
             .then(
               [&acc](result_type result) { acc.push_back(std::move(result)); });
@@ -112,7 +113,7 @@ inline auto async_transform(Iterator begin, Iterator end, Func&& func) {
 /// function invocations that resolves when all the function invocations
 /// complete.  If one or more return an exception, the return value contains one
 /// of the exceptions.
-template<typename Rng, typename Func>
+template<typename ContainerType, typename Rng, typename Func>
 requires requires(Func f, Rng r) {
     r.begin();
     r.end();
@@ -120,7 +121,8 @@ requires requires(Func f, Rng r) {
     seastar::futurize_invoke(f, *r.begin()).get();
 }
 inline auto async_transform(Rng& rng, Func&& func) {
-    return async_transform(rng.begin(), rng.end(), std::forward<Func>(func));
+    return async_transform<ContainerType>(
+      rng.begin(), rng.end(), std::forward<Func>(func));
 }
 
 /// \brief Run tasks synchronously in order and wait for completion only

--- a/src/v/ssx/tests/async_transforms.cc
+++ b/src/v/ssx/tests/async_transforms.cc
@@ -30,8 +30,9 @@ SEASTAR_THREAD_TEST_CASE(async_transform_iter_test) {
     std::vector<int> expected(10);
     std::iota(expected.begin(), expected.end(), 2);
 
-    std::vector<int> out_iter
-      = ssx::async_transform(input.begin(), input.end(), plus(2)).get();
+    std::vector<int> out_iter = ssx::async_transform<std::vector<int>>(
+                                  input.begin(), input.end(), plus(2))
+                                  .get();
     BOOST_TEST(std::equal(
       out_iter.begin(), out_iter.end(), expected.begin(), expected.end()));
 }
@@ -43,7 +44,8 @@ SEASTAR_THREAD_TEST_CASE(async_transform_range_test) {
     std::vector<int> expected(10);
     std::iota(expected.begin(), expected.end(), 2);
 
-    std::vector<int> out_range = ssx::async_transform(input, plus(2)).get();
+    std::vector<int> out_range
+      = ssx::async_transform<std::vector<int>>(input, plus(2)).get();
     BOOST_TEST(std::equal(
       out_range.begin(), out_range.end(), expected.begin(), expected.end()));
 }
@@ -51,11 +53,10 @@ SEASTAR_THREAD_TEST_CASE(async_transform_range_test) {
 SEASTAR_THREAD_TEST_CASE(async_transform_move_test) {
     std::vector<ss::sstring> input{"hello", "world", "this", "is", "FUN"};
     std::vector<ss::sstring> input_copy = input;
-    std::vector<ss::sstring> expected = ssx::async_transform(
-                                          input_copy.begin(),
-                                          input_copy.end(),
-                                          [](ss::sstring s) { return s; })
-                                          .get();
+    std::vector<ss::sstring> expected
+      = ssx::async_transform<std::vector<ss::sstring>>(
+          input_copy.begin(), input_copy.end(), [](ss::sstring s) { return s; })
+          .get();
     BOOST_TEST(
       std::equal(input.begin(), input.end(), expected.begin(), expected.end()));
 }
@@ -77,13 +78,12 @@ SEASTAR_THREAD_TEST_CASE(async_transform_noncopyable_test) {
     foos.emplace_back(1);
     foos.emplace_back(2);
     foos.emplace_back(3);
-    std::vector<noncopyable_foo> results = ssx::async_transform(
-                                             foos.begin(),
-                                             foos.end(),
-                                             [](noncopyable_foo& ncf) {
-                                                 return std::move(ncf);
-                                             })
-                                             .get();
+    std::vector<noncopyable_foo> results
+      = ssx::async_transform<std::vector<noncopyable_foo>>(
+          foos.begin(),
+          foos.end(),
+          [](noncopyable_foo& ncf) { return std::move(ncf); })
+          .get();
     BOOST_TEST(results[0].value() == 1);
     BOOST_TEST(results[1].value() == 2);
     BOOST_TEST(results[2].value() == 3);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1002,9 +1002,6 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     auto segments = std::vector<ss::lw_shared_ptr<segment>>(
       range.first, range.second);
 
-    const bool all_window_compacted = std::ranges::all_of(
-      segments, &segment::finished_windowed_compaction);
-
     const bool all_segments_self_compacted = std::ranges::all_of(
       segments, &segment::finished_self_compaction);
 
@@ -1053,89 +1050,34 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     // the segment which will be expanded to replace
     auto target = segments.front();
 
-    target->clear_cached_disk_usage();
-
-    // concatenate segments from the compaction range into replacement segment
-    // backed by a staging file. the process is completed while holding a read
-    // lock on the range, which is then released. the remainder of the
-    // compaction process operates on replacement segment, and any conflicting
-    // log operations are later identified before committing changes.
-    auto staging_path = target->reader().path().to_compaction_staging();
-    auto staging_to_clean = scoped_file_tracker{
-      cfg.files_to_cleanup, {staging_path, staging_path.to_compacted_index()}};
-    auto [replacement, generations]
-      = co_await storage::internal::make_concatenated_segment(
-        staging_path, segments, cfg, _manager.resources(), _feature_table);
-
-    // compact the combined data in the replacement segment. the partition size
-    // tracking needs to be adjusted as compaction routines assume the segment
-    // size is already contained in the partition size probe
-    replacement->mark_as_compacted_segment();
-    if (all_window_compacted) {
-        // replacement's _clean_compact_timestamp will have been set in
-        // make_concatenated_segment if both segments were cleanly compacted
-        // already.
-        replacement->mark_as_finished_windowed_compaction();
+    std::optional<compaction_result> opt_ret;
+    try {
+        opt_ret
+          = co_await storage::internal::concatenate_and_rebuild_target_segment(
+            target,
+            segments,
+            _stm_manager,
+            cfg,
+            *_probe,
+            *_readers_cache,
+            _manager.resources(),
+            _feature_table,
+            _segment_rewrite_lock);
+    } catch (const generation_id_mismatch_exception& e) {
+        // Early abort
+        vlog(gclog.info, "{}", e.what());
+        const auto total_size = std::accumulate(
+          segments.begin(),
+          segments.end(),
+          size_t(0),
+          [](size_t acc, ss::lw_shared_ptr<segment>& seg) {
+              return acc + seg->size_bytes();
+          });
+        co_return compaction_result{total_size};
     }
-    _probe->add_initial_segment(*replacement.get());
 
-    auto ret = co_await segment_self_compact(cfg, replacement);
-
-    _probe->delete_segment(*replacement.get());
-    vlog(gclog.debug, "Final compacted segment {}", replacement);
-
-    /*
-     * remove index files (ignoring failures if they do not exist). they will be
-     * rebuilt by the single segment compaction operation, and also ensures we
-     * examine segments correctly on recovery.
-     */
-    co_await ss::when_all_succeed(
-      maybe_remove_file(target->index().path().string()),
-      maybe_remove_file(target->reader().path().to_compacted_index().string()));
-
-    // Evict segment readers and prevent new ones from being added to the cache.
-    std::vector<ss::future<readers_cache::range_lock_holder>> holder_futs;
-    holder_futs.reserve(segments.size());
-    for (auto& segment : segments) {
-        holder_futs.push_back(_readers_cache->evict_segment_readers(segment));
-    }
-    auto holders = co_await ss::when_all_succeed(
-      holder_futs.begin(), holder_futs.end());
-
-    // lock the range. only metadata (e.g. open/rename/delete) i/o occurs with
-    // these locks held so it is a relatively short duration. all of the data
-    // copying and compaction i/o occurred above with no locks held. 5 retries
-    // with a max lock timeout of 1 second. if we don't get the locks there is
-    // probably a reader. compaction will revisit.
-    auto locks = co_await internal::write_lock_segments(segments, 1s, 5);
-
-    // fast check if we should abandon all the expensive i/o work if we happened
-    // to be racing with an operation like truncation or shutdown.
-    vassert(
-      generations.size() == segments.size(),
-      "Each segment must have corresponding generation");
-    auto gen_it = generations.begin();
-    for (const auto& segment : segments) {
-        // check generation id under write lock
-        if (unlikely(segment->get_generation_id() != *gen_it)) {
-            vlog(
-              gclog.info,
-              "Aborting compaction of a segment: {}. Generation id mismatch, "
-              "previous generation: {}",
-              *segment,
-              *gen_it);
-            ret.executed_compaction = false;
-            ret.size_after = ret.size_before;
-            co_return ret;
-        }
-        if (unlikely(segment->is_closed())) {
-            throw segment_closed_exception();
-        }
-        ++gen_it;
-    }
-    // transfer segment state from replacement to target
-    locks = co_await internal::transfer_segment(
-      target, replacement, cfg, *_probe, std::move(locks));
+    // This is guaranteed to have a value.
+    auto ret = *opt_ret;
 
     auto segment_to_remove = segments.back();
     // We are going to remove one of the segments, but its bytes have not
@@ -1152,9 +1094,7 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     // the segment set.  the current adjacent segment compaction limits
     // compaction to two segments, and we check that assumption here and use
     // simplified clean-up routine.
-    locks.clear();
-    holders.clear();
-    staging_to_clean.clear();
+
     vassert(segments.size() == 2, "Cannot compact more than two segments");
     auto it = std::find(_segs.begin(), _segs.end(), segment_to_remove);
     if (it != _segs.end()) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1085,17 +1085,13 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 
     /*
-     * remove index files. they will be rebuilt by the single segment compaction
-     * operation, and also ensures we examine segments correctly on recovery.
+     * remove index files (ignoring failures if they do not exist). they will be
+     * rebuilt by the single segment compaction operation, and also ensures we
+     * examine segments correctly on recovery.
      */
-    if (co_await ss::file_exists(target->index().path().string())) {
-        co_await ss::remove_file(target->index().path().string());
-    }
-
-    auto compact_index = target->reader().path().to_compacted_index();
-    if (co_await ss::file_exists(compact_index.string())) {
-        co_await ss::remove_file(compact_index.string());
-    }
+    co_await ss::when_all_succeed(
+      maybe_remove_file(target->index().path().string()),
+      maybe_remove_file(target->reader().path().to_compacted_index().string()));
 
     // Evict segment readers and prevent new ones from being added to the cache.
     std::vector<ss::future<readers_cache::range_lock_holder>> holder_futs;

--- a/src/v/storage/exceptions.h
+++ b/src/v/storage/exceptions.h
@@ -39,3 +39,14 @@ public:
 private:
     ss::sstring _msg;
 };
+
+class generation_id_mismatch_exception : public std::exception {
+public:
+    explicit generation_id_mismatch_exception(ss::sstring s)
+      : _msg(std::move(s)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -340,7 +340,7 @@ ss::future<> segment::flush() {
     });
 }
 ss::future<> segment::do_flush() {
-    _generation_id++;
+    advance_generation();
     if (!_appender) {
         return ss::make_ready_future<>();
     }
@@ -403,7 +403,7 @@ ss::future<> segment::do_truncate(
       "truncating segment {} at {}",
       _reader->filename(),
       new_max_offset);
-    _generation_id++;
+    advance_generation();
     cache_truncate(new_max_offset + model::offset(1));
     auto f = ss::now();
     if (is_compacted_segment()) {
@@ -543,7 +543,7 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
     const auto expected_end_physical = start_physical_offset
                                        + b.header().size_bytes;
 
-    _generation_id++;
+    advance_generation();
 
     // inflight index. trimmed on every dma_write in appender
     _inflight.emplace(expected_end_physical, b.last_offset());

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -702,10 +702,12 @@ void segment::advance_stable_offset(size_t filepos) {
 std::ostream& operator<<(std::ostream& o, const segment::offset_tracker& t) {
     fmt::print(
       o,
-      "{{term:{}, base_offset:{}, committed_offset:{}, dirty_offset:{}}}",
+      "{{term:{}, base_offset:{}, committed_offset:{}, stable_offset:{}, "
+      "dirty_offset:{}}}",
       t.get_term(),
       t.get_base_offset(),
       t.get_committed_offset(),
+      t.get_stable_offset(),
       t.get_dirty_offset());
     return o;
 }

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -947,7 +947,7 @@ ss::future<std::vector<compacted_index_reader>> make_indices_readers(
   std::vector<ss::lw_shared_ptr<segment>>& segments,
   std::optional<ntp_sanitizer_config> ntp_sanitizer_config,
   ss::abort_source* as) {
-    return ssx::async_transform(
+    return ssx::async_transform<std::vector<compacted_index_reader>>(
       segments.begin(),
       segments.end(),
       [san_cfg = ntp_sanitizer_config, as](ss::lw_shared_ptr<segment>& seg) {

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -37,6 +37,7 @@
 #include "storage/scoped_file_tracker.h"
 #include "storage/segment.h"
 #include "storage/types.h"
+#include "utils/file_io.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
@@ -820,17 +821,19 @@ make_concatenated_segment(
         }
     }
 
+    auto index_path = path.to_index();
     auto compacted_idx_path = path.to_compacted_index();
-    if (co_await ss::file_exists(ss::sstring(compacted_idx_path))) {
-        co_await ss::remove_file(ss::sstring(compacted_idx_path));
-    }
+
+    // Remove the segment, index, and compacted index (ignoring failures if they
+    // do not exist)
+    co_await ss::when_all_succeed(
+      maybe_remove_file(path.string()),
+      maybe_remove_file(index_path.string()),
+      maybe_remove_file(compacted_idx_path.string()));
+
     co_await write_concatenated_compacted_index(
       compacted_idx_path, segments, cfg, resources);
 
-    // concatenation process
-    if (co_await ss::file_exists(path.string())) {
-        co_await ss::remove_file(path.string());
-    }
     auto writer = co_await make_writer_handle(path, cfg.sanitizer_config);
     auto output = co_await ss::make_file_output_stream(std::move(writer));
     for (auto& segment : segments) {
@@ -865,11 +868,6 @@ make_concatenated_segment(
       cfg.sanitizer_config);
     co_await reader->load_size();
 
-    // build an empty index for the segment
-    auto index_name = path.to_index();
-    if (co_await ss::file_exists(index_name.string())) {
-        co_await ss::remove_file(index_name.string());
-    }
     // start the new index with the newest of the broker_timestamps from the
     // segments
     auto new_broker_timestamp = [&]() -> std::optional<model::timestamp> {
@@ -921,7 +919,7 @@ make_concatenated_segment(
       [](const auto& s) { return s->index().may_have_tombstone_records(); });
 
     segment_index index(
-      index_name,
+      index_path,
       offsets.get_base_offset(),
       segment_index::default_data_buffer_step,
       feature_table,

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -25,6 +25,7 @@
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
+#include "storage/exceptions.h"
 #include "storage/file_sanitizer.h"
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
@@ -63,6 +64,7 @@
 
 namespace storage::internal {
 using namespace storage; // NOLINT
+using namespace std::literals::chrono_literals;
 
 /// Check if the file is on BTRFS, and disable copy-on-write if so.  COW
 /// is not useful for logs and can cause issues.
@@ -1088,6 +1090,116 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
     co_await from->remove_persistent_state();
 
     co_return std::move(locks);
+}
+
+ss::future<compaction_result> concatenate_and_rebuild_target_segment(
+  ss::lw_shared_ptr<segment> target,
+  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  compaction_config cfg,
+  storage::probe& pb,
+  storage::readers_cache& readers_cache,
+  storage_resources& resources,
+  ss::sharded<features::feature_table>& feature_table,
+  mutex& segment_rewrite_lock) {
+    vassert(
+      segment_rewrite_lock.is_held(), "Segment rewrite lock should be held.");
+
+    const bool all_window_compacted = std::ranges::all_of(
+      segments, &segment::finished_windowed_compaction);
+
+    target->clear_cached_disk_usage();
+
+    // concatenate segments from the compaction range into replacement segment
+    // backed by a staging file. the process is completed while holding a read
+    // lock on the range, which is then released. the remainder of the
+    // compaction process operates on replacement segment, and any conflicting
+    // log operations are later identified before committing changes.
+    auto staging_path = target->reader().path().to_compaction_staging();
+    auto staging_to_clean = scoped_file_tracker{
+      cfg.files_to_cleanup, {staging_path, staging_path.to_compacted_index()}};
+    auto [replacement, generations] = co_await make_concatenated_segment(
+      staging_path, segments, cfg, resources, feature_table);
+
+    // compact the combined data in the replacement segment. the partition size
+    // tracking needs to be adjusted as compaction routines assume the segment
+    // size is already contained in the partition size probe
+    replacement->mark_as_compacted_segment();
+    if (all_window_compacted) {
+        // replacement's _clean_compact_timestamp will have been set in
+        // make_concatenated_segment if all segments were cleanly compacted
+        // already.
+        replacement->mark_as_finished_windowed_compaction();
+    }
+    pb.add_initial_segment(*replacement.get());
+
+    compaction_result ret = co_await self_compact_segment(
+      replacement,
+      stm_manager,
+      cfg,
+      pb,
+      readers_cache,
+      resources,
+      feature_table);
+    vlog(gclog.debug, "Final compacted segment {}", replacement);
+
+    /*
+     * remove index files (ignoring failures if they do not exist). they will be
+     * rebuilt by the single segment compaction operation, and also ensures we
+     * examine segments correctly on recovery.
+     */
+    co_await ss::when_all_succeed(
+      maybe_remove_file(target->index().path().string()),
+      maybe_remove_file(target->reader().path().to_compacted_index().string()));
+
+    // Evict segment readers and prevent new ones from being added to the cache.
+    std::vector<ss::future<readers_cache::range_lock_holder>> holder_futs;
+    holder_futs.reserve(segments.size());
+    for (auto& segment : segments) {
+        holder_futs.push_back(readers_cache.evict_segment_readers(segment));
+    }
+
+    auto holders = co_await ss::when_all_succeed(
+      holder_futs.begin(), holder_futs.end());
+
+    // lock the range. only metadata (e.g. open/rename/delete) i/o occurs with
+    // these locks held so it is a relatively short duration. all of the data
+    // copying and compaction i/o occurred above with no locks held. 5 retries
+    // with a max lock timeout of 1 second. if we don't get the locks there is
+    // probably a reader. compaction will revisit.
+    auto locks = co_await internal::write_lock_segments(segments, 1s, 5);
+
+    // fast check if we should abandon all the expensive i/o work if we happened
+    // to be racing with an operation like truncation or shutdown.
+    vassert(
+      generations.size() == segments.size(),
+      "Each segment must have corresponding generation");
+    auto gen_it = generations.begin();
+    for (const auto& segment : segments) {
+        // check generation id under write lock
+        if (unlikely(segment->get_generation_id() != *gen_it)) {
+            throw generation_id_mismatch_exception(fmt::format(
+              "Aborting compaction of a segment: {}. Generation id mismatch, "
+              "previous generation: {}",
+              *segment,
+              *gen_it));
+        }
+        if (unlikely(segment->is_closed())) {
+            throw segment_closed_exception();
+        }
+        ++gen_it;
+    }
+
+    pb.delete_segment(*replacement.get());
+    // transfer segment state from replacement to target
+    locks = co_await internal::transfer_segment(
+      target, replacement, cfg, pb, std::move(locks));
+
+    locks.clear();
+    holders.clear();
+    staging_to_clean.clear();
+
+    co_return ret;
 }
 
 ss::future<std::vector<ss::rwlock::holder>> write_lock_segments(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -94,6 +94,24 @@ make_concatenated_segment(
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table);
 
+// Must be called with _segments_rewrite_lock from the parent log held.
+// Concatenates all segments in `segments` and replaces the in-memory and
+// on-disk state of `target` with the built replacement. Self compaction is
+// performed on the replacement target before the swap occurs to ensure its
+// state is fully re-built (.base_index file, .compaction_index file, in-memory
+// states). Write locks for all passed segments will be held during
+// concatenation.
+ss::future<compaction_result> concatenate_and_rebuild_target_segment(
+  ss::lw_shared_ptr<segment> target,
+  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  compaction_config cfg,
+  storage::probe& pb,
+  storage::readers_cache& readers_cache,
+  storage_resources& resources,
+  ss::sharded<features::feature_table>& feature_table,
+  mutex& segment_rewrite_lock);
+
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path,
   std::vector<ss::lw_shared_ptr<segment>>,

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -560,6 +560,28 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "segment_concatenation_test",
+    timeout = "short",
+    srcs = [
+        "segment_concatenation_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        ":disk_log_builder",
+        ":disk_log_builder_fixture",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "//src/v/model",
+        "//src/v/random:generators",
+        "//src/v/storage",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:mutex",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "readers_cache_test",
     timeout = "short",
     srcs = [

--- a/src/v/storage/tests/segment_concatenation_test.cc
+++ b/src/v/storage/tests/segment_concatenation_test.cc
@@ -1,0 +1,221 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf.h"
+#include "bytes/iostream.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "random/generators.h"
+#include "storage/disk_log_impl.h"
+#include "storage/parser.h"
+#include "storage/scoped_file_tracker.h"
+#include "storage/segment.h"
+#include "storage/segment_deduplication_utils.h"
+#include "storage/segment_reader.h"
+#include "storage/segment_utils.h"
+#include "storage/tests/disk_log_builder_fixture.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "storage/types.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/defer.hh>
+
+#include <chrono>
+#include <numeric>
+#include <stdexcept>
+
+using namespace std::literals::chrono_literals;
+
+namespace {
+ss::abort_source never_abort;
+ss::logger test_log("segment_concatenation_test_log");
+
+struct read_segments_result {
+    iobuf buf;
+    size_t len;
+    auto operator==(const read_segments_result& o) const {
+        return std::tie(buf, len) == std::tie(o.buf, o.len);
+    }
+};
+
+struct segment_attrs_result {
+    model::offset base_offset;
+    model::offset dirty_offset;
+    model::offset committed_offset;
+    model::offset stable_offset;
+
+    size_t num_records{0};
+    size_t size_bytes{0};
+
+    auto operator==(const segment_attrs_result& o) const {
+        return std::tie(
+                 base_offset,
+                 dirty_offset,
+                 committed_offset,
+                 stable_offset,
+                 num_records,
+                 size_bytes)
+               == std::tie(
+                 o.base_offset,
+                 o.dirty_offset,
+                 o.committed_offset,
+                 o.stable_offset,
+                 o.num_records,
+                 o.size_bytes);
+    }
+};
+
+struct segment_comparision_fields {
+    segment_attrs_result attrs_result;
+    read_segments_result read_result;
+
+    auto operator==(const segment_comparision_fields& o) const {
+        return std::tie(attrs_result, read_result)
+               == std::tie(o.attrs_result, o.read_result);
+    }
+};
+
+segment_comparision_fields concat_read_segments(
+  std::vector<ss::lw_shared_ptr<storage::segment>> segments) {
+    size_t start_pos = 0;
+    size_t end_pos = segments.back()->file_size();
+    storage::concat_segment_reader_view cv{segments, start_pos, end_pos};
+    iobuf buf;
+    segment_comparision_fields res;
+    size_t num_records = 0;
+    size_t size_bytes = 0;
+    auto transform_stream_result
+      = storage::transform_stream(
+          cv.take_stream(),
+          make_iobuf_ref_output_stream(buf),
+          [&num_records, &size_bytes](model::record_batch_header h) {
+              num_records += h.record_count;
+              size_bytes += h.record_count;
+              return storage::batch_consumer::consume_result::accept_batch;
+          })
+          .get();
+
+    res.attrs_result = segment_attrs_result{
+      .base_offset = segments.front()->offsets().get_base_offset(),
+      .dirty_offset = segments.back()->offsets().get_dirty_offset(),
+      .committed_offset = segments.back()->offsets().get_committed_offset(),
+      .stable_offset = segments.back()->offsets().get_stable_offset(),
+      .num_records = num_records,
+      .size_bytes = size_bytes};
+    EXPECT_TRUE(transform_stream_result.has_value());
+    res.read_result = read_segments_result{
+      .buf = std::move(buf), .len = transform_stream_result.value()};
+    return res;
+}
+
+void concatenate_segments_from_log(
+  storage::disk_log_impl& log,
+  int expected_segments_to_compact,
+  ss::sharded<features::feature_table>& feature_table,
+  bool maybe_compress) {
+    storage::compaction_config cfg(
+      model::offset::max(), std::nullopt, never_abort);
+
+    const auto closed_segment_filter = [](const auto& s) -> bool {
+        return !s->has_appender();
+    };
+
+    auto log_segments = log.segments()
+                        | std::views::filter(closed_segment_filter);
+
+    std::vector<ss::lw_shared_ptr<storage::segment>> segments(
+      log_segments.begin(), log_segments.end());
+    EXPECT_EQ(segments.size(), expected_segments_to_compact);
+
+    // Self compaction shouldn't affect the number of records in the segment
+    // Compression may have an effect on read buffer/len though.
+    for (auto& seg : segments) {
+        auto read_result_before = concat_read_segments({seg});
+        log.segment_self_compact(cfg, seg).get();
+        auto read_result_after = concat_read_segments({seg});
+        if (maybe_compress) {
+            EXPECT_EQ(
+              read_result_before.attrs_result, read_result_after.attrs_result);
+        } else {
+            EXPECT_EQ(read_result_before, read_result_after);
+        }
+    }
+
+    auto expected_target_file_size = std::accumulate(
+      segments.begin(),
+      segments.end(),
+      size_t{0},
+      [](size_t sum, const auto& seg) { return sum + seg->file_size(); });
+
+    auto segments_read_result = concat_read_segments(segments);
+
+    auto fake_segment_rewrite_lock = mutex{"fake_segment_rewrite_lock"};
+    auto holder = fake_segment_rewrite_lock.get_units().get();
+
+    // the segment which will be expanded to replace
+    auto target = segments.front();
+
+    [[maybe_unused]] auto ret
+      = storage::internal::concatenate_and_rebuild_target_segment(
+          target,
+          segments,
+          log.stm_manager(),
+          cfg,
+          log.get_probe(),
+          log.readers(),
+          log.resources(),
+          feature_table,
+          fake_segment_rewrite_lock)
+          .get();
+
+    EXPECT_EQ(target->file_size(), expected_target_file_size);
+
+    auto target_read_result = concat_read_segments({target});
+    EXPECT_EQ(segments_read_result, target_read_result);
+}
+
+} // anonymous namespace
+
+// Params:
+// size_t number of segments to concatenate
+// bool maybe compress batches or not
+class MakeConcatenatedSegmentFixture
+  : public testing::Test
+  , public testing::WithParamInterface<std::tuple<size_t, bool>> {};
+
+TEST_P(MakeConcatenatedSegmentFixture, ConcatenateSegments) {
+    using namespace storage;
+    disk_log_builder b;
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    b | start();
+    auto& disk_log = b.get_disk_log_impl();
+
+    auto [num_segments, maybe_compress] = GetParam();
+    auto records_per_seg = random_generators::get_int(50, 200);
+    for (size_t i = 0; i < num_segments; ++i) {
+        auto offset = i * records_per_seg;
+        b
+          | add_random_batch(
+            offset, records_per_seg, maybe_compress_batches(maybe_compress));
+        disk_log.force_roll().get();
+    }
+
+    concatenate_segments_from_log(
+      disk_log, num_segments, b.feature_table(), maybe_compress);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  MakeConcatenatedSegmentTest,
+  MakeConcatenatedSegmentFixture,
+  testing::Combine(
+    testing::Values(1, 2, 3, 4, 5, 10, 20, 100), testing::Bool()));

--- a/src/v/utils/file_io.cc
+++ b/src/v/utils/file_io.cc
@@ -76,3 +76,13 @@ ss::future<> write_fully(const std::filesystem::path& p, iobuf buf) {
         return out.close();
     });
 }
+
+ss::future<> maybe_remove_file(std::string_view name) {
+    try {
+        co_await ss::remove_file(name);
+    } catch (const std::filesystem::filesystem_error& e) {
+        if (e.code() != std::errc::no_such_file_or_directory) {
+            throw;
+        }
+    }
+}

--- a/src/v/utils/file_io.h
+++ b/src/v/utils/file_io.h
@@ -34,3 +34,8 @@ ss::future<ss::sstring> read_fully_to_string(const std::filesystem::path&);
 
 /// \brief Write an entire buffer into the file at location 'path'
 ss::future<> write_fully(const std::filesystem::path&, iobuf buf);
+
+// Maybe removes the file with filename `name`. No error or indication is
+// returned if the file does not exist. Any other errors are propagated via
+// thrown exception.
+ss::future<> maybe_remove_file(std::string_view name);

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -73,6 +73,7 @@ public:
     }
 
     size_t waiters() const noexcept { return _sem.waiters(); }
+    bool is_held() const noexcept { return _sem.current() == 0; }
 
 private:
     ssx::semaphore _sem;

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -557,5 +557,6 @@ redpanda_cc_gtest(
         "//src/v/test_utils:random_bytes",
         "//src/v/utils:file_io",
         "@googletest//:gtest",
+        "@seastar",
     ],
 )

--- a/src/v/utils/tests/file_io_test.cc
+++ b/src/v/utils/tests/file_io_test.cc
@@ -12,7 +12,11 @@
 #include "test_utils/random_bytes.h"
 #include "utils/file_io.h"
 
+#include <seastar/core/file.hh>
+
 #include <gtest/gtest.h>
+
+#include <filesystem>
 
 class ReadFully : public ::testing::TestWithParam<size_t> {};
 
@@ -21,6 +25,31 @@ TEST_P(ReadFully, RoundTrip) {
     write_fully("out.dat", input.copy()).get();
     const auto output = read_fully("out.dat").get();
     EXPECT_EQ(input, output);
+}
+
+TEST(MaybeRemoveFile, FileIsRemoved) {
+    auto file = ss::sstring("panda_world.dat");
+    ss::open_file_dma(file, ss::open_flags::create).get();
+    EXPECT_TRUE(ss::file_exists(file).get());
+    EXPECT_NO_THROW(maybe_remove_file(file).get());
+    EXPECT_FALSE(ss::file_exists(file).get());
+}
+
+TEST(MaybeRemoveFile, MissingFileNoThrownException) {
+    auto file = "panda_world.dat";
+    EXPECT_FALSE(ss::file_exists(file).get());
+    EXPECT_NO_THROW(maybe_remove_file(file).get());
+}
+
+TEST(MaybeRemoveFile, OtherErrorThrowsException) {
+    // Using a non-empty directory removal attempt to demonstrate that any
+    // exception thrown other than a missing file is propagated by
+    // maybe_remove_file().
+    auto outer_dir = "panda_world";
+    auto dir = ss::sstring(outer_dir) + ss::sstring("/panda_city");
+    ss::recursive_touch_directory(dir).get();
+    EXPECT_THROW(
+      maybe_remove_file(outer_dir).get(), std::filesystem::filesystem_error);
 }
 
 namespace {


### PR DESCRIPTION
A series of commits pulled out from https://github.com/redpanda-data/redpanda/pull/25953 to make that PR more easily digestible and more centred around core functionality changes.

This is a series of _mostly_ non-functional tweaks within the `storage` layer, but also contains changes to some adjacently related code (`utils`, `ssx`) that will be relevant for the changes in https://github.com/redpanda-data/redpanda/pull/25953.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
