### PR TITLE
Return topic location information for outbound migration topics

### DIFF
--- a/src/v/cluster/data_migration_frontend.cc
+++ b/src/v/cluster/data_migration_frontend.cc
@@ -285,7 +285,10 @@ ss::future<result<id>> frontend::do_create_migration(data_migration migration) {
         create_migration_cmd_data{
           .id = id,
           .migration = std::move(migration),
-          .op_timestamp = model::timestamp::now()}),
+          .op_timestamp = model::timestamp::now(),
+          .fill_outbound_topic_locations = _features.is_active(
+            features::feature::topic_locations_in_outbound_migrations),
+        }),
       _operation_timeout + model::timeout_clock::now());
     if (ec) {
         co_return ec;

--- a/src/v/cluster/data_migration_table.cc
+++ b/src/v/cluster/data_migration_table.cc
@@ -198,6 +198,12 @@ migrations_table::apply(create_data_migration_cmd cmd) {
         co_return err->ec();
     }
 
+    if (auto* odm = std::get_if<outbound_migration>(&migration)) {
+        if (cmd.value.fill_outbound_topic_locations) {
+            fill_topic_locations(*odm);
+        }
+    }
+
     auto [it, success] = _migrations.try_emplace(
       id,
       migration_metadata{
@@ -320,6 +326,27 @@ migrations_table::validate_migrated_resources(
     }
 
     return std::nullopt;
+}
+
+void migrations_table::fill_topic_locations(outbound_migration& odm) const {
+    odm.topic_locations.reserve(odm.topics.size());
+    for (const auto& t : odm.topics) {
+        auto maybe_topic_md = _topics.local().get_topic_metadata_ref(t);
+        // Validated by validate_migrated_resources earlier.
+        vassert(
+          maybe_topic_md, "expecting topic {} to be present in topic table", t);
+        const auto& topic_md = maybe_topic_md->get();
+
+        auto location = topic_md.get_remote_location_hint().transform(
+          [](ss::sstring hint) {
+              return cloud_storage_location{.hint = std::move(hint)};
+          });
+
+        odm.topic_locations.push_back(topic_location{
+          .remote_topic = topic_md.get_configuration().remote_tp_ns(),
+          .location = std::move(location),
+        });
+    }
 }
 
 ss::future<std::error_code>

--- a/src/v/cluster/data_migration_table.h
+++ b/src/v/cluster/data_migration_table.h
@@ -139,6 +139,9 @@ private:
     std::optional<validation_error>
     validate_migrated_resources(const data_migration&) const;
 
+    // Assumes that migration topics have already been validated.
+    void fill_topic_locations(outbound_migration&) const;
+
 private:
     id _next_id{0};
     id _last_applied{};

--- a/src/v/cluster/data_migration_types.cc
+++ b/src/v/cluster/data_migration_types.cc
@@ -48,7 +48,9 @@ outbound_migration outbound_migration::copy() const {
       .topics = topics.copy(),
       .groups = groups.copy(),
       .copy_to = copy_to,
-      .auto_advance = auto_advance};
+      .auto_advance = auto_advance,
+      .topic_locations = topic_locations.copy(),
+    };
 }
 
 std::ostream& operator<<(std::ostream& o, state state) {
@@ -143,11 +145,13 @@ std::ostream& operator<<(std::ostream& o, const inbound_migration& dm) {
 std::ostream& operator<<(std::ostream& o, const outbound_migration& dm) {
     fmt::print(
       o,
-      "{{topics: {}, consumer_groups: {}, copy_to: {}, auto_advance: {}}}",
+      "{{topics: {}, consumer_groups: {}, copy_to: {}, auto_advance: {}, "
+      "topic_locations: {}}}",
       fmt::join(dm.topics, ", "),
       fmt::join(dm.groups, ", "),
       dm.copy_to,
-      dm.auto_advance);
+      dm.auto_advance,
+      fmt::join(dm.topic_locations, ", "));
     return o;
 }
 
@@ -197,10 +201,12 @@ std::ostream& operator<<(std::ostream& o, const data_migration_ntp_state& r) {
 std::ostream& operator<<(std::ostream& o, const create_migration_cmd_data& d) {
     fmt::print(
       o,
-      "{{id: {}, migration: {}, op_timestamp: {}}}",
+      "{{id: {}, migration: {}, op_timestamp: {}, "
+      "fill_outbound_topic_locations: {}}}",
       d.id,
       print_migration(d.migration),
-      d.op_timestamp);
+      d.op_timestamp,
+      d.fill_outbound_topic_locations);
     return o;
 }
 

--- a/src/v/cluster/data_migration_types.cc
+++ b/src/v/cluster/data_migration_types.cc
@@ -118,8 +118,15 @@ std::ostream& operator<<(std::ostream& o, const cloud_storage_location& l) {
     fmt::print(o, "{{hint: {}}}", l.hint);
     return o;
 }
+
 std::ostream& operator<<(std::ostream& o, const copy_target& t) {
     fmt::print(o, "{{bucket: {}}}", t.bucket);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const topic_location& tl) {
+    fmt::print(
+      o, "{{remote_topic: {}, location: {}}}", tl.remote_topic, tl.location);
     return o;
 }
 

--- a/src/v/cluster/data_migration_types.h
+++ b/src/v/cluster/data_migration_types.h
@@ -252,7 +252,7 @@ struct topic_location
 struct outbound_migration
   : serde::envelope<
       outbound_migration,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     // topics which ownership should be released
     chunked_vector<model::topic_namespace> topics;
@@ -263,11 +263,13 @@ struct outbound_migration
     std::optional<copy_target> copy_to;
     // run the migration through stages without explicit user action
     bool auto_advance = false;
+    // Topic locations. If not empty, must have the same size as topics.
+    chunked_vector<topic_location> topic_locations;
 
     outbound_migration copy() const;
 
     auto serde_fields() {
-        return std::tie(topics, groups, copy_to, auto_advance);
+        return std::tie(topics, groups, copy_to, auto_advance, topic_locations);
     }
 
     friend bool operator==(const outbound_migration&, const outbound_migration&)
@@ -379,13 +381,17 @@ struct data_migration_ntp_state
 struct create_migration_cmd_data
   : serde::envelope<
       create_migration_cmd_data,
-      serde::version<1>,
+      serde::version<2>,
       serde::compat_version<0>> {
     id id;
     data_migration migration;
     model::timestamp op_timestamp{};
+    bool fill_outbound_topic_locations = false;
 
-    auto serde_fields() { return std::tie(id, migration, op_timestamp); }
+    auto serde_fields() {
+        return std::tie(
+          id, migration, op_timestamp, fill_outbound_topic_locations);
+    }
     friend bool operator==(
       const create_migration_cmd_data&, const create_migration_cmd_data&)
       = default;

--- a/src/v/cluster/data_migration_types.h
+++ b/src/v/cluster/data_migration_types.h
@@ -139,6 +139,9 @@ struct cloud_storage_location
     operator==(const cloud_storage_location&, const cloud_storage_location&)
       = default;
 
+    friend std::ostream&
+    operator<<(std::ostream&, const cloud_storage_location&);
+
     auto serde_fields() { return std::tie(hint); }
 };
 
@@ -221,6 +224,25 @@ struct copy_target
 
     friend bool operator==(const copy_target&, const copy_target&) = default;
     friend std::ostream& operator<<(std::ostream&, const copy_target&);
+};
+
+// A struct with information needed to unambiguously find topic data in cloud
+// storage.
+struct topic_location
+  : serde::
+      envelope<topic_location, serde::version<0>, serde::compat_version<0>> {
+    // Topic name when its data was first written to cloud storage.
+    model::topic_namespace remote_topic;
+    // Location hint used to disambiguate between different topic instances.
+    // Empty for topics still using legacy (pre v24.2) cloud storage paths.
+    std::optional<cloud_storage_location> location;
+
+    auto serde_fields() { return std::tie(remote_topic, location); }
+
+    friend bool operator==(const topic_location&, const topic_location&)
+      = default;
+
+    friend std::ostream& operator<<(std::ostream&, const topic_location&);
 };
 
 /**

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -530,6 +530,17 @@ topic_metadata::get_remote_revision() const {
     return _fields.remote_revision;
 }
 
+std::optional<ss::sstring> topic_metadata::get_remote_location_hint() const {
+    const auto& remote_label = get_configuration().properties.remote_label;
+    if (!remote_label) {
+        return std::nullopt;
+    }
+
+    model::initial_revision_id remote_rev = get_remote_revision().value_or(
+      model::initial_revision_id{get_revision()});
+    return fmt::format("{}/{}", remote_label->cluster_uuid, remote_rev);
+}
+
 const topic_configuration& topic_metadata::get_configuration() const {
     return _fields.configuration;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2613,6 +2613,11 @@ public:
 
     model::revision_id get_revision() const;
     std::optional<model::initial_revision_id> get_remote_revision() const;
+    // Returns location hint that can be passed to topic_manifest_downloader to
+    // disambiguate topic instances in cloud storage. Has the following form:
+    // "<remote label>/<remote revision id>".
+    // Nullopt will be returned for legacy topics without a remote label.
+    std::optional<ss::sstring> get_remote_location_hint() const;
 
     const topic_metadata_fields& get_fields() const { return _fields; }
     topic_metadata_fields& get_fields() { return _fields; }

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -110,6 +110,8 @@ std::string_view to_string_view(feature f) {
         return "kafka_data_rpc";
     case feature::panda_linking_dr:
         return "panda_linking_dr";
+    case feature::topic_locations_in_outbound_migrations:
+        return "topic_locations_in_outbound_migrations";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -39,6 +39,7 @@ struct feature_table_snapshot;
 /// has been made available by another feature being retired.
 enum class feature : std::uint64_t {
     panda_linking_dr = 1ULL << 1U,
+    topic_locations_in_outbound_migrations = 1ULL << 2U,
     cloud_retention = 1ULL << 11U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
@@ -457,6 +458,12 @@ inline constexpr std::array feature_schema{
     "panda_linking_dr",
     feature::panda_linking_dr,
     feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v25_2_1,
+    "topic_locations_in_outbound_migrations",
+    feature::topic_locations_in_outbound_migrations,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };
 

--- a/src/v/redpanda/admin/api-doc/migration.def.json
+++ b/src/v/redpanda/admin/api-doc/migration.def.json
@@ -42,6 +42,26 @@
         }
     }
 },
+"outbound_topic": {
+    "type": "object",
+    "required": [
+        "topic"
+    ],
+    "properties": {
+        "topic": {
+            "type": "string",
+            "description": "Topic name"
+        },
+        "ns": {
+            "type": "string",
+            "description": "Topic namespace. If not present it is assumed that topic is in the \"kafka\" namespace"
+        },
+        "remote_location": {
+            "description": "Location of the form <original topic name>/<original cluster uuid>/<original revision id> used to find topic data in cloud storage. Can be used directly as source_topic_reference.topic field in inbound_topic.",
+            "type": "string"
+        }
+    }
+},
 "outbound_migration": {
     "type": "object",
     "required": [
@@ -58,7 +78,7 @@
             "type": "array",
             "description": "List of migrated topics",
             "items": {
-                "$ref": "namespaced_topic"
+                "$ref": "outbound_topic"
             }
         },
         "consumer_groups": {

--- a/src/v/redpanda/admin/migrations.cc
+++ b/src/v/redpanda/admin/migrations.cc
@@ -59,6 +59,19 @@ ss::httpd::migration_json::namespaced_topic to_admin_type(
     return ret;
 }
 
+ss::httpd::migration_json::outbound_topic to_admin_type(
+  const model::topic_namespace& tp_ns,
+  const cluster::data_migrations::topic_location* tp_loc) {
+    ss::httpd::migration_json::outbound_topic ret;
+    ret.ns = tp_ns.ns;
+    ret.topic = tp_ns.tp;
+    if (tp_loc && tp_loc->location) {
+        ret.remote_location = ssx::sformat(
+          "{}/{}", tp_loc->remote_topic.tp, tp_loc->location->hint);
+    }
+    return ret;
+}
+
 ss::httpd::migration_json::inbound_migration
 to_admin_type(const cluster::data_migrations::inbound_migration& idm) {
     ss::httpd::migration_json::inbound_migration migration;
@@ -87,8 +100,21 @@ to_admin_type(const cluster::data_migrations::outbound_migration& odm) {
     using migration_type_enum = ss::httpd::migration_json::outbound_migration::
       outbound_migration_migration_type;
     migration.migration_type = migration_type_enum::outbound;
-    for (auto& t : odm.topics) {
-        migration.topics.push(to_admin_type(t));
+
+    if (!(odm.topic_locations.empty()
+          || odm.topic_locations.size() == odm.topics.size())) {
+        // topic_locations should be either empty (written by pre-v25.2
+        // redpanda) or have the same size as topics
+        throw std::runtime_error(fmt::format(
+          "unexpected migration topic locations size: {}, expected: {}",
+          odm.topic_locations.size(),
+          odm.topics.size()));
+    }
+
+    for (size_t i = 0; i < odm.topics.size(); ++i) {
+        const auto* loc = !odm.topic_locations.empty() ? &odm.topic_locations[i]
+                                                       : nullptr;
+        migration.topics.push(to_admin_type(odm.topics[i], loc));
     }
     for (auto& cg : odm.groups) {
         migration.consumer_groups.push(cg);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -322,41 +322,24 @@ class OutboundDataMigration:
 
 class InboundTopic:
     def __init__(self,
-                 topic_name: NamespacedTopic,
-                 alias: NamespacedTopic | None = None,
-                 cluster_uuid: str | None = None,
-                 remote_revision: int | None = None):
-        if remote_revision is not None:
-            assert cluster_uuid
+                 source_topic_reference: NamespacedTopic,
+                 alias: NamespacedTopic | None = None):
+        """
+        source_topic_reference is the topic location in cloud storage.
+        source_topic_reference.topic can be just a topic name (if there is just one instance
+        of topic data in cloud storage), or a full location of the form
+        "<original topic name>/<original cluster uuid>/<original revision>".
 
-        self.topic_name = topic_name
+        alias is the name of the topic that will be created in the cluster
+        (if None, name from source_topic_reference is used).
+        """
+
+        self.source_topic_reference = source_topic_reference
         self.alias = alias
-        self.cluster_uuid = cluster_uuid
-        self.remote_revision = remote_revision
-
-    def location_hint(self):
-        """
-        A hint allowing to disambiguate different instances of topic data
-        in cloud storage when mounting a topic.
-        """
-
-        if self.remote_revision is not None:
-            return f"{self.cluster_uuid}/{self.remote_revision}"
-        elif self.cluster_uuid is not None:
-            return self.cluster_uuid
-        else:
-            return ""
-
-    def source_topic_reference(self):
-        ret = copy.copy(self.topic_name)
-        location_hint = self.location_hint()
-        if location_hint:
-            ret.topic += "/" + location_hint
-        return ret
 
     def as_dict(self):
         d = {
-            'source_topic_reference': self.source_topic_reference().as_dict(),
+            'source_topic_reference': self.source_topic_reference.as_dict(),
         }
         if self.alias:
             d['alias'] = self.alias.as_dict()

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -1254,9 +1254,25 @@ class DataMigrationsMultiClusterTest(RedpandaTest, DataMigrationTestMixin):
         Test that basic functionality like producing and consuming works when we
         migrate topics between different clusters.
         """
+
+        # After-test cloud storage integrity checker gets confused by topic aliases,
+        # so disable it. TODO: support it properly in the checker.
+        self.redpanda.si_settings.set_expected_damage(
+            {"ntr_no_topic_manifest", "missing_segments"})
+
         n_partitions = 10
-        workload_topic = TopicSpec(name="foo", partition_count=n_partitions)
-        workload_ns_topic = make_namespaced_topic(workload_topic.name)
+        topic_name = "foo"
+        workload_topic = TopicSpec(name=topic_name,
+                                   partition_count=n_partitions)
+        workload_ns_topic = make_namespaced_topic(topic_name)
+
+        alias_name = topic_name + "-alias"
+        alias_ns_topic = make_namespaced_topic(alias_name)
+
+        # To test various combinations of remote location and topic name being
+        # same/different from local cluster uuid and topic name, we test the
+        # following scenario:
+        # foo (cluster 1) -> foo-alias (cluster 2) -> foo-alias (cluster 3)
 
         dest_redpanda = self.start_extra_cluster()
 
@@ -1264,18 +1280,21 @@ class DataMigrationsMultiClusterTest(RedpandaTest, DataMigrationTestMixin):
         self.logger.info(f"created topic {workload_topic}")
 
         self.start_producer(workload_topic.name, self.redpanda)
-        self.migrate_between_clusters([workload_ns_topic], self.redpanda,
-                                      dest_redpanda)
+        self.migrate_between_clusters([workload_ns_topic],
+                                      self.redpanda,
+                                      dest_redpanda,
+                                      aliases=[alias_ns_topic])
         total_acked = self.stop_producer()
 
-        def wait_for_offsets(redpanda, expected):
+        def wait_for_offsets(redpanda, topic_name, expected):
             def predicate():
                 rpk = RpkTool(redpanda)
-                partitions = list(rpk.describe_topic(workload_topic.name))
+                partitions = list(rpk.describe_topic(topic_name))
                 if len(partitions) != n_partitions:
                     return False
                 total = sum(p.high_watermark for p in partitions)
-                self.logger.info(f"offsets: {total=}, {expected=}")
+                self.logger.info(
+                    f"topic {topic_name} offsets: {total=}, {expected=}")
                 return total == expected
 
             wait_until(
@@ -1284,27 +1303,27 @@ class DataMigrationsMultiClusterTest(RedpandaTest, DataMigrationTestMixin):
                 backoff_sec=1,
                 err_msg="timed out waiting for offsets of migrated topic")
 
-        wait_for_offsets(dest_redpanda, total_acked)
+        wait_for_offsets(dest_redpanda, alias_name, total_acked)
 
         self.logger.info("producing more to the second cluster")
-        self.start_producer(workload_topic.name, dest_redpanda)
+        self.start_producer(alias_name, dest_redpanda)
 
-        self.consume(workload_topic.name,
+        self.consume(alias_name,
                      redpanda=dest_redpanda,
                      msg_count=total_acked +
                      self.producer.produce_status.acked)
 
         another_redpanda = self.start_extra_cluster()
-        self.migrate_between_clusters([workload_ns_topic], dest_redpanda,
+        self.migrate_between_clusters([alias_ns_topic], dest_redpanda,
                                       another_redpanda)
 
         total_acked += self.stop_producer()
-        wait_for_offsets(another_redpanda, total_acked)
+        wait_for_offsets(another_redpanda, alias_name, total_acked)
 
         self.logger.info("producing more to the third cluster")
-        self.start_producer(workload_topic.name, another_redpanda)
+        self.start_producer(alias_name, another_redpanda)
         total_acked += self.stop_producer()
 
-        self.consume(workload_topic.name,
+        self.consume(alias_name,
                      redpanda=another_redpanda,
                      msg_count=total_acked)

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -516,7 +516,8 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                 self.toggle_license(on=False)
             self.check_migrations(in_migration_id, len(inbound_topics), 2)
 
-            self.log_topics(t.topic_name.topic for t in inbound_topics)
+            self.log_topics(t.source_topic_reference.topic
+                            for t in inbound_topics)
 
             self.execute_data_migration_action_flaky(in_migration_id,
                                                      MigrationAction.prepare)
@@ -583,9 +584,10 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
         # mount and consume from them in random order
         cluster_uuid = self.admin.get_cluster_uuid(self.redpanda.nodes[0])
         for i in sorted(range(3), key=lambda element: random.random()):
-            in_topic = InboundTopic(ns_topic,
-                                    cluster_uuid=cluster_uuid,
-                                    remote_revision=revisions[i])
+            # TODO: the proper way to get the source_topic_reference is to use the info
+            # provided by outbound migration json.
+            source_topic_ref = f"{ns_topic.topic}/{cluster_uuid}/{revisions[i]}"
+            in_topic = InboundTopic(make_namespaced_topic(source_topic_ref))
             in_migr_id = self.admin.mount_topics([in_topic]).json()["id"]
             self.wait_partitions_appear([topic])
             self.wait_migration_disappear(in_migr_id)
@@ -635,7 +637,7 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
             for i, t in enumerate(topics[:3])
         ]
         inbound_topics_spec = [
-            TopicSpec(name=(it.alias or it.topic_name).topic,
+            TopicSpec(name=(it.alias or it.source_topic_reference).topic,
                       partition_count=3) for it in inbound_topics
         ]
         reply = self.admin.mount_topics(inbound_topics).json()
@@ -996,10 +998,9 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
             remounted = False
             # two cycles max: to cancel halfway and to complete + check e2e
             while not remounted:
-                in_migration = InboundDataMigration(topics=[
-                    InboundTopic(topic_name=workload_ns_topic, alias=alias)
-                ],
-                                                    consumer_groups=[])
+                in_migration = InboundDataMigration(
+                    topics=[InboundTopic(workload_ns_topic, alias=alias)],
+                    consumer_groups=[])
                 in_migration_id = self.create_and_wait(in_migration)
 
                 # check if topic that is being migrated can not be created even if

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -230,10 +230,16 @@ class DataMigrationTestMixin:
                for state in states):
             self.assure_not_deletable(id, redpanda=redpanda)
 
-    def migrate_between_clusters(self, topics: list[NamespacedTopic],
-                                 source: RedpandaService,
-                                 dest: RedpandaService) -> None:
+    def migrate_between_clusters(
+            self,
+            topics: list[NamespacedTopic],
+            source: RedpandaService,
+            dest: RedpandaService,
+            aliases: list[NamespacedTopic] | None = None) -> None:
         assert source != dest
+
+        if aliases is not None:
+            assert len(aliases) == len(topics)
 
         out_migration = OutboundDataMigration(topics=topics,
                                               consumer_groups=[])
@@ -253,7 +259,7 @@ class DataMigrationTestMixin:
                                         namespace=out_topic_json.get("ns"))
             in_topic = NamespacedTopic(topic=out_topic_json["remote_location"],
                                        namespace=out_topic.ns)
-            alias = out_topic
+            alias = out_topic if aliases is None else aliases[i]
             in_topics.append(
                 InboundTopic(source_topic_reference=in_topic, alias=alias))
 

--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -242,23 +242,23 @@ class DataMigrationTestMixin:
         source.logger.info(
             f"created outbound migration, id {out_migration_id}")
 
-        # TODO: Outbound migrations should provide a better way of determining
-        # location hints for migrated topic instances. Currently if we don't know the
-        # originating cluster UUID, we can't determine the location hint at all.
-        # Here we assume that the topic was first created on self.redpanda.
-        # Getting the remote revision by calling an unrelated API is inefficient
-        # and awkward as well.
-        orig_cluster_uuid = self.redpanda._admin.get_cluster_uuid()
-        in_topics = []
-        for topic in topics:
-            anomalies = source._admin.get_cloud_storage_anomalies(
-                namespace="kafka", topic=topic.topic, partition=0)
-            remote_revision_id = anomalies["revision_id"]
+        out_migration = source._admin.get_data_migration(
+            out_migration_id).json()
+        assert len(out_migration["migration"]["topics"]) == len(topics)
 
+        in_topics = []
+        for i, out_topic_json in enumerate(
+                out_migration["migration"]["topics"]):
+            out_topic = NamespacedTopic(topic=out_topic_json["topic"],
+                                        namespace=out_topic_json.get("ns"))
+            in_topic = NamespacedTopic(topic=out_topic_json["remote_location"],
+                                       namespace=out_topic.ns)
+            alias = out_topic
             in_topics.append(
-                InboundTopic(topic,
-                             cluster_uuid=orig_cluster_uuid,
-                             remote_revision=remote_revision_id))
+                InboundTopic(source_topic_reference=in_topic, alias=alias))
+
+            self.logger.debug(
+                f"topic for inbound migration: {in_topics[-1].as_dict()}")
 
         in_migration = InboundDataMigration(topics=in_topics,
                                             consumer_groups=[])


### PR DESCRIPTION
* save topic location information to migrations table when the migration is created
* return it via Admin API for the clients to use when creating inbound migrations

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
