### PR TITLE
rptest: disable TS in delayed iceberg enabling

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -10,7 +10,6 @@ import datetime
 import re
 import time
 import random
-from rptest.clients.default import DefaultClient, TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -1128,23 +1127,26 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
     @skip_debug_mode
     def test_enabling_iceberg_in_existing_cluster(self, cloud_storage_type,
                                                   catalog_type):
-        count = 100
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
                               include_query_engines=[QueryEngineType.SPARK],
                               catalog_type=catalog_type) as dl:
 
-            topic = TopicSpec(name="delayed-iceberg-topic",
-                              partition_count=3,
-                              replication_factor=3,
-                              segment_bytes=1024 * 1024,
-                              redpanda_remote_read=False,
-                              redpanda_remote_write=False)
-
-            DefaultClient(dl.redpanda).create_topic(topic)
+            topic_name = "delayed-iceberg-topic"
+            RpkTool(self.redpanda).create_topic(topic_name,
+                                                partitions=3,
+                                                replicas=3,
+                                                config={
+                                                    "segment.bytes":
+                                                    1024 * 1024,
+                                                    "redpanda.remote.read":
+                                                    False,
+                                                    "redpanda.remote.write":
+                                                    False
+                                                })
 
             # produce ~120 MiB to the topic
-            dl.produce_to_topic(topic.name, 1024, 120 * 1024)
+            dl.produce_to_topic(topic_name, 1024, 120 * 1024)
             # wait for a while for the local snapshot to be taken
             time.sleep(5)
             dl.redpanda.restart_nodes(dl.redpanda.nodes)
@@ -1156,15 +1158,17 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
                            err_msg=f"Error waiting for topic {topic_name} \
                         state machines to catch up")
 
-            wait_for_topic(topic.name)
+            wait_for_topic(topic_name)
             bytes_read_before = self.redpanda.estimate_total_disk_bytes_read()
+            assert bytes_read_before, "Bytes read before enabling Iceberg should not be zero/none"
 
             # enable iceberg, this will restart the cluster
             dl.redpanda.set_cluster_config({"iceberg_enabled": True},
                                            expect_restart=True)
 
-            wait_for_topic(topic.name)
+            wait_for_topic(topic_name)
             bytes_read_after = self.redpanda.estimate_total_disk_bytes_read()
+            assert bytes_read_after, "Bytes read after enabling Iceberg should not be zero/none"
 
             self.logger.info(
                 f"Bytes read before: {bytes_read_before}, bytes read after: {bytes_read_after}"
@@ -1172,4 +1176,5 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
             # we introduce a small tolerance here, since the read bytes may
             # increase slightly due to term changes and leader elections.
             assert bytes_read_after <= bytes_read_before * 1.01,\
-            f"Enabling Iceberg in the cluster should not cause a major read increase"
+                "Enabling Iceberg in the cluster should not cause a major read increase," \
+                " expected ({bytes_read_after=}) <= ({bytes_read_before * 1.01=})"


### PR DESCRIPTION
https://redpandadata.atlassian.net/issues/CORE-9922

The TopicSpec properties do not do anything.

Not changing the default client as not to affect other tests for now.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
