### PR TITLE
`kafka`: use `chunked_vector` in `describe_groups_handler::handle`

### DIFF
--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -72,6 +72,7 @@
 #include "security/scram_authenticator.h"
 #include "ssx/future-util.h"
 #include "ssx/thread_worker.h"
+#include "ssx/when_all.h"
 #include "strings/string_switch.h"
 #include "strings/utf8.h"
 
@@ -1918,7 +1919,7 @@ describe_groups_handler::handle(request_context ctx, ss::smp_service_group) {
     describe_groups_response response;
 
     if (likely(!request.data.groups.empty())) {
-        std::vector<ss::future<described_group>> described;
+        chunked_vector<ss::future<described_group>> described;
         described.reserve(request.data.groups.size());
         for (auto& group_id : request.data.groups) {
             described.push_back(ctx.groups().describe_group(group_id).then(
@@ -1930,12 +1931,11 @@ describe_groups_handler::handle(request_context ctx, ss::smp_service_group) {
                   return res;
               }));
         }
-        auto group_v = co_await ss::when_all_succeed(
-          described.begin(), described.end());
+        auto group_v
+          = co_await ssx::when_all_succeed<chunked_vector<described_group>>(
+            std::move(described));
 
-        response.data.groups = {
-          std::make_move_iterator(group_v.begin()),
-          std::make_move_iterator(group_v.end())};
+        response.data.groups = std::move(group_v);
     }
 
     for (auto& group : unauthorized) {


### PR DESCRIPTION
We saw an occurance of an oversized allocation in the wild here.

Confusingly enough, the underlying data type of `describe_groups_response_data` is a `chunked_vector` already, which means we were just moving entries from an `std::vector` into a `chunked_vector` here anyways.

Use a `chunked_vector<ss::future<described_group>>` for `described` and `std::move()` assign the result to `response.data.groups` to avoid future potential for an oversized allocation here.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes


### Improvements

* Fixes an issue in which users could experience oversized allocations during a `DescribeGroup` request.