### PR TITLE
cs/remote_partition: do not try to enter gate in noexcept constructor

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -233,13 +233,14 @@ class partition_record_batch_reader_impl final
 public:
     explicit partition_record_batch_reader_impl(
       ss::shared_ptr<remote_partition> part,
+      ss::gate::holder holder,
       ss::lw_shared_ptr<storage::offset_translator_state> ot_state,
       ssx::semaphore_units units) noexcept
       : _rtc(part->_as)
       , _ctxlog(cst_log, _rtc, part->get_ntp().path())
       , _partition(std::move(part))
       , _ot_state(std::move(ot_state))
-      , _gate_guard(_partition->_gate)
+      , _gate_guard(std::move(holder))
       , _units(std::move(units)) {
         auto ntp = _partition->get_ntp();
         vlog(_ctxlog.trace, "Constructing reader {}", ntp);
@@ -1245,7 +1246,7 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       _segments.size());
 
     auto impl = std::make_unique<partition_record_batch_reader_impl>(
-      shared_from_this(), ot_state, std::move(units));
+      shared_from_this(), _gate.hold(), ot_state, std::move(units));
     co_await impl->start(config);
     co_return storage::translating_reader{
       model::record_batch_reader(std::move(impl)), std::move(ot_state)};


### PR DESCRIPTION
`remote_partition` reader constructor is marked as `noexcept`. Previously the gate holder was created in the constructor. When a holder is constructed from the gate it may throw `gate_closed_exception` when the gate is closed. This lead to an assertion being trigger as the constructor is not allowed to throw exceptions.

Fixes: CORE-12454

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none