### PR TITLE
[v25.1.x] dt/shard_placement_scale_test: wait for node rebalance instead of asserting it

### DIFF
--- a/tests/rptest/scale_tests/shard_placement_scale_test.py
+++ b/tests/rptest/scale_tests/shard_placement_scale_test.py
@@ -169,7 +169,8 @@ class ShardPlacementScaleTest(RedpandaTest):
 
         admin = Admin(self.redpanda)
 
-        assert len(admin.list_reconfigurations()) == 0
+        self.redpanda.wait_node_add_rebalance_finished(joiner_nodes,
+                                                       admin=admin)
 
         omb_topic = self.omb_topics()[0]
         for node in joiner_nodes:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26605
