### PR TITLE
rptest/datalake: stop leader balancing from delaying translation

### DIFF
--- a/tests/rptest/tests/datalake/rest_catalog_connection_test.py
+++ b/tests/rptest/tests/datalake/rest_catalog_connection_test.py
@@ -25,7 +25,9 @@ class RestCatalogConnectionTest(RedpandaTest):
                                    cloud_storage_enable_remote_write=False),
             extra_rp_conf={
                 "iceberg_enabled": True,
-                "iceberg_catalog_commit_interval_ms": 10000
+                "iceberg_catalog_commit_interval_ms": 10000,
+                # Leader balancing can delay the first translation.
+                "enable_leader_balancer": False,
             })
         self.catalog_service = IcebergRESTCatalog(
             test_context,


### PR DESCRIPTION
Leader balancing can shift leadership of topic partitions during iceberg translation. This can delay translation significantly during tests because the wait time before translation resets if no last translation timestamp has ever been replicated.

Turn off the leader balancer for tests that have been affected by this.

The ticket has more detailed analysis.

Fixes CORE-8244

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
