### PR TITLE
c/rm_frontend: more nuanced mapping of error when locking writes

### DIFF
--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -230,6 +230,51 @@ ss::future<begin_tx_reply> rm_partition_frontend::do_begin_tx(
             std::move(ntp), pid, tx_seq, transaction_timeout_ms, tm, mgr);
       });
 }
+namespace {
+ss::future<result<ssx::rwlock_unit, tx::errc>>
+hold_writes_enabled(ss::lw_shared_ptr<partition> partition) {
+    auto units_result = co_await partition->hold_writes_enabled();
+    if (units_result.has_value()) {
+        co_return result<ssx::rwlock_unit, tx::errc>{
+          std::move(units_result.value())};
+    }
+
+    auto err = units_result.error();
+    if (err.category() == cluster::error_category()) {
+        /**
+         * Handle different types of errors that can occur when trying to
+         * grab a write enable lock.
+         */
+        switch (cluster::errc(err.value())) {
+        case cluster::errc::not_leader:
+            co_return tx::errc::leader_not_found;
+        case cluster::errc::resource_is_being_migrated:
+            vlog(
+              txlog.warn,
+              "partition {} is not writable, errc: {}",
+              partition->ntp(),
+              units_result.error());
+            co_return tx::errc::partition_writes_locked;
+        case cluster::errc::timeout:
+            co_return tx::errc::timeout;
+        case cluster::errc::partition_disabled:
+            co_return tx::errc::partition_disabled;
+        default:
+            break;
+        }
+    } else if (err == raft::errc::not_leader) {
+        co_return tx::errc::leader_not_found;
+    } else if (err == raft::errc::timeout) {
+        co_return tx::errc::timeout;
+    }
+    vlog(
+      txlog.error,
+      "error holding a write enable lock for {}, errc: {}",
+      partition->ntp(),
+      err);
+    co_return tx::errc::unknown_server_error;
+}
+} // namespace
 
 ss::future<begin_tx_reply>
 rm_partition_frontend::do_begin_tx_on_partition_shard(
@@ -244,15 +289,9 @@ rm_partition_frontend::do_begin_tx_on_partition_shard(
         co_return begin_tx_reply{std::move(ntp), tx::errc::partition_not_found};
     }
 
-    auto maybe_partition_units = co_await partition->hold_writes_enabled();
+    auto maybe_partition_units = co_await hold_writes_enabled(partition);
     if (!maybe_partition_units.has_value()) {
-        vlog(
-          txlog.warn,
-          "partition {} is not writable, errc: {}",
-          ntp,
-          maybe_partition_units.error());
-        co_return begin_tx_reply{
-          std::move(ntp), tx::errc::partition_writes_locked};
+        co_return begin_tx_reply{std::move(ntp), maybe_partition_units.error()};
     }
 
     auto stm = partition->rm_stm();


### PR DESCRIPTION
When acquiring partition write enabled write lock units and checking partition properties stm state a `persisted_stm::sync()` is required. It may sometimes happen the `sync()` method fails f.e. partition leadership may has been lost or the timeout occurred. Those errors should not be mapped to the `partition_writes_locked` error which leads to resetting producer state.

This PR introduces more fine grained mapping of errors returned when the writes enabled lock can not be acquired.

Fixes: CORE-12273

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none