### PR TITLE
kafka/client: wire in prefix logger

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -88,6 +88,7 @@ redpanda_cc_library(
         "//src/v/strings:string_switch",
         "//src/v/thirdparty/c-ares",
         "//src/v/utils:mutex",
+        "//src/v/utils:prefix_logger",
         "//src/v/utils:retry",
         "//src/v/utils:truncating_logger",
         "//src/v/utils:unresolved_address",

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -43,7 +43,8 @@ namespace kafka::client {
 ss::future<shared_broker_t> make_broker(
   model::node_id node_id,
   net::unresolved_address addr,
-  const configuration& config) {
+  const configuration& config,
+  prefix_logger& logger) {
     return rpc::maybe_build_reloadable_certificate_credentials(
              config.broker_tls())
       .then([addr, client_id = config.client_identifier()](
@@ -53,32 +54,32 @@ ss::future<shared_broker_t> make_broker(
               .server_addr = addr, .credentials = std::move(creds)},
             std::move(client_id));
       })
-      .then([node_id, addr](ss::lw_shared_ptr<transport> client) {
+      .then([node_id, addr, &logger](
+              ss::lw_shared_ptr<transport> client) mutable {
           return client->connect().then(
-            [node_id, addr = std::move(addr), client] {
+            [node_id, addr = std::move(addr), client, &logger] {
                 auto prefix = client->client_id().has_value()
                                 ? ssx::sformat("{}: ", *client->client_id())
                                 : "";
                 vlog(
-                  kclog.info,
-                  "{}connected to broker:{} - {}:{}",
-                  prefix,
+                  logger.info,
+                  "connected to broker:{} - {}:{}",
                   node_id,
                   addr.host(),
                   addr.port());
                 return ss::make_lw_shared<broker>(node_id, std::move(*client));
             });
       })
-      .handle_exception_type([node_id](const std::system_error& ex) {
+      .handle_exception_type([node_id, &logger](const std::system_error& ex) {
           if (net::is_reconnect_error(ex) || is_dns_failure_error(ex)) {
               return ss::make_exception_future<shared_broker_t>(
                 broker_error(node_id, error_code::network_exception));
           }
-          vlog(kclog.warn, "std::system_error: {}", ex.what());
+          vlog(logger.warn, "std::system_error: {}", ex.what());
           return ss::make_exception_future<shared_broker_t>(ex);
       })
-      .then([&config](shared_broker_t broker) {
-          return do_authenticate(broker, config)
+      .then([&config, &logger](shared_broker_t broker) {
+          return do_authenticate(broker, config, logger)
             .then([broker]() { return broker; })
             .handle_exception([broker](std::exception_ptr ex) {
                 return broker->stop().then([ex]() {

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -18,6 +18,7 @@
 #include "model/metadata.h"
 #include "net/connection.h"
 #include "utils/mutex.h"
+#include "utils/prefix_logger.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -123,7 +124,8 @@ using shared_broker_t = ss::lw_shared_ptr<broker>;
 ss::future<shared_broker_t> make_broker(
   model::node_id node_id,
   net::unresolved_address addr,
-  const configuration& config);
+  const configuration& config,
+  prefix_logger& logger);
 
 struct broker_hash {
     using is_transparent = void;

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -65,7 +65,8 @@ ss::future<> brokers::apply(chunked_vector<metadata_response::broker>&& res) {
                      return make_broker(
                        b.node_id,
                        net::unresolved_address(b.host, b.port),
-                       _config);
+                       _config,
+                       *_logger);
                  })
           .then([this, &new_brokers, new_brokers_begin](
                   std::vector<shared_broker_t> broker_endpoints) mutable {

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -33,8 +33,10 @@ class brokers {
       = absl::flat_hash_set<shared_broker_t, broker_hash, broker_eq>;
 
 public:
-    explicit brokers(const configuration& config)
-      : _config(config) {};
+    explicit brokers(const configuration& config, prefix_logger& logger)
+      : _config(config)
+      , _logger(&logger) {};
+
     brokers(const brokers&) = delete;
     brokers(brokers&&) = default;
     brokers& operator=(const brokers&) = delete;
@@ -67,6 +69,7 @@ private:
     brokers_t _brokers;
     /// \brief Next broker to select with round-robin
     size_t _next_broker{0};
+    prefix_logger* _logger;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -52,18 +52,19 @@ namespace kafka::client {
 client::client(const YAML::Node& cfg, std::optional<external_mitigate> mitigater)
   : _config{cfg}
   , _seeds{_config.brokers()}
+  , _logger{kclog, _config.client_identifier().value_or("")}
   , _topic_cache{}
-  , _brokers{_config}
+  , _brokers{_config,_logger}
   , _wait_or_start_update_metadata{[this](wait_or_start::tag tag) {
       return update_metadata(tag);
   }}
-  , _producer{_config, _topic_cache, _brokers, _config.produce_ack_level(), [this](std::exception_ptr ex) {
+  , _producer{_config, _topic_cache, _brokers, _config.produce_ack_level(), _logger, [this](std::exception_ptr ex) {
       return mitigate_error(std::move(ex));
   }}
   , _external_mitigate(std::move(mitigater)) {}
 
 ss::future<> client::do_connect(net::unresolved_address addr) {
-    return make_broker(unknown_node_id, addr, _config)
+    return make_broker(unknown_node_id, addr, _config, _logger)
       .then([this](shared_broker_t broker) {
           return broker->dispatch(metadata_request{.list_all_topics = true})
             .then(
@@ -93,11 +94,11 @@ ss::future<> client::connect() {
 
 namespace {
 template<typename Func>
-ss::future<> catch_and_log(const client& c, Func&& f) noexcept {
+ss::future<> catch_and_log(const prefix_logger& logger, Func&& f) noexcept {
     return ss::futurize_invoke(std::forward<Func>(f))
       .discard_result()
-      .handle_exception([&c](std::exception_ptr e) {
-          vlog(kclog.debug, "{}exception during stop: {}", c, e);
+      .handle_exception([&logger](std::exception_ptr e) {
+          vlog(logger.debug, "exception during stop: {}", e);
       });
 }
 
@@ -105,24 +106,24 @@ ss::future<> catch_and_log(const client& c, Func&& f) noexcept {
 
 ss::future<> client::stop() noexcept {
     _as.request_abort();
-    co_await catch_and_log(*this, [this]() { return _producer.stop(); });
+    co_await catch_and_log(_logger, [this]() { return _producer.stop(); });
     co_await _gate.close();
     for (auto& [id, group] : _consumers) {
         while (!group.empty()) {
             auto c = *group.begin();
-            co_await catch_and_log(*this, [c]() {
+            co_await catch_and_log(_logger, [c]() {
                 // The consumer is constructed with an on_stopped which erases
                 // istelf from the map after leave() completes.
                 return c->leave();
             });
         }
     }
-    co_await catch_and_log(*this, [this]() { return _brokers.stop(); });
+    co_await catch_and_log(_logger, [this]() { return _brokers.stop(); });
 }
 
 ss::future<> client::update_metadata(wait_or_start::tag) {
     return ss::try_with_gate(_gate, [this]() {
-        vlog(kclog.debug, "{}updating metadata", *this);
+        vlog(_logger.debug, "updating metadata");
         return _brokers.any()
           .then([this](shared_broker_t broker) {
               return broker->dispatch(metadata_request{.list_all_topics = true})
@@ -140,8 +141,7 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
 
                     return apply(std::move(res));
                 })
-                .finally(
-                  [this]() { vlog(kclog.trace, "{}updated metadata", *this); });
+                .finally([this]() { vlog(_logger.trace, "updated metadata"); });
           })
           .handle_exception_type(
             [this](const broker_error&) { return connect(); });
@@ -154,7 +154,7 @@ ss::future<> client::apply(metadata_response res) {
         co_await _topic_cache.apply(std::move(res.data.topics));
         _controller = res.data.controller_id;
     } catch (const std::exception& ex) {
-        vlog(kclog.debug, "{}Failed to apply metadata request: {}", *this, ex);
+        vlog(_logger.debug, "Failed to apply metadata request: {}", ex);
         throw;
     }
 }
@@ -175,13 +175,13 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
           } catch (const broker_error& ex) {
               // If there are no brokers, reconnect
               if (ex.node_id == unknown_node_id) {
-                  vlog(kclog.warn, "{}broker_error: {}", *this, ex);
+                  vlog(_logger.warn, "broker_error: {}", ex);
                   return connect();
               } else if (ex.error == error_code::not_controller) {
-                  vlog(kclog.debug, "{}broker_error: {}", *this, ex);
+                  vlog(_logger.debug, "broker_error: {}", ex);
                   return _wait_or_start_update_metadata();
               } else {
-                  vlog(kclog.debug, "{}broker_error: {}", *this, ex);
+                  vlog(_logger.debug, "broker_error: {}", ex);
                   return _brokers.erase(ex.node_id).then([this]() {
                       return _wait_or_start_update_metadata();
                   });
@@ -189,10 +189,10 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
           } catch (const consumer_error& ex) {
               switch (ex.error) {
               case error_code::coordinator_not_available:
-                  vlog(kclog.debug, "{}consumer_error: {}", *this, ex);
+                  vlog(_logger.debug, "consumer_error: {}", ex);
                   return _wait_or_start_update_metadata();
               default:
-                  vlog(kclog.warn, "{}consumer_error: {}", *this, ex);
+                  vlog(_logger.warn, "consumer_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
           } catch (const partition_error& ex) {
@@ -200,35 +200,35 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
               case error_code::unknown_topic_or_partition:
               case error_code::not_leader_for_partition:
               case error_code::leader_not_available: {
-                  vlog(kclog.debug, "{}partition_error: {}", *this, ex);
+                  vlog(_logger.debug, "partition_error: {}", ex);
                   return _wait_or_start_update_metadata();
               }
               default:
-                  vlog(kclog.warn, "{}partition_error: {}", *this, ex);
+                  vlog(_logger.warn, "partition_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
           } catch (const topic_error& ex) {
               switch (ex.error) {
               case error_code::unknown_topic_or_partition:
-                  vlog(kclog.debug, "{}topic_error: {}", *this, ex);
+                  vlog(_logger.debug, "topic_error: {}", ex);
                   return _wait_or_start_update_metadata();
               default:
-                  vlog(kclog.warn, "{}topic_error: {}", *this, ex);
+                  vlog(_logger.warn, "topic_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
           } catch (const ss::gate_closed_exception&) {
-              vlog(kclog.debug, "{}gate_closed_exception", *this);
+              vlog(_logger.debug, "gate_closed_exception");
           } catch (const std::system_error& ex) {
               if (net::is_reconnect_error(ex)) {
-                  vlog(kclog.debug, "{}system_error: {}", *this, ex);
+                  vlog(_logger.debug, "system_error: {}", ex);
                   return _wait_or_start_update_metadata();
               } else {
-                  vlog(kclog.warn, "{}system_error: {}", *this, ex);
+                  vlog(_logger.warn, "system_error: {}", ex);
                   return ss::make_exception_future(ex);
               }
           } catch (const std::exception& ex) {
               // TODO(Ben): Probably vassert
-              vlog(kclog.error, "{}unknown exception: {}", *this, ex);
+              vlog(_logger.error, "unknown exception: {}", ex);
           }
           return ss::make_exception_future(ex);
       });
@@ -239,9 +239,8 @@ ss::future<produce_response::partition> client::produce_record_batch(
     return ss::try_with_gate(
       _gate, [this, tp{std::move(tp)}, batch{std::move(batch)}]() mutable {
           vlog(
-            kclog.debug,
-            "{}produce record_batch: {}, {{record_count: {}}}",
-            *this,
+            _logger.debug,
+            "produce record_batch: {}, {{record_count: {}}}",
             tp,
             batch.record_count());
           return _producer.produce(std::move(tp), std::move(batch));
@@ -526,6 +525,7 @@ client::create_consumer(const group_id& group_id, member_id name) {
              _brokers,
              group_id,
              name,
+             _logger,
              [this](std::exception_ptr ex) { return mitigate_error(ex); })
       .then([this, group_id, name](shared_broker_t coordinator) mutable {
           auto on_stopped = [this, group_id](const member_id& name) {
@@ -539,7 +539,8 @@ client::create_consumer(const group_id& group_id, member_id name) {
             std::move(group_id),
             std::move(name),
             std::move(on_stopped),
-            [this](std::exception_ptr ex) { return mitigate_error(ex); });
+            [this](std::exception_ptr ex) { return mitigate_error(ex); },
+            _logger);
       })
       .then([this, group_id](shared_consumer_t c) {
           auto name = c->name();
@@ -633,11 +634,7 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
                      + std::min(config_timout, timeout.value_or(config_timout));
     return gated_retry_with_mitigation([this, g_id, name, end, max_bytes]() {
         vlog(
-          kclog.debug,
-          "{}consumer_fetch: group_id: {}, name: {}",
-          *this,
-          g_id,
-          name);
+          _logger.debug, "consumer_fetch: group_id: {}, name: {}", g_id, name);
         return get_consumer(g_id, name)
           .then([end, max_bytes](shared_consumer_t c) {
               auto timeout = std::max(

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -29,6 +29,7 @@
 #include "kafka/protocol/list_offset.h"
 #include "model/timestamp.h"
 #include "ssx/semaphore.h"
+#include "utils/prefix_logger.h"
 #include "utils/retry.h"
 #include "utils/unresolved_address.h"
 
@@ -181,6 +182,7 @@ public:
     configuration& config() { return _config; }
 
 private:
+    friend class client_fetcher;
     ss::future<list_offsets_response>
     do_list_offsets(const list_offsets_request&);
 
@@ -210,18 +212,12 @@ private:
     /// \brief Apply metadata update
     ss::future<> apply(metadata_response res);
 
-    /// \brief Log the client ID if it exists, otherwise don't log
-    friend std::ostream& operator<<(std::ostream& os, const client& c) {
-        if (c._config.client_identifier().has_value()) {
-            fmt::print(os, "{}: ", c._config.client_identifier().value());
-        }
-        return os;
-    }
-
+    prefix_logger& logger() { return _logger; }
     /// \brief Client holds a copy of its configuration
     configuration _config;
     /// \brief Seeds are used when no brokers are connected.
     std::vector<net::unresolved_address> _seeds;
+    prefix_logger _logger;
     /// \brief Cache of topic information.
     topic_cache _topic_cache;
     /// \brief Broker lookup from topic_partition.

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -43,9 +43,8 @@ public:
     do_load_slice(model::timeout_clock::time_point t) final {
         if (!_batch_reader || _batch_reader->is_end_of_stream()) {
             vlog(
-              kclog.debug,
-              "{}fetch_batch_reader: fetch offset: {}",
-              _client,
+              _client.logger().debug,
+              "fetch_batch_reader: fetch offset: {}",
               _next_offset);
             auto res = co_await _client.fetch_partition(
               _tp,
@@ -54,9 +53,8 @@ public:
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 t - model::timeout_clock::now()));
             vlog(
-              kclog.debug,
-              "{}fetch_batch_reader: fetch result: {}",
-              _client,
+              _client.logger().debug,
+              "fetch_batch_reader: fetch result: {}",
               res);
             vassert(
               res.begin() != res.end() && ++res.begin() == res.end(),
@@ -80,9 +78,8 @@ public:
         }
         _next_offset = ++data.back().last_offset();
         vlog(
-          kclog.debug,
-          "{}fetch_batch_reader: next_offset: {}",
-          _client,
+          _client.logger().debug,
+          "fetch_batch_reader: next_offset: {}",
           _next_offset);
         co_return ret;
     }

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -92,42 +92,55 @@ consumer::consumer(
   kafka::group_id group_id,
   kafka::member_id name,
   ss::noncopyable_function<void(const kafka::member_id&)> on_stopped,
-  ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater)
+  ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater,
+  prefix_logger& logger)
   : _config(config)
   , _topic_cache(topic_cache)
   , _brokers(brokers)
   , _coordinator(std::move(coordinator))
   , _inactive_timer([me{shared_from_this()}]() {
-      vlog(kclog.info, "Consumer: {}: inactive", *me);
+      vlog(me->_logger->info, "Consumer: {}: inactive", *me);
       ssx::background = me->leave().discard_result().finally([me]() {});
   })
   , _group_id(std::move(group_id))
   , _name(std::move(name))
   , _topics()
   , _on_stopped(std::move(on_stopped))
-  , _external_mitigate(std::move(mitigater)) {}
+  , _external_mitigate(std::move(mitigater))
+  , _logger(&logger) {}
 
 void consumer::start() {
-    vlog(kclog.info, "Consumer: {}: start", *this);
+    vlog(_logger->info, "Consumer: {}: start", *this);
     _heartbeat_timer.set_callback([me{shared_from_this()}]() {
-        vlog(kclog.trace, "Consumer: {}: timer cb", *me);
+        vlog(me->_logger->trace, "Consumer: {}: timer cb", *me);
         (void)me->heartbeat()
           .handle_exception_type([me](const exception_base& e) {
               vlog(
-                kclog.info, "Consumer: {}: heartbeat failed: {}", *me, e.error);
+                me->_logger->info,
+                "Consumer: {}: heartbeat failed: {}",
+                *me,
+                e.error);
           })
           .handle_exception_type([me](const ss::gate_closed_exception& e) {
-              vlog(kclog.trace, "Consumer: {}: heartbeat failed: {}", *me, e);
+              vlog(
+                me->_logger->trace,
+                "Consumer: {}: heartbeat failed: {}",
+                *me,
+                e);
           })
           .handle_exception([me](const std::exception_ptr& e) {
-              vlog(kclog.error, "Consumer: {}: heartbeat failed: {}", *me, e);
+              vlog(
+                me->_logger->error,
+                "Consumer: {}: heartbeat failed: {}",
+                *me,
+                e);
           });
     });
     _heartbeat_timer.rearm_periodic(_config.consumer_heartbeat_interval());
 }
 
 ss::future<> consumer::stop() {
-    vlog(kclog.info, "Consumer: {}: stop", *this);
+    vlog(_logger->info, "Consumer: {}: stop", *this);
     // Clear the timer callbacks as they may hold a shared_from_this().
     _heartbeat_timer.cancel();
     _heartbeat_timer.set_callback([]() {});
@@ -145,7 +158,7 @@ ss::future<> consumer::stop() {
 }
 
 ss::future<> consumer::initialize() {
-    vlog(kclog.info, "Consumer: {}: initialize", *this);
+    vlog(_logger->info, "Consumer: {}: initialize", *this);
     refresh_inactivity_timer();
     return join();
 }
@@ -234,7 +247,7 @@ void consumer::on_leader_join(const join_group_response& res) {
       std::unique(_subscribed_topics.begin(), _subscribed_topics.end()));
 
     vlog(
-      kclog.info,
+      _logger->info,
       "Consumer: {}: join: members: {}, topics: {}",
       *this,
       _members,
@@ -403,9 +416,9 @@ consumer::offset_commit(chunked_vector<offset_commit_request_topic> topics) {
 ss::future<fetch_response>
 consumer::dispatch_fetch(broker_reqs_t::value_type br) {
     auto& [broker, req] = br;
-    vlog(kclog.trace, "Consumer: {}, fetch_req: {}", *this, req);
+    vlog(_logger->trace, "Consumer: {}, fetch_req: {}", *this, req);
     auto res = co_await broker->dispatch(std::move(req));
-    vlog(kclog.trace, "Consumer: {}, fetch_res: {}", *this, res);
+    vlog(_logger->trace, "Consumer: {}, fetch_res: {}", *this, res);
 
     if (res.data.error_code != error_code::none) {
         throw broker_error(broker->id(), res.data.error_code);
@@ -479,6 +492,7 @@ consumer::reset_coordinator_and_retry_request(request_factory req) {
              _brokers,
              group_id(),
              name(),
+             *_logger,
              [this](std::exception_ptr ex) { return _external_mitigate(ex); })
       .then(
         [this, req{std::move(req)}](shared_broker_t new_coordinator) mutable {
@@ -497,7 +511,7 @@ consumer::maybe_process_response_errors(request_factory req, response_t res) {
     switch (res.data.error_code) {
     case error_code::not_coordinator:
         vlog(
-          kclog.debug,
+          _logger->debug,
           "Wrong coordinator on consumer {}, getting new coordinator "
           "before retry",
           *me);
@@ -516,7 +530,7 @@ ss::future<metadata_response> consumer::maybe_process_response_errors(
         switch (topic.error_code) {
         case error_code::not_coordinator:
             vlog(
-              kclog.debug,
+              _logger->debug,
               "Wrong coordinator on consumer {}, topic {}, getting new "
               "coordinator before retry",
               *me,
@@ -539,7 +553,7 @@ ss::future<offset_commit_response> consumer::maybe_process_response_errors(
             switch (partition.error_code) {
             case error_code::not_coordinator:
                 vlog(
-                  kclog.debug,
+                  _logger->debug,
                   "Wrong coordinator on consumer {}, tp {}, getting new "
                   "coordinator before retry",
                   *me,
@@ -564,7 +578,7 @@ ss::future<describe_groups_response> consumer::maybe_process_response_errors(
         switch (group.error_code) {
         case error_code::not_coordinator:
             vlog(
-              kclog.debug,
+              _logger->debug,
               "Wrong coordinator on consumer {}, group {}, getting new "
               "coordinator before retry",
               *me,
@@ -586,7 +600,8 @@ ss::future<shared_consumer_t> make_consumer(
   group_id group_id,
   member_id name,
   ss::noncopyable_function<void(const member_id&)> on_stopped,
-  ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater) {
+  ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater,
+  prefix_logger& logger) {
     auto c = ss::make_lw_shared<consumer>(
       config,
       topic_cache,
@@ -595,7 +610,8 @@ ss::future<shared_consumer_t> make_consumer(
       std::move(group_id),
       std::move(name),
       std::move(on_stopped),
-      std::move(mitigater));
+      std::move(mitigater),
+      logger);
     return c->initialize().then([c]() mutable { return std::move(c); });
 }
 

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -58,7 +58,8 @@ public:
       group_id group_id,
       member_id name,
       ss::noncopyable_function<void(const member_id&)> on_stopped,
-      ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater);
+      ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater,
+      prefix_logger& logger);
 
     const kafka::group_id& group_id() const { return _group_id; }
     const kafka::member_id& member_id() const { return _member_id; }
@@ -175,6 +176,7 @@ private:
     ss::noncopyable_function<void(const kafka::member_id&)> _on_stopped;
     ss::noncopyable_function<ss::future<>(std::exception_ptr)>
       _external_mitigate;
+    prefix_logger* _logger;
 
     friend std::ostream& operator<<(std::ostream& os, const consumer& c) {
         fmt::print(
@@ -197,7 +199,8 @@ ss::future<shared_consumer_t> make_consumer(
   group_id group_id,
   member_id name,
   ss::noncopyable_function<void(const member_id&)> _on_stopped,
-  ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater);
+  ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater,
+  prefix_logger& logger);
 
 namespace detail {
 

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -42,8 +42,8 @@ produce_request make_produce_request(
     return produce_request(t_id, acks, std::move(topics));
 }
 
-produce_response::partition
-make_produce_response(model::partition_id p_id, std::exception_ptr ex) {
+produce_response::partition make_produce_response(
+  model::partition_id p_id, std::exception_ptr ex, prefix_logger& logger) {
     auto response = produce_response::partition{
       .partition_index{p_id},
       .error_code = error_code::none,
@@ -51,27 +51,27 @@ make_produce_response(model::partition_id p_id, std::exception_ptr ex) {
     try {
         std::rethrow_exception(std::move(ex));
     } catch (const partition_error& ex) {
-        vlog(kclog.debug, "handling partition_error {}", ex.what());
+        vlog(logger.debug, "handling partition_error {}", ex.what());
         response.error_code = ex.error;
     } catch (const broker_error& ex) {
-        vlog(kclog.debug, "handling broker_error {}", ex.what());
+        vlog(logger.debug, "handling broker_error {}", ex.what());
         response.error_code = ex.error;
     } catch (const ss::gate_closed_exception&) {
-        vlog(kclog.debug, "gate_closed_exception");
+        vlog(logger.debug, "gate_closed_exception");
         response.error_code = error_code::operation_not_attempted;
     } catch (const ss::abort_requested_exception&) {
         /// Could only occur when abort_source is triggered via stop()
-        vlog(kclog.debug, "sleep_aborted / abort_requested exception");
+        vlog(logger.debug, "sleep_aborted / abort_requested exception");
         response.error_code = error_code::operation_not_attempted;
     } catch (const std::exception& ex) {
-        vlog(kclog.warn, "std::exception {}", ex.what());
+        vlog(logger.warn, "std::exception {}", ex.what());
         response.error_code = error_code::unknown_server_error;
     }
     return response;
 }
 
 ss::future<> producer::stop() {
-    vlog(kclog.debug, "Stopping kafka/client producer");
+    vlog(_logger->debug, "Stopping kafka/client producer");
     /// Stop new messages from entering the system, the second abort source is
     /// triggered when the timeout below expires
     _ingest_as.request_abort();
@@ -89,7 +89,7 @@ ss::future<> producer::stop() {
     ss::abort_source exit;
     if (_config.produce_shutdown_delay() > 0ms) {
         vlog(
-          kclog.debug,
+          _logger->debug,
           "Waiting {}ms to allow final flush of producers batched records",
           _config.produce_shutdown_delay());
     }
@@ -97,20 +97,20 @@ ss::future<> producer::stop() {
                    .then([this] {
                        if (_config.produce_shutdown_delay() > 0ms) {
                            vlog(
-                             kclog.warn,
+                             _logger->warn,
                              "Forcefully stopping kafka client producer after "
                              "waiting {}ms for its gate to close",
                              _config.produce_shutdown_delay());
                        }
                        _as.request_abort();
                    })
-                   .handle_exception_type([](ss::sleep_aborted) {
-                       vlog(kclog.debug, "Producer shutdown cleanly");
+                   .handle_exception_type([this](ss::sleep_aborted) {
+                       vlog(_logger->debug, "Producer shutdown cleanly");
                    });
     co_await _gate.close();
     exit.request_abort();
     co_await std::move(abort);
-    vlog(kclog.debug, "Waiting for inflight state of false");
+    vlog(_logger->debug, "Waiting for inflight state of false");
     /// Wait until the produce_partition has no inflight records. That is
     /// because if in_flight is true, drain() and stop() will actually not call
     /// consume -> send(). This may have been the case when maybe_drain() above
@@ -118,13 +118,13 @@ ss::future<> producer::stop() {
     co_await ssx::parallel_transform(
       _partitions,
       [](partitions_t::value_type p) { return p.second->await_in_flight(); });
-    vlog(kclog.debug, "Calling produce_partition::stop()");
+    vlog(_logger->debug, "Calling produce_partition::stop()");
     /// At this point in time there are no inflight requests, for any data that
     /// remains in the buffers stop() will be guaranteed to call send() which
     /// will return error responses to the initial caller
     co_await ssx::parallel_transform(
       _partitions, [](partitions_t::value_type p) { return p.second->stop(); });
-    vlog(kclog.debug, "Producer stopped");
+    vlog(_logger->debug, "Producer stopped");
 }
 
 ss::future<produce_response::partition>
@@ -133,7 +133,8 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
         return ss::make_ready_future<produce_response::partition>(
           make_produce_response(
             tp.partition,
-            std::make_exception_ptr(ss::abort_requested_exception())));
+            std::make_exception_ptr(ss::abort_requested_exception()),
+            *_logger));
     }
     return get_context(std::move(tp))->produce(std::move(batch));
 }
@@ -159,7 +160,7 @@ ss::future<>
 producer::send(model::topic_partition tp, model::record_batch&& batch) {
     auto record_count = batch.record_count();
     vlog(
-      kclog.debug,
+      _logger->debug,
       "send record_batch: {}, {{record_count: {}}}",
       tp,
       record_count);
@@ -176,9 +177,9 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
                        },
                        [this](std::exception_ptr ex) {
                            return _error_handler(std::move(ex))
-                             .handle_exception([](std::exception_ptr ex) {
+                             .handle_exception([this](std::exception_ptr ex) {
                                  vlog(
-                                   kclog.trace,
+                                   _logger->trace,
                                    "Error during mitigation: {}",
                                    ex);
                                  // ignore failed mitigation
@@ -187,12 +188,12 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
                        _as);
                  });
              })
-      .handle_exception([p_id](std::exception_ptr ex) {
-          return make_produce_response(p_id, std::move(ex));
+      .handle_exception([this, p_id](std::exception_ptr ex) {
+          return make_produce_response(p_id, std::move(ex), *_logger);
       })
       .then([this, tp, record_count](produce_response::partition res) mutable {
           vlog(
-            kclog.debug,
+            _logger->debug,
             "sent record_batch: {}, {{record_count: {}}}, {}",
             tp,
             record_count,

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -17,6 +17,7 @@
 #include "kafka/client/topic_cache.h"
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
+#include "utils/prefix_logger.h"
 
 #include <absl/container/flat_hash_map.h>
 
@@ -37,9 +38,11 @@ public:
       topic_cache& topic_cache,
       brokers& brokers,
       int16_t acks,
+      prefix_logger& logger,
       error_handler&& error_handler)
       : _config{config}
       , _partitions{}
+      , _logger(&logger)
       , _error_handler(std::move(error_handler))
       , _topic_cache(topic_cache)
       , _brokers(brokers)
@@ -76,6 +79,7 @@ private:
     const configuration& _config;
     absl::flat_hash_map<model::topic_partition, shared_produce_partition>
       _partitions;
+    prefix_logger* _logger;
     error_handler _error_handler;
     topic_cache& _topic_cache;
     brokers& _brokers;

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -16,16 +16,13 @@
 
 namespace kafka::client {
 
-ss::future<>
-do_authenticate(shared_broker_t broker, const configuration& config) {
-    auto prefix = config.client_identifier().has_value()
-                    ? ssx::sformat("{}: ", *config.client_identifier())
-                    : "";
+ss::future<> do_authenticate(
+  shared_broker_t broker, const configuration& config, prefix_logger& logger) {
     if (config.sasl_mechanism().empty()) {
         vlog(
-          kclog.debug,
-          "{}Connecting to broker {} without authentication",
-          prefix,
+          logger.debug,
+          "Connecting to broker {} without authentication",
+
           broker->id());
         co_return;
     }
@@ -45,9 +42,8 @@ do_authenticate(shared_broker_t broker, const configuration& config) {
     auto username = config.scram_username();
 
     vlog(
-      kclog.debug,
-      "{}Connecting to broker {} with authentication: {}:{}",
-      prefix,
+      logger.debug,
+      "Connecting to broker {} with authentication: {}:{}",
       broker->id(),
       mechanism,
       username);

--- a/src/v/kafka/client/sasl_client.h
+++ b/src/v/kafka/client/sasl_client.h
@@ -19,7 +19,8 @@
 
 namespace kafka::client {
 
-ss::future<> do_authenticate(shared_broker_t, const configuration& config);
+ss::future<> do_authenticate(
+  shared_broker_t, const configuration& config, prefix_logger& logger);
 /*
  * SASL handshake negotiates mechanism. In this case that process is simple: if
  * the server doesn't support the requested mechanism there is no fallback.

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -117,6 +117,7 @@ ss::future<shared_broker_t> find_coordinator_with_retry_and_mitigation(
   brokers& cluster_brokers,
   const group_id& group_id,
   member_id name,
+  prefix_logger& logger,
   ErrFunc errFunc) {
     return gated_retry_with_mitigation_impl(
              retry_gate,
@@ -139,11 +140,12 @@ ss::future<shared_broker_t> find_coordinator_with_retry_and_mitigation(
                    });
              },
              errFunc)
-      .then([&client_config](find_coordinator_response res) {
+      .then([&client_config, &logger](find_coordinator_response res) {
           return make_broker(
             res.data.node_id,
             net::unresolved_address(res.data.host, res.data.port),
-            client_config);
+            client_config,
+            logger);
       });
 }
 


### PR DESCRIPTION
Instead of relaying on passing in the `client_id` prefix, let's use `prefix_logger` throughout the client implementation.

Fixes: CORE-12215

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none