### PR TITLE
`storage`: more cached disk usage improvements

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -255,13 +255,22 @@ ss::future<> segment::do_release_appender(
         std::optional<std::unique_ptr<compacted_index_writer>>&
           compacted_index) {
           return appender->close()
-            .then([this] { return _idx.flush(); })
-            .then([this, &compacted_index] {
+            .then([this] {
+                clear_cached_disk_usage();
+                return _idx.flush();
+            })
+            .then([&compacted_index] {
                 if (compacted_index) {
                     return compacted_index.value()->close();
                 }
-                clear_cached_disk_usage();
                 return ss::now();
+            })
+            .then([this, &compacted_index, &appender] {
+                std::optional<size_t> cmp_idx_size{std::nullopt};
+                if (compacted_index) {
+                    cmp_idx_size = compacted_index.value()->size_bytes();
+                }
+                set_cached_disk_usage(appender->size_bytes(), cmp_idx_size);
             });
       });
 }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -120,7 +120,9 @@ ss::future<usage> segment::persistent_size() {
      * segment appender will transparently extend the size of the segment file
      * using fallocate, always stat the on disk size for the head partition.
      */
-    if (!_appender && _data_disk_usage_size.has_value()) {
+    if (_appender) {
+        u.data = _appender->size_bytes();
+    } else if (_data_disk_usage_size.has_value()) {
         u.data = _data_disk_usage_size.value();
     } else {
         try {
@@ -139,7 +141,9 @@ ss::future<usage> segment::persistent_size() {
      * however, we pay for that stat() with no guarantee that the information
      * will be used.
      */
-    if (_compaction_index_size.has_value()) {
+    if (_compaction_index) {
+        u.compaction = _compaction_index.value()->size_bytes();
+    } else if (_compaction_index_size.has_value()) {
         u.compaction = _compaction_index_size.value();
     } else {
         auto path = reader().path().to_compacted_index();

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -278,15 +278,15 @@ public:
     }
 
     void clear_cached_disk_usage();
-    // Sets the cached disk usage for the `segment` and `compacted_index`. These
-    // are usually the values from the underlying `segment_{appender/reader}`
-    // for either of these objects. The base `segment_index` sets its disk usage
-    // in `flush_to_file()`.
+    // Sets the cached disk usage for the `segment` and optionally the
+    // `compacted_index`. These are usually the values from the underlying
+    // `segment_{appender/reader}` for either of these objects. The base
+    // `segment_index` sets its disk usage in `flush_to_file()`.
     //
-    // This function is used within the compaction subsystem to cut down on
-    // future calls to `stat()`, since the cached disk usage is cleared during
-    // every round of compaction, and we know from in-memory state how large
-    // these objects are going to be on disk.
+    // This function is widely used within the compaction subsystem to cut down
+    // on future calls to `stat()`, since the cached disk usage is cleared
+    // during every round of compaction, and we know from in-memory state how
+    // large these objects are going to be on disk.
     void set_cached_disk_usage(
       size_t new_seg_size, std::optional<size_t> new_compacted_index_size);
 

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -325,7 +325,12 @@ ss::future<> segment_appender::close() {
     _closed = true;
     return hard_flush()
       .then([this] { return do_truncation(_committed_offset); })
-      .then([this] { return _out.close(); });
+      .then([this] {
+          _fallocation_offset = _committed_offset;
+          _flushed_offset = _committed_offset;
+          _stable_offset = _committed_offset;
+          return _out.close();
+      });
 }
 
 ss::future<> segment_appender::do_next_adaptive_fallocation() {

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -84,6 +84,10 @@ public:
         return _committed_offset + _bytes_flush_pending;
     }
 
+    // The size of the underlying file on disk, which is the
+    // _fallocation_offset.
+    size_t size_bytes() const { return _fallocation_offset; }
+
     /**
      * @brief Appends a batch.
      *

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -401,7 +401,7 @@ std::ostream& operator<<(std::ostream& o, const spill_key_index& k) {
 
 size_t spill_key_index::size_bytes() const {
     if (_appender.has_value()) {
-        return _appender->file_byte_offset();
+        return _appender->size_bytes();
     }
     return 0;
 }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -6317,6 +6317,8 @@ TEST_F(storage_test_fixture, segment_cached_disk_usage_set_after_compaction) {
     // Test self-compaction
     {
         auto& s = segs[0];
+        // Freshly rolled segment should have cached sizes set.
+        check_cached_sizes(s);
         disk_log.segment_self_compact(cfg, s).get();
         check_cached_sizes(s);
     }


### PR DESCRIPTION
Quick follow-up to https://github.com/redpanda-data/redpanda/pull/26513. Only last 6 commits are new. Other PR should be reviewed first.

### Commit ac16830ea96697f2477c3a9677188ffba7289fc1

Sets offsets in `segment_appender::close()`.

We were not properly setting the book-kept offsets in the `segment_appender` while closing it. This commit fixes that so `_committed_offset`, `_fallocation_offset`, `_flushed_offset`, and `_stable_offset` will all report the same value after a `segment_appender` is closed (previously, the latter 3 would report untruncated/unflushed state). This will be relevant in the next commit.

### Commit 11129fe3f4238a59c68aedbfbb791a9b47e66e37

Adds `segment_appender::size_bytes()`.

Previously, uses of `_appender->file_byte_offset()` were used to set the cached file size after a `segment_appender` was closed. However, while a `segment_appender` is open, this function returns the position of the cursor within the file, not the file size itself (as we `fallocate()` up front in the `segment_appender`). To properly report the size of a file with an open `segment_appender`, we should be returning `_fallocation_offset` instead. With the fix from the previous commit, this offset will also now be accurate after the `segment_appender` is closed.

### Commit 23ff40fd2dffbf5a12fb034c9f93c2074c6c847c

Use `segment_appender::size_bytes()` in `spill_key_index::size_bytes()` instead of `segment_appender::file_byte_offset()` for the aforementioned reason of accurate file size reporting while the `appender` is open.

### Commit db02ffd9780692e3fb775f36ace93cf63e6cc891

This commit seeks to cut down on the number of syscalls made due to calls to `persistent_size()` on an open `segment`. We clear the cached values for open `segment`s during a lot of operations- 
* `do_flush()`
* `truncate()`
* `do_append()`
* `advance_stable_offset()`

to name a few. While a `segment` is still open, we have access to its `appender` and its `compacted_index_writer`, which means we can simply defer to these objects' `size_bytes()` [aka `_fallocation_offset`] instead of issuing a syscall.

### Commit 0c22b4a2428ef1bed434dc481e8883e461124ff5

Just a simple comment tweak for `set_cached_disk_usage()`.

### Commit 1873fba2e38f9e02f7bcf13f14f0c0b479ef1476

An optimization in `do_release_appender()`, which has the effect of leaving a freshly closed `segment` with cached disk usages intact instead of cleared (since this is the last time we will have access to its `appender` and `compacted_index_writer`).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Cut down the amount of time spent in `fstat()` syscalls in the `storage` layer EVEN MORE IN GENERAL!