### PR TITLE
iceberg: encode partition field names to comply with Avro spec

### DIFF
--- a/src/v/iceberg/schema_avro.cc
+++ b/src/v/iceberg/schema_avro.cc
@@ -185,6 +185,79 @@ maybe_optional_from_avro(const avro::NodePtr& n, with_field_ids with_ids) {
     return {type_from_avro(child, with_ids), field_required::no};
 }
 
+/// Checks if the given name is a valid Avro name.
+///
+/// From the Avro specification:
+///     The name portion of the fullname of named types, record field names, and
+///     enum symbols must:
+///      - start with [A-Za-z_]
+///      - subsequently contain only [A-Za-z0-9_].
+bool valid_avro_name(const ss::sstring& name) noexcept {
+    if (name.empty()) {
+        return false;
+    }
+
+    if (!std::isalpha(static_cast<unsigned char>(name[0])) && name[0] != '_') {
+        return false;
+    }
+
+    for (const auto& c : name) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::pair<char, char> to_hex_digits(char c) {
+    static constexpr std::string_view hex_digits = "0123456789ABCDEF";
+    auto byte = static_cast<uint8_t>(c);
+    return {hex_digits[byte >> 4], hex_digits[byte & 0xF]};
+}
+
+template<bool isFirst>
+void append_sanitized_avro_name_char(std::vector<char>& dest, char c) {
+    if constexpr (isFirst) {
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            dest.push_back('_');
+            dest.push_back(c);
+            return;
+        }
+    }
+
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_') {
+        dest.push_back(c);
+    } else {
+        auto [high, low] = to_hex_digits(c);
+        dest.push_back('_');
+        dest.push_back('x');
+        dest.push_back(high);
+        dest.push_back(low);
+    }
+}
+
+/// Mimics Iceberg Java implementation of sanitizing Avro names.
+ss::sstring sanitize_avro_name(const ss::sstring& name) {
+    if (name.length() == 0) {
+        throw std::invalid_argument("Avro name cannot be empty");
+    }
+
+    std::vector<char> sanitized_name;
+
+    // It is quite common to encode a nested field separator (partition name) so
+    // we allocate space to replace `.` with `_x2E` without reallocating. If
+    // there is more to replace, `std::vector` will handle it.
+    sanitized_name.reserve(name.length() + 3);
+
+    append_sanitized_avro_name_char<true>(sanitized_name, name[0]);
+    for (size_t i = 1; i < name.length(); ++i) {
+        append_sanitized_avro_name_char<false>(sanitized_name, name[i]);
+    }
+
+    return {sanitized_name.data(), sanitized_name.size()};
+}
+
 } // namespace
 
 avro::Schema field_to_avro(const nested_field& field) {
@@ -200,8 +273,11 @@ struct_type_to_avro(const struct_type& type, std::string_view name) {
     const auto& fields = type.fields;
     for (const auto& field_ptr : fields) {
         const auto child_schema = field_to_avro(*field_ptr);
+
         avro_schema.addField(
-          field_ptr->name,
+          valid_avro_name(field_ptr->name)
+            ? field_ptr->name
+            : sanitize_avro_name(field_ptr->name),
           field_to_avro(*field_ptr),
           field_attrs(field_ptr->id()),
           // Optional fields (unions types with null children) have

--- a/src/v/iceberg/tests/schema_avro_test.cc
+++ b/src/v/iceberg/tests/schema_avro_test.cc
@@ -238,6 +238,54 @@ TEST(SchemaAvroSerialization, TestStruct) {
     ASSERT_EQ(s.schema_struct, parsed_struct);
 }
 
+TEST(SchemaAvroSerialization, TestStructInvalidFieldNames) {
+    struct_type type;
+    type.fields.emplace_back(nested_field::create(
+      0, "42_starts_with_digit", field_required::yes, int_type()));
+    type.fields.emplace_back(nested_field::create(
+      0, "42.also.has.dots", field_required::yes, int_type()));
+
+    // Note: Encoding this type of characters is inconsistent between Redpanda,
+    // Java Iceberg, and Python Iceberg.
+    // - Redpanda encodes one char (byte) at a time: `_xF0_x9F_x98_x8E`,
+    // - Java encodes one UTF-16 char at a time: `_xD83D_xDE0E`.
+    // - Python encodes unicode character at a time: `_x1F60E`.
+    type.fields.emplace_back(
+      nested_field::create(0, "😎", field_required::yes, int_type()));
+    schema s{
+      .schema_struct = std::move(type),
+      .schema_id = schema::id_t{0},
+      .identifier_field_ids = {}};
+    auto avro_root = struct_type_to_avro(s.schema_struct, "test_schema");
+    auto avro_schema = avro::ValidSchema(avro_root);
+    const auto expected_str = R"({
+    "type": "record",
+    "name": "test_schema",
+    "fields": [
+        {
+            "name": "_42_starts_with_digit",
+            "type": "int",
+            "field-id": 0
+        },
+        {
+            "name": "_42_x2Ealso_x2Ehas_x2Edots",
+            "type": "int",
+            "field-id": 0
+        },
+        {
+            "name": "_xF0_x9F_x98_x8E",
+            "type": "int",
+            "field-id": 0
+        }
+    ]
+}
+)";
+    ASSERT_STREQ(expected_str, avro_schema.toJson().c_str());
+
+    // We don't try to parse it back as these names aren't decoded when
+    // deserializing from Avro.
+}
+
 TEST(SchemaAvroSerialization, TestMap) {
     struct_type type;
     type.fields.emplace_back(nested_field::create(


### PR DESCRIPTION
Previously, partition field names in Iceberg metadata could contain dots ('.') to represent nested fields (e.g., 'redpanda.timestamp'). This is invalid per the Avro specification, which only allows [A-Za-z_][A-Za-z0-9_]* for field names. As a result, Avro files written by Redpanda were rejected by the official Avro C library and tools like avrocat, and caused interoperability issues with systems that strictly validate Avro schemas (e.g., DuckDB, AWS Glue).

This change introduces encoding for all record field names in Avro metadata, ensuring compliance with the Avro spec and improving compatibility with the broader Iceberg ecosystem. The encoding approach matches the behavior of Java and Python Iceberg implementations, avoiding divergence and future interoperability issues. Existing tables written with invalid field names can be "optimized" with Spark to re-encode partition names if needed.

See ticket discussion for details and rationale.

See https://redpandadata.atlassian.net/browse/CORE-11982

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Iceberg integration: Encode avro record field names to avoid using disallowed characters (like dots with default partitioning `hour(redpanda.timestamp)`. This makes it possible to read Iceberg data with latest version of DuckDB.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
