### PR TITLE
[v25.1.x] dl/tests/mux: fix choosing random start offset

### DIFF
--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -519,8 +519,9 @@ TEST_F(RecordMultiplexerTest, TestMultiplexingFromMiddleOfBatch) {
                        .records = 100,
                      })
                      .get();
-    auto start_offset = model::offset(random_generators::get_int(0, 100));
     auto last_offset = batches.back().last_offset();
+    auto start_offset = model::offset(
+      random_generators::get_int<model::offset::type>(0, last_offset));
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     mux
       .multiplex(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26582
