### PR TITLE
Consumer group blocking

### DIFF
--- a/src/v/container/fragmented_vector.h
+++ b/src/v/container/fragmented_vector.h
@@ -120,8 +120,9 @@ public:
      */
     fragmented_vector(std::initializer_list<value_type> elems)
       : fragmented_vector(elems.begin(), elems.end()) {}
+
     /**
-     * @brief Construct a new vector from a given range
+     * @brief Construct a new vector by moving from a given range
      */
     template<typename Range>
     requires std::ranges::sized_range<Range>
@@ -129,6 +130,17 @@ public:
       : fragmented_vector() {
         reserve(std::ranges::size(range));
         std::move(range.begin(), range.end(), std::back_inserter(*this));
+    }
+
+    /**
+     * @brief Construct a new vector by copying from a const range
+     */
+    template<typename Range>
+    requires(std::ranges::sized_range<Range>)
+    fragmented_vector(std::from_range_t, const Range& range)
+      : fragmented_vector() {
+        reserve(std::ranges::size(range));
+        std::copy(range.begin(), range.end(), std::back_inserter(*this));
     }
 
     fragmented_vector& operator=(fragmented_vector&& other) noexcept {

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -36,6 +36,8 @@ namespace features {
 
 std::string_view to_string_view(feature f) {
     switch (f) {
+    case feature::consumer_groups_migrations:
+        return "consumer_groups_migrations";
     case feature::cloud_retention:
         return "cloud_retention";
     case feature::node_isolation:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -41,6 +41,7 @@ enum class feature : std::uint64_t {
     cluster_linking_dr = 1ULL << 1U,
     topic_locations_in_outbound_migrations = 1ULL << 2U,
     schema_registry_authz = 1ULL << 3U,
+    consumer_groups_migrations = 1ULL << 7U,
     cloud_retention = 1ULL << 11U,
     node_isolation = 1ULL << 19U,
     group_offset_retention = 1ULL << 20U,
@@ -470,6 +471,12 @@ inline constexpr std::array feature_schema{
     release_version::v25_2_1,
     "schema_registry_authz",
     feature::schema_registry_authz,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v25_2_1,
+    "consumer_groups_migrations",
+    feature::consumer_groups_migrations,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -116,8 +116,7 @@ group::group(
   ss::lw_shared_ptr<cluster::partition> partition,
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
-  ss::sharded<features::feature_table>& feature_table,
-  group_metadata_serializer serializer)
+  ss::sharded<features::feature_table>& feature_table)
   : _id(std::move(id))
   , _state(s)
   , _state_timestamp(model::timestamp::now())
@@ -130,7 +129,6 @@ group::group(
   , _probe(_members, _static_members, _offsets, _lag_metrics)
   , _ctxlog(cg_klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
-  , _md_serializer(std::move(serializer))
   , _term(term)
   , _enable_group_metrics(conf.enable_consumer_group_metrics.bind(
       std::function{enabled_metrics::from_vector}))
@@ -151,8 +149,7 @@ group::group(
   ss::lw_shared_ptr<cluster::partition> partition,
   model::term_id term,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
-  ss::sharded<features::feature_table>& feature_table,
-  group_metadata_serializer serializer)
+  ss::sharded<features::feature_table>& feature_table)
   : _id(std::move(id))
   , _state(md.members.empty() ? group_state::empty : group_state::stable)
   , _state_timestamp(
@@ -171,7 +168,6 @@ group::group(
   , _probe(_members, _static_members, _offsets, _lag_metrics)
   , _ctxlog(cg_klog, *this)
   , _ctx_txlog(cluster::txlog, *this)
-  , _md_serializer(std::move(serializer))
   , _term(term)
   , _enable_group_metrics(conf.enable_consumer_group_metrics.bind(
       std::function{enabled_metrics::from_vector}))
@@ -2171,7 +2167,7 @@ void group::update_store_offset_builder(
         value.expiry_timestamp = expiry_timestamp.value();
     }
 
-    auto kv = _md_serializer.to_kv(
+    auto kv = group_metadata_serializer::to_kv(
       offset_metadata_kv{.key = std::move(key), .value = std::move(value)});
     builder.add_raw_kv(std::move(kv.key), std::move(kv.value));
 }
@@ -2606,7 +2602,8 @@ void group::add_offset_tombstone_record(
       .topic = tp.topic,
       .partition = tp.partition,
     };
-    auto kv = _md_serializer.to_kv(offset_metadata_kv{.key = std::move(key)});
+    auto kv = group_metadata_serializer::to_kv(
+      offset_metadata_kv{.key = std::move(key)});
     builder.add_raw_kv(std::move(kv.key), std::nullopt);
 }
 
@@ -2615,7 +2612,8 @@ void group::add_group_tombstone_record(
     group_metadata_key key{
       .group_id = group,
     };
-    auto kv = _md_serializer.to_kv(group_metadata_kv{.key = std::move(key)});
+    auto kv = group_metadata_serializer::to_kv(
+      group_metadata_kv{.key = std::move(key)});
     builder.add_raw_kv(std::move(kv.key), std::nullopt);
 }
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3241,36 +3241,42 @@ void group::maybe_rearm_timer() {
 }
 
 ss::future<> group::do_abort_old_txes() {
-    auto unit = _catchup_lock->attempt_read_lock();
-    if (!unit) {
-        co_return;
-    }
-
-    absl::btree_set<model::producer_identity> expired;
-
-    for (auto& [pid, producer] : _producers) {
-        if (
-          producer.transaction == nullptr
-          || !producer.transaction->is_expired()) {
-            continue;
-        }
-
-        expired.insert(model::producer_identity{pid, producer.epoch});
-    }
-    bool has_error = false;
-    for (auto pid : expired) {
-        auto ec = co_await try_abort_old_tx(pid);
-        if (ec != cluster::tx::errc::none) {
-            has_error = true;
-        }
-    }
-
-    if (!has_error) {
+    if (co_await abort_txes(true) == cluster::tx::errc::none) {
         // if no error was triggered during abort of transaction we may try to
         // schedule a next expiration earlier if there are transactions pending
         // to be expired
         maybe_rearm_timer();
     }
+}
+
+ss::future<cluster::tx::errc> group::abort_txes(bool expired_only) {
+    auto unit = _catchup_lock->attempt_read_lock();
+    if (!unit) {
+        vlog(
+          _ctx_txlog.trace, "can't abort txes: coordinator_load_in_progress");
+        co_return cluster::tx::errc::stale;
+    }
+
+    absl::btree_set<model::producer_identity> to_abort;
+
+    for (auto& [pid, producer] : _producers) {
+        if (
+          producer.transaction == nullptr
+          || (expired_only && !producer.transaction->is_expired())) {
+            continue;
+        }
+
+        to_abort.insert(model::producer_identity{pid, producer.epoch});
+    }
+    auto last_error = cluster::tx::errc::none;
+    for (auto pid : to_abort) {
+        auto ec = co_await try_abort_old_tx(pid);
+        if (ec != cluster::tx::errc::none) {
+            last_error = ec;
+        }
+    }
+
+    co_return last_error;
 }
 
 ss::future<cluster::tx::errc>

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -266,8 +266,7 @@ public:
       ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
-      ss::sharded<features::feature_table>&,
-      group_metadata_serializer);
+      ss::sharded<features::feature_table>&);
 
     // constructor used when loading state from log
     group(
@@ -278,8 +277,7 @@ public:
       ss::lw_shared_ptr<cluster::partition> partition,
       model::term_id,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
-      ss::sharded<features::feature_table>&,
-      group_metadata_serializer);
+      ss::sharded<features::feature_table>&);
 
     ~group() noexcept;
 
@@ -836,7 +834,7 @@ private:
         cluster::simple_batch_builder builder(
           model::record_batch_type::raft_data, model::offset(0));
 
-        auto kv = _md_serializer.to_kv(group_metadata_kv{
+        auto kv = group_metadata_serializer::to_kv(group_metadata_kv{
           .key = std::move(key), .value = std::move(metadata)});
         builder.add_raw_kv(std::move(kv.key), std::move(kv.value));
 
@@ -956,7 +954,6 @@ private:
       _probe;
     ctx_log _ctxlog;
     ctx_log _ctx_txlog;
-    group_metadata_serializer _md_serializer;
     /**
      * flag indicating that the group rebalance is a result of initial join i.e.
      * the group was in Empty state before it went into PreparingRebalance

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -719,6 +719,12 @@ public:
 
     void set_lag_metrics(consumer_lag_metrics lag_metrics);
 
+    /*
+     *  If expired_only is false aborts all TXes.
+     *  If expired_only is true aborts only expired TXes.
+     */
+    ss::future<cluster::tx::errc> abort_txes(bool expired_only);
+
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;

--- a/src/v/kafka/server/group_data_parser.h
+++ b/src/v/kafka/server/group_data_parser.h
@@ -58,14 +58,28 @@ namespace kafka {
 
 template<class T>
 concept GroupDataParserBase = requires(T base, model::record_batch b) {
-    base.handle_raft_data(std::move(b));
-    base.handle_tx_offsets(b.header(), kafka::group_tx::offsets_metadata{});
-    base.handle_commit(b.header(), group_tx::commit_metadata{});
-    base.handle_abort(b.header(), group_tx::abort_metadata{});
-    base.handle_fence_v0(b.header(), group_tx::fence_metadata_v0{});
-    base.handle_fence_v1(b.header(), group_tx::fence_metadata_v1{});
-    base.handle_fence(b.header(), kafka::group_tx::fence_metadata{});
-    base.handle_version_fence(features::feature_table::version_fence{});
+    { base.handle_raft_data(std::move(b)) } -> std::same_as<ss::future<>>;
+    {
+        base.handle_tx_offsets(b.header(), kafka::group_tx::offsets_metadata{})
+    } -> std::same_as<ss::future<>>;
+    {
+        base.handle_commit(b.header(), group_tx::commit_metadata{})
+    } -> std::same_as<ss::future<>>;
+    {
+        base.handle_abort(b.header(), group_tx::abort_metadata{})
+    } -> std::same_as<ss::future<>>;
+    {
+        base.handle_fence_v0(b.header(), group_tx::fence_metadata_v0{})
+    } -> std::same_as<ss::future<>>;
+    {
+        base.handle_fence_v1(b.header(), group_tx::fence_metadata_v1{})
+    } -> std::same_as<ss::future<>>;
+    {
+        base.handle_fence(b.header(), kafka::group_tx::fence_metadata{})
+    } -> std::same_as<ss::future<>>;
+    {
+        base.handle_version_fence(features::feature_table::version_fence{})
+    } -> std::same_as<ss::future<>>;
 };
 
 template<class Base>

--- a/src/v/kafka/server/group_data_parser.h
+++ b/src/v/kafka/server/group_data_parser.h
@@ -80,6 +80,13 @@ concept GroupDataParserBase = requires(T base, model::record_batch b) {
     {
         base.handle_version_fence(features::feature_table::version_fence{})
     } -> std::same_as<ss::future<>>;
+    {
+        base.handle_group_block(
+          kafka::group_block{std::move(b.copy_records()[0])})
+    } -> std::same_as<void>;
+    {
+        std::as_const(base).is_group_blocked(kafka::group_id{})
+    } -> std::same_as<bool>;
 };
 
 template<class Base>
@@ -122,10 +129,27 @@ protected:
               std::move(b));
             return handle_version_fence(fence);
         }
+        case model::record_batch_type::group_block: {
+            return handle_group_block(std::move(b));
+        }
         default:
             vlog(klog.debug, "ignoring batch with type: {}", b.header().type);
             return ss::make_ready_future<>();
         }
+    }
+
+    bool is_group_blocked_verbose(
+      kafka::group_id group_id, std::string_view skipped_msg) const {
+        if (unlikely(
+              static_cast<const Base*>(this)->is_group_blocked(group_id))) {
+            vlog(
+              cg_klog.error,
+              "[group: {}] skipping {}, group is blocked",
+              group_id,
+              skipped_msg);
+            return true;
+        }
+        return false;
     }
 
 private:
@@ -175,29 +199,42 @@ private:
           fence_version,
           group::fence_control_record_version);
     }
+
     ss::future<> handle_raft_data(model::record_batch b) {
         return static_cast<Base*>(this)->handle_raft_data(std::move(b));
     }
     ss::future<> handle_tx_offsets(
       model::record_batch_header header,
       kafka::group_tx::offsets_metadata data) {
+        if (is_group_blocked_verbose(data.group_id, "tx offsets")) {
+            return ss::now();
+        }
         return static_cast<Base*>(this)->handle_tx_offsets(
           header, std::move(data));
     }
     ss::future<> handle_fence_v0(
       model::record_batch_header header,
       kafka::group_tx::fence_metadata_v0 data) {
+        if (is_group_blocked_verbose(data.group_id, "fence v0")) {
+            return ss::now();
+        }
         return static_cast<Base*>(this)->handle_fence_v0(
           header, std::move(data));
     }
     ss::future<> handle_fence_v1(
       model::record_batch_header header,
       kafka::group_tx::fence_metadata_v1 data) {
+        if (is_group_blocked_verbose(data.group_id, "fence v1")) {
+            return ss::now();
+        }
         return static_cast<Base*>(this)->handle_fence_v1(
           header, std::move(data));
     }
     ss::future<> handle_fence(
       model::record_batch_header header, kafka::group_tx::fence_metadata data) {
+        if (is_group_blocked_verbose(data.group_id, "fence")) {
+            return ss::now();
+        }
         return static_cast<Base*>(this)->handle_fence(header, std::move(data));
     }
     ss::future<> handle_abort(
@@ -207,11 +244,20 @@ private:
     ss::future<> handle_commit(
       model::record_batch_header header,
       kafka::group_tx::commit_metadata data) {
+        if (is_group_blocked_verbose(data.group_id, "commit")) {
+            return ss::now();
+        }
         return static_cast<Base*>(this)->handle_commit(header, std::move(data));
     }
     ss::future<>
     handle_version_fence(features::feature_table::version_fence fence) {
         return static_cast<Base*>(this)->handle_version_fence(fence);
+    }
+    ss::future<> handle_group_block(model::record_batch b) {
+        co_await model::for_each_record(b, [this](model::record& r) {
+            static_cast<Base*>(this)->handle_group_block(
+              kafka::group_block{std::move(r)});
+        });
     }
 };
 } // namespace kafka

--- a/src/v/kafka/server/group_data_parser.h
+++ b/src/v/kafka/server/group_data_parser.h
@@ -79,40 +79,39 @@ public:
 
 protected:
     ss::future<> parse(model::record_batch b) {
-        if (b.header().type == model::record_batch_type::raft_data) {
+        switch (b.header().type) {
+        case model::record_batch_type::raft_data:
             return handle_raft_data(std::move(b));
-        }
-        // silently ignore raft configuration.
-        if (b.header().type == model::record_batch_type::raft_configuration) {
+        case model::record_batch_type::raft_configuration:
+            // silently ignore raft configuration.
             return ss::now();
-        }
-        if (b.header().type == model::record_batch_type::group_prepare_tx) {
+        case model::record_batch_type::group_prepare_tx: {
             auto data = parse_tx_batch<kafka::group_tx::offsets_metadata>(
               b, group::prepared_tx_record_version);
             return handle_tx_offsets(b.header(), std::move(data));
         }
-        if (b.header().type == model::record_batch_type::group_commit_tx) {
+        case model::record_batch_type::group_commit_tx: {
             auto data = parse_tx_batch<group_tx::commit_metadata>(
               b, group::commit_tx_record_version);
             return handle_commit(b.header(), std::move(data));
         }
-        if (b.header().type == model::record_batch_type::group_abort_tx) {
+        case model::record_batch_type::group_abort_tx: {
             auto data = parse_tx_batch<group_tx::abort_metadata>(
               b, group::aborted_tx_record_version);
             return handle_abort(b.header(), std::move(data));
         }
-        if (
-          b.header().type == model::record_batch_type::tx_fence
-          || b.header().type == model::record_batch_type::group_fence_tx) {
+        case model::record_batch_type::tx_fence:
+        case model::record_batch_type::group_fence_tx:
             return parse_fence(std::move(b));
-        }
-        if (b.header().type == model::record_batch_type::version_fence) {
+        case model::record_batch_type::version_fence: {
             auto fence = features::feature_table::decode_version_fence(
               std::move(b));
             return handle_version_fence(fence);
         }
-        vlog(klog.debug, "ignoring batch with type: {}", b.header().type);
-        return ss::make_ready_future<>();
+        default:
+            vlog(klog.debug, "ignoring batch with type: {}", b.header().type);
+            return ss::make_ready_future<>();
+        }
     }
 
 private:

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -682,6 +682,98 @@ ss::future<> group_manager::reload_groups() {
     co_await ss::when_all_succeed(futures.begin(), futures.end());
 }
 
+ss::future<result<model::offset>> group_manager::set_blocked_for_groups(
+  const model::ntp& co_ntp,
+  const chunked_vector<kafka::group_id>& group_ids,
+  bool to_block) {
+    if (!_feature_table.local().is_active(
+          features::feature::consumer_groups_migrations)) {
+        vlog(
+          cg_klog.warn,
+          "set blocked request for {} failed - consumer groups migrations "
+          "feature is not active",
+          co_ntp);
+        co_return cluster::errc::feature_disabled;
+    }
+    auto p = get_attached_partition(co_ntp);
+    if (!p) {
+        vlog(
+          cg_klog.warn,
+          "set blocked request for {} failed - attached partition not found",
+          co_ntp);
+        co_return cluster::errc::partition_not_exists;
+    }
+    if (!p->catchup_lock->try_read_lock()) {
+        vlog(
+          cluster::txlog.trace,
+          "can't set blocked: coordinator_load_in_progress");
+        co_return cluster::tx::errc::coordinator_load_in_progress;
+    }
+    p->catchup_lock->read_unlock();
+    auto holder = co_await p->catchup_lock->hold_read_lock();
+
+    const auto affected_gids
+      = group_ids
+        | std::views::filter([this, to_block](const kafka::group_id& group_id) {
+              return to_block != _blocked_groups.contains(group_id);
+          })
+        | std::ranges::to<chunked_vector<kafka::group_id>>();
+
+    // in case we return early with an exception or another error
+    auto revert_blocking = ss::defer([this, &affected_gids, to_block] {
+        if (to_block) {
+            _blocked_groups.erase(affected_gids.begin(), affected_gids.end());
+        }
+    });
+    if (to_block) {
+        // block early to avoid racing with new transactions
+        _blocked_groups.insert(affected_gids.begin(), affected_gids.end());
+
+        auto last_error = cluster::tx::errc::none;
+        co_await ss::max_concurrent_for_each(
+          group_ids, 5, [this, &last_error](auto& group_id) {
+              if (auto group = get_group(group_id)) {
+                  return group->abort_txes(false).then([&last_error](auto ec) {
+                      if (ec != cluster::tx::errc::none) {
+                          last_error = ec;
+                      }
+                  });
+              }
+              return ss::make_ready_future<>();
+          });
+        if (last_error != cluster::tx::errc::none) {
+            vlog(
+              cg_klog.warn,
+              "Failed to abort transactions for blocked groups: {}",
+              last_error);
+            co_return last_error;
+        }
+    }
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::group_block, model::offset{0});
+    for (const auto& group_id : group_ids) {
+        group_block{group_id, to_block}.add_to_batch_builder(builder);
+    }
+
+    auto result = co_await p->partition->raft()->replicate(
+      p->term,
+      std::move(builder).build(),
+      raft::replicate_options(raft::consistency_level::quorum_ack));
+
+    if (!result) {
+        co_return result.error();
+    }
+
+    // unblock only when replicated
+    if (!to_block) {
+        _blocked_groups.erase(affected_gids.cbegin(), affected_gids.cend());
+    }
+
+    revert_blocking.cancel();
+    co_return result.value().last_offset;
+}
+
 ss::future<group_offsets_snapshot_result> group_manager::snapshot_groups(
   const model::ntp& ntp, size_t max_num_groups_per_snap) {
     auto it = _partitions.find(ntp);
@@ -976,6 +1068,7 @@ ss::future<> group_manager::recover_partition(
           return do_recover_group(
             term, p, std::move(pair.first), std::move(pair.second));
       });
+    _blocked_groups = std::move(ctx.blocked_groups);
 }
 
 ss::future<> group_manager::do_recover_group(
@@ -1149,7 +1242,7 @@ ss::future<> group_manager::write_version_fence(
 
 group::join_group_stages group_manager::join_group(join_group_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, join_group_api::key);
+      r.ntp, r.data.group_id, join_group_api::key, false);
     if (error != error_code::none) {
         return group::join_group_stages(
           make_join_error(r.data.member_id, error));
@@ -1228,7 +1321,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
 
 group::sync_group_stages group_manager::sync_group(sync_group_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, sync_group_api::key);
+      r.ntp, r.data.group_id, sync_group_api::key, false);
     if (error != error_code::none) {
         if (error == error_code::coordinator_load_in_progress) {
             // <kafka>The coordinator is loading, which means we've lost the
@@ -1262,7 +1355,7 @@ group::sync_group_stages group_manager::sync_group(sync_group_request&& r) {
 
 ss::future<heartbeat_response> group_manager::heartbeat(heartbeat_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, heartbeat_api::key);
+      r.ntp, r.data.group_id, heartbeat_api::key, false);
     if (error != error_code::none) {
         if (error == error_code::coordinator_load_in_progress) {
             // <kafka>the group is still loading, so respond just
@@ -1288,7 +1381,7 @@ ss::future<heartbeat_response> group_manager::heartbeat(heartbeat_request&& r) {
 ss::future<leave_group_response>
 group_manager::leave_group(leave_group_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, leave_group_api::key);
+      r.ntp, r.data.group_id, leave_group_api::key, false);
     if (error != error_code::none) {
         return make_leave_error(error);
     }
@@ -1346,7 +1439,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
           // TODO: use correct key instead of offset_commit_api::key
           // check other txn places
           auto error = validate_group_status(
-            r.ntp, r.data.group_id, offset_commit_api::key);
+            r.ntp, r.data.group_id, offset_commit_api::key, false);
           if (error != error_code::none) {
               return ss::make_ready_future<txn_offset_commit_response>(
                 txn_offset_commit_response(r, error));
@@ -1397,7 +1490,7 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
     return p->catchup_lock->hold_read_lock().then(
       [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
-            r.ntp, r.group_id, offset_commit_api::key);
+            r.ntp, r.group_id, offset_commit_api::key, false);
           if (error != error_code::none) {
               if (error == error_code::not_coordinator) {
                   return ss::make_ready_future<cluster::commit_group_tx_reply>(
@@ -1440,7 +1533,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
     return p->catchup_lock->hold_read_lock().then(
       [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
-            r.ntp, r.group_id, offset_commit_api::key);
+            r.ntp, r.group_id, offset_commit_api::key, false);
           if (error != error_code::none) {
               auto ec = error == error_code::not_coordinator
                           ? cluster::tx::errc::not_coordinator
@@ -1490,7 +1583,7 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
     return p->catchup_lock->hold_read_lock().then(
       [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
           auto error = validate_group_status(
-            r.ntp, r.group_id, offset_commit_api::key);
+            r.ntp, r.group_id, offset_commit_api::key, true);
           if (error != error_code::none) {
               auto ec = error == error_code::not_coordinator
                           ? cluster::tx::errc::not_coordinator
@@ -1513,7 +1606,7 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
 group::offset_commit_stages
 group_manager::offset_commit(offset_commit_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, offset_commit_api::key);
+      r.ntp, r.data.group_id, offset_commit_api::key, false);
     if (error != error_code::none) {
         return group::offset_commit_stages(offset_commit_response(r, error));
     }
@@ -1551,7 +1644,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
 ss::future<offset_fetch_response>
 group_manager::offset_fetch(offset_fetch_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, offset_fetch_api::key);
+      r.ntp, r.data.group_id, offset_fetch_api::key, true);
     if (error != error_code::none) {
         return ss::make_ready_future<offset_fetch_response>(
           offset_fetch_response(error));
@@ -1569,7 +1662,7 @@ group_manager::offset_fetch(offset_fetch_request&& r) {
 ss::future<offset_delete_response>
 group_manager::offset_delete(offset_delete_request&& r) {
     auto error = validate_group_status(
-      r.ntp, r.data.group_id, offset_delete_api::key);
+      r.ntp, r.data.group_id, offset_delete_api::key, false);
     if (error != error_code::none) {
         co_return offset_delete_response(error);
     }
@@ -1653,7 +1746,7 @@ group_manager::list_groups(const list_groups_filter_data& filter_data) const {
 
 described_group
 group_manager::describe_group(const model::ntp& ntp, const kafka::group_id& g) {
-    auto error = validate_group_status(ntp, g, describe_groups_api::key);
+    auto error = validate_group_status(ntp, g, describe_groups_api::key, true);
     if (error != error_code::none) {
         return describe_groups_response::make_empty_described_group(g, error);
     }
@@ -1730,7 +1823,7 @@ ss::future<std::vector<deletable_group_result>> group_manager::delete_groups(
 
     for (auto& group_info : groups) {
         auto error = validate_group_status(
-          group_info.first, group_info.second, delete_groups_api::key);
+          group_info.first, group_info.second, delete_groups_api::key, false);
         if (error != error_code::none) {
             results.push_back(deletable_group_result{
               .group_id = std::move(group_info.second),
@@ -1791,7 +1884,15 @@ bool group_manager::valid_group_id(const group_id& group, api_key api) {
  * - check for group being shutdown
  */
 error_code group_manager::validate_group_status(
-  const model::ntp& ntp, const group_id& group, api_key api) {
+  const model::ntp& ntp,
+  const group_id& group,
+  api_key api,
+  bool allow_blocked) const {
+    if (unlikely(!allow_blocked && _blocked_groups.contains(group))) {
+        vlog(cg_klog.debug, "Group {} is blocked for operation {}", group, api);
+        return error_code::invalid_group_id;
+    }
+
     if (!valid_group_id(group, api)) {
         vlog(
           cg_klog.debug,

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -74,8 +74,7 @@ group_manager::group_manager(
   ss::sharded<cluster::topic_table>& topic_table,
   ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
   ss::sharded<features::feature_table>& feature_table,
-  ss::sharded<consumer_group_lag_metrics_frontend>& lag_metrics_frontend,
-  group_metadata_serializer_factory serializer_factory)
+  ss::sharded<consumer_group_lag_metrics_frontend>& lag_metrics_frontend)
   : _tp_ns(std::move(tp_ns))
   , _gm(gm)
   , _pm(pm)
@@ -83,7 +82,6 @@ group_manager::group_manager(
   , _tx_frontend(tx_frontend)
   , _feature_table(feature_table)
   , _lag_metrics_frontend(lag_metrics_frontend)
-  , _serializer_factory(std::move(serializer_factory))
   , _conf(config::shard_local_cfg())
   , _self(cluster::make_self_broker(config::node()))
   , _offset_retention_check(_conf.group_offset_retention_check_ms.bind())
@@ -911,9 +909,7 @@ ss::future<> group_manager::handle_partition_leader_change(
                   .then([this, term, p, timeout, expected_to_read](
                           model::record_batch_reader reader) {
                       return std::move(reader)
-                        .consume(
-                          group_recovery_consumer(_serializer_factory(), p->as),
-                          timeout)
+                        .consume(group_recovery_consumer(p->as), timeout)
                         .then([this, term, p, expected_to_read](
                                 group_recovery_consumer_state state) {
                             if (state.last_read_offset < expected_to_read) {
@@ -1008,8 +1004,7 @@ ss::future<> group_manager::do_recover_group(
               p->partition,
               term,
               _tx_frontend,
-              _feature_table,
-              _serializer_factory());
+              _feature_table);
             _groups.emplace(group_id, group);
             group->reschedule_all_member_heartbeats();
         }
@@ -1218,8 +1213,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
           p,
           it->second->term,
           _tx_frontend,
-          _feature_table,
-          _serializer_factory());
+          _feature_table);
         _groups.emplace(r.data.group_id, group);
         _groups.rehash(0);
         is_new_group = true;
@@ -1371,8 +1365,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
                 p->partition,
                 p->term,
                 _tx_frontend,
-                _feature_table,
-                _serializer_factory());
+                _feature_table);
               _groups.emplace(r.data.group_id, group);
               _groups.rehash(0);
           }
@@ -1466,8 +1459,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 p->partition,
                 p->term,
                 _tx_frontend,
-                _feature_table,
-                _serializer_factory());
+                _feature_table);
               _groups.emplace(r.group_id, group);
               _groups.rehash(0);
           }
@@ -1540,8 +1532,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               p->partition,
               p->term,
               _tx_frontend,
-              _feature_table,
-              _serializer_factory());
+              _feature_table);
             _groups.emplace(r.data.group_id, group);
             _groups.rehash(0);
         } else {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -703,14 +703,13 @@ ss::future<result<model::offset>> group_manager::set_blocked_for_groups(
           co_ntp);
         co_return cluster::errc::partition_not_exists;
     }
-    if (!p->catchup_lock->try_read_lock()) {
+    auto maybe_holder = p->catchup_lock->attempt_read_lock();
+    if (!maybe_holder) {
         vlog(
           cluster::txlog.trace,
           "can't set blocked: coordinator_load_in_progress");
         co_return cluster::tx::errc::coordinator_load_in_progress;
     }
-    p->catchup_lock->read_unlock();
-    auto holder = co_await p->catchup_lock->hold_read_lock();
 
     const auto affected_gids
       = group_ids
@@ -1422,7 +1421,8 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
         return ss::make_ready_future<txn_offset_commit_response>(
           txn_offset_commit_response(r, error_code::not_coordinator));
     }
-    if (!p->catchup_lock->try_read_lock()) {
+    auto maybe_holder = p->catchup_lock->attempt_read_lock();
+    if (!maybe_holder) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1432,40 +1432,35 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
           txn_offset_commit_response(
             r, error_code::coordinator_load_in_progress));
     }
-    p->catchup_lock->read_unlock();
+    // TODO: use correct key instead of offset_commit_api::key
+    // check other txn places
+    auto error = validate_group_status(
+      r.ntp, r.data.group_id, offset_commit_api::key, false);
+    if (error != error_code::none) {
+        return ss::make_ready_future<txn_offset_commit_response>(
+          txn_offset_commit_response(r, error));
+    }
 
-    return p->catchup_lock->hold_read_lock().then(
-      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
-          // TODO: use correct key instead of offset_commit_api::key
-          // check other txn places
-          auto error = validate_group_status(
-            r.ntp, r.data.group_id, offset_commit_api::key, false);
-          if (error != error_code::none) {
-              return ss::make_ready_future<txn_offset_commit_response>(
-                txn_offset_commit_response(r, error));
-          }
+    auto group = get_group(r.data.group_id);
+    if (!group) {
+        // <kafka>the group is not relying on Kafka for group
+        // management, so allow the commit</kafka>
 
-          auto group = get_group(r.data.group_id);
-          if (!group) {
-              // <kafka>the group is not relying on Kafka for group
-              // management, so allow the commit</kafka>
+        group = ss::make_lw_shared<kafka::group>(
+          r.data.group_id,
+          group_state::empty,
+          _conf,
+          p->catchup_lock,
+          p->partition,
+          p->term,
+          _tx_frontend,
+          _feature_table);
+        _groups.emplace(r.data.group_id, group);
+        _groups.rehash(0);
+    }
 
-              group = ss::make_lw_shared<kafka::group>(
-                r.data.group_id,
-                group_state::empty,
-                _conf,
-                p->catchup_lock,
-                p->partition,
-                p->term,
-                _tx_frontend,
-                _feature_table);
-              _groups.emplace(r.data.group_id, group);
-              _groups.rehash(0);
-          }
-
-          return group->handle_txn_offset_commit(std::move(r))
-            .finally([unit = std::move(unit), group] {});
-      });
+    return group->handle_txn_offset_commit(std::move(r))
+      .finally([unit = std::move(*maybe_holder), group] {});
 }
 
 ss::future<cluster::commit_group_tx_reply>
@@ -1475,7 +1470,8 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
         return ss::make_ready_future<cluster::commit_group_tx_reply>(
           make_commit_tx_reply(cluster::tx::errc::not_coordinator));
     }
-    if (!p->catchup_lock->try_read_lock()) {
+    auto maybe_holder = p->catchup_lock->attempt_read_lock();
+    if (!maybe_holder) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1485,31 +1481,26 @@ group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
           make_commit_tx_reply(
             cluster::tx::errc::coordinator_load_in_progress));
     }
-    p->catchup_lock->read_unlock();
+    auto error = validate_group_status(
+      r.ntp, r.group_id, offset_commit_api::key, false);
+    if (error != error_code::none) {
+        if (error == error_code::not_coordinator) {
+            return ss::make_ready_future<cluster::commit_group_tx_reply>(
+              make_commit_tx_reply(cluster::tx::errc::not_coordinator));
+        } else {
+            return ss::make_ready_future<cluster::commit_group_tx_reply>(
+              make_commit_tx_reply(cluster::tx::errc::timeout));
+        }
+    }
 
-    return p->catchup_lock->hold_read_lock().then(
-      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
-          auto error = validate_group_status(
-            r.ntp, r.group_id, offset_commit_api::key, false);
-          if (error != error_code::none) {
-              if (error == error_code::not_coordinator) {
-                  return ss::make_ready_future<cluster::commit_group_tx_reply>(
-                    make_commit_tx_reply(cluster::tx::errc::not_coordinator));
-              } else {
-                  return ss::make_ready_future<cluster::commit_group_tx_reply>(
-                    make_commit_tx_reply(cluster::tx::errc::timeout));
-              }
-          }
+    auto group = get_group(r.group_id);
+    if (!group) {
+        return ss::make_ready_future<cluster::commit_group_tx_reply>(
+          make_commit_tx_reply(cluster::tx::errc::timeout));
+    }
 
-          auto group = get_group(r.group_id);
-          if (!group) {
-              return ss::make_ready_future<cluster::commit_group_tx_reply>(
-                make_commit_tx_reply(cluster::tx::errc::timeout));
-          }
-
-          return group->handle_commit_tx(std::move(r))
-            .finally([unit = std::move(unit), group] {});
-      });
+    return group->handle_commit_tx(std::move(r))
+      .finally([unit = std::move(*maybe_holder), group] {});
 }
 
 ss::future<cluster::begin_group_tx_reply>
@@ -1519,7 +1510,8 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
           make_begin_tx_reply(cluster::tx::errc::not_coordinator));
     }
-    if (!p->catchup_lock->try_read_lock()) {
+    auto maybe_holder = p->catchup_lock->attempt_read_lock();
+    if (!maybe_holder) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1528,38 +1520,34 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
           make_begin_tx_reply(cluster::tx::errc::coordinator_load_in_progress));
     }
-    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock->hold_read_lock().then(
-      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
-          auto error = validate_group_status(
-            r.ntp, r.group_id, offset_commit_api::key, false);
-          if (error != error_code::none) {
-              auto ec = error == error_code::not_coordinator
-                          ? cluster::tx::errc::not_coordinator
-                          : cluster::tx::errc::timeout;
-              return ss::make_ready_future<cluster::begin_group_tx_reply>(
-                make_begin_tx_reply(ec));
-          }
+    auto error = validate_group_status(
+      r.ntp, r.group_id, offset_commit_api::key, false);
+    if (error != error_code::none) {
+        auto ec = error == error_code::not_coordinator
+                    ? cluster::tx::errc::not_coordinator
+                    : cluster::tx::errc::timeout;
+        return ss::make_ready_future<cluster::begin_group_tx_reply>(
+          make_begin_tx_reply(ec));
+    }
 
-          auto group = get_group(r.group_id);
-          if (!group) {
-              group = ss::make_lw_shared<kafka::group>(
-                r.group_id,
-                group_state::empty,
-                _conf,
-                p->catchup_lock,
-                p->partition,
-                p->term,
-                _tx_frontend,
-                _feature_table);
-              _groups.emplace(r.group_id, group);
-              _groups.rehash(0);
-          }
+    auto group = get_group(r.group_id);
+    if (!group) {
+        group = ss::make_lw_shared<kafka::group>(
+          r.group_id,
+          group_state::empty,
+          _conf,
+          p->catchup_lock,
+          p->partition,
+          p->term,
+          _tx_frontend,
+          _feature_table);
+        _groups.emplace(r.group_id, group);
+        _groups.rehash(0);
+    }
 
-          return group->handle_begin_tx(std::move(r))
-            .finally([unit = std::move(unit), group] {});
-      });
+    return group->handle_begin_tx(std::move(r))
+      .finally([unit = std::move(*maybe_holder), group] {});
 }
 
 ss::future<cluster::abort_group_tx_reply>
@@ -1569,7 +1557,8 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
           make_abort_tx_reply(cluster::tx::errc::not_coordinator));
     }
-    if (!p->catchup_lock->try_read_lock()) {
+    auto maybe_holder = p->catchup_lock->attempt_read_lock();
+    if (!maybe_holder) {
         // transaction operations can't run in parallel with loading
         // state from the log (happens once per term change)
         vlog(
@@ -1578,29 +1567,25 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
         return ss::make_ready_future<cluster::abort_group_tx_reply>(
           make_abort_tx_reply(cluster::tx::errc::coordinator_load_in_progress));
     }
-    p->catchup_lock->read_unlock();
 
-    return p->catchup_lock->hold_read_lock().then(
-      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
-          auto error = validate_group_status(
-            r.ntp, r.group_id, offset_commit_api::key, true);
-          if (error != error_code::none) {
-              auto ec = error == error_code::not_coordinator
-                          ? cluster::tx::errc::not_coordinator
-                          : cluster::tx::errc::timeout;
-              return ss::make_ready_future<cluster::abort_group_tx_reply>(
-                make_abort_tx_reply(ec));
-          }
+    auto error = validate_group_status(
+      r.ntp, r.group_id, offset_commit_api::key, true);
+    if (error != error_code::none) {
+        auto ec = error == error_code::not_coordinator
+                    ? cluster::tx::errc::not_coordinator
+                    : cluster::tx::errc::timeout;
+        return ss::make_ready_future<cluster::abort_group_tx_reply>(
+          make_abort_tx_reply(ec));
+    }
 
-          auto group = get_group(r.group_id);
-          if (!group) {
-              return ss::make_ready_future<cluster::abort_group_tx_reply>(
-                make_abort_tx_reply(cluster::tx::errc::timeout));
-          }
+    auto group = get_group(r.group_id);
+    if (!group) {
+        return ss::make_ready_future<cluster::abort_group_tx_reply>(
+          make_abort_tx_reply(cluster::tx::errc::timeout));
+    }
 
-          return group->handle_abort_tx(std::move(r))
-            .finally([unit = std::move(unit), group] {});
-      });
+    return group->handle_abort_tx(std::move(r))
+      .finally([unit = std::move(*maybe_holder), group] {});
 }
 
 group::offset_commit_stages

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -188,6 +188,14 @@ public:
 
     ss::future<> reload_groups();
 
+    /*
+     * May misbehave if called concurrently for intersecting sets of groups.
+     */
+    ss::future<result<model::offset>> set_blocked_for_groups(
+      const model::ntp& co_ntp,
+      const chunked_vector<kafka::group_id>&,
+      bool to_block);
+
     // Returns the groups being managed by the attached partition of the given
     // NTP, returning an error if the partition is not serving groups on this
     // shard (e.g. not leader, still loading groups, etc).
@@ -204,7 +212,10 @@ public:
 
 public:
     error_code validate_group_status(
-      const model::ntp& ntp, const group_id& group, api_key api);
+      const model::ntp& ntp,
+      const group_id& group,
+      api_key api,
+      bool allow_blocked) const;
 
     static bool valid_group_id(const group_id& group, api_key api);
 
@@ -310,6 +321,7 @@ private:
     ss::sharded<consumer_group_lag_metrics_frontend>& _lag_metrics_frontend;
     config::configuration& _conf;
     absl::node_hash_map<group_id, group_ptr> _groups;
+    chunked_hash_set<kafka::group_id> _blocked_groups;
     absl::node_hash_map<model::ntp, ss::lw_shared_ptr<attached_partition>>
       _partitions;
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -127,8 +127,7 @@ public:
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::tx_gateway_frontend>& tx_frontend,
       ss::sharded<features::feature_table>&,
-      ss::sharded<consumer_group_lag_metrics_frontend>&,
-      group_metadata_serializer_factory);
+      ss::sharded<consumer_group_lag_metrics_frontend>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -309,7 +308,6 @@ private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_frontend;
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<consumer_group_lag_metrics_frontend>& _lag_metrics_frontend;
-    group_metadata_serializer_factory _serializer_factory;
     config::configuration& _conf;
     absl::node_hash_map<group_id, group_ptr> _groups;
     absl::node_hash_map<model::ntp, ss::lw_shared_ptr<attached_partition>>

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -280,7 +280,7 @@ private:
       ss::lowres_clock::time_point timeout);
 
     ss::lw_shared_ptr<attached_partition>
-    get_attached_partition(model::ntp ntp) {
+    get_attached_partition(const model::ntp& ntp) {
         auto it = _partitions.find(ntp);
         if (it == _partitions.end()) {
             return nullptr;

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -329,63 +329,56 @@ iobuf maybe_unwrap_from_iobuf(iobuf buffer) {
 }
 } // namespace
 
-group_metadata_serializer make_consumer_offsets_serializer() {
-    struct impl final : group_metadata_serializer::impl {
-        group_metadata_type get_metadata_type(iobuf buffer) final {
-            auto reader = protocol::decoder(
-              maybe_unwrap_from_iobuf(std::move(buffer)));
-            return decode_metadata_type(reader);
-        };
+namespace group_metadata_serializer {
+group_metadata_type get_metadata_type(iobuf buffer) {
+    auto reader = protocol::decoder(maybe_unwrap_from_iobuf(std::move(buffer)));
+    return decode_metadata_type(reader);
+};
 
-        group_metadata_serializer::key_value to_kv(group_metadata_kv md) final {
-            group_metadata_serializer::key_value ret;
-            ret.key = metadata_to_iobuf(md.key);
-            if (md.value) {
-                ret.value = metadata_to_iobuf(*md.value);
-            }
+key_value to_kv(group_metadata_kv md) {
+    key_value ret;
+    ret.key = metadata_to_iobuf(md.key);
+    if (md.value) {
+        ret.value = metadata_to_iobuf(*md.value);
+    }
 
-            return ret;
-        }
-
-        group_metadata_serializer::key_value
-        to_kv(offset_metadata_kv md) final {
-            group_metadata_serializer::key_value ret;
-            ret.key = metadata_to_iobuf(md.key);
-            if (md.value) {
-                ret.value = metadata_to_iobuf(*md.value);
-            }
-
-            return ret;
-        }
-
-        group_metadata_kv decode_group_metadata(model::record record) final {
-            group_metadata_kv ret;
-            protocol::decoder k_reader(
-              maybe_unwrap_from_iobuf(record.release_key()));
-            ret.key = group_metadata_key::decode(k_reader);
-            if (record.has_value()) {
-                protocol::decoder v_reader(record.release_value());
-                ret.value = group_metadata_value::decode(v_reader);
-            }
-
-            return ret;
-        }
-
-        offset_metadata_kv decode_offset_metadata(model::record record) final {
-            offset_metadata_kv ret;
-            protocol::decoder k_reader(
-              maybe_unwrap_from_iobuf(record.release_key()));
-            ret.key = offset_metadata_key::decode(k_reader);
-            if (record.has_value()) {
-                protocol::decoder v_reader(record.release_value());
-                ret.value = offset_metadata_value::decode(v_reader);
-            }
-
-            return ret;
-        }
-    };
-    return group_metadata_serializer(std::make_unique<impl>());
+    return ret;
 }
+
+key_value to_kv(offset_metadata_kv md) {
+    group_metadata_serializer::key_value ret;
+    ret.key = metadata_to_iobuf(md.key);
+    if (md.value) {
+        ret.value = metadata_to_iobuf(*md.value);
+    }
+
+    return ret;
+}
+
+group_metadata_kv decode_group_metadata(model::record record) {
+    group_metadata_kv ret;
+    protocol::decoder k_reader(maybe_unwrap_from_iobuf(record.release_key()));
+    ret.key = group_metadata_key::decode(k_reader);
+    if (record.has_value()) {
+        protocol::decoder v_reader(record.release_value());
+        ret.value = group_metadata_value::decode(v_reader);
+    }
+
+    return ret;
+}
+
+offset_metadata_kv decode_offset_metadata(model::record record) {
+    offset_metadata_kv ret;
+    protocol::decoder k_reader(maybe_unwrap_from_iobuf(record.release_key()));
+    ret.key = offset_metadata_key::decode(k_reader);
+    if (record.has_value()) {
+        protocol::decoder v_reader(record.release_value());
+        ret.value = offset_metadata_value::decode(v_reader);
+    }
+
+    return ret;
+}
+} // namespace group_metadata_serializer
 
 std::ostream& operator<<(std::ostream& o, const member_state& v) {
     fmt::print(

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -27,6 +27,7 @@
 #include <fmt/ostream.h>
 
 #include <chrono>
+#include <optional>
 #include <string_view>
 
 namespace kafka {
@@ -328,6 +329,33 @@ iobuf maybe_unwrap_from_iobuf(iobuf buffer) {
     return buffer;
 }
 } // namespace
+
+std::ostream& operator<<(std::ostream& o, const group_block& block) {
+    fmt::print(
+      o, "{{group_id: {}, is_blocked: {}}}", block.group_id, block.is_blocked);
+    return o;
+}
+
+group_block::group_block(kafka::group_id group_id, bool is_blocked)
+  : group_id(std::move(group_id))
+  , is_blocked(is_blocked) {}
+group_block::group_block(model::record record)
+  : group_id(protocol::decoder(record.release_key()).read_string())
+  , is_blocked(!record.is_tombstone()) {}
+
+void group_block::add_to_batch_builder(storage::record_batch_builder& b) const {
+    iobuf key;
+    protocol::encoder ke{key};
+    ke.write(group_id);
+
+    // unblock to act as a tombstone
+    std::optional<iobuf> value;
+    if (is_blocked) {
+        value.emplace();
+    }
+
+    b.add_raw_kv(std::move(key), std::move(value));
+}
 
 namespace group_metadata_serializer {
 group_metadata_type get_metadata_type(iobuf buffer) {

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -177,52 +177,18 @@ inline group_metadata_version read_metadata_version(protocol::decoder& reader) {
     return group_metadata_version{reader.read_int16()};
 }
 
-class group_metadata_serializer {
-public:
-    struct key_value {
-        iobuf key;
-        std::optional<iobuf> value;
-    };
-    struct impl {
-        virtual group_metadata_type get_metadata_type(iobuf) = 0;
-        virtual key_value to_kv(group_metadata_kv) = 0;
-        virtual key_value to_kv(offset_metadata_kv) = 0;
-
-        virtual group_metadata_kv decode_group_metadata(model::record) = 0;
-        virtual offset_metadata_kv decode_offset_metadata(model::record) = 0;
-        virtual ~impl() = default;
-    };
-
-    explicit group_metadata_serializer(std::unique_ptr<impl> impl)
-      : _impl(std::move(impl)) {}
-
-    group_metadata_type get_metadata_type(iobuf buf) {
-        return _impl->get_metadata_type(std::move(buf));
-    };
-
-    key_value to_kv(group_metadata_kv md) {
-        return _impl->to_kv(std::move(md));
-    }
-    key_value to_kv(offset_metadata_kv md) {
-        return _impl->to_kv(std::move(md));
-    }
-
-    group_metadata_kv decode_group_metadata(model::record record) {
-        return _impl->decode_group_metadata(std::move(record));
-    }
-
-    offset_metadata_kv decode_offset_metadata(model::record record) {
-        return _impl->decode_offset_metadata(std::move(record));
-    }
-
-private:
-    std::unique_ptr<impl> _impl;
+namespace group_metadata_serializer {
+struct key_value {
+    iobuf key;
+    std::optional<iobuf> value;
 };
+group_metadata_type get_metadata_type(iobuf buf);
+key_value to_kv(group_metadata_kv md);
+key_value to_kv(offset_metadata_kv md);
+group_metadata_kv decode_group_metadata(model::record record);
+offset_metadata_kv decode_offset_metadata(model::record record);
+}; // namespace group_metadata_serializer
 
-group_metadata_serializer make_consumer_offsets_serializer();
-
-using group_metadata_serializer_factory
-  = ss::noncopyable_function<group_metadata_serializer()>;
 namespace group_tx {
 struct fence_metadata_v0 {
     kafka::group_id group_id;

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -177,6 +177,15 @@ inline group_metadata_version read_metadata_version(protocol::decoder& reader) {
     return group_metadata_version{reader.read_int16()};
 }
 
+struct group_block {
+    kafka::group_id group_id;
+    bool is_blocked;
+    friend std::ostream& operator<<(std::ostream&, const group_block&);
+
+    group_block(kafka::group_id group_id, bool is_blocked);
+    explicit group_block(model::record record);
+    void add_to_batch_builder(storage::record_batch_builder&) const;
+};
 namespace group_metadata_serializer {
 struct key_value {
     iobuf key;
@@ -190,6 +199,7 @@ offset_metadata_kv decode_offset_metadata(model::record record);
 }; // namespace group_metadata_serializer
 
 namespace group_tx {
+
 struct fence_metadata_v0 {
     kafka::group_id group_id;
     friend std::ostream& operator<<(std::ostream&, const fence_metadata_v0&);

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -178,15 +178,16 @@ group_recovery_consumer::operator()(model::record_batch batch) {
 
 void group_recovery_consumer::handle_record(model::record r) {
     try {
-        auto record_type = _serializer.get_metadata_type(r.key().copy());
+        auto record_type = group_metadata_serializer::get_metadata_type(
+          r.key().copy());
         switch (record_type) {
         case offset_commit:
             handle_offset_metadata(
-              _serializer.decode_offset_metadata(std::move(r)));
+              group_metadata_serializer::decode_offset_metadata(std::move(r)));
             return;
         case group_metadata:
             handle_group_metadata(
-              _serializer.decode_group_metadata(std::move(r)));
+              group_metadata_serializer::decode_group_metadata(std::move(r)));
             return;
         case noop:
             // ignore noops, they are handled for backward compatibility

--- a/src/v/kafka/server/group_recovery_consumer.cc
+++ b/src/v/kafka/server/group_recovery_consumer.cc
@@ -166,6 +166,18 @@ ss::future<> group_recovery_consumer::handle_version_fence(
     co_return;
 }
 
+void group_recovery_consumer::handle_group_block(kafka::group_block gb) {
+    if (gb.is_blocked) {
+        _state.blocked_groups.insert(gb.group_id);
+    } else {
+        _state.blocked_groups.erase(gb.group_id);
+    }
+}
+
+bool group_recovery_consumer::is_group_blocked(kafka::group_id group_id) const {
+    return _state.blocked_groups.contains(group_id);
+}
+
 ss::future<ss::stop_iteration>
 group_recovery_consumer::operator()(model::record_batch batch) {
     if (_as.abort_requested()) {
@@ -203,6 +215,9 @@ void group_recovery_consumer::handle_record(model::record r) {
 }
 
 void group_recovery_consumer::handle_group_metadata(group_metadata_kv md) {
+    if (is_group_blocked_verbose(md.key.group_id, "group metadata")) {
+        return;
+    }
     if (md.value) {
         // until we switch over to a compacted topic or use raft snapshots,
         // always take the latest entry in the log.
@@ -222,6 +237,9 @@ void group_recovery_consumer::handle_group_metadata(group_metadata_kv md) {
 }
 
 void group_recovery_consumer::handle_offset_metadata(offset_metadata_kv md) {
+    if (is_group_blocked_verbose(md.key.group_id, "offsets")) {
+        return;
+    }
     model::topic_partition tp(md.key.topic, md.key.partition);
     if (md.value) {
         vlog(

--- a/src/v/kafka/server/group_recovery_consumer.h
+++ b/src/v/kafka/server/group_recovery_consumer.h
@@ -44,10 +44,8 @@ public:
      * deduplicate both group and commit metadata snapshots.
      */
 
-    explicit group_recovery_consumer(
-      group_metadata_serializer serializer, ss::abort_source& as)
-      : _serializer(std::move(serializer))
-      , _as(as) {}
+    explicit group_recovery_consumer(ss::abort_source& as)
+      : _as(as) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
 
@@ -74,7 +72,6 @@ private:
     void handle_offset_metadata(offset_metadata_kv);
     group_recovery_consumer_state _state;
     model::offset _batch_base_offset;
-    group_metadata_serializer _serializer;
     ss::abort_source& _as;
 };
 } // namespace kafka

--- a/src/v/kafka/server/group_recovery_consumer.h
+++ b/src/v/kafka/server/group_recovery_consumer.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "absl/container/node_hash_map.h"
+#include "container/chunked_hash_map.h"
 #include "kafka/server/group_data_parser.h"
 #include "kafka/server/group_metadata.h"
 #include "kafka/server/group_stm.h"
@@ -23,6 +24,7 @@ namespace kafka {
 
 struct group_recovery_consumer_state {
     absl::node_hash_map<kafka::group_id, group_stm> groups;
+    chunked_hash_set<kafka::group_id> blocked_groups;
     /*
      * recovered committed offsets are by default non-reclaimable, and marked as
      * reclaimable if this flag is set to true. the flag is set to true if and
@@ -65,6 +67,8 @@ public:
     ss::future<> handle_commit(
       model::record_batch_header, kafka::group_tx::commit_metadata);
     ss::future<> handle_version_fence(features::feature_table::version_fence);
+    void handle_group_block(kafka::group_block);
+    bool is_group_blocked(kafka::group_id) const;
 
 private:
     void handle_record(model::record);

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -19,8 +19,7 @@ group_tx_tracker_stm::group_tx_tracker_stm(
   ss::sharded<features::feature_table>& feature_table)
   : raft::persisted_stm<>("group_tx_tracker_stm.snapshot", logger, raft)
   , group_data_parser<group_tx_tracker_stm>()
-  , _feature_table(feature_table)
-  , _serializer(make_consumer_offsets_serializer()) {
+  , _feature_table(feature_table) {
     _stale_tx_fence_gc_timer.set_callback([this] {
         ssx::spawn_with_gate(
           _gate, [this] { return gc_expired_tx_fence_transactions(); });
@@ -168,14 +167,15 @@ ss::future<iobuf> group_tx_tracker_stm::take_raft_snapshot(model::offset) {
 
 ss::future<> group_tx_tracker_stm::handle_raft_data(model::record_batch batch) {
     co_await model::for_each_record(batch, [this](model::record& r) {
-        auto record_type = _serializer.get_metadata_type(r.key().copy());
+        auto record_type = group_metadata_serializer::get_metadata_type(
+          r.key().copy());
         switch (record_type) {
         case offset_commit:
         case noop:
             return;
         case group_metadata:
             handle_group_metadata(
-              _serializer.decode_group_metadata(std::move(r)));
+              group_metadata_serializer::decode_group_metadata(std::move(r)));
             return;
         }
         __builtin_unreachable();

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -137,6 +137,8 @@ group_tx_tracker_stm::apply_local_snapshot(
     iobuf_parser parser(std::move(snap_buf));
     auto snap = co_await serde::read_async<snapshot>(parser);
     _all_txs = std::move(snap.transactions);
+    _blocked_groups.insert(
+      snap.blocked_groups.cbegin(), snap.blocked_groups.cend());
     co_return raft::local_snapshot_applied::yes;
 }
 
@@ -145,11 +147,13 @@ group_tx_tracker_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     auto holder = _gate.hold();
     // Copy over the snapshot state for a consistent view.
     auto offset = last_applied_offset();
-    snapshot snap;
-    snap.transactions = _all_txs;
-    iobuf snap_buf;
+    snapshot snap{
+      .transactions{_all_txs},
+      .blocked_groups{std::from_range, _blocked_groups},
+    };
     apply_units.return_all();
-    co_await serde::write_async(snap_buf, snap);
+    iobuf snap_buf;
+    co_await serde::write_async(snap_buf, std::move(snap));
     co_return raft::stm_snapshot::create(
       supported_local_snapshot_version, offset, std::move(snap_buf));
 }
@@ -183,6 +187,9 @@ ss::future<> group_tx_tracker_stm::handle_raft_data(model::record_batch batch) {
 }
 
 void group_tx_tracker_stm::handle_group_metadata(group_metadata_kv md) {
+    if (is_group_blocked_verbose(md.key.group_id, "group metadata")) {
+        return;
+    }
     if (md.value) {
         vlog(cg_klog.trace, "[group: {}] update", md.key.group_id);
         // A group may checkpoint periodically as the member's state changes,
@@ -266,6 +273,20 @@ ss::future<> group_tx_tracker_stm::handle_version_fence(
   features::feature_table::version_fence) {
     // ignore
     return ss::now();
+}
+
+void group_tx_tracker_stm::handle_group_block(kafka::group_block gb) {
+    if (gb.is_blocked) {
+        _blocked_groups.insert(gb.group_id);
+        // there shouldn't be any transactions in progress, doing just in case
+        _all_txs.erase(gb.group_id);
+    } else {
+        _blocked_groups.erase(gb.group_id);
+    }
+}
+
+bool group_tx_tracker_stm::is_group_blocked(kafka::group_id group_id) const {
+    return _blocked_groups.contains(group_id);
 }
 
 bool group_tx_tracker_stm_factory::is_applicable_for(

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -156,7 +156,6 @@ private:
     all_txs_t _all_txs;
 
     ss::sharded<features::feature_table>& _feature_table;
-    group_metadata_serializer _serializer;
     ss::abort_source _as;
     static constexpr ss::lowres_clock::duration tx_fence_gc_frequency{1h};
     ss::timer<ss::lowres_clock> _stale_tx_fence_gc_timer;

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -13,6 +13,7 @@
 
 #include "cluster/state_machine_registry.h"
 #include "container/chunked_hash_map.h"
+#include "container/fragmented_vector.h"
 #include "kafka/server/group_data_parser.h"
 #include "raft/persisted_stm.h"
 #include "serde/rw/envelope.h"
@@ -120,6 +121,8 @@ public:
     ss::future<> handle_commit(
       model::record_batch_header, kafka::group_tx::commit_metadata);
     ss::future<> handle_version_fence(features::feature_table::version_fence);
+    void handle_group_block(kafka::group_block);
+    bool is_group_blocked(kafka::group_id) const;
 
     ss::future<> stop() final;
 
@@ -133,10 +136,12 @@ public:
 private:
     static constexpr int8_t supported_local_snapshot_version = 1;
     struct snapshot
-      : serde::envelope<snapshot, serde::version<0>, serde::compat_version<0>> {
+      : serde::envelope<snapshot, serde::version<1>, serde::compat_version<0>> {
         all_txs_t transactions;
+        chunked_vector<kafka::group_id> blocked_groups;
 
-        auto serde_fields() { return std::tie(transactions); }
+        auto serde_fields() { return std::tie(transactions, blocked_groups); }
+        friend bool operator==(const snapshot&, const snapshot&) = default;
     };
 
     void handle_group_metadata(group_metadata_kv);
@@ -154,6 +159,7 @@ private:
     void maybe_end_tx(kafka::group_id, model::producer_identity, model::offset);
 
     all_txs_t _all_txs;
+    chunked_hash_set<kafka::group_id> _blocked_groups;
 
     ss::sharded<features::feature_table>& _feature_table;
     ss::abort_source _as;

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -39,8 +39,7 @@ using namespace std::chrono_literals;
 struct cg_recovery_test_fixture : seastar_test {
     ss::future<group_recovery_consumer_state>
     recover_from_batches(chunked_circular_buffer<model::record_batch> batches) {
-        group_recovery_consumer consumer(
-          make_consumer_offsets_serializer(), as);
+        group_recovery_consumer consumer(as);
 
         return model::make_memory_record_batch_reader(std::move(batches))
           .consume(std::move(consumer), model::no_timeout);
@@ -50,7 +49,7 @@ struct cg_recovery_test_fixture : seastar_test {
         storage::record_batch_builder buider(
           model::record_batch_type::raft_data, offset++);
 
-        auto kv = serializer.to_kv(std::move(metadata));
+        auto kv = group_metadata_serializer::to_kv(std::move(metadata));
         buider.add_raw_kv(std::move(kv.key), std::move(kv.value));
 
         return std::move(buider).build();
@@ -61,7 +60,7 @@ struct cg_recovery_test_fixture : seastar_test {
         storage::record_batch_builder buider(
           model::record_batch_type::raft_data, offset++);
         for (auto& m : metadata) {
-            auto kv = serializer.to_kv(std::move(m));
+            auto kv = group_metadata_serializer::to_kv(std::move(m));
             buider.add_raw_kv(std::move(kv.key), std::move(kv.value));
         }
 
@@ -134,7 +133,6 @@ struct cg_recovery_test_fixture : seastar_test {
             .metadata = std::move(metadata)}};
     }
 
-    group_metadata_serializer serializer = make_consumer_offsets_serializer();
     ss::abort_source as;
     model::offset offset{0};
 

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -30,6 +30,7 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <tuple>
 
 using namespace std::chrono_literals;
@@ -267,6 +268,16 @@ struct cg_recovery_test_fixture : seastar_test {
             g_1_metadata.copy(),
             std::vector<offset_metadata_kv>{o_md, o_md_2}));
     }
+
+    void add_block_batch(
+      chunked_circular_buffer<model::record_batch>& batches,
+      kafka::group_id group_id,
+      bool blocked) {
+        storage::record_batch_builder block_builder(
+          model::record_batch_type::group_block, model::offset{0});
+        group_block{group_id, blocked}.add_to_batch_builder(block_builder);
+        batches.push_back(std::move(block_builder).build());
+    }
 };
 
 TEST_F_CORO(cg_recovery_test_fixture, test_single_group_recovery) {
@@ -495,4 +506,32 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
 
     expect_committed_offsets(
       gr_1_state.offsets(), "test-1/0@1024", "test-2/10@256");
+}
+
+TEST_F_CORO(cg_recovery_test_fixture, recover_blocked) {
+    auto [meta, batches] = serialize_single_group();
+    const auto gr_1 = meta.key.group_id;
+    model::producer_identity pid(100, 0);
+    model::tx_seq tx_seq(3);
+    batches.push_back(make_tx_fence_batch(
+      pid,
+      group_tx::fence_metadata{
+        .group_id = gr_1,
+        .tx_seq = tx_seq,
+        .transaction_timeout_ms = 10s,
+        .tm_partition = model::partition_id(10),
+      }));
+
+    auto state = co_await recover_from_batches(copy_batches(batches));
+    EXPECT_FALSE(state.blocked_groups.contains(gr_1));
+
+    // block
+    add_block_batch(batches, gr_1, true);
+    state = co_await recover_from_batches(copy_batches(batches));
+    EXPECT_TRUE(state.blocked_groups.contains(gr_1));
+
+    // unblock
+    add_block_batch(batches, gr_1, false);
+    state = co_await recover_from_batches(copy_batches(batches));
+    EXPECT_FALSE(state.blocked_groups.contains(gr_1));
 }

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -15,7 +15,9 @@
 #include "kafka/protocol/join_group.h"
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/schemata/join_group_request.h"
+#include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/group.h"
+#include "kafka/server/group_manager.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
@@ -138,6 +140,88 @@ FIXTURE_TEST(empty_offset_commit_request, consumer_offsets_fixture) {
         auto resp = client.dispatch(std::move(req)).get();
         BOOST_REQUIRE(!resp.data.errored());
     }
+}
+
+FIXTURE_TEST(block_test, consumer_offsets_fixture) {
+    scoped_config cfg;
+    cfg.get("group_topic_partitions").set_value(1);
+
+    model::topic t{"topic"};
+    kafka::group_id g{"group"};
+    kafka::group_instance_id gi("group-instance");
+
+    add_topic(model::topic_namespace_view{model::kafka_namespace, t}).get();
+    wait_for_consumer_offsets_topic(gi);
+
+    auto client = make_kafka_client().get();
+    auto client_stop = [&client] {
+        client.stop().then([&client] { client.shutdown(); }).get();
+    };
+    auto deferred = ss::defer(decltype(client_stop)(client_stop));
+    client.connect().get();
+
+    auto gntp = app.coordinator_ntp_mapper.local().ntp_for(g);
+    BOOST_REQUIRE(gntp);
+
+    auto can_commit_offset = [&] {
+        for (int _ : std::views::iota(0, 5)) {
+            auto req = offset_commit_request{.data{
+              .group_id = g,
+              .group_instance_id = gi,
+              .topics = chunked_vector<offset_commit_request_topic>::single(
+                offset_commit_request_topic{
+                  .name = t,
+                  .partitions
+                  = chunked_vector<offset_commit_request_partition>::single(
+                    offset_commit_request_partition{
+                      .partition_index = model::partition_id{0},
+                      .committed_offset = model::offset{0}})})}};
+            auto res = client.dispatch(std::move(req)).get();
+            if (!res.data.errored()) {
+                return true;
+            }
+            if (
+              res.data.topics[0].partitions[0].error_code
+              != kafka::error_code::not_coordinator) {
+                return false;
+            }
+        }
+        return false;
+    };
+
+    auto set_blocked = [&](bool blocked) {
+        auto res = app._group_manager.local()
+                     .set_blocked_for_groups(*gntp, {g}, blocked)
+                     .get();
+        BOOST_REQUIRE(res.has_value());
+    };
+
+    auto restart = [&] {
+        client_stop();
+        consumer_offsets_fixture::restart(should_wipe::no);
+        wait_for_consumer_offsets_topic(gi);
+        wait_for_leader(*gntp).get();
+        client = make_kafka_client().get();
+        client.connect().get();
+    };
+
+    BOOST_REQUIRE(can_commit_offset());
+
+    // block
+    set_blocked(true);
+    BOOST_REQUIRE(!can_commit_offset());
+
+    // make sure retart keeps it blocked
+    restart();
+    BOOST_REQUIRE(!can_commit_offset());
+
+    // unblock
+    set_blocked(false);
+    BOOST_REQUIRE(can_commit_offset());
+
+    // make sure retart keeps it unblocked
+    restart();
+    BOOST_REQUIRE(can_commit_offset());
 }
 
 FIXTURE_TEST(conditional_retention_test, consumer_offsets_fixture) {

--- a/src/v/kafka/server/tests/group_metadata_serialization_test.cc
+++ b/src/v/kafka/server/tests/group_metadata_serialization_test.cc
@@ -159,8 +159,6 @@ model::record to_record(T t) {
 }
 
 FIXTURE_TEST(test_consumer_offsets_serializer, fixture) {
-    auto serializer = kafka::make_consumer_offsets_serializer();
-
     kafka::group_metadata_key group_md_key;
     group_md_key.group_id = random_named_string<kafka::group_id>();
 
@@ -175,12 +173,13 @@ FIXTURE_TEST(test_consumer_offsets_serializer, fixture) {
          boost::irange(0, random_generators::get_int(0, 10))) {
         group_md.members.push_back(random_member_state());
     }
-    auto group_kv = serializer.to_kv(kafka::group_metadata_kv{
-      .key = group_md_key,
-      .value = group_md.copy(),
-    });
+    auto group_kv = kafka::group_metadata_serializer::to_kv(
+      kafka::group_metadata_kv{
+        .key = group_md_key,
+        .value = group_md.copy(),
+      });
 
-    auto group_md_kv = serializer.decode_group_metadata(
+    auto group_md_kv = kafka::group_metadata_serializer::decode_group_metadata(
       to_record(std::move(group_kv)));
 
     BOOST_REQUIRE_EQUAL(group_md_key, group_md_kv.key);
@@ -198,13 +197,15 @@ FIXTURE_TEST(test_consumer_offsets_serializer, fixture) {
     offset_md.metadata = random_named_string<ss::sstring>();
     offset_md.commit_timestamp = model::timestamp::now();
 
-    auto offset_kv = serializer.to_kv(kafka::offset_metadata_kv{
-      .key = offset_key,
-      .value = offset_md,
-    });
+    auto offset_kv = kafka::group_metadata_serializer::to_kv(
+      kafka::offset_metadata_kv{
+        .key = offset_key,
+        .value = offset_md,
+      });
 
-    auto offset_md_kv = serializer.decode_offset_metadata(
-      to_record(std::move(offset_kv)));
+    auto offset_md_kv
+      = kafka::group_metadata_serializer::decode_offset_metadata(
+        to_record(std::move(offset_kv)));
 
     BOOST_REQUIRE_EQUAL(offset_key, offset_md_kv.key);
     BOOST_REQUIRE_EQUAL(offset_md, offset_md_kv.value);
@@ -220,46 +221,46 @@ model::record build_tombstone_record(iobuf buffer) {
 }
 
 FIXTURE_TEST(test_unwrapping_tombstones_from_iobuf, fixture) {
-    std::vector<kafka::group_metadata_serializer> serializers;
-    serializers.reserve(1);
-    serializers.push_back(kafka::make_consumer_offsets_serializer());
+    kafka::group_metadata_key group_md_key;
+    group_md_key.group_id = random_named_string<kafka::group_id>();
 
-    for (auto& serializer : serializers) {
-        kafka::group_metadata_key group_md_key;
-        group_md_key.group_id = random_named_string<kafka::group_id>();
+    auto group_kv = kafka::group_metadata_serializer::to_kv(
+      kafka::group_metadata_kv{
+        .key = group_md_key,
+      });
+    auto group_tombstone = build_tombstone_record(group_kv.key.copy());
+    // not wrapped in iobuf
+    auto decoded_group_md_kv
+      = kafka::group_metadata_serializer::decode_group_metadata(
+        std::move(group_tombstone));
 
-        auto group_kv = serializer.to_kv(kafka::group_metadata_kv{
-          .key = group_md_key,
-        });
-        auto group_tombstone = build_tombstone_record(group_kv.key.copy());
-        // not wrapped in iobuf
-        auto decoded_group_md_kv = serializer.decode_group_metadata(
-          std::move(group_tombstone));
+    auto iobuf_decoded_group_md_kv
+      = kafka::group_metadata_serializer::decode_group_metadata(
+        build_tombstone_record(reflection::to_iobuf(group_kv.key.copy())));
 
-        auto iobuf_decoded_group_md_kv = serializer.decode_group_metadata(
-          build_tombstone_record(reflection::to_iobuf(group_kv.key.copy())));
+    BOOST_REQUIRE_EQUAL(group_md_key, decoded_group_md_kv.key);
+    BOOST_REQUIRE_EQUAL(group_md_key, iobuf_decoded_group_md_kv.key);
 
-        BOOST_REQUIRE_EQUAL(group_md_key, decoded_group_md_kv.key);
-        BOOST_REQUIRE_EQUAL(group_md_key, iobuf_decoded_group_md_kv.key);
+    kafka::offset_metadata_key offset_key;
+    offset_key.group_id = random_named_string<kafka::group_id>();
+    ;
+    offset_key.topic = random_named_string<model::topic>();
+    offset_key.partition = random_named_int<model::partition_id>();
 
-        kafka::offset_metadata_key offset_key;
-        offset_key.group_id = random_named_string<kafka::group_id>();
-        ;
-        offset_key.topic = random_named_string<model::topic>();
-        offset_key.partition = random_named_int<model::partition_id>();
+    auto offset_kv = kafka::group_metadata_serializer::to_kv(
+      kafka::offset_metadata_kv{
+        .key = offset_key,
+      });
 
-        auto offset_kv = serializer.to_kv(kafka::offset_metadata_kv{
-          .key = offset_key,
-        });
+    // not wrapped in iobuf
+    auto offset_md_kv
+      = kafka::group_metadata_serializer::decode_offset_metadata(
+        build_tombstone_record(offset_kv.key.copy()));
 
-        // not wrapped in iobuf
-        auto offset_md_kv = serializer.decode_offset_metadata(
-          build_tombstone_record(offset_kv.key.copy()));
+    auto iobuf_offset_md_kv
+      = kafka::group_metadata_serializer::decode_offset_metadata(
+        build_tombstone_record(reflection::to_iobuf(offset_kv.key.copy())));
 
-        auto iobuf_offset_md_kv = serializer.decode_offset_metadata(
-          build_tombstone_record(reflection::to_iobuf(offset_kv.key.copy())));
-
-        BOOST_REQUIRE_EQUAL(offset_key, offset_md_kv.key);
-        BOOST_REQUIRE_EQUAL(offset_key, iobuf_offset_md_kv.key);
-    }
+    BOOST_REQUIRE_EQUAL(offset_key, offset_md_kv.key);
+    BOOST_REQUIRE_EQUAL(offset_key, iobuf_offset_md_kv.key);
 }

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -63,8 +63,7 @@ static group get() {
       nullptr,
       model::term_id(),
       fr,
-      feature_table,
-      make_consumer_offsets_serializer());
+      feature_table);
 }
 
 static const std::vector<member_protocol> test_group_protos = {

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -404,6 +404,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "datalake_translation_state";
     case record_batch_type::cluster_link:
         return o << "cluster_link";
+    case record_batch_type::group_block:
+        return o << "group_block";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -60,7 +60,8 @@ enum class record_batch_type : int8_t {
     dl_stm_command = 37,       // dl_stm command batch
     datalake_translation_state = 38, // maintains state for translation progress
     cluster_link = 39,               // cluster link update batches
-    MAX = cluster_link,
+    group_block = 40, // (un)blocks group names in a consumer offsets partition
+    MAX = group_block,
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);
@@ -78,7 +79,8 @@ inline std::vector<model::record_batch_type> offset_translator_batch_types() {
       model::record_batch_type::version_fence,
       model::record_batch_type::prefix_truncate,
       model::record_batch_type::partition_properties_update,
-      model::record_batch_type::datalake_translation_state};
+      model::record_batch_type::datalake_translation_state,
+      model::record_batch_type::group_block};
 }
 
 } // namespace model

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2095,8 +2095,7 @@ void application::wire_up_redpanda_services(
       std::ref(controller->get_topics_state()),
       std::ref(tx_gateway_frontend),
       std::ref(controller->get_feature_table()),
-      std::ref(_consumer_group_lag_metrics_frontend),
-      &kafka::make_consumer_offsets_serializer)
+      std::ref(_consumer_group_lag_metrics_frontend))
       .get();
     construct_service(
       offsets_recoverer,


### PR DESCRIPTION
As a preparation to migrate consumer groups, introduce a consumer offsets partition command to block a consumer group.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
