### PR TITLE
build: bump llvm20 version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -167,15 +167,15 @@ COMPILERS = {
     "next": {
         "tars": {
             "aarch64": {
-                "build_date": "2025-06-04",
-                "sha": "a543fc0d1d9608e52bc5aaa0c7a66f1303f198a483fc8695bc8af39ec0847e02",
+                "build_date": "2025-06-18",
+                "sha": "895bc671e9d75e80fb09b1cf842b3191239d4aeb1bf79bb8108490571481c177",
             },
             "x86_64": {
-                "build_date": "2025-06-04",
-                "sha": "7583b655e6b309ae72353f53181f4aa72ae98c81582de01aa08ba669dc03b1e4",
+                "build_date": "2025-06-18",
+                "sha": "6eee67bc40ffe6a8470df0f8bea5ab0e99ad5785d1cc84d2c5d14c1a9021b3da",
             },
         },
-        "version": "20.1.6",
+        "version": "20.1.7",
     },
 }
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -7378,7 +7378,7 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "A+u2LOTdHfpDgS94zRvkPJu/Zdu++ZN5a8ruhZFRcRI=",
-        "usagesDigest": "7cQCQMYHRMakftftFUSW1bvDzzyScYxgeOeZwTw/O6A=",
+        "usagesDigest": "IA3VY3eCQ0agjYBS73Jyh+E890b93T9etIojaGQbxEs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -7567,20 +7567,20 @@
               "exec_os": "",
               "libclang_rt": {},
               "llvm_mirror": "",
-              "llvm_version": "20.1.6",
+              "llvm_version": "20.1.7",
               "llvm_versions": {},
               "netrc": "",
               "sha256": {
-                "linux-aarch64": "a543fc0d1d9608e52bc5aaa0c7a66f1303f198a483fc8695bc8af39ec0847e02",
-                "linux-x86_64": "7583b655e6b309ae72353f53181f4aa72ae98c81582de01aa08ba669dc03b1e4"
+                "linux-aarch64": "895bc671e9d75e80fb09b1cf842b3191239d4aeb1bf79bb8108490571481c177",
+                "linux-x86_64": "6eee67bc40ffe6a8470df0f8bea5ab0e99ad5785d1cc84d2c5d14c1a9021b3da"
               },
               "strip_prefix": {},
               "urls": {
                 "linux-aarch64": [
-                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.6/llvm-20.1.6-debian-11-aarch64-2025-06-04.tar.zst"
+                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.7/llvm-20.1.7-debian-11-aarch64-2025-06-18.tar.zst"
                 ],
                 "linux-x86_64": [
-                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.6/llvm-20.1.6-debian-11-x86_64-2025-06-04.tar.zst"
+                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.7/llvm-20.1.7-debian-11-x86_64-2025-06-18.tar.zst"
                 ]
               }
             }
@@ -7630,7 +7630,7 @@
               "link_flags": {},
               "link_libs": {},
               "llvm_versions": {
-                "": "20.1.6"
+                "": "20.1.7"
               },
               "opt_compile_flags": {},
               "opt_link_flags": {},


### PR DESCRIPTION
This pulls in the fix for the constexpr default parameter bug

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
