### PR TITLE
cloud_topics: write using chunked_vector

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -125,6 +125,8 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/base",
+        "//src/v/container:chunked_circular_buffer",
+        "//src/v/container:fragmented_vector",
         "//src/v/model",
         "//src/v/storage",
         "@seastar",

--- a/src/v/cloud_topics/api.h
+++ b/src/v/cloud_topics/api.h
@@ -11,8 +11,10 @@
 #pragma once
 
 #include "base/outcome.h"
+#include "container/chunked_circular_buffer.h"
+#include "container/fragmented_vector.h"
 #include "model/fundamental.h"
-#include "model/record_batch_reader.h"
+#include "model/record.h"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/future.hh>
@@ -38,7 +40,7 @@ public:
     virtual ss::future<result<chunked_circular_buffer<model::record_batch>>>
     write_and_debounce(
       model::ntp ntp,
-      model::record_batch_reader r,
+      chunked_vector<model::record_batch> batches,
       std::chrono::milliseconds timeout)
       = 0;
 

--- a/src/v/cloud_topics/app_impl.cc
+++ b/src/v/cloud_topics/app_impl.cc
@@ -78,7 +78,7 @@ public:
     ss::future<result<chunked_circular_buffer<model::record_batch>>>
     write_and_debounce(
       model::ntp ntp,
-      model::record_batch_reader r,
+      chunked_vector<model::record_batch> r,
       std::chrono::milliseconds timeout) override {
         return _write_pipeline->write_and_debounce(
           std::move(ntp), std::move(r), timeout);

--- a/src/v/cloud_topics/app_impl.h
+++ b/src/v/cloud_topics/app_impl.h
@@ -10,10 +10,10 @@
  */
 #pragma once
 
-#include "base/outcome.h"
 #include "cloud_topics/api.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/distributed.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 

--- a/src/v/cloud_topics/batcher/tests/aggregator_test.cc
+++ b/src/v/cloud_topics/batcher/tests/aggregator_test.cc
@@ -8,14 +8,11 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
-#include "bytes/iostream.h"
 #include "cloud_topics/batcher/aggregator.h"
 #include "cloud_topics/core/serializer.h"
 #include "cloud_topics/core/write_request.h"
-#include "container/chunked_circular_buffer.h"
 #include "model/namespace.h"
 #include "model/record.h"
-#include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
 #include "model/timeout_clock.h"
 #include "random/generators.h"
@@ -34,7 +31,7 @@ static ss::logger test_log("aggregator_test_log"); // NOLINT
 
 cloud_topics::core::serialized_chunk get_random_serialized_chunk(
   int num_batches, int num_records_per_batch) { // NOLINT
-    chunked_circular_buffer<model::record_batch> batches;
+    chunked_vector<model::record_batch> batches;
     model::offset o{0};
     for (int ix_batch = 0; ix_batch < num_batches; ix_batch++) {
         auto batch = model::test::make_random_batch(
@@ -42,9 +39,7 @@ cloud_topics::core::serialized_chunk get_random_serialized_chunk(
         o = model::next_offset(batch.last_offset());
         batches.push_back(std::move(batch));
     }
-    auto reader = model::make_memory_record_batch_reader(std::move(batches));
-    auto fut = cloud_topics::core::serialize_in_memory_record_batch_reader(
-      std::move(reader));
+    auto fut = cloud_topics::core::serialize_batches(std::move(batches));
     return fut.get();
 }
 

--- a/src/v/cloud_topics/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/batcher/tests/batcher_test.cc
@@ -51,14 +51,14 @@ namespace cloud_topics = experimental::cloud_topics;
 struct reader_with_content {
     chunked_vector<bytes> keys;
     chunked_vector<bytes> records;
-    model::record_batch_reader reader;
+    chunked_vector<model::record_batch> batches;
 };
 
 reader_with_content
-get_random_reader(int num_batches, int num_records) { // NOLINT
+get_random_batches(int num_batches, int num_records) { // NOLINT
     chunked_vector<bytes> keys;
     chunked_vector<bytes> records;
-    ss::chunked_fifo<model::record_batch> fifo;
+    chunked_vector<model::record_batch> batches;
     model::offset offset{0};
     for (int i = 0; i < num_batches; i++) {
         // Build a record batch
@@ -73,14 +73,12 @@ get_random_reader(int num_batches, int num_records) { // NOLINT
             builder.add_raw_kv(std::move(k), std::move(v));
             offset += 1;
         }
-        fifo.push_back(std::move(builder).build());
+        batches.push_back(std::move(builder).build());
     }
-    auto reader = model::make_fragmented_memory_record_batch_reader(
-      std::move(fifo));
     return {
       .keys = std::move(keys),
       .records = std::move(records),
-      .reader = std::move(reader),
+      .batches = std::move(batches),
     };
 }
 
@@ -146,7 +144,7 @@ TEST_CORO(batcher_test, single_write_request) {
       .pipeline = &pipeline,
     };
     int num_batches = 10;
-    auto [_, records, reader] = get_random_reader(num_batches, 10);
+    auto [_, records, reader] = get_random_batches(num_batches, 10);
     // Expect single upload to be made
     mock.expect_upload_object(records);
 
@@ -194,9 +192,9 @@ TEST_CORO(batcher_test, many_write_requests) {
     };
 
     std::vector<size_t> expected_num_batches = {10, 20, 10};
-    auto [_1, records1, reader1] = get_random_reader(10, 10);
-    auto [_2, records2, reader2] = get_random_reader(20, 10);
-    auto [_3, records3, reader3] = get_random_reader(10, 20);
+    auto [_1, records1, reader1] = get_random_batches(10, 10);
+    auto [_2, records2, reader2] = get_random_batches(20, 10);
+    auto [_3, records3, reader3] = get_random_batches(10, 20);
 
     chunked_vector<bytes> all_records;
     std::copy(
@@ -277,9 +275,9 @@ TEST_CORO(batcher_test, expired_write_request) {
 
     int expected_num_batches = 33;
     int expected_num_records = 33;
-    auto [_1, included_records, included_reader] = get_random_reader(
+    auto [_1, included_records, included_batches] = get_random_batches(
       expected_num_batches, expected_num_records);
-    auto [_2, timedout_records, timedout_reader] = get_random_reader(1, 1);
+    auto [_2, timedout_records, timedout_batches] = get_random_batches(1, 1);
 
     chunked_vector<bytes> all_records;
     std::copy(
@@ -296,7 +294,7 @@ TEST_CORO(batcher_test, expired_write_request) {
 
     const auto timeout = 1s;
     auto expect_fail_fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(timedout_reader), timeout);
+      model::controller_ntp, std::move(timedout_batches), timeout);
 
     // Let time pass to invalidate the first enqueued write request
     co_await sleep_until(
@@ -304,7 +302,7 @@ TEST_CORO(batcher_test, expired_write_request) {
     ss::manual_clock::advance(timeout);
 
     auto expect_pass_fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(included_reader), timeout);
+      model::controller_ntp, std::move(included_batches), timeout);
 
     // Make sure that both write requests are pending
     co_await sleep_until(

--- a/src/v/cloud_topics/core/serializer.cc
+++ b/src/v/cloud_topics/core/serializer.cc
@@ -61,9 +61,15 @@ struct serializing_consumer {
 };
 
 ss::future<serialized_chunk>
-serialize_in_memory_record_batch_reader(model::record_batch_reader rdr) {
-    co_return co_await std::move(rdr).consume(
-      serializing_consumer{}, model::no_timeout);
+serialize_batches(chunked_vector<model::record_batch> batches) {
+    serializing_consumer consumer;
+    for (auto& batch : batches) {
+        auto stop = co_await consumer(std::move(batch));
+        if (stop) {
+            break;
+        }
+    }
+    co_return consumer.end_of_stream();
 }
 
 } // namespace experimental::cloud_topics::core

--- a/src/v/cloud_topics/core/serializer.h
+++ b/src/v/cloud_topics/core/serializer.h
@@ -47,6 +47,6 @@ struct serialized_chunk {
 /// Serialize record batch reader into the iobuf.
 ///
 ss::future<serialized_chunk>
-serialize_in_memory_record_batch_reader(model::record_batch_reader rdr);
+serialize_batches(chunked_vector<model::record_batch> batches);
 
 } // namespace experimental::cloud_topics::core

--- a/src/v/cloud_topics/core/tests/event_filter_test.cc
+++ b/src/v/cloud_topics/core/tests/event_filter_test.cc
@@ -94,14 +94,15 @@ TEST_CORO(EventFilterTest, filter_triggered_once) {
     };
     auto batches = co_await model::test::make_random_batches(spec);
     size_t reader_size_bytes = get_serialized_size(batches);
-    auto reader = model::make_memory_record_batch_reader(std::move(batches));
     core::write_pipeline<ss::lowres_clock> pipeline;
     auto stage = pipeline.register_write_pipeline_stage();
     core::event_filter<ss::lowres_clock> flt(
       core::event_type::new_write_request, stage.id());
     auto sub = pipeline.subscribe(flt);
     auto write = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader), 1s);
+      model::controller_ntp,
+      chunked_vector<model::record_batch>(std::move(batches)),
+      1s);
     auto event = co_await std::move(sub);
     ASSERT_EQ_CORO(event.pending_write_bytes, reader_size_bytes);
     auto pending = stage.pull_write_requests(
@@ -128,11 +129,12 @@ TEST_CORO(EventFilterTest, filter_has_memory) {
     };
     auto batches = co_await model::test::make_random_batches(spec);
     size_t reader_size_bytes = get_serialized_size(batches);
-    auto reader = model::make_memory_record_batch_reader(std::move(batches));
     core::write_pipeline<ss::lowres_clock> pipeline;
     auto stage = pipeline.register_write_pipeline_stage();
     auto write = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader), 1s);
+      model::controller_ntp,
+      chunked_vector<model::record_batch>(std::move(batches)),
+      1s);
     // wait until submitted
     // this is needed because 'write_and_debounce' has a scheduling point
     // before the write request is added to the list

--- a/src/v/cloud_topics/core/tests/pipeline_bench.cc
+++ b/src/v/cloud_topics/core/tests/pipeline_bench.cc
@@ -107,12 +107,11 @@ struct write_pipeline_bench {};
 PERF_TEST_C(write_pipeline_bench, propagation_latency) {
     ct::core::write_pipeline<> pipeline;
     write_pipeline_sink sink(pipeline);
-    auto reader = model::make_empty_record_batch_reader();
     sink.start();
 
     perf_tests::start_measuring_time();
     perf_tests::do_not_optimize(co_await pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader), std::chrono::milliseconds(10)));
+      model::controller_ntp, {}, std::chrono::milliseconds(10)));
     perf_tests::stop_measuring_time();
 
     co_await sink.stop();

--- a/src/v/cloud_topics/core/tests/serializer_test.cc
+++ b/src/v/cloud_topics/core/tests/serializer_test.cc
@@ -15,12 +15,12 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
+
 namespace cloud_topics = experimental::cloud_topics;
 
 TEST(SerializerTest, EmptyReader) {
-    auto res = cloud_topics::core::serialize_in_memory_record_batch_reader(
-                 model::make_empty_record_batch_reader())
-                 .get();
+    auto res = cloud_topics::core::serialize_batches({}).get();
     ASSERT_TRUE(res.payload.empty());
     ASSERT_TRUE(res.batches.empty());
 }
@@ -31,13 +31,12 @@ class SerializerFixture
 TEST_P(SerializerFixture, Consume) {
     auto num_batches = std::get<0>(GetParam());
     auto num_records = std::get<1>(GetParam());
-    auto test_data = model::make_memory_record_batch_reader(
-      model::test::make_random_batches(
-        {.count = num_batches, .records = num_records})
-        .get());
-    auto res = cloud_topics::core::serialize_in_memory_record_batch_reader(
-                 std::move(test_data))
-                 .get();
+    auto test_data = model::test::make_random_batches(
+                       {.count = num_batches, .records = num_records})
+                       .get();
+    chunked_vector<model::record_batch> batches;
+    std::ranges::move(std::move(test_data), std::back_inserter(batches));
+    auto res = cloud_topics::core::serialize_batches(std::move(batches)).get();
     ASSERT_GT(res.payload.size_bytes(), 0);
     ASSERT_EQ(res.batches.size(), num_batches);
     ASSERT_TRUE(

--- a/src/v/cloud_topics/core/tests/write_pipeline_test.cc
+++ b/src/v/cloud_topics/core/tests/write_pipeline_test.cc
@@ -60,14 +60,12 @@ TEST_CORO(write_pipeline_test, single_write_request) {
     cloud_topics::core::write_pipeline_accessor accessor{
       .pipeline = &pipeline,
     };
-    auto reader = model::make_empty_record_batch_reader();
     // Expect single upload to be made
 
     auto stage = pipeline.register_write_pipeline_stage();
 
     const auto timeout = 1s;
-    auto fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader), timeout);
+    auto fut = pipeline.write_and_debounce(model::controller_ntp, {}, timeout);
 
     // Make sure the write request is in the _pending list
     co_await sleep_until(
@@ -96,7 +94,7 @@ TEST_CORO(batcher_test, expired_write_request) {
 
     const auto timeout = 1s;
     auto expect_fail_fut = pipeline.write_and_debounce(
-      model::controller_ntp, model::make_empty_record_batch_reader(), timeout);
+      model::controller_ntp, {}, timeout);
 
     // Expire first request
     co_await sleep_until(
@@ -104,7 +102,7 @@ TEST_CORO(batcher_test, expired_write_request) {
     ss::manual_clock::advance(timeout);
 
     auto expect_pass_fut = pipeline.write_and_debounce(
-      model::controller_ntp, model::make_empty_record_batch_reader(), timeout);
+      model::controller_ntp, {}, timeout);
 
     // Make sure that both write requests are pending
     co_await sleep_until(

--- a/src/v/cloud_topics/core/write_pipeline.cc
+++ b/src/v/cloud_topics/core/write_pipeline.cc
@@ -41,15 +41,14 @@ template<class Clock>
 ss::future<result<chunked_circular_buffer<model::record_batch>>>
 write_pipeline<Clock>::write_and_debounce(
   model::ntp ntp,
-  model::record_batch_reader r,
+  chunked_vector<model::record_batch> batches,
   std::chrono::milliseconds timeout) {
     auto h = this->hold_gate();
     // The write request is stored on the stack of the
     // fiber until the 'response' promise is set. The
     // promise can be set by any fiber that completed
     // the request processing.
-    auto data_chunk = co_await core::serialize_in_memory_record_batch_reader(
-      std::move(r));
+    auto data_chunk = co_await core::serialize_batches(std::move(batches));
     auto sz = data_chunk.payload.size_bytes();
     // Grab the semaphore after the size of the write request
     // is known. It's impossible to do this in advance because

--- a/src/v/cloud_topics/core/write_pipeline.h
+++ b/src/v/cloud_topics/core/write_pipeline.h
@@ -54,7 +54,7 @@ public:
     ss::future<result<chunked_circular_buffer<model::record_batch>>>
     write_and_debounce(
       model::ntp ntp,
-      model::record_batch_reader r,
+      chunked_vector<model::record_batch> batches,
       std::chrono::milliseconds timeout);
 
     using write_requests_list

--- a/src/v/cloud_topics/throttler/tests/throttler_test.cc
+++ b/src/v/cloud_topics/throttler/tests/throttler_test.cc
@@ -118,8 +118,7 @@ size_t get_serialized_size(const model::record_batch& rb) {
     return res;
 }
 
-size_t get_serialized_size(
-  const chunked_circular_buffer<model::record_batch>& batches) {
+size_t get_serialized_size(const chunked_vector<model::record_batch>& batches) {
     size_t acc = 0;
     for (const auto& rb : batches) {
         auto sz = get_serialized_size(rb);
@@ -136,9 +135,9 @@ TEST_CORO(throttler_test, no_throttling) {
       .count = 100,
       .records = 10,
     };
-    auto batches = co_await model::test::make_random_batches(spec);
+    auto batches = chunked_vector<model::record_batch>(
+      co_await model::test::make_random_batches(spec));
     size_t reader_size_bytes = get_serialized_size(batches);
-    auto reader = model::make_memory_record_batch_reader(std::move(batches));
 
     cloud_topics::core::write_pipeline<ss::manual_clock> pipeline;
 
@@ -171,7 +170,7 @@ TEST_CORO(throttler_test, no_throttling) {
     // This fut will become ready when something will get the write
     // request from the pipeline and acknowledge it.
     auto write_fut = pipeline.write_and_debounce(
-      model::controller_ntp, std::move(reader), 1s);
+      model::controller_ntp, std::move(batches), 1s);
     co_await sleep_until(1ms, [throttler_accessor, reader_size_bytes] {
         return throttler_accessor.units_available() == reader_size_bytes;
     });


### PR DESCRIPTION
The write path no longer uses readers, it uses chunked_vector

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
