### PR TITLE
dt/shard_placement_scale_test: wait for node rebalance instead of asserting it

### DIFF
--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -169,7 +169,8 @@ class ShardPlacementScaleTest(RedpandaTest):
 
         admin = Admin(self.redpanda)
 
-        assert len(admin.list_reconfigurations()) == 0
+        self.redpanda.wait_node_add_rebalance_finished(joiner_nodes,
+                                                       admin=admin)
 
         omb_topic = self.omb_topics()[0]
         for node in joiner_nodes:


### PR DESCRIPTION
The test had a timing assumption that the node rebalance finishes by the time OMB finishes. With new node types it is no longer true as node rebalance takes a bit longer. Wait for rebalance to finish instead.

Fixes https://redpandadata.atlassian.net/browse/CORE-12271

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes
* none