### PR TITLE
archival: Ensure that skip_offset_range only appears in reupload mode

### DIFF
--- a/src/v/cluster/archival/archival_policy.cc
+++ b/src/v/cluster/archival/archival_policy.cc
@@ -74,6 +74,7 @@ ss::future<segment_collector_stream_result> archival_policy::get_next_segment(
       force_upload);
 
     segment_collector segment_collector{
+      segment_collector_mode::new_upload,
       begin_inclusive,
       manifest,
       *log,
@@ -83,7 +84,7 @@ ss::future<segment_collector_stream_result> archival_policy::get_next_segment(
       end_exclusive,
       flush_offset};
 
-    segment_collector.collect_segments(segment_collector_mode::new_upload);
+    segment_collector.collect_segments();
     if (!segment_collector.segment_ready_for_upload()) {
         co_return candidate_creation_error::no_segments_collected;
     }
@@ -109,6 +110,7 @@ archival_policy::get_next_compacted_segment(
         co_return candidate_creation_error::no_segments_collected;
     }
     segment_collector compacted_segment_collector{
+      segment_collector_mode::compacted_reupload,
       begin_inclusive,
       manifest,
       *log,

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3309,8 +3309,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
           log,
           run->meta.size_bytes,
           run->meta.committed_offset);
-        collector.collect_segments(
-          segment_collector_mode::non_compacted_reupload);
+        collector.collect_segments();
         auto candidate = co_await collector.make_upload_candidate_stream(
           _conf->segment_upload_timeout());
 

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3303,6 +3303,7 @@ ntp_archiver::find_reupload_candidate(manifest_scanner_t scanner) {
         auto log_generic = _parent.log();
         auto& log = *log_generic;
         segment_collector collector(
+          segment_collector_mode::non_compacted_reupload,
           run->meta.base_offset,
           manifest(),
           log,

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -203,8 +203,8 @@ static bool is_reupload_mode(segment_collector_mode mode) {
 }
 } // namespace
 
-void segment_collector::collect_segments(segment_collector_mode mode) {
-    if (_manifest.size() == 0 && is_reupload_mode(mode)) {
+void segment_collector::collect_segments() {
+    if (_manifest.size() == 0 && is_reupload_mode(_mode)) {
         vlog(
           archival_log.debug,
           "No segments to collect for ntp {}, manifest empty",
@@ -215,7 +215,7 @@ void segment_collector::collect_segments(segment_collector_mode mode) {
     // start_offset < log start due to eviction of segments before
     // they could be uploaded, skip forward to log start.
     if (_begin_inclusive < _log.offsets().start_offset) {
-        switch (mode) {
+        switch (_mode) {
         case segment_collector_mode::new_upload:
         case segment_collector_mode::compacted_reupload:
             vlog(
@@ -244,7 +244,7 @@ void segment_collector::collect_segments(segment_collector_mode mode) {
 
     // Handle begin offset alignment to manifest segment boundary (if
     // required).
-    switch (mode) {
+    switch (_mode) {
     case segment_collector_mode::compacted_reupload:
         align_begin_offset_to_manifest();
         break;
@@ -274,7 +274,7 @@ void segment_collector::collect_segments(segment_collector_mode mode) {
     }
 
     if (
-      is_reupload_mode(mode)
+      is_reupload_mode(_mode)
       && _begin_inclusive >= _manifest.get_last_offset()) {
         vlog(
           archival_log.warn,
@@ -299,7 +299,7 @@ void segment_collector::collect_segments(segment_collector_mode mode) {
             return;
         }
         if (
-          is_reupload_mode(mode)
+          is_reupload_mode(_mode)
           && _target_end_inclusive.value() > _manifest.get_last_offset()) {
             vlog(
               archival_log.debug,
@@ -312,18 +312,18 @@ void segment_collector::collect_segments(segment_collector_mode mode) {
         }
     }
 
-    do_collect(mode);
+    do_collect();
 }
 
 segment_collector::segment_seq segment_collector::segments() {
     return _segments;
 }
 
-void segment_collector::do_collect(segment_collector_mode mode) {
+void segment_collector::do_collect() {
     auto projected_end_inclusive = _target_end_inclusive.value_or(
       model::offset{});
     if (projected_end_inclusive == model::offset{}) {
-        projected_end_inclusive = find_replacement_boundary(mode);
+        projected_end_inclusive = find_replacement_boundary(_mode);
     }
     // In case of the new upload:
     // - _target_end_inclusive is not set means that the upload is not forced
@@ -355,7 +355,7 @@ void segment_collector::do_collect(segment_collector_mode mode) {
           = _segments.empty()
               ? model::offset{}
               : _segments.back()->offsets().get_committed_offset();
-        switch (mode) {
+        switch (_mode) {
         case segment_collector_mode::compacted_reupload:
         case segment_collector_mode::non_compacted_reupload:
             return last_collected <= _manifest.get_last_offset();
@@ -368,7 +368,7 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         // which is above the _manifest.get_last_offset().
         // Otherwise, we need to find the next segment which is below the
         // _manifest.get_last_offset().
-        auto result = find_next_segment(start, mode);
+        auto result = find_next_segment(start, _mode);
         if (result.segment.get() == nullptr) {
             break;
         }
@@ -418,7 +418,7 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         // re-aligned if it falls inside manifest segment.
         if (
           _segments.empty()
-          && mode == segment_collector_mode::compacted_reupload) {
+          && _mode == segment_collector_mode::compacted_reupload) {
             // We may have found our first segment, but we can't always use
             // its base offset:
             // - it's possible the log has been prefix truncated within a
@@ -467,7 +467,7 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         _can_replace_manifest_segment = true;
     }
 
-    if (is_reupload_mode(mode)) {
+    if (is_reupload_mode(_mode)) {
         align_end_offset_to_manifest(
           _target_end_inclusive.value_or(last_collected));
     } else {

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -953,10 +953,15 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
           _end_inclusive,
           tail_seek.offset_inside_batch,
           tail_seek.offset);
-        co_return skip_offset_range{
-          .begin_offset = _begin_inclusive,
-          .end_offset = _end_inclusive,
-          .reason = candidate_creation_error::offset_inside_batch};
+        if (is_reupload_mode(_mode)) {
+            co_return skip_offset_range{
+              .begin_offset = _begin_inclusive,
+              .end_offset = _end_inclusive,
+              .reason = candidate_creation_error::offset_inside_batch};
+        } else {
+            // This should never occur, but return an error here just in case.
+            co_return candidate_creation_error::offset_inside_batch;
+        }
     }
 
     vlog(
@@ -1000,9 +1005,11 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
     // is smaller than that of the replaced one. Skip the upload if that's
     // not the case.
     if (auto to_replace = _manifest.find(starting_offset);
-        to_replace != _manifest.end()
-        && to_replace->committed_offset == final_offset) {
-        if (to_replace->size_bytes <= content_length) {
+        to_replace != _manifest.end()) {
+        if (
+          is_reupload_mode(_mode)
+          && to_replace->committed_offset == final_offset
+          && to_replace->size_bytes <= content_length) {
             vlog(
               archival_log.debug,
               "Skipping re-upload of compacted segment as its size has "
@@ -1013,6 +1020,13 @@ ss::future<candidate_creation_result> segment_collector::make_upload_candidate(
               .begin_offset = _begin_inclusive,
               .end_offset = _end_inclusive,
               .reason = candidate_creation_error::upload_size_unchanged};
+        }
+        if (!is_reupload_mode(_mode)) {
+            vlog(
+              archival_log.debug,
+              "New segment upload already appears in manifest: {}",
+              _segments.front());
+            co_return candidate_creation_error::concurrency_error;
         }
     }
 

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -161,6 +161,7 @@ operator<<(std::ostream& os, const skip_offset_range& skip_range) {
 }
 
 segment_collector::segment_collector(
+  segment_collector_mode mode,
   model::offset begin_inclusive,
   const cloud_storage::partition_manifest& manifest,
   const storage::log& log,
@@ -175,15 +176,18 @@ segment_collector::segment_collector(
   , _target_end_inclusive(end_inclusive)
   , _collected_size(0)
   , _end_exclusive(end_exclusive)
-  , _flush_offset(flush_offset) {}
+  , _flush_offset(flush_offset)
+  , _mode(mode) {}
 
 segment_collector::segment_collector(
+  segment_collector_mode mode,
   model::offset begin_inclusive,
   const cloud_storage::partition_manifest& manifest,
   const storage::log& log,
   size_t max_uploaded_segment_size,
   std::optional<model::offset> end_inclusive)
   : segment_collector(
+      mode,
       begin_inclusive,
       manifest,
       log,

--- a/src/v/cluster/archival/segment_reupload.h
+++ b/src/v/cluster/archival/segment_reupload.h
@@ -172,8 +172,7 @@ public:
     ///
     /// \param mode defines what segments should be collected
     ///        compacted or normal.
-    void collect_segments(
-      segment_collector_mode mode = segment_collector_mode::compacted_reupload);
+    void collect_segments();
 
     segment_seq segments();
 
@@ -219,7 +218,7 @@ private:
 
     /// Collects segments until the end of the manifest, or until the
     /// end of compacted segments in log.
-    void do_collect(segment_collector_mode mode);
+    void do_collect();
 
     lookup_result
     find_next_segment(model::offset start_offset, segment_collector_mode mode);

--- a/src/v/cluster/archival/segment_reupload.h
+++ b/src/v/cluster/archival/segment_reupload.h
@@ -138,6 +138,7 @@ public:
     using sizes_seq = std::vector<uint64_t>;
 
     segment_collector(
+      segment_collector_mode mode,
       model::offset begin_inclusive,
       const cloud_storage::partition_manifest& manifest,
       const storage::log& log,
@@ -158,6 +159,7 @@ public:
     /// \param flush_offset offset specified by a flush operation upstream,
     ///        has no effect in reupload mode
     segment_collector(
+      segment_collector_mode mode,
       model::offset begin_inclusive,
       const cloud_storage::partition_manifest& manifest,
       const storage::log& log,
@@ -257,6 +259,7 @@ private:
     size_t _collected_size;
     std::optional<model::offset> _end_exclusive;
     std::optional<model::offset> _flush_offset;
+    segment_collector_mode _mode;
 };
 
 } // namespace archival

--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -1451,7 +1451,7 @@ SEASTAR_THREAD_TEST_CASE(test_adjacent_segment_collection) {
       12001752,
       model::offset{115}};
 
-    collector.collect_segments(segment_collector_mode::non_compacted_reupload);
+    collector.collect_segments();
     auto candidate = require_upload_candidate(
       collector.make_upload_candidate(10s).get());
     BOOST_REQUIRE_EQUAL(
@@ -1652,7 +1652,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_concurrent_compaction) {
       max_upload_size,
       model::offset{39}};
 
-    collector.collect_segments(segment_collector_mode::non_compacted_reupload);
+    collector.collect_segments();
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive(), model::offset{10});
     BOOST_REQUIRE_EQUAL(collector.end_inclusive(), model::offset{39});
 
@@ -1741,7 +1741,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size};
 
-    collector1.collect_segments(segment_collector_mode::new_upload);
+    collector1.collect_segments();
     BOOST_REQUIRE_EQUAL(collector1.begin_inclusive(), model::offset{00});
     BOOST_REQUIRE_EQUAL(collector1.end_inclusive(), model::offset{19});
     validate_non_compacted_collector(collector1);
@@ -1754,7 +1754,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size};
 
-    collector2.collect_segments(segment_collector_mode::new_upload);
+    collector2.collect_segments();
     BOOST_REQUIRE_EQUAL(collector2.begin_inclusive(), model::offset{20});
     BOOST_REQUIRE_EQUAL(collector2.end_inclusive(), model::offset{29});
     validate_non_compacted_collector(collector2);
@@ -1768,7 +1768,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size};
 
-    collector3.collect_segments(segment_collector_mode::new_upload);
+    collector3.collect_segments();
     BOOST_REQUIRE(!collector3.segment_ready_for_upload());
     validate_non_compacted_collector(collector3);
 
@@ -1783,7 +1783,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size,
       model::offset{39}};
-    collector4.collect_segments(segment_collector_mode::new_upload);
+    collector4.collect_segments();
     BOOST_REQUIRE(collector4.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector4.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector4.end_inclusive(), model::offset{39});
@@ -1803,7 +1803,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size,
       model::offset{42}};
-    collector5.collect_segments(segment_collector_mode::new_upload);
+    collector5.collect_segments();
     BOOST_REQUIRE(collector5.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector5.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector5.end_inclusive(), model::offset{42});
@@ -1818,7 +1818,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size,
       model::offset{42}};
-    collector6.collect_segments(segment_collector_mode::new_upload);
+    collector6.collect_segments();
     BOOST_REQUIRE(collector6.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector6.begin_inclusive(), model::offset{8});
     BOOST_REQUIRE_EQUAL(collector6.end_inclusive(), model::offset{42});
@@ -1832,7 +1832,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       max_upload_size,
       model::offset{45}};
-    collector7.collect_segments(segment_collector_mode::new_upload);
+    collector7.collect_segments();
     BOOST_REQUIRE(collector7.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector7.begin_inclusive(), model::offset{42});
     BOOST_REQUIRE_EQUAL(collector7.end_inclusive(), model::offset{45});
@@ -1848,7 +1848,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       m,
       b.get_disk_log_impl(),
       first_segment_size};
-    collector8.collect_segments(segment_collector_mode::new_upload);
+    collector8.collect_segments();
     BOOST_REQUIRE(collector8.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector8.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector8.end_inclusive(), model::offset{19});
@@ -1863,7 +1863,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       first_segment_size,
       model::offset{42} /*this will be ignored*/};
-    collector9.collect_segments(segment_collector_mode::new_upload);
+    collector9.collect_segments();
     BOOST_REQUIRE(collector9.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector9.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector9.end_inclusive(), model::offset{19});
@@ -1879,7 +1879,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
       b.get_disk_log_impl(),
       first_segment_size,
       model::offset{42} /*this will be ignored*/};
-    collector10.collect_segments(segment_collector_mode::new_upload);
+    collector10.collect_segments();
     BOOST_REQUIRE(collector10.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector10.begin_inclusive(), model::offset{18});
     BOOST_REQUIRE_EQUAL(collector10.end_inclusive(), model::offset{19});
@@ -1924,7 +1924,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
       b.get_disk_log_impl(),
       max_upload_size};
 
-    collector1.collect_segments(segment_collector_mode::new_upload);
+    collector1.collect_segments();
     BOOST_REQUIRE_EQUAL(collector1.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector1.end_inclusive(), model::offset{0});
     BOOST_REQUIRE(collector1.segment_ready_for_upload());
@@ -1937,7 +1937,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
       m,
       b.get_disk_log_impl(),
       max_upload_size};
-    collector2.collect_segments(segment_collector_mode::new_upload);
+    collector2.collect_segments();
     BOOST_REQUIRE_EQUAL(collector2.begin_inclusive(), model::offset{1});
     BOOST_REQUIRE_EQUAL(collector2.end_inclusive(), model::offset{1});
     BOOST_REQUIRE(collector2.segment_ready_for_upload());
@@ -1950,7 +1950,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
       m,
       b.get_disk_log_impl(),
       max_upload_size};
-    collector3.collect_segments(segment_collector_mode::new_upload);
+    collector3.collect_segments();
     BOOST_REQUIRE(!collector3.segment_ready_for_upload());
     validate_non_compacted_collector(collector3);
 
@@ -1963,7 +1963,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
       b.get_disk_log_impl(),
       max_upload_size,
       model::offset{2}};
-    collector4.collect_segments(segment_collector_mode::new_upload);
+    collector4.collect_segments();
     BOOST_REQUIRE_EQUAL(collector4.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector4.end_inclusive(), model::offset{2});
     BOOST_REQUIRE(collector4.segment_ready_for_upload());
@@ -1981,7 +1981,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
       b.get_disk_log_impl(),
       max_upload_size,
       model::offset{3}};
-    collector5.collect_segments(segment_collector_mode::new_upload);
+    collector5.collect_segments();
     BOOST_REQUIRE_EQUAL(collector5.begin_inclusive(), model::offset{0});
     BOOST_REQUIRE_EQUAL(collector5.end_inclusive(), model::offset{3});
     BOOST_REQUIRE(collector5.segment_ready_for_upload());
@@ -2163,8 +2163,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_fuzz) {
             * 10, // Make sure the size limit is not affecting anything
           end_bound.max()};
 
-        closed_range_collector.collect_segments(
-          segment_collector_mode::new_upload);
+        closed_range_collector.collect_segments();
 
         validate_non_compacted_collector(closed_range_collector);
         check_upload_candidate(
@@ -2220,8 +2219,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_fuzz) {
           expected_size,
           std::nullopt};
 
-        open_range_collector.collect_segments(
-          segment_collector_mode::new_upload);
+        open_range_collector.collect_segments();
         validate_non_compacted_collector(open_range_collector);
         check_upload_candidate(
           open_range_collector, start_bound, end_bound, expected_size);

--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -2225,3 +2225,43 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_fuzz) {
           open_range_collector, start_bound, end_bound, expected_size);
     }
 }
+
+SEASTAR_THREAD_TEST_CASE(test_new_segment_never_skip_offsets) {
+    // Start with empty manifest and try to upload
+    cloud_storage::partition_manifest m(
+      model::ntp{"test_ns", "test_tpc", 0}, model::initial_revision_id{0});
+
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+    b | start(ntp_config{{"test_ns", "test_tpc", 0}, {data_path}});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    populate_log(
+      b,
+      {.segment_starts = {0, 20},
+       .compacted_segment_indices = {},
+       .last_segment_num_records = 10});
+
+    {
+        // with a clean manifest, we should be able to upload the segment, but
+        // the begin offset lands inside a batch.
+        archival::segment_collector collector{
+          segment_collector_mode::new_upload,
+          model::offset{10},
+          m,
+          b.get_disk_log_impl(),
+          max_upload_size,
+          model::offset{19},
+        };
+        collector.collect_segments();
+
+        auto c = collector.make_upload_candidate_stream(1s).get();
+        BOOST_REQUIRE(std::holds_alternative<candidate_creation_error>(c));
+        BOOST_REQUIRE(
+          std::get<candidate_creation_error>(c)
+          == candidate_creation_error::offset_inside_batch);
+    }
+}

--- a/src/v/cluster/archival/tests/segment_reupload_test.cc
+++ b/src/v/cluster/archival/tests/segment_reupload_test.cc
@@ -223,7 +223,11 @@ SEASTAR_THREAD_TEST_CASE(test_segment_collection) {
        .last_segment_num_records = 10});
 
     archival::segment_collector collector{
-      model::offset{4}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{4},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -256,7 +260,11 @@ SEASTAR_THREAD_TEST_CASE(test_make_upload_candidate_stream) {
        .last_segment_num_records = 10});
 
     archival::segment_collector collector{
-      model::offset{4}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{4},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
@@ -309,7 +317,11 @@ SEASTAR_THREAD_TEST_CASE(test_make_upload_candidate_skip_offsets) {
        .last_segment_num_records = 10});
 
     archival::segment_collector collector{
-      model::offset{4}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{4},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
     auto result
@@ -337,7 +349,11 @@ SEASTAR_THREAD_TEST_CASE(test_start_ahead_of_manifest) {
     {
         // start ahead of manifest end, no collection happens.
         archival::segment_collector collector{
-          model::offset{400}, m, b.get_disk_log_impl(), max_upload_size};
+          segment_collector_mode::compacted_reupload,
+          model::offset{400},
+          m,
+          b.get_disk_log_impl(),
+          max_upload_size};
 
         collector.collect_segments();
 
@@ -350,7 +366,11 @@ SEASTAR_THREAD_TEST_CASE(test_start_ahead_of_manifest) {
         // start at manifest end. the collector will advance it first to prevent
         // overlap. no collection happens.
         archival::segment_collector collector{
-          model::offset{39}, m, b.get_disk_log_impl(), max_upload_size};
+          segment_collector_mode::compacted_reupload,
+          model::offset{39},
+          m,
+          b.get_disk_log_impl(),
+          max_upload_size};
 
         collector.collect_segments();
 
@@ -373,7 +393,11 @@ SEASTAR_THREAD_TEST_CASE(test_empty_manifest) {
     auto defer = ss::defer([&b] { b.stop().get(); });
 
     archival::segment_collector collector{
-      model::offset{2}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{2},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -408,7 +432,11 @@ SEASTAR_THREAD_TEST_CASE(test_short_compacted_segment_inside_manifest_segment) {
        .last_segment_num_records = 2});
 
     archival::segment_collector collector{
-      model::offset{1}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{1},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -438,7 +466,11 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
        .last_segment_num_records = 10});
 
     archival::segment_collector collector{
-      model::offset{1}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{1},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -477,7 +509,11 @@ SEASTAR_THREAD_TEST_CASE(
        .last_segment_num_records = 5});
 
     archival::segment_collector collector{
-      model::offset{0}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -516,7 +552,11 @@ SEASTAR_THREAD_TEST_CASE(
        .last_segment_num_records = 3});
 
     archival::segment_collector collector{
-      model::offset{0}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -551,7 +591,11 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_larger_than_manifest_segment) {
        .last_segment_num_records = 20});
 
     archival::segment_collector collector{
-      model::offset{2}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{2},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -592,7 +636,11 @@ SEASTAR_THREAD_TEST_CASE(test_collect_capped_by_size) {
                       + b.get_segment(1).file_size()
                       + b.get_segment(2).file_size();
     archival::segment_collector collector{
-      model::offset{0}, m, b.get_disk_log_impl(), max_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      max_size};
 
     collector.collect_segments();
 
@@ -636,7 +684,11 @@ SEASTAR_THREAD_TEST_CASE(test_no_compacted_segments) {
        .last_segment_num_records = 20});
 
     archival::segment_collector collector{
-      model::offset{5}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{5},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
 
@@ -666,7 +718,11 @@ SEASTAR_THREAD_TEST_CASE(test_segment_name_adjustment) {
        .last_segment_num_records = 20});
 
     archival::segment_collector collector{
-      model::offset{8}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{8},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
     auto name = collector.adjust_segment_name();
@@ -695,7 +751,11 @@ SEASTAR_THREAD_TEST_CASE(test_segment_name_no_adjustment) {
        .last_segment_num_records = 20});
 
     archival::segment_collector collector{
-      model::offset{8}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{8},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
     auto name = collector.adjust_segment_name();
@@ -733,7 +793,11 @@ SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
                           + b.get_segment(1).file_size()
                           + b.get_segment(2).file_size();
         archival::segment_collector collector{
-          model::offset{0}, m, b.get_disk_log_impl(), max_size};
+          segment_collector_mode::compacted_reupload,
+          model::offset{0},
+          m,
+          b.get_disk_log_impl(),
+          max_size};
 
         collector.collect_segments();
 
@@ -777,7 +841,11 @@ SEASTAR_THREAD_TEST_CASE(test_collected_segments_completely_cover_gap) {
                           + b.get_segment(1).file_size()
                           + b.get_segment(2).file_size();
         archival::segment_collector collector{
-          model::offset{0}, m, b.get_disk_log_impl(), max_size};
+          segment_collector_mode::compacted_reupload,
+          model::offset{0},
+          m,
+          b.get_disk_log_impl(),
+          max_size};
 
         collector.collect_segments();
 
@@ -827,7 +895,11 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_after_manifest_start) {
        .last_segment_num_records = 20});
 
     archival::segment_collector collector{
-      model::offset{0}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector.collect_segments();
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
@@ -880,7 +952,11 @@ SEASTAR_THREAD_TEST_CASE(test_upload_candidate_generation) {
                       + b.get_segment(1).size_bytes()
                       + b.get_segment(2).size_bytes();
     archival::segment_collector collector{
-      model::offset{5}, m, b.get_disk_log_impl(), max_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{5},
+      m,
+      b.get_disk_log_impl(),
+      max_size};
 
     collector.collect_segments();
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
@@ -962,7 +1038,11 @@ SEASTAR_THREAD_TEST_CASE(test_upload_aligned_to_non_existent_offset) {
     size_t max_size = b.get_segment(0).size_bytes()
                       + b.get_segment(1).size_bytes();
     archival::segment_collector collector{
-      model::offset{5}, m, b.get_disk_log_impl(), max_size};
+      segment_collector_mode::compacted_reupload,
+      model::offset{5},
+      m,
+      b.get_disk_log_impl(),
+      max_size};
 
     collector.collect_segments();
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
@@ -1037,7 +1117,11 @@ SEASTAR_THREAD_TEST_CASE(test_same_size_reupload_skipped) {
 
     {
         archival::segment_collector collector{
-          model::offset{0}, m, b.get_disk_log_impl(), first_seg_size};
+          segment_collector_mode::compacted_reupload,
+          model::offset{0},
+          m,
+          b.get_disk_log_impl(),
+          first_seg_size};
 
         collector.collect_segments();
         BOOST_REQUIRE_EQUAL(collector.collected_size(), first_seg_size);
@@ -1075,6 +1159,7 @@ SEASTAR_THREAD_TEST_CASE(test_same_size_reupload_skipped) {
 
     {
         archival::segment_collector collector{
+          segment_collector_mode::compacted_reupload,
           model::offset{0},
           m,
           b.get_disk_log_impl(),
@@ -1145,7 +1230,11 @@ SEASTAR_THREAD_TEST_CASE(test_do_not_reupload_self_concatenated) {
 
     {
         archival::segment_collector collector{
-          model::offset{0}, m, b.get_disk_log_impl(), seg_size * 10};
+          segment_collector_mode::compacted_reupload,
+          model::offset{0},
+          m,
+          b.get_disk_log_impl(),
+          seg_size * 10};
 
         collector.collect_segments();
         BOOST_REQUIRE_EQUAL(collector.segments().size(), 0);
@@ -1223,7 +1312,11 @@ SEASTAR_THREAD_TEST_CASE(test_do_not_reupload_prefix_truncated) {
     b.update_start_offset(model::offset{100}).get();
 
     archival::segment_collector collector{
-      model::offset{0}, m, b.get_disk_log_impl(), seg_size * 10};
+      segment_collector_mode::compacted_reupload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      seg_size * 10};
 
     // Since we can't replace offsets starting at 0, the first remote segment
     // isn't eligible for reupload and we should start from the next segment.
@@ -1305,7 +1398,11 @@ SEASTAR_THREAD_TEST_CASE(test_bump_start_when_not_aligned) {
     // start offset of the upload candidate should be aligned with our
     // manifest.
     archival::segment_collector collector{
-      model::offset{500}, m, b.get_disk_log_impl(), seg_size * 10};
+      segment_collector_mode::compacted_reupload,
+      model::offset{500},
+      m,
+      b.get_disk_log_impl(),
+      seg_size * 10};
     collector.collect_segments();
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
     BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
@@ -1347,6 +1444,7 @@ SEASTAR_THREAD_TEST_CASE(test_adjacent_segment_collection) {
       .get();
 
     archival::segment_collector collector{
+      segment_collector_mode::non_compacted_reupload,
       model::offset{104},
       m,
       b.get_disk_log_impl(),
@@ -1547,6 +1645,7 @@ SEASTAR_THREAD_TEST_CASE(test_segment_concurrent_compaction) {
 
     // Should be aligned to the manifest segments.
     archival::segment_collector collector{
+      segment_collector_mode::non_compacted_reupload,
       model::offset{10},
       m,
       b.get_disk_log_impl(),
@@ -1636,7 +1735,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // upload flow in the ntp_archiver. The archiver uploads segments
     // when they are sealed.
     archival::segment_collector collector1{
-      model::offset{0}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::new_upload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector1.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE_EQUAL(collector1.begin_inclusive(), model::offset{00});
@@ -1645,7 +1748,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
 
     // Upload the segment in the middle of the log.
     archival::segment_collector collector2{
-      model::offset{20}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::new_upload,
+      model::offset{20},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector2.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE_EQUAL(collector2.begin_inclusive(), model::offset{20});
@@ -1655,7 +1762,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // Upload the last segment of the log. This should fail because
     // the segment is not sealed.
     archival::segment_collector collector3{
-      model::offset{40}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::new_upload,
+      model::offset{40},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector3.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE(!collector3.segment_ready_for_upload());
@@ -1666,6 +1777,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // and max size. The collection will include the whole log
     // except the last unsealed segment.
     archival::segment_collector collector4{
+      segment_collector_mode::new_upload,
       model::offset{0},
       m,
       b.get_disk_log_impl(),
@@ -1685,6 +1797,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // data that we have up to the LSO. The LSO could be in the middle of
     // of the unsealed segment in this case.
     archival::segment_collector collector5{
+      segment_collector_mode::new_upload,
       model::offset{0},
       m,
       b.get_disk_log_impl(),
@@ -1699,6 +1812,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // Similar to the previous case but the start of the upload is not aligned
     // to the segment boundary. So does the end of the upload.
     archival::segment_collector collector6{
+      segment_collector_mode::new_upload,
       model::offset{8},
       m,
       b.get_disk_log_impl(),
@@ -1712,6 +1826,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
 
     // The upload starts and stops inside the unsealed segment.
     archival::segment_collector collector7{
+      segment_collector_mode::new_upload,
       model::offset{42},
       m,
       b.get_disk_log_impl(),
@@ -1728,7 +1843,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     auto first_segment_size
       = b.get_disk_log_impl().segments().front()->file_size();
     archival::segment_collector collector8{
-      model::offset{0}, m, b.get_disk_log_impl(), first_segment_size};
+      segment_collector_mode::new_upload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      first_segment_size};
     collector8.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE(collector8.segment_ready_for_upload());
     BOOST_REQUIRE_EQUAL(collector8.begin_inclusive(), model::offset{0});
@@ -1738,6 +1857,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // Same case but the last offset is set explicitly. The collector should
     // chose the same segment as in the previous case.
     archival::segment_collector collector9{
+      segment_collector_mode::new_upload,
       model::offset{0},
       m,
       b.get_disk_log_impl(),
@@ -1753,6 +1873,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload) {
     // with the segment boundary. The collector will stop on a segment boundary
     // anyway based on the segment size.
     archival::segment_collector collector10{
+      segment_collector_mode::new_upload,
       model::offset{18},
       m,
       b.get_disk_log_impl(),
@@ -1797,7 +1918,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
 
     // Upload first segment which contains only one record [0-0 offset range]
     archival::segment_collector collector1{
-      model::offset{0}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::new_upload,
+      model::offset{0},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
 
     collector1.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE_EQUAL(collector1.begin_inclusive(), model::offset{0});
@@ -1807,7 +1932,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
 
     // Upload second segment which contains only one record [1-1 offset range]
     archival::segment_collector collector2{
-      model::offset{1}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::new_upload,
+      model::offset{1},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
     collector2.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE_EQUAL(collector2.begin_inclusive(), model::offset{1});
     BOOST_REQUIRE_EQUAL(collector2.end_inclusive(), model::offset{1});
@@ -1816,7 +1945,11 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
 
     // Upload second segment which contains only one record [3-3 offset range]
     archival::segment_collector collector3{
-      model::offset{3}, m, b.get_disk_log_impl(), max_upload_size};
+      segment_collector_mode::new_upload,
+      model::offset{3},
+      m,
+      b.get_disk_log_impl(),
+      max_upload_size};
     collector3.collect_segments(segment_collector_mode::new_upload);
     BOOST_REQUIRE(!collector3.segment_ready_for_upload());
     validate_non_compacted_collector(collector3);
@@ -1824,6 +1957,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
     // Upload series of segments. Last segment which is not sealed is not
     // included.
     archival::segment_collector collector4{
+      segment_collector_mode::new_upload,
       model::offset{0},
       m,
       b.get_disk_log_impl(),
@@ -1841,6 +1975,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_off_by_one) {
     // to the collector. This means that the collector now knows that it's safe
     // to read from unsealed segment below this offset.
     archival::segment_collector collector5{
+      segment_collector_mode::new_upload,
       model::offset{0},
       m,
       b.get_disk_log_impl(),
@@ -2020,6 +2155,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_fuzz) {
           start_bound.min(),
           end_bound.max());
         archival::segment_collector closed_range_collector{
+          segment_collector_mode::new_upload,
           start_bound.min(),
           m,
           b.get_disk_log_impl(),
@@ -2077,6 +2213,7 @@ SEASTAR_THREAD_TEST_CASE(test_new_segment_upload_fuzz) {
           start_bound.min(),
           end_bound.max());
         archival::segment_collector open_range_collector{
+          segment_collector_mode::new_upload,
           start_bound.min(),
           m,
           b.get_disk_log_impl(),


### PR DESCRIPTION
During segment collection for upload, a leadership change can occur, leaving the uploader fiber to complete any work in progress before going to sleep. So the following is possible:

1. Segment collection for new segment upload on S0, the leader
2. Partition leadership changes to S1 before (1) completes
3. S1 uploads the next segment, updates manifest
3. (1) continues to the point of checking its upload candidate against the manifest to see whether a compacted upload would be a no-op. Normally the lookup fails in new_upload mode because the segment does not appear in the manifest yet. However in this case the manifest was already updated elsewhere, so the lookup succeeds, effectively tricking segment_collector into thinking it is in reupload mode. If the size of the collected segment matches what S1 already uploaded, then the candidate is discarded via skip_offset_range.
4. Back at the call site in ntp_archiver_service, skip_offset_range is expected to appear only in reupload mode, but this was a new upload. This triggers an assert.

This commit guards against that situation by plumbing the upload mode into make_segment_upload and adds a check to the reupload size sanity check to ensure that we are indeed in reupload mode before returning skip_offset_range.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
