### PR TITLE
`raft`: `state_machine_manager` followups

### DIFF
--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -653,7 +653,9 @@ ss::future<> state_machine_manager::background_apply_fiber(
             if (fut.failed()) {
                 const auto e = fut.get_exception();
                 // do not log known shutdown exceptions as errors
-                if (!ssx::is_shutdown_exception(e)) {
+                if (ssx::is_shutdown_exception(e)) {
+                    std::rethrow_exception(e);
+                } else {
                     vlog(_log.error, "error applying raft snapshot - {}", e);
                     co_await ss::sleep_abortable(100ms, _as);
                 }

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -569,7 +569,7 @@ ss::future<> state_machine_manager::try_apply_in_foreground() {
     }
 }
 
-ss::future<> state_machine_manager::apply() {
+ss::future<> state_machine_manager::apply() noexcept {
     /**
      * If any of the state machine is behind, dispatch background apply fibers
      */

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -210,7 +210,7 @@ private:
       raft::snapshot_metadata metadata,
       storage::snapshot_reader& reader,
       std::vector<ssx::semaphore_units> background_apply_units);
-    ss::future<> apply();
+    ss::future<> apply() noexcept;
     ss::future<> try_apply_in_foreground();
 
     ss::future<std::vector<ssx::semaphore_units>>


### PR DESCRIPTION
Two follow ups from https://github.com/redpanda-data/redpanda/pull/26490 & https://github.com/redpanda-data/redpanda/pull/26491:

1. Mark `state_machine_manager::apply()` as `noexcept` per request https://github.com/redpanda-data/redpanda/pull/26490#issuecomment-2981655846
2. Add back a `std::rethrow_exception()` in case of shutdown exception as pointed out here: https://github.com/redpanda-data/redpanda/pull/26490#discussion_r2155329097

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
