### PR TITLE
m/record: added very basic defensive check to prevent crashes

### DIFF
--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -95,6 +95,16 @@ static std::vector<model::record_header>
 parse_record_headers(Parser& parser, ParserData parser_data) {
     std::vector<model::record_header> headers;
     auto [header_count, _] = parser.read_varlong();
+    /**
+     * If records buffer is corrupted, it may result in reading very large
+     * number, check if it is the case and throw an exception.
+     */
+    if (static_cast<size_t>(header_count) > parser.bytes_left()) [[unlikely]] {
+        throw std::out_of_range(fmt::format(
+          "Expected {} headers, but only {} bytes left",
+          header_count,
+          parser.bytes_left()));
+    }
     headers.reserve(header_count);
     for (int i = 0; i < header_count; ++i) {
         auto [key_length, kv] = parser.read_varlong();

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -106,3 +106,16 @@ SEASTAR_THREAD_TEST_CASE(extra_bytes_iterator) {
     BOOST_TEST(it.has_next());
     BOOST_REQUIRE_THROW(it.next(), std::out_of_range);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_corrupted_record_bytes) {
+    auto b = model::test::make_random_batch(model::offset(0), 10, false);
+    // use the trick to get mutable access to the records
+    auto fields = b.serde_fields();
+    auto& records = std::get<1>(fields);
+    for (auto& f : records) {
+        std::fill_n(f.get_write(), f.size(), 0xFF);
+    }
+    auto f = model::for_each_record(
+      b, [](model::record& r) { BOOST_CHECK(r.offset_delta() >= 0); });
+    BOOST_REQUIRE_THROW(f.get(), std::out_of_range);
+}


### PR DESCRIPTION
Redpada store `model::record_batch` records as opaque bytes. The bytes are materialized to individual `model::record` lazily when iterating over the batch records. During the record materialization record header vector is parsed. The vector size is stored in a variable length encoded integer. If the data in the record buffer are invalid the size may be incorrectly deserialized leading to a very large allocation. Added basic defensive check that compares the requested vector size with the number of bytes left in the buffer. It the size is greater then the exception is thrown as we know that header is never smaller than one byte.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- prevents Redpanda from crashing when reading invalid record data