### PR TITLE
c/force_reconfiguration: may the force (reconfiguration) be with you

### DIFF
--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -189,7 +189,7 @@ FIXTURE_TEST(
         BOOST_CHECK_EQUAL(counts, expected);
     };
 
-    auto create_topic_cmd = make_create_topic_cmd("test_tp_1", 4, 3);
+    auto create_topic_cmd = make_create_topic_cmd("test_tp_1", 7, 3);
     logger.info("create topic {}", create_topic_cmd.key);
     dispatch_command(create_topic_cmd);
 
@@ -197,8 +197,8 @@ FIXTURE_TEST(
     allocator.local().register_node(
       create_allocation_node(model::node_id(4), 4));
 
-    check_allocated_counts({4, 4, 4, 0});
-    check_final_counts({4, 4, 4, 0});
+    check_allocated_counts({7, 7, 7, 0});
+    check_final_counts({7, 7, 7, 0});
 
     // get data needed to move a partition
     auto get_partition = [&](model::partition_id::type id) {
@@ -235,14 +235,14 @@ FIXTURE_TEST(
         logger.info("move ntp {}", ntp);
         dispatch_command(
           cluster::move_partition_replicas_cmd{ntp, new_replicas});
-        check_allocated_counts({4, 4, 4, 1});
-        check_final_counts({3, 4, 4, 1});
+        check_allocated_counts({7, 7, 7, 1});
+        check_final_counts({6, 7, 7, 1});
 
         logger.info("finish move");
         dispatch_command(
           cluster::finish_moving_partition_replicas_cmd{ntp, new_replicas});
-        check_allocated_counts({3, 4, 4, 1});
-        check_final_counts({3, 4, 4, 1});
+        check_allocated_counts({6, 7, 7, 1});
+        check_final_counts({6, 7, 7, 1});
     }
 
     // move + cancel + force_cancel + finish
@@ -252,30 +252,30 @@ FIXTURE_TEST(
         logger.info("move ntp {}", ntp);
         dispatch_command(
           cluster::move_partition_replicas_cmd{ntp, new_replicas});
-        check_allocated_counts({3, 4, 4, 2});
-        check_final_counts({2, 4, 4, 2});
+        check_allocated_counts({6, 7, 7, 2});
+        check_final_counts({5, 7, 7, 2});
 
         logger.info("cancel move");
         dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
           ntp,
           cluster::cancel_moving_partition_replicas_cmd_data{
             cluster::force_abort_update{false}}});
-        check_allocated_counts({3, 4, 4, 2});
-        check_final_counts({3, 4, 4, 1});
+        check_allocated_counts({6, 7, 7, 2});
+        check_final_counts({6, 7, 7, 1});
 
         logger.info("force-cancel move");
         dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
           ntp,
           cluster::cancel_moving_partition_replicas_cmd_data{
             cluster::force_abort_update{true}}});
-        check_allocated_counts({3, 4, 4, 2});
-        check_final_counts({3, 4, 4, 1});
+        check_allocated_counts({6, 7, 7, 2});
+        check_final_counts({6, 7, 7, 1});
 
         logger.info("finish move");
         dispatch_command(
           cluster::finish_moving_partition_replicas_cmd{ntp, old_replicas});
-        check_allocated_counts({3, 4, 4, 1});
-        check_final_counts({3, 4, 4, 1});
+        check_allocated_counts({6, 7, 7, 1});
+        check_final_counts({6, 7, 7, 1});
     }
 
     // move + cancel + revert_cancel
@@ -285,23 +285,23 @@ FIXTURE_TEST(
         logger.info("move ntp {}", ntp);
         dispatch_command(
           cluster::move_partition_replicas_cmd{ntp, new_replicas});
-        check_allocated_counts({3, 4, 4, 2});
-        check_final_counts({2, 4, 4, 2});
+        check_allocated_counts({6, 7, 7, 2});
+        check_final_counts({5, 7, 7, 2});
 
         logger.info("cancel move");
         dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
           ntp,
           cluster::cancel_moving_partition_replicas_cmd_data{
             cluster::force_abort_update{false}}});
-        check_allocated_counts({3, 4, 4, 2});
-        check_final_counts({3, 4, 4, 1});
+        check_allocated_counts({6, 7, 7, 2});
+        check_final_counts({6, 7, 7, 1});
 
         logger.info("revert_cancel move");
         dispatch_command(cluster::revert_cancel_partition_move_cmd(
           int8_t{0},
           cluster::revert_cancel_partition_move_cmd_data{.ntp = ntp}));
-        check_allocated_counts({2, 4, 4, 2});
-        check_final_counts({2, 4, 4, 2});
+        check_allocated_counts({5, 7, 7, 2});
+        check_final_counts({5, 7, 7, 2});
     }
 
     // force_move
@@ -318,18 +318,142 @@ FIXTURE_TEST(
         new_replicas = std::vector({*repl_it});
 
         logger.info(
-          "force_partition_reconfiguration ntp {} to {}", ntp, new_replicas);
+          "force_partition_reconfiguration ntp {} from {} to {}",
+          ntp,
+          old_replicas,
+          new_replicas);
         dispatch_command(cluster::force_partition_reconfiguration_cmd{
           ntp,
           cluster::force_partition_reconfiguration_cmd_data(new_replicas)});
-        check_allocated_counts({2, 4, 4, 2});
-        check_final_counts({2, 3, 3, 2});
+        check_allocated_counts({5, 7, 7, 2});
+        check_final_counts({5, 6, 6, 2});
 
         logger.info("finish move");
         dispatch_command(
           cluster::finish_moving_partition_replicas_cmd{ntp, new_replicas});
-        check_allocated_counts({2, 3, 3, 2});
-        check_final_counts({2, 3, 3, 2});
+        check_allocated_counts({5, 6, 6, 2});
+        check_final_counts({5, 6, 6, 2});
+    }
+
+    // move in progress + force_move
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(4);
+
+        logger.info("move ntp {}", ntp);
+        dispatch_command(
+          cluster::move_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({5, 6, 6, 3});
+        check_final_counts({4, 6, 6, 3});
+
+        auto repl_it = std::find_if(
+          new_replicas.begin(), new_replicas.end(), [](const auto& bs) {
+              return bs.node_id() == 4;
+          });
+
+        BOOST_REQUIRE(repl_it != new_replicas.end());
+        auto force_replicas = std::vector({*repl_it});
+
+        logger.info(
+          "force_partition_reconfiguration ntp {} to {}", ntp, force_replicas);
+        dispatch_command(cluster::force_partition_reconfiguration_cmd{
+          ntp,
+          cluster::force_partition_reconfiguration_cmd_data(force_replicas)});
+        check_allocated_counts({5, 6, 6, 3});
+        check_final_counts({4, 5, 5, 3});
+
+        logger.info("finish move");
+        dispatch_command(
+          cluster::finish_moving_partition_replicas_cmd{ntp, force_replicas});
+        check_allocated_counts({4, 5, 5, 3});
+        check_final_counts({4, 5, 5, 3});
+    }
+
+    // move in progress + cancel + force_move + finish
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(5);
+
+        logger.info("move ntp {}", ntp);
+        dispatch_command(
+          cluster::move_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({4, 5, 5, 4});
+        check_final_counts({3, 5, 5, 4});
+
+        logger.info("cancel move");
+        dispatch_command(cluster::cancel_moving_partition_replicas_cmd{
+          ntp,
+          cluster::cancel_moving_partition_replicas_cmd_data{
+            cluster::force_abort_update{false}}});
+        check_allocated_counts({4, 5, 5, 4});
+        check_final_counts({4, 5, 5, 3});
+
+        auto repl_it = std::find_if(
+          new_replicas.begin(), new_replicas.end(), [](const auto& bs) {
+              return bs.node_id() == 4;
+          });
+
+        BOOST_REQUIRE(repl_it != new_replicas.end());
+        auto force_replicas = std::vector({*repl_it});
+
+        logger.info("force_move ntp {} to {}", ntp, force_replicas);
+        dispatch_command(cluster::force_partition_reconfiguration_cmd{
+          ntp,
+          cluster::force_partition_reconfiguration_cmd_data(force_replicas)});
+        check_allocated_counts({4, 5, 5, 4});
+        check_final_counts({3, 4, 4, 4});
+
+        logger.info("finish move");
+        dispatch_command(
+          cluster::finish_moving_partition_replicas_cmd{ntp, force_replicas});
+        check_allocated_counts({3, 4, 4, 4});
+        check_final_counts({3, 4, 4, 4});
+    }
+
+    // move in progress + force move + force move + finish
+    {
+        auto [ntp, old_replicas, new_replicas] = get_partition(6);
+
+        logger.info("move ntp {}", ntp);
+        dispatch_command(
+          cluster::move_partition_replicas_cmd{ntp, new_replicas});
+        check_allocated_counts({3, 4, 4, 5});
+        check_final_counts({2, 4, 4, 5});
+
+        auto repl_it = std::find_if(
+          new_replicas.begin(), new_replicas.end(), [](const auto& bs) {
+              return bs.node_id() == 4;
+          });
+
+        BOOST_REQUIRE(repl_it != new_replicas.end());
+        auto force_replicas4 = std::vector({*repl_it});
+
+        logger.info("force_move ntp {} to {}", ntp, force_replicas4);
+        dispatch_command(cluster::force_partition_reconfiguration_cmd{
+          ntp,
+          cluster::force_partition_reconfiguration_cmd_data(force_replicas4)});
+        check_allocated_counts({3, 4, 4, 5});
+        check_final_counts({2, 3, 3, 5});
+
+        // force move back to node 1, simulates a stuck force reconfiguration
+        repl_it = std::find_if(
+          old_replicas.begin(), old_replicas.end(), [](const auto& bs) {
+              return bs.node_id() == 1;
+          });
+
+        BOOST_REQUIRE(repl_it != old_replicas.end());
+        auto force_replicas1 = std::vector({*repl_it});
+
+        logger.info("force_move ntp {} to {}", ntp, force_replicas1);
+        dispatch_command(cluster::force_partition_reconfiguration_cmd{
+          ntp,
+          cluster::force_partition_reconfiguration_cmd_data(force_replicas1)});
+        check_allocated_counts({3, 4, 4, 4});
+        check_final_counts({3, 3, 3, 4});
+
+        logger.info("finish move");
+        dispatch_command(
+          cluster::finish_moving_partition_replicas_cmd{ntp, force_replicas1});
+        check_allocated_counts({3, 3, 3, 4});
+        check_final_counts({3, 3, 3, 4});
     }
 
     // move topic + topic delete
@@ -342,8 +466,8 @@ FIXTURE_TEST(
         }
         dispatch_command(
           cluster::move_topic_replicas_cmd(create_topic_cmd.key, cmd_data));
-        check_allocated_counts({4, 4, 4, 2});
-        check_final_counts({4, 4, 4, 0});
+        check_allocated_counts({7, 7, 7, 4});
+        check_final_counts({7, 7, 7, 0});
 
         logger.info("delete topic");
         dispatch_command(cluster::delete_topic_cmd(

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1988,6 +1988,15 @@ chunked_vector<model::ntp> topic_table::all_updates_in_progress() const {
     return ret;
 }
 
+std::optional<topic_table::in_progress_update>
+topic_table::update_in_progress(const model::ntp& ntp) const {
+    auto it = _updates_in_progress.find(ntp);
+    if (it == _updates_in_progress.end()) {
+        return std::nullopt;
+    }
+    return std::make_optional<in_progress_update>(it->second);
+}
+
 void topic_table::change_partition_replicas(
   model::ntp ntp,
   const replicas_t& new_assignment,

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -855,9 +855,6 @@ std::error_code topic_table::validate_force_reconfigurable_partition(
     if (!topic_md || topic_md->get().get_revision() != entry.topic_revision) {
         return errc::topic_not_exists;
     }
-    if (is_update_in_progress(ntp)) {
-        return errc::update_in_progress;
-    }
     const auto& current_assignment = get_partition_assignment(ntp);
     if (!current_assignment) {
         return errc::no_partition_assignments;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -2020,7 +2020,6 @@ void topic_table::change_partition_replicas(
         update_revision,
         policy,
         &_probe));
-    auto previous_assignment = current_assignment.replicas;
     // replace partition replica set
     current_assignment.replicas = new_assignment;
     _topics_map_revision++;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -721,23 +721,41 @@ topic_table::apply(force_partition_reconfiguration_cmd cmd, model::offset o) {
         co_return errc::partition_disabled;
     }
 
-    if (auto it = _updates_in_progress.find(cmd.key);
-        it != _updates_in_progress.end()) {
-        co_return errc::update_in_progress;
+    const auto& new_replicas = cmd.value.replicas;
+    auto update_revision = model::revision_id{o};
+    auto& current_assignment = current_assignment_it->second;
+
+    auto it = _updates_in_progress.find(cmd.key);
+    if (it != _updates_in_progress.end()) {
+        // update in progress, amend it to update target replicas.
+        it->second.force_set_state(
+          new_replicas,
+          model::revision_id{o},
+          reconfiguration_policy::full_local_retention);
+    } else {
+        _updates_in_progress.emplace(
+          cmd.key,
+          in_progress_update(
+            current_assignment.replicas,
+            new_replicas,
+            reconfiguration_state::force_update,
+            update_revision,
+            /**
+             * For now use default full local retention policy when force
+             * reconfiguring partition.
+             */
+            reconfiguration_policy::full_local_retention,
+            &_probe));
     }
+    _topics_map_revision++;
 
-    change_partition_replicas(
-      cmd.key,
-      cmd.value.replicas,
-      current_assignment_it->second,
-      o,
-      true,
-      /**
-       * For now use default full local retention policy when force
-       * reconfiguring partition.
-       */
-      reconfiguration_policy::full_local_retention);
+    current_assignment.replicas = cmd.value.replicas;
 
+    _pending_ntp_deltas.emplace_back(
+      std::move(cmd.key),
+      current_assignment.group,
+      update_revision,
+      topic_table_ntp_delta_type::replicas_updated);
     co_await notify_waiters();
 
     co_return errc::success;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -140,10 +140,10 @@ public:
             }
         }
 
-        in_progress_update(const in_progress_update&) = delete;
+        in_progress_update(const in_progress_update&) = default;
         in_progress_update(in_progress_update&&) = default;
-        in_progress_update& operator=(const in_progress_update&) = delete;
-        in_progress_update& operator=(in_progress_update&&) = delete;
+        in_progress_update& operator=(const in_progress_update&) = default;
+        in_progress_update& operator=(in_progress_update&&) = default;
 
         const reconfiguration_state& get_state() const { return _state; }
 
@@ -704,6 +704,12 @@ public:
     chunked_vector<model::ntp> all_ntps_moving_per_node(model::node_id) const;
 
     chunked_vector<model::ntp> all_updates_in_progress() const;
+
+    /**
+     * Returns the in-progress update for the given ntp, if it exists.
+     */
+    std::optional<in_progress_update>
+    update_in_progress(const model::ntp&) const;
 
     model::revision_id last_applied_revision() const {
         return _last_applied_revision_id;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -158,6 +158,26 @@ public:
             _last_cmd_revision = rev;
         }
 
+        void force_set_state(
+          const replicas_t& new_replicas,
+          model::revision_id rev,
+          reconfiguration_policy policy) {
+            /**
+             * a move from (A (prev) -> B (target)) -> C (force, new_replicas)
+             * is redefined to
+             * A -> C irrespective of whether the current move is a
+             * cancellation.
+             *
+             * This is logically equivalent to this in progress move never
+             * happening, and this makes it easy to account for allocation
+             * changes.
+             */
+            _target_replicas = new_replicas;
+            _last_cmd_revision = _update_revision = rev;
+            _policy = policy;
+            _state = reconfiguration_state::force_update;
+        }
+
         const replicas_t& get_previous_replicas() const {
             return _previous_replicas;
         }

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -216,13 +216,8 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
             "currently being updated",
             ntp);
 
-          auto to_add = subtract(
-            *new_target_replicas, current_assignment->replicas);
-          _partition_allocator.local().add_final_counts(to_add);
-
-          auto to_remove = subtract(
+          update_final_counts(
             current_assignment->replicas, *new_target_replicas);
-          _partition_allocator.local().remove_final_counts(to_remove);
 
           _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
             ntp.ns,
@@ -402,12 +397,10 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
             "currently being cancelled",
             ntp);
 
-          auto to_add = subtract(*target_replicas, *previous_replicas);
-          _partition_allocator.local().add_final_counts(to_add);
+          update_final_counts(*previous_replicas, *target_replicas);
 
           auto to_delete = subtract(*previous_replicas, *target_replicas);
           _partition_allocator.local().remove_allocations(to_delete);
-          _partition_allocator.local().remove_final_counts(to_delete);
 
           _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
             ntp.ns,
@@ -543,15 +536,22 @@ void topic_updates_dispatcher::add_allocations_for_new_partitions(
     }
 }
 
+void topic_updates_dispatcher::update_final_counts(
+  const std::vector<model::broker_shard>& previous,
+  const std::vector<model::broker_shard>& target) {
+    auto to_add = subtract(target, previous);
+    _partition_allocator.local().add_final_counts(to_add);
+
+    auto to_remove = subtract(previous, target);
+    _partition_allocator.local().remove_final_counts(to_remove);
+}
+
 void topic_updates_dispatcher::update_allocations_for_reconfiguration(
   const std::vector<model::broker_shard>& previous,
   const std::vector<model::broker_shard>& target) {
     auto to_add = subtract(target, previous);
     _partition_allocator.local().add_allocations(to_add);
-    _partition_allocator.local().add_final_counts(to_add);
-
-    auto to_remove = subtract(previous, target);
-    _partition_allocator.local().remove_final_counts(to_remove);
+    update_final_counts(previous, target);
 }
 
 ss::future<>

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -415,6 +415,10 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
 ss::future<std::error_code> topic_updates_dispatcher::apply(
   force_partition_reconfiguration_cmd cmd, model::offset base_offset) {
     auto p_as = _topic_table.local().get_partition_assignment(cmd.key);
+    // make a copy of the current in progress state, if any
+    auto maybe_in_progress_state_before
+      = _topic_table.local().update_in_progress(cmd.key);
+
     auto ec = co_await dispatch_updates_to_cores(cmd, base_offset);
     if (ec) {
         co_return ec;
@@ -426,7 +430,77 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
       "Partition {} have to exist before successful force-reconfiguration",
       ntp);
 
-    update_allocations_for_reconfiguration(p_as->replicas, cmd.value.replicas);
+    if (maybe_in_progress_state_before) {
+        auto& before_state = maybe_in_progress_state_before.value();
+
+        // undo any allocations from in progress move.
+
+        // For example, consider the following move
+        // --- (A (prev) -> B (target)) -> C (force)
+
+        // During the move A -> B, allocations amounting to (B - A) are added
+        // to account for the in progress move. Here we undo those allocations.
+        //
+        // note: A cancellation only updates final moves, so no allocator
+        // changes are made.
+
+        // Detailed example:
+
+        // Say a partition is being force reconfigured from [1, 2, 3] -> [2, 3,
+        // 4] and then force reconfigured to [4, 6, 8] while the reconfiguration
+        // is stuck.
+
+        // To make it more interesting, say there was a cancellation of the
+        // reconfiguration which is stuck too because [2, 3] are not available.
+
+        // Initial state:
+        // allocations (A) and final counts (F) follow {broker: allocations}
+        // dict notation.
+
+        // [1, 2, 3], allocations: [1:1, 2:1, 3:1], final counts: [1:1, 2:1,
+        // 3:1]
+        //
+        // reconfiguration [1, 2, 3] -> [2, 3, 4], A: [1:1, 2:1, 3:1, 4:1], F:
+        // [1:0, 2:1, 3:1, 4:1]
+        //
+        // reconfiguration is stuck and canceled
+        //
+        // reconfiguration [1, 2, 3] <- (cancel) [2, 3, 4] A: [1:1, 2:1, 3:1,
+        // 4:1], F: [1:1, 2:1, 3:1, 4:0]
+
+        // force reconfiguration to [4, 6, 8] while the canceling
+        // reconfiguration is stuck
+
+        // force reconfiguration [1, 2, 3] -> [4, 6, 8]
+        //  -- step 1 -- undo allocations from [1, 2, 3] -> [2, 3, 4] --
+        //  to_remove = [4] A: [1:1, 2:1, 3:1, 4:0]
+        //  -- step 2 -- add allocations for [4, 6, 8] -- to_add = [4:1, 6:1,
+        //  8:1]  A: [1:1, 2:1, 3:1, 4:1, 6:1, 8:1]
+        //  -- step 3 -- update final counts : F [1:0, 2:0, 3:0, 4:1, 6:1, 8:1]
+
+        // step 1:
+        auto to_remove = subtract(
+          before_state.get_target_replicas(),
+          before_state.get_previous_replicas());
+        _partition_allocator.local().remove_allocations(to_remove);
+
+        // Now add any new allocations from the force reconfiguration
+
+        // step 2:
+        auto to_add = subtract(
+          cmd.value.replicas, before_state.get_previous_replicas());
+        _partition_allocator.local().add_allocations(to_add);
+
+        // step 3:
+        // update final counts.
+        update_final_counts(p_as->replicas, cmd.value.replicas);
+
+    } else {
+        // This is a force reconfiguration of a partition that was not
+        // being moved before. This is equivalent to a plain (unforced) move.
+        update_allocations_for_reconfiguration(
+          p_as->replicas, cmd.value.replicas);
+    }
 
     _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
       ntp.ns,

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -117,6 +117,10 @@ private:
     template<typename T>
     void add_allocations_for_new_partitions(const T&);
 
+    void update_final_counts(
+      const std::vector<model::broker_shard>& previous,
+      const std::vector<model::broker_shard>& target);
+
     void update_allocations_for_reconfiguration(
       const std::vector<model::broker_shard>& previous,
       const std::vector<model::broker_shard>& target);

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1362,17 +1362,6 @@ topics_frontend::partitions_with_lost_majority(
                     continue;
                 }
                 model::ntp ntp(tn.ns, tn.tp, assignment.id);
-                if (topics.updates_in_progress().contains(ntp)) {
-                    // force reconfiguration does not support in progress
-                    // moves. this check can be relaxed once the limitation
-                    // is fixed.
-                    vlog(
-                      clusterlog.debug,
-                      "{} lost majority but skipping as an update is in "
-                      "progress.",
-                      ntp);
-                    continue;
-                }
                 result.emplace_back(
                   std::move(ntp),
                   topic_revision,
@@ -1415,17 +1404,16 @@ topics_frontend::force_recover_partitions_from_nodes(
     for (const auto& entry : user_approved_force_recovery_partitions) {
         // check if there is an in progress movemement, reject if so.
         // this is a conservative check and can be relaxed.
-        auto in_progress_move = topics.is_update_in_progress(entry.ntp);
         auto current_assignment = topics.get_partition_assignment(entry.ntp);
         auto assignment_match = current_assignment
                                 && are_replica_sets_equal(
                                   current_assignment->replicas,
                                   entry.assignment);
-        if (in_progress_move || !assignment_match) {
+        if (!assignment_match) {
             vlog(
               clusterlog.info,
               "rejecting force recovery of partitions from brokers {}, ntp: "
-              "{}, move in progress: {}, expected replica set: {}, current "
+              "{}, expected replica set: {}, current "
               "assignment: {}, the state may have changed since the original "
               "request was made, try again.",
               nodes,

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -480,17 +480,11 @@ admin_server::force_set_partition_replicas_handler(
     const auto& in_progress = topics.updates_in_progress();
     const auto in_progress_it = in_progress.find(ntp);
 
-    if (in_progress_it != in_progress.end()) {
-        throw ss::httpd::bad_request_exception(
-          fmt::format("A partition operation is in progress. Check "
-                      "reconfigurations and "
-                      "cancel in flight update before issuing force "
-                      "replica set update."));
-    }
     const auto current_assignment = topics.get_partition_assignment(ntp);
     if (current_assignment) {
         const auto& current_replicas = current_assignment->replicas;
-        if (current_replicas == replicas) {
+        if (
+          current_replicas == replicas && in_progress_it == in_progress.end()) {
             vlog(
               adminlog.info,
               "Request to change ntp {} replica set to {}, no change",

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -212,6 +212,43 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
     def _reconfiguration(self, replicas):
         self.reconfigure(new_replicas=replicas, force=False)
 
+    def _cancel_reconfiguration(self):
+        def do_cancel():
+            try:
+                self.redpanda._admin.cancel_partition_move(
+                    topic=self.topic,
+                    partition=0,
+                    node=random.choice(self.redpanda.started_nodes()))
+                return True
+            except requests.exceptions.RetryError:
+                return False
+            except requests.exceptions.ConnectionError:
+                return False
+            except requests.exceptions.HTTPError:
+                return False
+
+        self.redpanda.wait_until(
+            do_cancel,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg=f"Unable to cancel reconfiguration for {self.topic}/0")
+
+    def _wait_for_reconfigurations(self):
+        def has_reconfigurations():
+            try:
+                return len(
+                    self.redpanda._admin.list_reconfigurations(
+                        node=random.choice(self.redpanda.started_nodes()))) > 0
+            except:
+                return False
+
+        self.redpanda.wait_until(
+            has_reconfigurations,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg=f"Timed out waiting for reconfigurations for {self.topic}/0"
+        )
+
     def _start_consumer(self):
         self.start_consumer()
         # Wait for all consumer offsets partitions to have a stable leadership.
@@ -309,6 +346,74 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         # New group should include the killed node.
         self.redpanda._admin.await_stable_leader(topic=self.topic,
                                                  replication=len(alive) + 1,
+                                                 hosts=self._alive_nodes(),
+                                                 timeout_s=self.WAIT_TIMEOUT_S)
+
+    @cluster(num_nodes=5)
+    # If cancellation is True, cancels the in progress stuck move and then force reconfigures
+    @matrix(cancellation=[True, False])
+    def test_reconfiguring_in_progress_move(self, cancellation):
+        """
+        Tests that a partition move stuck in progress can be reconfigured. Additionally also checks that a stuck cancellation can be reconfigured."""
+        self.start_redpanda(num_nodes=5)
+        assert self.redpanda
+
+        self.topic = "topic"
+        self.client().create_topic(
+            TopicSpec(name=self.topic, replication_factor=3))
+
+        (killed, alive) = self._stop_majority_nodes(replication=3)
+
+        assert alive, "At least one replica should be alive"
+
+        # Issue a regular partition move while the partition is leaderless.
+        # this should be stuck
+        self._reconfiguration(alive)
+        self._wait_for_reconfigurations()
+        if cancellation:
+            # Cancel the stuck move
+            self._cancel_reconfiguration()
+
+        # Randomness here may choose existing replicas or a totally new set of replicas.
+        # Both are interesting cases to test.
+        new_replicas = [
+            Replica(dict(node_id=self.redpanda.node_id(replica), core=0))
+            for replica in random.sample(self.redpanda.started_nodes(), 3)
+        ]
+
+        self._force_reconfiguration(new_replicas)
+
+        self.redpanda._admin.await_stable_leader(topic=self.topic,
+                                                 replication=3,
+                                                 hosts=self._alive_nodes(),
+                                                 timeout_s=self.WAIT_TIMEOUT_S)
+
+    @cluster(num_nodes=5)
+    def test_reconfiguring_force_reconfiguration(self):
+        """
+        Test ensures that a stuck force reconfiguration can be force reconfigured"""
+        self.start_redpanda(num_nodes=5)
+        assert self.redpanda
+
+        self.topic = "topic"
+        self.client().create_topic(
+            TopicSpec(name=self.topic, replication_factor=3))
+
+        (killed, alive) = self._stop_majority_nodes(replication=3)
+
+        # This would never finish
+        self._force_reconfiguration([killed[0]])
+        self._wait_for_reconfigurations()
+
+        new_replica_count = random.choice([1, 3])
+        new_replicas = [
+            Replica(dict(node_id=self.redpanda.node_id(replica),
+                         core=0)) for replica in random.sample(
+                             self.redpanda.started_nodes(), new_replica_count)
+        ]
+        self._force_reconfiguration(new_replicas)
+        self.redpanda._admin.await_stable_leader(topic=self.topic,
+                                                 replication=new_replica_count,
                                                  hosts=self._alive_nodes(),
                                                  timeout_s=self.WAIT_TIMEOUT_S)
 

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -176,10 +176,15 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         self._wait_until_no_leader()
         return (killed, alive)
 
-    def _do_force_reconfiguration(self, replicas):
+    def _do_reconfigure(self, replicas, force: bool):
         try:
-            self.redpanda._admin.force_set_partition_replicas(
-                topic=self.topic, partition=0, replicas=replicas)
+            if force:
+                self.redpanda._admin.force_set_partition_replicas(
+                    topic=self.topic, partition=0, replicas=replicas)
+            else:
+                self.redpanda._admin.set_partition_replicas(topic=self.topic,
+                                                            partition=0,
+                                                            replicas=replicas)
             return True
         except requests.exceptions.RetryError:
             return False
@@ -188,18 +193,24 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         except requests.exceptions.HTTPError:
             return False
 
-    def _force_reconfiguration(self, new_replicas):
+    def reconfigure(self, new_replicas, force: bool):
         replicas = [
             dict(node_id=replica.node_id, core=replica.core)
             for replica in new_replicas
         ]
         self.redpanda.logger.info(f"Force reconfiguring to: {replicas}")
         self.redpanda.wait_until(
-            lambda: self._do_force_reconfiguration(replicas=replicas),
+            lambda: self._do_reconfigure(replicas=replicas, force=force),
             timeout_sec=60,
             backoff_sec=2,
             err_msg=f"Unable to force reconfigure {self.topic}/0 to {replicas}"
         )
+
+    def _force_reconfiguration(self, replicas):
+        self.reconfigure(new_replicas=replicas, force=True)
+
+    def _reconfiguration(self, replicas):
+        self.reconfigure(new_replicas=replicas, force=False)
 
     def _start_consumer(self):
         self.start_consumer()
@@ -354,7 +365,7 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
             Replica(dict(node_id=self.redpanda.node_id(replica), core=0)) for
             replica in self.redpanda.started_nodes()[:target_replica_set_size]
         ]
-        self._force_reconfiguration(new_replicas=new_replicas)
+        self._force_reconfiguration(new_replicas)
 
         self.redpanda._admin.await_stable_leader(
             topic=self.topic,

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -124,7 +124,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             lambda: self.metrics_correct(prev_assignment, assignmets),
             timeout_sec=10)
 
-    def _random_move_and_cancel(self, unclean_abort):
+    def _random_move_and_cancel(self, unclean_abort, force_back):
         metadata = self.client().describe_topics()
         topic, partition = self._random_partition(metadata)
         prev_assignment, assignments = self._dispatch_random_partition_move(
@@ -133,6 +133,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self._wait_for_move_in_progress(topic, partition)
         self.check_metrics(prev_assignment, assignments)
         self._request_move_cancel(unclean_abort=unclean_abort,
+                                  force_back=force_back,
                                   topic=topic,
                                   partition=partition,
                                   previous_assignment=prev_assignment)
@@ -147,10 +148,11 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(replication_factor=[1, 3],
             unclean_abort=[True, False],
+            force_back=[True, False],
             recovery=[NO_RECOVERY, RESTART_RECOVERY],
             compacted=[False, True])
     def test_cancelling_partition_move(self, replication_factor, unclean_abort,
-                                       recovery, compacted):
+                                       force_back, recovery, compacted):
         """
         Cancel partition moving with active consumer / producer
         """
@@ -183,7 +185,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self._throttle_recovery(10)
 
         for _ in range(self.moves):
-            self._random_move_and_cancel(unclean_abort)
+            self._random_move_and_cancel(unclean_abort=unclean_abort,
+                                         force_back=force_back)
             if recovery == RESTART_RECOVERY:
                 # restart one of the nodes after each move
                 self.redpanda.restart_nodes(
@@ -191,7 +194,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         # start consumer late in the process for the compaction to trigger
         if compacted:
             self.start_consumer(1, verify_offsets=False)
-        if unclean_abort:
+        if unclean_abort or force_back:
             # do not run offsets validation as we may experience data loss since partition movement is forcibly cancelling
             wait_until(lambda: self.producer.num_acked > 20000, timeout_sec=60)
 

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -259,6 +259,29 @@ class PartitionMovementMixin():
                                                  assignment["node_id"],
                                                  assignment["core"])
 
+    def _force_set_partition_assignments(self,
+                                         topic,
+                                         partition,
+                                         assignments,
+                                         admin=None):
+        self.logger.info(
+            f"setting assignments for {topic}/{partition}: {assignments}")
+
+        if admin is None:
+            admin = Admin(self.redpanda)
+
+        admin.force_set_partition_replicas(topic, partition,
+                                           [{
+                                               "node_id": a["node_id"],
+                                               "core": self.INVALID_CORE,
+                                           } for a in assignments])
+
+        for assignment in assignments:
+            if "core" in assignment:
+                admin.set_partition_replica_core(topic, partition,
+                                                 assignment["node_id"],
+                                                 assignment["core"])
+
     def _dispatch_random_partition_move(self,
                                         topic,
                                         partition,
@@ -309,6 +332,7 @@ class PartitionMovementMixin():
                              partition,
                              previous_assignment,
                              unclean_abort,
+                             force_back=False,
                              new_assignment=None,
                              timeout=90):
         """
@@ -319,6 +343,9 @@ class PartitionMovementMixin():
         result can be equal to initial movement assignment. (PR 8393)
         When request cancellation without throttling recovery rate
         or partition is empty, initial movement assignment must be provided
+
+        :param force_back: when true, the partition will be force moved back to the original assignment
+        immediately after cancellation/abort.
         """
         self._wait_for_move_in_progress(topic, partition)
         admin = Admin(self.redpanda)
@@ -330,6 +357,15 @@ class PartitionMovementMixin():
         except requests.exceptions.HTTPError as e:
             # we do not throttle cross core moves, it may already be finished
             assert e.response.status_code == 400
+            return
+
+        if force_back:
+            self._force_set_partition_assignments(topic,
+                                                  partition,
+                                                  previous_assignment,
+                                                  admin=admin)
+            self._wait_post_move(topic, partition, previous_assignment,
+                                 timeout)
             return
 
         # wait for previous assignment or new assigment if movement cannot be cancelled


### PR DESCRIPTION
Allows force reconfiguration of partition in any state (including stuck force reconfiguration). This behavior change helps unblock stuck partitions due to the following reasons (for example, stuck in move / cancelation without leader, stuck in force reconfiguration etc) which are difficult to unblock today without a lot of gymnastics.

Fixes: https://redpandadata.atlassian.net/browse/INC-831

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
### Features

* Force reconfiguration now supports updating any in-progress move, regardless of its state. This makes it much easier to use as an escape hatch to recover partitions in various stuck scenarios that would otherwise be difficult to recover.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
