### PR TITLE
`rptest`: better summaries for mixed version test failures with `BadLogLines` 

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4100,6 +4100,16 @@ class RedpandaService(RedpandaServiceBase):
         version_str = self.get_version(node)
         return ri_int_tuple(RI_VERSION_RE.findall(version_str)[0])
 
+    def get_version_if_not_head(self, node):
+        """
+        Returns the redpanda binary version as a string if it differs from HEAD.
+        I.e., if this node is running a previous version of redpanda.
+        """
+        cur_ver = self._installer.installed_version(node)
+        if cur_ver != RedpandaInstaller.HEAD:
+            return self.get_version(node)
+        return None
+
     def stop(self, **kwargs):
         """
         Override default stop() to execude stop_node in parallel

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1752,7 +1752,8 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
                     f"{RedpandaServiceBase.STDOUT_STDERR_CAPTURE} not found on {node.account.hostname}. Skipping log scan."
                 )
                 continue
-            _searchable_nodes.append(node)
+            _searchable_nodes.append(
+                (self.get_version_if_not_head(node), node))
 
         lsearcher = LogSearchLocal(self._context, allow_list, self.logger,
                                    RedpandaServiceBase.STDOUT_STDERR_CAPTURE)
@@ -2494,7 +2495,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
                                    self.logger,
                                    self.kubectl,
                                    test_start_time=test_start_time)
-        lsearcher.search_logs(self.pods)
+        lsearcher.search_logs([(None, pod) for pod in self.pods])
 
     def copy_cloud_logs(self, test_start_time):
         """Method makes sure that agent and cloud logs is copied after the test

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -61,12 +61,14 @@ class BadLogLines(Exception):
         # in the string output so that for single line failures, it isn't necessary
         # for folks to search back in the log to find the culprit.
         example_lines = next(iter(self.node_to_lines.items()))[1]
-        example = next(iter(example_lines))
+        example = next(iter(example_lines['lines']))
 
-        summary = ','.join([
-            f'{i[0].account.hostname}({len(i[1])})'
-            for i in self.node_to_lines.items()
-        ])
+        summary_list = []
+        for i in self.node_to_lines.items():
+            version_or_none = i[1]["version"]
+            node_info = f'<{i[0].account.hostname}:{version_or_none}>' if version_or_none is not None else f'{i[0].account.hostname}'
+            summary_list.append(f'{node_info}({len(i[1])})')
+        summary = ','.join(summary_list)
         return f"<BadLogLines nodes={summary} example=\"{example}\">"
 
     def __repr__(self):
@@ -168,11 +170,14 @@ class LogSearch(ABC):
             return True
         return False
 
-    def _search(self, nodes):
-        bad_lines = collections.defaultdict(list)
+    def _search(self, versioned_nodes):
+        bad_lines = collections.defaultdict(lambda: {
+            'version': None,
+            'lines': []
+        })
         test_name = self._context.function_name
         sw = Stopwatch()
-        for node in nodes:
+        for (version, node) in versioned_nodes:
             sw.start()
             hostname = self._get_hostname(node)
             self.logger.info(f"Scanning node {hostname} log for errors...")
@@ -190,7 +195,8 @@ class LogSearch(ABC):
                     allowed = self._check_oversized_allocations(line)
                 # If detected bad lines, log it and add to the list
                 if not allowed:
-                    bad_lines[node].append(line)
+                    bad_lines[node]['version'] = version
+                    bad_lines[node]['lines'].append(line)
                     self.logger.warn(f"[{test_name}] Unexpected log line on "
                                      f"{hostname}: {line}")
             self.logger.info(
@@ -198,9 +204,12 @@ class LogSearch(ABC):
                     f"##### Time spent to scan bad logs on '{hostname}'"))
         return bad_lines
 
-    def search_logs(self, nodes):
+    def search_logs(self, versioned_nodes):
+        """
+        versioned_nodes is a list of Tuple[version, node]
+        """
         # Do log search
-        bad_loglines = self._search(nodes)
+        bad_loglines = self._search(versioned_nodes)
         # If anything, raise exception
         if bad_loglines:
             # Call class overriden method to get proper Exception class

--- a/tests/rptest/tests/strict_data_init_test.py
+++ b/tests/rptest/tests/strict_data_init_test.py
@@ -33,7 +33,7 @@ class StrictDataInitTest(RedpandaTest):
         try:
             self.redpanda.raise_on_bad_logs()
         except BadLogLines as b:
-            bad_lines = b.node_to_lines[target_node]
+            bad_lines = b.node_to_lines[target_node]['lines']
             assert any(STRICT_DATA_ERR_MSG_SUFFIX in b for b in bad_lines)
         else:
             assert False, "The reason why redpanda failed to start isn't due to a nonexistent magic file"


### PR DESCRIPTION
This PR adds additional context (the `redpanda` version) to the output of a `BadLogLines` exception failure in ducktape for brokers running non-HEAD versions of `redpanda`.

For a historical example of why this is beneficial and also an illustration of the changes here, consider a failure previously encountered in a mixed version test like `random_node_operations_test` (captured in [JIRA-12310](https://redpandadata.atlassian.net/browse/CORE-12310)):

```
rptest.services.utils.BadLogLines: <BadLogLines nodes=docker-rp-18(1) example="WARN  2025-06-20 10:36:04,882 [shard 0:main] seastar - Exceptional future ignored: std::runtime_error (couldn't download manifest: cloud_storage::error_outcome:2), backtrace: ...">
```

This particular failure was fixed in `dev` with commit https://github.com/redpanda-data/redpanda/pull/26491. However, at the time, this change did _not_ receive backports, and what this meant was JIRA tickets would continue to be populated showing that the above log line was still an active failure in `redpanda` (an example of which is captured in [JIRA-12484](https://redpandadata.atlassian.net/browse/CORE-12484))

And on first glance of a summary page, a human would come to the same conclusion ("I thought I fixed this failure, it's still happening in CI on `dev`, huh?"). However, this log line would be appearing within this test due to brokers running a previous version of the binary which did not have this fix, something not immediately apparent when grokking JIRA tickets or CI build summary pages. What _would_ make this apparent, and would help with organizing JIRA tickets per `redpanda` version, would be if the output was instead:

```
rptest.services.utils.BadLogLines: <BadLogLines nodes=<docker-rp-18(1):v24.3.15> example="WARN  2025-06-20 10:36:04,882 [shard 0:main] seastar - Exceptional future ignored: std::runtime_error (couldn't download manifest: cloud_storage::error_outcome:2), backtrace: ...>
```

After these changes, this is what the output for a `BadLogLines` exception detected on a ducktape node running a non-HEAD version of `redpanda` will look like. The output for a ducktape node running HEAD will not have this new formatting, and will instead continue to look like the first output in this cover letter.

The benefit of these changes can be summarized in two points:

1. More immediately grokkable failure summaries for mixed version tests
2. Better automated ticket organization in JIRA for mixed version tests (indicating exactly which version of `redpanda` is seeing failures)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
