### PR TITLE
cluster/tests/distributed_kv_stm/list: prevent timeouts

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -1168,7 +1168,7 @@ redpanda_cc_gtest(
     srcs = [
         "distributed_kv_stm_tests.cc",
     ],
-    cpu = 1,
+    cpu = 3,
     deps = [
         ":raft_fixture_retry_policy",
         "//src/v/base",

--- a/src/v/cluster/tests/distributed_kv_stm_tests.cc
+++ b/src/v/cluster/tests/distributed_kv_stm_tests.cc
@@ -133,7 +133,7 @@ TEST_F_CORO(kv_stm_fixture, test_stm_list) {
     }
     // List and put can be called concurrently. We don't make any guarentees
     // (it's eventually consistent), but it shouldn't crash.
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 500; ++i) {
         kvs[i] = i;
         co_await put(kvs);
         ASSERT_TRUE_CORO(co_await list());


### PR DESCRIPTION
Currently it often times out in CI and locally.
Typical local execution time for me was 60s when run multiple instances, and the timeout is 60s as well.
1. Give it 3 cores as it runs 3 nodes: reduces run time from 60 to 25s
2. Reduce test length by running less cycles: 25s->13s

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
