### PR TITLE
[v25.1.x] Fixed upgrade test to actually restart consumer in older Redpanda versions

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -169,6 +169,7 @@ class KgoVerifierService(Service):
         # Check that the PID we just launched is still running as a confirmation
         # that it is the one.
         self._assert_running(node)
+        self._stopped = False
 
     def _await_ready(self, node):
         """
@@ -199,9 +200,13 @@ class KgoVerifierService(Service):
         node.account.ssh_output(f"ps -p {self._pid}", allow_fail=False)
 
     def stop_node(self, node, **kwargs):
+        error = None
         if self._status_thread:
             self._status_thread.stop()
-            self._status_thread.raise_on_error()
+            try:
+                self._status_thread.raise_on_error()
+            except Exception as e:
+                error = e
             self._status_thread = None
             # Record that we just stopped, so that we can't wait() after.
             # This is done inside this if statement because stop_node() is also
@@ -223,6 +228,8 @@ class KgoVerifierService(Service):
 
         self._pid = None
         self._release_port()
+        if error:
+            raise error
 
     def clean_node(self, node: ClusterNode):
         self._redpanda.logger.info(f"{self.__class__.__name__}.clean_node")
@@ -726,7 +733,6 @@ class KgoVerifierProducer(KgoVerifierService):
             cmd += " --validate-latest-values"
 
         self.spawn(cmd, node)
-
         self._status_thread = StatusThread(self, node, ProduceStatus)
         self._status_thread.start()
 

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -247,7 +247,30 @@ class UpgradeBackToBackTest(PreallocNodesTest):
 
             # Wait for consumers to finish work and check invariants.
             for consumer in self._consumers:
-                consumer.wait()
+                max_retries = 5
+                while max_retries > 0:
+                    max_retries -= 1
+                    try:
+                        self.logger.info(
+                            f"Waiting for consumer {consumer} to finish work..."
+                        )
+                        consumer.wait()
+                        break
+                    except Exception as e:
+                        # consumer status endpoint timeout, in v22 we need to tolerate the offset for leader epoch handler error
+                        if current_version[0] <= 22:
+                            self.logger.info(
+                                f"restarting consumer, Redpanda running {current_version} version, error: {e}"
+                            )
+                            try:
+                                consumer.stop()
+                            except Exception as stop_exception:
+                                self.logger.info(
+                                    f"failed to stop consumer {consumer} - {stop_exception}"
+                                )
+                            consumer.start(clean=False)
+                        else:
+                            raise e
 
             # Check consumer invariants after each upgrade.
             assert self._seq_consumer.consumer_status.validator.valid_reads >= wrote_at_least


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26102 