### PR TITLE
iceberg: add support for `write.{data,metadata}.path` table properties

### DIFF
--- a/src/v/datalake/catalog_schema_manager.cc
+++ b/src/v/datalake/catalog_schema_manager.cc
@@ -20,6 +20,21 @@
 namespace datalake {
 
 namespace {
+
+// NB: Use the concrete type not the alias iceberg::table_properties_t
+// so changes to the alias can't silently destroy the deep copy semantics
+// of this function.
+chunked_hash_map<ss::sstring, ss::sstring, sstring_hash, sstring_eq>
+copy_properties(
+  const chunked_hash_map<ss::sstring, ss::sstring, sstring_hash, sstring_eq>&
+    props) {
+    chunked_hash_map<ss::sstring, ss::sstring, sstring_hash, sstring_eq> result;
+    for (const auto& [key, value] : props) {
+        result.emplace(key, value);
+    }
+    return result;
+}
+
 schema_manager::errc log_and_convert_catalog_err(
   iceberg::catalog::errc e, std::string_view log_msg) {
     switch (e) {
@@ -146,6 +161,7 @@ simple_schema_manager::ensure_table_schema(
           table_location_prefix_(),
           fmt::join(table_id.ns, "/"),
           table_id.table)),
+        .properties = std::nullopt,
       });
 
     co_return std::nullopt;
@@ -164,6 +180,7 @@ simple_schema_manager::get_table_info(
       .schema = it->second.schema.copy(),
       .partition_spec = it->second.partition_spec.copy(),
       .location = it->second.location,
+      .properties = it->second.properties.transform(copy_properties),
     };
 }
 
@@ -281,6 +298,7 @@ catalog_schema_manager::get_table_info(
       .schema = cur_schema->copy(),
       .partition_spec = cur_spec->copy(),
       .location = table.location,
+      .properties = table.properties.transform(copy_properties),
     };
 }
 

--- a/src/v/datalake/catalog_schema_manager.h
+++ b/src/v/datalake/catalog_schema_manager.h
@@ -40,6 +40,7 @@ public:
         iceberg::schema schema;
         iceberg::partition_spec partition_spec;
         iceberg::uri location;
+        std::optional<iceberg::table_properties_t> properties;
 
         // Fills the field IDs of the given type with those in the current
         // schema. Returns true on success.

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -33,7 +33,6 @@
 
 constexpr std::chrono::milliseconds translation_jitter{500};
 constexpr std::chrono::milliseconds translation_jitter_base{5000};
-static constexpr std::string_view iceberg_data_path_prefix = "data";
 
 namespace datalake {
 
@@ -696,7 +695,6 @@ datalake_manager::handle_translator_state_change(const model::ntp& ntp) {
         std::move(record_translator),
         std::move(table_creator),
         _location_provider,
-        remote_path{iceberg_data_path_prefix},
         *reservations,
         _topic_table,
         _features,

--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -136,7 +136,7 @@ partitioning_writer::finish() && {
 
         files.push_back(partitioned_file{
           .local_file = std::move(file_res.value()),
-          .table_location = remote_prefix_,
+          .data_location = remote_prefix_,
           .schema_id = schema_id_,
           .partition_spec_id = spec_.spec_id,
           .partition_key = std::move(pk),

--- a/src/v/datalake/partitioning_writer.h
+++ b/src/v/datalake/partitioning_writer.h
@@ -58,7 +58,7 @@ public:
 
     struct partitioned_file {
         local_file_metadata local_file;
-        remote_path table_location;
+        remote_path data_location;
         iceberg::schema::id_t schema_id;
         iceberg::partition_spec::id_t partition_spec_id;
         iceberg::partition_key partition_key;

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -28,6 +28,22 @@
 namespace datalake {
 
 namespace {
+
+// Get the data location for the table. Some catalogs require using the property
+// `write.data.path`. Otherwise, it defaults to <table location>/data.
+iceberg::uri get_data_location(const schema_manager::table_info& table_info) {
+    static constexpr std::string_view write_data_path_prop = "write.data.path";
+
+    if (table_info.properties.has_value()) {
+        auto it = table_info.properties->find(write_data_path_prop);
+        if (it != table_info.properties->end()) {
+            return iceberg::uri(it->second);
+        }
+    }
+
+    return iceberg::uri(fmt::format("{}/data", table_info.location));
+}
+
 template<typename Func>
 requires requires(Func f, model::record_batch batch) {
     { f(std::move(batch)) } -> std::same_as<ss::future<ss::stop_iteration>>;
@@ -258,9 +274,9 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 co_return ss::stop_iteration::yes;
             }
 
-            auto table_remote_path = _location_provider.from_uri(
-              load_res.value().location);
-            if (!table_remote_path) {
+            auto data_location = get_data_location(load_res.value());
+            auto data_remote_path = _location_provider.from_uri(data_location);
+            if (!data_remote_path) {
                 vlog(
                   _log.warn,
                   "Error getting location prefix for {} while creating writer "
@@ -278,7 +294,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 load_res.value().schema.schema_id,
                 std::move(record_type.type),
                 std::move(load_res.value().partition_spec),
-                std::move(table_remote_path.value())));
+                std::move(data_remote_path.value())));
             writer_iter = iter;
         }
 
@@ -476,9 +492,9 @@ record_multiplexer::handle_invalid_record(
                 co_return writer_error::unknown_error;
             }
 
-            auto table_remote_path = _location_provider.from_uri(
-              load_res.value().location);
-            if (!table_remote_path) {
+            auto data_location = get_data_location(load_res.value());
+            auto data_remote_path = _location_provider.from_uri(data_location);
+            if (!data_remote_path) {
                 vlog(
                   _log.warn,
                   "Error getting location prefix for {} while creating writer "
@@ -493,7 +509,7 @@ record_multiplexer::handle_invalid_record(
               load_res.value().schema.schema_id,
               std::move(record_type.type),
               std::move(load_res.value().partition_spec),
-              std::move(table_remote_path.value()));
+              std::move(data_remote_path.value()));
         }
 
         int64_t estimated_size = (key ? key->size_bytes() : 0)

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -201,7 +201,6 @@ TEST_F(TranslateTaskTest, TestHappyPathTranslation) {
     auto result = std::move(task)
                     .finish(
                       translation_task::custom_partitioning_enabled::yes,
-                      datalake::remote_path("test/location/1"),
                       test_rcn,
                       as)
                     .get();
@@ -232,7 +231,6 @@ TEST_F(TranslateTaskTest, TestDataFileMissing) {
     auto result = std::move(task)
                     .finish(
                       translation_task::custom_partitioning_enabled::yes,
-                      datalake::remote_path("test/location/1"),
                       test_rcn,
                       as)
                     .get();
@@ -267,7 +265,6 @@ TEST_F(TranslateTaskTest, TestUploadError) {
     auto result = std::move(task)
                     .finish(
                       translation_task::custom_partitioning_enabled::yes,
-                      datalake::remote_path("test/location/1"),
                       test_rcn,
                       as)
                     .get();

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -490,7 +490,6 @@ public:
       std::unique_ptr<record_translator> record_translator,
       std::unique_ptr<table_creator> table_creator,
       location_provider location_provider,
-      remote_path upload_path_prefix,
       scheduling::reservations_tracker& reservations,
       ss::sharded<cluster::topic_table>* topics,
       ss::sharded<features::feature_table>* features,
@@ -504,7 +503,6 @@ public:
       , _record_translator(std::move(record_translator))
       , _table_creator(std::move(table_creator))
       , _location_provider(std::move(location_provider))
-      , _upload_path_prefix(std::move(upload_path_prefix))
       , _reservations(reservations)
       , _topics(topics->local())
       , _features(features->local())
@@ -602,8 +600,8 @@ public:
         }
         vlog(datalake_log.debug, "[{}] finishing translation", _ntp);
         auto task = std::exchange(_in_progress_translation, std::nullopt);
-        auto result = co_await std::move(task.value())
-                        .finish(_cp_enabled, _upload_path_prefix, rcn, as);
+        auto result
+          = co_await std::move(task.value()).finish(_cp_enabled, rcn, as);
 
         if (result.has_error()) {
             co_return map_error_code(result.error());
@@ -665,7 +663,6 @@ private:
     std::unique_ptr<record_translator> _record_translator;
     std::unique_ptr<table_creator> _table_creator;
     location_provider _location_provider;
-    remote_path _upload_path_prefix;
     scheduling::reservations_tracker& _reservations;
     cluster::topic_table& _topics;
     features::feature_table& _features;
@@ -687,7 +684,6 @@ translation_context::make_default_translation_context(
   std::unique_ptr<record_translator> record_translator,
   std::unique_ptr<table_creator> table_creator,
   location_provider location_provider,
-  remote_path upload_path_prefix,
   scheduling::reservations_tracker& reservations,
   ss::sharded<cluster::topic_table>* topics,
   ss::sharded<features::feature_table>* features,
@@ -702,7 +698,6 @@ translation_context::make_default_translation_context(
       std::move(record_translator),
       std::move(table_creator),
       std::move(location_provider),
-      std::move(upload_path_prefix),
       reservations,
       topics,
       features,

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -291,7 +291,6 @@ public:
       std::unique_ptr<record_translator>,
       std::unique_ptr<table_creator>,
       location_provider,
-      remote_path,
       scheduling::reservations_tracker&,
       ss::sharded<cluster::topic_table>*,
       ss::sharded<features::feature_table>*,

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -65,11 +65,10 @@ ss::future<checked<remote_path, translation_task::errc>> execute_single_upload(
   prefix_logger& logger,
   cloud_data_io& _cloud_io,
   const partitioning_writer::partitioned_file& file,
-  const remote_path& remote_path_prefix,
   retry_chain_node& parent_rcn,
   lazy_abort_source& lazy_as) {
     auto file_remote_path = remote_path{
-      file.table_location / remote_path_prefix / file.partition_key_path
+      file.data_location / file.partition_key_path
       / file.local_file.path().filename()};
 
     // (Approximate because I'm ignoring backoff) ~5 retries at 1
@@ -126,7 +125,6 @@ upload_files(
   cloud_data_io& _cloud_io,
   const chunked_vector<partitioning_writer::partitioned_file>& files,
   translation_task::custom_partitioning_enabled is_custom_partitioning_enabled,
-  const remote_path& remote_path_prefix,
   retry_chain_node& rcn,
   lazy_abort_source& lazy_as) {
     chunked_vector<coordinator::data_file> ret;
@@ -135,7 +133,7 @@ upload_files(
     std::optional<translation_task::errc> upload_error;
     for (auto& file : files) {
         auto r = co_await execute_single_upload(
-          logger, _cloud_io, file, remote_path_prefix, rcn, lazy_as);
+          logger, _cloud_io, file, rcn, lazy_as);
 
         if (r.has_error()) {
             vlog(
@@ -280,7 +278,6 @@ ss::future<
   checked<coordinator::translated_offset_range, translation_task::errc>>
 translation_task::finish(
   custom_partitioning_enabled is_custom_partitioning_enabled,
-  const remote_path& remote_path_prefix,
   retry_chain_node& rcn,
   ss::abort_source& as) && {
     auto mux_result = co_await std::move(_multiplexer).finish();
@@ -331,7 +328,6 @@ translation_task::finish(
           *_cloud_io,
           write_result.data_files,
           is_custom_partitioning_enabled,
-          remote_path_prefix,
           rcn,
           lazy_as);
         if (upload_res.has_error()) {
@@ -347,7 +343,6 @@ translation_task::finish(
           *_cloud_io,
           write_result.dlq_files,
           is_custom_partitioning_enabled,
-          remote_path_prefix,
           rcn,
           lazy_as);
         if (dlq_upload_res.has_error()) {

--- a/src/v/datalake/translation_task.h
+++ b/src/v/datalake/translation_task.h
@@ -88,7 +88,6 @@ public:
      */
     ss::future<checked<coordinator::translated_offset_range, errc>> finish(
       custom_partitioning_enabled is_custom_partitioning_enabled,
-      const remote_path& remote_path_prefix,
       retry_chain_node& parent_rcn,
       ss::abort_source&) &&;
 

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -821,6 +821,7 @@ redpanda_cc_library(
         ":uri",
         "//src/v/container:fragmented_vector",
         "//src/v/model",
+        "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:named_type",
         "//src/v/utils:uuid",
     ],

--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -27,18 +27,38 @@
 namespace iceberg {
 
 namespace {
+
+// Derive the metadata location from table properties.
+// Some catalogs require respecting the property `write.metadata.path`,
+// but the default location is <table location>/metadata.
+uri get_metadata_location(const table_metadata& table) {
+    static constexpr std::string_view write_metadata_path_prop
+      = "write.metadata.path";
+
+    if (table.properties.has_value()) {
+        auto it = table.properties->find(write_metadata_path_prop);
+        if (it != table.properties->end()) {
+            return uri(it->second);
+        }
+    }
+
+    return uri(fmt::format("{}/metadata", table.location));
+}
+
 uri get_manifest_path(
-  const uri& location, const uuid_t& commit_uuid, size_t num) {
+  const table_metadata& table, const uuid_t& commit_uuid, size_t num) {
+    auto metadata_location = get_metadata_location(table);
     return uri(
-      fmt::format("{}/metadata/{}-m{}.avro", location, commit_uuid, num));
+      fmt::format("{}/{}-m{}.avro", metadata_location, commit_uuid, num));
 }
 uri get_manifest_list_path(
-  const uri& location,
+  const table_metadata& table,
   snapshot_id snap_id,
   const uuid_t& commit_uuid,
   size_t num) {
+    auto metadata_location = get_metadata_location(table);
     return uri{fmt::format(
-      "{}/metadata/snap-{}-{}-{}.avro", location, snap_id(), commit_uuid, num)};
+      "{}/snap-{}-{}-{}.avro", metadata_location, snap_id(), commit_uuid, num)};
 }
 
 action::errc to_action_errc(metadata_io::errc e) {
@@ -248,7 +268,7 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
     // naming uniqueness. Retries for us are expected to take the form of an
     // entirely new transaction.
     const auto new_mlist_path = get_manifest_list_path(
-      table_.location, new_snap_id, commit_uuid_, 0);
+      table_, new_snap_id, commit_uuid_, 0);
 
     vlog(
       log.info,
@@ -516,7 +536,7 @@ merge_append_action::merge_mfiles(
     }
 
     const auto merged_manifest_path = get_manifest_path(
-      table_.location, ctx.commit_uuid, generate_manifest_num());
+      table_, ctx.commit_uuid, generate_manifest_num());
     const auto mfile_up_res = co_await upload_as_manifest(
       merged_manifest_path, *schema, pspec, std::move(merged_entries));
     if (mfile_up_res.has_error()) {

--- a/src/v/iceberg/table_metadata.h
+++ b/src/v/iceberg/table_metadata.h
@@ -17,12 +17,16 @@
 #include "iceberg/snapshot.h"
 #include "iceberg/transform.h"
 #include "iceberg/uri.h"
+#include "utils/absl_sstring_hash.h"
 #include "utils/named_type.h"
 #include "utils/uuid.h"
 
 #include <optional>
 
 namespace iceberg {
+
+using table_properties_t
+  = chunked_hash_map<ss::sstring, ss::sstring, sstring_hash, sstring_eq>;
 
 enum class sort_direction {
     asc,
@@ -67,7 +71,7 @@ struct table_metadata {
     partition_spec::id_t default_spec_id;
     partition_field::id_t last_partition_id;
 
-    std::optional<chunked_hash_map<ss::sstring, ss::sstring>> properties;
+    std::optional<table_properties_t> properties;
     std::optional<snapshot_id> current_snapshot_id;
     std::optional<chunked_vector<snapshot>> snapshots;
 

--- a/src/v/iceberg/table_metadata_json.cc
+++ b/src/v/iceberg/table_metadata_json.cc
@@ -130,7 +130,7 @@ table_metadata parse_table_meta(const json::Value& v) {
     auto last_partition_id = parse_required_i32(v, "last-partition-id");
 
     auto properties_json = parse_optional_object(v, "properties");
-    std::optional<chunked_hash_map<ss::sstring, ss::sstring>> properties;
+    std::optional<table_properties_t> properties;
     if (properties_json.has_value()) {
         properties.emplace();
         for (const auto& m : properties_json.value()) {

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -852,3 +852,36 @@ TEST_F(MergeAppendActionTest, TestMergeWithMultiplePartitionSpecs) {
     ASSERT_EQ(merged_mfile->deleted_files_count, 0);
     ASSERT_EQ(merged_mfile->deleted_rows_count, 0);
 }
+
+TEST_F(MergeAppendActionTest, TestWriteMetadataPathProperty) {
+    // Create a table with a custom metadata path.
+    const auto custom_path = fmt::format(
+      "s3://{}/custom/metadata", bucket_name());
+    auto table = create_table();
+    table_properties_t props;
+    props.emplace("write.metadata.path", custom_path);
+    table.properties = std::move(props);
+
+    // Add some data files to trigger manifest creation.
+    transaction tx(std::move(table));
+    auto files = create_data_files(tx.table(), "test_file", 2, 10);
+    auto res = tx.merge_append(io, std::move(files)).get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+
+    const auto& updated_table = tx.table();
+    ASSERT_TRUE(updated_table.snapshots.has_value());
+    ASSERT_EQ(updated_table.snapshots->size(), 1);
+
+    // Check that the manifest list path uses the custom metadata location
+    const auto& snapshot = updated_table.snapshots->back();
+    const auto& manifest_list_path = snapshot.manifest_list_path;
+    ASSERT_TRUE(manifest_list_path().starts_with(custom_path));
+
+    // Download the manifest list and check manifest paths.
+    auto mlist_res = io.download_manifest_list(manifest_list_path).get();
+    ASSERT_TRUE(mlist_res.has_value());
+    ASSERT_EQ(mlist_res.value().files.size(), 1);
+
+    const auto& manifest_path = mlist_res.value().files[0].manifest_path;
+    ASSERT_TRUE(manifest_path().starts_with(custom_path));
+}

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -227,9 +227,8 @@ iceberg::table_metadata create_table_metadata() {
       .partition_specs = create_test_partition_spec(),
       .default_spec_id = iceberg::partition_spec::id_t{1},
       .last_partition_id = iceberg::partition_field::id_t{1},
-      .properties = chunked_hash_map<
-        ss::sstring,
-        ss::sstring>{{"read.split.target.size", "134217728"}},
+      .properties
+      = iceberg::table_properties_t{{"read.split.target.size", "134217728"}},
       .current_snapshot_id = iceberg::snapshot_id(200),
       .snapshots = chunked_vector<iceberg::snapshot>{iceberg::snapshot{
         .id = iceberg::snapshot_id{200},
@@ -439,9 +438,8 @@ iceberg::table_metadata create_empty_table_metadata(const ss::sstring& bucket) {
       .partition_specs = create_test_partition_spec(),
       .default_spec_id = iceberg::partition_spec::id_t{1},
       .last_partition_id = iceberg::partition_field::id_t{1},
-      .properties = chunked_hash_map<
-        ss::sstring,
-        ss::sstring>{{"read.split.target.size", "134217728"}},
+      .properties
+      = iceberg::table_properties_t{{"read.split.target.size", "134217728"}},
       .current_snapshot_id = std::nullopt,
       .snapshots = chunked_vector<iceberg::snapshot>{},
       .sort_orders = create_sort_orders(),


### PR DESCRIPTION
This adds support for the `write.metadata.path` and `write.data.path` table properties, which for some catalogs specify where metadata and data, respectively, should be written. In their absence, the default is `{table location}/metadata` and `{table location}/data`, respectively.

I have tested this manually with the databricks_test.py Ducktape test. I'm planning to follow up with some unit tests for `write.data.path`. This change includes unit tests for `write.metadata.path`.

Fixes CORE-12152

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Adds support for the Iceberg table properties `write.metadata.path` and `write.data.path`. When an Iceberg catalog defines these properties, Redpanda will use them to determine where to write Iceberg table metadata and data, respectively, instead of using default locations based on the table location.

