### PR TITLE
[CORE-8673] test: deflake kafka time query test

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -694,6 +694,11 @@ class TimeQueryKafkaTest(Test, BaseTimeQuery):
     """
     log_segment_size = 1024 * 1024
 
+    # apply retention more frequently. as of writing, the default is 30 seconds
+    # and then every 5 minutes. this is problematic if a test expects more
+    # frequent operation, but misses that initial round at 30 seconds.
+    log_retention_check_interval_ms = 30 * 1000
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -701,11 +706,17 @@ class TimeQueryKafkaTest(Test, BaseTimeQuery):
                                    num_nodes=1,
                                    version=V_3_0_0)
 
+        server_prop_overrides = [[
+            "log.retention.check.interval.ms",
+            self.log_retention_check_interval_ms
+        ]]
+
         self.kafka = KafkaServiceAdapter(
             self.test_context,
             KafkaService(self.test_context,
                          num_nodes=3,
                          zk=self.zk,
+                         server_prop_overrides=server_prop_overrides,
                          version=V_3_0_0))
 
         self._client = DefaultClient(self.kafka)


### PR DESCRIPTION
When the test starts up retention is scheduled inside of Kafka at 30seconds, and then periodically after that every 5 minutes.
```
    [2025-06-23 18:42:50,481] DEBUG Scheduling task kafka-log-retention with initial delay 30000 ms and period 300000 ms. (kafka.utils.KafkaScheduler)
```
The first thing the test does is creates a topic and starts writing data into it.
```
    [DEBUG - 2025-06-23 18:43:07,811 - kafka_cli_tools - _execute - lineno:675]: Created topic tqtopic.

    [DEBUG - 2025-06-23 18:43:12,015 - kgo_verifier_services -
    _ingest_status - lineno:428]: KgoVerifierProducer-0-281471707496992
    status: [{'topic': 'tqtopic', 'sent': 1025, 'acked': 0,
```
While the produce is going on, the initial retention check in Kafka runs on all three brokers, with nothing to do because the default retention size and time is much larger than what has been produced.
```
    [2025-06-23 18:43:20,084] DEBUG Garbage collecting 'tqtopic-0' (kafka.log.LogManager)
    [2025-06-23 18:43:20,086] DEBUG Log cleanup completed. 0 files deleted in 0 seconds (kafka.log.LogManager)

    [2025-06-23 18:43:19,802] DEBUG Garbage collecting 'tqtopic-0' (kafka.log.LogManager)
    [2025-06-23 18:43:19,803] DEBUG Log cleanup completed. 0 files deleted in 0 seconds (kafka.log.LogManager)

    [2025-06-23 18:43:20,484] DEBUG Garbage collecting 'tqtopic-0' (kafka.log.LogManager)
    [2025-06-23 18:43:20,485] DEBUG Scheduling task kafka-delete-logs with initial delay 60000 ms and period -1 ms. (kafka.utils.KafkaScheduler)
```
After this, produce ends
```
    [DEBUG - 2025-06-23 18:43:22,026 - kgo_verifier_services -
    _ingest_status - lineno:428]: KgoVerifierProducer-0-281471707496992
    status: [{'topic': 'tqtopic', 'sent': 3072, 'acked': 3072,
```
And finally retention is set to be small (for the test) in order to trigger the removal of data and alter the starting offset
```
    [DEBUG - 2025-06-23 18:43:22,589 - rpk - _execute - lineno:1217]:
    Executing command:
    ['/var/lib/buildkite-agent/builds/arm64-xfs-builders-i-02d050a5b241dfbc6-1/redpanda/redpanda/vbuild/redpanda_installs/ci/bin/rpk',
    'topic', '-X',
    'brokers=docker-rp-15:9092,docker-rp-11:9092,docker-rp-23:9092',
    'alter-config', 'tqtopic', '--set', 'retention.bytes=1048576',
```
The test then proceeds to wait 120 seconds for retention to be applied and the starting offset to change. However, the it will need to wait up to 5 minutes for this to happen because it missed the initial retention pass that happened 30 seconds after start up.

This commit addresses the issue by configuring Kafka to run retention more frequently (every 30 seconds) so that it will run within the 120 second window given.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
