### PR TITLE
cloud_storage_clients/s3_client: Logging Upgrade

### DIFF
--- a/src/v/cloud_storage_clients/BUILD
+++ b/src/v/cloud_storage_clients/BUILD
@@ -33,6 +33,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/bytes:iostream",
         "//src/v/bytes:streambuf",
         "//src/v/cloud_roles",

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -10,8 +10,10 @@
 
 #include "cloud_storage_clients/s3_client.h"
 
+#include "base/units.h"
 #include "base/vlog.h"
 #include "bytes/bytes.h"
+#include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/s3_error.h"
@@ -400,6 +402,7 @@ std::string request_creator::make_target(
 
 // client //
 
+namespace {
 inline cloud_storage_clients::s3_error_code
 status_to_error_code(boost::beast::http::status s) {
     // According to this https://repost.aws/knowledge-center/http-5xx-errors-s3
@@ -428,9 +431,48 @@ rest_error_response parse_xml_rest_error_response(iobuf&& buf) {
     }
 }
 
+rest_error_response parse_unknown_format_error_response(
+  boost::beast::http::status status, iobuf buf) {
+    static constexpr auto max_body_size = static_cast<size_t>(4_KiB);
+    static constexpr auto truncation_warning_segment = " [truncated~4096]";
+
+    auto maybe_truncation_warning = "";
+    auto read_size = buf.size_bytes();
+
+    // if the error message exceeds reasonable size (4k), truncate it and
+    // indicate a truncation to the recipient
+    if (read_size > max_body_size) {
+        maybe_truncation_warning = truncation_warning_segment;
+        read_size = max_body_size;
+    }
+
+    ss::sstring error_body = "";
+    iobuf_parser parser{std::move(buf)};
+
+    // this is the unhappy unhappy path, handle potentially invalid utf8
+    try {
+        error_body = parser.read_string_safe(read_size);
+    } catch (const invalid_utf8_exception& e) {
+        vlog(s3_log.info, "response body contains invalid utf8 {}", e);
+    } catch (...) {
+        vlog(s3_log.error, "error parse error {}", std::current_exception());
+        throw;
+    }
+
+    return rest_error_response{
+      fmt::format("{}", status_to_error_code(status)),
+      fmt::format(
+        "http status: {}, error body{}: {}",
+        status,
+        maybe_truncation_warning,
+        error_body),
+      "",
+      ""};
+}
+
 template<typename ResultT = void>
 ss::future<ResultT> parse_rest_error_response(
-  response_content_type type, boost::beast::http::status result, iobuf&& buf) {
+  response_content_type type, boost::beast::http::status result, iobuf buf) {
     // AWS errors occasionally come with an empty body
     // (See https://github.com/redpanda-data/redpanda/issues/6061)
     // Without a proper code, we treat it as a hint to gracefully retry
@@ -443,16 +485,18 @@ ss::future<ResultT> parse_rest_error_response(
             // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
             return ss::make_exception_future<ResultT>(
               parse_xml_rest_error_response(std::move(buf)));
+        } else {
+            // render out up to 4k of plaintext or json errors
+            return ss::make_exception_future<ResultT>(
+              parse_unknown_format_error_response(result, std::move(buf)));
         }
     }
 
-    auto result_prefix = buf.empty() ? "Empty error response, " : "";
-    rest_error_response err(
+    return ss::make_exception_future<ResultT>(rest_error_response(
       fmt::format("{}", status_to_error_code(result)),
-      fmt::format("{}status code {}", result_prefix, result),
+      fmt::format("Empty error response, status code {}", result),
       "",
-      "");
-    return ss::make_exception_future<ResultT>(err);
+      ""));
 }
 
 /// Head response doesn't give us an XML encoded error object in
@@ -489,6 +533,7 @@ ss::future<ResultT> parse_head_error_response(
         throw;
     }
 }
+} // namespace
 
 template<typename T>
 ss::future<result<T, error_outcome>> s3_client::send_request(
@@ -884,8 +929,15 @@ ss::future<> s3_client::do_put_object(
               [](const ss::abort_requested_exception& err) {
                   return ss::make_exception_future<>(err);
               })
-            .handle_exception_type([this](const rest_error_response& err) {
+            .handle_exception_type([this, id](const rest_error_response& err) {
                 _probe->register_failure(err.code(), op_type_tag::upload);
+                if (err.code() == s3_error_code::_unknown) {
+                    vlog(
+                      s3_log.error,
+                      "S3 PUT request failed with error for key {}: {}",
+                      id,
+                      err);
+                }
                 return ss::make_exception_future<>(err);
             })
             .handle_exception([id](std::exception_ptr eptr) {

--- a/src/v/cloud_storage_clients/s3_error.cc
+++ b/src/v/cloud_storage_clients/s3_error.cc
@@ -625,4 +625,12 @@ std::string_view rest_error_response::resource() const noexcept {
     return _resource;
 }
 
+std::ostream& operator<<(std::ostream& o, const rest_error_response& err) {
+    static constexpr auto format
+      = "code: {}, message: {}, request_id: {}, resource: {}";
+    fmt::print(
+      o, format, err._code_str, err._message, err._request_id, err._resource);
+    return o;
+}
+
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/s3_error.h
+++ b/src/v/cloud_storage_clients/s3_error.h
@@ -181,6 +181,9 @@ public:
     std::string_view request_id() const noexcept;
     std::string_view resource() const noexcept;
 
+    friend std::ostream&
+    operator<<(std::ostream& o, const rest_error_response& err);
+
 private:
     s3_error_code _code;
     /// Error code string representation, this string is almost always short

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -124,6 +124,8 @@ static constexpr auto no_such_config_payload = R"xml(
 </Error>
 )xml";
 
+static constexpr auto unexpected_payload = "unexpected!";
+
 void set_routes(ss::httpd::routes& r) {
     using namespace ss::httpd;
     using reply = ss::http::reply;
@@ -145,6 +147,15 @@ void set_routes(ss::httpd::routes& r) {
           return error_payload;
       },
       "xml");
+    auto unexpected_put_response = new flexible_function_handler(
+      [](
+        [[maybe_unused]] const_req req,
+        reply& reply,
+        [[maybe_unused]] ss::sstring& type) {
+          reply.set_status(reply::status_type::bad_request);
+          return unexpected_payload;
+      },
+      "txt");
     auto get_response = new function_handler(
       [](const_req req) {
           BOOST_REQUIRE(!req.get_header("x-amz-content-sha256").empty());
@@ -199,7 +210,7 @@ void set_routes(ss::httpd::routes& r) {
     auto unexpected_error_response = new function_handler(
       []([[maybe_unused]] const_req req, reply& reply) {
           reply.set_status(reply::status_type::internal_server_error);
-          return "unexpected!";
+          return unexpected_payload;
       },
       "txt");
     auto key_not_found_response = new flexible_function_handler(
@@ -314,6 +325,8 @@ void set_routes(ss::httpd::routes& r) {
     r.add(operation_type::PUT, url("/test-error"), erroneous_put_response);
     r.add(operation_type::GET, url("/test"), get_response);
     r.add(operation_type::GET, url("/test-error"), erroneous_get_response);
+    r.add(
+      operation_type::PUT, url("/test-unexpected"), unexpected_put_response);
     r.add(operation_type::DELETE, url("/test"), empty_delete_response);
     r.add(
       operation_type::DELETE, url("/test-error"), erroneous_delete_response);
@@ -429,6 +442,27 @@ SEASTAR_TEST_CASE(test_put_object_failure) {
         BOOST_REQUIRE(!result);
         BOOST_REQUIRE_EQUAL(
           result.error(), cloud_storage_clients::error_outcome::retry);
+        server->stop().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_put_object_unexpected) {
+    return ss::async([] {
+        auto conf = transport_configuration();
+        auto [server, client] = started_client_and_server(conf);
+        iobuf payload;
+        payload.append(expected_payload, expected_payload_size);
+        auto payload_stream = make_iobuf_input_stream(std::move(payload));
+        const auto result
+          = client
+              ->put_object(
+                cloud_storage_clients::bucket_name("test-bucket"),
+                cloud_storage_clients::object_key("test-unexpected"),
+                expected_payload_size,
+                std::move(payload_stream),
+                100ms)
+              .get();
+        BOOST_REQUIRE(!result);
         server->stop().get();
     });
 }


### PR DESCRIPTION
s3_client discards the body of error responses if theyre not xml formatted. This is a problem because some s3 tests periodically fail on Bad Request with no further description of what failed the request.

This pr adds text logging for non-xml errors.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
### Improvements
* Allows s3 client to log non-xml error response bodies

