### PR TITLE
[CORE-9601] `rptest`: deflake `datalake/compaction_test.py`

### DIFF
--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -183,14 +183,27 @@ class CompactionTest(RedpandaTest):
                 metrics_endpoint=MetricsEndpoint.METRICS,
                 topic=self.topic_name)
 
+        def get_complete_sliding_window_rounds():
+            return self.redpanda.metric_sum(
+                metric_name=
+                "vectorized_storage_log_complete_sliding_window_rounds_total",
+                metrics_endpoint=MetricsEndpoint.METRICS,
+                topic=self.topic_name)
+
+        self.prev_sliding_window_rounds = -1
+
         def compaction_has_completed():
-            return get_dirty_segment_bytes() == 0
+            new_sliding_window_rounds = get_complete_sliding_window_rounds()
+            res = self.prev_sliding_window_rounds == new_sliding_window_rounds and get_dirty_segment_bytes(
+            ) == 0
+            self.prev_sliding_window_rounds = new_sliding_window_rounds
+            return res
 
         wait_until(
             compaction_has_completed,
             timeout_sec=180,
             backoff_sec=self.extra_rp_conf['log_compaction_interval_ms'] /
-            1000,
+            1000 * 4,
             err_msg="Compaction did not stabilize.")
 
     def verify_log_and_table(self, dl: DatalakeServices):


### PR DESCRIPTION
It seems that the number of dirty bytes in the log was not a air-tight indicator of compaction being finished on its own. This is due to the restart of all of the nodes in the cluster being issued right before a call to `redpanda.metric_sum()`. This can be race-y and return `0` immediately after a restart, before the log has a chance to book-keep the correct value for dirty bytes given the existing segments on disk.

Re-use a proven metric, that being the number of complete sliding window compaction rounds, and sample it over multiple periods of `log_compaction_interval_ms` to be sure that compaction has settled before attempting to verify the compacted log with `KgoSeqConsumer`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
