### PR TITLE
tests: added more logging to make it easier to debug test failures

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -556,12 +556,18 @@ class ConsumerGroupTest(RedpandaTest):
         ev_loop = asyncio.new_event_loop()
 
         def poll_once(i):
-            consumer = KafkaConsumer(group_id=f"g-{i}",
-                                     bootstrap_servers=self.redpanda.brokers(),
-                                     enable_auto_commit=True)
-            consumer.subscribe([self.topic_spec.name])
-            consumer.poll(1)
-            consumer.close(autocommit=True)
+            try:
+                consumer = KafkaConsumer(
+                    group_id=f"g-{i}",
+                    bootstrap_servers=self.redpanda.brokers(),
+                    enable_auto_commit=True,
+                    client_id=f"python-consumer-client-{i}")
+                consumer.subscribe([self.topic_spec.name])
+                consumer.poll(1)
+                consumer.close(autocommit=True)
+            except Exception as e:
+                self.logger.error(f"Failed to poll group g-{i}: {e}")
+                raise
 
         async def create_groups(r):
             await asyncio.gather(*[


### PR DESCRIPTION
Previously we didn't know which consumer failed with an exception, more logging will make it obvious.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none