### PR TITLE
Refactored configuration management in kafka client

### DIFF
--- a/src/v/datalake/tests/translator_test.cc
+++ b/src/v/datalake/tests/translator_test.cc
@@ -32,8 +32,8 @@ public:
         // create a kafka client for the cluster.
         auto* rp = instance(model::node_id{0});
         _client = std::make_unique<kc::client>(rp->proxy_client_config());
-        _client->config().retry_base_backoff.set_value(1ms);
-        _client->config().retries.set_value(size_t(20));
+        _client->set_retry_base_backoff(1ms);
+        _client->set_max_retries(size_t(20));
         _client->connect().get();
     }
 

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -16,8 +16,10 @@
 #include "net/dns.h"
 #include "rpc/rpc_utils.h"
 #include "thirdparty/c-ares/ares.h"
+#include "utils/unresolved_address.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/net/dns.hh>
 
 namespace {
@@ -40,53 +42,82 @@ bool is_dns_failure_error(const std::system_error& e) {
 
 namespace kafka::client {
 
-ss::future<shared_broker_t> make_broker(
-  model::node_id node_id,
-  net::unresolved_address addr,
-  const configuration& config,
-  prefix_logger& logger) {
-    return rpc::maybe_build_reloadable_certificate_credentials(
-             config.broker_tls())
-      .then([addr, client_id = config.client_identifier()](
-              ss::shared_ptr<ss::tls::certificate_credentials> creds) mutable {
-          return ss::make_lw_shared<transport>(
-            net::base_transport::configuration{
-              .server_addr = addr, .credentials = std::move(creds)},
-            std::move(client_id));
-      })
-      .then([node_id, addr, &logger](
-              ss::lw_shared_ptr<transport> client) mutable {
-          return client->connect().then(
-            [node_id, addr = std::move(addr), client, &logger] {
-                auto prefix = client->client_id().has_value()
-                                ? ssx::sformat("{}: ", *client->client_id())
-                                : "";
-                vlog(
-                  logger.info,
-                  "connected to broker:{} - {}:{}",
-                  node_id,
-                  addr.host(),
-                  addr.port());
-                return ss::make_lw_shared<broker>(node_id, std::move(*client));
-            });
-      })
-      .handle_exception_type([node_id, &logger](const std::system_error& ex) {
-          if (net::is_reconnect_error(ex) || is_dns_failure_error(ex)) {
-              return ss::make_exception_future<shared_broker_t>(
-                broker_error(node_id, error_code::network_exception));
-          }
-          vlog(logger.warn, "std::system_error: {}", ex.what());
-          return ss::make_exception_future<shared_broker_t>(ex);
-      })
-      .then([&config, &logger](shared_broker_t broker) {
-          return do_authenticate(broker, config, logger)
-            .then([broker]() { return broker; })
-            .handle_exception([broker](std::exception_ptr ex) {
-                return broker->stop().then([ex]() {
-                    return ss::make_exception_future<shared_broker_t>(ex);
-                });
-            });
-      });
+broker_factory::broker_factory(
+  const connection_configuration& config, prefix_logger& logger)
+  : _config(config)
+  , _logger(&logger)
+  , _client_id(_config.client_id.value_or("redpanda-client")) {}
+
+ss::future<shared_broker_t> broker_factory::create_broker(
+  model::node_id node_id, net::unresolved_address addr) {
+    net::base_transport::configuration transport_cfg{
+      .server_addr = addr,
+    };
+    vlog(
+      _logger->debug,
+      "Creating transport for broker {} - {}:{}",
+      node_id,
+      addr.host(),
+      addr.port());
+    if (_config.broker_tls) {
+        transport_cfg.credentials
+          = co_await _config.broker_tls->build_credentials();
+    }
+    auto broker_transport = ss::make_lw_shared<transport>(
+      std::move(transport_cfg), _config.client_id);
+    try {
+        vlog(
+          _logger->debug,
+          "connecting to {} - {}:{}",
+          node_id,
+          addr.host(),
+          addr.port());
+        co_await broker_transport->connect();
+    } catch (const std::system_error& ex) {
+        if (net::is_reconnect_error(ex) || is_dns_failure_error(ex)) {
+            throw broker_error(node_id, error_code::network_exception);
+        }
+        vlog(_logger->warn, "std::system_error: {}", ex.what());
+        throw;
+    }
+    vlog(
+      _logger->info,
+      "connected to broker:{} - {}:{}",
+      node_id,
+      addr.host(),
+      addr.port());
+    auto connected_broker = ss::make_lw_shared<broker>(
+      node_id, std::move(*broker_transport));
+    if (!_config.sasl_cfg) {
+        vlog(
+          _logger->debug,
+          "broker {} - {}:{}, doesn't require authentication",
+          node_id,
+          addr.host(),
+          addr.port());
+        co_return connected_broker;
+    }
+    auto f = co_await ss::coroutine::as_future(
+      do_authenticate(connected_broker, _config.sasl_cfg.value(), *_logger));
+    if (f.failed()) {
+        auto ex = f.get_exception();
+        vlog(
+          _logger->warn,
+          "broker {} - {}:{}, error during authentication: {}",
+          node_id,
+          addr.host(),
+          addr.port(),
+          ex);
+        co_await connected_broker->stop();
+        std::rethrow_exception(ex);
+    }
+    vlog(
+      _logger->trace,
+      "broker {} - {}:{} authenticated",
+      node_id,
+      addr.host(),
+      addr.port());
+    co_return connected_broker;
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -121,11 +121,22 @@ private:
 
 using shared_broker_t = ss::lw_shared_ptr<broker>;
 
-ss::future<shared_broker_t> make_broker(
-  model::node_id node_id,
-  net::unresolved_address addr,
-  const configuration& config,
-  prefix_logger& logger);
+/**
+ * Simple class used to create broker objects. Created broker objects use
+ * configuration provided when creating the factory.
+ */
+struct broker_factory {
+    broker_factory(
+      const connection_configuration& config, prefix_logger& logger);
+
+    ss::future<shared_broker_t>
+    create_broker(model::node_id, net::unresolved_address addr);
+
+private:
+    const connection_configuration& _config;
+    prefix_logger* _logger;
+    ss::sstring _client_id;
+};
 
 struct broker_hash {
     using is_transparent = void;

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -59,11 +59,8 @@ ss::future<> brokers::apply(chunked_vector<metadata_response::broker>&& res) {
                  new_brokers_begin,
                  new_brokers.end(),
                  [this](const metadata_response::broker& b) {
-                     return make_broker(
-                       b.node_id,
-                       net::unresolved_address(b.host, b.port),
-                       _config,
-                       *_logger);
+                     return _factory.create_broker(
+                       b.node_id, net::unresolved_address(b.host, b.port));
                  })
           .then([this, &new_brokers, new_brokers_begin](
                   std::vector<shared_broker_t> broker_endpoints) mutable {
@@ -87,6 +84,10 @@ ss::future<> brokers::apply(chunked_vector<metadata_response::broker>&& res) {
               std::swap(brokers, _brokers);
           });
     });
+}
+ss::future<shared_broker_t>
+brokers::create_broker(model::node_id node_id, net::unresolved_address addr) {
+    return _factory.create_broker(node_id, std::move(addr));
 }
 
 bool brokers::empty() const { return _brokers.empty(); }

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -20,29 +20,26 @@ ss::future<> brokers::stop() {
       [](const shared_broker_t& broker) { return broker->stop(); });
 }
 
-ss::future<shared_broker_t> brokers::any() {
+shared_broker_t brokers::any() {
     if (_brokers.empty()) {
-        return ss::make_exception_future<shared_broker_t>(
-          broker_error(unknown_node_id, error_code::broker_not_available));
+        throw broker_error(unknown_node_id, error_code::broker_not_available);
     }
-
-    return ss::make_ready_future<shared_broker_t>(
-      *std::next(_brokers.begin(), _next_broker++ % _brokers.size()));
+    _next_broker = ++_next_broker % _brokers.size();
+    return *std::next(_brokers.begin(), _next_broker);
 }
 
-ss::future<shared_broker_t> brokers::find(model::node_id id) {
+shared_broker_t brokers::find(model::node_id id) {
     auto b_it = _brokers.find(id);
     if (b_it == _brokers.end()) {
-        return ss::make_exception_future<shared_broker_t>(
-          broker_error(id, error_code::broker_not_available));
+        throw broker_error(id, error_code::broker_not_available);
     }
-    return ss::make_ready_future<shared_broker_t>(*b_it);
+    return *b_it;
 }
 
 ss::future<> brokers::erase(model::node_id node_id) {
     if (auto b_it = _brokers.find(node_id); b_it != _brokers.end()) {
         auto broker = *b_it;
-        _brokers.erase(broker);
+        _brokers.erase(b_it);
         return broker->stop().finally([broker]() {});
     }
     return ss::now();
@@ -92,8 +89,6 @@ ss::future<> brokers::apply(chunked_vector<metadata_response::broker>&& res) {
     });
 }
 
-ss::future<bool> brokers::empty() const {
-    return ss::make_ready_future<bool>(_brokers.empty());
-}
+bool brokers::empty() const { return _brokers.empty(); }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -33,9 +33,11 @@ class brokers {
       = absl::flat_hash_set<shared_broker_t, broker_hash, broker_eq>;
 
 public:
-    explicit brokers(const configuration& config, prefix_logger& logger)
+    explicit brokers(
+      const connection_configuration& config, prefix_logger& logger)
       : _config(config)
-      , _logger(&logger) {};
+      , _logger(&logger)
+      , _factory(_config, *_logger) {};
 
     brokers(const brokers&) = delete;
     brokers(brokers&&) = default;
@@ -63,13 +65,17 @@ public:
     /// \brief Returns true if there are no connected brokers
     bool empty() const;
 
+    ss::future<shared_broker_t>
+    create_broker(model::node_id node_id, net::unresolved_address addr);
+
 private:
-    const configuration& _config;
+    const connection_configuration& _config;
     /// \brief Brokers map a model::node_id to a client.
     brokers_t _brokers;
     /// \brief Next broker to select with round-robin
     size_t _next_broker{0};
     prefix_logger* _logger;
+    broker_factory _factory;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -49,10 +49,10 @@ public:
     /// \brief Retrieve any broker.
     ///
     /// The broker returned is fetched using a round-robin strategy.
-    ss::future<shared_broker_t> any();
+    shared_broker_t any();
 
     /// \brief Retrieve the broker for the given node_id.
-    ss::future<shared_broker_t> find(model::node_id id);
+    shared_broker_t find(model::node_id id);
 
     /// \brief Remove a broker.
     ss::future<> erase(model::node_id id);
@@ -61,7 +61,7 @@ public:
     ss::future<> apply(chunked_vector<metadata_response::broker>&& brokers);
 
     /// \brief Returns true if there are no connected brokers
-    ss::future<bool> empty() const;
+    bool empty() const;
 
 private:
     const configuration& _config;

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -158,7 +158,7 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
 ss::future<> client::apply(metadata_response res) {
     try {
         co_await _brokers.apply(std::move(res.data.brokers));
-        co_await _topic_cache.apply(std::move(res.data.topics));
+        _topic_cache.apply(std::move(res.data.topics));
         _controller = res.data.controller_id;
     } catch (const std::exception& ex) {
         vlog(_logger.debug, "Failed to apply metadata request: {}", ex);
@@ -264,7 +264,8 @@ ss::future<produce_response> client::produce_records(
         auto p_id = record.partition_id;
         if (!p_id) {
             p_id = co_await gated_retry_with_mitigation([&, this]() {
-                       return _topic_cache.partition_for(topic, record);
+                       return ss::make_ready_future<model::partition_id>(
+                         _topic_cache.partition_for(topic, record));
                    }).handle_exception([](std::exception_ptr) {
                 // Assume auto topic creation is on and assign to first
                 // partition
@@ -416,7 +417,7 @@ client::do_list_offsets(const list_offsets_request& unsharded_req) {
     for (const auto& topic : unsharded_req.data.topics) {
         for (const auto& partition : topic.partitions) {
             model::topic_partition tp{topic.name, partition.partition_index};
-            auto node_id = co_await _topic_cache.leader(tp);
+            auto node_id = _topic_cache.leader(tp);
 
             auto& topics
               = reqs.try_emplace(node_id, kafka::list_offsets_request{})
@@ -508,16 +509,12 @@ ss::future<fetch_response> client::fetch_partition(
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
           return gated_retry_with_mitigation([this, &tp, &build_request]() {
-                     return _topic_cache.leader(tp)
-                       .then([this](model::node_id leader) {
-                           return _brokers.find(leader);
-                       })
-                       .then([&tp, &build_request](shared_broker_t&& b) {
-                           return b->dispatch(build_request(tp))
-                             .then([b, &tp](fetch_response res) {
-                                 return maybe_throw_exception(
-                                   b, tp, std::move(res));
-                             });
+                     auto leader = _topic_cache.leader(tp);
+                     auto broker = _brokers.find(leader);
+                     return broker->dispatch(build_request(tp))
+                       .then([broker, &tp](fetch_response res) {
+                           return maybe_throw_exception(
+                             broker, tp, std::move(res));
                        });
                  })
             .handle_exception([&tp](std::exception_ptr ex) {

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -50,22 +50,27 @@
 
 namespace kafka::client {
 
-client::client(const YAML::Node& cfg, std::optional<external_mitigate> mitigater)
-  : _config{cfg}
-  , _seeds{_config.brokers()}
-  , _logger{kclog, _config.client_identifier().value_or("")}
+client::client(
+  const YAML::Node& cfg, std::optional<external_mitigate> mitigater)
+  : _config{client_configuration::from_config_store(configuration(cfg))}
+  , _seeds{_config.connection_cfg.initial_brokers}
+  , _logger{kclog, _config.connection_cfg.client_id.value_or("")}
   , _topic_cache{}
-  , _brokers{_config,_logger}
+  , _brokers{_config.connection_cfg, _logger}
   , _wait_or_start_update_metadata{[this](wait_or_start::tag tag) {
       return update_metadata(tag);
   }}
-  , _producer{_config, _topic_cache, _brokers, _config.produce_ack_level(), _logger, [this](std::exception_ptr ex) {
-      return mitigate_error(std::move(ex));
-  }}
+  , _producer(
+      _config.producer_cfg,
+      _config.retries_cfg,
+      _topic_cache,
+      _brokers,
+      _logger,
+      [this](std::exception_ptr ex) { return mitigate_error(std::move(ex)); })
   , _external_mitigate(std::move(mitigater)) {}
 
 ss::future<> client::do_connect(net::unresolved_address addr) {
-    return make_broker(unknown_node_id, addr, _config, _logger)
+    return _brokers.create_broker(unknown_node_id, std::move(addr))
       .then([this](shared_broker_t broker) {
           return broker->dispatch(metadata_request{.list_all_topics = true})
             .then(
@@ -80,13 +85,18 @@ ss::future<> client::connect() {
 
     return ss::do_with(size_t{0}, [this](size_t& retries) {
         return retry_with_mitigation(
-          _config.retries(),
-          _config.retry_base_backoff(),
+          _config.retries_cfg.max_retries,
+          _config.retries_cfg.retry_base_backoff,
           [this, retries]() {
               return do_connect(_seeds[retries % _seeds.size()]);
           },
           [this, &retries](std::exception_ptr ex) {
               ++retries;
+              vlog(
+                _logger.info,
+                "Failed to connect to seed {}: {}, retrying",
+                retries,
+                ex);
               return external_mitigate_error(ex);
           },
           _as);
@@ -164,6 +174,11 @@ ss::future<> client::apply(metadata_response res) {
         vlog(_logger.debug, "Failed to apply metadata request: {}", ex);
         throw;
     }
+}
+
+void client::set_credentials(std::optional<sasl_configuration> creds) {
+    vlog(_logger.debug, "Setting credentials: {}", creds);
+    _config.connection_cfg.sasl_cfg = std::move(creds);
 }
 
 ss::future<> client::external_mitigate_error(std::exception_ptr ex) const {
@@ -498,9 +513,9 @@ ss::future<fetch_response> client::fetch_partition(
   model::offset offset,
   std::chrono::milliseconds timeout,
   std::optional<int32_t> max_bytes) {
-    const auto min_bytes = _config.consumer_request_min_bytes();
+    const auto min_bytes = _config.consumer_cfg.fetch_min_bytes;
     const int32_t max_bytes_value = max_bytes.value_or(
-      _config.consumer_request_max_bytes());
+      _config.consumer_cfg.fetch_max_bytes);
     auto build_request = [offset, min_bytes, max_bytes_value, timeout](
                            model::topic_partition& tp) {
         return make_fetch_request(
@@ -530,18 +545,19 @@ ss::future<member_id>
 client::create_consumer(const group_id& group_id, member_id name) {
     return find_coordinator_with_retry_and_mitigation(
              _gate,
-             _config,
+             _config.retries_cfg.max_retries,
+             _config.retries_cfg.retry_base_backoff,
              _brokers,
              group_id,
              name,
-             _logger,
              [this](std::exception_ptr ex) { return mitigate_error(ex); })
       .then([this, group_id, name](shared_broker_t coordinator) mutable {
           auto on_stopped = [this, group_id](const member_id& name) {
               _consumers[group_id].erase(name);
           };
           return make_consumer(
-            _config,
+            _config.consumer_cfg,
+            _config.retries_cfg,
             _topic_cache,
             _brokers,
             std::move(coordinator),
@@ -638,7 +654,7 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
   const member_id& name,
   std::optional<std::chrono::milliseconds> timeout,
   std::optional<int32_t> max_bytes) {
-    const auto config_timout = _config.consumer_request_timeout.value();
+    const auto config_timout = _config.consumer_cfg.request_timeout;
     const auto end = model::timeout_clock::now()
                      + std::min(config_timout, timeout.value_or(config_timout));
     return gated_retry_with_mitigation([this, g_id, name, end, max_bytes]() {

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -125,9 +125,15 @@ ss::future<> client::stop() noexcept {
 ss::future<> client::update_metadata(wait_or_start::tag) {
     return ss::try_with_gate(_gate, [this]() {
         vlog(_logger.debug, "updating metadata");
-        return _brokers.any()
-          .then([this](shared_broker_t broker) {
-              return broker->dispatch(metadata_request{.list_all_topics = true})
+        auto f = ss::now();
+        if (_brokers.empty()) {
+            // If there are no brokers, connect to the seeds
+            f = connect();
+        }
+        return f
+          .then([this] {
+              return _brokers.any()
+                ->dispatch(metadata_request{.list_all_topics = true})
                 .then([this](metadata_response res) {
                     // Create new seeds from the returned set of brokers if
                     // they're not empty
@@ -141,11 +147,11 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
                     }
 
                     return apply(std::move(res));
-                })
-                .finally([this]() { vlog(_logger.trace, "updated metadata"); });
+                });
           })
           .handle_exception_type(
-            [this](const broker_error&) { return connect(); });
+            [this](const broker_error&) { return connect(); })
+          .finally([this]() { vlog(_logger.trace, "updated metadata"); });
     });
 }
 
@@ -312,11 +318,8 @@ ss::future<produce_response> client::produce_records(
 
 ss::future<metadata_response> client::fetch_metadata(metadata_request req) {
     co_return co_await gated_retry_with_mitigation(
-      [this, req{std::move(req)}]() {
-          return _brokers.any().then(
-            [req{req.copy()}](shared_broker_t broker) mutable {
-                return broker->dispatch(std::move(req));
-            });
+      [this, req = std::move(req)]() {
+          return _brokers.any()->dispatch(req.copy());
       });
 }
 
@@ -324,15 +327,13 @@ ss::future<create_topics_response>
 client::create_topic(kafka::creatable_topic req) {
     return gated_retry_with_mitigation([this, req{std::move(req)}]() {
         auto controller = _controller;
-        return _brokers.find(controller)
-          .then([req](auto broker) mutable {
-              chunked_vector<kafka::creatable_topic> cv;
-              cv.push_back(std::move(req));
-              return broker->dispatch(kafka::create_topics_request{
+        auto broker = _brokers.find(controller);
+        chunked_vector<kafka::creatable_topic> cv;
+        cv.push_back(std::move(req));
+        return broker->dispatch(kafka::create_topics_request{
                 .data = {
                   .topics = std::move(cv),
-                }});
-          })
+                }})
           .then([controller](auto res) {
               auto ec = res.data.topics[0].error_code;
               switch (ec) {
@@ -431,10 +432,7 @@ client::do_list_offsets(const list_offsets_request& unsharded_req) {
 
     auto mapper = [this](auto kv) {
         auto node_id = kv.first;
-        return _brokers.find(node_id).then(
-          [req = std::move(kv.second)](shared_broker_t broker) mutable {
-              return broker->dispatch(std::move(req));
-          });
+        return _brokers.find(node_id)->dispatch(std::move(kv.second));
     };
 
     auto reducer = [](list_offsets_response result, list_offsets_response val) {
@@ -689,8 +687,6 @@ ss::future<kafka::describe_configs_response> client::describe_topics(
 ss::future<kafka::describe_configs_response> client::do_describe_topics(
   chunked_vector<model::topic> topics,
   std::optional<chunked_vector<ss::sstring>> configuration_keys) {
-    auto broker = co_await _brokers.any();
-
     chunked_vector<describe_configs_resource> dcr;
     dcr.reserve(topics.size());
     for (const auto& topic : topics) {
@@ -702,7 +698,7 @@ ss::future<kafka::describe_configs_response> client::do_describe_topics(
         });
     }
 
-    co_return co_await broker->dispatch(
+    co_return co_await _brokers.any()->dispatch(
       describe_configs_request{.data = {.resources = std::move(dcr)}});
 }
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -496,13 +496,16 @@ ss::future<fetch_response> maybe_throw_exception(
 ss::future<fetch_response> client::fetch_partition(
   model::topic_partition tp,
   model::offset offset,
-  int32_t max_bytes,
-  std::chrono::milliseconds timeout) {
+  std::chrono::milliseconds timeout,
+  std::optional<int32_t> max_bytes) {
     const auto min_bytes = _config.consumer_request_min_bytes();
-    auto build_request =
-      [offset, min_bytes, max_bytes, timeout](model::topic_partition& tp) {
-          return make_fetch_request(tp, offset, min_bytes, max_bytes, timeout);
-      };
+    const int32_t max_bytes_value = max_bytes.value_or(
+      _config.consumer_request_max_bytes());
+    auto build_request = [offset, min_bytes, max_bytes_value, timeout](
+                           model::topic_partition& tp) {
+        return make_fetch_request(
+          tp, offset, min_bytes, max_bytes_value, timeout);
+    };
 
     return ss::do_with(
       std::move(build_request),

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -85,8 +85,8 @@ public:
     std::invoke_result_t<Func> gated_retry_with_mitigation(Func func) {
         return gated_retry_with_mitigation_impl(
           _gate,
-          _config.retries(),
-          _config.retry_base_backoff(),
+          _config.retries_cfg.max_retries,
+          _config.retries_cfg.retry_base_backoff,
           std::move(func),
           [this](std::exception_ptr ex) { return mitigate_error(ex); },
           _as);
@@ -179,7 +179,31 @@ public:
 
     bool is_connected() const { return !_brokers.empty(); }
 
-    configuration& config() { return _config; }
+    void set_credentials(std::optional<sasl_configuration> creds);
+
+    void set_max_retries(size_t max_retries) {
+        _config.retries_cfg.max_retries = max_retries;
+    }
+
+    void set_retry_base_backoff(std::chrono::milliseconds retry_base_backoff) {
+        _config.retries_cfg.retry_base_backoff = retry_base_backoff;
+    }
+
+    void set_batch_record_count(int32_t count) {
+        _producer.set_batch_record_count(count);
+    }
+
+    void set_batch_size_bytes(int32_t size) {
+        _producer.set_batch_size_bytes(size);
+    }
+
+    void set_batch_delay(std::chrono::milliseconds delay) {
+        _producer.set_batch_delay(delay);
+    }
+
+    const std::optional<sasl_configuration>& get_credentials() const {
+        return _config.connection_cfg.sasl_cfg;
+    }
 
 private:
     friend class client_fetcher;
@@ -214,7 +238,7 @@ private:
 
     prefix_logger& logger() { return _logger; }
     /// \brief Client holds a copy of its configuration
-    configuration _config;
+    client_configuration _config;
     /// \brief Seeds are used when no brokers are connected.
     std::vector<net::unresolved_address> _seeds;
     prefix_logger _logger;

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -123,8 +123,8 @@ public:
     ss::future<fetch_response> fetch_partition(
       model::topic_partition tp,
       model::offset offset,
-      int32_t max_bytes,
-      std::chrono::milliseconds timeout);
+      std::chrono::milliseconds timeout,
+      std::optional<int32_t> max_bytes = std::nullopt);
 
     ss::future<member_id>
     create_consumer(const group_id& g_id, member_id name = kafka::no_member);

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -100,9 +100,7 @@ public:
     ss::future<typename std::invoke_result_t<Func>::api_type::response_type>
     dispatch(Func func) {
         return gated_retry_with_mitigation([this, func{std::move(func)}]() {
-            return _brokers.any().then([func](shared_broker_t broker) {
-                return broker->dispatch(func());
-            });
+            return _brokers.any()->dispatch(func());
         });
     }
 
@@ -179,9 +177,7 @@ public:
 
     ss::future<> update_metadata() { return _wait_or_start_update_metadata(); }
 
-    ss::future<bool> is_connected() const {
-        return _brokers.empty().then(std::logical_not<>());
-    }
+    bool is_connected() const { return !_brokers.empty(); }
 
     configuration& config() { return _config; }
 

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -49,7 +49,6 @@ public:
             auto res = co_await _client.fetch_partition(
               _tp,
               _next_offset,
-              _client.config().consumer_request_max_bytes,
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 t - model::timeout_clock::now()));
             vlog(

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -26,20 +26,33 @@
 #include <exception>
 
 namespace kafka::client {
-
-ss::future<std::unique_ptr<kafka::client::configuration>>
+namespace {
+std::optional<sasl_configuration> create_sasl_configuration_from_client_cfg(
+  const kafka::client::configuration& client_cfg) {
+    if (
+      client_cfg.scram_password.is_overriden()
+      || client_cfg.scram_username.is_overriden()
+      || client_cfg.sasl_mechanism.is_overriden()) {
+        return sasl_configuration{
+          .mechanism = client_cfg.sasl_mechanism(),
+          .username = client_cfg.scram_username(),
+          .password = client_cfg.scram_password(),
+        };
+    }
+    return std::nullopt;
+}
+} // namespace
+ss::future<std::optional<kafka::client::sasl_configuration>>
 create_client_credentials(
   cluster::controller& controller,
   const config::configuration& cluster_cfg,
   const kafka::client::configuration& client_cfg,
   security::acl_principal principal) {
-    auto new_cfg = std::make_unique<kafka::client::configuration>(
-      to_yaml(client_cfg, config::redact_secrets::no));
-
+    auto sasl_cfg = create_sasl_configuration_from_client_cfg(client_cfg);
     // If AuthZ is not enabled, don't create credentials.
     if (!cluster_cfg.kafka_enable_authorization().value_or(
           cluster_cfg.enable_sasl())) {
-        co_return new_cfg;
+        co_return sasl_cfg;
     }
 
     // If the configuration is overriden, use it.
@@ -47,7 +60,7 @@ create_client_credentials(
       client_cfg.scram_password.is_overriden()
       || client_cfg.scram_username.is_overriden()
       || client_cfg.sasl_mechanism.is_overriden()) {
-        co_return new_cfg;
+        co_return sasl_cfg;
     }
 
     // Get the internal secret for user
@@ -60,39 +73,10 @@ create_client_credentials(
             "Failed to fetch credential for principal: {}", principal)));
     }
 
-    new_cfg->sasl_mechanism.set_value(pw.credential.mechanism());
-    new_cfg->scram_username.set_value(pw.credential.user()());
-    new_cfg->scram_password.set_value(pw.credential.password()());
-
-    co_return new_cfg;
-}
-
-void set_client_credentials(
-  const kafka::client::configuration& client_cfg,
-  kafka::client::client& client) {
-    client.config().sasl_mechanism.set_value(client_cfg.sasl_mechanism());
-    client.config().scram_username.set_value(client_cfg.scram_username());
-    client.config().scram_password.set_value(client_cfg.scram_password());
-}
-
-ss::future<> set_client_credentials(
-  const kafka::client::configuration& client_cfg,
-  ss::sharded<kafka::client::client>& client) {
-    co_await client.invoke_on_all([&client_cfg](kafka::client::client& client) {
-        client.config().sasl_mechanism.set_value(client_cfg.sasl_mechanism());
-        client.config().scram_username.set_value(client_cfg.scram_username());
-        client.config().scram_password.set_value(client_cfg.scram_password());
-    });
-}
-
-model::compression compression_from_str(std::string_view v) {
-    return string_switch<model::compression>(v)
-      .match("none", model::compression::none)
-      .match("gzip", model::compression::gzip)
-      .match("snappy", model::compression::snappy)
-      .match("lz4", model::compression::lz4)
-      .match("zstd", model::compression::zstd)
-      .default_match(model::compression::none);
+    co_return sasl_configuration{
+      .mechanism = pw.credential.mechanism(),
+      .username = pw.credential.user()(),
+      .password = pw.credential.password()()};
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -25,21 +25,11 @@
 
 namespace kafka::client {
 
-ss::future<std::unique_ptr<kafka::client::configuration>>
+ss::future<std::optional<kafka::client::sasl_configuration>>
 create_client_credentials(
   cluster::controller& controller,
   const config::configuration& cluster_cfg,
   const kafka::client::configuration& client_cfg,
   security::acl_principal principal);
-
-void set_client_credentials(
-  const kafka::client::configuration& client_cfg,
-  kafka::client::client& client);
-
-ss::future<> set_client_credentials(
-  const kafka::client::configuration& client_cfg,
-  ss::sharded<kafka::client::client>& client);
-
-model::compression compression_from_str(std::string_view v);
 
 } // namespace kafka::client

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -11,6 +11,10 @@
 
 #include "base/units.h"
 #include "config/configuration.h"
+#include "kafka/client/logger.h"
+#include "rpc/rpc_utils.h"
+#include "security/oidc_authenticator.h"
+#include "security/scram_authenticator.h"
 
 namespace kafka::client {
 using namespace std::chrono_literals;
@@ -170,4 +174,227 @@ configuration::configuration()
       {},
       "test_client") {}
 
+namespace {
+model::compression compression_from_str(std::string_view v) {
+    if (v == "none") {
+        return model::compression::none;
+    } else if (v == "gzip") {
+        return model::compression::gzip;
+    } else if (v == "snappy") {
+        return model::compression::snappy;
+    } else if (v == "lz4") {
+        return model::compression::lz4;
+    } else if (v == "zstd") {
+        return model::compression::zstd;
+    }
+    throw std::invalid_argument(
+      ss::format("Unsupported compression type: {}", v));
+}
+
+void validate_sasl_properties(
+  std::string_view mechanism,
+  std::string_view username,
+  std::string_view password) {
+    if (
+      mechanism != security::scram_sha256_authenticator::name
+      && mechanism != security::scram_sha512_authenticator::name
+      && mechanism != security::oidc::sasl_authenticator::name) [[unlikely]] {
+        throw std::invalid_argument(ss::format(
+          "Unknown SASL mechanism: {}, currently Redpanda client only supports "
+          "SCRAM-256, SCRAM-512 and OAUTHBEARER",
+          mechanism));
+    }
+
+    if (username.empty()) [[unlikely]] {
+        throw std::invalid_argument("Scram username can not be empty");
+    }
+
+    if (password.empty()) [[unlikely]] {
+        throw std::invalid_argument("Scram password can not be empty");
+    }
+}
+
+} // namespace
+
+producer_configuration
+producer_configuration::from_config_store(const configuration& cfg) {
+    auto compression_type = compression_from_str(
+      cfg.produce_compression_type.value());
+    return producer_configuration{
+      .batch_record_count = cfg.produce_batch_record_count,
+      .batch_size_bytes = cfg.produce_batch_size_bytes,
+      .batch_delay = cfg.produce_batch_delay,
+      .compression_type = compression_type,
+      .shutdown_delay = cfg.produce_shutdown_delay.value(),
+      .ack_level = acks(cfg.produce_ack_level.value()),
+    };
+}
+
+consumer_configuration
+consumer_configuration::from_config_store(const configuration& cfg) {
+    return consumer_configuration{
+      .request_timeout = cfg.consumer_request_timeout.value(),
+      .fetch_min_bytes = cfg.consumer_request_min_bytes.value(),
+      .fetch_max_bytes = cfg.consumer_request_max_bytes.value(),
+      .session_timeout = cfg.consumer_session_timeout.value(),
+      .rebalance_timeout = cfg.consumer_rebalance_timeout.value(),
+      .heartbeat_interval = cfg.consumer_heartbeat_interval.value(),
+    };
+}
+
+connection_configuration
+connection_configuration::from_config_store(const configuration& cfg) {
+    connection_configuration ret{
+      .initial_brokers = cfg.brokers.value(),
+      .client_id = cfg.client_identifier.value(),
+    };
+
+    if (!cfg.sasl_mechanism().empty()) {
+        validate_sasl_properties(
+          cfg.sasl_mechanism(), cfg.scram_username(), cfg.scram_password());
+        ret.sasl_cfg = sasl_configuration{
+          .mechanism = cfg.sasl_mechanism(),
+          .username = cfg.scram_username(),
+          .password = cfg.scram_password(),
+        };
+    }
+    ret.broker_tls = tls_configuration::from_tls_config(cfg.broker_tls.value());
+
+    return ret;
+}
+
+client_configuration
+client_configuration::from_config_store(const configuration& cfg) {
+    return client_configuration{
+      .connection_cfg = connection_configuration::from_config_store(cfg),
+      .producer_cfg = producer_configuration::from_config_store(cfg),
+      .consumer_cfg = consumer_configuration::from_config_store(cfg),
+      .retries_cfg = retries_configuration{
+          .max_retries = cfg.retries.value(),
+          .retry_base_backoff = cfg.retry_base_backoff.value(),
+      },
+    };
+}
+namespace {
+key_store create_key_store(const config::key_cert_container& container) {
+    return ss::visit(
+      container,
+      [](const config::key_cert& kc) {
+          return key_store{key_cert_path{
+            .key = std::filesystem::path(kc.key_file),
+            .cert = std::filesystem::path(kc.cert_file),
+          }};
+      },
+      [](const config::p12_container& pkcs) {
+          return key_store{pkcs12{
+            .cert = std::filesystem::path(pkcs.p12_path),
+            .password = pkcs.p12_password,
+          }};
+      });
+}
+} // namespace
+
+std::optional<tls_configuration>
+tls_configuration::from_tls_config(const config::tls_config& cfg) {
+    if (!cfg.is_enabled()) {
+        return std::nullopt;
+    }
+
+    tls_configuration ret;
+    auto& cert_files = cfg.get_key_cert_files();
+
+    if (cert_files.has_value()) {
+        ret.k_store = create_key_store(cert_files.value());
+    }
+    if (cfg.get_truststore_file().has_value()) {
+        ret.truststore = std::filesystem::path(
+          cfg.get_truststore_file().value());
+    }
+
+    return ret;
+}
+
+ss::future<ss::shared_ptr<ss::tls::certificate_credentials>>
+tls_configuration::build_credentials() const {
+    ss::tls::credentials_builder builder;
+    builder.enable_server_precedence();
+    builder.set_cipher_string(
+      {config::tlsv1_2_cipher_string.data(),
+       config::tlsv1_2_cipher_string.size()});
+    builder.set_ciphersuites(
+      {config::tlsv1_3_ciphersuites.data(),
+       config::tlsv1_3_ciphersuites.size()});
+    builder.set_minimum_tls_version(
+      from_config(config::shard_local_cfg().tls_min_version()));
+    builder.set_dh_level(ss::tls::dh_params::level::MEDIUM);
+
+    if (config::shard_local_cfg().tls_enable_renegotiation()) {
+        builder.enable_tls_renegotiation();
+    }
+    if (truststore) {
+        co_await ss::visit(
+          *truststore,
+          [&builder](const std::filesystem::path& path) {
+              return builder.set_x509_trust_file(
+                path.string(), ss::tls::x509_crt_format::PEM);
+          },
+          [&builder](const ss::sstring& truststore_str) {
+              builder.set_x509_trust(
+                truststore_str, ss::tls::x509_crt_format::PEM);
+              return ss::now();
+          });
+    }
+    if (k_store) {
+        co_await ss::visit(
+          *k_store,
+          [&builder](const key_cert_path& kc) {
+              return builder.set_x509_key_file(
+                kc.cert.string(),
+                kc.key.string(),
+                ss::tls::x509_crt_format::PEM);
+          },
+          [&builder](const key_cert& kc) {
+              builder.set_x509_key(
+                kc.cert, kc.key, ss::tls::x509_crt_format::PEM);
+              return ss::now();
+          },
+          [&builder](const pkcs12& pkcs) {
+              return ss::visit(
+                pkcs.cert,
+                [&builder, &pkcs](const std::filesystem::path& p) {
+                    return builder.set_simple_pkcs12_file(
+                      p.string(), ss::tls::x509_crt_format::PEM, pkcs.password);
+                },
+                [&pkcs, &builder](const ss::sstring& p12_str) {
+                    builder.set_simple_pkcs12(
+                      p12_str, ss::tls::x509_crt_format::PEM, pkcs.password);
+                    return ss::now();
+                });
+          });
+    }
+    co_return co_await builder.build_reloadable_certificate_credentials(
+      [](
+        const std::unordered_set<ss::sstring>& updated,
+        const std::exception_ptr& eptr) {
+          rpc::log_certificate_reload_event(
+            kclog, "kafka-client", updated, eptr);
+      });
+}
+
+auto format_as(const sasl_configuration& cfg) {
+    return fmt::format(
+      "sasl_configuration{{mechanism: {}, username: {}, password: <redacted>}}",
+      cfg.mechanism,
+      cfg.username);
+}
+
 } // namespace kafka::client
+auto fmt::formatter<kafka::client::sasl_configuration>::format(
+  const kafka::client::sasl_configuration& sasl_cfg,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{mechanism: {}, username: {}, password: <redacted>}}",
+      sasl_cfg.mechanism,
+      sasl_cfg.username);
+}

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -21,6 +21,107 @@
 #include <chrono>
 
 namespace kafka::client {
+struct configuration;
+
+using acks = named_type<int16_t, struct acks_tag>;
+
+static constexpr acks acks_none{0};
+static constexpr acks acks_leader{1};
+static constexpr acks acks_all{-1};
+/**
+ * Producer specific properties.
+ */
+struct producer_configuration {
+    int32_t batch_record_count;
+    int32_t batch_size_bytes;
+    std::chrono::milliseconds batch_delay;
+    model::compression compression_type;
+    std::chrono::milliseconds shutdown_delay;
+    acks ack_level;
+
+    static producer_configuration from_config_store(const configuration& cfg);
+};
+
+/**
+ * Consumer specific properties.
+ */
+
+struct consumer_configuration {
+    std::chrono::milliseconds request_timeout;
+    int32_t fetch_min_bytes;
+    int32_t fetch_max_bytes;
+    std::chrono::milliseconds session_timeout;
+    std::chrono::milliseconds rebalance_timeout;
+    std::chrono::milliseconds heartbeat_interval;
+    static consumer_configuration from_config_store(const configuration& cfg);
+};
+/**
+ * Common configuration for retries.
+ */
+struct retries_configuration {
+    size_t max_retries;
+    std::chrono::milliseconds retry_base_backoff;
+};
+/**
+ * TLS settings for the client
+ */
+using certificate_configuration
+  = std::variant<std::filesystem::path, ss::sstring>;
+
+struct key_cert_path {
+    std::filesystem::path key;
+    std::filesystem::path cert;
+};
+struct key_cert {
+    ss::sstring key;
+    ss::sstring cert;
+};
+
+struct pkcs12 {
+    certificate_configuration cert;
+    ss::sstring password;
+};
+
+using key_store = std::variant<key_cert, key_cert_path, pkcs12>;
+struct tls_configuration {
+    std::optional<certificate_configuration> truststore;
+    std::optional<key_store> k_store;
+    static std::optional<tls_configuration>
+    from_tls_config(const config::tls_config&);
+
+    ss::future<ss::shared_ptr<ss::tls::certificate_credentials>>
+    build_credentials() const;
+};
+
+struct sasl_configuration {
+    ss::sstring mechanism;
+    ss::sstring username;
+    ss::sstring password;
+};
+
+/**
+ * Connection configuration for the Kafka client. If the TLS or SASL settings
+ * are present,they will be used to connect to the brokers.
+ */
+struct connection_configuration {
+    std::vector<net::unresolved_address> initial_brokers;
+    std::optional<tls_configuration> broker_tls;
+    std::optional<sasl_configuration> sasl_cfg;
+    std::optional<ss::sstring> client_id;
+    static connection_configuration from_config_store(const configuration& cfg);
+};
+
+/**
+ * Currently the `kafka::client::client is an aggregate of consumer and
+ * producer. Client configuration holds all necessary properties.
+ */
+struct client_configuration {
+    connection_configuration connection_cfg;
+    producer_configuration producer_cfg;
+    consumer_configuration consumer_cfg;
+    retries_configuration retries_cfg;
+    static client_configuration from_config_store(const configuration& cfg);
+};
 
 /// Pandaproxy client configuration
 ///
@@ -55,3 +156,10 @@ struct configuration final : public config::config_store {
 };
 
 } // namespace kafka::client
+template<>
+struct fmt::formatter<kafka::client::sasl_configuration>
+  : fmt::formatter<std::string_view> {
+    auto format(
+      const kafka::client::sasl_configuration&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
+};

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -436,7 +436,7 @@ ss::future<fetch_response> consumer::fetch(
     for (const auto& [t, ps] : _assignment) {
         for (const auto& p : ps) {
             auto tp = model::topic_partition{t, p};
-            auto leader = co_await _topic_cache.leader(tp);
+            auto leader = _topic_cache.leader(tp);
             auto broker = _brokers.find(leader);
             auto& session = _fetch_sessions[broker];
 

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -85,7 +85,8 @@ reduce_fetch_response(fetch_response result, fetch_response val) {
 } // namespace detail
 
 consumer::consumer(
-  const configuration& config,
+  consumer_configuration config,
+  retries_configuration& retries_cfg,
   topic_cache& topic_cache,
   brokers& brokers,
   shared_broker_t coordinator,
@@ -94,7 +95,8 @@ consumer::consumer(
   ss::noncopyable_function<void(const kafka::member_id&)> on_stopped,
   ss::noncopyable_function<ss::future<>(std::exception_ptr)> mitigater,
   prefix_logger& logger)
-  : _config(config)
+  : _config(std::move(config))
+  , _retries_cfg(retries_cfg)
   , _topic_cache(topic_cache)
   , _brokers(brokers)
   , _coordinator(std::move(coordinator))
@@ -136,7 +138,7 @@ void consumer::start() {
                 e);
           });
     });
-    _heartbeat_timer.rearm_periodic(_config.consumer_heartbeat_interval());
+    _heartbeat_timer.rearm_periodic(_config.heartbeat_interval);
 }
 
 ss::future<> consumer::stop() {
@@ -171,8 +173,8 @@ ss::future<> consumer::join() {
         req.client_id = kafka::client_id("test_client");
         req.data = {
           .group_id = me->_group_id,
-          .session_timeout_ms = cfg.consumer_session_timeout(),
-          .rebalance_timeout_ms = cfg.consumer_rebalance_timeout(),
+          .session_timeout_ms = cfg.session_timeout,
+          .rebalance_timeout_ms = cfg.rebalance_timeout,
           .member_id = me->_member_id,
           .protocol_type = consumer_group_protocol_type,
           .protocols = make_join_group_request_protocols(me->_topics)};
@@ -190,7 +192,7 @@ ss::future<> consumer::join() {
           case error_code::illegal_generation:
               return join();
           case error_code::not_coordinator:
-              return ss::sleep_abortable(_config.retry_base_backoff(), _as)
+              return ss::sleep_abortable(_retries_cfg.retry_base_backoff, _as)
                 .then([this]() { return join(); });
           case error_code::none:
               _generation_id = res.data.generation_id;
@@ -358,8 +360,7 @@ ss::future<> consumer::heartbeat() {
 }
 
 void consumer::refresh_inactivity_timer() {
-    _inactive_timer.rearm(
-      ss::timer<>::clock::now() + _config.consumer_session_timeout());
+    _inactive_timer.rearm(ss::timer<>::clock::now() + _config.session_timeout);
 }
 
 ss::future<describe_groups_response> consumer::describe_group() {
@@ -447,9 +448,9 @@ ss::future<fetch_response> consumer::fetch(
                               .data = {
                               .replica_id = consumer_replica_id,
                               .max_wait_ms = timeout,
-                              .min_bytes = _config.consumer_request_min_bytes,
+                              .min_bytes = _config.fetch_min_bytes,
                               .max_bytes = max_bytes.value_or(
-                                _config.consumer_request_max_bytes),
+                                _config.fetch_max_bytes),
                               .isolation_level = model::isolation_level::
                                 read_uncommitted, // READ_UNCOMMITTED
                               .session_id = session.id(),
@@ -466,7 +467,7 @@ ss::future<fetch_response> consumer::fetch(
                 .partition = p,
                 .fetch_offset = session.offset(tp),
                 .partition_max_bytes = max_bytes.value_or(
-                  _config.consumer_request_max_bytes)});
+                  _config.fetch_max_bytes)});
         }
     }
 
@@ -488,11 +489,11 @@ ss::future<
 consumer::reset_coordinator_and_retry_request(request_factory req) {
     return find_coordinator_with_retry_and_mitigation(
              _gate,
-             _config,
+             _retries_cfg.max_retries,
+             _retries_cfg.retry_base_backoff,
              _brokers,
              group_id(),
              name(),
-             *_logger,
              [this](std::exception_ptr ex) { return _external_mitigate(ex); })
       .then(
         [this, req{std::move(req)}](shared_broker_t new_coordinator) mutable {
@@ -593,7 +594,8 @@ ss::future<describe_groups_response> consumer::maybe_process_response_errors(
 }
 
 ss::future<shared_consumer_t> make_consumer(
-  const configuration& config,
+  const consumer_configuration& config,
+  retries_configuration& retries_config,
   topic_cache& topic_cache,
   brokers& brokers,
   shared_broker_t coordinator,
@@ -604,6 +606,7 @@ ss::future<shared_consumer_t> make_consumer(
   prefix_logger& logger) {
     auto c = ss::make_lw_shared<consumer>(
       config,
+      retries_config,
       topic_cache,
       brokers,
       std::move(coordinator),

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -437,7 +437,7 @@ ss::future<fetch_response> consumer::fetch(
         for (const auto& p : ps) {
             auto tp = model::topic_partition{t, p};
             auto leader = co_await _topic_cache.leader(tp);
-            auto broker = co_await _brokers.find(leader);
+            auto broker = _brokers.find(leader);
             auto& session = _fetch_sessions[broker];
 
             auto& req = broker_reqs

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -51,7 +51,8 @@ public:
     /// The consumer may become inactive of its own accord through a timeout.
     /// This callback can be used as a notification system for cleanup.
     consumer(
-      const configuration& config,
+      consumer_configuration config,
+      retries_configuration& retries_cfg,
       topic_cache& topic_cache,
       brokers& brokers,
       shared_broker_t coordinator,
@@ -153,7 +154,8 @@ private:
       typename std::invoke_result_t<request_factory>::api_type::response_type>
     reset_coordinator_and_retry_request(request_factory req);
 
-    const configuration& _config;
+    consumer_configuration _config;
+    retries_configuration& _retries_cfg;
     topic_cache& _topic_cache;
     brokers& _brokers;
     shared_broker_t _coordinator;
@@ -192,7 +194,8 @@ private:
 using shared_consumer_t = ss::lw_shared_ptr<consumer>;
 
 ss::future<shared_consumer_t> make_consumer(
-  const configuration& config,
+  const consumer_configuration& config,
+  retries_configuration& retries_cfg,
   topic_cache& topic_cache,
   brokers& brokers,
   shared_broker_t coordinator,

--- a/src/v/kafka/client/fwd.h
+++ b/src/v/kafka/client/fwd.h
@@ -14,6 +14,7 @@
 namespace kafka::client {
 
 struct configuration;
+struct sasl_configuration;
 class client;
 
 } // namespace kafka::client

--- a/src/v/kafka/client/produce_partition.h
+++ b/src/v/kafka/client/produce_partition.h
@@ -31,9 +31,9 @@ public:
     using response = produce_batcher::partition_response;
     using consumer = ss::noncopyable_function<void(model::record_batch&&)>;
 
-    produce_partition(const configuration& config, consumer&& c)
-      : _config{config}
-      , _batcher{compression_from_str(config.produce_compression_type())}
+    produce_partition(producer_configuration config, consumer&& c)
+      : _config{std::move(config)}
+      , _batcher{_config.compression_type}
       , _timer{[this]() {
           ssx::spawn_with_gate(_gate, [this]() { return try_consume(); });
       }}
@@ -112,7 +112,7 @@ private:
         // nearly immediately after this call.  Otherwise use the produce
         // batch delay when arming the timer.
         if (!threshold_met()) {
-            rearm_timer_delay = _config.produce_batch_delay();
+            rearm_timer_delay = _config.batch_delay;
         }
         _timer.cancel();
         _timer.arm(rearm_timer_delay);
@@ -120,11 +120,8 @@ private:
 
     /// \brief Validates that the size threshold has been met to trigger produce
     bool threshold_met() const {
-        auto batch_record_count = _config.produce_batch_record_count();
-        auto batch_size_bytes = _config.produce_batch_size_bytes();
-
-        return _record_count >= batch_record_count
-               || _size_bytes >= batch_size_bytes;
+        return _record_count >= _config.batch_record_count
+               || _size_bytes >= _config.batch_size_bytes;
     }
 
     /// \brief Checks to see if the consumer can run
@@ -133,7 +130,7 @@ private:
     /// records available
     bool consumer_can_run() const { return !_in_flight && _record_count > 0; }
 
-    const configuration& _config;
+    producer_configuration _config;
     produce_batcher _batcher{};
     ss::timer<> _timer{};
     consumer _consumer;

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -29,7 +29,7 @@ using namespace std::chrono_literals;
 namespace kafka::client {
 
 produce_request make_produce_request(
-  model::topic_partition tp, model::record_batch&& batch, int16_t acks) {
+  model::topic_partition tp, model::record_batch&& batch, acks acks) {
     chunked_vector<produce_request::partition> partitions;
     partitions.emplace_back(produce_request::partition{
       .partition_index{tp.partition},
@@ -87,20 +87,20 @@ ss::future<> producer::stop() {
     /// configured interval or when the gate is eventually closed whichever
     /// comes first.
     ss::abort_source exit;
-    if (_config.produce_shutdown_delay() > 0ms) {
+    if (_config.shutdown_delay > 0ms) {
         vlog(
           _logger->debug,
           "Waiting {}ms to allow final flush of producers batched records",
-          _config.produce_shutdown_delay());
+          _config.shutdown_delay);
     }
-    auto abort = ss::sleep_abortable(_config.produce_shutdown_delay(), exit)
+    auto abort = ss::sleep_abortable(_config.shutdown_delay, exit)
                    .then([this] {
-                       if (_config.produce_shutdown_delay() > 0ms) {
+                       if (_config.shutdown_delay > 0ms) {
                            vlog(
                              _logger->warn,
                              "Forcefully stopping kafka client producer after "
                              "waiting {}ms for its gate to close",
-                             _config.produce_shutdown_delay());
+                             _config.shutdown_delay);
                        }
                        _as.request_abort();
                    })
@@ -144,7 +144,7 @@ producer::do_send(model::topic_partition tp, model::record_batch batch) {
     auto leader = _topic_cache.leader(tp);
     auto broker = _brokers.find(leader);
     auto res = co_await broker->dispatch(
-      make_produce_request(std::move(tp), std::move(batch), _acks));
+      make_produce_request(std::move(tp), std::move(batch), _config.ack_level));
     auto topic = std::move(res.data.responses[0]);
     auto partition = std::move(topic.partitions[0]);
     if (partition.error_code != error_code::none) {
@@ -170,8 +170,8 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
              [this, tp](model::record_batch& batch) mutable {
                  return ss::with_gate(_gate, [this, tp, &batch]() {
                      return retry_with_mitigation(
-                       _config.retries(),
-                       _config.retry_base_backoff(),
+                       _retries_config.max_retries,
+                       _retries_config.retry_base_backoff,
                        [this, tp{std::move(tp)}, &batch]() {
                            return do_send(tp, batch.share());
                        },

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -141,7 +141,7 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
 
 ss::future<produce_response::partition>
 producer::do_send(model::topic_partition tp, model::record_batch batch) {
-    auto leader = co_await _topic_cache.leader(tp);
+    auto leader = _topic_cache.leader(tp);
     auto broker = _brokers.find(leader);
     auto res = co_await broker->dispatch(
       make_produce_request(std::move(tp), std::move(batch), _acks));

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -142,7 +142,7 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
 ss::future<produce_response::partition>
 producer::do_send(model::topic_partition tp, model::record_batch batch) {
     auto leader = co_await _topic_cache.leader(tp);
-    auto broker = co_await _brokers.find(leader);
+    auto broker = _brokers.find(leader);
     auto res = co_await broker->dispatch(
       make_produce_request(std::move(tp), std::move(batch), _acks));
     auto topic = std::move(res.data.responses[0]);

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -34,24 +34,34 @@ public:
       = absl::flat_hash_map<model::topic_partition, shared_produce_partition>;
 
     producer(
-      const configuration& config,
+      producer_configuration config,
+      retries_configuration& retries_config,
       topic_cache& topic_cache,
       brokers& brokers,
-      int16_t acks,
       prefix_logger& logger,
       error_handler&& error_handler)
       : _config{config}
+      , _retries_config(retries_config)
       , _partitions{}
       , _logger(&logger)
       , _error_handler(std::move(error_handler))
       , _topic_cache(topic_cache)
-      , _brokers(brokers)
-      , _acks(acks) {}
+      , _brokers(brokers) {}
 
     ss::future<produce_response::partition>
     produce(model::topic_partition tp, model::record_batch&& batch);
 
     ss::future<> stop();
+
+    void set_batch_record_count(int32_t count) {
+        _config.batch_record_count = count;
+    }
+
+    void set_batch_size_bytes(int32_t size) { _config.batch_size_bytes = size; }
+
+    void set_batch_delay(std::chrono::milliseconds delay) {
+        _config.batch_delay = delay;
+    }
 
 private:
     ss::future<> send(model::topic_partition tp, model::record_batch&& batch);
@@ -76,14 +86,14 @@ private:
           .first->second;
     }
 
-    const configuration& _config;
+    producer_configuration _config;
+    retries_configuration& _retries_config;
     absl::flat_hash_map<model::topic_partition, shared_produce_partition>
       _partitions;
     prefix_logger* _logger;
     error_handler _error_handler;
     topic_cache& _topic_cache;
     brokers& _brokers;
-    int16_t _acks;
     ss::abort_source _as;
     ss::abort_source _ingest_as;
     ss::gate _gate;

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -17,17 +17,10 @@
 namespace kafka::client {
 
 ss::future<> do_authenticate(
-  shared_broker_t broker, const configuration& config, prefix_logger& logger) {
-    if (config.sasl_mechanism().empty()) {
-        vlog(
-          logger.debug,
-          "Connecting to broker {} without authentication",
-
-          broker->id());
-        co_return;
-    }
-
-    auto mechanism = config.sasl_mechanism();
+  shared_broker_t broker,
+  const sasl_configuration& config,
+  prefix_logger& logger) {
+    const auto mechanism = config.mechanism;
 
     if (
       mechanism != security::scram_sha256_authenticator::name
@@ -39,7 +32,7 @@ ss::future<> do_authenticate(
           fmt_with_ctx(ssx::sformat, "Unknown mechanism: {}", mechanism)};
     }
 
-    auto username = config.scram_username();
+    auto username = config.username;
 
     vlog(
       logger.debug,
@@ -51,7 +44,7 @@ ss::future<> do_authenticate(
     // perform handshake
     co_await do_sasl_handshake(broker, mechanism);
 
-    auto password = config.scram_password();
+    auto password = config.password;
 
     if (username.empty() || password.empty()) {
         throw broker_error{

--- a/src/v/kafka/client/sasl_client.h
+++ b/src/v/kafka/client/sasl_client.h
@@ -20,7 +20,7 @@
 namespace kafka::client {
 
 ss::future<> do_authenticate(
-  shared_broker_t, const configuration& config, prefix_logger& logger);
+  shared_broker_t, const sasl_configuration& config, prefix_logger& logger);
 /*
  * SASL handshake negotiates mechanism. In this case that process is simple: if
  * the server doesn't support the requested mechanism there is no fallback.

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -84,8 +84,8 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
 
     info("Connecting client");
     auto client = make_connected_client();
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(10));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(10));
     client.connect().get();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });
 

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -35,8 +35,8 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
 
     info("Connecting client");
     auto client = make_connected_client();
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(1));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(1));
     client.connect().get();
 
     {
@@ -44,7 +44,7 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
         auto ntp = make_default_ntp(
           model::topic("unknown"), model::partition_id(0));
         auto res{
-          client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
+          client.fetch_partition(ntp.tp, model::offset(0), 1000ms, 1024).get()};
         const auto& p = res.data.responses[0];
         BOOST_REQUIRE_EQUAL(p.topic, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
@@ -63,9 +63,9 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
 
     {
         info("Fetching from nonempty known topic");
-        client.config().retries.set_value(size_t(3));
+        client.set_max_retries(size_t(3));
         auto res{
-          client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
+          client.fetch_partition(ntp.tp, model::offset(0), 1000ms, 1024).get()};
         const auto& p = res.data.responses[0];
         BOOST_REQUIRE_EQUAL(p.topic, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);

--- a/src/v/kafka/client/test/list_offsets.cc
+++ b/src/v/kafka/client/test/list_offsets.cc
@@ -23,8 +23,8 @@ FIXTURE_TEST(test_unknown_topic, list_offsets_fixture) {
     auto client = make_connected_client();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });
 
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(5));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(5));
 
     BOOST_REQUIRE_EXCEPTION(
       client.list_offsets(unknown_tp).get(),

--- a/src/v/kafka/client/test/metadata.cc
+++ b/src/v/kafka/client/test/metadata.cc
@@ -102,9 +102,10 @@ FIXTURE_TEST(test_authz_response, metadata_fixture) {
     BOOST_REQUIRE(!errors_in_acl_results(acl_result));
 
     auto client = make_client();
-    client.config().sasl_mechanism.set_value(ss::sstring{"SCRAM-SHA-256"});
-    client.config().scram_username.set_value(username);
-    client.config().scram_password.set_value(password);
+    client.set_credentials(kc::sasl_configuration{
+      .mechanism = ss::sstring{"SCRAM-SHA-256"},
+      .username = username,
+      .password = password});
     client.connect().get();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });
 

--- a/src/v/kafka/client/test/produce.cc
+++ b/src/v/kafka/client/test/produce.cc
@@ -29,8 +29,8 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
 
     auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
     auto client = make_connected_client();
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(0));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(0));
 
     info("Connecting client");
     wait_for_controller_leadership().get();
@@ -53,16 +53,16 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
     BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
     BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
 
-    client.config().produce_batch_record_count.set_value(3);
-    client.config().produce_batch_size_bytes.set_value(1024);
-    client.config().produce_batch_delay.set_value(1000ms);
+    client.set_batch_record_count(3);
+    client.set_batch_size_bytes(1024);
+    client.set_batch_delay(1000ms);
 
     auto bat0 = make_batch(model::offset(0), 2);
     auto bat1 = make_batch(model::offset(2), 1);
     auto bat2 = make_batch(model::offset(3), 3);
 
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(10));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(10));
 
     info("Producing to known topic");
     auto req0_fut = client.produce_record_batch(tp, std::move(bat0));
@@ -89,12 +89,12 @@ FIXTURE_TEST(produce_clean_shutdown, kafka_client_fixture) {
 
     auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
     auto client = make_connected_client();
-    client.config().retry_base_backoff.set_value(1ms);
+    client.set_retry_base_backoff(1ms);
 
     /// Set a high retry value that previous to the changes to the
     /// retry_with_migitation loops, would hold up the client from exiting
     /// during shutdown
-    client.config().retries.set_value(size_t(10000));
+    client.set_max_retries(size_t(10000));
 
     info("Connecting client");
     wait_for_controller_leadership().get();

--- a/src/v/kafka/client/test/produce_partition.cc
+++ b/src/v/kafka/client/test/produce_partition.cc
@@ -39,7 +39,8 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
     // configuration under test
     cfg.produce_batch_record_count.set_value(3);
 
-    kc::produce_partition producer(cfg, consumer);
+    kc::produce_partition producer(
+      kc::producer_configuration::from_config_store(cfg), consumer);
 
     auto c_res0_fut = producer.produce(make_batch(model::offset(0), 2));
     auto c_res1_fut = producer.produce(make_batch(model::offset(2), 1));

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -34,8 +34,8 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
 
     auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
     auto client = make_connected_client();
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(0));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(0));
 
     {
         info("Checking no topics");
@@ -68,7 +68,7 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
     }
 
     {
-        client.config().retries.set_value(size_t(5));
+        client.set_max_retries(size_t(5));
         info("Checking for known topic - controller ready");
         auto res = client.dispatch(make_list_topics_req()).get();
         BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
@@ -116,10 +116,12 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
 
     auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
     auto kafka_client = make_client();
-    kafka_client.config().sasl_mechanism.set_value(
-      ss::sstring{"SCRAM-SHA-256"});
-    kafka_client.config().scram_username.set_value(username);
-    kafka_client.config().scram_password.set_value(userpass);
+    kafka_client.set_credentials(kc::sasl_configuration{
+      .mechanism = "SCRAM-SHA-256",
+      .username = username,
+      .password = userpass,
+    });
+
     kafka_client.connect().get();
 
     {
@@ -139,7 +141,11 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
         // Setting the password has no effect until the client disconnects
         info("Changing password");
         userpass = "foobar";
-        kafka_client.config().scram_password.set_value(userpass);
+        kafka_client.set_credentials(kc::sasl_configuration{
+          .mechanism = "SCRAM-SHA-256",
+          .username = username,
+          .password = userpass,
+        });
     }
 
     {

--- a/src/v/kafka/client/test/retry.cc
+++ b/src/v/kafka/client/test/retry.cc
@@ -24,8 +24,8 @@ FIXTURE_TEST(test_retry_produce, kafka_client_fixture) {
     auto client = make_connected_client();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });
 
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(5));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(5));
 
     auto res = client
                  .produce_record_batch(
@@ -68,8 +68,8 @@ FIXTURE_TEST(test_retry_create_topic, kafka_client_create_topic_fixture) {
     auto client = make_connected_client();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });
 
-    client.config().retry_base_backoff.set_value(10ms);
-    client.config().retries.set_value(size_t(5));
+    client.set_retry_base_backoff(10ms);
+    client.set_max_retries(size_t(5));
 
     auto make_topic = [](ss::sstring name) {
         return kafka::creatable_topic{

--- a/src/v/kafka/client/test/test_config_utils.cc
+++ b/src/v/kafka/client/test/test_config_utils.cc
@@ -85,8 +85,8 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
 
     // Default configuration, no authz - expect no changes
     {
-        auto config = create_credentials().get();
-        BOOST_REQUIRE_EQUAL(*config, client_cfg);
+        auto sasl_cfg = create_credentials().get();
+        BOOST_REQUIRE(!sasl_cfg.has_value());
         BOOST_REQUIRE(!ec_store.has(ec_store.find(principal)));
     }
 
@@ -104,8 +104,8 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
 
     // Expect no changes as authz isn't enabled:
     {
-        auto config = create_credentials().get();
-        BOOST_REQUIRE_EQUAL(*config, client_cfg);
+        auto sasl_cfg = create_credentials().get();
+        BOOST_REQUIRE(!sasl_cfg.has_value());
         BOOST_REQUIRE(!ec_store.has(ec_store.find(principal)));
     }
 
@@ -116,8 +116,14 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
         client_cfg.sasl_mechanism.set_value(
           ss::sstring{security::scram_sha512_authenticator::name});
 
-        auto config = create_credentials().get();
-        BOOST_REQUIRE_EQUAL(*config, client_cfg);
+        auto sasl_cfg = create_credentials().get();
+        BOOST_REQUIRE(sasl_cfg.has_value());
+        BOOST_REQUIRE_EQUAL(
+          sasl_cfg->mechanism, client_cfg.sasl_mechanism.value());
+        BOOST_REQUIRE_EQUAL(
+          sasl_cfg->username, client_cfg.scram_username.value());
+        BOOST_REQUIRE_EQUAL(
+          sasl_cfg->password, client_cfg.scram_password.value());
         BOOST_REQUIRE(!ec_store.has(ec_store.find(principal)));
 
         // reset the credentials
@@ -131,11 +137,12 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
 
     // Expect credentials are created.
     {
-        auto config = create_credentials().get();
+        auto sasl_cfg = create_credentials().get();
+        BOOST_REQUIRE(sasl_cfg.has_value());
         BOOST_REQUIRE_EQUAL(
-          config->sasl_mechanism(), security::scram_sha512_authenticator::name);
-        BOOST_REQUIRE(config->scram_username.is_overriden());
-        BOOST_REQUIRE(config->scram_password.is_overriden());
+          sasl_cfg->mechanism, security::scram_sha512_authenticator::name);
+        BOOST_REQUIRE_NE(sasl_cfg->username, "");
+        BOOST_REQUIRE_NE(sasl_cfg->password, "");
         BOOST_REQUIRE(ec_store.has(ec_store.find(principal)));
     }
 }

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -20,8 +20,8 @@
 
 namespace kafka::client {
 
-ss::future<>
-topic_cache::apply(small_fragment_vector<metadata_response::topic>&& topics) {
+void topic_cache::apply(
+  small_fragment_vector<metadata_response::topic>&& topics) {
     topics_t cache;
     cache.reserve(topics.size());
     for (const auto& t : topics) {
@@ -41,35 +41,30 @@ topic_cache::apply(small_fragment_vector<metadata_response::topic>&& topics) {
     }
     cache.rehash(0);
     std::exchange(_topics, std::move(cache));
-    return ss::now();
 }
 
-ss::future<model::node_id>
-topic_cache::leader(model::topic_partition tp) const {
+model::node_id topic_cache::leader(model::topic_partition tp) const {
     if (auto topic_it = _topics.find(tp.topic); topic_it != _topics.end()) {
         const auto& parts = topic_it->second.partitions;
         if (auto part_it = parts.find(tp.partition); part_it != parts.end()) {
             const auto& part = part_it->second;
             if (part.leader == unknown_node_id) {
-                return ss::make_exception_future<model::node_id>(
-                  partition_error(tp, error_code::leader_not_available));
+                throw partition_error(tp, error_code::leader_not_available);
             }
-            return ss::make_ready_future<model::node_id>(part.leader);
+            return part.leader;
         }
     }
-    return ss::make_exception_future<model::node_id>(
-      partition_error(std::move(tp), error_code::unknown_topic_or_partition));
+    throw partition_error(
+      std::move(tp), error_code::unknown_topic_or_partition);
 }
 
-ss::future<model::partition_id>
+model::partition_id
 topic_cache::partition_for(model::topic_view tv, const record_essence& rec) {
     if (auto topic_it = _topics.find(tv); topic_it != _topics.end()) {
         auto& pd = topic_it->second;
-        return ss::make_ready_future<model::partition_id>(
-          *pd.partitioner_func(rec, pd.partitions.size()));
+        return *pd.partitioner_func(rec, pd.partitions.size());
     }
-    return ss::make_exception_future<model::partition_id>(
-      topic_error(tv, error_code::unknown_topic_or_partition));
+    throw topic_error(tv, error_code::unknown_topic_or_partition);
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -47,14 +47,13 @@ public:
     ~topic_cache() noexcept = default;
 
     /// \brief Apply the given metadata response.
-    ss::future<>
-    apply(small_fragment_vector<metadata_response::topic>&& topics);
+    void apply(small_fragment_vector<metadata_response::topic>&& topics);
 
     /// \brief Obtain the leader for the given topic-partition
-    ss::future<model::node_id> leader(model::topic_partition tp) const;
+    model::node_id leader(model::topic_partition tp) const;
 
     /// \brief Obtain the partition_id for the given record
-    ss::future<model::partition_id>
+    model::partition_id
     partition_for(model::topic_view tv, const record_essence& rec);
 
 private:

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -113,16 +113,16 @@ std::invoke_result_t<Func> gated_retry_with_mitigation_impl(
 template<typename ErrFunc>
 ss::future<shared_broker_t> find_coordinator_with_retry_and_mitigation(
   ss::gate& retry_gate,
-  const configuration& client_config,
+  size_t max_retries,
+  std::chrono::milliseconds retry_base_backoff,
   brokers& cluster_brokers,
   const group_id& group_id,
   member_id name,
-  prefix_logger& logger,
   ErrFunc errFunc) {
     return gated_retry_with_mitigation_impl(
              retry_gate,
-             client_config.retries(),
-             client_config.retry_base_backoff(),
+             max_retries,
+             retry_base_backoff,
              [group_id, name, &cluster_brokers]() {
                  return cluster_brokers.any()
                    ->dispatch(find_coordinator_request(group_id))
@@ -137,12 +137,10 @@ ss::future<shared_broker_t> find_coordinator_with_retry_and_mitigation(
                    });
              },
              errFunc)
-      .then([&client_config, &logger](find_coordinator_response res) {
-          return make_broker(
+      .then([&cluster_brokers](find_coordinator_response res) {
+          return cluster_brokers.create_broker(
             res.data.node_id,
-            net::unresolved_address(res.data.host, res.data.port),
-            client_config,
-            logger);
+            net::unresolved_address(res.data.host, res.data.port));
       });
 }
 

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -125,10 +125,7 @@ ss::future<shared_broker_t> find_coordinator_with_retry_and_mitigation(
              client_config.retry_base_backoff(),
              [group_id, name, &cluster_brokers]() {
                  return cluster_brokers.any()
-                   .then([group_id](shared_broker_t broker) {
-                       return broker->dispatch(
-                         find_coordinator_request(group_id));
-                   })
+                   ->dispatch(find_coordinator_request(group_id))
                    .then([group_id, name](find_coordinator_response res) {
                        if (res.data.error_code != error_code::none) {
                            return ss::make_exception_future<

--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -95,9 +95,14 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
     } else {
         // If the passwords don't match, update the password on the client, so
         // that it can reconnect.
-        if (it_hash->client->config().scram_password.value() != user.pass) {
+        auto& current_credentials = it_hash->client->get_credentials();
+        if (current_credentials && current_credentials->password != user.pass) {
             vlog(plog.debug, "Updating password for user {}", k);
-            it_hash->client->config().scram_password.set_value(user.pass);
+            it_hash->client->set_credentials(kafka::client::sasl_configuration{
+              .mechanism = current_credentials->mechanism,
+              .username = current_credentials->username,
+              .password = user.pass,
+            });
         } else {
             vlog(plog.debug, "Reuse client for user {}", k);
         }

--- a/src/v/pandaproxy/rest/api.cc
+++ b/src/v/pandaproxy/rest/api.cc
@@ -49,6 +49,7 @@ ss::future<> api::start() {
 
     co_await _proxy.start(
       config::to_yaml(_cfg, config::redact_secrets::no),
+      config::to_yaml(_client_cfg, config::redact_secrets::no),
       _sg,
       _max_memory,
       std::ref(_client),
@@ -80,7 +81,21 @@ ss::future<> api::set_config(ss::sstring name, std::any val) {
 ss::future<> api::set_client_config(ss::sstring name, std::any val) {
     return _proxy.invoke_on_all(
       [name{std::move(name)}, val{std::move(val)}](pandaproxy::rest::proxy& p) {
-          p.client_config().get(name).set_value(val);
+          return p.client().invoke_on_all(
+            [name, val](kafka::client::client& client) {
+                if (name == "retries") {
+                    client.set_max_retries(std::any_cast<size_t>(val));
+                } else if (name == "retry_base_backoff_ms") {
+                    client.set_retry_base_backoff(
+                      std::any_cast<std::chrono::milliseconds>(val));
+                } else if (name == "produce_batch_delay_ms") {
+                    client.set_batch_delay(
+                      std::any_cast<std::chrono::milliseconds>(val));
+                } else {
+                    throw std::runtime_error(
+                      fmt::format("Unsupported client config: {}", name));
+                }
+            });
       });
 }
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -148,7 +148,7 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
       .dispatch([offset, timeout, max_bytes, res_fmt, tp{std::move(tp)}](
                   kafka::client::client& client) mutable {
           return client
-            .fetch_partition(std::move(tp), offset, max_bytes, timeout)
+            .fetch_partition(std::move(tp), offset, timeout, max_bytes)
             .then([res_fmt](kafka::fetch_response res) {
                 ::json::chunked_buffer buf;
                 ::json::iobuf_writer<::json::chunked_buffer> w(buf);

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -102,12 +102,14 @@ server::routes_t get_proxy_routes(ss::gate& gate, one_shot& es) {
 
 proxy::proxy(
   const YAML::Node& config,
+  const YAML::Node& client_cfg,
   ss::smp_service_group smp_sg,
   size_t max_memory,
   ss::sharded<kafka::client::client>& client,
   ss::sharded<kafka_client_cache>& client_cache,
   cluster::controller* controller)
   : _config(config)
+  , _client_cfg(client_cfg)
   , _mem_sem(max_memory, "pproxy/mem")
   , _inflight_sem(config::shard_local_cfg().max_in_flight_pandaproxy_requests_per_shard(), "pproxy/inflight")
   , _inflight_config_binding(config::shard_local_cfg().max_in_flight_pandaproxy_requests_per_shard.bind())
@@ -150,10 +152,6 @@ ss::future<> proxy::stop() {
 
 configuration& proxy::config() { return _config; }
 
-kafka::client::configuration& proxy::client_config() {
-    return _client.local().config();
-}
-
 ss::future<> proxy::do_start() {
     if (_is_started) {
         co_return;
@@ -174,12 +172,12 @@ ss::future<> proxy::do_start() {
 }
 
 ss::future<> proxy::configure() {
-    auto config = co_await kafka::client::create_client_credentials(
-      *_controller,
-      config::shard_local_cfg(),
-      _client.local().config(),
-      principal);
-    co_await kafka::client::set_client_credentials(*config, _client);
+    auto sasl_config = co_await kafka::client::create_client_credentials(
+      *_controller, config::shard_local_cfg(), _client_cfg, principal);
+    co_await _client.invoke_on_all(
+      [sasl_config = std::move(sasl_config)](kafka::client::client& c) {
+          c.set_credentials(sasl_config);
+      });
 
     const auto& store = _controller->get_ephemeral_credential_store().local();
     bool has_ephemeral_credentials = store.has(store.find(principal));

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -31,6 +31,7 @@ public:
     using server = auth_ctx_server<proxy>;
     proxy(
       const YAML::Node& config,
+      const YAML::Node& client_cfg,
       ss::smp_service_group smp_sg,
       size_t max_memory,
       ss::sharded<kafka::client::client>& client,
@@ -41,7 +42,6 @@ public:
     ss::future<> stop();
 
     configuration& config();
-    kafka::client::configuration& client_config();
     ss::sharded<kafka::client::client>& client() { return _client; }
     ss::sharded<kafka_client_cache>& client_cache() { return _client_cache; }
     ss::future<> mitigate_error(std::exception_ptr);
@@ -53,6 +53,7 @@ private:
     ss::future<> do_inform(model::node_id);
 
     configuration _config;
+    kafka::client::configuration _client_cfg;
     ssx::semaphore _mem_sem;
     adjustable_semaphore _inflight_sem;
     config::binding<size_t> _inflight_config_binding;

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -63,6 +63,7 @@ ss::future<> api::start() {
       _node_id, _sg, std::ref(_client), std::ref(*_store));
     co_await _service.start(
       config::to_yaml(_cfg, config::redact_secrets::no),
+      config::to_yaml(_client_cfg, config::redact_secrets::no),
       _sg,
       _max_memory,
       std::ref(_client),

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -680,8 +680,4 @@ ss::future<> service::stop() {
 
 configuration& service::config() { return _config; }
 
-kafka::client::configuration& service::client_config() {
-    return _client.local().config();
-}
-
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -456,12 +456,12 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
 }
 
 ss::future<> service::configure() {
-    auto config = co_await kafka::client::create_client_credentials(
-      *_controller,
-      config::shard_local_cfg(),
-      _client.local().config(),
-      principal);
-    co_await kafka::client::set_client_credentials(*config, _client);
+    auto sasl_config = co_await kafka::client::create_client_credentials(
+      *_controller, config::shard_local_cfg(), _client_config, principal);
+    co_await _client.invoke_on_all(
+      [sasl_config = std::move(sasl_config)](kafka::client::client& c) {
+          c.set_credentials(sasl_config);
+      });
 
     const auto& store = _controller->get_ephemeral_credential_store().local();
     bool has_ephemeral_credentials = store.has(store.find(principal));
@@ -621,6 +621,7 @@ ss::future<> service::fetch_internal_topic() {
 
 service::service(
   const YAML::Node& config,
+  const YAML::Node& client_config,
   ss::smp_service_group smp_sg,
   size_t max_memory,
   ss::sharded<kafka::client::client>& client,
@@ -629,6 +630,7 @@ service::service(
   std::unique_ptr<cluster::controller>& controller,
   ss::sharded<security::audit::audit_log_manager>& audit_mgr)
   : _config(config)
+  , _client_config(client_config)
   , _mem_sem(max_memory, "pproxy/schema-svc")
   , _inflight_sem(config::shard_local_cfg()
                     .max_in_flight_schema_registry_requests_per_shard())

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -49,7 +49,6 @@ public:
     ss::future<> stop();
 
     configuration& config();
-    kafka::client::configuration& client_config();
     ss::sharded<kafka::client::client>& client() { return _client; }
     seq_writer& writer() { return _writer.local(); }
     sharded_store& schema_store() { return _store; }

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -37,6 +37,7 @@ class service : public ss::peering_sharded_service<service> {
 public:
     service(
       const YAML::Node& config,
+      const YAML::Node& client_config,
       ss::smp_service_group smp_sg,
       size_t max_memory,
       ss::sharded<kafka::client::client>& client,
@@ -67,6 +68,7 @@ private:
     ss::future<> create_internal_topic();
     ss::future<> fetch_internal_topic();
     configuration _config;
+    kafka::client::configuration _client_config;
     ssx::semaphore _mem_sem;
     adjustable_semaphore _inflight_sem;
     config::binding<size_t> _inflight_config_binding;

--- a/src/v/pandaproxy/test/kafka_client_cache.cc
+++ b/src/v/pandaproxy/test/kafka_client_cache.cc
@@ -71,9 +71,7 @@ SEASTAR_THREAD_TEST_CASE(cache_make_client_scram_sha_256) {
         // client without a principal
         pp::client_ptr client = client_cache.make_client(
           user, config::rest_authn_method::none);
-        BOOST_TEST(client->config().sasl_mechanism.value() == "");
-        BOOST_TEST(client->config().scram_username.value() == "");
-        BOOST_TEST(client->config().scram_password.value() == "");
+        BOOST_TEST(!client->get_credentials().has_value());
     }
 
     {
@@ -82,10 +80,9 @@ SEASTAR_THREAD_TEST_CASE(cache_make_client_scram_sha_256) {
         pp::client_ptr client = client_cache.make_client(
           user, config::rest_authn_method::http_basic);
         BOOST_TEST(
-          client->config().sasl_mechanism.value()
-          == ss::sstring{"SCRAM-SHA-256"});
-        BOOST_TEST(client->config().scram_username.value() == user.name);
-        BOOST_TEST(client->config().scram_password.value() == user.pass);
+          client->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-256"});
+        BOOST_TEST(client->get_credentials()->username == user.name);
+        BOOST_TEST(client->get_credentials()->password == user.pass);
     }
 }
 
@@ -99,9 +96,7 @@ SEASTAR_THREAD_TEST_CASE(cache_make_client_scram_sha_512) {
         // client without a principal
         pp::client_ptr client = client_cache.make_client(
           user, config::rest_authn_method::none);
-        BOOST_TEST(client->config().sasl_mechanism.value() == "");
-        BOOST_TEST(client->config().scram_username.value() == "");
-        BOOST_TEST(client->config().scram_password.value() == "");
+        BOOST_TEST(!client->get_credentials().has_value());
     }
 
     {
@@ -110,10 +105,9 @@ SEASTAR_THREAD_TEST_CASE(cache_make_client_scram_sha_512) {
         pp::client_ptr client = client_cache.make_client(
           user, config::rest_authn_method::http_basic);
         BOOST_TEST(
-          client->config().sasl_mechanism.value()
-          == ss::sstring{"SCRAM-SHA-512"});
-        BOOST_TEST(client->config().scram_username.value() == user.name);
-        BOOST_TEST(client->config().scram_password.value() == user.pass);
+          client->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-512"});
+        BOOST_TEST(client->get_credentials()->username == user.name);
+        BOOST_TEST(client->get_credentials()->password == user.pass);
     }
 }
 
@@ -131,17 +125,17 @@ SEASTAR_THREAD_TEST_CASE(cache_fetch_or_insert) {
       user, config::rest_authn_method::http_basic);
     pp::client_ptr client = item.first;
     BOOST_TEST(
-      client->config().sasl_mechanism.value() == ss::sstring{"SCRAM-SHA-256"});
-    BOOST_TEST(client->config().scram_username.value() == user.name);
-    BOOST_TEST(client->config().scram_password.value() == user.pass);
+      client->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-256"});
+    BOOST_TEST(client->get_credentials()->username == user.name);
+    BOOST_TEST(client->get_credentials()->password == user.pass);
 
     // Second fetch tests found path: user password did not change
     item = client_cache.get_client(user, config::rest_authn_method::http_basic);
     client = item.first;
     BOOST_TEST(
-      client->config().sasl_mechanism.value() == ss::sstring{"SCRAM-SHA-256"});
-    BOOST_TEST(client->config().scram_username.value() == user.name);
-    BOOST_TEST(client->config().scram_password.value() == user.pass);
+      client->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-256"});
+    BOOST_TEST(client->get_credentials()->username == user.name);
+    BOOST_TEST(client->get_credentials()->password == user.pass);
 
     pp::credential_t user2{user};
     user2.pass = "parrot";
@@ -151,13 +145,13 @@ SEASTAR_THREAD_TEST_CASE(cache_fetch_or_insert) {
       user2, config::rest_authn_method::http_basic);
     pp::client_ptr client2 = item.first;
     BOOST_TEST(
-      client2->config().sasl_mechanism.value() == ss::sstring{"SCRAM-SHA-256"});
-    BOOST_TEST(client2->config().scram_username.value() == user.name);
-    BOOST_TEST(client2->config().scram_password.value() == user2.pass);
+      client2->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-256"});
+    BOOST_TEST(client2->get_credentials()->username == user.name);
+    BOOST_TEST(client2->get_credentials()->password == user2.pass);
     BOOST_TEST(
-      client->config().sasl_mechanism.value() == ss::sstring{"SCRAM-SHA-256"});
-    BOOST_TEST(client->config().scram_username.value() == user.name);
-    BOOST_TEST(client->config().scram_password.value() == user2.pass);
+      client->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-256"});
+    BOOST_TEST(client->get_credentials()->username == user.name);
+    BOOST_TEST(client->get_credentials()->password == user2.pass);
 
     user2.name = "party";
     // Fourth fetch tests not-found path: cache.size == cache.max_size and cache
@@ -167,9 +161,9 @@ SEASTAR_THREAD_TEST_CASE(cache_fetch_or_insert) {
       user2, config::rest_authn_method::http_basic);
     client2 = item.first;
     BOOST_TEST(
-      client2->config().sasl_mechanism.value() == ss::sstring{"SCRAM-SHA-256"});
-    BOOST_TEST(client2->config().scram_username.value() == user2.name);
-    BOOST_TEST(client2->config().scram_password.value() == user2.pass);
+      client2->get_credentials()->mechanism == ss::sstring{"SCRAM-SHA-256"});
+    BOOST_TEST(client2->get_credentials()->username == user2.name);
+    BOOST_TEST(client2->get_credentials()->password == user2.pass);
     BOOST_TEST(client_cache.size() == s);
     BOOST_TEST(client_cache.max_size() == max_s);
 }

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -239,10 +239,11 @@ ss::future<> audit_client::set_client_credentials() {
         throw std::runtime_error(fmt::format(
           "Failed to fetch credential for principal: {}", audit_principal));
     }
-
-    _client.config().sasl_mechanism.set_value(pw.credential.mechanism());
-    _client.config().scram_username.set_value(pw.credential.user()());
-    _client.config().scram_password.set_value(pw.credential.password()());
+    _client.set_credentials(kafka::client::sasl_configuration{
+      .mechanism = pw.credential.mechanism(),
+      .username = pw.credential.user()(),
+      .password = pw.credential.password()(),
+    });
 }
 
 ss::future<> audit_client::configure() {
@@ -265,7 +266,7 @@ ss::future<> audit_client::configure() {
         /// client to refresh its metadata on a subsequent request.
         /// Explicitly set `client::config::retries` to its default value.
         /// We might want to make this tunable at some point.
-        _client.config().retries.reset();
+        _client.set_max_retries(5);
         vlog(adtlog.info, "Audit log client initialized");
     } catch (...) {
         vlog(


### PR DESCRIPTION
Previously the `configuraiton` object was a source of configuration for
every part of the Kafka client. It contained properties that were
connection specific, common retry settings but also very specific
consumer and producer settings. Additionally the configuration object
was an instance of `configuration_store` the abstraction that is
designed to hold application configuration.

Refactored Kafka client configuration management to separate connection,
producer and consumer specific setting into separate aggregates. This
way it is going to be easier to reuse parts of the client in other
projects. Additionally exposed api that allow changing the
configuration properties in runtime. Previously it wasn't clear which
properties can be modified during client operation.

Fixes: CORE-12244

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none