### PR TITLE
http: Unify shutdown/cleanup logic

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -460,11 +460,9 @@ ss::future<> abs_client::stop() {
     vlog(abs_log.debug, "Stopping ABS client");
 
     co_await _client.stop();
-    co_await _client.wait_input_shutdown();
 
     if (_adls_client) {
         co_await _adls_client->stop();
-        co_await _adls_client->wait_input_shutdown();
     }
 
     vlog(abs_log.debug, "Stopped ABS client");

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -470,7 +470,7 @@ ss::future<> abs_client::stop() {
     vlog(abs_log.debug, "Stopped ABS client");
 }
 
-void abs_client::shutdown() { _client.shutdown_now(); }
+void abs_client::shutdown() { _client.shutdown(); }
 
 template<typename T>
 ss::future<result<T, error_outcome>> abs_client::send_request(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -648,7 +648,7 @@ ss::future<bool> s3_client::self_configure_test(const bucket_name& bucket) {
 
 ss::future<> s3_client::stop() { return _client.stop(); }
 
-void s3_client::shutdown() { _client.shutdown_now(); }
+void s3_client::shutdown() { _client.shutdown(); }
 
 ss::future<result<http::client::response_stream_ref, error_outcome>>
 s3_client::get_object(

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -173,6 +173,25 @@ ss::future<client::request_response_t> client::make_request(
       });
 }
 
+void client::shutdown() noexcept {
+    /**
+     * Calling transport::shutdown will shutdown the underlying transport
+     * and cause active connections and on-going connection attempts to
+     * fail. However, the underlying transport can be reused by calling
+     * transport::connect. This behavior is not sufficient to break out of a
+     * connection retry loop, such as `client::get_connected`. Instead, we
+     * set a flag that is checked in such situations so that fast tear down
+     * can occur.
+     *
+     * Note that we avoid doing this by closing the _connect_gate because
+     * http clients are stored in a pool and reused. Closing this gate is
+     * reserved for shutting down the pool and all the connections, making
+     * reuse more difficult to orchestrate correctly.
+     */
+    _shutdown_now = true;
+    net::base_transport::shutdown();
+}
+
 ss::future<reconnect_result_t> client::get_connected(
   ss::lowres_clock::duration timeout, prefix_logger ctxlog) {
     auto clear_shutdown_signal = ss::defer(

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -246,11 +246,10 @@ ss::future<> client::stop() {
     }
     _stopped = true;
     co_await _connect_gate.close();
+    shutdown();
     // Can safely stop base_transport
     co_return co_await base_transport::stop();
 }
-
-void client::fail_outstanding_futures() noexcept { shutdown(); }
 
 ss::future<ss::temporary_buffer<char>> client::receive() {
     return _in.read()

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -266,6 +266,7 @@ ss::future<> client::stop() {
     _stopped = true;
     co_await _connect_gate.close();
     shutdown();
+    co_await base_transport::wait_input_shutdown();
     // Can safely stop base_transport
     co_return co_await base_transport::stop();
 }

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -125,9 +125,6 @@ public:
     /// method instead.
     void shutdown() noexcept;
 
-    /// Wait until the remote client shut down the connection gracefully.
-    using net::base_transport::wait_input_shutdown;
-
     /// Return immediately if connected or make connection attempts
     /// until success, timeout or error
     ss::future<reconnect_result_t>

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -143,8 +143,6 @@ public:
     ss::future<reconnect_result_t>
     get_connected(ss::lowres_clock::duration timeout, prefix_logger ctxlog);
 
-    void fail_outstanding_futures() noexcept override;
-
     // Response state machine
     class response_stream final
       : public ss::enable_shared_from_this<response_stream> {

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -85,7 +85,7 @@ public:
       ss::lowres_clock::duration timeout = default_connect_timeout)
       = 0;
 
-    virtual ss::future<> shutdown_and_stop() = 0;
+    virtual ss::future<> stop() = 0;
 
     virtual ~abstract_client() = default;
 };
@@ -116,7 +116,7 @@ public:
       ss::lowres_clock::duration max_idle_time);
 
     /// Stop must be called before destroying the client object.
-    ss::future<> stop();
+    ss::future<> stop() final;
     using net::base_transport::shutdown;
     using net::base_transport::wait_input_shutdown;
 
@@ -137,9 +137,6 @@ public:
         _shutdown_now = true;
         shutdown();
     }
-
-    // close the connect gate and fail_outstanding_futures which calls shutdown
-    ss::future<> shutdown_and_stop() final { co_return co_await stop(); }
 
     /// Return immediately if connected or make connection attempts
     /// until success, timeout or error

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -116,7 +116,13 @@ public:
       ss::lowres_clock::duration max_idle_time);
 
     /// Stop must be called before destroying the client object.
+    /// The http client can not be used after that.
     ss::future<> stop() final;
+
+    /// The 'shutdown' method can be used to disconnect the http client
+    /// from the server. The client can be reconnected after that.
+    /// To permanently spin down a client for destruction, call the 'stop'
+    /// method instead.
     using net::base_transport::shutdown;
     using net::base_transport::wait_input_shutdown;
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -123,26 +123,10 @@ public:
     /// from the server. The client can be reconnected after that.
     /// To permanently spin down a client for destruction, call the 'stop'
     /// method instead.
-    using net::base_transport::shutdown;
-    using net::base_transport::wait_input_shutdown;
+    void shutdown() noexcept;
 
-    /**
-     * Calling transport::shutdown will shutdown the underlying transport and
-     * cause active connections and on-going connection attempts to fail.
-     * However, the underlying transport can be reused by calling
-     * transport::connect. This behavior is not sufficient to break out of a
-     * connection retry loop, such as `client::get_connected`. Instead, we set a
-     * flag that is checked in such situations so that fast tear down can occur.
-     *
-     * Note that we avoid doing this by closing the _connect_gate because http
-     * clients are stored in a pool and reused. Closing this gate is reserved
-     * for shutting down the pool and all the connections, making reuse more
-     * difficult to orchestrate correctly.
-     */
-    void shutdown_now() noexcept {
-        _shutdown_now = true;
-        shutdown();
-    }
+    /// Wait until the remote client shut down the connection gracefully.
+    using net::base_transport::wait_input_shutdown;
 
     /// Return immediately if connected or make connection attempts
     /// until success, timeout or error

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -330,12 +330,8 @@ auto with_client(client&& cl, Func func) {
       "Func's move constructor must not throw");
     return ss::do_with(
       std::move(cl), [func = std::move(func)](client& cl) mutable {
-          return ss::futurize_invoke(func, cl).finally([&cl] {
-              return cl.stop().then([&cl] {
-                  cl.shutdown();
-                  return ss::make_ready_future<>();
-              });
-          });
+          return ss::futurize_invoke(func, cl).finally(
+            [&cl] { return cl.stop(); });
       });
 }
 

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -226,7 +226,7 @@ ss::sstring catalog_client::root_path() const {
 }
 ss::future<> catalog_client::shutdown() {
     auto gate_f = _gate.close();
-    co_await _http_client->shutdown_and_stop();
+    co_await _http_client->stop();
     co_await std::move(gate_f);
 }
 ss::future<expected<ss::sstring>>

--- a/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
+++ b/src/v/iceberg/rest_client/tests/catalog_client_tests.cc
@@ -45,7 +45,7 @@ public:
        std::optional<iobuf>,
        ss::lowres_clock::duration),
       (override));
-    MOCK_METHOD(ss::future<>, shutdown_and_stop, (), (override));
+    MOCK_METHOD(ss::future<>, stop, (), (override));
 };
 
 std::unique_ptr<http::abstract_client>

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -38,7 +38,7 @@ public:
        ss::lowres_clock::duration),
       (override));
 
-    MOCK_METHOD(ss::future<>, shutdown_and_stop, (), (override));
+    MOCK_METHOD(ss::future<>, stop, (), (override));
 };
 
 static constexpr auto endpoint = "http://localhost:8181";


### PR DESCRIPTION
The http client has a bunch of method related to shutdown. This PR attempts to unify all of them and leave only `stop` and `shutdown`. The `stop` is used to dispose the client and `shutdown` is used to disconnect.
This is just a refactoring. The logic is not changed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none