### PR TITLE
kc/consumer: fixed resource leak when coordinator changes

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -497,10 +497,18 @@ consumer::reset_coordinator_and_retry_request(request_factory req) {
              [this](std::exception_ptr ex) { return _external_mitigate(ex); })
       .then(
         [this, req{std::move(req)}](shared_broker_t new_coordinator) mutable {
-            _coordinator = new_coordinator;
+            auto old_coordinator = std::move(_coordinator);
+            _coordinator = std::move(new_coordinator);
+            auto f = ss::now();
+            if (old_coordinator) {
+                f = old_coordinator->stop().finally([old_coordinator] {});
+            }
+
             // Calling req_res here will re-issue the request on the
             // new coordinator
-            return req_res(std::move(req));
+            return f.then([this, req = std::move(req)]() mutable {
+                return req_res(std::move(req));
+            });
         });
 }
 


### PR DESCRIPTION
Each `kafka::client::consumer` owns a separate coordinator broker connection. When coordinator changes the connection is exchanged with the new one. Currently the connection is not closed which will lead to a resource leak.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none