### PR TITLE
pandaproxy/sr: add inner iterations to stabilize sr api benchmarks

### DIFF
--- a/src/v/pandaproxy/schema_registry/test/api_bench.cc
+++ b/src/v/pandaproxy/schema_registry/test/api_bench.cc
@@ -70,8 +70,8 @@ pps::schema_version middle_version(int n_versions) {
     return pps::schema_version{n_versions / 2};
 }
 
-pps::schema_version next_version(int n_versions) {
-    return pps::schema_version{n_versions + 1};
+pps::schema_version last_version(int n_versions) {
+    return pps::schema_version{n_versions};
 }
 
 void setup_client(::http::client& client, perf_settings ps) {
@@ -88,22 +88,27 @@ void setup_client(::http::client& client, perf_settings ps) {
     }
 }
 
+constexpr size_t inner_iters = 100;
+
 void perf_body(
   ::http::client& client, const endpoint& ep, const perf_settings& ps) {
     const auto subject = make_subject(ps.i_subject);
     const auto version = ps.version_logic(ps.n_versions);
     const auto schema = make_proto_schema(subject, version);
     const auto payload = make_payload(schema);
+
     perf_tests::start_measuring_time();
-    auto res = ep.fn(client, subject, payload);
-    perf_tests::do_not_optimize(res);
+    for (size_t i = 0; i < inner_iters; ++i) {
+        auto res = ep.fn(client, subject, payload);
+        perf_tests::do_not_optimize(res);
+        dassert(
+          res.headers.result() == boost::beast::http::status::ok,
+          "{err_ctx} failed for sub {} version {}",
+          ep.name,
+          subject,
+          version);
+    }
     perf_tests::stop_measuring_time();
-    vassert(
-      res.headers.result() == boost::beast::http::status::ok,
-      "{err_ctx} failed for sub {} version {}",
-      ep.name,
-      subject,
-      version);
 }
 
 } // namespace
@@ -119,14 +124,14 @@ public:
     sr_bench_fixture operator=(sr_bench_fixture&&) = delete;
     ~sr_bench_fixture() = default;
 
-    future<void> run_test(endpoint ep, perf_settings ps) {
+    future<size_t> run_test(endpoint ep, perf_settings ps) {
         auto client = make_schema_reg_client();
         ss::thread_attributes thread_attr;
         co_await ss::async(thread_attr, [&client, &ep, ps] {
             setup_client(client, ps);
             perf_body(client, ep, ps);
         });
-        co_return;
+        co_return inner_iters;
     }
 };
 
@@ -136,103 +141,103 @@ static std::map<std::string_view, endpoint> perf_apis{
   {schema_lookup, endpoint{.fn = lookup_schema, .name = schema_lookup}},
   {schema_post, endpoint{.fn = post_schema, .name = schema_post}}};
 
-PERF_TEST_C(sr_bench_fixture, lookup_x1_1) {
+PERF_TEST_CN(sr_bench_fixture, lookup_x1_1) {
     perf_settings ss{
       .n_subjects = 1,
       .n_versions = 1,
       .i_subject = 0,
       .version_logic = middle_version};
-    co_await run_test(perf_apis[schema_lookup], ss);
+    co_return co_await run_test(perf_apis[schema_lookup], ss);
 }
-PERF_TEST_C(sr_bench_fixture, lookup_x1_10) {
+PERF_TEST_CN(sr_bench_fixture, lookup_x1_10) {
     perf_settings ss{
       .n_subjects = 1,
       .n_versions = 10,
       .i_subject = 0,
       .version_logic = middle_version};
-    co_await run_test(perf_apis[schema_lookup], ss);
+    co_return co_await run_test(perf_apis[schema_lookup], ss);
 }
-PERF_TEST_C(sr_bench_fixture, lookup_x1_100) {
+PERF_TEST_CN(sr_bench_fixture, lookup_x1_100) {
     perf_settings ss{
       .n_subjects = 1,
       .n_versions = 100,
       .i_subject = 0,
       .version_logic = middle_version};
-    co_await run_test(perf_apis[schema_lookup], ss);
+    co_return co_await run_test(perf_apis[schema_lookup], ss);
 }
 
-PERF_TEST_C(sr_bench_fixture, lookup_x10_1) {
+PERF_TEST_CN(sr_bench_fixture, lookup_x10_1) {
     perf_settings ss{
       .n_subjects = 10,
       .n_versions = 1,
       .i_subject = 0,
       .version_logic = middle_version};
-    co_await run_test(perf_apis[schema_lookup], ss);
+    co_return co_await run_test(perf_apis[schema_lookup], ss);
 }
-PERF_TEST_C(sr_bench_fixture, lookup_x10_10) {
+PERF_TEST_CN(sr_bench_fixture, lookup_x10_10) {
     perf_settings ss{
       .n_subjects = 10,
       .n_versions = 10,
       .i_subject = 0,
       .version_logic = middle_version};
-    co_await run_test(perf_apis[schema_lookup], ss);
+    co_return co_await run_test(perf_apis[schema_lookup], ss);
     ;
 }
-PERF_TEST_C(sr_bench_fixture, lookup_x20_20) {
+PERF_TEST_CN(sr_bench_fixture, lookup_x20_20) {
     perf_settings ss{
       .n_subjects = 20,
       .n_versions = 20,
       .i_subject = 0,
       .version_logic = middle_version};
-    co_await run_test(perf_apis[schema_lookup], ss);
+    co_return co_await run_test(perf_apis[schema_lookup], ss);
 }
 
-PERF_TEST_C(sr_bench_fixture, post_x1_1) {
+PERF_TEST_CN(sr_bench_fixture, post_x1_1) {
     perf_settings ss{
       .n_subjects = 1,
       .n_versions = 1,
       .i_subject = 0,
-      .version_logic = next_version};
-    co_await run_test(perf_apis[schema_post], ss);
+      .version_logic = last_version};
+    co_return co_await run_test(perf_apis[schema_post], ss);
 }
-PERF_TEST_C(sr_bench_fixture, post_x1_10) {
+PERF_TEST_CN(sr_bench_fixture, post_x1_10) {
     perf_settings ss{
       .n_subjects = 1,
       .n_versions = 10,
       .i_subject = 0,
-      .version_logic = next_version};
-    co_await run_test(perf_apis[schema_post], ss);
+      .version_logic = last_version};
+    co_return co_await run_test(perf_apis[schema_post], ss);
 }
-PERF_TEST_C(sr_bench_fixture, post_x1_100) {
+PERF_TEST_CN(sr_bench_fixture, post_x1_100) {
     perf_settings ss{
       .n_subjects = 1,
       .n_versions = 100,
       .i_subject = 0,
-      .version_logic = next_version};
-    co_await run_test(perf_apis[schema_post], ss);
+      .version_logic = last_version};
+    co_return co_await run_test(perf_apis[schema_post], ss);
 }
 
-PERF_TEST_C(sr_bench_fixture, post_x10_1) {
+PERF_TEST_CN(sr_bench_fixture, post_x10_1) {
     perf_settings ss{
       .n_subjects = 10,
       .n_versions = 1,
       .i_subject = 0,
-      .version_logic = next_version};
-    co_await run_test(perf_apis[schema_post], ss);
+      .version_logic = last_version};
+    co_return co_await run_test(perf_apis[schema_post], ss);
 }
-PERF_TEST_C(sr_bench_fixture, post_x10_10) {
+PERF_TEST_CN(sr_bench_fixture, post_x10_10) {
     perf_settings ss{
       .n_subjects = 10,
       .n_versions = 10,
       .i_subject = 0,
-      .version_logic = next_version};
-    co_await run_test(perf_apis[schema_post], ss);
+      .version_logic = last_version};
+    co_return co_await run_test(perf_apis[schema_post], ss);
 }
-PERF_TEST_C(sr_bench_fixture, post_x20_20) {
+PERF_TEST_CN(sr_bench_fixture, post_x20_20) {
     perf_settings ss{
       .n_subjects = 20,
       .n_versions = 20,
       .i_subject = 0,
-      .version_logic = next_version};
-    co_await run_test(perf_apis[schema_post], ss);
+      .version_logic = last_version};
+    co_return co_await run_test(perf_apis[schema_post], ss);
 }

--- a/src/v/pandaproxy/schema_registry/test/api_bench.cc
+++ b/src/v/pandaproxy/schema_registry/test/api_bench.cc
@@ -24,6 +24,22 @@ namespace pps = pandaproxy::schema_registry;
 
 namespace {
 
+struct perf_settings {
+    using lookup_version_logic = pps::schema_version (*)(int);
+
+    int n_subjects;
+    int n_versions;
+    int i_subject;
+    lookup_version_logic version_logic;
+};
+
+struct endpoint {
+    using signature = consumed_response (*)(
+      ::http::client&, const pps::subject&, const ss::sstring&);
+    signature fn;
+    ss::sstring name;
+};
+
 ss::sstring make_proto_schema(const pps::subject& sub, int n_fields) {
     ss::sstring body = ss::format(
       "syntax = \"proto3\";\nmessage MyType{} {{\n", sub);
@@ -47,10 +63,21 @@ pps::subject make_subject(int i_sub) {
     return pps::subject{ss::format("TestSubject{}", i_sub)};
 }
 
-void setup_client(::http::client& client, int n_subjects, int n_versions) {
-    for (int i_sub = 0; i_sub < n_subjects; ++i_sub) {
+pps::schema_version middle_version(int n_versions) {
+    if (n_versions == 1) {
+        return pps::schema_version{1};
+    }
+    return pps::schema_version{n_versions / 2};
+}
+
+pps::schema_version next_version(int n_versions) {
+    return pps::schema_version{n_versions + 1};
+}
+
+void setup_client(::http::client& client, perf_settings ps) {
+    for (int i_sub = 0; i_sub < ps.n_subjects; ++i_sub) {
         pps::subject sub = make_subject(i_sub);
-        for (int i_ver = 1; i_ver <= n_versions; ++i_ver) {
+        for (int i_ver = 1; i_ver <= ps.n_versions; ++i_ver) {
             auto schema = make_proto_schema(sub, i_ver);
             auto payload = make_payload(schema);
             auto res = post_schema(client, sub, payload);
@@ -61,36 +88,22 @@ void setup_client(::http::client& client, int n_subjects, int n_versions) {
     }
 }
 
-void measure_lookup_schema(
-  ::http::client& client,
-  const pps::subject& sub,
-  const pps::schema_version ver) {
-    auto schema = make_proto_schema(sub, ver);
-    auto payload = make_payload(schema);
+void perf_body(
+  ::http::client& client, const endpoint& ep, const perf_settings& ps) {
+    const auto subject = make_subject(ps.i_subject);
+    const auto version = ps.version_logic(ps.n_versions);
+    const auto schema = make_proto_schema(subject, version);
+    const auto payload = make_payload(schema);
     perf_tests::start_measuring_time();
-    auto res = lookup_schema(client, sub, payload);
+    auto res = ep.fn(client, subject, payload);
+    perf_tests::do_not_optimize(res);
     perf_tests::stop_measuring_time();
     vassert(
       res.headers.result() == boost::beast::http::status::ok,
-      "Schema lookup failed for sub {} version {}",
-      sub,
-      ver);
-}
-
-void measure_post_schema(
-  ::http::client& client,
-  const pps::subject& sub,
-  const pps::schema_version ver) {
-    auto schema = make_proto_schema(sub, ver);
-    auto payload = make_payload(schema);
-    perf_tests::start_measuring_time();
-    auto res = post_schema(client, sub, payload);
-    perf_tests::stop_measuring_time();
-    vassert(
-      res.headers.result() == boost::beast::http::status::ok,
-      "Schema post failed for sub {} version {}",
-      sub,
-      ver);
+      "{err_ctx} failed for sub {} version {}",
+      ep.name,
+      subject,
+      version);
 }
 
 } // namespace
@@ -106,78 +119,120 @@ public:
     sr_bench_fixture operator=(sr_bench_fixture&&) = delete;
     ~sr_bench_fixture() = default;
 
-    template<typename Fn>
-    future<void> run_test(int n_subjects, int n_versions, Fn fn) {
+    future<void> run_test(endpoint ep, perf_settings ps) {
         auto client = make_schema_reg_client();
         ss::thread_attributes thread_attr;
-        co_await ss::async(thread_attr, [&client, n_subjects, n_versions, fn] {
-            setup_client(client, n_subjects, n_versions);
-            fn(client);
+        co_await ss::async(thread_attr, [&client, &ep, ps] {
+            setup_client(client, ps);
+            perf_body(client, ep, ps);
         });
         co_return;
     }
 };
 
+static constexpr const char* schema_lookup{"Schema lookup"};
+static constexpr const char* schema_post{"Schema post"};
+static std::map<std::string_view, endpoint> perf_apis{
+  {schema_lookup, endpoint{.fn = lookup_schema, .name = schema_lookup}},
+  {schema_post, endpoint{.fn = post_schema, .name = schema_post}}};
+
 PERF_TEST_C(sr_bench_fixture, lookup_x1_1) {
-    co_await run_test(1, 1, [](::http::client& client) {
-        measure_lookup_schema(client, make_subject(0), pps::schema_version{1});
-    });
+    perf_settings ss{
+      .n_subjects = 1,
+      .n_versions = 1,
+      .i_subject = 0,
+      .version_logic = middle_version};
+    co_await run_test(perf_apis[schema_lookup], ss);
 }
 PERF_TEST_C(sr_bench_fixture, lookup_x1_10) {
-    co_await run_test(1, 10, [](::http::client& client) {
-        measure_lookup_schema(client, make_subject(0), pps::schema_version{5});
-    });
+    perf_settings ss{
+      .n_subjects = 1,
+      .n_versions = 10,
+      .i_subject = 0,
+      .version_logic = middle_version};
+    co_await run_test(perf_apis[schema_lookup], ss);
 }
 PERF_TEST_C(sr_bench_fixture, lookup_x1_100) {
-    co_await run_test(1, 100, [](::http::client& client) {
-        measure_lookup_schema(client, make_subject(0), pps::schema_version{50});
-    });
+    perf_settings ss{
+      .n_subjects = 1,
+      .n_versions = 100,
+      .i_subject = 0,
+      .version_logic = middle_version};
+    co_await run_test(perf_apis[schema_lookup], ss);
 }
 
 PERF_TEST_C(sr_bench_fixture, lookup_x10_1) {
-    co_await run_test(10, 1, [](::http::client& client) {
-        measure_lookup_schema(client, make_subject(0), pps::schema_version{1});
-    });
+    perf_settings ss{
+      .n_subjects = 10,
+      .n_versions = 1,
+      .i_subject = 0,
+      .version_logic = middle_version};
+    co_await run_test(perf_apis[schema_lookup], ss);
 }
 PERF_TEST_C(sr_bench_fixture, lookup_x10_10) {
-    co_await run_test(10, 10, [](::http::client& client) {
-        measure_lookup_schema(client, make_subject(0), pps::schema_version{5});
-    });
+    perf_settings ss{
+      .n_subjects = 10,
+      .n_versions = 10,
+      .i_subject = 0,
+      .version_logic = middle_version};
+    co_await run_test(perf_apis[schema_lookup], ss);
+    ;
 }
 PERF_TEST_C(sr_bench_fixture, lookup_x20_20) {
-    co_await run_test(20, 20, [](::http::client& client) {
-        measure_lookup_schema(client, make_subject(0), pps::schema_version{10});
-    });
+    perf_settings ss{
+      .n_subjects = 20,
+      .n_versions = 20,
+      .i_subject = 0,
+      .version_logic = middle_version};
+    co_await run_test(perf_apis[schema_lookup], ss);
 }
 
 PERF_TEST_C(sr_bench_fixture, post_x1_1) {
-    co_await run_test(1, 1, [](::http::client& client) {
-        measure_post_schema(client, make_subject(0), pps::schema_version{2});
-    });
+    perf_settings ss{
+      .n_subjects = 1,
+      .n_versions = 1,
+      .i_subject = 0,
+      .version_logic = next_version};
+    co_await run_test(perf_apis[schema_post], ss);
 }
 PERF_TEST_C(sr_bench_fixture, post_x1_10) {
-    co_await run_test(1, 10, [](::http::client& client) {
-        measure_post_schema(client, make_subject(0), pps::schema_version{11});
-    });
+    perf_settings ss{
+      .n_subjects = 1,
+      .n_versions = 10,
+      .i_subject = 0,
+      .version_logic = next_version};
+    co_await run_test(perf_apis[schema_post], ss);
 }
 PERF_TEST_C(sr_bench_fixture, post_x1_100) {
-    co_await run_test(1, 100, [](::http::client& client) {
-        measure_post_schema(client, make_subject(0), pps::schema_version{101});
-    });
+    perf_settings ss{
+      .n_subjects = 1,
+      .n_versions = 100,
+      .i_subject = 0,
+      .version_logic = next_version};
+    co_await run_test(perf_apis[schema_post], ss);
 }
 
 PERF_TEST_C(sr_bench_fixture, post_x10_1) {
-    co_await run_test(10, 1, [](::http::client& client) {
-        measure_post_schema(client, make_subject(0), pps::schema_version{2});
-    });
+    perf_settings ss{
+      .n_subjects = 10,
+      .n_versions = 1,
+      .i_subject = 0,
+      .version_logic = next_version};
+    co_await run_test(perf_apis[schema_post], ss);
 }
 PERF_TEST_C(sr_bench_fixture, post_x10_10) {
-    co_await run_test(10, 10, [](::http::client& client) {
-        measure_post_schema(client, make_subject(0), pps::schema_version{11});
-    });
+    perf_settings ss{
+      .n_subjects = 10,
+      .n_versions = 10,
+      .i_subject = 0,
+      .version_logic = next_version};
+    co_await run_test(perf_apis[schema_post], ss);
 }
 PERF_TEST_C(sr_bench_fixture, post_x20_20) {
-    co_await run_test(20, 20, [](::http::client& client) {
-        measure_post_schema(client, make_subject(0), pps::schema_version{21});
-    });
+    perf_settings ss{
+      .n_subjects = 20,
+      .n_versions = 20,
+      .i_subject = 0,
+      .version_logic = next_version};
+    co_await run_test(perf_apis[schema_post], ss);
 }


### PR DESCRIPTION
Fixes: [CORE-12336](https://redpandadata.atlassian.net/browse/CORE-12336)

This pr includes:
- Rework the benchmark to reduce code/logic duplication
- Add inner iterations to each benchmark to have more stable results.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12336]: https://redpandadata.atlassian.net/browse/CORE-12336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ