### PR TITLE
[CORE-12029] net: fix race condition in conn quota test

### DIFF
--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -249,6 +249,12 @@ void conn_quota_fixture::test_borrows(
     // a reclaim.
     vlog(logger.debug, "Trigger a reclaim");
     scq.invoke_on(1, [this](conn_quota&) { shard_units.erase(1); }).get();
+    // Reclaiming happens through a shard 1->0 background fiber fired through
+    // ~units(), which is not covered by waiting on the invoked task.
+    // The following invoke_on starts a task that includes a shard 2->0 request.
+    // Add a barier to protect against race condition between shard {1|2} ->
+    // shard 0 requests
+    tests::flush_tasks();
     scq
       .invoke_on(
         2,


### PR DESCRIPTION
Fixes: [CORE-12029](https://redpandadata.atlassian.net/browse/CORE-12029)

As described in the comments in the code...

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12029]: https://redpandadata.atlassian.net/browse/CORE-12029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ