### PR TITLE
bazel: add elfutils to install-deps.sh

### DIFF
--- a/bazel/install-deps.sh
+++ b/bazel/install-deps.sh
@@ -29,6 +29,7 @@ deb_deps=(
   automake
   autopoint
   bison
+  elfutils
   git
   libtool
   make
@@ -41,6 +42,7 @@ fedora_deps=(
   autoconf
   automake
   bison
+  elfutils
   gettext-devel
   git
   libtool


### PR DESCRIPTION
`eu-strip` from the `elfutils` package is required for successfully generating debuginfo RPMs.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

