### PR TITLE
bazel: remove old cmake runfiles hack

### DIFF
--- a/src/v/crypto/tests/crypto_bench.cc
+++ b/src/v/crypto/tests/crypto_bench.cc
@@ -49,16 +49,11 @@ public:
 #endif
         _thread_worker->start({.name = "worker"}).get();
         auto module_dir = test_utils::get_runfile_path("src/v/crypto/tests");
-        if (!module_dir.has_value()) {
-            char* var = std::getenv("MODULE_DIR");
-            vassert(var != nullptr, "MODULE_DIR is not set");
-            module_dir = var;
-        }
         _svc
           .start(
             std::ref(*_thread_worker),
             get_config_file_path(),
-            module_dir.value(),
+            module_dir,
             fips_mode)
           .get();
         _svc.invoke_on_all(&crypto::ossl_context_service::start).get();
@@ -74,14 +69,8 @@ private:
     ss::sharded<crypto::ossl_context_service> _svc;
 
     static std::string get_config_file_path() {
-        auto conf_file = test_utils::get_runfile_path(
+        return test_utils::get_runfile_path(
           "src/v/crypto/tests/openssl_conf.cnf");
-        if (!conf_file.has_value()) {
-            char* var = std::getenv("OPENSSL_CONF");
-            vassert(var != nullptr, "OPENSSL_CONF is not set");
-            conf_file = var;
-        }
-        return conf_file.value();
     }
 };
 

--- a/src/v/crypto/tests/ossl_context_service_failure_tests.cc
+++ b/src/v/crypto/tests/ossl_context_service_failure_tests.cc
@@ -36,12 +36,7 @@ public:
 
     ss::sstring module_dir() const {
         auto module_dir = test_utils::get_runfile_path("src/v/crypto/tests");
-        if (!module_dir.has_value()) {
-            char* var = std::getenv("MODULE_DIR");
-            vassert(var != nullptr, "MODULE_DIR is not set");
-            module_dir = var;
-        }
-        return ss::sstring{module_dir.value()};
+        return ss::sstring{module_dir};
     }
 
 protected:

--- a/src/v/crypto/tests/ossl_context_service_test.cc
+++ b/src/v/crypto/tests/ossl_context_service_test.cc
@@ -69,15 +69,10 @@ public:
         }
 #endif
         auto module_dir = test_utils::get_runfile_path("src/v/crypto/tests");
-        if (!module_dir.has_value()) {
-            char* var = std::getenv("MODULE_DIR");
-            vassert(var != nullptr, "MODULE_DIR is not set");
-            module_dir = var;
-        }
         ASSERT_NO_THROW_CORO(co_await svc.start(
           std::ref(*thread_worker()),
           get_config_file_path(),
-          ss::sstring{module_dir.value()},
+          ss::sstring{module_dir},
           param.fips_mode));
 
         ASSERT_NO_THROW_CORO(

--- a/src/v/crypto/tests/ossl_context_service_test_base.h
+++ b/src/v/crypto/tests/ossl_context_service_test_base.h
@@ -23,13 +23,13 @@
 
 #include <memory>
 
+// XXX
 inline std::string get_config_file_path() {
     char* var = std::getenv("OPENSSL_CONF");
     if (var != nullptr) {
         return var;
     }
-    return test_utils::get_runfile_path("src/v/crypto/tests/openssl_conf.cnf")
-      .value_or("");
+    return test_utils::get_runfile_path("src/v/crypto/tests/openssl_conf.cnf");
 }
 
 class ossl_context_base_test_framework : public seastar_test {
@@ -65,14 +65,11 @@ protected:
         if (char* override = ::getenv("MODULE_DIR"); override != nullptr) {
             module_dir = override;
         }
-        if (!module_dir.has_value()) {
-            co_return false;
-        }
-        auto dir_type = co_await ss::file_type(module_dir.value());
+        auto dir_type = co_await ss::file_type(module_dir);
         if (!dir_type || *dir_type != ss::directory_entry_type::directory) {
             co_return false;
         } else {
-            auto fips_file = module_dir.value() + "/fips.so";
+            auto fips_file = module_dir + "/fips.so";
             co_return co_await ss::file_exists(fips_file);
         }
     }

--- a/src/v/iceberg/conversion/tests/BUILD
+++ b/src/v/iceberg/conversion/tests/BUILD
@@ -57,7 +57,6 @@ cc_proto_library(
 redpanda_test_cc_library(
     name = "proto_definitions_wrapper",
     hdrs = ["proto_definitions.h"],
-    defines = ["BAZEL_TEST=1"],
     include_prefix = "iceberg/conversion/tests",
     deps = [
         ":complex_cc_proto",

--- a/src/v/iceberg/conversion/tests/proto_definitions.h
+++ b/src/v/iceberg/conversion/tests/proto_definitions.h
@@ -9,16 +9,8 @@
  */
 #pragma once
 
-#ifdef BAZEL_TEST
 #include "src/v/iceberg/conversion/tests/testdata/complex.pb.h"
 #include "src/v/iceberg/conversion/tests/testdata/iceberg_ready_test_messages_edition2023.pb.h"
 #include "src/v/iceberg/conversion/tests/testdata/not_supported.pb.h"
 #include "src/v/iceberg/conversion/tests/testdata/person.pb.h"
 #include "src/v/iceberg/conversion/tests/testdata/proto2.pb.h"
-#else
-#include "testdata/complex.pb.h"
-#include "testdata/iceberg_ready_test_messages_edition2023.pb.h"
-#include "testdata/not_supported.pb.h"
-#include "testdata/person.pb.h"
-#include "testdata/proto2.pb.h"
-#endif

--- a/src/v/iceberg/tests/manifest_serialization_test.cc
+++ b/src/v/iceberg/tests/manifest_serialization_test.cc
@@ -312,11 +312,8 @@ TEST(ManifestSerializationTest, TestSerializeManifestData) {
     ss::engine().set_strict_dma(false);
     auto manifest_path = test_utils::get_runfile_path(
       "src/v/iceberg/tests/testdata/nested_manifest.avro");
-    if (!manifest_path.has_value()) {
-        manifest_path = "nested_manifest.avro";
-    }
     auto orig_buf = iobuf{
-      ss::util::read_entire_file(manifest_path.value()).get()};
+      ss::util::read_entire_file(manifest_path).get()};
     auto m = parse_manifest(orig_buf.copy());
     ASSERT_EQ(100, m.entries.size());
     ASSERT_EQ(m.metadata.manifest_content_type, manifest_content_type::data);

--- a/src/v/iceberg/tests/manifest_serialization_test.cc
+++ b/src/v/iceberg/tests/manifest_serialization_test.cc
@@ -312,8 +312,7 @@ TEST(ManifestSerializationTest, TestSerializeManifestData) {
     ss::engine().set_strict_dma(false);
     auto manifest_path = test_utils::get_runfile_path(
       "src/v/iceberg/tests/testdata/nested_manifest.avro");
-    auto orig_buf = iobuf{
-      ss::util::read_entire_file(manifest_path).get()};
+    auto orig_buf = iobuf{ss::util::read_entire_file(manifest_path).get()};
     auto m = parse_manifest(orig_buf.copy());
     ASSERT_EQ(100, m.entries.size());
     ASSERT_EQ(m.metadata.manifest_content_type, manifest_content_type::data);

--- a/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
@@ -61,9 +61,8 @@ struct simple_sharded_store {
 };
 
 std::filesystem::path test_dir() {
-    auto test_path = test_utils::get_runfile_path(
+    return test_utils::get_runfile_path(
       "src/v/pandaproxy/schema_registry/test/testdata/protobuf");
-    return {test_path.value_or(".")};
 }
 
 enum class SchemaType { input, sanitized, normalized };

--- a/src/v/serde/avro/tests/parser_test.cc
+++ b/src/v/serde/avro/tests/parser_test.cc
@@ -114,8 +114,7 @@ void parsed_to_avro(
 struct AvroParserTest : ::testing::TestWithParam<std::tuple<std::string_view>> {
     ::avro::ValidSchema load_json_schema(std::string_view schema_file) {
         auto desc_path = test_utils::get_runfile_path(
-                           fmt::format(
-                             "src/v/serde/avro/tests/testdata/{}", schema_file));
+          fmt::format("src/v/serde/avro/tests/testdata/{}", schema_file));
 
         auto schema = read_fully_to_string(desc_path).get();
 

--- a/src/v/serde/avro/tests/parser_test.cc
+++ b/src/v/serde/avro/tests/parser_test.cc
@@ -115,8 +115,7 @@ struct AvroParserTest : ::testing::TestWithParam<std::tuple<std::string_view>> {
     ::avro::ValidSchema load_json_schema(std::string_view schema_file) {
         auto desc_path = test_utils::get_runfile_path(
                            fmt::format(
-                             "src/v/serde/avro/tests/testdata/{}", schema_file))
-                           .value_or(std::string(schema_file));
+                             "src/v/serde/avro/tests/testdata/{}", schema_file));
 
         auto schema = read_fully_to_string(desc_path).get();
 

--- a/src/v/serde/json/tests/data.cc
+++ b/src/v/serde/json/tests/data.cc
@@ -23,8 +23,7 @@ ss::future<iobuf> json_test_suite_sample() {
 
     auto test_case_path = test_utils::get_runfile_path(
       "src/v/serde/json/tests/testdata/json-test-suite/sample.json");
-    vassert(test_case_path.has_value(), "Failed to get test case path");
-    sample_buf = co_await read_fully(test_case_path.value());
+    sample_buf = co_await read_fully(test_case_path);
 
     co_return sample_buf->copy();
 }

--- a/src/v/serde/json/tests/dom_rapidjson_test.cc
+++ b/src/v/serde/json/tests/dom_rapidjson_test.cc
@@ -130,9 +130,8 @@ constexpr auto golden = R"(json_value(array(
 TEST_CORO(dom_rapidjson_test, json_checker_pass1) {
     auto test_case_path = test_utils::get_runfile_path(
       "src/v/serde/json/tests/testdata/jsonchecker/pass1.json");
-    vassert(test_case_path.has_value(), "Failed to get test case path");
 
-    auto contents = co_await read_fully(test_case_path.value());
+    auto contents = co_await read_fully(test_case_path);
 
     auto v = co_await test::dom::parse_document_rapidjson(std::move(contents));
     std::stringstream ss;

--- a/src/v/serde/json/tests/dom_serde_test.cc
+++ b/src/v/serde/json/tests/dom_serde_test.cc
@@ -130,9 +130,8 @@ constexpr auto golden = R"(json_value(array(
 TEST_CORO(dom_serde_test, json_checker_pass1) {
     auto test_case_path = test_utils::get_runfile_path(
       "src/v/serde/json/tests/testdata/jsonchecker/pass1.json");
-    vassert(test_case_path.has_value(), "Failed to get test case path");
 
-    auto contents = co_await read_fully(test_case_path.value());
+    auto contents = co_await read_fully(test_case_path);
 
     auto v = co_await test::dom::parse_document_serde(std::move(contents));
     std::stringstream ss;

--- a/src/v/serde/json/tests/json_checker_test.cc
+++ b/src/v/serde/json/tests/json_checker_test.cc
@@ -29,9 +29,8 @@ TEST_P_CORO(json_checker_test, all) {
 
     auto test_case_path = test_utils::get_runfile_path(
       fmt::format("src/v/serde/json/tests/testdata/jsonchecker/{}", test_case));
-    vassert(test_case_path.has_value(), "Failed to get test case path");
 
-    auto contents = co_await read_fully(test_case_path.value());
+    auto contents = co_await read_fully(test_case_path);
     // Use depth limit of 19 to properly fail fail18.json (20 levels) while
     // allowing pass2.json (19 levels, "Not too deep") to succeed
     auto config = parser_config{.max_depth = 19};
@@ -65,9 +64,8 @@ std::vector<std::string> collect_test_cases() {
 
     auto test_case_path = test_utils::get_runfile_path(
       "src/v/serde/json/tests/testdata/jsonchecker");
-    vassert(test_case_path.has_value(), "Failed to get test case path");
 
-    std::filesystem::path dir_path(test_case_path.value());
+    std::filesystem::path dir_path(test_case_path);
     vassert(
       std::filesystem::exists(dir_path),
       "Directory does not exist: {}",

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -144,11 +144,6 @@ redpanda_test_cc_library(
         "@fmt",
     ],
     include_prefix = "test_utils",
-    # TODO(bazel) when cmake build is removed then this can be removed, and its
-    # associated used in runfiles.cc.
-    local_defines = [
-        "BAZEL_TEST=1",
-    ],
     visibility = ["//visibility:public"],
 )
 

--- a/src/v/test_utils/runfiles.cc
+++ b/src/v/test_utils/runfiles.cc
@@ -1,21 +1,17 @@
 #include "test_utils/runfiles.h"
 
-#include <cstdlib>
-#include <filesystem>
-
-#ifdef BAZEL_TEST
 #include "tools/cpp/runfiles/runfiles.h"
-#endif
 
 #include <fmt/format.h>
 
+#include <cstdlib>
+#include <filesystem>
 #include <memory>
 
 namespace test_utils {
 
 std::optional<std::string>
 get_runfile_path([[maybe_unused]] std::string_view path) {
-#ifdef BAZEL_TEST
     using bazel::tools::cpp::runfiles::Runfiles;
     std::string error;
     std::unique_ptr<Runfiles> runfiles;
@@ -31,9 +27,6 @@ get_runfile_path([[maybe_unused]] std::string_view path) {
         throw std::runtime_error(error);
     }
     return runfiles->Rlocation(fmt::format("_main/{}", path));
-#else
-    return std::nullopt;
-#endif
 }
 
 } // namespace test_utils

--- a/src/v/test_utils/runfiles.cc
+++ b/src/v/test_utils/runfiles.cc
@@ -10,8 +10,7 @@
 
 namespace test_utils {
 
-std::string
-get_runfile_path(std::string_view path) {
+std::string get_runfile_path(std::string_view path) {
     using bazel::tools::cpp::runfiles::Runfiles;
     std::string error;
     std::unique_ptr<Runfiles> runfiles;

--- a/src/v/test_utils/runfiles.cc
+++ b/src/v/test_utils/runfiles.cc
@@ -10,8 +10,8 @@
 
 namespace test_utils {
 
-std::optional<std::string>
-get_runfile_path([[maybe_unused]] std::string_view path) {
+std::string
+get_runfile_path(std::string_view path) {
     using bazel::tools::cpp::runfiles::Runfiles;
     std::string error;
     std::unique_ptr<Runfiles> runfiles;

--- a/src/v/test_utils/runfiles.h
+++ b/src/v/test_utils/runfiles.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <optional>
 #include <string>
 #include <string_view>
 
@@ -11,10 +10,8 @@ namespace test_utils {
  *  - Add a `data = [path/to/some.file]` to the test target
  *  - Call get_runfile_path with "root/.../path/to/some.file"
  *
- * If the return value is std::nullopt then it means that the test is being
- * compiled with CMake. Otherwise, it is compiled with Bazel and the return
- * value contains the path to the data file.
+ * The return value is the path to the file.
  */
-std::optional<std::string> get_runfile_path(std::string_view);
+std::string get_runfile_path(std::string_view);
 
 } // namespace test_utils

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -119,8 +119,7 @@ void WasmTestFixture::load_wasm(std::string_view filename) {
                   std::string(
                     std::filesystem::path(
                       "src/transform-sdk/go/transform/internal/testdata")
-                    / file.stem() / file.filename()))
-                  .value_or(std::string(filename));
+                    / file.stem() / file.filename()));
     auto wasm_file = ss::util::read_entire_file(path).get();
     auto buf = model::wasm_binary_iobuf(std::make_unique<iobuf>());
     for (auto& chunk : wasm_file) {

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -115,11 +115,9 @@ void WasmTestFixture::TearDown() {
 
 void WasmTestFixture::load_wasm(std::string_view filename) {
     std::filesystem::path file(filename);
-    auto path = test_utils::get_runfile_path(
-                  std::string(
-                    std::filesystem::path(
-                      "src/transform-sdk/go/transform/internal/testdata")
-                    / file.stem() / file.filename()));
+    auto path = test_utils::get_runfile_path(std::string(
+      std::filesystem::path("src/transform-sdk/go/transform/internal/testdata")
+      / file.stem() / file.filename()));
     auto wasm_file = ss::util::read_entire_file(path).get();
     auto buf = model::wasm_binary_iobuf(std::make_unique<iobuf>());
     for (auto& chunk : wasm_file) {

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -76,12 +76,10 @@ public:
         };
         auto wasm_binary = model::wasm_binary_iobuf(std::make_unique<iobuf>());
         {
-            auto path
-              = test_utils::get_runfile_path(
-                  std::string(
-                    std::filesystem::path(
-                      "src/transform-sdk/go/transform/internal/testdata")
-                    / file.stem() / file.filename()));
+            auto path = test_utils::get_runfile_path(std::string(
+              std::filesystem::path(
+                "src/transform-sdk/go/transform/internal/testdata")
+              / file.stem() / file.filename()));
             fmt::print(std::cerr, "Loading wasm file: {}\n", path);
             auto data = co_await ss::util::read_entire_file_contiguous(path);
             wasm_binary()->append(data.data(), data.size());

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -81,8 +81,7 @@ public:
                   std::string(
                     std::filesystem::path(
                       "src/transform-sdk/go/transform/internal/testdata")
-                    / file.stem() / file.filename()))
-                  .value_or(std::string(file));
+                    / file.stem() / file.filename()));
             fmt::print(std::cerr, "Loading wasm file: {}\n", path);
             auto data = co_await ss::util::read_entire_file_contiguous(path);
             wasm_binary()->append(data.data(), data.size());


### PR DESCRIPTION
* bazel: remove old cmake runfiles hack

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
