### PR TITLE
ct: L0 end to end workflow

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -14,6 +14,7 @@ package(default_visibility = [
     "//src/v/cloud_topics/tests:__pkg__",
     "//src/v/cloud_topics/throttler:__pkg__",
     "//src/v/cloud_topics/throttler/tests:__pkg__",
+    "//src/v/kafka/data:__pkg__",
 ])
 
 redpanda_cc_library(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -52,8 +52,11 @@ partition::partition(
   ss::lw_shared_ptr<const archival::configuration> archival_conf,
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<archival::upload_housekeeping_service>& upload_hks,
-  std::optional<cloud_storage_clients::bucket_name> read_replica_bucket)
+  std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
+  std::optional<
+    std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>> dp)
   : _raft(std::move(r))
+  , _data_plane_api(dp)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
   , _archival_conf(std::move(archival_conf))
@@ -1840,6 +1843,12 @@ ss::future<result<ssx::rwlock_unit>> partition::hold_writes_enabled() {
     }
 
     co_return *std::move(maybe_units);
+}
+
+std::optional<
+  std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+partition::get_cloud_topics_data_api() noexcept {
+    return _data_plane_api;
 }
 
 } // namespace cluster

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -32,7 +32,8 @@
 
 namespace experimental::cloud_topics {
 class dl_stm_api;
-};
+class app;
+}; // namespace experimental::cloud_topics
 
 namespace cluster {
 class partition_manager;
@@ -57,6 +58,9 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<archival::upload_housekeeping_service>&,
       std::optional<cloud_storage_clients::bucket_name> read_replica_bucket
+      = std::nullopt,
+      std::optional<
+        std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>> dp
       = std::nullopt);
 
     ~partition() = default;
@@ -400,6 +404,12 @@ public:
     // Acquire a shared lock for producing to the partition.
     ss::future<result<ssx::rwlock_unit>> hold_writes_enabled();
 
+    // Returns a pointer to the data plane api if cloud topics is enabled for
+    // this partition. Otherwise, nullopt is returned
+    std::optional<
+      std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+    get_cloud_topics_data_api() noexcept;
+
 private:
     ss::future<>
     replicate_unsafe_reset(cloud_storage::partition_manifest manifest);
@@ -426,6 +436,9 @@ private:
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::shared_ptr<experimental::cloud_topics::dl_stm_api> _dl_stm_api;
+    std::optional<
+      std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+      _data_plane_api;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -59,7 +59,10 @@ partition_manager::partition_manager(
   ss::lw_shared_ptr<const archival::configuration> archival_conf,
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<archival::upload_housekeeping_service>& upload_hks,
-  config::binding<std::chrono::milliseconds> partition_shutdown_timeout)
+  config::binding<std::chrono::milliseconds> partition_shutdown_timeout,
+  std::optional<
+    std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+    dp_api)
   : _storage(storage.local())
   , _raft_manager(raft)
   , _partition_recovery_mgr(recovery_mgr)
@@ -68,7 +71,8 @@ partition_manager::partition_manager(
   , _archival_conf(std::move(archival_conf))
   , _feature_table(feature_table)
   , _upload_hks(upload_hks)
-  , _partition_shutdown_timeout(std::move(partition_shutdown_timeout)) {
+  , _partition_shutdown_timeout(std::move(partition_shutdown_timeout))
+  , _data_plane_api(dp_api) {
     _leader_notify_handle
       = _raft_manager.local().register_leadership_notification(
         [this](
@@ -299,7 +303,8 @@ ss::future<consensus_ptr> partition_manager::manage(
       _archival_conf,
       _feature_table,
       _upload_hks,
-      read_replica_bucket);
+      read_replica_bucket,
+      _data_plane_api);
 
     _ntp_table.emplace(log->config().ntp(), p);
     _raft_table.emplace(group, p);

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -32,12 +32,19 @@
 
 #include <chrono>
 
+namespace experimental::cloud_topics {
+class app;
+}
+
 namespace cluster {
 class partition_manager
   : public ss::peering_sharded_service<partition_manager> {
 public:
     using ntp_table_container
       = model::ntp_map_type<ss::lw_shared_ptr<partition>>;
+
+    using sharded_data_plane_ref
+      = std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>;
 
     partition_manager(
       ss::sharded<storage::api>&,
@@ -48,7 +55,9 @@ public:
       ss::lw_shared_ptr<const archival::configuration>,
       ss::sharded<features::feature_table>&,
       ss::sharded<archival::upload_housekeeping_service>&,
-      config::binding<std::chrono::milliseconds>);
+      config::binding<std::chrono::milliseconds>,
+      std::optional<
+        std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>);
 
     ~partition_manager();
 
@@ -301,6 +310,11 @@ private:
     std::optional<raft::group_manager_notification_id> _leader_notify_handle;
 
     state_machine_registry _stm_registry;
+
+    // The value is set only if cloud topics are enabled
+    std::optional<
+      std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+      _data_plane_api;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
     friend std::ostream& operator<<(

--- a/src/v/kafka/data/BUILD
+++ b/src/v/kafka/data/BUILD
@@ -14,10 +14,12 @@ redpanda_cc_library(
 redpanda_cc_library(
     name = "partition_proxy",
     srcs = [
+        "cloud_topic_partition.cc",
         "partition_proxy.cc",
         "replicated_partition.cc",
     ],
     hdrs = [
+        "cloud_topic_partition.h",
         "partition_proxy.h",
         "replicated_partition.h",
     ],
@@ -31,11 +33,16 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/cloud_storage",
+        "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics:extent_meta",
+        "//src/v/cloud_topics:placeholder",
         "//src/v/kafka/protocol",
         "//src/v/kafka/server:errors",
         "//src/v/model",
         "//src/v/raft",
         "//src/v/storage",
+        "//src/v/storage:record_batch_builder",
         "//src/v/utils:truncating_logger",
         "@boost//:outcome",
         "@seastar",

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -1,0 +1,589 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/data/cloud_topic_partition.h"
+
+#include "cloud_storage/types.h"
+#include "cloud_topics/app.h"
+#include "cloud_topics/data_plane_api.h"
+#include "cloud_topics/dl_placeholder.h"
+#include "cloud_topics/extent_meta.h"
+#include "cluster/partition.h"
+#include "cluster/rm_stm.h"
+#include "cluster/types.h"
+#include "kafka/protocol/batch_reader.h"
+#include "kafka/protocol/errors.h"
+#include "logger.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "model/timeout_clock.h"
+#include "raft/consensus_utils.h"
+#include "raft/errc.h"
+#include "raft/replicate.h"
+#include "storage/record_batch_builder.h"
+#include "storage/types.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <chrono>
+#include <iterator>
+#include <optional>
+#include <system_error>
+
+namespace kafka {
+
+namespace {
+
+struct placeholder_batches_with_size {
+    ss::circular_buffer<model::record_batch> batches;
+    // Total size of all referenced data
+    size_t extent_size{0};
+};
+
+static constexpr auto L0_upload_default_timeout = 1s;
+static constexpr auto L0_replicate_default_timeout = 1s;
+
+// Create a placeholder batch using the original header and the extent.
+// The caller is supposed to use the correct batch header
+// that matches the extent.
+static model::record_batch make_placeholder_batch(
+  const model::record_batch_header& hdr,
+  const experimental::cloud_topics::extent_meta& extent) {
+    vassert(hdr.record_count > 0, "Empty record batch not allowed {}", hdr);
+
+    experimental::cloud_topics::dl_placeholder placeholder{
+      .id = extent.id,
+      .offset = extent.first_byte_offset,
+      .size_bytes = extent.byte_range_size,
+    };
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::dl_placeholder, hdr.base_offset);
+
+    builder.set_producer_identity(hdr.producer_id, hdr.producer_epoch);
+
+    auto first_key = serde::to_iobuf(
+      experimental::cloud_topics::dl_placeholder_record_key::payload);
+
+    auto first_value = serde::to_iobuf(placeholder);
+
+    // In case of a placeholder batch the first record contains the
+    // actual placeholder and the remaining records are empty. The remaining
+    // records are added to avoid confusing any other code that may expect
+    // that the number of records in the batch is equal to the number of
+    // offsets in the header.
+    builder.add_raw_kv(std::move(first_key), std::move(first_value));
+
+    for (int i = 1; i < hdr.record_count; ++i) {
+        builder.add_raw_kv(std::nullopt, std::nullopt);
+    }
+
+    auto ph = std::move(builder).build();
+    ph.header().first_timestamp = hdr.first_timestamp;
+    ph.header().max_timestamp = hdr.max_timestamp;
+    ph.header().base_sequence = hdr.base_sequence;
+    ph.header().header_crc = model::internal_header_only_crc(ph.header());
+    return ph;
+}
+
+// Utility function to convert array of extent_meta structs to
+// array of placeholder batches.
+static placeholder_batches_with_size convert_to_placeholders(
+  const chunked_vector<experimental::cloud_topics::extent_meta>& extents,
+  chunked_vector<model::record_batch_header> original_headers) {
+    // TODO: avoid copying this buffer
+    ss::circular_buffer<model::record_batch_header> headers;
+    std::copy(
+      original_headers.begin(),
+      original_headers.end(),
+      std::back_inserter(headers));
+    placeholder_batches_with_size result;
+    result.batches.reserve(extents.size());
+    for (const auto& extent : extents) {
+        auto header = headers.front();
+        headers.pop_front();
+        vassert(
+          extent.base_offset() <= extent.last_offset(),
+          "Extent base offset {} is greater than committed offset {}",
+          extent.base_offset(),
+          extent.last_offset());
+
+        // Every extent maps to a single batch produced by the client
+        // and therefore we need to create a placeholder batch for it.
+        auto batch = make_placeholder_batch(header, extent);
+
+        result.batches.push_back(std::move(batch));
+        result.extent_size += extent.byte_range_size;
+    }
+    return result;
+}
+
+} // namespace
+
+cloud_topic_partition::cloud_topic_partition(
+  ss::lw_shared_ptr<cluster::partition> p,
+  ss::shared_ptr<experimental::cloud_topics::data_plane_api> app) noexcept
+  : _partition(std::move(p))
+  , _ct_api(std::move(app)) {}
+
+cloud_topic_partition::cloud_topic_partition(
+  ss::lw_shared_ptr<cluster::partition> p,
+  ss::sharded<experimental::cloud_topics::app>& ct_app) noexcept
+  : cloud_topic_partition(std::move(p), ct_app.local().get_data_plane_api()) {}
+
+const model::ntp& cloud_topic_partition::ntp() const {
+    return _partition->ntp();
+}
+
+static model::offset get_log_end_offset(cluster::partition& p) {
+    auto ot_state = p.get_offset_translator_state();
+    // Local log is empty
+    if (p.dirty_offset() < p.raft_start_offset()) {
+        return ot_state->from_log_offset(p.raft_start_offset());
+    }
+    // Local log is not empty
+    return ot_state->from_log_offset(model::next_offset(p.dirty_offset()));
+}
+
+static ss::future<std::vector<cluster::tx::tx_range>>
+get_aborted_transactions_local(
+  cluster::partition& p, cloud_storage::offset_range offsets) {
+    // The reconciled data should have aborted transactions removed.
+    // This means that we should only read aborted transactions for
+    // recent offsets which are not reconciled yet.
+
+    auto ot_state = p.get_offset_translator_state();
+    auto source = co_await p.aborted_transactions(
+      offsets.begin_rp, offsets.end_rp);
+
+    std::vector<cluster::tx::tx_range> target;
+    target.reserve(source.size());
+    for (const auto& range : source) {
+        target.emplace_back(
+          range.pid,
+          ot_state->from_log_offset(range.first),
+          ot_state->from_log_offset(range.last));
+    }
+
+    co_return target;
+}
+
+model::offset cloud_topic_partition::local_start_offset() const {
+    // NOTE: the "local" start offset is only used by the datalake subsystem.
+    // The method defines the boundary starting from which the translation
+    // could be performed. In case of cloud topics there is no such boundary
+    // because all data if fetched from the cloud storage. Therefore this method
+    // is just an alias for the 'start_offset'.
+    return start_offset();
+}
+
+model::offset cloud_topic_partition::start_offset() const {
+    // Ask partition for its start offset
+    // TODO: query metadata layer to get the actual start offset.
+    // the 'partition::sync_kafka_start_offset_override' is not invoked here
+    // because it's tied to both archival_metadata_stm and log_eviction_stm.
+    // For cloud topics we will do log eviction differently and the
+    // DeleteRecords API is not implemented yet. So the code is just
+    // using the start_offset of the Raft log at the moment which is incorrect.
+    auto so = _partition->raft_start_offset();
+    auto kso = _partition->get_offset_translator_state()->from_log_offset(so);
+    return kso;
+}
+
+ss::future<result<model::offset, error_code>>
+cloud_topic_partition::sync_effective_start(model::timeout_clock::duration) {
+    // TODO: ask metadata layer
+    co_return start_offset();
+}
+
+model::offset cloud_topic_partition::high_watermark() const {
+    auto ot_state = _partition->get_offset_translator_state();
+    return ot_state->from_log_offset(_partition->high_watermark());
+}
+
+checked<model::offset, error_code>
+cloud_topic_partition::last_stable_offset() const {
+    auto maybe_lso = _partition->last_stable_offset();
+    if (maybe_lso == model::invalid_lso) {
+        return error_code::offset_not_available;
+    }
+    auto ot_state = _partition->get_offset_translator_state();
+    return ot_state->from_log_offset(maybe_lso);
+}
+
+bool cloud_topic_partition::is_leader() const {
+    return _partition->is_leader();
+}
+
+ss::future<std::error_code> cloud_topic_partition::linearizable_barrier() {
+    auto r = co_await _partition->linearizable_barrier();
+    if (r) {
+        co_return raft::errc::success;
+    }
+    co_return r.error();
+}
+
+cluster::partition_probe& cloud_topic_partition::probe() {
+    return _partition->probe();
+}
+
+kafka::leader_epoch cloud_topic_partition::leader_epoch() const {
+    return leader_epoch_from_term(_partition->raft()->confirmed_term());
+}
+
+ss::future<storage::translating_reader> cloud_topic_partition::make_reader(
+  storage::log_reader_config cfg,
+  std::optional<model::timeout_clock::time_point> timeout) {
+    vassert(_ct_api != nullptr, "cloud topics api not initialized");
+
+    auto ot_state = _partition->get_offset_translator_state();
+
+    cfg.start_offset = ot_state->to_log_offset(cfg.start_offset);
+    cfg.max_offset = ot_state->to_log_offset(cfg.max_offset);
+    cfg.translate_offsets = storage::translate_offsets::yes;
+    cfg.type_filter = {model::record_batch_type::dl_placeholder};
+
+    // TODO: add code path that fetches metadata from the metadata layer for L1
+    // read path
+
+    // This part comprises the metadata layer query. The partition is a metadata
+    // storage for the cloud topic.
+    auto underlying = co_await _partition->make_reader(cfg, timeout);
+    auto placeholders = co_await model::consume_reader_to_chunked_vector(
+      std::move(underlying), model::no_timeout);
+
+    // TODO: convert to a extent_meta
+    auto extents = [ph = std::move(placeholders)]() mutable {
+        chunked_vector<experimental::cloud_topics::extent_meta> res;
+        for (auto&& batch : ph) {
+            experimental::cloud_topics::extent_meta e{
+              .base_offset = model::offset_cast(batch.base_offset()),
+              .last_offset = model::offset_cast(batch.last_offset()),
+            };
+            iobuf payload = std::move(batch).release_data();
+            iobuf_parser parser(std::move(payload));
+            auto record = model::parse_one_record_from_buffer(parser);
+            iobuf value = std::move(record).release_value();
+            auto placeholder
+              = serde::from_iobuf<experimental::cloud_topics::dl_placeholder>(
+                std::move(value));
+            e.id = placeholder.id;
+            e.first_byte_offset = placeholder.offset;
+            e.byte_range_size = placeholder.size_bytes;
+            res.push_back(e);
+        }
+        return res;
+    }();
+
+    // This part comprises the data plane query. The 'cloud_topics::api' is
+    // responsible for moving the data from the cloud storage to the local
+    // cache.
+    auto data_batches = co_await _ct_api->materialize(
+      ntp(),
+      cfg.max_bytes,
+      std::move(extents),
+      // TODO: use configurable default timeout or derive from the log reader
+      // config
+      10s);
+
+    if (!data_batches) {
+        throw std::system_error(data_batches.error());
+    }
+
+    co_return storage::translating_reader(
+      model::make_fragmented_memory_record_batch_reader(
+        std::move(data_batches.value())),
+      ot_state);
+}
+
+ss::future<std::vector<cluster::tx::tx_range>>
+cloud_topic_partition::aborted_transactions(
+  model::offset base,
+  model::offset last,
+  ss::lw_shared_ptr<const storage::offset_translator_state> ot_state) {
+    auto base_rp = ot_state->to_log_offset(base);
+    auto last_rp = ot_state->to_log_offset(last);
+    cloud_storage::offset_range offsets = {
+      .begin = model::offset_cast(base),
+      .end = model::offset_cast(last),
+      .begin_rp = base_rp,
+      .end_rp = last_rp,
+    };
+    co_return co_await get_aborted_transactions_local(*_partition, offsets);
+}
+
+ss::future<std::optional<storage::timequery_result>>
+cloud_topic_partition::timequery(storage::timequery_config cfg) {
+    // cluster::partition::timequery returns a result in Kafka offsets,
+    // no further offset translation is required here.
+    // TODO: take metadata layer state into account
+    return _partition->timequery(cfg);
+}
+
+namespace {
+struct upload_and_replicate_stages {
+    model::ntp ntp;
+    ss::lw_shared_ptr<cluster::partition> partition;
+    chunked_vector<model::record_batch> batches;
+    model::batch_identity batch_id;
+    raft::replicate_options opts;
+    std::chrono::milliseconds timeout;
+
+    upload_and_replicate_stages(
+      ss::lw_shared_ptr<cluster::partition> partition,
+      chunked_vector<model::record_batch> batches,
+      model::batch_identity batch_id,
+      raft::replicate_options opts,
+      std::chrono::milliseconds timeout)
+      : ntp(partition->ntp())
+      , partition(std::move(partition))
+      , batches(std::move(batches))
+      , batch_id(batch_id)
+      , opts(opts)
+      , timeout(timeout) {}
+
+    ss::promise<> request_enqueued;
+    ss::promise<result<raft::replicate_result>> replicate_finished;
+};
+
+static ss::future<> bg_upload_and_replicate(
+  ss::shared_ptr<experimental::cloud_topics::data_plane_api> api,
+  ss::lw_shared_ptr<cluster::partition> partition,
+  model::record_batch_header header,
+  ss::lw_shared_ptr<upload_and_replicate_stages> op) {
+    vassert(api != nullptr, "cloud topics api is not initialized");
+    auto fallback = ss::defer([op] {
+        // This guarantees that the promises are set.
+        // The error code used here does not represent the
+        // actual error.
+        op->request_enqueued.set_value();
+        op->replicate_finished.set_value(raft::errc::timeout);
+    });
+    auto timeout = op->timeout == 0ms ? L0_upload_default_timeout : op->timeout;
+    auto res = co_await api->write_and_debounce(
+      op->ntp, std::move(op->batches), timeout);
+
+    if (res.has_error()) {
+        vlog(
+          kdlog.debug,
+          "LO object upload has failed: {}",
+          res.error().message());
+        co_return;
+    }
+
+    chunked_vector<model::record_batch_header> headers;
+    headers.push_back(header);
+    auto placeholders = convert_to_placeholders(
+      res.value(), std::move(headers));
+
+    vassert(
+      placeholders.batches.size() == 1,
+      "Expected single batch, got {}",
+      placeholders.batches.size());
+
+    // Replicate
+    auto replicate_stages = partition->replicate_in_stages(
+      op->batch_id, std::move(placeholders.batches.front()), op->opts);
+
+    fallback.cancel();
+
+    // Forward future result to the 'op'. The expectation is that at this point
+    // the target promises (inside 'op') are used to generate futures and these
+    // futures are awaited.
+    replicate_stages.request_enqueued.forward_to(
+      std::move(op->request_enqueued));
+
+    auto replicate_fut = std::move(replicate_stages.replicate_finished)
+                           .then(
+                             [](result<cluster::kafka_result> res)
+                               -> result<raft::replicate_result> {
+                                 if (res.has_error()) {
+                                     return res.error();
+                                 }
+                                 return raft::replicate_result{
+                                   model::offset(res.value().last_offset())};
+                             });
+
+    replicate_fut.forward_to(std::move(op->replicate_finished));
+}
+} // namespace
+
+ss::future<result<model::offset>> cloud_topic_partition::replicate(
+  chunked_vector<model::record_batch> batches, raft::replicate_options opts) {
+    using ret_t = result<model::offset>;
+    chunked_vector<model::record_batch_header> headers;
+    headers.reserve(batches.size());
+    for (const auto& batch : batches) {
+        headers.push_back(batch.header());
+    }
+
+    // Dataplane.
+    auto res = co_await _ct_api->write_and_debounce(
+      ntp(),
+      std::move(batches),
+      opts.timeout.value_or(L0_replicate_default_timeout));
+
+    if (res.has_error()) {
+        co_return ret_t(res.error());
+    }
+
+    auto placeholders = convert_to_placeholders(
+      res.value(), std::move(headers));
+
+    chunked_vector<model::record_batch> placeholder_batches;
+    for (auto&& batch : placeholders.batches) {
+        placeholder_batches.push_back(std::move(batch));
+    }
+
+    auto result = co_await _partition->replicate(
+      std::move(placeholder_batches), opts);
+
+    if (!result) {
+        co_return ret_t(result.error());
+    }
+    co_return ret_t(model::offset(result.value().last_offset()));
+}
+
+ss::future<result<model::offset>> cloud_topic_partition::replicate(
+  model::record_batch batch, raft::replicate_options opts) {
+    return replicate(
+      chunked_vector<model::record_batch>::single(std::move(batch)), opts);
+}
+
+raft::replicate_stages cloud_topic_partition::replicate(
+  model::batch_identity batch_id,
+  model::record_batch batch,
+  raft::replicate_options opts) {
+    auto header = batch.header();
+    chunked_vector<model::record_batch> batch_vec;
+    batch_vec.push_back(std::move(batch));
+    auto op_state = ss::make_lw_shared<upload_and_replicate_stages>(
+      _partition,
+      std::move(batch_vec),
+      batch_id,
+      opts,
+      opts.timeout.value_or(L0_replicate_default_timeout));
+
+    raft::replicate_stages out(raft::errc::success);
+    out.request_enqueued = op_state->request_enqueued.get_future();
+    out.replicate_finished = op_state->replicate_finished.get_future();
+    ssx::background = bg_upload_and_replicate(
+      _ct_api, _partition, header, op_state);
+    return out;
+}
+
+ss::future<std::optional<model::offset>>
+cloud_topic_partition::get_leader_epoch_last_offset(
+  kafka::leader_epoch epoch) const {
+    auto ot_state = _partition->get_offset_translator_state();
+    model::term_id term(epoch);
+    auto first_local_offset = _partition->raft_start_offset();
+    auto first_local_term = _partition->get_term(first_local_offset);
+    auto last_local_term = _partition->term();
+
+    if (term > last_local_term) {
+        co_return std::nullopt;
+    }
+
+    if (term >= first_local_term) {
+        auto last_offset = _partition->get_term_last_offset(term);
+        if (last_offset) {
+            co_return ot_state->from_log_offset(*last_offset);
+        }
+    }
+
+    co_return start_offset();
+}
+
+ss::future<error_code> cloud_topic_partition::prefix_truncate(
+  model::offset, ss::lowres_clock::time_point) {
+    /// DeleteRecords API is not supported in cloud topics yet.
+    co_return error_code::invalid_topic_exception;
+}
+
+ss::future<error_code> cloud_topic_partition::validate_fetch_offset(
+  model::offset fetch_offset,
+  bool reading_from_follower,
+  model::timeout_clock::time_point deadline) {
+    if (reading_from_follower && !_partition->is_leader()) {
+        // TODO: implement follower fetching for cloud topics
+        co_return error_code::not_leader_for_partition;
+    }
+
+    auto timeout = deadline - model::timeout_clock::now();
+    auto so = co_await sync_effective_start(timeout);
+    if (!so) {
+        co_return so.error();
+    }
+
+    if (
+      fetch_offset < so.value()
+      || fetch_offset > get_log_end_offset(*_partition)) {
+        co_return error_code::offset_out_of_range;
+    }
+
+    co_return error_code::none;
+}
+
+result<partition_info> cloud_topic_partition::get_partition_info() const {
+    auto ot_state = _partition->get_offset_translator_state();
+    partition_info ret;
+    ret.leader = _partition->get_leader_id();
+    ret.replicas.reserve(_partition->raft()->get_follower_count() + 1);
+    auto followers = _partition->get_follower_metrics();
+
+    if (followers.has_error()) {
+        return followers.error();
+    }
+    auto start_offset = _partition->raft_start_offset();
+
+    auto clamped_translate = [ot_state,
+                              start_offset](model::offset to_translate) {
+        return to_translate >= start_offset
+                 ? ot_state->from_log_offset(to_translate)
+                 : ot_state->from_log_offset(start_offset);
+    };
+
+    for (const auto& follower_metric : followers.value()) {
+        ret.replicas.push_back(replica_info{
+          .id = follower_metric.id,
+          .high_watermark = model::next_offset(
+            clamped_translate(follower_metric.match_index)),
+          .log_end_offset = model::next_offset(
+            clamped_translate(follower_metric.dirty_log_index)),
+          .is_alive = follower_metric.is_live,
+        });
+    }
+
+    ret.replicas.push_back(replica_info{
+      .id = _partition->raft()->self().id(),
+      .high_watermark = high_watermark(),
+      .log_end_offset = get_log_end_offset(*_partition),
+      .is_alive = true,
+    });
+
+    return {std::move(ret)};
+}
+
+size_t cloud_topic_partition::estimate_size_between(
+  kafka::offset, kafka::offset) const {
+    // TODO: implement this function
+    // This function can't be implemented yet because the L1 read path is not
+    // completely implemented.
+    return 0;
+}
+
+} // namespace kafka

--- a/src/v/kafka/data/cloud_topic_partition.h
+++ b/src/v/kafka/data/cloud_topic_partition.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cloud_storage/types.h"
+#include "kafka/data/partition_proxy.h"
+#include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "raft/replicate.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <boost/numeric/conversion/cast.hpp>
+
+#include <optional>
+#include <system_error>
+
+namespace experimental::cloud_topics {
+class data_plane_api;
+class app;
+} // namespace experimental::cloud_topics
+
+namespace kafka {
+
+/// CloudTopics entry point
+///
+/// This class serves as the entry point into the cloud-topics (CT) subsystem,
+/// which comprises two main components: the data plane and the metadata layer.
+///
+/// Data Plane:
+/// - Accessible via the 'cloud_topics::app' instance passed through the
+///   constructor.
+/// - Contains 'core::read_pipeline' and 'core::write_pipeline'.
+///
+/// Metadata layer:
+/// - Composed of 'cluster::partition' and 'metastore' components
+///
+/// Write Request Path:
+/// - Batch is pushed to the data plane (app::write_and_debounce method).
+/// - Data plane returns a placeholder for the record batch, containing
+///   metadata to locate data in cloud storage.
+/// - 'cloud_topic_partition' pushes the placeholder to the metadata layer by
+///   replicating 'dl_placeholder' batch.
+///
+/// Read Request Path:
+/// - 'dl_placeholder' batches are queried from the metadata layer, fetched
+///   from 'cluster::partition'.
+/// - Includes information about aborted transactions.
+/// - 'dl_placeholder' batches are 'materialized' using the data plane.
+///
+/// Currently, the data plane is explicitly a sharded service. The control
+/// plane includes 'cluster::partition' and 'dl_stm', with no explicit API
+/// boundary. However, component use is limited to allow future
+/// introduction of such an API.
+///
+class cloud_topic_partition final : public kafka::partition_proxy::impl {
+public:
+    explicit cloud_topic_partition(
+      ss::lw_shared_ptr<cluster::partition> p,
+      ss::shared_ptr<experimental::cloud_topics::data_plane_api> ct) noexcept;
+
+    explicit cloud_topic_partition(
+      ss::lw_shared_ptr<cluster::partition> p,
+      ss::sharded<experimental::cloud_topics::app>& ct_app) noexcept;
+
+    const model::ntp& ntp() const final;
+
+    ss::future<result<model::offset, error_code>>
+    sync_effective_start(model::timeout_clock::duration timeout) final;
+
+    model::offset local_start_offset() const final;
+
+    model::offset start_offset() const final;
+
+    model::offset high_watermark() const final;
+
+    checked<model::offset, error_code> last_stable_offset() const final;
+
+    bool is_leader() const final;
+
+    ss::future<error_code>
+      prefix_truncate(model::offset, ss::lowres_clock::time_point) final;
+
+    ss::future<std::error_code> linearizable_barrier() final;
+
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(storage::timequery_config cfg) final;
+
+    ss::future<result<model::offset>>
+      replicate(model::record_batch, raft::replicate_options) final;
+
+    ss::future<result<model::offset>> replicate(
+      chunked_vector<model::record_batch>, raft::replicate_options) final;
+    raft::replicate_stages replicate(
+      model::batch_identity,
+      model::record_batch,
+      raft::replicate_options) final;
+
+    ss::future<storage::translating_reader> make_reader(
+      storage::log_reader_config cfg,
+      std::optional<model::timeout_clock::time_point>) final;
+
+    ss::future<std::vector<model::tx_range>> aborted_transactions(
+      model::offset base,
+      model::offset last,
+      ss::lw_shared_ptr<const storage::offset_translator_state>) final;
+
+    cluster::partition_probe& probe() final;
+
+    ss::future<std::optional<model::offset>>
+      get_leader_epoch_last_offset(kafka::leader_epoch) const final;
+
+    kafka::leader_epoch leader_epoch() const final;
+
+    ss::future<error_code> validate_fetch_offset(
+      model::offset, bool, model::timeout_clock::time_point) final;
+
+    result<partition_info> get_partition_info() const final;
+
+    size_t estimate_size_between(kafka::offset, kafka::offset) const final;
+
+private:
+    raft::replicate_stages upload_and_replicate(
+      model::batch_identity batch_id,
+      model::record_batch,
+      raft::replicate_options);
+
+    ss::lw_shared_ptr<cluster::partition> _partition;
+    ss::shared_ptr<experimental::cloud_topics::data_plane_api> _ct_api;
+};
+
+} // namespace kafka

--- a/src/v/kafka/data/partition_proxy.cc
+++ b/src/v/kafka/data/partition_proxy.cc
@@ -11,7 +11,9 @@
 
 #include "partition_proxy.h"
 
+#include "cloud_topics/app.h"
 #include "cluster/partition_manager.h"
+#include "kafka/data/cloud_topic_partition.h"
 #include "kafka/data/replicated_partition.h"
 
 namespace kafka {
@@ -23,6 +25,18 @@ partition_proxy make_with_impl(Args&&... args) {
 
 partition_proxy
 make_partition_proxy(const ss::lw_shared_ptr<cluster::partition>& partition) {
+    if (partition->get_ntp_config().cloud_topic_enabled()) {
+        auto ct_data_plane = partition->get_cloud_topics_data_api();
+        if (
+          ct_data_plane.has_value()
+          && !ct_data_plane->get().local_is_initialized()) {
+            throw std::runtime_error(
+              "Cloud topic partition can't be created because the cloud-topics "
+              "subsystem is not initialized");
+        }
+        auto api = ct_data_plane->get().local().get_data_plane_api();
+        return make_with_impl<cloud_topic_partition>(partition, api);
+    }
     return make_with_impl<replicated_partition>(partition);
 }
 

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -14,6 +14,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "config/configuration.h"
+#include "kafka/data/partition_proxy.h"
 #include "kafka/data/replicated_partition.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/kafka_batch_adapter.h"
@@ -139,20 +140,22 @@ error_code map_produce_error_code(std::error_code ec) {
  */
 partition_produce_stages partition_append(
   model::partition_id id,
-  ss::lw_shared_ptr<replicated_partition> partition,
+  partition_proxy partition,
   model::batch_identity bid,
   std::unique_ptr<model::record_batch> batch,
   int16_t acks,
   int32_t num_records,
   int64_t num_bytes,
   std::chrono::milliseconds timeout_ms) {
-    auto stages = partition->replicate(
+    auto stages = partition.replicate(
       bid, std::move(*batch), acks_to_replicate_options(acks, timeout_ms));
     return partition_produce_stages{
       .dispatched = std::move(stages.request_enqueued),
       .produced = stages.replicate_finished.then_wrapped(
-        [partition, id, num_records = num_records, num_bytes](
-          ss::future<result<raft::replicate_result>> f) {
+        [partition = std::move(partition),
+         id,
+         num_records = num_records,
+         num_bytes](ss::future<result<raft::replicate_result>> f) mutable {
             produce_response::partition p{.partition_index = id};
             try {
                 auto r = f.get();
@@ -162,9 +165,9 @@ partition_produce_stages partition_append(
                     p.base_offset = model::offset(
                       r.value().last_offset - (num_records - 1));
                     p.error_code = error_code::none;
-                    partition->probe().add_records_produced(num_records);
-                    partition->probe().add_bytes_produced(num_bytes);
-                    partition->probe().add_batches_produced(1);
+                    partition.probe().add_records_produced(num_records);
+                    partition.probe().add_bytes_produced(num_bytes);
+                    partition.probe().add_batches_produced(1);
                 } else {
                     p.error_code = map_produce_error_code(r.error());
                 }
@@ -399,10 +402,10 @@ partition_produce_stages produce_topic_partition(
                           return finalize_request_with_error_code(
                             err, std::move(dispatch), ntp, source_shard);
                       }
+                      auto proxy = kafka::make_partition_proxy(partition);
                       auto stages = partition_append(
                         ntp.tp.partition,
-                        ss::make_lw_shared<replicated_partition>(
-                          std::move(partition)),
+                        std::move(proxy),
                         bid,
                         std::move(batch),
                         acks,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1692,7 +1692,8 @@ void application::wire_up_redpanda_services(
       ss::sharded_parameter([] {
           return config::shard_local_cfg()
             .partition_manager_shutdown_watchdog_timeout.bind();
-      }))
+      }),
+      std::ref(cloud_topics_api))
       .get();
     vlog(_log.info, "Partition manager started");
     construct_service(


### PR DESCRIPTION
This PR adds a `cloud_topic_partition` class which connects the metadata and the data layer.
In the fetch request the placeholders are fetched from the underlying partition and converted into `extent_meta` values. These values are used to query the data layer. The result is transferred to the client.
In the produce request the data is first moved to the data layer where it's uploaded as part of the L0 upload process. Then the data layer returns an `extent_meta` struct which is converted to `placeholder` type and replicated. The `cloud_topics` namespace contains an end to end test already. Previously the test was working because `cloud_topics` infra wasn't used and the data was replicated and queried using the normal topic. But with this PR the test will start stressing the L0 code paths.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none