### PR TITLE
ssx: Checkpoint mutex

### DIFF
--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -715,6 +715,7 @@ redpanda_cc_library(
         "//src/v/serde:vector",
         "//src/v/ssx:async_algorithm",
         "//src/v/ssx:async_clear",
+        "//src/v/ssx:checkpoint_mutex",
         "//src/v/ssx:event",
         "//src/v/ssx:future_util",
         "//src/v/ssx:rate_limited_function",

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -41,6 +41,7 @@
 #include "model/record.h"
 #include "net/connection.h"
 #include "raft/fundamental.h"
+#include "ssx/checkpoint_mutex.h"
 #include "ssx/future-util.h"
 #include "storage/disk_log_impl.h"
 #include "storage/fs_utils.h"
@@ -679,7 +680,7 @@ ss::future<std::error_code> ntp_archiver::process_anomalies(
   cloud_storage::scrub_status status,
   cloud_storage::anomalies detected) {
     // If there's ongoing housekeeping job, let it finish first.
-    auto units = co_await ss::get_units(_mutex, 1, _as);
+    auto units = co_await _mutex.get_units(_as);
 
     auto sync_timeout = config::shard_local_cfg()
                           .cloud_storage_metadata_sync_timeout_ms.value();
@@ -777,7 +778,7 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
     // as soon as we can, rather than potentially waiting for segment
     // uploads).
     {
-        auto units = co_await ss::get_units(_uploads_active, 1);
+        auto units = co_await _uploads_active.get_units();
         co_await maybe_upload_manifest(upload_loop_prologue_ctx_label);
         co_await flush_manifest_clean_offset();
     }
@@ -787,11 +788,11 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
         // the process of doing uploads + wait for us to drop out if they
         // e.g. set _paused.
         vassert(!_paused, "may_begin_uploads must ensure !_paused");
-        auto units = co_await ss::get_units(_uploads_active, 1);
+        auto units = co_await _uploads_active.get_units();
         vlog(
           _rtclog.trace,
           "upload_until_term_change: got units (current {}), paused={}",
-          _uploads_active.current(),
+          _uploads_active.has_units(),
           _paused);
 
         // Bump up archival STM's state to make sure that it's not lagging
@@ -897,11 +898,11 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
 
         // Drop _uploads_active lock: we are not considered active while
         // sleeping for backoff at the end of the loop.
-        units.return_all();
+        units.release();
         vlog(
           _rtclog.trace,
           "upload_until_term_change: released units (current {})",
-          _uploads_active.current());
+          _uploads_active.has_units());
 
         if (
           !result.has_value()
@@ -2358,7 +2359,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
       max_offset_exclusive);
     ss::gate::holder holder(_gate);
     try {
-        auto units = co_await ss::get_units(_mutex, 1, _as);
+        auto units = co_await _mutex.get_units(_as);
         auto scheduled_uploads = co_await schedule_uploads(
           max_offset_exclusive);
         co_return co_await wait_all_scheduled_uploads(
@@ -2509,7 +2510,7 @@ ss::future<> ntp_archiver::housekeeping() {
             // Acquire mutex to prevent concurrency between
             // external housekeeping jobs from upload_housekeeping_service
             // and retention/GC
-            auto units = co_await ss::get_units(_mutex, 1, _as);
+            auto units = co_await _mutex.get_units(_as);
             if (stm_retention_needed()) {
                 co_await apply_retention();
                 co_await garbage_collect();
@@ -3315,7 +3316,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
     } else {
         vlog(_rtclog.debug, "Scan result: {}", run);
     }
-    auto units = co_await ss::get_units(_mutex, 1, _as);
+    auto units = co_await _mutex.get_units(_as);
     if (run->meta.base_offset >= _parent.raft_start_offset()) {
         auto log_generic = _parent.log();
         auto& log = *log_generic;
@@ -3610,11 +3611,11 @@ ntp_archiver::prepare_transfer_leadership(ss::lowres_clock::duration timeout) {
 
     ss::gate::holder holder(_gate);
     try {
-        co_await ss::get_units(_uploads_active, 1, timeout);
+        auto units = co_await _uploads_active.get_units(timeout);
         vlog(
           _rtclog.trace,
           "prepare_transfer_leadership: got units (current {})",
-          _uploads_active.current());
+          _uploads_active.has_units());
     } catch (const ss::semaphore_timed_out&) {
         // In this situation, it is possible that the old leader (this node)
         // will leave an orphan object behind in object storage, because
@@ -3650,7 +3651,7 @@ void ntp_archiver::complete_transfer_leadership() {
     vlog(
       _rtclog.trace,
       "complete_transfer_leadership: current units (current {})",
-      _uploads_active.current());
+      _uploads_active.has_units());
     _paused = false;
     _leader_cond.signal();
 }

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "ssx/checkpoint_mutex.h"
 #include "ssx/event.h"
 #include "storage/fwd.h"
 #include "utils/retry_chain_node.h"
@@ -333,7 +334,7 @@ public:
         const cloud_storage::partition_manifest& manifest)>;
 
     struct find_reupload_candidate_result {
-        std::optional<ssx::semaphore_units> units;
+        std::optional<ssx::checkpoint_mutex_units> units;
         std::optional<upload_candidate_with_locks> locks;
         archival_stm_fence read_write_fence;
     };
@@ -717,7 +718,7 @@ private:
     // NOTE: must be taken before doing anything that acquires segment read
     // locks (e.g. selecting segments for upload, replicating and waiting on
     // the underlying Raft STM).
-    ssx::semaphore _mutex{1, "archive/ntp"};
+    ssx::checkpoint_mutex _mutex{"archive/ntp"};
 
     ss::lw_shared_ptr<const configuration> _conf;
     config::binding<std::chrono::milliseconds> _sync_manifest_timeout;
@@ -749,7 +750,7 @@ private:
     // Held while the inner segment upload/manifest sync loop is running,
     // to enable code that uses _paused to wait until ongoing activity
     // has stopped.
-    ssx::named_semaphore<ss::lowres_clock> _uploads_active{1, "uploads_active"};
+    ssx::checkpoint_mutex _uploads_active{"uploads_active"};
 
     config::binding<std::chrono::milliseconds> _housekeeping_interval;
     simple_time_jitter<ss::lowres_clock> _housekeeping_jitter;

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -107,6 +107,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "checkpoint_mutex",
+    hdrs = [
+        "checkpoint_mutex.h",
+    ],
+    include_prefix = "ssx",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":sformat",
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "task_local",
     hdrs = [
         "task_local_ptr.h",

--- a/src/v/ssx/checkpoint_mutex.h
+++ b/src/v/ssx/checkpoint_mutex.h
@@ -357,8 +357,7 @@ template<typename Func>
 auto basic_checkpoint_mutex<Clock>::with(
   Func&& func, vlog::file_line line) noexcept {
     return get_units(line).then(
-      [f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                     ) mutable {
+      [f = std::forward<Func>(func)](basic_mutex_units<Clock> units) mutable {
           return seastar::futurize_invoke(std::forward<Func>(f))
             .finally([units = std::move(units)] {});
       });
@@ -369,11 +368,11 @@ template<typename Func>
 auto basic_checkpoint_mutex<Clock>::with(
   Clock::time_point deadline, Func&& func, vlog::file_line line) noexcept {
     return get_units(deadline, line)
-      .then([f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                           ) mutable {
-          return seastar::futurize_invoke(std::forward<Func>(f))
-            .finally([units = std::move(units)] {});
-      });
+      .then(
+        [f = std::forward<Func>(func)](basic_mutex_units<Clock> units) mutable {
+            return seastar::futurize_invoke(std::forward<Func>(f))
+              .finally([units = std::move(units)] {});
+        });
 }
 
 template<typename Clock>
@@ -381,11 +380,11 @@ template<typename Func>
 auto basic_checkpoint_mutex<Clock>::with(
   Clock::duration timeout, Func&& func, vlog::file_line line) noexcept {
     return get_units(timeout, line)
-      .then([f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                           ) mutable {
-          return seastar::futurize_invoke(std::forward<Func>(f))
-            .finally([units = std::move(units)] {});
-      });
+      .then(
+        [f = std::forward<Func>(func)](basic_mutex_units<Clock> units) mutable {
+            return seastar::futurize_invoke(std::forward<Func>(f))
+              .finally([units = std::move(units)] {});
+        });
 }
 
 template<typename Clock>
@@ -393,8 +392,7 @@ template<typename Func>
 auto basic_checkpoint_mutex<Clock>::with(
   seastar::abort_source& as, Func&& func, vlog::file_line line) noexcept {
     return get_units(as, line).then(
-      [f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                     ) mutable {
+      [f = std::forward<Func>(func)](basic_mutex_units<Clock> units) mutable {
           return seastar::futurize_invoke(std::forward<Func>(f))
             .finally([units = std::move(units)] {});
       });

--- a/src/v/ssx/checkpoint_mutex.h
+++ b/src/v/ssx/checkpoint_mutex.h
@@ -358,8 +358,9 @@ auto basic_checkpoint_mutex<Clock>::with(
   Func&& func, vlog::file_line line) noexcept {
     return get_units(line).then(
       [f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                     [[maybe_unused]]) mutable {
-          return seastar::futurize_invoke(std::forward<Func>(f));
+                                     ) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f))
+            .finally([units = std::move(units)] {});
       });
 }
 
@@ -369,8 +370,9 @@ auto basic_checkpoint_mutex<Clock>::with(
   Clock::time_point deadline, Func&& func, vlog::file_line line) noexcept {
     return get_units(deadline, line)
       .then([f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                           [[maybe_unused]]) mutable {
-          return seastar::futurize_invoke(std::forward<Func>(f));
+                                           ) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f))
+            .finally([units = std::move(units)] {});
       });
 }
 
@@ -380,8 +382,9 @@ auto basic_checkpoint_mutex<Clock>::with(
   Clock::duration timeout, Func&& func, vlog::file_line line) noexcept {
     return get_units(timeout, line)
       .then([f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                           [[maybe_unused]]) mutable {
-          return seastar::futurize_invoke(std::forward<Func>(f));
+                                           ) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f))
+            .finally([units = std::move(units)] {});
       });
 }
 
@@ -391,8 +394,9 @@ auto basic_checkpoint_mutex<Clock>::with(
   seastar::abort_source& as, Func&& func, vlog::file_line line) noexcept {
     return get_units(as, line).then(
       [f = std::forward<Func>(func)](basic_mutex_units<Clock> units
-                                     [[maybe_unused]]) mutable {
-          return seastar::futurize_invoke(std::forward<Func>(f));
+                                     ) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f))
+            .finally([units = std::move(units)] {});
       });
 }
 

--- a/src/v/ssx/checkpoint_mutex.h
+++ b/src/v/ssx/checkpoint_mutex.h
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/source_location.h"
+#include "base/vassert.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sstring.hh>
+
+#include <chrono>
+#include <utility>
+
+namespace ssx {
+
+template<typename Clock = seastar::timer<>::clock>
+struct basic_mutex_checkpoint {
+    vlog::file_line line;
+    Clock::time_point time;
+};
+
+template<class Clock>
+class basic_mutex_units;
+
+namespace detail {
+struct checkpoint_mutex_locker;
+}
+
+/// Checkpoint mutex allows the user to store some additional information
+/// about the waiter, such as the call site (file and line) and the time when
+/// it was awaited. In the event of a timeout the exception will contain the
+/// call site that acquired the mutex last.
+/// The mutex can be inspected at any moment.
+template<typename Clock = seastar::timer<>::clock>
+class basic_checkpoint_mutex {
+    /// Stores information about the checkpoint that acquired units last.
+    struct checkpoint_store {
+        bool has_checkpoint() const noexcept { return _current.has_value(); }
+        // Get the name of the checkpoint that acquired units last.
+        seastar::sstring
+        format_checkpoint(const seastar::sstring& name) const noexcept {
+            if (has_checkpoint()) {
+                auto now = Clock::now();
+                typename Clock::duration delta{0};
+                if (now > _current.value().time) {
+                    delta = now - _current.value().time;
+                }
+                return ssx::sformat(
+                  "{}: {} at {}ms",
+                  name,
+                  _current.value().line,
+                  std::chrono::duration_cast<std::chrono::milliseconds>(delta)
+                    .count());
+            }
+            return ssx::sformat("{}: no checkpoint", name);
+        }
+        void
+        add_checkpoint(vlog::file_line ln, Clock::time_point time) noexcept {
+            _current = basic_mutex_checkpoint<Clock>{ln, time};
+        }
+        void release() noexcept { _current.reset(); }
+        std::optional<basic_mutex_checkpoint<Clock>> _current;
+    };
+
+    template<class Base>
+    class derived_checkpoint_exception : public Base {
+    public:
+        explicit derived_checkpoint_exception(
+          seastar::sstring name, const checkpoint_store* cs) noexcept
+          : _msg(cs->format_checkpoint(name))
+          , _checkpoint(cs->_current) {}
+
+        const char* what() const noexcept override { return _msg.c_str(); }
+
+        const auto& get_checkpoint() const noexcept { return _checkpoint; }
+
+    private:
+        seastar::sstring _msg;
+        std::optional<basic_mutex_checkpoint<Clock>> _checkpoint;
+    };
+
+    using checkpoint_mutex_timed_out
+      = derived_checkpoint_exception<seastar::semaphore_timed_out>;
+    using checkpoint_mutex_broken
+      = derived_checkpoint_exception<seastar::broken_semaphore>;
+    using checkpoint_mutex_aborted
+      = derived_checkpoint_exception<seastar::semaphore_aborted>;
+
+    struct checkpoint_mutex_exception_factory {
+        explicit checkpoint_mutex_exception_factory(
+          seastar::sstring name, const checkpoint_store* cs) noexcept
+          : _name(std::move(name))
+          , _cs(cs) {}
+        checkpoint_mutex_timed_out timeout() const noexcept {
+            return checkpoint_mutex_timed_out("Mutex timed out, " + _name, _cs);
+        }
+        checkpoint_mutex_broken broken() const noexcept {
+            return checkpoint_mutex_broken("Broken mutex, " + _name, _cs);
+        }
+        checkpoint_mutex_aborted aborted() const noexcept {
+            return checkpoint_mutex_aborted(
+              "Mutex wait aborted, " + _name, _cs);
+        }
+
+        seastar::sstring _name;
+        // The checkpoint_store is owned by the basic_checkpoint_mutex instance.
+        const checkpoint_store* _cs;
+    };
+
+public:
+    explicit basic_checkpoint_mutex(seastar::sstring name)
+      : _sem(
+          1,
+          checkpoint_mutex_exception_factory{
+            std::move(name), &_checkpoint_store}) {}
+
+    void broken() noexcept { _sem.broken(); }
+
+    bool has_units() const noexcept { return _sem.available_units() > 0; }
+
+    std::optional<basic_mutex_checkpoint<Clock>>
+    get_blocking_checkpoint() const noexcept {
+        return _checkpoint_store._current;
+    }
+
+    auto get_units(vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    auto get_units(
+      Clock::duration timeout,
+      vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    auto get_units(
+      Clock::time_point deadline,
+      vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    auto get_units(
+      seastar::abort_source& as,
+      vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    template<typename Func>
+    auto with(
+      Func&& func, vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    template<typename Func>
+    auto with(
+      Clock::duration timeout,
+      Func&& func,
+      vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    template<typename Func>
+    auto with(
+      Clock::time_point timeout,
+      Func&& func,
+      vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    template<typename Func>
+    auto with(
+      seastar::abort_source& as,
+      Func&& func,
+      vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    auto
+    try_get_units(vlog::file_line line = vlog::file_line::current()) noexcept;
+
+    bool ready() const noexcept {
+        return _sem.waiters() == 0 && _sem.available_units() == 1;
+    }
+
+    size_t waiters() const noexcept { return _sem.waiters(); }
+
+private:
+    bool try_lock(vlog::file_line line) {
+        if (_sem.try_wait(1)) {
+            // The checkpoint store is updated when the semaphore is acquired.
+            _checkpoint_store.add_checkpoint(line, Clock::now());
+            return true;
+        }
+        return false;
+    }
+
+    seastar::future<> lock(vlog::file_line line) {
+        return _sem.wait(1).then([this, line]() mutable {
+            // The checkpoint store is updated when the semaphore is acquired.
+            _checkpoint_store.add_checkpoint(line, Clock::now());
+        });
+    }
+
+    seastar::future<>
+    lock(vlog::file_line line, typename Clock::duration timeout) {
+        return _sem.wait(timeout, 1).then([this, line]() mutable {
+            _checkpoint_store.add_checkpoint(line, Clock::now());
+        });
+    }
+
+    seastar::future<>
+    lock(vlog::file_line line, typename Clock::time_point deadline) {
+        return _sem.wait(deadline, 1).then([this, line]() mutable {
+            _checkpoint_store.add_checkpoint(line, Clock::now());
+        });
+    }
+
+    seastar::future<> lock(vlog::file_line line, seastar::abort_source& as) {
+        return _sem.wait(as, 1).then([this, line]() mutable {
+            _checkpoint_store.add_checkpoint(line, Clock::now());
+        });
+    }
+
+    void release() noexcept {
+        vassert(_sem.available_units() == 0, "Mutex is not acquired");
+        _sem.signal(1);
+        // Clear the checkpoint store when the semaphore is released.
+        _checkpoint_store._current.reset();
+    }
+
+    friend class basic_mutex_units<Clock>;
+    friend struct detail::checkpoint_mutex_locker;
+
+    // The checkpoint store is used to keep track of the last checkpoint that
+    // was able to acquire units.
+    checkpoint_store _checkpoint_store;
+    seastar::basic_semaphore<checkpoint_mutex_exception_factory, Clock> _sem;
+};
+
+template<class Clock = seastar::timer<>::clock>
+class [[nodiscard]] basic_mutex_units {
+public:
+    basic_mutex_units() noexcept = default;
+    explicit basic_mutex_units(basic_checkpoint_mutex<Clock>& mut)
+      : _mut(&mut) {
+        // This c-tor assumes that the units are already acquired.
+        vassert(!_mut->has_units(), "The mutex is not acquired");
+    }
+    ~basic_mutex_units() noexcept {
+        // Release the mutex if it is being held.
+        release();
+    }
+    basic_mutex_units(const basic_mutex_units&) = delete;
+    basic_mutex_units& operator=(const basic_mutex_units&) = delete;
+    basic_mutex_units(basic_mutex_units&& other) noexcept
+      : _mut(std::exchange(other._mut, nullptr)) {
+        // Move constructor transfers ownership of the mutex.
+        // The moved-from object will not hold any mutex.
+        if (_mut) {
+            vassert(!_mut->has_units(), "The mutex is not acquired");
+        }
+    }
+    basic_mutex_units& operator=(basic_mutex_units&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        _mut = std::exchange(other._mut, nullptr);
+        if (_mut) {
+            vassert(!_mut->has_units(), "The mutex is not acquired");
+        }
+        return *this;
+    }
+    void release() noexcept {
+        if (_mut) {
+            _mut->release();
+            _mut = nullptr;
+        }
+    }
+
+private:
+    basic_checkpoint_mutex<Clock>* _mut;
+};
+
+namespace detail {
+struct checkpoint_mutex_locker {
+    template<typename Clock>
+    static std::optional<basic_mutex_units<Clock>>
+    try_lock(basic_checkpoint_mutex<Clock>& mut, vlog::file_line line) {
+        if (mut.try_lock(line)) {
+            return basic_mutex_units<Clock>(mut);
+        }
+        return std::nullopt;
+    }
+    template<typename Clock>
+    static seastar::future<basic_mutex_units<Clock>>
+    lock(basic_checkpoint_mutex<Clock>& mut, vlog::file_line line) {
+        return mut.lock(line).then(
+          [&mut]() { return basic_mutex_units<Clock>(mut); });
+    }
+    template<typename Clock>
+    static seastar::future<basic_mutex_units<Clock>> lock(
+      basic_checkpoint_mutex<Clock>& mut,
+      typename Clock::time_point deadline,
+      vlog::file_line line) {
+        return mut.lock(line, deadline).then([&mut]() {
+            return basic_mutex_units<Clock>(mut);
+        });
+    }
+    template<typename Clock>
+    static seastar::future<basic_mutex_units<Clock>> lock(
+      basic_checkpoint_mutex<Clock>& mut,
+      typename Clock::duration timeout,
+      vlog::file_line line) {
+        return mut.lock(line, timeout).then([&mut]() {
+            return basic_mutex_units<Clock>(mut);
+        });
+    }
+    template<typename Clock>
+    static seastar::future<basic_mutex_units<Clock>> lock(
+      basic_checkpoint_mutex<Clock>& mut,
+      seastar::abort_source& as,
+      vlog::file_line line) {
+        return mut.lock(line, as).then(
+          [&mut]() { return basic_mutex_units<Clock>(mut); });
+    }
+};
+
+} // namespace detail
+
+template<class Clock>
+auto basic_checkpoint_mutex<Clock>::get_units(vlog::file_line line) noexcept {
+    return detail::checkpoint_mutex_locker::lock(*this, line);
+}
+
+template<class Clock>
+auto basic_checkpoint_mutex<Clock>::get_units(
+  Clock::duration timeout, vlog::file_line line) noexcept {
+    return detail::checkpoint_mutex_locker::lock(*this, timeout, line);
+}
+
+template<class Clock>
+auto basic_checkpoint_mutex<Clock>::get_units(
+  Clock::time_point deadline, vlog::file_line line) noexcept {
+    return detail::checkpoint_mutex_locker::lock(*this, deadline, line);
+}
+
+template<class Clock>
+auto basic_checkpoint_mutex<Clock>::get_units(
+  seastar::abort_source& as, vlog::file_line line) noexcept {
+    return detail::checkpoint_mutex_locker::lock(*this, as, line);
+}
+
+template<typename Clock>
+auto basic_checkpoint_mutex<Clock>::try_get_units(
+  vlog::file_line line) noexcept {
+    return detail::checkpoint_mutex_locker::try_lock(*this, line);
+}
+
+template<typename Clock>
+template<typename Func>
+auto basic_checkpoint_mutex<Clock>::with(
+  Func&& func, vlog::file_line line) noexcept {
+    return get_units(line).then(
+      [f = std::forward<Func>(func)](basic_mutex_units<Clock> units
+                                     [[maybe_unused]]) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f));
+      });
+}
+
+template<typename Clock>
+template<typename Func>
+auto basic_checkpoint_mutex<Clock>::with(
+  Clock::time_point deadline, Func&& func, vlog::file_line line) noexcept {
+    return get_units(deadline, line)
+      .then([f = std::forward<Func>(func)](basic_mutex_units<Clock> units
+                                           [[maybe_unused]]) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f));
+      });
+}
+
+template<typename Clock>
+template<typename Func>
+auto basic_checkpoint_mutex<Clock>::with(
+  Clock::duration timeout, Func&& func, vlog::file_line line) noexcept {
+    return get_units(timeout, line)
+      .then([f = std::forward<Func>(func)](basic_mutex_units<Clock> units
+                                           [[maybe_unused]]) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f));
+      });
+}
+
+template<typename Clock>
+template<typename Func>
+auto basic_checkpoint_mutex<Clock>::with(
+  seastar::abort_source& as, Func&& func, vlog::file_line line) noexcept {
+    return get_units(as, line).then(
+      [f = std::forward<Func>(func)](basic_mutex_units<Clock> units
+                                     [[maybe_unused]]) mutable {
+          return seastar::futurize_invoke(std::forward<Func>(f));
+      });
+}
+
+using checkpoint_mutex = basic_checkpoint_mutex<>;
+using checkpoint_mutex_units = basic_mutex_units<>;
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -259,3 +259,18 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "checkpoint_mutex_test",
+    timeout = "short",
+    srcs = [
+        "checkpoint_mutex_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:checkpoint_mutex",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/checkpoint_mutex_test.cc
+++ b/src/v/ssx/tests/checkpoint_mutex_test.cc
@@ -203,10 +203,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
     // Acquire the mutex normally.
     auto res = mutex
                  .with([&] {
-		     return ss::sleep(500ms).then([&] {
-                     EXPECT_FALSE(mutex.has_units());
-                     return 1;
-		       });
+                     return ss::sleep(500ms).then([&] {
+                         EXPECT_FALSE(mutex.has_units());
+                         return 1;
+                     });
                  })
                  .get();
     EXPECT_TRUE(mutex.has_units());
@@ -216,10 +216,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
             .with(
               1s,
               [&] {
-		     return ss::sleep(500ms).then([&] {
-                  EXPECT_FALSE(mutex.has_units());
-                  return 2;
-		});
+                  return ss::sleep(500ms).then([&] {
+                      EXPECT_FALSE(mutex.has_units());
+                      return 2;
+                  });
               })
             .get();
     EXPECT_TRUE(mutex.has_units());
@@ -229,10 +229,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
             .with(
               ss::timer<>::clock::now() + 1s,
               [&] {
-		     return ss::sleep(500ms).then([&] {
-                  EXPECT_FALSE(mutex.has_units());
-                  return 3;
-		});
+                  return ss::sleep(500ms).then([&] {
+                      EXPECT_FALSE(mutex.has_units());
+                      return 3;
+                  });
               })
             .get();
     EXPECT_TRUE(mutex.has_units());
@@ -243,10 +243,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
             .with(
               as,
               [&] {
-		     return ss::sleep(500ms).then([&] {
-                  EXPECT_FALSE(mutex.has_units());
-                  return 4;
-		});
+                  return ss::sleep(500ms).then([&] {
+                      EXPECT_FALSE(mutex.has_units());
+                      return 4;
+                  });
               })
             .get();
     EXPECT_TRUE(mutex.has_units());

--- a/src/v/ssx/tests/checkpoint_mutex_test.cc
+++ b/src/v/ssx/tests/checkpoint_mutex_test.cc
@@ -203,8 +203,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
     // Acquire the mutex normally.
     auto res = mutex
                  .with([&] {
+		     return ss::sleep(500ms).then([&] {
                      EXPECT_TRUE(mutex.has_units() == false);
                      return 1;
+		       });
                  })
                  .get();
     EXPECT_TRUE(mutex.has_units() == true);
@@ -214,8 +216,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
             .with(
               1s,
               [&] {
+		     return ss::sleep(500ms).then([&] {
                   EXPECT_TRUE(mutex.has_units() == false);
                   return 2;
+		});
               })
             .get();
     EXPECT_TRUE(mutex.has_units() == true);
@@ -225,8 +229,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
             .with(
               ss::timer<>::clock::now() + 1s,
               [&] {
+		     return ss::sleep(500ms).then([&] {
                   EXPECT_TRUE(mutex.has_units() == false);
                   return 3;
+		});
               })
             .get();
     EXPECT_TRUE(mutex.has_units() == true);
@@ -237,8 +243,10 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
             .with(
               as,
               [&] {
+		     return ss::sleep(500ms).then([&] {
                   EXPECT_TRUE(mutex.has_units() == false);
                   return 4;
+		});
               })
             .get();
     EXPECT_TRUE(mutex.has_units() == true);

--- a/src/v/ssx/tests/checkpoint_mutex_test.cc
+++ b/src/v/ssx/tests/checkpoint_mutex_test.cc
@@ -204,12 +204,12 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
     auto res = mutex
                  .with([&] {
 		     return ss::sleep(500ms).then([&] {
-                     EXPECT_TRUE(mutex.has_units() == false);
+                     EXPECT_FALSE(mutex.has_units());
                      return 1;
 		       });
                  })
                  .get();
-    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.has_units());
     EXPECT_EQ(res, 1);
 
     res = mutex
@@ -217,12 +217,12 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
               1s,
               [&] {
 		     return ss::sleep(500ms).then([&] {
-                  EXPECT_TRUE(mutex.has_units() == false);
+                  EXPECT_FALSE(mutex.has_units());
                   return 2;
 		});
               })
             .get();
-    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.has_units());
     EXPECT_EQ(res, 2);
 
     res = mutex
@@ -230,12 +230,12 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
               ss::timer<>::clock::now() + 1s,
               [&] {
 		     return ss::sleep(500ms).then([&] {
-                  EXPECT_TRUE(mutex.has_units() == false);
+                  EXPECT_FALSE(mutex.has_units());
                   return 3;
 		});
               })
             .get();
-    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.has_units());
     EXPECT_EQ(res, 3);
 
     ss::abort_source as;
@@ -244,11 +244,11 @@ TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
               as,
               [&] {
 		     return ss::sleep(500ms).then([&] {
-                  EXPECT_TRUE(mutex.has_units() == false);
+                  EXPECT_FALSE(mutex.has_units());
                   return 4;
 		});
               })
             .get();
-    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.has_units());
     EXPECT_EQ(res, 4);
 }

--- a/src/v/ssx/tests/checkpoint_mutex_test.cc
+++ b/src/v/ssx/tests/checkpoint_mutex_test.cc
@@ -1,0 +1,246 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/source_location.h"
+#include "ssx/checkpoint_mutex.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/timer.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+namespace ss = seastar;
+
+TEST(CheckpointMutex, checkpoint_mutex_lock) {
+    ssx::checkpoint_mutex mutex("test_checkpoint_mutex");
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.get_blocking_checkpoint() == std::nullopt);
+
+    // Acquire the mutex normally.
+    auto line = vlog::file_line::current();
+    auto units = mutex.get_units().get();
+    EXPECT_TRUE(mutex.has_units() == false);
+    EXPECT_EQ(
+      mutex.get_blocking_checkpoint()->line.filename,
+      ss::sstring("checkpoint_mutex_test.cc"));
+    EXPECT_EQ(mutex.get_blocking_checkpoint()->line.line, line.line + 1);
+
+    line = vlog::file_line::current();
+    auto fut = mutex.get_units();
+    EXPECT_TRUE(fut.available() == false);
+
+    // We have another waiter so the mutex should not be available.
+    units.release();
+    EXPECT_TRUE(mutex.has_units() == false);
+
+    // Another waiter should be able to acquire the mutex.
+    auto units2 = std::move(fut).get();
+    EXPECT_EQ(
+      mutex.get_blocking_checkpoint()->line.filename,
+      ss::sstring("checkpoint_mutex_test.cc"));
+    EXPECT_EQ(mutex.get_blocking_checkpoint()->line.line, line.line + 1);
+
+    units2.release();
+    EXPECT_TRUE(mutex.has_units() == true);
+}
+
+TEST(CheckpointMutex, checkpoint_mutex_broken) {
+    ssx::checkpoint_mutex mutex("test_checkpoint_mutex");
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.get_blocking_checkpoint() == std::nullopt);
+
+    // Acquire the mutex normally.
+    auto line = vlog::file_line::current();
+    auto units = mutex.get_units().get();
+    EXPECT_TRUE(mutex.has_units() == false);
+    EXPECT_EQ(
+      mutex.get_blocking_checkpoint()->line.filename,
+      ss::sstring("checkpoint_mutex_test.cc"));
+    EXPECT_EQ(mutex.get_blocking_checkpoint()->line.line, line.line + 1);
+
+    auto units2 = mutex.get_units(); // async
+
+    // Break the mutex.
+    mutex.broken();
+    EXPECT_TRUE(mutex.has_units() == false);
+
+    bool thrown = false;
+    try {
+        std::move(units2).get();
+    } catch (const ss::broken_semaphore& e) {
+        ss::sstring msg = e.what();
+        // Message should contain the name of the checkpoint that held
+        // the units when the semaphore was broken.
+        EXPECT_TRUE(msg.find("checkpoint_mutex_test.cc") != ss::sstring::npos);
+        thrown = true;
+    }
+    EXPECT_TRUE(thrown);
+}
+
+TEST(CheckpointMutex, checkpoint_mutex_aborted) {
+    ssx::checkpoint_mutex mutex("test_checkpoint_mutex");
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.get_blocking_checkpoint() == std::nullopt);
+
+    // Acquire the mutex normally.
+    auto line = vlog::file_line::current();
+    auto units = mutex.get_units().get();
+    EXPECT_TRUE(mutex.has_units() == false);
+    EXPECT_EQ(
+      mutex.get_blocking_checkpoint()->line.filename,
+      ss::sstring("checkpoint_mutex_test.cc"));
+    EXPECT_EQ(mutex.get_blocking_checkpoint()->line.line, line.line + 1);
+
+    ss::abort_source as;
+    auto units2 = mutex.get_units(as); // async
+
+    // Invoke the abort source to simulate an aborted operation.
+    as.request_abort();
+    EXPECT_TRUE(mutex.has_units() == false);
+
+    bool thrown = false;
+    try {
+        std::move(units2).get();
+    } catch (const ss::semaphore_aborted& e) {
+        ss::sstring msg = e.what();
+        // Message should contain the name of the checkpoint that held
+        // the units
+        EXPECT_TRUE(msg.find("checkpoint_mutex_test") != ss::sstring::npos);
+        thrown = true;
+    }
+    EXPECT_TRUE(thrown);
+
+    thrown = false;
+
+    // Check that this works even if we're called with the source which is
+    // already aborted.
+    auto units3 = mutex.get_units(as); // async
+
+    EXPECT_TRUE(mutex.has_units() == false);
+
+    try {
+        std::move(units3).get();
+    } catch (const ss::semaphore_aborted& e) {
+        ss::sstring msg = e.what();
+        EXPECT_TRUE(msg.find("checkpoint_mutex_test") != ss::sstring::npos);
+        EXPECT_TRUE(
+          msg.find(ssx::sformat("{}", line.line + 1)) != ss::sstring::npos);
+        thrown = true;
+    }
+    EXPECT_TRUE(thrown);
+}
+
+TEST(CheckpointMutex, checkpoint_mutex_timed_out) {
+    ssx::checkpoint_mutex mutex("test_checkpoint_mutex");
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_TRUE(mutex.get_blocking_checkpoint() == std::nullopt);
+
+    // Acquire the mutex normally.
+    auto line = vlog::file_line::current();
+    auto units = mutex.get_units().get();
+    EXPECT_TRUE(mutex.has_units() == false);
+    EXPECT_EQ(
+      mutex.get_blocking_checkpoint()->line.filename,
+      ss::sstring("checkpoint_mutex_test.cc"));
+    EXPECT_EQ(mutex.get_blocking_checkpoint()->line.line, line.line + 1);
+
+    // Check with the deadline
+    auto deadline = std::chrono::steady_clock::now() + 1ms;
+    auto units2 = mutex.get_units(deadline); // async
+
+    // Sleep long enough to ensure that the timeout occurs.
+    ss::sleep(100ms).get();
+    EXPECT_TRUE(mutex.has_units() == false);
+
+    bool thrown = false;
+    try {
+        std::move(units2).get();
+    } catch (const ss::semaphore_timed_out& e) {
+        ss::sstring msg = e.what();
+        EXPECT_TRUE(msg.find("checkpoint_mutex_test.cc") != ss::sstring::npos);
+        EXPECT_TRUE(
+          msg.find(ssx::sformat("{}", line.line + 1)) != ss::sstring::npos);
+        thrown = true;
+    }
+    EXPECT_TRUE(thrown);
+
+    // Check with the timeout
+    thrown = false;
+    auto units3 = mutex.get_units(10ms); // async
+
+    // Sleep long enough to ensure that the timeout occurs.
+    ss::sleep(100ms).get();
+    EXPECT_TRUE(mutex.has_units() == false);
+
+    try {
+        std::move(units3).get();
+    } catch (const ss::semaphore_timed_out& e) {
+        ss::sstring msg = e.what();
+        EXPECT_TRUE(msg.find("checkpoint_mutex_test.cc") != ss::sstring::npos);
+        EXPECT_TRUE(
+          msg.find(ssx::sformat("{}", line.line + 1)) != ss::sstring::npos);
+        thrown = true;
+    }
+    EXPECT_TRUE(thrown);
+}
+
+TEST(CheckpointMutex, checkpoint_mutex_lock_with) {
+    ssx::checkpoint_mutex mutex("test_checkpoint_mutex");
+
+    // Acquire the mutex normally.
+    auto res = mutex
+                 .with([&] {
+                     EXPECT_TRUE(mutex.has_units() == false);
+                     return 1;
+                 })
+                 .get();
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_EQ(res, 1);
+
+    res = mutex
+            .with(
+              1s,
+              [&] {
+                  EXPECT_TRUE(mutex.has_units() == false);
+                  return 2;
+              })
+            .get();
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_EQ(res, 2);
+
+    res = mutex
+            .with(
+              ss::timer<>::clock::now() + 1s,
+              [&] {
+                  EXPECT_TRUE(mutex.has_units() == false);
+                  return 3;
+              })
+            .get();
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_EQ(res, 3);
+
+    ss::abort_source as;
+    res = mutex
+            .with(
+              as,
+              [&] {
+                  EXPECT_TRUE(mutex.has_units() == false);
+                  return 4;
+              })
+            .get();
+    EXPECT_TRUE(mutex.has_units() == true);
+    EXPECT_EQ(res, 4);
+}


### PR DESCRIPTION
This PR implements a `checkpoint_mutex`. The mutex can remember the last callsite that was able to acquire it. This information can be accessed in order to generate the diagnostic dump. It is also included into exception messages.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none