### PR TITLE
`storage`: call `reserve()` in `storage::range()`

### DIFF
--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -28,6 +28,7 @@ range(segment_set::underlying_t segs) {
       segment_set(std::move(segs)));
 
     chunked_vector<ss::future<ss::rwlock::holder>> dispatch;
+    dispatch.reserve(ctx->range.size());
     for (auto& s : ctx->range) {
         dispatch.push_back(s->read_lock());
     }


### PR DESCRIPTION
For some reason, this `reserve()` call was dropped in commit https://github.com/redpanda-data/redpanda/pull/26111/commits/a59cdd88a486ec605d268903fa9b9c824b0e440e when the container type was switched from `std::vector<>` to `chunked_vector<>`.

Fix the regression by adding the call to `reserve()` back to the function before calling `push_back()` in a loop.

Backporting since the original PR https://github.com/redpanda-data/redpanda/pull/26111 was also backported.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [X] v24.2.x

## Release Notes

* none
