### PR TITLE
rptest: collect usage stats only from started nodes

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4174,9 +4174,11 @@ class RedpandaService(RedpandaServiceBase):
             "vectorized_storage_log_batches_written")
 
     def stop_node(self, node, timeout=None, forced=False):
-        # collect usage stats before the node is stopped, the usage stats
-        # accumulate metrics from all the nodes before they are stopped.
-        self._update_usage_stats(node)
+        if node in self._started:
+            # collect usage stats before the node is stopped, the usage stats
+            # accumulate metrics from all the nodes before they are stopped.
+            self._update_usage_stats(node)
+
         # Assume node is stopped once we enter this path. If stopping succeeds
         # it is the obvious thing to do. If stopping fails we can't differentiate
         # between a node that stopped or will eventually stop so for all intents


### PR DESCRIPTION
stop_node is called before start_node as a cleanup mechanism

This causes the following warning `Cannot check metrics - Node docker-rp-1 is not started`

Using _started we can detect if the node we are currently stopping was previously started and try to update usage stats only if that is the case.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
