### PR TITLE
[v24.2.x] m/record: added very basic defensive check to prevent crashes

### DIFF
--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -94,6 +94,16 @@ static std::vector<model::record_header>
 parse_record_headers(Parser& parser, ParserData parser_data) {
     std::vector<model::record_header> headers;
     auto [header_count, _] = parser.read_varlong();
+    /**
+     * If records buffer is corrupted, it may result in reading very large
+     * number, check if it is the case and throw an exception.
+     */
+    if (static_cast<size_t>(header_count) > parser.bytes_left()) [[unlikely]] {
+        throw std::out_of_range(fmt::format(
+          "Expected {} headers, but only {} bytes left",
+          header_count,
+          parser.bytes_left()));
+    }
     headers.reserve(header_count);
     for (int i = 0; i < header_count; ++i) {
         auto [key_length, kv] = parser.read_varlong();

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -106,3 +106,16 @@ SEASTAR_THREAD_TEST_CASE(extra_bytes_iterator) {
     BOOST_TEST(it.has_next());
     BOOST_REQUIRE_THROW(it.next(), std::out_of_range);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_corrupted_record_bytes) {
+    auto b = model::test::make_random_batch(model::offset(0), 10, false);
+    // use the trick to get mutable access to the records
+    auto fields = b.serde_fields();
+    auto& records = std::get<1>(fields);
+    for (auto& f : records) {
+        std::fill_n(f.get_write(), f.size(), 0xFF);
+    }
+    auto f = model::for_each_record(
+      b, [](model::record& r) { BOOST_CHECK(r.offset_delta() >= 0); });
+    BOOST_REQUIRE_THROW(f.get(), std::out_of_range);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26482
