### PR TITLE
rptest/docker: remove llvm from ducktape deps

### DIFF
--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -21,7 +21,6 @@ apt-get install -qq \
   krb5-user \
   libatomic1 \
   libyajl-dev \
-  llvm \
   lsof \
   net-tools \
   netcat-openbsd \


### PR DESCRIPTION
We are now installing llvm-20 in tool-pkgs, so remove bare llvm (which is llvm 14 and not suitable for interacting with Redpanda binaries).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
