### PR TITLE
[CORE-12505] kafka: update list_offsets to return the leader epoch of the offest

### DIFF
--- a/src/v/kafka/data/partition_proxy.h
+++ b/src/v/kafka/data/partition_proxy.h
@@ -59,6 +59,7 @@ public:
         virtual kafka::leader_epoch leader_epoch() const = 0;
         virtual ss::future<std::optional<model::offset>>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
+        virtual kafka::leader_epoch get_leader_epoch(model::offset) const = 0;
 
         virtual bool is_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
@@ -154,6 +155,10 @@ public:
     ss::future<std::optional<model::offset>>
     get_leader_epoch_last_offset(kafka::leader_epoch epoch) const {
         return _impl->get_leader_epoch_last_offset(epoch);
+    }
+
+    kafka::leader_epoch get_leader_epoch(model::offset o) const {
+        return _impl->get_leader_epoch(o);
     }
 
     ss::future<error_code> validate_fetch_offset(

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -431,6 +431,11 @@ replicated_partition::get_leader_epoch_last_offset(
     co_return std::max(offset_unbounded.value(), start_offset());
 }
 
+kafka::leader_epoch
+replicated_partition::get_leader_epoch(model::offset o) const {
+    return leader_epoch_from_term(_partition->get_term(o));
+}
+
 ss::future<std::optional<model::offset>>
 replicated_partition::get_leader_epoch_last_offset_unbounded(
   kafka::leader_epoch epoch) const {

--- a/src/v/kafka/data/replicated_partition.h
+++ b/src/v/kafka/data/replicated_partition.h
@@ -86,6 +86,8 @@ public:
     ss::future<std::optional<model::offset>>
       get_leader_epoch_last_offset(kafka::leader_epoch) const final;
 
+    kafka::leader_epoch get_leader_epoch(model::offset o) const final;
+
     /**
      * A leader epoch is used by Kafka clients to determine if a replica is up
      * to date with the leader and to detect truncation.

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -103,6 +103,9 @@ public:
     get_leader_epoch_last_offset(kafka::leader_epoch) const final {
         throw std::runtime_error("unimplemented");
     }
+    kafka::leader_epoch get_leader_epoch(model::offset) const final {
+        throw std::runtime_error("unimplemented");
+    }
     bool is_leader() const final { return true; }
     ss::future<std::error_code> linearizable_barrier() final {
         throw std::runtime_error("unimplemented");

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -121,14 +121,14 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           ktp.get_partition(),
           model::timestamp(-1),
           maybe_start_ofs.value(),
-          kafka_partition->leader_epoch());
+          kafka_partition->get_leader_epoch(maybe_start_ofs.value()));
 
     } else if (timestamp == list_offsets_request::latest_timestamp) {
         co_return list_offsets_response::make_partition(
           ktp.get_partition(),
           model::timestamp(-1),
           offset,
-          kafka_partition->leader_epoch());
+          kafka_partition->get_leader_epoch(offset));
     }
     auto min_offset = kafka_partition->start_offset();
     auto max_offset = model::prev_offset(offset);
@@ -139,7 +139,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           ktp.get_partition(),
           model::timestamp(-1),
           model::offset(-1),
-          kafka_partition->leader_epoch());
+          leader_epoch{-1});
     }
 
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
@@ -151,7 +151,10 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
     auto id = ktp.get_partition();
     if (res) {
         co_return list_offsets_response::make_partition(
-          id, res->time, res->offset, kafka_partition->leader_epoch());
+          id,
+          res->time,
+          res->offset,
+          kafka_partition->get_leader_epoch(res->offset));
     }
     co_return list_offsets_response::make_partition(id, error_code::none);
 }

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -20,9 +20,10 @@ from functools import cache
 from ducktape.utils.util import wait_until
 from rptest.utils.functional import flat_map
 
-KclPartitionOffset = namedtuple(
-    'KclPartitionOffset',
-    ['broker', 'topic', 'partition', 'start_offset', 'end_offset', 'error'])
+KclPartitionOffset = namedtuple('KclPartitionOffset', [
+    'broker', 'topic', 'partition', 'start_offset', 'start_epoch',
+    'end_offset', 'end_epoch', 'error'
+])
 
 KclPartitionEpochEndOffset = namedtuple('KclPartitionEpochEndOffset', [
     'broker', 'topic', 'partition', 'leader_epoch', 'epoch_end_offset', 'error'
@@ -94,8 +95,19 @@ class KCL:
                         if m['end_offset'] is not None else -1, m['error']))
         return ret
 
-    def list_offsets(self, topics):
+    def list_offsets(self, topics, with_epochs=False):
+        def offset_and_epoch(entry):
+            parts = entry.split('/')
+            if len(parts) == 2:
+                return (int(parts[0]), int(parts[1]))
+            if len(parts) == 1:
+                return (int(parts[0]), -1)
+            raise RuntimeError("Invalid entry in kcl reply: '{entry}'")
+
         cmd = ['misc', 'list-offsets']
+        if with_epochs:
+            cmd += ["--with-epochs"]
+
         if isinstance(topics, list):
             cmd += topics
         else:
@@ -105,14 +117,17 @@ class KCL:
         ret = []
         for l in lines:
             m = re.match(
-                r" *(?P<broker>\d+) +(?P<topic>.+?) +(?P<partition>\d+) +(?P<start>-?\d*?) +(?P<end>-?\d*?) +(?P<error>.*) *",
+                r" *(?P<broker>\d+) +(?P<topic>.+?) +(?P<partition>\d+) +(?P<start>-?\d+(?:/\d+)?) +(?P<end>-?\d+(?:/\d+)?) +(?P<error>.*)",
                 l)
             if m:
+                start_offset, start_epoch = offset_and_epoch(
+                    m['start']) if m['start'] else (-1, -1)
+                end_offset, end_epoch = offset_and_epoch(
+                    m['end']) if m['end'] else (-1, -1)
                 ret.append(
                     KclPartitionOffset(m['broker'], m['topic'],
-                                       int(m['partition']),
-                                       int(m['start']) if m['start'] else -1,
-                                       int(m['end']) if m['end'] else -1,
+                                       int(m['partition']), start_offset,
+                                       start_epoch, end_offset, end_epoch,
                                        m['error']))
         return ret
 

--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -258,3 +258,53 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
             )
             # Check partition_offsets is a subset of fetched_offsets
             assert fetched_offsets == fetched_offsets | partition_offsets, f"Mismatched offsets for leader epoch {epoch}"
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_leader_epoch_for_offset(self):
+
+        topic = TopicSpec(partition_count=1, replication_factor=3)
+
+        # create test topics
+        self.client().create_topic(topic)
+
+        def produce(msg_count):
+            self.logger.debug(f"Producing {msg_count} messages")
+
+            msg_size = 512
+
+            producer = KgoVerifierProducer(self.test_context, self.redpanda,
+                                           topic.name, msg_size, msg_count,
+                                           self.preallocated_nodes)
+            producer.start()
+            producer.wait()
+
+        admin = Admin(self.redpanda)
+
+        def transfer_leadership():
+            self.logger.debug("Transfering leadership")
+            admin.partition_transfer_leadership("kafka",
+                                                topic=topic.name,
+                                                partition=0)
+
+        n_epochs = 2
+        n_records_per_epoch = 10
+        n_records = n_epochs * n_records_per_epoch
+
+        for _ in range(n_epochs):
+            produce(n_records_per_epoch)
+            transfer_leadership()
+
+        kcl = KCL(self.redpanda)
+
+        def req_list_offests():
+            kcl_res = kcl.list_offsets([topic.name], with_epochs=True)
+            return (bool(kcl_res), kcl_res)
+
+        offsets = wait_until_result(
+            req_list_offests,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout while waiting for list offsets request")[0]
+
+        assert offsets.start_epoch == 1, f"Mismatched epochs for offset 0. Expected '1', got '{offsets.start_epoch}'"
+        assert offsets.end_epoch == n_epochs, f"Mismatched epochs for offset {n_records-1}. Expected '{n_epochs}', got '{offsets.end_epoch}'"


### PR DESCRIPTION
Fixes: [CORE-12505](https://redpandadata.atlassian.net/browse/CORE-12505)

Changes in this PR:
- expose "offset to leader epoch'" functionality in partition proxy.
- `list_offsets` request now returns the leader epoch of the offset, instead of the partition's. This is for agreement with reference implementation.
- Extend `KCL.list_offsets` function to optionally return leader epochs.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixed a bug where ListOffsets requests would return the current leader epoch, instead of the leader epoch of the offset.

[CORE-12505]: https://redpandadata.atlassian.net/browse/CORE-12505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ