### PR TITLE
[CORE-10097] rptests/services: fix ocsf server startup issue

### DIFF
--- a/tests/rptest/services/ocsf_server.py
+++ b/tests/rptest/services/ocsf_server.py
@@ -63,7 +63,7 @@ class OcsfServer(Service):
         hostname = node.account.hostname
         return f'http://{hostname}:{HTTP_PORT}/api/{path}'
 
-    def get_api_version(self, node=None):
+    def get_api_version(self, node=None, timeout_sec=5):
         """Returns current verison of OCSF server
         
         Parameters
@@ -79,19 +79,13 @@ class OcsfServer(Service):
 
         def _wait_for_api_version():
             r = requests.get(uri)
-            if r.status_code != 200:
-                return (False, None)
-            return (True, r)
+            return (r.status_code == 200, r)
 
         r = wait_until_result(_wait_for_api_version,
-                              timeout_sec=5,
+                              timeout_sec=timeout_sec,
                               backoff_sec=1,
                               retry_on_exc=True,
                               err_msg=f'Could not get API version from {uri}')
-
-        r = requests.get(uri)
-        if r.status_code != 200:
-            raise Exception(f'Unexepected status code: {r.status_code}')
         return r.json()['version']
 
     def validate_schema(self, schema, node=None):

--- a/tests/rptest/services/ocsf_server.py
+++ b/tests/rptest/services/ocsf_server.py
@@ -136,20 +136,9 @@ class OcsfServer(Service):
         self.logger.debug(f'Starting OCSF Server with cmd "{cmd}"')
         node.account.ssh(cmd, allow_fail=False)
 
-        def _wait_for_version():
-            try:
-                _ = self.get_api_version()
-                return True
-            except Exception:
-                # Ignore exceptions as server may be coming up and
-                # connections may time out
-                pass
-            return False
-
-        wait_until(_wait_for_version,
-                   timeout_sec=10,
-                   backoff_sec=1,
-                   err_msg='Failed to get version from server during startup')
+        # Wait for server to come up online
+        version = self.get_api_version(timeout_sec=30)
+        self.logger.debug(f'OCSF Server online with version "{version}"')
 
     def stop_node(self, node):
         cmd = self._stop_cmd()


### PR DESCRIPTION
Fixes: [CORE-10097](https://redpandadata.atlassian.net/browse/CORE-10097)

Startup of ocsf server in arm64 seems to be taking slightly longer than 10s (~12 seconds).
Increase startup timeout to 10s -> 30s.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-10097]: https://redpandadata.atlassian.net/browse/CORE-10097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ