### PR TITLE
dl/catalog_client: pass an abort source

### DIFF
--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -132,7 +132,7 @@ filesystem_catalog_factory::filesystem_catalog_factory(
   , bucket_(bucket) {}
 
 ss::future<std::unique_ptr<iceberg::catalog>>
-filesystem_catalog_factory::create_catalog() {
+filesystem_catalog_factory::create_catalog(ss::abort_source&) {
     vlog(
       datalake_log.info,
       "Creating filesystem catalog with bucket: {} and location: {}",
@@ -181,7 +181,7 @@ rest_catalog_factory::make_credentials_or_token() {
 }
 
 ss::future<std::unique_ptr<iceberg::catalog>>
-rest_catalog_factory::create_catalog() {
+rest_catalog_factory::create_catalog(ss::abort_source& as) {
     // TODO: add config level validation
     throw_if_not_present(config_->iceberg_rest_catalog_endpoint);
 
@@ -205,7 +205,7 @@ rest_catalog_factory::create_catalog() {
         }
     }
     auto http_client = std::make_unique<http::client>(
-      std::move(transport_config), nullptr, client_probe_);
+      std::move(transport_config), &as, client_probe_);
 
     auto creds_and_token = make_credentials_or_token();
 

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -204,10 +204,8 @@ rest_catalog_factory::create_catalog() {
             throw;
         }
     }
-    std::unique_ptr<http::abstract_client> http_client
-      = static_cast<std::unique_ptr<http::abstract_client>>(
-        std::make_unique<http::client>(
-          std::move(transport_config), nullptr, client_probe_));
+    auto http_client = std::make_unique<http::client>(
+      std::move(transport_config), nullptr, client_probe_);
 
     auto creds_and_token = make_credentials_or_token();
 

--- a/src/v/datalake/coordinator/catalog_factory.h
+++ b/src/v/datalake/coordinator/catalog_factory.h
@@ -26,7 +26,8 @@ namespace datalake::coordinator {
 class catalog_factory {
 public:
     virtual ~catalog_factory() = default;
-    virtual ss::future<std::unique_ptr<iceberg::catalog>> create_catalog() = 0;
+    virtual ss::future<std::unique_ptr<iceberg::catalog>>
+    create_catalog(ss::abort_source&) = 0;
 };
 /**
  * Rest catalog factory, the catalog properties are set based on the
@@ -38,7 +39,8 @@ public:
       config::configuration& config, ss::metrics::label_instance);
     ~rest_catalog_factory() override;
 
-    ss::future<std::unique_ptr<iceberg::catalog>> create_catalog() final;
+    ss::future<std::unique_ptr<iceberg::catalog>>
+    create_catalog(ss::abort_source&) final;
 
 private:
     struct credentials_and_token {
@@ -63,7 +65,8 @@ public:
       cloud_io::remote& remote,
       const cloud_storage_clients::bucket_name& bucket);
 
-    ss::future<std::unique_ptr<iceberg::catalog>> create_catalog() final;
+    ss::future<std::unique_ptr<iceberg::catalog>>
+    create_catalog(ss::abort_source&) final;
 
 private:
     config::configuration* config_;

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -54,7 +54,7 @@ coordinator_manager::coordinator_manager(
 coordinator_manager::~coordinator_manager() = default;
 
 ss::future<> coordinator_manager::start() {
-    catalog_ = co_await catalog_factory_->create_catalog();
+    catalog_ = co_await catalog_factory_->create_catalog(as_);
     schema_mgr_ = std::make_unique<catalog_schema_manager>(*catalog_);
     file_committer_ = std::make_unique<iceberg_file_committer>(
       storage_,
@@ -91,6 +91,7 @@ ss::future<> coordinator_manager::start() {
 }
 
 ss::future<> coordinator_manager::shutdown() {
+    as_.request_abort();
     if (manage_notifications_) {
         pm_.unregister_manage_notification(*manage_notifications_);
     }

--- a/src/v/datalake/coordinator/coordinator_manager.h
+++ b/src/v/datalake/coordinator/coordinator_manager.h
@@ -65,6 +65,7 @@ private:
     ss::future<checked<std::nullopt_t, coordinator::errc>>
     remove_tombstone(const model::topic&, model::revision_id);
 
+    ss::abort_source as_;
     ss::gate gate_;
     model::node_id self_;
     storage::api& storage_;

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -223,7 +223,7 @@ datalake_manager::get_or_create_probe(const model::ntp& ntp) {
 
 ss::future<> datalake_manager::start() {
     _disk_manager->set_manager_reference(container());
-    _catalog = co_await _catalog_factory->create_catalog();
+    _catalog = co_await _catalog_factory->create_catalog(_as->local());
     _schema_mgr = std::make_unique<catalog_schema_manager>(*_catalog);
     // partition managed notification, this is particularly
     // relevant for cross core movements without a term change.


### PR DESCRIPTION
Check the discussion in https://redpandadata.slack.com/archives/C07FJGU5AKV/p1750111223794369?thread_ts=1750088839.683199&cid=C07FJGU5AKV

Passing an abort source slightly alleviates the issue but the actual fix should be in the http/client. Nevertheless seems safer to pass an abort source as the client implementation seems to rely on the passed abort source during shut down.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
