### PR TITLE
[v25.1.x] Added property to control enablement of `__consumer_offsets` cache

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1344,6 +1344,34 @@ ss::future<std::error_code> controller_backend::create_partition(
           log_revision,
           topic_rev,
           remote_rev);
+
+        if (
+          model::topic_namespace_view(ntp_config.ntp())
+          == model::kafka_consumer_offsets_nt) [[unlikely]] {
+            vassert(
+              ntp_config.has_overrides(),
+              "there must be an override for "
+              "__consumer_offsets topic");
+            auto cache_enabled
+              = config::shard_local_cfg()
+                  .consumer_offsets_topic_batch_cache_enabled();
+            ntp_config.get_overrides().cache_enabled = storage::with_cache(
+              config::shard_local_cfg()
+                .consumer_offsets_topic_batch_cache_enabled());
+            /**
+             * Log with an info level as this is not a common case, but
+             * rather an exception. The __consumer_offsets topic is
+             * created without batch cache enabled by default.
+             */
+            if (cache_enabled) {
+                vlog(
+                  clusterlog.info,
+                  "[{}] enabling batch cache for __consumer_offsets topic "
+                  "partition",
+                  ntp_config.ntp());
+            }
+        }
+
         auto rtp = cfg.properties.remote_topic_properties;
         const bool is_cloud_topic = ntp_config.is_archival_enabled()
                                     || ntp_config.is_remote_fetch_enabled();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4151,6 +4151,15 @@ configuration::configuration()
        .visibility = visibility::tunable},
       50_MiB,
       {.min = 1_MiB})
+  , consumer_offsets_topic_batch_cache_enabled(
+      *this,
+      "consumer_offsets_topic_batch_cache_enabled",
+      "This property lets you enable the batch cache for the consumer offsets "
+      "topic. By default, the cache for consumer offsets topic is disabled. "
+      "Changing this property is not recommended in production systems, as it "
+      "may affect performance. The change is applied only after the restart.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , development_enable_cloud_topics(
       *this,
       "development_enable_cloud_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -766,6 +766,7 @@ struct configuration final : public config_store {
       datalake_scratch_space_soft_limit_size_percent;
     property<double> datalake_disk_usage_overage_coeff;
     bounded_property<size_t> datalake_scheduler_disk_reservation_block_size;
+    property<bool> consumer_offsets_topic_batch_cache_enabled;
 
     configuration();
 

--- a/tests/rptest/tests/consumer_offsets_batch_cache_test.py
+++ b/tests/rptest/tests/consumer_offsets_batch_cache_test.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import random
+import time
+
+from ducktape.utils.util import wait_until
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import DefaultClient, RedpandaTest
+
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kcl import KCL
+from confluent_kafka import Consumer, TopicPartition
+import re
+
+
+class ConsumerOffsetsCacheTest(RedpandaTest):
+    def _consumer_offsets_cache_hit_ratio(self):
+        cached_read_metrics = self.redpanda.metrics_sample(
+            "vectorized_storage_log_cached_read_bytes",
+            nodes=self.redpanda.nodes)
+        read_metrics = self.redpanda.metrics_sample(
+            "vectorized_storage_log_read_bytes", nodes=self.redpanda.nodes)
+
+        def _sum_metric_value(metrics):
+            return sum(s.value for s in metrics.samples
+                       if s.labels["topic"] == "__consumer_offsets")
+
+        total_read = _sum_metric_value(read_metrics)
+        cache_read = _sum_metric_value(cached_read_metrics)
+        self.logger.info(
+            f"Read from cache: {cache_read}, total read: {total_read}")
+        self.logger.info(f"Read metrics: {_sum_metric_value(read_metrics)}")
+        return cache_read / total_read if total_read > 0 else None
+
+    def _commit_random_offsets(self, topic: str, partition: int):
+        # Create a consumer that will commit random offsets without consuming
+        consumer = Consumer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': 'test-consumer-group',
+            'enable.auto.commit': False,
+            'auto.offset.reset': 'earliest'
+        })
+
+        # Commit random offsets for the topic partition
+        try:
+            partition = 0
+            for _ in range(100):
+                # Generate a random offset between 0 and 1000
+                random_offset = random.randint(0, 1000)
+
+                # Commit the random offset
+                consumer.commit(offsets=[
+                    TopicPartition(topic, partition, offset=random_offset)
+                ],
+                                asynchronous=False)
+        finally:
+            consumer.close()
+
+    @cluster(num_nodes=3)
+    def test_enabling_consumer_offsets_cache_test(self):
+        topic = TopicSpec(name="test-topic",
+                          partition_count=1,
+                          replication_factor=3)
+
+        DefaultClient(self.redpanda).create_topic(topic)
+        self._commit_random_offsets(topic.name, 0)
+
+        ratio_no_cache = self._consumer_offsets_cache_hit_ratio()
+        assert ratio_no_cache == 0.0, "By default consumer offsets cache should not be enabled"
+        self.redpanda.set_cluster_config(
+            {
+                "consumer_offsets_topic_batch_cache_enabled": True,
+            },
+            expect_restart=True)
+        self._commit_random_offsets(topic.name, 0)
+        hit_ratio = self._consumer_offsets_cache_hit_ratio()
+        # hit ratio is not exactly 1.0 as the topic is read once during the
+        # startup, the cache is cold during that operation
+        assert hit_ratio > 0.8, "Consumer offsets topic should use cache now"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26522
