### PR TITLE
datalake/translator: add trace logging for flaky debugging

### DIFF
--- a/src/v/datalake/partitioning_writer.cc
+++ b/src/v/datalake/partitioning_writer.cc
@@ -134,6 +134,12 @@ partitioning_writer::finish() && {
             continue;
         }
 
+        vlog(
+          datalake_log.trace,
+          "writer finished: file_bytes={}, file_path={}",
+          file_res.value().size_bytes,
+          file_res.value().path());
+
         files.push_back(partitioned_file{
           .local_file = std::move(file_res.value()),
           .data_location = remote_prefix_,
@@ -142,6 +148,13 @@ partitioning_writer::finish() && {
           .partition_key = std::move(pk),
           .partition_key_path = std::move(partition_key_path_res.value())});
     }
+
+    vlog(
+      datalake_log.trace,
+      "partitioning writer finish complete: schema_id={}, files_created={}",
+      schema_id_,
+      files.size());
+
     if (first_error != writer_error::ok) {
         co_return first_error;
     }

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -115,6 +115,16 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
     const auto decompressed_size_bytes = batch.size_bytes();
     _translation_probe.increment_decompressed_bytes_processed(
       decompressed_size_bytes);
+    vlog(
+      _log.trace,
+      "processing batch: offset_range=[{},{}], records={}, "
+      "raw_bytes={}, decompressed_bytes={}",
+      batch.base_offset(),
+      batch.last_offset(),
+      batch.record_count(),
+      raw_size_bytes,
+      decompressed_size_bytes);
+
     auto first_timestamp = batch.header().first_timestamp.value();
     auto it = model::record_batch_iterator::create(batch);
     while (it.has_next()) {
@@ -331,6 +341,13 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
         }
         _result.value().last_offset = offset;
     }
+
+    vlog(
+      _log.trace,
+      "batch processing complete: last_offset={}, writers_active={}",
+      _result.has_value() ? _result.value().last_offset : kafka::offset{-1},
+      _writers.size());
+
     co_return ss::stop_iteration::no;
 }
 
@@ -350,15 +367,24 @@ ss::future<writer_error> record_multiplexer::flush_writers() {
 
 ss::future<result<record_multiplexer::write_result, writer_error>>
 record_multiplexer::finish() && {
+    vlog(
+      _log.trace,
+      "starting multiplexer finish: writers={}, kafka_bytes_processed={}",
+      _writers.size(),
+      _reader_bytes_processed);
+
     auto writers = std::move(_writers);
     for (auto& [id, writer] : writers) {
         auto res = co_await std::move(*writer).finish();
         if (res.has_error()) {
+            vlog(_log.trace, "writer finish error: {}", res.error());
             _error = res.error();
             continue;
         }
         if (_result) {
             auto& files = res.value();
+            vlog(
+              _log.trace, "writer finished: files_created={})", files.size());
             std::move(
               files.begin(),
               files.end(),
@@ -372,6 +398,10 @@ record_multiplexer::finish() && {
             _error = res.error();
         } else if (_result) {
             auto& files = res.value();
+            vlog(
+              _log.trace,
+              "invalid record writer finished: dlq_files_created={}",
+              files.size());
             std::move(
               files.begin(),
               files.end(),
@@ -386,6 +416,16 @@ record_multiplexer::finish() && {
         co_return writer_error::no_data;
     }
     _result->kafka_bytes_processed = _reader_bytes_processed;
+
+    vlog(
+      _log.trace,
+      "multiplexer finish complete: offset_range=[{},{}], "
+      "total_records={}, kafka_bytes={}",
+      _result->start_offset,
+      _result->last_offset,
+      _result->last_offset() - _result->start_offset() + 1,
+      _result->kafka_bytes_processed);
+
     co_return std::move(*_result);
 }
 

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -736,6 +736,13 @@ public:
          * Everything there is to translate was translated
          */
         if (last_translated == max_offset_for_translation) {
+            vlog(
+              datalake_log.trace,
+              "[{}] translation up-to-date: last_translated={}, "
+              "max_translatable={}",
+              _partition->ntp(),
+              last_translated,
+              max_offset_for_translation.value_or(kafka::offset{-1}));
             return no_lag;
         }
         const auto last_ts = _stm->cached_last_translated_timestamp();
@@ -745,6 +752,13 @@ public:
         if (!last_ts.has_value()) {
             // no target is set and we do not have any translated offsets, it
             // means that the lag is 0
+            vlog(
+              datalake_log.trace,
+              "[{}] lag calculation - no last_ts: last_translated={}, "
+              "max_translatable={}",
+              _partition->ntp(),
+              last_translated,
+              max_offset_for_translation.value_or(kafka::offset{-1}));
             if (!_translation_target.has_value()) {
                 return no_lag;
             }
@@ -752,6 +766,14 @@ public:
               std::max<int64_t>(0, (now - _translation_target->ts).value())};
         }
 
+        vlog(
+          datalake_log.trace,
+          "[{}] lag calculation - using last_ts: "
+          "last_translated={}, max_translatable={}, last_ts={}",
+          _partition->ntp(),
+          last_translated,
+          max_offset_for_translation.value_or(kafka::offset{-1}),
+          last_ts.value());
         return std::chrono::milliseconds{
           std::max<int64_t>(0, (now - last_ts.value()).value())};
     }


### PR DESCRIPTION
This adds some trace logging around Iceberg translation. There's a flaky test where a parquet file was written containing a single row after the lag threshold was reached, and then the rest of the records were written to a second file immediately after. It's not clear from the logs how this happened, so I'm adding a bit of trace logging that might help locate the problem if it reoccurs.

The flaky in question is one instance of CORE-12037.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

