### PR TITLE
[v25.1.x] tests/rno: do not suspend nodes for longer than 4 seconds

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -546,8 +546,11 @@ class RandomNodeOperationsTest(PreallocNodesTest):
 
         fi = None
         if enable_failures:
-            fi = FailureInjectorBackgroundThread(self.redpanda, self.logger,
-                                                 lock)
+            fi = FailureInjectorBackgroundThread(
+                self.redpanda,
+                self.logger,
+                max_suspend_duration_seconds=4,
+                lock=lock)
             fi.start()
 
         # main workload loop


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26594
