### PR TITLE
raft/c: warn on struck truncation.

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -36,6 +36,7 @@
 #include "reflection/adl.h"
 #include "rpc/types.h"
 #include "ssx/future-util.h"
+#include "ssx/watchdog.h"
 #include "storage/api.h"
 #include "storage/kvstore.h"
 #include "storage/ntp_config.h"
@@ -2655,10 +2656,21 @@ ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
         co_return;
     }
 
-    // Release the lock when truncating the log because it can take some
-    // time while we wait for readers to be evicted.
-    co_await _log->truncate_prefix(
-      storage::truncate_prefix_config(model::next_offset(last_included_index)));
+    {
+        auto truncation_offset = model::next_offset(last_included_index);
+        ssx::watchdog wd15min(15min, [this, truncation_offset] {
+            vlog(
+              _ctxlog.warn,
+              "Truncation at offset {} is taking more than 15min, log offsets: "
+              "{}",
+              truncation_offset,
+              _log->offsets());
+        });
+        // Release the lock when truncating the log because it can take some
+        // time while we wait for readers to be evicted.
+        co_await _log->truncate_prefix(
+          storage::truncate_prefix_config(truncation_offset));
+    }
 
     /*
      * We do not need to keep an oplock when updating the flushed offset here as


### PR DESCRIPTION
The timeout is generously long to detect only legitimately stuck truncations.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
