### PR TITLE
`raft`: don't rethrow in `state_machine_manager::background_apply_fiber()`

### DIFF
--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -626,8 +626,8 @@ ss::future<> state_machine_manager::background_apply_fiber(
                 // do not log known shutdown exceptions as errors
                 if (!ssx::is_shutdown_exception(e)) {
                     vlog(_log.error, "error applying raft snapshot - {}", e);
+                    co_await ss::sleep_abortable(100ms, _as);
                 }
-                std::rethrow_exception(e);
             }
             continue;
         }


### PR DESCRIPTION
Exceptions rethrown here are not caught at any level above `background_apply_fiber()`, and can lead to a full shutdown of the backgrounded `apply()` fiber that was launched in `state_machine_manager::start()`.

This is asymmetrical to `try_apply_in_foreground()`, where all exceptions are caught and are not rethrown.

https://github.com/redpanda-data/redpanda/blob/42216aaf29611f315a60fe2d9491245a1e732aa7/src/v/raft/state_machine_manager.cc#L566-L569

The hope is that errors are transient, and future attempts in the detached `apply()` fiber will succeed.

This has recently manifested as log lines in `random_node_operations_test`, in which a failure to download a manifest for the `archival_metadata_stm` lead to an exception being thrown and not caught, with a log line like:

```
WARN  2025-06-16 06:03:33,830 [shard 0:main] seastar - Exceptional future ignored: std::runtime_error (couldn't download manifest: cloud_storage::error_outcome:2), backtrace: 0x83d351b 0x8125ee3 0x209eb53 0x76afa3f 0x209ec17 0x81d7127 0x81d4753
```

This is likely a transient error, and instead of breaking the entire `apply()` fiber, should just log an error and be retried on the next iteration.

It also looks like the historical context for why this `rethrow_exception` statement exists is because the code in `background_apply_fiber()` seems mostly plucked from `apply_raft_snapshot()`,

https://github.com/redpanda-data/redpanda/blob/42216aaf29611f315a60fe2d9491245a1e732aa7/src/v/raft/state_machine_manager.cc#L398-L405

where the exception would have been caught at a higher level.

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
