### PR TITLE
[CORE-8321] bazel/openssl-fips: remove activate flag for fips

### DIFF
--- a/bazel/thirdparty/openssl-fips.BUILD
+++ b/bazel/thirdparty/openssl-fips.BUILD
@@ -68,7 +68,7 @@ genrule(
     name = "fipsmodule_cnf",
     srcs = [":gen_dir"],
     outs = ["fipsmodule.cnf"],
-    cmd = "cp -L $(SRCS)/etc/ssl/fipsmodule.cnf $@",
+    cmd = "cp -L $(SRCS)/etc/ssl/fipsmodule.cnf $@ && sed -i '/activate = 1/d' $@",
     visibility = [
         "//visibility:public",
     ],


### PR DESCRIPTION
Implements: [CORE-8321](https://redpandadata.atlassian.net/browse/CORE-8321)

As described above

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none



[CORE-8321]: https://redpandadata.atlassian.net/browse/CORE-8321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ