### PR TITLE
[v24.2.x] storage: fix index state truncate overflow

### DIFF
--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -232,19 +232,27 @@ ss::future<> segment_index::truncate(
     if (new_max_offset < _state.base_offset) {
         co_return;
     }
-    const uint32_t i = new_max_offset() - _state.base_offset();
-    auto it = std::lower_bound(
-      std::begin(_state.relative_offset_index),
-      std::end(_state.relative_offset_index),
-      i,
-      std::less<uint32_t>{});
+    static constexpr int64_t u32_max = std::numeric_limits<uint32_t>::max();
+    int64_t delta = new_max_offset() - base_offset();
+    // NOTE: we expect that deltas above u32_max would have not been
+    // added to the index, unless by an older buggy version of Redpanda.
+    // With this in mind, either there are no entries above u32_max, or
+    // offset_lower_bound() isn't going to work correctly anyway, so we just
+    // skip removal and rely on queries to detect the overflow.
+    if (delta <= u32_max) {
+        auto it = std::lower_bound(
+          std::begin(_state.relative_offset_index),
+          std::end(_state.relative_offset_index),
+          delta,
+          std::less<uint32_t>{});
 
-    if (it != _state.relative_offset_index.end()) {
-        _needs_persistence = true;
-        int remove_back_elems = std::distance(
-          it, _state.relative_offset_index.end());
-        while (remove_back_elems-- > 0) {
-            _state.pop_back();
+        if (it != _state.relative_offset_index.end()) {
+            _needs_persistence = true;
+            int remove_back_elems = std::distance(
+              it, _state.relative_offset_index.end());
+            while (remove_back_elems-- > 0) {
+                _state.pop_back();
+            }
         }
     }
 


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/26051
Fixes https://github.com/redpanda-data/redpanda/issues/26192

CONFLICT:
- similar to https://github.com/redpanda-data/redpanda/pull/26024, the appropriate code in this branch is in segment_index instead of index_state
- because of this, the index_state unit test is removed

Similar to https://github.com/redpanda-data/redpanda/pull/25979, when an index contains state that leads it to overflow, it is unreliable. In this case, this could affect truncation, and result in us removing incorrect index entries.

So, this makes the truncate avoid removing entries if this case is detected, with the expectation that no entries are added that have overflowed.

Note, this bug doesn't appear to be as severe as #25979 in that:
- suffix truncation is generally more rare
- the overflowing index problem is generally a problem with:
  - large segments, much larger than the default allowed size
  - compacted segments, which we expect to be relatively rare to suffix truncate with tiered storage

Nonetheless, some kind of fix seems appropriate because it's difficult to reason about the overflow otherwise.

(cherry picked from commit e882d67ed669224fc7e713c423b3211eaf591eac)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
