### PR TITLE
[CORE-12249] rptests/tests: disable questionable test

### DIFF
--- a/tests/rptest/tests/connection_rate_limit_test.py
+++ b/tests/rptest/tests/connection_rate_limit_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
+from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 
 import time
@@ -111,6 +112,7 @@ class ConnectionRateLimitTest(PreallocNodesTest):
 
         return sum(deltas) / len(deltas)
 
+    @ignore  # https://redpandadata.atlassian.net/browse/CORE-12249
     @cluster(num_nodes=8)
     def connection_rate_test(self):
         self._producer.start(clean=False)


### PR DESCRIPTION
Disables failing dt test: [CORE-12249](https://redpandadata.atlassian.net/browse/CORE-12249)

This is *not* a fix. The relevant functionality needs to be tested.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12249]: https://redpandadata.atlassian.net/browse/CORE-12249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ