### PR TITLE
[v24.3.x] storage: fix index state truncate overflow

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -763,12 +763,21 @@ bool index_state::truncate(
     if (new_max_offset < base_offset) {
         return needs_persistence;
     }
-    const uint32_t i = new_max_offset() - base_offset();
-    auto res = index.offset_lower_bound(i);
-    size_t remove_back_elems = index.size() - res.value_or(index.size());
-    if (remove_back_elems > 0) {
-        needs_persistence = true;
-        pop_back(remove_back_elems);
+    static constexpr int64_t u32_max = std::numeric_limits<uint32_t>::max();
+    int64_t delta = new_max_offset() - base_offset();
+    // NOTE: we expect that deltas above u32_max would have not been
+    // added to the index, unless by an older buggy version of Redpanda.
+    // With this in mind, either there are no entries above u32_max, or
+    // offset_lower_bound() isn't going to work correctly anyway, so we just
+    // skip removal and rely on queries to detect the overflow.
+    if (delta <= u32_max) {
+        auto i = static_cast<uint32_t>(delta);
+        auto res = index.offset_lower_bound(i);
+        size_t remove_back_elems = index.size() - res.value_or(index.size());
+        if (remove_back_elems > 0) {
+            needs_persistence = true;
+            pop_back(remove_back_elems);
+        }
     }
     if (new_max_offset < max_offset) {
         needs_persistence = true;

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -408,3 +408,36 @@ BOOST_AUTO_TEST_CASE(non_data_timestamps_with_overflow) {
       true,
       0);
 }
+
+BOOST_AUTO_TEST_CASE(index_overflow_truncate) {
+    storage::index_state state;
+
+    // Previous versions of Redpanda can have an index with offsets spanning
+    // greater than uint32 offset space. In these cases, the index is not
+    // reliable and truncation shouldn't attempt to truncate entries based on
+    // an overflown lookup. But, queries should fallback to returning the
+    // beginning of the index.
+    const model::timestamp dummy_ts;
+    const storage::offset_delta_time should_offset{false};
+    storage::offset_time_index time_idx{dummy_ts, should_offset};
+    constexpr long uint32_max = std::numeric_limits<uint32_t>::max();
+    state.add_entry(0, time_idx, 1);
+    state.add_entry(100, time_idx, 2);
+    state.add_entry(static_cast<uint32_t>(uint32_max + 1), time_idx, 3);
+    state.add_entry(static_cast<uint32_t>(uint32_max + 10), time_idx, 4);
+    state.max_offset = model::offset{uint32_max + 10};
+    BOOST_CHECK_EQUAL(4, state.size());
+
+    // The truncation shouldn't remove index entries, given the overflow.
+    auto needs_flush = state.truncate(
+      model::offset(uint32_max + 1), model::timestamp::now());
+    BOOST_CHECK(needs_flush);
+    BOOST_CHECK_EQUAL(4, state.size());
+    BOOST_CHECK_EQUAL(state.max_offset, model::offset{uint32_max + 1});
+
+    // Queries for the offset should start from the beginning of the segment.
+    auto res = state.find_nearest(model::offset(uint32_max + 1));
+    BOOST_REQUIRE(res.has_value());
+    BOOST_CHECK_EQUAL(res->offset, model::offset{0});
+    BOOST_CHECK_EQUAL(res->filepos, 1);
+}


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/26051
Fixes https://github.com/redpanda-data/redpanda/issues/26194

CONFLICT:
- previous test in index_state.cc was different from dev

Similar to https://github.com/redpanda-data/redpanda/pull/25979, when an index contains state that leads it to overflow, it is unreliable. In this case, this could affect truncation, and result in us removing incorrect index entries.

So, this makes the truncate avoid removing entries if this case is detected, with the expectation that no entries are added that have overflowed.

Note, this bug doesn't appear to be as severe as #25979 in that:
- suffix truncation is generally more rare
- the overflowing index problem is generally a problem with:
  - large segments, much larger than the default allowed size
  - compacted segments, which we expect to be relatively rare to suffix truncate with tiered storage

Nonetheless, some kind of fix seems appropriate because it's difficult to reason about the overflow otherwise.

(cherry picked from commit e882d67ed669224fc7e713c423b3211eaf591eac)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
