### PR TITLE
dt: Use mode_checks.is_debug_mode instead of manual checks

### DIFF
--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -33,6 +33,7 @@ from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_
 from rptest.archival.s3_client import S3Client
 from rptest.clients.rpk import RpkTool
 from rptest.clients.rpk import RpkException
+from rptest.utils.mode_checks import is_debug_mode
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
@@ -159,7 +160,7 @@ class EndToEndTest(Test):
         the much slower debug builds of redpanda, which generally cannot
         keep up with significant quantities of data or partition counts.
         """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
+        return is_debug_mode()
 
     def start_consumer(self,
                        num_nodes=1,

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -639,6 +639,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @skip_debug_mode
     def test_full_nodes(self):
         """
         Test partition balancer full disk node handling with the following scenario:
@@ -653,8 +654,6 @@ class PartitionBalancerTest(PartitionBalancerService):
         skip_reason = None
         if not self.test_context.globals.get('use_xfs_partitions', False):
             skip_reason = "looks like we are not using separate partitions for each node"
-        elif os.environ.get('BUILD_TYPE', None) == 'debug':
-            skip_reason = "debug builds are too slow"
 
         if skip_reason:
             self.logger.warn("skipping test: " + skip_reason)
@@ -763,6 +762,7 @@ class PartitionBalancerTest(PartitionBalancerService):
             assert used_ratio < 0.81
 
     @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @skip_debug_mode
     def test_nodes_with_reclaimable_space(self):
         """
         Test partition balancer cooperation with space management policy
@@ -771,8 +771,6 @@ class PartitionBalancerTest(PartitionBalancerService):
         skip_reason = None
         if not self.test_context.globals.get('use_xfs_partitions', False):
             skip_reason = "looks like we are not using separate partitions for each node"
-        elif os.environ.get('BUILD_TYPE', None) == 'debug':
-            skip_reason = "debug builds are too slow"
 
         if skip_reason:
             self.logger.warn("skipping test: " + skip_reason)

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -51,7 +51,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self.partition_count = 20
         self.consumer_timeout_seconds = 90
 
-        if os.environ.get('BUILD_TYPE', None) == 'debug':
+        if self.debug_mode:
             self.throughput = 500
             self.min_records = 5000
         else:

--- a/tests/rptest/tests/rack_aware_replica_placement_test.py
+++ b/tests/rptest/tests/rack_aware_replica_placement_test.py
@@ -159,7 +159,7 @@ class RackAwarePlacementTest(RedpandaTest):
 
     def _partition_count(self):
         # use smaller number of partitions for debug builds
-        if os.environ.get('BUILD_TYPE', None) == 'debug':
+        if self.debug_mode:
             return random.randint(20, 40)
 
         return random.randint(200, 300)

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -35,7 +35,7 @@ def cleanup_on_early_exit(caller):
 
 
 def is_debug_mode():
-    return os.environ.get('BUILD_TYPE', None) == 'debug'
+    return os.environ.get('BUILD_TYPE', None) in ['debug', 'sanitizer']
 
 
 def skip_debug_mode(*args, **kwargs):


### PR DESCRIPTION
Don't reimplement the same check in a bunch of places.

Also treat `sanitizer` bazel build mode as debug

We are introducing a bunch of new modes that should be treated as debug.
Treat them as such for DT purposes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


