### PR TITLE
dl/tests/mux: fix choosing random start offset

### DIFF
--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -518,8 +518,9 @@ TEST_F(RecordMultiplexerTest, TestMultiplexingFromMiddleOfBatch) {
                        .records = 100,
                      })
                      .get();
-    auto start_offset = model::offset(random_generators::get_int(0, 100));
     auto last_offset = batches.back().last_offset();
+    auto start_offset = model::offset(
+      random_generators::get_int<model::offset::type>(0, last_offset));
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     mux
       .multiplex(


### PR DESCRIPTION
There is an off by one error in random max offset bound. If the chosen start is 100 (> last_offset = 99), there is no data and an exception is thrown. Bound the max offset to last offset.

Fixes: https://redpandadata.atlassian.net/issues/CORE-12241

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
