### PR TITLE
[CORE-12305] crypto: add cleanup step for internal evp cache

### DIFF
--- a/src/v/crypto/crypto.cc
+++ b/src/v/crypto/crypto.cc
@@ -20,6 +20,23 @@
 #include <absl/container/node_hash_map.h>
 
 #include <sstream>
+
+namespace {
+namespace evp_cache {
+auto& get_md_map() {
+    static thread_local absl::
+      node_hash_map<crypto::digest_type, crypto::internal::EVP_MD_ptr>
+        md_map;
+    return md_map;
+}
+
+auto& get_mac() {
+    static thread_local crypto::internal::EVP_MAC_ptr mac;
+    return mac;
+}
+} // namespace evp_cache
+} // namespace
+
 namespace crypto {
 std::ostream& operator<<(std::ostream& os, digest_type type) {
     switch (type) {
@@ -129,7 +146,8 @@ EVP_MD* get_md(digest_type type) {
     // Map of pre-fetched MD pointers.  This replaces the older way of getting
     // a digest pointer via something like `EVP_sha256()`.  The old way is
     // slower compared to pre-fetching the algorithm.
-    static thread_local absl::node_hash_map<digest_type, EVP_MD_ptr> md_map;
+    absl::node_hash_map<digest_type, EVP_MD_ptr>& md_map
+      = ::evp_cache::get_md_map();
     auto it = md_map.find(type);
     if (it == md_map.end()) {
         auto alg = fmt::to_string(type);
@@ -149,7 +167,7 @@ EVP_MD* get_md(digest_type type) {
 }
 
 EVP_MAC* get_mac() {
-    static thread_local EVP_MAC_ptr mac;
+    EVP_MAC_ptr& mac = ::evp_cache::get_mac();
     if (!mac) {
         mac = EVP_MAC_ptr(EVP_MAC_fetch(nullptr, "HMAC", "?provider=fips"));
         if (!mac) {
@@ -157,6 +175,11 @@ EVP_MAC* get_mac() {
         }
     }
     return mac.get();
+}
+
+void clear_evp_cache() {
+    ::evp_cache::get_md_map().clear();
+    ::evp_cache::get_mac().reset();
 }
 
 bool fips_enabled() { return 1 == OSSL_PROVIDER_available(nullptr, "fips"); }

--- a/src/v/crypto/internal.h
+++ b/src/v/crypto/internal.h
@@ -26,7 +26,11 @@ inline bytes_span<> char_span_to_bytes_span(std::span<char> v) {
     return {reinterpret_cast<bytes_span<>::value_type*>(v.data()), v.size()};
 }
 
+// These functions create use an internal cache to speed up lookups.
 EVP_MD* get_md(digest_type type);
 EVP_MAC* get_mac();
+// The internal cache needs to be cleared when openssl is teared-down.
+void clear_evp_cache();
+
 bool fips_enabled();
 } // namespace crypto::internal

--- a/src/v/crypto/ossl_context_service.cc
+++ b/src/v/crypto/ossl_context_service.cc
@@ -14,6 +14,7 @@
 #include "base/outcome.h"
 #include "base/vassert.h"
 #include "base/vlog.h"
+#include "internal.h"
 #include "ssl_utils.h"
 #include "ssx/thread_worker.h"
 #include "thirdparty/openssl/crypto.h"
@@ -252,6 +253,7 @@ public:
     }
 
     ss::future<> stop() {
+        internal::clear_evp_cache();
         vlog(lg.trace, "Stopping service...");
         _base_provider.reset();
         _default_provider.reset();


### PR DESCRIPTION
Implements: [CORE-12305](https://redpandadata.atlassian.net/browse/CORE-12305)
Fixes: CORE-12296

`crypto::internal::get_md` and `crypto:internal::get_mac` functions have an internal cache to speed up lookups. Currently, when the openssl module is teared-down and set-up again, these caches don't get cleared. A cleanup step is added to the `ossl_context_service` tear-down to prevent this from coming up in tests, where multiple restarts of the openssl module takes place.

Note: this only affects tests. It doesn't affect redpanda, as there is no restart of the openssl module involved.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none



[CORE-12305]: https://redpandadata.atlassian.net/browse/CORE-12305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ