### PR TITLE
feature_table: bump min compatible version

### DIFF
--- a/bazel/stamp_vars.sh
+++ b/bazel/stamp_vars.sh
@@ -29,7 +29,7 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="${SCRIPT_DIR}/.."
 
-git_tag=$(git -C "$WORKSPACE_DIR" describe --always --abbrev=0 --match='v*')
+git_tag=$(git -C "$WORKSPACE_DIR" describe --tags --always --abbrev=0 --match='v*')
 echo "STABLE_GIT_LATEST_TAG ${git_tag}"
 
 # For CI builds we don't want to use the commit hash as that prevents caching of binaries,

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -153,10 +153,10 @@ constexpr cluster_version latest_version = to_cluster_version(
 // a freshly initialized node will start at. All features up to this cluster
 // version will automatically be enabled when Redpanda starts.
 constexpr cluster_version earliest_version = to_cluster_version(
-  release_version::v24_2_1);
+  release_version::v25_1_1);
 
 static_assert(
-  latest_version - earliest_version == 3L,
+  latest_version - earliest_version == 1L,
   "Consider upgrading the earliest_version in lockstep whenever you increment "
   "the latest_version");
 

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -554,6 +554,37 @@ class RedpandaInstaller:
         )
         return result
 
+    def upgrade_path_to_head(
+            self, version: RedpandaVersion) -> list[RedpandaVersionTriple]:
+        """
+        For a given version, return the upgrade path that is supported, which is currently the policy of
+        latest minor in each feature release.
+        """
+        if version == RedpandaInstaller.HEAD:
+            version = self.head_version()
+        versions = self.released_versions  # in descending order
+        # find the first version
+        if len(version) == 2:
+            start_idx = next(i for i, v in enumerate(versions)
+                             if v[:2] == version)
+        else:
+            start_idx = versions.index(version)
+        next_versions = versions[:start_idx]
+        latest_version_by_line: dict[RedpandaVersionLine,
+                                     RedpandaVersionTriple] = {}
+        for v in next_versions:
+            line = v[:2]
+            if line not in latest_version_by_line or v > latest_version_by_line[
+                    line]:
+                latest_version_by_line[line] = v
+        latest_versions = list(latest_version_by_line.values())
+        latest_versions.sort()
+        if self.head_version() not in latest_versions:
+            latest_versions.append(self.head_version())
+        self._redpanda.logger.debug(
+            f"upgrade path to head from {version} is {latest_versions}")
+        return latest_versions
+
     def latest_for_line(
         self, release_line: RedpandaVersionLine
     ) -> tuple[RedpandaVersionTriple, bool]:

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -169,8 +169,11 @@ class JavaCompressionTest(EndToEndTest):
         self.consume()
 
         # Install the latest version of `redpanda` and restart nodes
-        self.redpanda._installer.install(self.redpanda.nodes,
-                                         RedpandaInstaller.HEAD)
+        for version in self.redpanda._installer.upgrade_path_to_head(
+                pre_big_endian_snappy_fix_version):
+            self.redpanda._installer.install(self.redpanda.nodes, version)
+            self.redpanda.stop_node(self.redpanda.nodes[0])
+            self.redpanda.start_node(self.redpanda.nodes[0])
         self.redpanda.stop_node(self.redpanda.nodes[0])
 
         # Delete all the compaction indices to force self compaction of segments.

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -269,7 +269,7 @@ class ShardPlacementTest(PreallocNodesTest):
 
         # Upgrade the cluster and wait for the feature activation.
 
-        installer.install(seed_nodes, (24, 3))
+        installer.install([*seed_nodes, *joiner_nodes], (24, 3))
         self.redpanda.restart_nodes(seed_nodes)
         self.redpanda.wait_for_membership(first_start=False)
 


### PR DESCRIPTION
Our policy is currently once version at a time for upgrades. If we want
to loosen that, we should opt into doing it, and test this.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
