### PR TITLE
[CORE-12155] Introduce external timeout for cloud_storage client leases

### DIFF
--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -86,6 +86,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:logger",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
+        "//src/v/ssx:watchdog",
         "@boost//:beast",
         "@boost//:lexical_cast",
         "@boost//:range",

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -22,6 +22,7 @@
 #include "model/metadata.h"
 #include "ssx/future-util.h"
 #include "ssx/semaphore.h"
+#include "ssx/watchdog.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
@@ -242,7 +243,8 @@ ss::future<upload_result> remote::upload_stream(
         if (max_retries.has_value()) {
             max_retries = max_retries.value() - 1;
         }
-        auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+        auto lease = co_await _pool.local().acquire_with_timeout(
+          fib.root_abort_source(), fib.get_deadline(), fib());
         transfer_details.on_request(fib.retry_count());
 
         // Client acquisition can take some time. Do a check before starting
@@ -349,7 +351,8 @@ ss::future<download_result> remote::download_stream(
 
     auto lease = co_await [this, &fib, &transfer_details] {
         transfer_details.on_client_acquire();
-        return _pool.local().acquire(fib.root_abort_source());
+        return _pool.local().acquire_with_timeout(
+          fib.root_abort_source(), fib.get_deadline(), fib());
     }();
 
     auto permit = fib.retry();
@@ -448,7 +451,8 @@ remote::download_object(download_request download_request) {
     const auto bucket = transfer_details.bucket;
     const auto object_type = download_request.display_str;
 
-    auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+    auto lease = co_await _pool.local().acquire_with_timeout(
+      fib.root_abort_source(), fib.get_deadline(), fib());
 
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Downloading {} from {}", object_type, path);
@@ -532,7 +536,8 @@ ss::future<download_result> remote::object_exists(
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+    auto lease = co_await _pool.local().acquire_with_timeout(
+      fib.root_abort_source(), fib.get_deadline(), fib());
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Check {} {}", object_type, path);
     std::optional<download_result> result;
@@ -602,7 +607,8 @@ remote::delete_object(transfer_details transfer_details) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+    auto lease = co_await _pool.local().acquire_with_timeout(
+      fib.root_abort_source(), fib.get_deadline(), fib());
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Delete object {}", path);
     std::optional<upload_result> result;
@@ -755,7 +761,8 @@ ss::future<upload_result> remote::delete_object_batch(
 
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+    auto lease = co_await _pool.local().acquire_with_timeout(
+      fib.root_abort_source(), fib.get_deadline(), fib());
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Deleting a batch of size {}", keys.size());
     std::optional<upload_result> result;
@@ -939,7 +946,8 @@ ss::future<list_result> remote::list_objects(
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+    auto lease = co_await _pool.local().acquire_with_timeout(
+      fib.root_abort_source(), fib.get_deadline(), fib());
     auto permit = fib.retry();
     vlog(ctxlog.debug, "List objects {}", bucket);
     std::optional<list_result> result;
@@ -1062,7 +1070,8 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
 
     std::optional<upload_result> result;
     while (!_gate.is_closed() && permit.is_allowed && !result) {
-        auto lease = co_await _pool.local().acquire(fib.root_abort_source());
+        auto lease = co_await _pool.local().acquire_with_timeout(
+          fib.root_abort_source(), fib.get_deadline(), fib());
 
         vlog(
           ctxlog.debug,

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -85,6 +85,17 @@ cloud_io::provider infer_provider(
     }
 }
 
+template<typename ErrT>
+ErrT throw_if_not_timeout(const std::exception_ptr& e, ErrT on_timeout) {
+    try {
+        std::rethrow_exception(e);
+    } catch (const ss::timed_out_error&) {
+        return on_timeout;
+    } catch (...) {
+        throw;
+    }
+}
+
 } // namespace
 
 namespace cloud_io {
@@ -243,8 +254,14 @@ ss::future<upload_result> remote::upload_stream(
         if (max_retries.has_value()) {
             max_retries = max_retries.value() - 1;
         }
-        auto lease = co_await _pool.local().acquire_with_timeout(
-          fib.root_abort_source(), fib.get_deadline(), fib());
+        auto fut = co_await ss::coroutine::as_future(
+          _pool.local().acquire_with_timeout(
+            fib.root_abort_source(), fib.get_deadline(), fib()));
+        if (fut.failed()) {
+            co_return throw_if_not_timeout(
+              fut.get_exception(), upload_result::timedout);
+        }
+        auto lease = std::move(fut).get();
         transfer_details.on_request(fib.retry_count());
 
         // Client acquisition can take some time. Do a check before starting
@@ -349,11 +366,16 @@ ss::future<download_result> remote::download_stream(
         hu = co_await _resources->get_hydration_units(1);
     }
 
-    auto lease = co_await [this, &fib, &transfer_details] {
+    auto fut = co_await [this, &fib, &transfer_details] {
         transfer_details.on_client_acquire();
-        return _pool.local().acquire_with_timeout(
-          fib.root_abort_source(), fib.get_deadline(), fib());
+        return ss::coroutine::as_future(_pool.local().acquire_with_timeout(
+          fib.root_abort_source(), fib.get_deadline(), fib()));
     }();
+    if (fut.failed()) {
+        co_return throw_if_not_timeout(
+          fut.get_exception(), download_result::timedout);
+    }
+    auto lease = std::move(fut).get();
 
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Download {} {}", stream_label, path);
@@ -451,8 +473,14 @@ remote::download_object(download_request download_request) {
     const auto bucket = transfer_details.bucket;
     const auto object_type = download_request.display_str;
 
-    auto lease = co_await _pool.local().acquire_with_timeout(
-      fib.root_abort_source(), fib.get_deadline(), fib());
+    auto fut = co_await ss::coroutine::as_future(
+      _pool.local().acquire_with_timeout(
+        fib.root_abort_source(), fib.get_deadline(), fib()));
+    if (fut.failed()) {
+        co_return throw_if_not_timeout(
+          fut.get_exception(), download_result::timedout);
+    }
+    auto lease = std::move(fut).get();
 
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Downloading {} from {}", object_type, path);
@@ -536,8 +564,14 @@ ss::future<download_result> remote::object_exists(
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire_with_timeout(
-      fib.root_abort_source(), fib.get_deadline(), fib());
+    auto fut = co_await ss::coroutine::as_future(
+      _pool.local().acquire_with_timeout(
+        fib.root_abort_source(), fib.get_deadline(), fib()));
+    if (fut.failed()) {
+        co_return throw_if_not_timeout(
+          fut.get_exception(), download_result::timedout);
+    }
+    auto lease = std::move(fut).get();
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Check {} {}", object_type, path);
     std::optional<download_result> result;
@@ -607,8 +641,14 @@ remote::delete_object(transfer_details transfer_details) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire_with_timeout(
-      fib.root_abort_source(), fib.get_deadline(), fib());
+    auto fut = co_await ss::coroutine::as_future(
+      _pool.local().acquire_with_timeout(
+        fib.root_abort_source(), fib.get_deadline(), fib()));
+    if (fut.failed()) {
+        co_return throw_if_not_timeout(
+          fut.get_exception(), upload_result::timedout);
+    }
+    auto lease = std::move(fut).get();
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Delete object {}", path);
     std::optional<upload_result> result;
@@ -761,8 +801,14 @@ ss::future<upload_result> remote::delete_object_batch(
 
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire_with_timeout(
-      fib.root_abort_source(), fib.get_deadline(), fib());
+    auto fut = co_await ss::coroutine::as_future(
+      _pool.local().acquire_with_timeout(
+        fib.root_abort_source(), fib.get_deadline(), fib()));
+    if (fut.failed()) {
+        co_return throw_if_not_timeout(
+          fut.get_exception(), upload_result::timedout);
+    }
+    auto lease = std::move(fut).get();
     auto permit = fib.retry();
     vlog(ctxlog.debug, "Deleting a batch of size {}", keys.size());
     std::optional<upload_result> result;
@@ -946,8 +992,14 @@ ss::future<list_result> remote::list_objects(
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(log, fib);
-    auto lease = co_await _pool.local().acquire_with_timeout(
-      fib.root_abort_source(), fib.get_deadline(), fib());
+    auto fut = co_await ss::coroutine::as_future(
+      _pool.local().acquire_with_timeout(
+        fib.root_abort_source(), fib.get_deadline(), fib()));
+    if (fut.failed()) {
+        co_return throw_if_not_timeout(
+          fut.get_exception(), cloud_storage_clients::error_outcome::retry);
+    }
+    auto lease = std::move(fut).get();
     auto permit = fib.retry();
     vlog(ctxlog.debug, "List objects {}", bucket);
     std::optional<list_result> result;
@@ -1070,8 +1122,14 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
 
     std::optional<upload_result> result;
     while (!_gate.is_closed() && permit.is_allowed && !result) {
-        auto lease = co_await _pool.local().acquire_with_timeout(
-          fib.root_abort_source(), fib.get_deadline(), fib());
+        auto fut = co_await ss::coroutine::as_future(
+          _pool.local().acquire_with_timeout(
+            fib.root_abort_source(), fib.get_deadline(), fib()));
+        if (fut.failed()) {
+            co_return throw_if_not_timeout(
+              fut.get_exception(), upload_result::timedout);
+        }
+        auto lease = std::move(fut).get();
 
         vlog(
           ctxlog.debug,

--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/net",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
+        "//src/v/ssx:watchdog",
         "//src/v/strings:string_switch",
         "//src/v/thirdparty/libxml2",
         "//src/v/utils:base64",

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -443,7 +443,11 @@ auto client_pool::acquire_with_timeout(
         // client_pool teardown
         auto to = deadline - ss::lowres_clock::now();
         lease._wd = std::make_unique<ssx::watchdog>(
-          to, [client = lease.client, to, ctx = std::move(ctx)]() mutable {
+          to,
+          [probe = _probe,
+           client = lease.client,
+           to,
+           ctx = std::move(ctx)]() mutable {
               if (ctx.has_value()) {
                   vlog(
                     pool_log.debug,
@@ -456,6 +460,7 @@ auto client_pool::acquire_with_timeout(
                     "Lease expired after {}. Shutting down client...",
                     to);
               }
+              probe->register_timeout();
               client->shutdown();
           });
     }

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -249,12 +249,17 @@ std::tuple<unsigned int, unsigned int> pick_two_random_shards() {
 ///       the lifetime of the pointer ends).
 /// \return client pointer (via future that can wait if all clients
 ///         are in use)
-ss::future<client_pool::client_lease>
-client_pool::acquire(ss::abort_source& as) {
+ss::future<client_pool::client_lease> client_pool::acquire(
+  ss::abort_source& as, std::optional<ss::lowres_clock::time_point> deadline) {
     auto guard = _gate.hold();
 
     std::optional<unsigned int> source_sid;
     std::optional<http_client_ptr> client;
+
+    auto deadline_reached = [&deadline] {
+        return deadline.has_value()
+               && ss::lowres_clock::now() >= deadline.value();
+    };
 
     try {
         // If credentials have not yet been acquired, wait for them. It is
@@ -281,7 +286,7 @@ client_pool::acquire(ss::abort_source& as) {
             }
         }
 
-        while (!client.has_value() && !_gate.is_closed()
+        while (!client.has_value() && !deadline_reached() && !_gate.is_closed()
                && !_as.abort_requested()) {
             if (likely(!_pool.empty())) {
                 client = _pool.back();
@@ -294,7 +299,7 @@ client_pool::acquire(ss::abort_source& as) {
                 // client connections then wait util one of the clients is
                 // freed.
                 co_await ssx::with_timeout_abortable(
-                  _cvar.wait(), model::no_timeout, as);
+                  _cvar.wait(), deadline.value_or(model::no_timeout), as);
 
                 vlog(
                   pool_log.debug,
@@ -358,6 +363,8 @@ client_pool::acquire(ss::abort_source& as) {
     }
     if (_gate.is_closed() || _as.abort_requested()) {
         throw ss::gate_closed_exception();
+    } else if (!client.has_value() && deadline_reached()) {
+        throw ss::timed_out_error();
     }
     vassert(client.has_value(), "'acquire' invariant is broken");
 
@@ -430,7 +437,7 @@ auto client_pool::acquire_with_timeout(
   ss::abort_source& as,
   ss::lowres_clock::time_point deadline,
   std::optional<ss::sstring> ctx) -> ss::future<client_lease> {
-    auto lease = co_await acquire(as);
+    auto lease = co_await acquire(as, deadline);
     if (deadline < ss::lowres_clock::time_point::max()) {
         // take a copy of the shared_ptr held by the lease to avoid racing with
         // client_pool teardown

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -426,6 +426,35 @@ client_pool::acquire(ss::abort_source& as) {
     co_return lease;
 }
 
+auto client_pool::acquire_with_timeout(
+  ss::abort_source& as,
+  ss::lowres_clock::time_point deadline,
+  std::optional<ss::sstring> ctx) -> ss::future<client_lease> {
+    auto lease = co_await acquire(as);
+    if (deadline < ss::lowres_clock::time_point::max()) {
+        // take a copy of the shared_ptr held by the lease to avoid racing with
+        // client_pool teardown
+        auto to = deadline - ss::lowres_clock::now();
+        lease._wd = std::make_unique<ssx::watchdog>(
+          to, [client = lease.client, to, ctx = std::move(ctx)]() mutable {
+              if (ctx.has_value()) {
+                  vlog(
+                    pool_log.debug,
+                    "{} - Lease expired after {}. Shutting down client...",
+                    ctx.value(),
+                    to);
+              } else {
+                  vlog(
+                    pool_log.debug,
+                    "Lease expired after {}. Shutting down client...",
+                    to);
+              }
+              client->shutdown();
+          });
+    }
+    co_return lease;
+}
+
 void client_pool::update_usage_stats() {
     if (_probe) {
         _probe->register_utilization(normalized_num_clients_in_use());

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -128,9 +128,14 @@ public:
     /// \note it's guaranteed that the client can only be acquired once
     ///       before it gets released (release happens implicitly, when
     ///       the lifetime of the pointer ends).
+    /// \param as
+    /// \param deadline - Optional timeout. If deadline is reached before a
+    ///                   client becomes available, throw ss::timed_out_error
     /// \return client pointer (via future that can wait if all clients
     ///         are in use)
-    ss::future<client_lease> acquire(ss::abort_source& as);
+    ss::future<client_lease> acquire(
+      ss::abort_source& as,
+      std::optional<ss::lowres_clock::time_point> deadline = std::nullopt);
 
     /// \brief Acquire http client from the pool for a specified duration.
     ///
@@ -139,6 +144,8 @@ public:
     ///   - Fed through to a watchdog timer governing the lifetime of the lease.
     ///     If it fires before the lease is returned, immediately calls shutdown
     ///     on the enclosed client.
+    ///   - Passed to client_pool::acquire, which throws if we reach the
+    ///     deadline before a client becomes available.
     ///
     /// \param as
     /// \param deadline - Lease expiration time, after which the client is

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -14,6 +14,7 @@
 #include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/client_probe.h"
 #include "container/intrusive_list_helpers.h"
+#include "ssx/watchdog.h"
 #include "utils/stop_signal.h"
 
 #include <seastar/core/circular_buffer.hh>
@@ -48,6 +49,7 @@ public:
         ss::abort_source::subscription as_sub;
         intrusive_list_hook _hook;
         std::unique_ptr<client_probe::hist_t::measurement> _track_duration;
+        std::unique_ptr<ssx::watchdog> _wd;
 
         client_lease(
           http_client_ptr p,
@@ -76,7 +78,8 @@ public:
         client_lease(client_lease&& other) noexcept
           : client(std::move(other.client))
           , deleter(std::move(other.deleter))
-          , as_sub(std::move(other.as_sub)) {
+          , as_sub(std::move(other.as_sub))
+          , _wd(std::move(other._wd)) {
             _hook.swap_nodes(other._hook);
         }
 
@@ -85,6 +88,7 @@ public:
             deleter = std::move(other.deleter);
             as_sub = std::move(other.as_sub);
             _hook.swap_nodes(other._hook);
+            _wd = std::move(other._wd);
             return *this;
         }
 
@@ -127,6 +131,24 @@ public:
     /// \return client pointer (via future that can wait if all clients
     ///         are in use)
     ss::future<client_lease> acquire(ss::abort_source& as);
+
+    /// \brief Acquire http client from the pool for a specified duration.
+    ///
+    /// Same invariants as ::acquire apply (see above).
+    /// The provided timeout is applied in two distinct ways:
+    ///   - Fed through to a watchdog timer governing the lifetime of the lease.
+    ///     If it fires before the lease is returned, immediately calls shutdown
+    ///     on the enclosed client.
+    ///
+    /// \param as
+    /// \param deadline - Lease expiration time, after which the client is
+    ///                   forcibly shut down.
+    /// \param ctx - Optional context for the log message. e.g. the string
+    ///              representation of a retry_chain_node.
+    ss::future<client_lease> acquire_with_timeout(
+      ss::abort_source& as,
+      ss::lowres_clock::time_point deadline,
+      std::optional<ss::sstring> ctx = std::nullopt);
 
     /// \brief Get number of connections
     size_t size() const noexcept;

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -102,6 +102,8 @@ void client_probe::register_utilization(unsigned clients_in_use) {
     _pool_utilization = clients_in_use;
 }
 
+void client_probe::register_timeout() { _total_timeouts += 1; }
+
 void client_probe::setup_internal_metrics(
   net::metrics_disabled disable, std::span<raw_label> raw_labels) {
     namespace sm = ss::metrics;
@@ -203,6 +205,13 @@ void client_probe::setup_internal_metrics(
           sm::description("Utilization of the cloud storage pool(0 - unused, "
                           "100 - fully utilized)"),
           labels),
+        sm::make_counter(
+          "lease_timeouts_total",
+          [this] { return _total_timeouts; },
+          sm::description(
+            "Number of cloud storage client lease timeouts, usually indicating "
+            "something stuck in the transport layer."),
+          labels),
       });
 }
 
@@ -281,6 +290,13 @@ void client_probe::setup_public_metrics(
           [this] { return _pool_utilization; },
           sm::description("Utilization of the cloud storage pool(0 - unused, "
                           "100 - fully utilized)"),
+          labels),
+        sm::make_counter(
+          "lease_timeouts_total",
+          [this] { return _total_timeouts; },
+          sm::description(
+            "Number of cloud storage client lease timeouts, usually indicating "
+            "something stuck in the netransport layer."),
           labels),
       });
 }

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -86,6 +86,8 @@ public:
     std::unique_ptr<hist_t::measurement> register_lease_duration();
     /// Utilization metric which is used to decide if borrowing is possible
     void register_utilization(unsigned clients_in_use);
+    /// Register client timeout
+    void register_timeout();
 
 private:
     struct raw_label {
@@ -114,6 +116,8 @@ private:
     hist_t _lease_duration;
     /// Current utilization of the client pool
     uint64_t _pool_utilization;
+    /// Total client timeouts;
+    uint64_t _total_timeouts{0};
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };

--- a/src/v/cloud_storage_clients/tests/BUILD
+++ b/src/v/cloud_storage_clients/tests/BUILD
@@ -22,6 +22,7 @@ redpanda_cc_btest(
     ],
     deps = [
         "//src/v/base",
+        "//src/v/cloud_io/tests:s3_imposter",
         "//src/v/cloud_storage_clients",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -17,6 +17,8 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/timed_out_error.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
@@ -106,7 +108,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
       .start(
         num_connections_per_shard,
         sconf,
-        cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty)
+        cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty)
       .get();
 
     pool
@@ -166,5 +168,86 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
                        .get();
 
         BOOST_REQUIRE_EQUAL(lease._wd, nullptr);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
+    auto sconf = ss::sharded_parameter([] {
+        auto conf = transport_configuration();
+        return conf;
+    });
+    auto conf = transport_configuration();
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    size_t num_connections_per_shard = 0;
+    pool
+      .start(
+        num_connections_per_shard,
+        sconf,
+        cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty)
+      .get();
+
+    pool
+      .invoke_on_all([&conf](cloud_storage_clients::client_pool& p) {
+          auto cred = cloud_roles::aws_credentials{
+            conf.access_key.value(),
+            conf.secret_key.value(),
+            std::nullopt,
+            conf.region};
+          p.load_credentials(cred);
+      })
+      .get();
+    auto pool_stop = ss::defer([&pool] { pool.stop().get(); });
+
+    {
+        // acquire should time out. no abort required.
+        ss::abort_source as;
+
+        auto f = pool.local().acquire(as, ss::lowres_clock::now() + 100ms);
+        while (!pool.local().has_waiters()) {
+            ss::yield().get();
+        }
+
+        BOOST_TEST_REQUIRE(
+          !f.available(), "acquire should be blocked as pool is empty");
+
+        BOOST_REQUIRE_THROW(f.get(), ss::timed_out_error);
+    }
+
+    {
+        // time_point::max should be fine here. we just won't time out anytime
+        // soon.
+        ss::abort_source as;
+
+        auto f = pool.local().acquire(as, ss::lowres_clock::time_point::max());
+        while (!pool.local().has_waiters()) {
+            ss::yield().get();
+        }
+
+        BOOST_TEST_REQUIRE(
+          !f.available(), "acquire should be blocked as pool is empty");
+
+        as.request_abort();
+
+        BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
+    }
+
+    {
+        // call through acquire_with_timeout
+
+        ss::abort_source as;
+        BOOST_REQUIRE_THROW(
+          pool.local()
+            .acquire_with_timeout(as, ss::lowres_clock::now() + 100ms)
+            .get(),
+          ss::timed_out_error);
+    }
+
+    {
+        // passing a deadline in the past should behave sanely
+        ss::abort_source as;
+        BOOST_REQUIRE_THROW(
+          pool.local().acquire(as, ss::lowres_clock::time_point::min()).get(),
+          ss::timed_out_error);
     }
 }

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "base/seastarx.h"
+#include "cloud_io/tests/s3_imposter.h"
 #include "cloud_storage_clients/client_pool.h"
 
 #include <seastar/core/abort_source.hh>
@@ -16,6 +17,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/with_timeout.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
@@ -89,4 +91,80 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_abortable) {
     as.request_abort();
 
     BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
+    auto sconf = ss::sharded_parameter([] {
+        auto conf = transport_configuration();
+        return conf;
+    });
+    auto conf = transport_configuration();
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    size_t num_connections_per_shard = 1;
+    pool
+      .start(
+        num_connections_per_shard,
+        sconf,
+        cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty)
+      .get();
+
+    pool
+      .invoke_on_all([&conf](cloud_storage_clients::client_pool& p) {
+          auto cred = cloud_roles::aws_credentials{
+            conf.access_key.value(),
+            conf.secret_key.value(),
+            std::nullopt,
+            conf.region};
+          p.load_credentials(cred);
+      })
+      .get();
+    auto pool_stop = ss::defer([&pool] { pool.stop().get(); });
+
+    ss::abort_source as;
+    using namespace std::chrono_literals;
+
+    {
+        auto lease = pool.local()
+                       .acquire_with_timeout(
+                         as, ss::lowres_clock::now() + 100ms)
+                       .get();
+
+        // The request should fail w/in 500ms due to lease expiry
+        // Note that the default timeout for the request itself is 5s
+        auto res = ss::with_timeout(
+                     ss::lowres_clock::now() + 500ms,
+                     lease.client->list_objects(random_test_bucket_name()))
+                     .get();
+
+        BOOST_REQUIRE(res.has_error());
+        BOOST_REQUIRE_EQUAL(
+          res.error(), cloud_storage_clients::error_outcome::retry);
+
+        // return the lease to the pool
+    }
+
+    {
+        auto lease = pool.local().acquire(as).get();
+
+        auto f = ss::with_timeout(
+          ss::lowres_clock::now() + 500ms,
+          lease.client->list_objects(random_test_bucket_name()));
+
+        // This time the lease never expires, so internally we should keep
+        // trying to connect for at least 500ms.
+        BOOST_REQUIRE_THROW(f.get(), ss::timed_out_error);
+    }
+
+    {
+        // check that passing time_point::max for timeout will skip watchdog
+        // creation to avoid overflow in sleep_abortable
+
+        auto lease = pool.local()
+                       .acquire_with_timeout(
+                         as, ss::lowres_clock::time_point::max())
+                       .get();
+
+        BOOST_REQUIRE_EQUAL(lease._wd, nullptr);
+    }
 }

--- a/src/v/ssx/tests/watchdog_test.cc
+++ b/src/v/ssx/tests/watchdog_test.cc
@@ -39,3 +39,22 @@ SEASTAR_THREAD_TEST_CASE(watchdog_test_trigger) {
     }
     BOOST_REQUIRE(watchdog_triggered == true);
 }
+
+SEASTAR_THREAD_TEST_CASE(watchdog_test_negative_timeout) {
+    bool watchdog_triggered = false;
+    {
+        ssx::watchdog wd(ss::lowres_clock::duration::min(), [&] {
+            watchdog_triggered = true;
+        });
+        ss::sleep(10ms).get();
+    }
+    BOOST_REQUIRE(watchdog_triggered);
+
+    watchdog_triggered = false;
+
+    {
+        ssx::watchdog wd(-1us, [&] { watchdog_triggered = true; });
+        ss::sleep(10ms).get();
+    }
+    BOOST_REQUIRE(watchdog_triggered);
+}

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -9,6 +9,7 @@
 import json
 import random
 import re
+import socket
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -31,6 +32,7 @@ from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsum
 from rptest.services.metrics_check import MetricCheck
 from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, \
     MetricsEndpoint
+from rptest.services.utils import LogSearchLocal
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.tests.redpanda_test import RedpandaTest
@@ -39,6 +41,11 @@ from rptest.util import (
     produce_until_segments,
     wait_for_removal_of_n_segments,
     wait_for_local_storage_truncate,
+)
+from rptest.utils.cluster_topology import (
+    ClusterTopology,
+    NetemSpec,
+    NodeQdisc,
 )
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP, quiesce_uploads
@@ -164,7 +171,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
                                 self.logger)
 
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=get_cloud_storage_type())
+    @matrix(cloud_storage_type=get_cloud_storage_type()[0:1])
     def test_reset(self, cloud_storage_type):
         brokers = self.redpanda.started_nodes()
 
@@ -1552,3 +1559,160 @@ class EndToEndHydrationTimeoutTest(EndToEndShadowIndexingBase):
         # Disable chunk reads so that hydration downloads full segments and takes longer.
         self._start_redpanda({'cloud_storage_disable_chunk_reads': True})
         self.workload()
+
+
+class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
+    small_segment_size = 4096
+    chunk_size = small_segment_size * 0.75
+    topic_name = f"{EndToEndShadowIndexingBase.s3_topic_name}"
+    topics = (TopicSpec(name=topic_name,
+                        partition_count=128,
+                        replication_factor=1,
+                        redpanda_remote_write=True,
+                        redpanda_remote_read=True,
+                        retention_bytes=-1,
+                        retention_ms=-1,
+                        segment_bytes=small_segment_size), )
+
+    def __init__(self, test_context):
+        self.num_brokers = 1
+        si_settings = SISettings(
+            test_context,
+            log_segment_size=self.small_segment_size,
+            cloud_storage_cache_size=20 * 2**30,
+            cloud_storage_segment_max_upload_interval_sec=1,
+        )
+        super().__init__(
+            test_context,
+            node_prealloc_count=1,
+            extra_rp_conf={
+                # Avoid segment merging so we can generate many segments
+                # quickly.
+                "cloud_storage_enable_segment_merging": False,
+                'log_segment_size_min': 1024,
+                'cloud_storage_cache_chunk_size': self.chunk_size,
+                'cloud_storage_cluster_metadata_upload_interval_ms': 1000,
+                'enable_cluster_metadata_upload_loop': True,
+                'controller_snapshot_max_age_sec': 1,
+            },
+            environment={'__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS': 5000},
+            si_settings=si_settings,
+            # These tests write many objects; set a higher scrub timeout.
+            cloud_storage_scrub_timeout_s=120)
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+
+    def setUp(self):
+        pass
+
+    class EnableTrafficShaping:
+        def __init__(self, redpanda):
+            self.redpanda = redpanda
+
+        def __enter__(self) -> NodeQdisc:
+            s3_service_ep = self.redpanda.si_settings.cloud_storage_api_endpoint
+
+            #  block all outgoing https if we can't get an IP address or the api endpoint is not config'ed
+            s3_service_dest = ":443"
+            try:
+                s3_service_dest = socket.gethostbyname(s3_service_ep)
+            except:
+                pass
+
+            self.rp_qdisc = NodeQdisc(self.redpanda.nodes[0],
+                                      ClusterTopology._get_if_in_use(), 1)
+            self.rp_qdisc.initialize()
+            self.rp_qdisc.add(target_addresses=[s3_service_dest],
+                              spec=NetemSpec(300, 100))
+            self.rp_qdisc.drop_incoming(s3_service_dest)
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.rp_qdisc.remove_all()
+
+    @skip_debug_mode
+    @cluster(num_nodes=2)
+    def test_many_partitions_recovery_with_traffic_shaping(self):
+        """
+        Test that reproduces an OOM when doing recovery with a large dataset in
+        the bucket.
+        """
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=1024,
+                                       msg_count=10 * 1000 * 1000,
+                                       rate_limit_bps=256 *
+                                       self.small_segment_size,
+                                       custom_node=self.preallocated_nodes)
+
+        with self.EnableTrafficShaping(self.redpanda) as ts:
+            self.redpanda.start()
+            self.kafka_tools.create_topic(self.topics[0])
+            rpk = RpkTool(self.redpanda)
+            rpk.alter_topic_config(
+                self.topic, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_MS,
+                '1000')
+
+            def count_timeouts():
+                v = self.redpanda.metric_sum(
+                    metric_name="redpanda_cloud_client_lease_timeouts_total",
+                    metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
+                    nodes=self.redpanda.nodes[0:1],
+                    expect_metric=True)
+                self.logger.info(
+                    f"redpanda_cloud_client_lease_timeout_total: {v}")
+                return v
+
+            def pool_utilization(pct):
+                v = self.redpanda.metrics_sample(
+                    "redpanda_cloud_client_client_pool_utilization",
+                    metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
+                    nodes=self.redpanda.nodes[0:1])
+                u = [s.value for s in v.samples]
+                self.logger.info(
+                    f"redpanda_cloud_client_client_pool_utilization: {json.dumps(u)}"
+                )
+                return all(v == pct for v in u)
+
+            producer.start()
+            self.logger.debug(
+                "Wait until the client pool is backed up due to long-running requests"
+            )
+            try:
+                wait_until(lambda:
+                           (count_timeouts() > 40 and pool_utilization(100)),
+                           timeout_sec=180,
+                           backoff_sec=3)
+            finally:
+                producer.stop()
+                producer.wait()
+
+        self.logger.debug(
+            "Now check that the things return to normal after traffic shaping is switched off"
+        )
+        producer.start()
+        try:
+            wait_until(
+                lambda: nodes_report_cloud_segments(self.redpanda, 10000),
+                timeout_sec=180,
+                backoff_sec=3)
+        finally:
+            producer.stop()
+            producer.wait()
+
+        node = self.redpanda.nodes[0]
+        self.redpanda.stop()
+        self.redpanda.remove_local_data(node)
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    auto_assign_node_id=True,
+                                    omit_seeds_on_idx_one=False)
+        self.redpanda._admin.await_stable_leader("controller",
+                                                 partition=0,
+                                                 namespace='redpanda',
+                                                 timeout_s=60,
+                                                 backoff_s=2)
+
+        rpk = RpkTool(self.redpanda)
+        rpk.cluster_recovery_start(wait=True)
+        wait_until(lambda: len(set(rpk.list_topics())) == 1,
+                   timeout_sec=120,
+                   backoff_sec=3)

--- a/tests/rptest/utils/cluster_topology.py
+++ b/tests/rptest/utils/cluster_topology.py
@@ -38,6 +38,7 @@ class NodeQdisc():
         # all traffic is by default assigned to the first band
         self.default_prio_map = '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
         self.next_flow = 2
+        self.has_ingress_shaping = False
 
     def initialize(self):
         # create prio queue wit desired number of bands
@@ -72,13 +73,30 @@ class NodeQdisc():
         self._tc_qdisc_add(queue_spec=queue)
 
         for a in target_addresses:
+            match_rule = ['ip', 'dst', a]
+            if a[0] == ':':
+                match_rule = ['ip', 'dport', a[1:], "0xffff"]
+
             self._tc_execute([
                 'filter', 'add', 'dev', self.dev, 'protocol', 'ip', 'parent',
-                '1:', 'prio', f'{self.next_flow-1}', 'u32', 'match', 'ip',
-                'dst', a, 'flowid', f'1:{self.next_flow}'
+                '1:', 'prio', f'{self.next_flow-1}', 'u32', 'match',
+                *match_rule, 'flowid', f'1:{self.next_flow}'
             ])
 
         self.next_flow += 1
+
+    def drop_incoming(self, src_address):
+        self.has_ingress_shaping = True
+        self._tc_execute(
+            ['qdisc', 'add', 'dev', self.dev, 'handle', 'ffff:', 'ingress'])
+        match_rule = ['ip', 'src', src_address]
+        if src_address[0] == ':':
+            match_rule = ['ip', 'sport', src_address[1:], "0xffff"]
+
+        self._tc_execute([
+            'filter', 'add', 'dev', self.dev, 'parent', 'ffff:', 'protocol',
+            'ip', 'u32', 'match', *match_rule, "action", "drop"
+        ])
 
     def _tc_qdisc_add(self, queue_spec):
         return self._tc_execute(['qdisc', 'add', 'dev', self.dev] + queue_spec)
@@ -99,6 +117,8 @@ class NodeQdisc():
 
     def remove_all(self):
         self._tc_execute(['qdisc', 'del', 'dev', self.dev, 'root'])
+        if self.has_ingress_shaping:
+            self._tc_execute(['qdisc', 'del', 'dev', self.dev, 'ingress'])
 
 
 class TopologyNode():


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds external timeouts governing the various HTTP request originating from `cloud_io::remote`. The context here is that stream interfaces don't provide any timeout facility, so a stream wrapping a connected `http::client` can hang indefinitely if the underlying connection gets stuck.

General idea:
1. Embed a watchdog timer in each `client_lease` acquired from `client_pool`
2. If the watchdog fires before the lease is returned, call `client::shutdown` immediately to cleanly terminate any open connections and log a message.

TODO:
- [x] Add some more background to this comment
- [x] ducktape test is hardcoded to to the IP address of my local minio container. replace with something generic that will work across docker & CDT
- [ ] is this sufficiently well tested?
   - [x] are we confident it doesn't break things when timeouts occur? (I think so)
   - [x] are we confident that it gets us out of jail during a stuck connection? (??)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
