### PR TITLE
tests/ducktape: deflake offset_for_leader_epoch test

### DIFF
--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import random
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from rptest.util import wait_until_result
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kcl import KCL
@@ -192,21 +193,18 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
         offsets = {}
 
         def get_offsets_for_leader_epoch(epoch):
-            offsets_for_leader_epoch = []
-
             def have_all_offsets():
-                offsets_for_leader_epoch.clear()
                 offsets = kcl.offset_for_leader_epoch(topics=[topic.name],
                                                       leader_epoch=epoch)
-                offsets_for_leader_epoch.extend(offsets)
-                return all([
-                    ofle.epoch_end_offset != -1
-                    for ofle in offsets_for_leader_epoch
-                ])
+                invalid_result = any(
+                    [entry.epoch_end_offset == -1 for entry in offsets])
+                return (False, None) if invalid_result else (True, {
+                    entry.partition:
+                    entry.epoch_end_offset
+                    for entry in offsets
+                })
 
-            wait_until(have_all_offsets, 30, 1)
-
-            return offsets_for_leader_epoch
+            return wait_until_result(have_all_offsets, 30, 1)
 
         rpk = RpkTool(self.redpanda)
 
@@ -253,8 +251,10 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
             for p in offsets:
                 epoch_offsets[p.leader_epoch][p.id] = p.high_watermark
 
-        for epoch, partitions in epoch_offsets.items():
-            offsets_for_leader_epoch = get_offsets_for_leader_epoch(epoch)
-            for p in offsets_for_leader_epoch:
-                assert p.partition in partitions
-                assert partitions[p.partition] == p.epoch_end_offset
+        for epoch, partition_offsets in epoch_offsets.items():
+            fetched_offsets = get_offsets_for_leader_epoch(epoch)
+            self.logger.debug(
+                f"Fetched offsets for epoch {epoch} : {fetched_offsets}, expected: {partition_offsets}"
+            )
+            # Check partition_offsets is a subset of fetched_offsets
+            assert fetched_offsets == fetched_offsets | partition_offsets, f"Mismatched offsets for leader epoch {epoch}"


### PR DESCRIPTION
Ocassionally a partition can jump epochs (eg: move from term 5 to term 7) resulting in a hole in the epoch chain (which is totally ok).

The failing test assertion implies that every partition must have a valid mapping for every epoch populated in epoch_offsets map which is not correct. The commit relaxes that requirement.

Fixes: https://redpandadata.atlassian.net/browse/CORE-9983

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
