### PR TITLE
[CORE-9790] `rptest`: dirty ratio deflake

### DIFF
--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -80,14 +80,11 @@ class LogCompactionTestBase():
         producer.start()
 
         def seen_dirty_ratio_above_zero():
-            dirty_bytes_nonzero = self.get_dirty_segment_bytes() > 0
-            closed_bytes_nonzero = self.get_closed_segment_bytes() > 0
-            dirty_ratio_nonzero = self.get_dirty_ratio() > 0.0
-            return dirty_bytes_nonzero and closed_bytes_nonzero and dirty_ratio_nonzero
+            return self.get_dirty_ratio() > 0.0
 
         wait_until(seen_dirty_ratio_above_zero,
                    timeout_sec=10,
-                   backoff_sec=0.1,
+                   backoff_sec=0.001,
                    err_msg="Did not see a non-zero dirty ratio.")
 
         producer.wait_for_latest_value_map()


### PR DESCRIPTION
Occasionally (but very rarely), this test would flake due to a non-zero dirty ratio never being witnessed.

While it seems unlikely that this should be happening, sampling metrics like `vectorized_storage_log_{closed/dirty}_segment_bytes` which are constantly changing while compaction is occurring means that there is a non-zero chance of never witnessing a discrete value above 0.

Reduce the backoff by two orders of magnitude in order to lower the chances of this flake occurring, and also reduce redundant queries to the `MetricsEndpoint` that ultimately test the same condition.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
 