### PR TITLE
rptest: don't query unstarted nodes for metrics

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4148,7 +4148,10 @@ class RedpandaService(RedpandaServiceBase):
         except Exception as e:
             self.logger.warn(f"Error setting trace loggers: {e}")
 
-    def _update_usage_stats(self, node):
+    def _update_usage_stats(self, node: ClusterNode):
+        if node not in self._started:
+            return
+
         def _metrics_sum(name: str) -> int:
             try:
                 samples = self.metrics_sample(name, [node])


### PR DESCRIPTION
Recently we changed the rptest wrapper to query each node during
stop_node for metrics. However, it turns out that stop_node is called
by DT itself as part of clean_node, which always results in a failed
metric query and a bunch of spam to the warning log (which shows up
on the console in DT).

Check if the node is started before querying it to avoid this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


