### PR TITLE
tests: account for target reply bytes in delayed datalake enablement test

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -1079,6 +1079,7 @@ class DatalakeMetricsTest(RedpandaTest):
 
 class DatalakeDelayedEnablementTest(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):
+        self.target_reply_bytes = 5 * 1024 * 1024  # 5 MiB
         super(DatalakeDelayedEnablementTest, self).__init__(
             test_ctx,
             num_brokers=3,
@@ -1086,7 +1087,7 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
             extra_rp_conf={
                 "iceberg_catalog_commit_interval_ms": 5000,
                 "log_compaction_interval_ms": 2000,
-                "storage_target_replay_bytes": 5 * 1024 * 1024
+                "storage_target_replay_bytes": self.target_reply_bytes
             },
             schema_registry_config=SchemaRegistryConfig(),
             pandaproxy_config=PandaproxyConfig(),
@@ -1120,6 +1121,28 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
 
         return True
 
+    def estimate_total_disk_bytes_read(self):
+        try:
+            samples = self.redpanda.metrics_sample(
+                "vectorized_io_queue_total_read_bytes_total",
+                nodes=self.redpanda.started_nodes())
+        except Exception as e:
+            self.logger.warn(
+                f"Cannot check metrics, did a test finish with all nodes down? ({e})"
+            )
+            return None
+        total = 0
+        if samples is not None and samples.samples:
+            for s in samples.samples:
+                self.logger.debug(
+                    f"{s.family} on node {s.node.account.hostname} with labels: {s.labels} has value {s.value}"
+                )
+                total += s.value
+        else:
+            return None
+
+        return total
+
     @cluster(num_nodes=6)
     # this test doesn't have to run with different catalog types
     @matrix(cloud_storage_type=supported_storage_types(),
@@ -1149,7 +1172,6 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
             dl.produce_to_topic(topic_name, 1024, 120 * 1024)
             # wait for a while for the local snapshot to be taken
             time.sleep(5)
-            dl.redpanda.restart_nodes(dl.redpanda.nodes)
 
             def wait_for_topic(topic_name: str):
                 wait_until(lambda: self.is_topic_fully_caught_up(topic_name),
@@ -1159,7 +1181,10 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
                         state machines to catch up")
 
             wait_for_topic(topic_name)
-            bytes_read_before = self.redpanda.estimate_total_disk_bytes_read()
+            dl.redpanda.restart_nodes(dl.redpanda.nodes)
+
+            wait_for_topic(topic_name)
+            bytes_read_before = self.estimate_total_disk_bytes_read()
             assert bytes_read_before, "Bytes read before enabling Iceberg should not be zero/none"
 
             # enable iceberg, this will restart the cluster
@@ -1167,7 +1192,7 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
                                            expect_restart=True)
 
             wait_for_topic(topic_name)
-            bytes_read_after = self.redpanda.estimate_total_disk_bytes_read()
+            bytes_read_after = self.estimate_total_disk_bytes_read()
             assert bytes_read_after, "Bytes read after enabling Iceberg should not be zero/none"
 
             self.logger.info(
@@ -1175,6 +1200,7 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
             )
             # we introduce a small tolerance here, since the read bytes may
             # increase slightly due to term changes and leader elections.
-            assert bytes_read_after <= bytes_read_before * 1.01,\
-                "Enabling Iceberg in the cluster should not cause a major read increase," \
-                " expected ({bytes_read_after=}) <= ({bytes_read_before * 1.01=})"
+            max_read_bytes = bytes_read_before + self.target_reply_bytes
+            assert bytes_read_after <= max_read_bytes,\
+                f"Enabling Iceberg in the cluster should not cause a major read increase," \
+                f" expected ({bytes_read_after=}) <= ({max_read_bytes=})"


### PR DESCRIPTION
Redpanda has built in mechanism that controls the amount of bytes read during reply. The amount of bytes read while starting is dynamic and depends from various conditions in which the process was restarted. The bytes read during startup are influenced by last segment size of all partitions, existence of local snapshots, configuration manager snapshots, kvstore snapshot existence and other factors. In order to account for that while still validating if enabling datalake dose not increase the reply read bytes significantly we account the target reply bytes when comparing bytes read during startup before and after enablement of datalake services.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none