### PR TITLE
tests: wait for stable metrics in delayed enablement test

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -1122,6 +1122,32 @@ class DatalakeDelayedEnablementTest(RedpandaTest):
         return True
 
     def estimate_total_disk_bytes_read(self):
+        max_samples = 30
+        current_value = 0
+        stable_values = 0
+        expected_stable_values = 5
+        for s in range(max_samples):
+            total = self.do_estimate_total_disk_bytes_read()
+            if total is not None:
+                self.logger.debug(
+                    f"Estimated total disk bytes read: {total} bytes sample {s}"
+                )
+                if total == current_value:
+                    stable_values += 1
+                    if stable_values >= expected_stable_values:
+                        self.logger.debug(
+                            f"Stable value reached: {current_value} bytes after {s} samples"
+                        )
+                        break
+                else:
+                    stable_values = 0
+                    current_value = total
+
+            time.sleep(0.5)
+
+        return current_value
+
+    def do_estimate_total_disk_bytes_read(self):
         try:
             samples = self.redpanda.metrics_sample(
                 "vectorized_io_queue_total_read_bytes_total",


### PR DESCRIPTION
Sometimes the metrics queried from Redpanda are not fully reported. This makes the test to fail intermittently. Changed the way metrics are queried to wait for the reported metrics value to quiesce before performing validation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none