### PR TITLE
[CORE-8392] http: Add shutdown connection error code

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -419,16 +419,33 @@ ss::future<download_result> remote::download_stream(
 
         switch (resp.error()) {
         case cloud_storage_clients::error_outcome::retry:
-            vlog(
-              ctxlog.debug,
-              "Downloading {} from {}, {} backoff required",
-              stream_label,
-              bucket,
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                permit.delay));
-            transfer_details.on_backoff();
-            co_await ss::sleep_abortable(permit.delay, fib.root_abort_source());
-            permit = fib.retry();
+            if (_as.abort_requested()) {
+                // When the remote is stopped we may still get the 'timeout'
+                // error from the http client. This error is interpreted
+                // as a retriable error by the cloud_storage_client.
+                // In order to distinguish between the two cases (shutdown vs
+                // timeout) the state of the abort_source is checked.
+                vlog(
+                  ctxlog.debug,
+                  "Downloading {} from {}, skipping backoff because of the "
+                  "shutdown",
+                  stream_label,
+                  bucket);
+                result = download_result::timedout;
+                break;
+            } else {
+                vlog(
+                  ctxlog.debug,
+                  "Downloading {} from {}, {} backoff required",
+                  stream_label,
+                  bucket,
+                  std::chrono::duration_cast<std::chrono::milliseconds>(
+                    permit.delay));
+                transfer_details.on_backoff();
+                co_await ss::sleep_abortable(
+                  permit.delay, fib.root_abort_source());
+                permit = fib.retry();
+            }
             break;
         case cloud_storage_clients::error_outcome::operation_not_supported:
             [[fallthrough]];


### PR DESCRIPTION
The 'get_connected' method of the http client can only return two error codes: timed_out and connected. Because of that the code uses 'timed_out' as an error code which is returned if the shutdown is requested. When this bubbles up the code in the 'remote' interpeats it as a 'retryable' error and retries the request which in turn leads to a situation when the 'probe' object is accessed after the shutdown is requested and the 'remote' is stopped.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none