### PR TITLE
Minor MPT fixups

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -770,7 +770,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             'topic_partitions_per_shard':
             DEFAULT_PARTITIONS_PER_SHARD,
             'topic_memory_per_partition':
-            DEFAULT_MIB_PER_PARTITION * 1024 * 1024,
+            int(DEFAULT_MIB_PER_PARTITION * 1024 * 1024),
             'topic_partitions_memory_allocation_percent':
             DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
         })
@@ -860,7 +860,7 @@ class ManyPartitionsTest(PreallocNodesTest):
             'topic_partitions_per_shard':
             topic_partitions_per_shard,
             'topic_memory_per_partition':
-            mib_per_partition * 1024 * 1024,
+            int(mib_per_partition * 1024 * 1024),
             'topic_partitions_memory_allocation_percent':
             DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT,
         })

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -42,10 +42,10 @@ DEFAULT_MIB_PER_PARTITION = ScaleParameters.DEFAULT_MIB_PER_PARTITION
 DEFAULT_PARTITIONS_PER_SHARD = 3000
 
 # How much memory is reserved for partitions for this test.
-# We use the 1.5x the default order to test higher than default density
+# We use the 2x the default order to test higher than default density
 # (in a memory sense) and also to hit the per-shard max of 3,000 partitions
 DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT = int(
-    ScaleParameters.DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT * 1.5)
+    ScaleParameters.DEFAULT_PARTITIONS_MEMORY_ALLOCATION_PERCENT * 2)
 
 # Large volume of data to write. If tiered storage is enabled this is the
 # amount of data to retain total. Otherwise, this can be used as a large volume


### PR DESCRIPTION
Some minor MPT improvements:

 - Increase partition reservation share to reach the 3000k density on 4GB per shard instance types
 - Drive by fix a benign float config bug 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


