### PR TITLE
quota_manager_bench: reduce requests to 100K

### DIFF
--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -26,7 +26,7 @@
 namespace kafka {
 
 static const auto fixed_client_id = "shared-client-id";
-static const size_t total_requests{3 << 20};
+static const size_t total_requests = 100000;
 static const size_t unique_client_id_count = 1000;
 
 std::vector<ss::sstring> initialize_client_ids() {


### PR DESCRIPTION
Reduce the number of requests in the quota manager benchmark from 3M to 100K. This speeds up the benchmark by about a factor of 3 in my local testing.

This benchmark occasionally times out at 60s today, so this will hopefully eliminate that.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
