### PR TITLE
`storage`: set cached disk usage after compaction rounds

### DIFF
--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -77,6 +77,7 @@ public:
     virtual void set_flag(compacted_index::footer_flags) = 0;
     virtual void print(std::ostream&) const = 0;
     const ss::sstring& filename() const { return _name; }
+    virtual size_t size_bytes() const = 0;
 
 private:
     friend std::ostream&

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -580,7 +580,6 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
               seg->reader().filename(),
               result);
             if (result.did_compact()) {
-                seg->clear_cached_disk_usage();
                 _compaction_ratio.update(result.compaction_ratio());
                 const ssize_t removed_bytes = ssize_t(result.size_before)
                                               - ssize_t(result.size_after);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1661,7 +1661,8 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     co_await seg->index().drop_all_data();
 
     // Rename the data file.
-    co_await internal::do_swap_data_file_handles(tmpname, seg, cfg, *_probe);
+    co_await internal::do_swap_data_file_handles(
+      tmpname, seg, cfg, *_probe, compacted_idx_writer->size_bytes());
 
     // Persist the state of our indexes in their new names.
     seg->index().swap_index_state(std::move(new_idx));

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -189,6 +189,14 @@ void segment::clear_cached_disk_usage() {
     _compaction_index_size.reset();
 }
 
+void segment::set_cached_disk_usage(
+  size_t new_seg_size, std::optional<size_t> new_compacted_index_size) {
+    _data_disk_usage_size = new_seg_size;
+    if (new_compacted_index_size.has_value()) {
+        _compaction_index_size = new_compacted_index_size.value();
+    }
+}
+
 ss::future<size_t> segment::remove_persistent_state() {
     vassert(is_closed(), "Cannot clear state from unclosed segment");
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -38,7 +38,8 @@ struct segment_closed_exception final : std::exception {
 };
 namespace testing_details {
 class offset_tracker_accessor;
-};
+class segment_accessor;
+}; // namespace testing_details
 
 class segment {
 public:
@@ -371,6 +372,7 @@ private:
     std::optional<ss::lowres_clock::time_point> _first_write;
 
     friend std::ostream& operator<<(std::ostream&, const segment&);
+    friend class testing_details::segment_accessor;
 };
 
 /**

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -277,6 +277,17 @@ public:
     }
 
     void clear_cached_disk_usage();
+    // Sets the cached disk usage for the `segment` and `compacted_index`. These
+    // are usually the values from the underlying `segment_{appender/reader}`
+    // for either of these objects. The base `segment_index` sets its disk usage
+    // in `flush_to_file()`.
+    //
+    // This function is used within the compaction subsystem to cut down on
+    // future calls to `stat()`, since the cached disk usage is cleared during
+    // every round of compaction, and we know from in-memory state how large
+    // these objects are going to be on disk.
+    void set_cached_disk_usage(
+      size_t new_seg_size, std::optional<size_t> new_compacted_index_size);
 
     /// Fallback timestamp method, for use if the timestamps in the index
     /// appear to be invalid (e.g. too far in the future)

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -181,6 +181,7 @@ ss::future<bool> segment_index::materialize_index() {
 ss::future<bool> segment_index::materialize_index_from_file(ss::file f) {
     auto size = co_await f.size();
     auto buf = co_await f.dma_read_bulk<char>(0, size);
+    _disk_usage_size = size;
     if (buf.empty()) {
         co_return false;
     }
@@ -229,6 +230,9 @@ ss::future<> segment_index::flush_to_file(ss::file backing_file) {
     for (const auto& f : b) {
         co_await out.write(f.get(), f.size());
     }
+
+    _disk_usage_size = b.size_bytes();
+
     co_await out.flush();
 }
 

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -51,8 +51,8 @@ segment_reader::~segment_reader() noexcept {
 ss::future<> segment_reader::load_size() {
     ss::gate::holder guard{_gate};
 
-    auto s = co_await stat();
-    set_file_size(s.st_size);
+    auto s = co_await fsize();
+    set_file_size(s);
 };
 
 ss::future<segment_reader_handle> segment_reader::data_stream(size_t pos) {

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -130,6 +130,15 @@ ss::future<> segment_reader::put() {
     }
 }
 
+ss::future<size_t> segment_reader::fsize() {
+    ss::gate::holder guard{_gate};
+
+    auto handle = co_await get();
+    auto r = co_await _data_file.size();
+    co_await handle.close();
+    co_return r;
+}
+
 ss::future<struct stat> segment_reader::stat() {
     ss::gate::holder guard{_gate};
 

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -132,6 +132,9 @@ public:
     /// close the underlying file handle
     ss::future<> close();
 
+    // Performs a syscall to get the size of _data_file on disk.
+    ss::future<size_t> fsize();
+
     /// perform syscall stat
     ss::future<struct stat> stat();
 

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -281,8 +281,8 @@ static ss::future<segment_set> unsafe_do_recover(
           to_recover.begin(),
           to_recover.end(),
           [](ss::lw_shared_ptr<segment>& segment) {
-              auto stat = segment->reader().stat().get();
-              if (stat.st_size != 0) {
+              auto size = segment->reader().fsize().get();
+              if (size != 0) {
                   return true;
               }
               vlog(stlog.info, "Removing empty segment: {}", segment);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -544,7 +544,7 @@ ss::future<> do_swap_data_file_handles(
  * Executes segment compaction, returns size of compacted segment or an empty
  * optional if segment wasn't compacted
  */
-ss::future<std::optional<size_t>> do_self_compact_segment(
+ss::future<compaction_result> do_self_compact_segment(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
@@ -553,6 +553,8 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
   offset_delta_time apply_offset,
   ss::rwlock::holder read_holder,
   ss::sharded<features::feature_table>& feature_table) {
+    auto size_before = s->size_bytes();
+
     if (cfg.asrc) {
         cfg.asrc->check();
     }
@@ -597,7 +599,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
           "generation: {}, skipping compaction",
           s->get_generation_id(),
           segment_generation);
-        co_return std::nullopt;
+        co_return compaction_result(size_before);
     }
 
     if (s->is_closed()) {
@@ -615,7 +617,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     co_await s->reset_batch_cache_index();
     co_await s->index().flush();
     s->advance_generation();
-    co_return s->size_bytes();
+    co_return compaction_result(size_before, s->size_bytes());
 }
 
 ss::future<> build_compaction_index(
@@ -784,9 +786,8 @@ ss::future<compaction_result> self_compact_segment(
         || (state == compacted_index::recovery_state::already_compacted);
     vassert(is_valid_index_state, "Unexpected state {}", state);
 
-    auto sz_before = s->size_bytes();
     auto apply_offset = should_apply_delta_time_offset(feature_table);
-    auto sz_after = co_await do_self_compact_segment(
+    auto res = co_await do_self_compact_segment(
       s,
       cfg,
       pb,
@@ -796,15 +797,14 @@ ss::future<compaction_result> self_compact_segment(
       std::move(read_holder),
       feature_table);
 
-    // compaction wasn't executed, return
-    if (!sz_after) {
-        co_return compaction_result(sz_before);
+    if (res.did_compact()) {
+        pb.segment_compacted();
+        pb.add_compaction_removed_bytes(
+          ssize_t(res.size_before) - ssize_t(res.size_after));
+        s->mark_as_finished_self_compaction();
     }
 
-    pb.segment_compacted();
-    pb.add_compaction_removed_bytes(ssize_t(sz_before) - ssize_t(*sz_after));
-    s->mark_as_finished_self_compaction();
-    co_return compaction_result(sz_before, *sz_after);
+    co_return res;
 }
 
 ss::future<std::tuple<

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -271,23 +271,25 @@ ss::future<size_t> write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
-    size_t cmp_idx_size{0};
-    std::exception_ptr eptr;
+    // integrity verified in `do_detect_compaction_index_state`
+    auto fut = co_await ss::coroutine::as_future(
+      do_write_clean_compacted_index(reader, cfg, resources));
+
     try {
-        // integrity verified in `do_detect_compaction_index_state`
-        cmp_idx_size = co_await do_write_clean_compacted_index(
-          reader, cfg, resources);
+        co_await reader.close();
     } catch (...) {
-        eptr = std::current_exception();
+        auto e = std::current_exception();
+        vlog(
+          gclog.debug,
+          "Caught exception {} while closing compacted_index_reader",
+          e);
     }
 
-    co_await reader.close();
-
-    if (eptr) {
-        std::rethrow_exception(eptr);
+    if (fut.failed()) {
+        std::rethrow_exception(fut.get_exception());
     }
 
-    co_return cmp_idx_size;
+    co_return fut.get();
 }
 
 ss::future<compacted_index::recovery_state>

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -224,7 +224,7 @@ natural_index_of_entries_to_keep(compacted_index_reader reader) {
     return reader.consume(compaction_key_reducer(), model::no_timeout);
 }
 
-ss::future<> copy_filtered_entries(
+ss::future<size_t> copy_filtered_entries(
   compacted_index_reader reader,
   roaring::Roaring to_copy_index,
   std::unique_ptr<compacted_index_writer> writer) {
@@ -245,9 +245,11 @@ ss::future<> copy_filtered_entries(
     if (eptr) {
         std::rethrow_exception(eptr);
     }
+
+    co_return writer->size_bytes();
 }
 
-static ss::future<> do_write_clean_compacted_index(
+static ss::future<size_t> do_write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
@@ -258,20 +260,23 @@ static ss::future<> do_write_clean_compacted_index(
       cfg.files_to_cleanup, {tmpname}};
     auto truncating_writer = make_file_backed_compacted_index(
       tmpname.string(), true, resources, cfg.sanitizer_config);
-    co_await copy_filtered_entries(
+    auto cmp_idx_size = co_await copy_filtered_entries(
       reader, std::move(bitmap), std::move(truncating_writer));
     co_await ss::rename_file(std::string(tmpname), ss::sstring(reader.path()));
     staging_to_clean.clear();
+    co_return cmp_idx_size;
 };
 
-ss::future<> write_clean_compacted_index(
+ss::future<size_t> write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
+    size_t cmp_idx_size{0};
     std::exception_ptr eptr;
     try {
         // integrity verified in `do_detect_compaction_index_state`
-        co_await do_write_clean_compacted_index(reader, cfg, resources);
+        cmp_idx_size = co_await do_write_clean_compacted_index(
+          reader, cfg, resources);
     } catch (...) {
         eptr = std::current_exception();
     }
@@ -281,6 +286,8 @@ ss::future<> write_clean_compacted_index(
     if (eptr) {
         std::rethrow_exception(eptr);
     }
+
+    co_return cmp_idx_size;
 }
 
 ss::future<compacted_index::recovery_state>
@@ -338,7 +345,7 @@ generate_compacted_list(model::offset o, compacted_index_reader reader) {
       .finally([reader] {});
 }
 
-ss::future<> do_compact_segment_index(
+ss::future<size_t> do_compact_segment_index(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage_resources& resources) {
@@ -568,7 +575,7 @@ ss::future<compaction_result> do_self_compact_segment(
 
     // broker_timestamp is used for retention.ms, but it's only in the index,
     // not it in the segment itself. save it to restore it later
-    co_await do_compact_segment_index(s, cfg, resources);
+    auto cmp_idx_size = co_await do_compact_segment_index(s, cfg, resources);
     // copy the bytes after segment is good - note that we
     // need to do it with the READ-lock, not the write lock
     auto staging_file = s->reader().path().to_staging();
@@ -617,7 +624,7 @@ ss::future<compaction_result> do_self_compact_segment(
     co_await s->reset_batch_cache_index();
     co_await s->index().flush();
     s->advance_generation();
-    co_return compaction_result(size_before, s->size_bytes());
+    co_return compaction_result(size_before, s->size_bytes(), cmp_idx_size);
 }
 
 ss::future<> build_compaction_index(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -268,13 +268,21 @@ ss::future<> write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
-    // integrity verified in `do_detect_compaction_index_state`
-    return do_write_clean_compacted_index(reader, cfg, resources)
-      .finally([reader]() mutable {
-          return reader.close().then_wrapped(
-            [reader](ss::future<>) { /*ignore*/ });
-      });
+    std::exception_ptr eptr;
+    try {
+        // integrity verified in `do_detect_compaction_index_state`
+        co_await do_write_clean_compacted_index(reader, cfg, resources);
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    co_await reader.close();
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }
+
 ss::future<compacted_index::recovery_state>
 do_detect_compaction_index_state(segment_full_path p, compaction_config cfg) {
     using flags = compacted_index::footer_flags;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -521,7 +521,8 @@ ss::future<> do_swap_data_file_handles(
   std::filesystem::path compacted,
   ss::lw_shared_ptr<storage::segment> s,
   storage::compaction_config cfg,
-  probe& pb) {
+  probe& pb,
+  std::optional<size_t> new_cmp_idx_size) {
     co_await s->reader().close();
 
     ss::sstring old_name = compacted.string();
@@ -540,6 +541,11 @@ ss::future<> do_swap_data_file_handles(
       config::shard_local_cfg().storage_read_readahead_count(),
       cfg.sanitizer_config);
     co_await r->load_size();
+
+    // We know the size of the segment and compacted index files. To save on
+    // future file_stat() calls due to these values being unset, set the cached
+    // disk usage here.
+    s->set_cached_disk_usage(r->file_size(), new_cmp_idx_size);
 
     // update partition size probe
     pb.delete_segment(*s.get());
@@ -616,7 +622,8 @@ ss::future<compaction_result> do_self_compact_segment(
     co_await s->index().drop_all_data();
 
     auto compacted_file = s->reader().path().to_staging();
-    co_await do_swap_data_file_handles(compacted_file, s, cfg, pb);
+    co_await do_swap_data_file_handles(
+      compacted_file, s, cfg, pb, cmp_idx_size);
     staging_to_clean.clear();
 
     s->index().swap_index_state(std::move(idx));
@@ -1078,14 +1085,16 @@ ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> from,
   compaction_config cfg,
   probe& probe,
-  chunked_vector<ss::rwlock::holder> locks) {
+  chunked_vector<ss::rwlock::holder> locks,
+  std::optional<size_t> new_cmp_idx_size) {
     co_await from->close();
 
     co_await to->index().drop_all_data();
 
     // segment data file
     auto from_path = from->reader().path();
-    co_await do_swap_data_file_handles(from_path, to, cfg, probe);
+    co_await do_swap_data_file_handles(
+      from_path, to, cfg, probe, new_cmp_idx_size);
 
     // offset index
     to->index().swap_index_state(
@@ -1203,9 +1212,9 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
     }
 
     pb.delete_segment(*replacement.get());
-    // transfer segment state from replacement to target
+    // transfer segment state from replacement to target.
     locks = co_await internal::transfer_segment(
-      target, replacement, cfg, pb, std::move(locks));
+      target, replacement, cfg, pb, std::move(locks), ret.cmp_idx_size_after);
 
     locks.clear();
     holders.clear();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -228,23 +228,23 @@ ss::future<> copy_filtered_entries(
   compacted_index_reader reader,
   roaring::Roaring to_copy_index,
   std::unique_ptr<compacted_index_writer> writer) {
-    return ss::do_with(
-      std::move(writer),
-      [bm = std::move(to_copy_index),
-       reader](std::unique_ptr<compacted_index_writer>& writer) mutable {
-          reader.reset();
-          return reader
-            .consume(
-              index_filtered_copy_reducer(std::move(bm), *writer),
-              model::no_timeout)
-            // must be last
-            .finally([&writer] {
-                writer->set_flag(
-                  compacted_index::footer_flags::self_compaction);
-                // do not handle exception on the close
-                return writer->close();
-            });
-      });
+    std::exception_ptr eptr;
+    try {
+        reader.reset();
+        co_await reader.consume(
+          index_filtered_copy_reducer(std::move(to_copy_index), *writer),
+          model::no_timeout);
+        writer->set_flag(compacted_index::footer_flags::self_compaction);
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    // do not handle exception on the close
+    co_await writer->close();
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }
 
 static ss::future<> do_write_clean_compacted_index(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -176,14 +176,17 @@ uint64_t segment_size_from_config(const storage::ntp_config&);
 ss::future<roaring::Roaring>
   natural_index_of_entries_to_keep(compacted_index_reader);
 
-ss::future<> copy_filtered_entries(
+// Returns the size of the built compacted index in bytes.
+ss::future<size_t> copy_filtered_entries(
   storage::compacted_index_reader input,
   roaring::Roaring to_copy_index_filter,
   storage::compacted_index_writer output);
 
 /// \brief writes a new `*.compacted_index` file and *closes* the
 /// input compacted_index_reader file
-ss::future<> write_clean_compacted_index(
+///
+/// Returns the size of the built compacted index in bytes.
+ss::future<size_t> write_clean_compacted_index(
   storage::compacted_index_reader,
   storage::compaction_config,
   storage_resources& resources);

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -124,7 +124,8 @@ ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> from,
   compaction_config cfg,
   probe& probe,
-  chunked_vector<ss::rwlock::holder>);
+  chunked_vector<ss::rwlock::holder>,
+  std::optional<size_t> new_cmp_idx_size);
 
 /*
  * Acquire write locks on multiple segments. The process will proceed until
@@ -222,7 +223,8 @@ ss::future<> do_swap_data_file_handles(
   std::filesystem::path compacted,
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
-  probe&);
+  probe&,
+  std::optional<size_t>);
 
 // Generates a random jitter percentage [as a fraction] with in the passed
 // percents range.

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -399,6 +399,13 @@ std::ostream& operator<<(std::ostream& o, const spill_key_index& k) {
     return o;
 }
 
+size_t spill_key_index::size_bytes() const {
+    if (_appender.has_value()) {
+        return _appender->file_byte_offset();
+    }
+    return 0;
+}
+
 } // namespace storage::internal
 
 namespace storage {

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -81,6 +81,7 @@ public:
     ss::future<> close() final;
     void print(std::ostream&) const final;
     void set_flag(compacted_index::footer_flags) final;
+    size_t size_bytes() const final;
 
 private:
     /**

--- a/src/v/storage/tests/common.h
+++ b/src/v/storage/tests/common.h
@@ -39,4 +39,15 @@ public:
     }
 };
 
+class segment_accessor {
+public:
+    static std::optional<size_t> data_disk_usage_size(storage::segment& s) {
+        return s._data_disk_usage_size;
+    }
+
+    static std::optional<size_t> compaction_index_size(storage::segment& s) {
+        return s._compaction_index_size;
+    }
+};
+
 } // namespace storage::testing_details

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4960,6 +4960,10 @@ public:
         return std::ranges::max(diffs);
     }
 
+    static std::optional<size_t> disk_usage_size(segment_index& index) {
+        return index._disk_usage_size;
+    }
+
 private:
     segment_index& _index;
     size_t _size;
@@ -6250,6 +6254,91 @@ TEST_F(storage_test_fixture, find_sliding_ranges) {
             }
         } else {
             ASSERT_TRUE(!adjacent_ranges.has_value());
+        }
+    }
+}
+
+TEST_F(storage_test_fixture, segment_cached_disk_usage_set_after_compaction) {
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "a", 0);
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(0));
+        log->force_roll().get();
+    };
+
+    add_segment_func();
+    add_segment_func();
+
+    ss::abort_source as;
+    storage::compaction_config cfg(model::offset::max(), std::nullopt, as);
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+
+    auto check_cached_sizes = [](auto& seg) {
+        auto disk
+          = storage::testing_details::segment_accessor::data_disk_usage_size(
+            *seg);
+        auto cidx
+          = storage::testing_details::segment_accessor::compaction_index_size(
+            *seg);
+        auto sidx = storage::segment_index_observer::disk_usage_size(
+          seg->index());
+        ASSERT_TRUE(disk.has_value());
+        ASSERT_TRUE(cidx.has_value());
+        ASSERT_TRUE(sidx.has_value());
+
+        ASSERT_EQ(disk.value(), ss::file_size(seg->path().string()).get());
+        ASSERT_EQ(
+          cidx.value(),
+          ss::file_size(seg->path().to_compacted_index().string()).get());
+        ASSERT_EQ(
+          sidx.value(), ss::file_size(seg->path().to_index().string()).get());
+    };
+
+    auto& segs = log->segments();
+
+    // Test self-compaction
+    {
+        auto& s = segs[0];
+        disk_log.segment_self_compact(cfg, s).get();
+        check_cached_sizes(s);
+    }
+
+    // Test adjacent compaction
+    {
+        disk_log.adjacent_merge_compact(segs, cfg).get();
+        for (auto& s : segs) {
+            if (s->finished_self_compaction()) {
+                check_cached_sizes(s);
+            }
+        }
+    }
+
+    // Test sliding window compaction
+    {
+        disk_log.sliding_window_compact(cfg).get();
+        for (auto& s : segs) {
+            if (s->finished_self_compaction()) {
+                ASSERT_TRUE(s->has_clean_compact_timestamp());
+                check_cached_sizes(s);
+            }
         }
     }
 }

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -567,10 +567,14 @@ struct compaction_result {
       , size_before(sz)
       , size_after(sz) {}
 
-    compaction_result(size_t before, size_t after)
+    compaction_result(
+      size_t before,
+      size_t after,
+      std::optional<size_t> cmp_idx_size_after = std::nullopt)
       : executed_compaction(true)
       , size_before(before)
-      , size_after(after) {}
+      , size_after(after)
+      , cmp_idx_size_after(cmp_idx_size_after) {}
 
     bool did_compact() const { return executed_compaction; }
 
@@ -582,6 +586,8 @@ struct compaction_result {
     bool executed_compaction;
     size_t size_before;
     size_t size_after;
+    // The size of the new compacted index, if one was made.
+    std::optional<size_t> cmp_idx_size_after{std::nullopt};
     friend std::ostream& operator<<(std::ostream&, const compaction_result&);
 };
 


### PR DESCRIPTION
# Prelude
[Check out this cool flamegraph!](https://pprof.me/94592b10a8121eb1844e4e99e92b2dc2/?cur_path=%25255B%25255D)

What's not so cool is the nearly 15% of cumulative CPU time spent within `segment::persistent_size()`:

![image](https://github.com/user-attachments/assets/fdec4082-a7b3-4959-99ba-a2fb0bf2da0b)

# The Cover Letter

The major motivation for these changes is the number of calls being made to `fstat()` for each `segment` during a housekeeping round. These syscalls must go through the seastar `syscall_work_queue`, and take up much more CPU utilization than they should when studying a flamegraph.

The common thread in all of the flamegraph stack traces is `segment::persistent_size()`, which issues `fstat()` commands to acquire the size of the `segment`, `segment_index` and `compacted_index` if they are not currently cached. Compaction on a segment unsets all of these via `segment::clear_cached_disk_usage()`:

https://github.com/redpanda-data/redpanda/blob/00c76c3aa6a9815a84e14c2f9ad1ba6d7bde02b3/src/v/storage/segment_utils.cc#L520 

Within `log_manager::gc_loop()`, we query a `log` for its `disk_usage()`, which must make calls to EACH `segment`'s `persistent_size()`. What is likely even more responsible for the calls to `disk_usage()` is from the `disk_space_manager::run_loop()`, which according to the default `retention_local_trim_interval`, occurs every `30s`.

https://github.com/redpanda-data/redpanda/blob/00c76c3aa6a9815a84e14c2f9ad1ba6d7bde02b3/src/v/resource_mgmt/storage.cc#L515

It is clear to see that compaction constantly invalidating these values and then not re-assigning them could result in a lot of time spent in syscalls to disk every time urgent gc is issued/every space management loop. Thankfully, we have enough state in memory to reassign (at the very least, a rough estimation) the size instead of just clearing the cache.

This should all have the intended effect of cutting down on system calls in the housekeeping layer.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Cut down the amount of time spent in `fstat()` syscalls during `storage` layer housekeeping.