### PR TITLE
rptest: mark cluster_restore_test with ignore

### DIFF
--- a/tests/rptest/tests/datalake/cluster_restore_test.py
+++ b/tests/rptest/tests/datalake/cluster_restore_test.py
@@ -6,7 +6,7 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
-from ducktape.mark import matrix
+from ducktape.mark import ignore, matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool
@@ -395,6 +395,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                 all_topics
             ), "Expected one table per topic (i.e. no DLQ tables)"
 
+    @ignore
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())
@@ -501,6 +502,7 @@ class DatalakeClusterRestoreTest(RedpandaTest):
                 rpk.alter_topic_config(t, "redpanda.remote.write", "true")
             rpk.alter_topic_config("_schemas", "redpanda.remote.write", "true")
 
+    @ignore
     @cluster(num_nodes=6)
     @matrix(cloud_storage_type=supported_storage_types(),
             catalog_type=supported_catalog_types())


### PR DESCRIPTION
It's very flaky. I think the issue is that the test waits for the max offset of the table to increase after restoring rather than waiting for the count of the table to go up.

Marks the tests as @ignore to denoise CI.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
