### PR TITLE
rptest/datalake: log metrics query results in flaky test

### DIFF
--- a/tests/rptest/tests/datalake/custom_partitioning_test.py
+++ b/tests/rptest/tests/datalake/custom_partitioning_test.py
@@ -301,6 +301,11 @@ class DatalakeCustomPartitioningTest(RedpandaTest):
             assert len(metric2samples) == len(metric_patterns)
             metric2value_sum = dict()
             for metric, samples in metric2samples.items():
+                # Log raw samples from all nodes to investigate missing metrics.
+                self.logger.debug(
+                    f"Raw samples for {metric}: {[(s.node.name, s.labels, s.value) for s in samples.samples]}"
+                )
+
                 value_sum = sum(
                     s.value
                     for s in samples.label_filter({


### PR DESCRIPTION
DatalakeCustomPartitioningTest test_basic is sometimes flaky because it sees too few translations and files created in the metrics query, even though the query occurs long after translations are finished and uploads are done, and there are no signs of metrics errors or any other cause of the discrepancy. As a first step towards debugging this issue, log the results of the metrics query for each node at the debug level. This should narrow down the problem to a particular node, which will make correlation with the logs easier.

The flaky issue is CORE-12037.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
