### PR TITLE
[v24.2.x] `storage`: call `reserve()` in `storage::range()`

### DIFF
--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -28,6 +28,7 @@ range(segment_set::underlying_t segs) {
       segment_set(std::move(segs)));
 
     chunked_vector<ss::future<ss::rwlock::holder>> dispatch;
+    dispatch.reserve(ctx->range.size());
     for (auto& s : ctx->range) {
         dispatch.push_back(s->read_lock());
     }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26439
