### PR TITLE
[CORE-8848] `rptest`: deflake `CompactionGapsTest`

### DIFF
--- a/tests/rptest/tests/datalake/compaction_test.py
+++ b/tests/rptest/tests/datalake/compaction_test.py
@@ -36,7 +36,9 @@ class CompactionGapsTest(RedpandaTest):
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "datalake_coordinator_snapshot_max_delay_secs": 10,
                 "log_compaction_interval_ms": 10000,
-                "min_cleanable_dirty_ratio": 0.0
+                "min_cleanable_dirty_ratio": 0.0,
+                "log_compaction_merge_max_ranges": 1,
+                "log_compaction_merge_max_segments_per_range": 2
             },
             *args,
             **kwargs)


### PR DESCRIPTION
This test began flaking after https://github.com/redpanda-data/redpanda/pull/25953 adjacent compaction over ranges was merged.

The test expects to see a certain number of segments produced, and adjacent compaction over ranges is often able to outpace the rate of segment production in keeping the number of segments down, leading to a timeout like

```
AssertionError: Unable to reach segment count 8 in 180s, current count 6
```

Set `log_compaction_merge_max_ranges=1` and `log_compaction_merge_max_segments_per_range=2` to revert adjacent compaction to its previous, less effective behavior (one pair of segments combined per sliding window round) in order to prevent it from outpacing the producer.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
