### PR TITLE
`rptest`: add `assert` to `KgoRepeaterService.free()`

### DIFF
--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -415,6 +415,10 @@ class KgoRepeaterService(Service):
             r = requests.get(self._remote_url(node, "reset"), timeout=10)
             r.raise_for_status()
 
+    def free(self):
+        assert self._stopped, "Cannot free KgoRepeaterService before stopping it"
+        return super().free()
+
 
 @contextmanager
 def repeater_traffic(context,


### PR DESCRIPTION
To catch any locations where we might be freeing a repeater service without first stopping it (which may be leading to port issues in CDT).

Opening for CI, will amend any found issues in this PR.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
