### PR TITLE
clang-tidy: do not warn on copying ss::shared_ptr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,5 +30,7 @@ CheckOptions:
     value:           KiB;MiB;GiB;TiB
   - key:             hicpp-uppercase-literal-suffix.NewSuffixes
     value:           KiB;MiB;GiB;TiB
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           seastar::shared_ptr;seastar::lw_shared_ptr;
 ...
 


### PR DESCRIPTION
Silence
https://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-value-param.html for `seastar::shared_ptr`.

If a shared pointer is passed by value then likely that was the intention.

Also https://stackoverflow.com/a/60883927

Some warnings are still displayed but generally this reduces clutter in the IDE.

Known issues:
- https://github.com/llvm/llvm-project/issues/145032

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
