### PR TITLE
raft: rename take_snapshot to take_raft_snapshot

### DIFF
--- a/src/v/cloud_topics/dl_stm/dl_stm.cc
+++ b/src/v/cloud_topics/dl_stm/dl_stm.cc
@@ -115,7 +115,7 @@ ss::future<> dl_stm::apply_raft_snapshot(const iobuf& buf) {
     co_return;
 }
 
-ss::future<iobuf> dl_stm::take_snapshot(model::offset snapshot_at) {
+ss::future<iobuf> dl_stm::take_raft_snapshot(model::offset snapshot_at) {
     auto st = _state.get_state_at(snapshot_at);
     co_return serde::to_iobuf(std::move(st));
 }

--- a/src/v/cloud_topics/dl_stm/dl_stm.h
+++ b/src/v/cloud_topics/dl_stm/dl_stm.h
@@ -40,7 +40,7 @@ private:
     take_local_snapshot(ssx::semaphore_units u) override;
 
     ss::future<> apply_raft_snapshot(const iobuf&) override;
-    ss::future<iobuf> take_snapshot(model::offset) override;
+    ss::future<iobuf> take_raft_snapshot(model::offset) override;
 
 private:
     dl_stm_state _state;

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -279,7 +279,9 @@ public:
 
     model::offset max_removable_local_log_offset() override;
 
-    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final {
+        co_return iobuf{};
+    }
 
     size_t get_compacted_replaced_bytes() const {
         return _compacted_replaced_bytes;

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -171,7 +171,9 @@ public:
     }
 
     // TODO: implement delete retention with incremental raft snapshots.
-    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final {
+        co_return iobuf{};
+    }
 
     /**
      * Discover the partition that is responsible for holding this key.

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -44,7 +44,9 @@ public:
     ss::future<stm_allocation_result>
     allocate_id(model::timeout_clock::duration timeout);
 
-    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final {
+        co_return iobuf{};
+    }
 
     ss::future<stm_allocation_result>
     reset_next_id(int64_t, model::timeout_clock::duration timeout);

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -106,7 +106,9 @@ public:
     /// if a start offset override exists and if so what its value is.
     kafka::offset kafka_start_offset_override();
 
-    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final {
+        co_return iobuf{};
+    }
 
     raft::stm_initial_recovery_policy
     get_initial_recovery_policy() const final {

--- a/src/v/cluster/partition_properties_stm.cc
+++ b/src/v/cluster/partition_properties_stm.cc
@@ -45,10 +45,12 @@ partition_properties_stm::partition_properties_stm(
       .writes_disabled = writes_disabled::no,
       .update_offset = model::offset{}}}) {}
 
-ss::future<iobuf> partition_properties_stm::take_snapshot(model::offset o) {
+ss::future<iobuf>
+partition_properties_stm::take_raft_snapshot(model::offset o) {
     if (o < _raft->start_offset()) {
         throw std::invalid_argument(fmt::format(
-          "can not take raft snapshot at offset {} which is smaller than raft "
+          "can not take raft snapshot at offset {} which is smaller than "
+          "raft "
           "start offset",
           o,
           _raft->start_offset()));

--- a/src/v/cluster/partition_properties_stm.h
+++ b/src/v/cluster/partition_properties_stm.h
@@ -34,7 +34,7 @@ public:
       storage::kvstore& kvstore,
       config::binding<std::chrono::milliseconds> sync_timeout);
 
-    ss::future<iobuf> take_snapshot(model::offset) final;
+    ss::future<iobuf> take_raft_snapshot(model::offset) final;
 
     // Updates partition properties to disable writes;
     // returns the offset of the blocking message

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -221,7 +221,9 @@ public:
 
     uint64_t get_local_snapshot_size() const override;
 
-    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final {
+        co_return iobuf{};
+    }
 
     const producers_t& get_producers() const { return _producers; }
 

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -237,12 +237,12 @@ TEST_F_CORO(partition_properties_stm_fixture, test_snapshot) {
 
     auto snap_before_disabled
       = partition_properties_stm_accessor::snap_from_iobuf(
-        co_await get_leader_stm()->take_snapshot(o));
+        co_await get_leader_stm()->take_raft_snapshot(o));
     ASSERT_EQ_CORO(
       snap_before_disabled.writes_disabled, stm_t::writes_disabled::no);
     // take snapshot at disable command offset
     auto snap_at_disabled = partition_properties_stm_accessor::snap_from_iobuf(
-      co_await get_leader_stm()->take_snapshot(
+      co_await get_leader_stm()->take_raft_snapshot(
         model::next_offset(before_disabled.value())));
     ASSERT_EQ_CORO(
       snap_at_disabled.writes_disabled, stm_t::writes_disabled::yes);
@@ -252,12 +252,12 @@ TEST_F_CORO(partition_properties_stm_fixture, test_snapshot) {
       before_enabled.value(), before_disabled.value() + model::offset(2));
     auto snap_before_enabled
       = partition_properties_stm_accessor::snap_from_iobuf(
-        co_await get_leader_stm()->take_snapshot(o));
+        co_await get_leader_stm()->take_raft_snapshot(o));
     ASSERT_EQ_CORO(
       snap_before_enabled.writes_disabled, stm_t::writes_disabled::yes);
 
     auto snap_at_enabled = partition_properties_stm_accessor::snap_from_iobuf(
-      co_await get_leader_stm()->take_snapshot(
+      co_await get_leader_stm()->take_raft_snapshot(
         model::next_offset(before_enabled.value())));
     ASSERT_EQ_CORO(snap_at_enabled.writes_disabled, stm_t::writes_disabled::no);
 
@@ -266,7 +266,7 @@ TEST_F_CORO(partition_properties_stm_fixture, test_snapshot) {
       before_enabled.value() + model::offset(2));
     auto snap_after_enabled
       = partition_properties_stm_accessor::snap_from_iobuf(
-        co_await get_leader_stm()->take_snapshot(
+        co_await get_leader_stm()->take_raft_snapshot(
           model::next_offset(before_enabled.value())));
     ASSERT_EQ_CORO(
       snap_after_enabled.writes_disabled, stm_t::writes_disabled::no);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -345,7 +345,9 @@ public:
     size_t tx_cache_size() const;
 
     std::optional<tx_metadata> oldest_tx() const;
-    ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
+    ss::future<iobuf> take_raft_snapshot(model::offset) final {
+        co_return iobuf{};
+    }
 
     /**
      * Resets state of finished transaction. This operation is done in memory.

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -231,7 +231,7 @@ ss::future<> translation_stm::apply_raft_snapshot(const iobuf&) {
     co_return;
 }
 
-ss::future<iobuf> translation_stm::take_snapshot(model::offset) {
+ss::future<iobuf> translation_stm::take_raft_snapshot(model::offset) {
     co_return iobuf{};
 }
 

--- a/src/v/datalake/translation/state_machine.h
+++ b/src/v/datalake/translation/state_machine.h
@@ -38,7 +38,7 @@ public:
       take_local_snapshot(ssx::semaphore_units) override;
 
     ss::future<> apply_raft_snapshot(const iobuf&) final;
-    ss::future<iobuf> take_snapshot(model::offset) final;
+    ss::future<iobuf> take_raft_snapshot(model::offset) final;
 
     raft::consensus* raft() const { return _raft; }
 

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -162,7 +162,7 @@ ss::future<> group_tx_tracker_stm::apply_raft_snapshot(const iobuf&) {
     return ss::now();
 }
 
-ss::future<iobuf> group_tx_tracker_stm::take_snapshot(model::offset) {
+ss::future<iobuf> group_tx_tracker_stm::take_raft_snapshot(model::offset) {
     return ss::make_ready_future<iobuf>(iobuf());
 }
 

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -104,7 +104,7 @@ public:
       take_local_snapshot(ssx::semaphore_units) override;
 
     ss::future<> apply_raft_snapshot(const iobuf&) final;
-    ss::future<iobuf> take_snapshot(model::offset) final;
+    ss::future<iobuf> take_raft_snapshot(model::offset) final;
 
     ss::future<> handle_raft_data(model::record_batch);
     ss::future<> handle_tx_offsets(

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -259,7 +259,7 @@ bool write_at_offset_stm::is_offset_translated_batch(
            != _offset_translated_batches.end();
 }
 
-ss::future<iobuf> write_at_offset_stm::take_snapshot(model::offset) {
+ss::future<iobuf> write_at_offset_stm::take_raft_snapshot(model::offset) {
     // this state machine doesn't need snapshot as its state is based on
     // snapshot metadata i.e. start offset
     co_return iobuf{};

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -101,7 +101,7 @@ public:
       std::optional<kafka::offset> prev_log_offset,
       model::timeout_clock::duration timeout);
 
-    ss::future<iobuf> take_snapshot(model::offset) final;
+    ss::future<iobuf> take_raft_snapshot(model::offset) final;
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 
     raft::stm_initial_recovery_policy

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -89,7 +89,7 @@ public:
      * Returns a snapshot of an STM state with requested last included offset
      */
     virtual ss::future<iobuf>
-    take_snapshot(model::offset last_included_offset) = 0;
+    take_raft_snapshot(model::offset last_included_offset) = 0;
 
     /**
      * Last successfully applied offset
@@ -174,10 +174,11 @@ class no_at_offset_snapshot_stm_base : public state_machine_base {
         return snapshot_at_offset_supported::no;
     }
 
-    ss::future<iobuf> take_snapshot(model::offset offset) final {
+    ss::future<iobuf> take_raft_snapshot(model::offset offset) final {
         if (offset != last_applied_offset()) {
             throw std::logic_error(fmt::format(
-              "State machine that do not support taking snapshot at arbitrary "
+              "State machine that do not support taking snapshot at "
+              "arbitrary "
               "offset can to take snapshot at requested offset: {}, current "
               "last applied offset: {}",
               offset,

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -720,7 +720,8 @@ state_machine_manager::take_snapshot(model::offset last_included_offset) {
     managed_snapshot snapshot;
     co_await ss::coroutine::parallel_for_each(
       _machines, [last_included_offset, &snapshot](auto entry_pair) {
-          return entry_pair.second->stm->take_snapshot(last_included_offset)
+          return entry_pair.second->stm
+            ->take_raft_snapshot(last_included_offset)
             .then([&snapshot, key = entry_pair.first](auto snapshot_part) {
                 snapshot.snapshot_map.try_emplace(
                   key, std::move(snapshot_part));
@@ -753,7 +754,7 @@ state_machine_manager::take_snapshot() {
     managed_snapshot snapshot;
     co_await ss::coroutine::parallel_for_each(
       _machines, [snapshot_offset, &snapshot](auto entry_pair) {
-          return entry_pair.second->stm->take_snapshot(snapshot_offset)
+          return entry_pair.second->stm->take_raft_snapshot(snapshot_offset)
             .then([&snapshot, key = entry_pair.first](auto snapshot_part) {
                 snapshot.snapshot_map.try_emplace(
                   key, std::move(snapshot_part));

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -244,7 +244,7 @@ public:
     };
 
     ss::future<iobuf>
-    take_snapshot(model::offset last_included_offset) override {
+    take_raft_snapshot(model::offset last_included_offset) override {
         kv_state inc_state;
         // build incremental snapshot
         auto snap = co_await raft_node.raft()->open_snapshot();
@@ -497,7 +497,7 @@ public:
 
     ss::future<> apply_raft_snapshot(const iobuf&) override { co_return; };
 
-    ss::future<iobuf> take_snapshot(model::offset) override {
+    ss::future<iobuf> take_raft_snapshot(model::offset) override {
         co_return iobuf{};
     }
 

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -123,7 +123,7 @@ public:
       : simple_kv_base<>(rn) {}
 
     ss::future<iobuf>
-    take_snapshot(model::offset last_included_offset) override {
+    take_raft_snapshot(model::offset last_included_offset) override {
         state_t inc_state;
         // build incremental snapshot
         auto snap = co_await raft_node.raft()->open_snapshot();


### PR DESCRIPTION
For duality with `apply_raft_snapshot`, and to make the split of local
and raft snapshots more clear in persisted_stm.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
