### PR TITLE
Replaced `kafka::client` transport

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -28,6 +28,8 @@
 #include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
 
+#include <seastar/coroutine/as_future.hh>
+
 #include <gtest/gtest.h>
 
 #include <iterator>
@@ -80,6 +82,7 @@ TEST_F(ManualFixture, TestSpilloverRetentionCompactedTopic) {
     auto partition = app.partition_manager.local().get(ntp);
     auto& archiver = partition->archiver().value().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(records_per_seg)
                            .produce()
@@ -91,6 +94,7 @@ TEST_F(ManualFixture, TestSpilloverRetentionCompactedTopic) {
     archiver.apply_archive_retention().get();
 
     tests::kafka_list_offsets_transport lister(make_kafka_client().get());
+    auto deferred_l_close = ss::defer([&lister] { lister.stop().get(); });
     lister.start().get();
 
     auto offset
@@ -125,6 +129,8 @@ TEST_F(ManualFixture, TestSizeEstimationWithCloud) {
     auto partition = app.partition_manager.local().get(ntp);
     auto& archiver = partition->archiver().value().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
+
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(records_per_seg)
                            .additional_local_segments(10)
@@ -226,6 +232,8 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
     ASSERT_TRUE(archiver.sync_for_tests().get());
 
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
+
     ASSERT_EQ(3, gen.records_per_batch(3).produce().get());
     ASSERT_EQ(2, log->segments().size());
     ASSERT_EQ(1, archiver.manifest().size());
@@ -250,6 +258,8 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
     // has been truncated, this exercises reading from cloud storage.
     kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
+
     auto consumed_records = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -300,6 +310,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
 
     kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
     // Produce to partition until the manifest is large enough to trigger
     // spillover
@@ -429,6 +440,8 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
     // Consume from start offset of the partition (data available in the STM).
     vlog(e2e_test_log.info, "Consuming from the partition");
     kafka_consume_transport consumer(make_kafka_client().get());
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
+
     consumer.start().get();
     std::vector<kv_t> consumed_records;
     auto next_offset = archive_ko;
@@ -564,12 +577,10 @@ public:
 
 namespace {
 
-ss::future<bool> check_consume_from_beginning(
-  kafka::client::transport client,
+ss::future<bool> do_check_consume_from_beginning(
+  kafka_consume_transport& consumer,
   const model::topic& topic_name,
   ss::gate& gate) {
-    kafka_consume_transport consumer(std::move(client));
-    co_await consumer.start();
     int iters = 0;
     while (iters == 0 || !gate.is_closed()) {
         auto holder = gate.hold();
@@ -592,6 +603,19 @@ ss::future<bool> check_consume_from_beginning(
     co_return true;
 }
 
+ss::future<bool> check_consume_from_beginning(
+  kafka::client::transport client,
+  const model::topic& topic_name,
+  ss::gate& gate) {
+    kafka_consume_transport consumer(std::move(client));
+    co_await consumer.start();
+    auto res_f = co_await ss::coroutine::as_future(
+      do_check_consume_from_beginning(consumer, topic_name, gate));
+
+    co_await consumer.stop();
+    co_return res_f.get();
+}
+
 } // namespace
 
 TEST_P(CloudStorageEndToEndManualTest, TestConsumeDuringSpillover) {
@@ -599,6 +623,8 @@ TEST_P(CloudStorageEndToEndManualTest, TestConsumeDuringSpillover) {
     const auto records_per_seg = 5;
     const auto num_segs = 40;
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
+
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(records_per_seg)
                            .produce()
@@ -646,6 +672,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
     const auto records_per_seg = 5;
     const auto num_segs = 40;
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(records_per_seg)
                            .batch_time_delta_ms(10)
@@ -716,6 +743,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
 
     tests::kafka_list_offsets_transport lister(make_kafka_client().get());
     lister.start().get();
+    auto deferred_l_close = ss::defer([&lister] { lister.stop().get(); });
 
     // Timequery to somewhere within the segment that was deleted. This should
     // succeed, and return the next offset after the new start.
@@ -780,7 +808,7 @@ TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
 
     kafka_produce_transport producer(fx_l->make_kafka_client().get());
     producer.start().get();
-
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
     auto get_reclaimable = [&]() -> std::optional<std::vector<size_t>> {
         auto report = app.controller->get_health_monitor()
                         .local()
@@ -871,6 +899,7 @@ TEST_F(EndToEndFixture, TestLocalTimequery) {
     const auto batch_time_delta_ms = 10;
     const auto base_timestamp = model::timestamp{0};
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(batches_per_segment)
                            .base_timestamp(base_timestamp)
@@ -950,6 +979,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
     const auto batch_time_delta_ms = 10;
     const auto base_timestamp = model::timestamp{0};
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(batches_per_segment)
                            .base_timestamp(base_timestamp)
@@ -1042,6 +1072,7 @@ TEST_F(ReadReplicaFixture, TestCloudStorageTimequeryReadReplicaMode) {
     const auto batch_time_delta_ms = 10;
     const auto base_timestamp = model::timestamp{0};
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(batches_per_segment)
                            .base_timestamp(base_timestamp)
@@ -1137,6 +1168,7 @@ TEST_P(EndToEndFixture, TestMixedTimequery) {
     const auto batches_per_segment = 1;
     const auto batch_time_delta_ms = 10;
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(batches_per_segment)
                            .base_timestamp(model::timestamp{0})

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -140,6 +140,7 @@ public:
 
 FIXTURE_TEST(test_timequery_below_deleted_offset, delete_records_e2e_fixture) {
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     // Use a starting timestamp and make sure each batch gets a different
     // timestamp.
     BOOST_REQUIRE_EQUAL(
@@ -157,6 +158,7 @@ FIXTURE_TEST(test_timequery_below_deleted_offset, delete_records_e2e_fixture) {
     auto first_seg_max_ts = first_seg->max_timestamp;
     tests::kafka_list_offsets_transport lister(make_kafka_client().get());
     lister.start().get();
+    auto deferred_l_close = ss::defer([&lister] { lister.stop().get(); });
 
     // Sanity check: timequery the end of the first cloud segment.
     auto offset = lister
@@ -171,6 +173,7 @@ FIXTURE_TEST(test_timequery_below_deleted_offset, delete_records_e2e_fixture) {
     // Delete into the second segment.
     kafka_delete_records_transport deleter(make_kafka_client("deleter").get());
     deleter.start().get();
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     auto second_seg_end_offset = kafka::offset_cast(
       second_seg->last_kafka_offset());
     auto lwm
@@ -220,6 +223,7 @@ FIXTURE_TEST(
         wait_for_leader(ntp, 10s).get();
         tests::remote_segment_generator gen(
           make_kafka_client().get(), *partition);
+        auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
         BOOST_REQUIRE_EQUAL(
           9,
           // 3 segments each with 3 batches, + 1 segment for the leadership
@@ -228,6 +232,7 @@ FIXTURE_TEST(
     }
     tests::kafka_offset_for_epoch_transport offer(make_kafka_client().get());
     offer.start().get();
+    auto deferred_o_close = ss::defer([&offer] { offer.stop().get(); });
     auto last_in_term_2 = offer
                             .offset_for_leader_partition(
                               topic_name,
@@ -237,6 +242,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(model::offset(9), last_in_term_2);
     kafka_delete_records_transport deleter(make_kafka_client().get());
     deleter.start().get();
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     auto lwm = deleter
                  .delete_records_from_partition(
                    topic_name, model::partition_id(0), model::offset(13), 5s)
@@ -256,6 +262,7 @@ FIXTURE_TEST(
 FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
     // Create a segment with three distinct batches.
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     BOOST_REQUIRE_EQUAL(
       9, gen.num_segments(3).batches_per_segment(3).produce().get());
     BOOST_REQUIRE_EQUAL(3, archiver->manifest().size());
@@ -263,6 +270,7 @@ FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
     // Delete in the middle of a segment.
     kafka_delete_records_transport deleter(make_kafka_client("deleter").get());
     deleter.start().get();
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     auto lwm = deleter
                  .delete_records_from_partition(
                    topic_name, model::partition_id(0), model::offset(1), 5s)
@@ -273,6 +281,7 @@ FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
 
     kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
     auto consumed_records = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -295,6 +304,7 @@ FIXTURE_TEST(test_delete_from_archive_consume, delete_records_e2e_fixture) {
     const auto records_per_seg = 5;
     const auto num_segs = 40;
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
                            .batches_per_segment(records_per_seg)
                            .produce()
@@ -317,8 +327,10 @@ FIXTURE_TEST(test_delete_from_archive_consume, delete_records_e2e_fixture) {
     // Delete at every offset, ensuring we consume properly at each offset.
     kafka_delete_records_transport deleter(make_kafka_client().get());
     deleter.start().get();
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
     for (int i = 1; i < total_records; i++) {
         auto lwm = deleter
                      .delete_records_from_partition(
@@ -344,6 +356,7 @@ FIXTURE_TEST(test_delete_from_archive_consume, delete_records_e2e_fixture) {
 FIXTURE_TEST(
   test_delete_from_local_storage_truncation, delete_records_e2e_fixture) {
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     size_t records_per_seg = 5;
     BOOST_REQUIRE_GE(
       250,
@@ -361,6 +374,7 @@ FIXTURE_TEST(
     // DeleteRecords to just before the end of the local log.
     kafka_delete_records_transport deleter(make_kafka_client().get());
     deleter.start().get();
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     auto new_start_offset = kafka::offset(245);
     BOOST_REQUIRE_EQUAL(
       new_start_offset,
@@ -447,6 +461,7 @@ FIXTURE_TEST(
 // DeleteRecords request lands in the STM manifest.
 FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     size_t records_per_seg = 5;
     BOOST_REQUIRE_GE(
       250,
@@ -462,6 +477,7 @@ FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
     BOOST_REQUIRE_EQUAL(stm_manifest.size(), segs_per_spill);
     kafka_delete_records_transport deleter(make_kafka_client().get());
     deleter.start().get();
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
 
     // Truncate within the STM at the bound, leaving one segment.
     auto stm_truncate_offset
@@ -515,6 +531,7 @@ FIXTURE_TEST(test_delete_from_stm_truncation, delete_records_e2e_fixture) {
 // DeleteRecords request lands in the archive.
 FIXTURE_TEST(test_delete_from_archive_truncation, delete_records_e2e_fixture) {
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     size_t records_per_seg = 5;
     BOOST_REQUIRE_GE(
       250,
@@ -530,7 +547,7 @@ FIXTURE_TEST(test_delete_from_archive_truncation, delete_records_e2e_fixture) {
     BOOST_REQUIRE_EQUAL(stm_manifest.size(), segs_per_spill);
     kafka_delete_records_transport deleter(make_kafka_client().get());
     deleter.start().get();
-
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     // Truncate within the bounds of the first archive segment. Nothing should
     // be removed.
     auto& spillover = stm_manifest.get_spillover_map();

--- a/src/v/cloud_storage/tests/produce_utils.h
+++ b/src/v/cloud_storage/tests/produce_utils.h
@@ -52,6 +52,8 @@ public:
     }
     kafka_produce_transport& producer() { return _producer; }
 
+    ss::future<> stop() { co_await _producer.stop(); }
+
     // Produces records, flushing and rolling the local log, and uploading
     // according to the given parameters. Once the given segments are produced,
     // the partition manifest is uploaded.

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -42,6 +42,7 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     BOOST_REQUIRE_EQUAL(
       30, gen.records_per_batch(10).num_segments(3).produce().get());
     BOOST_REQUIRE_EQUAL(3, archiver.manifest().size());
@@ -68,6 +69,7 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
 
     kafka_consume_transport consumer(rr_rp->make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
     model::offset next(0);
     while (next < model::offset(30)) {
         auto consumed_records = consumer
@@ -110,6 +112,7 @@ FIXTURE_TEST(
     // Send the delete request to the _read replica_. This is not allowed.
     tests::kafka_delete_records_transport deleter(
       rr_rp->make_kafka_client().get());
+    auto deferred_close = ss::defer([&deleter] { deleter.stop().get(); });
     deleter.start().get();
     BOOST_REQUIRE_EXCEPTION(
       deleter
@@ -138,6 +141,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     BOOST_REQUIRE_EQUAL(
       30, gen.batches_per_segment(10).num_segments(3).produce().get());
     BOOST_REQUIRE_EQUAL(3, archiver.manifest().size());
@@ -146,6 +150,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     // fixture because make_kafka_client() uses global configs that will be
     // overwritten by the new fixture.
     tests::kafka_delete_records_transport deleter(make_kafka_client().get());
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
 
     auto rr_rp = start_read_replica_fixture();
     cluster::topic_properties read_replica_props;
@@ -166,6 +171,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
 
     kafka_consume_transport consumer(rr_rp->make_kafka_client().get());
     consumer.start().get();
+    auto deferred_close = ss::defer([&consumer] { consumer.stop().get(); });
     auto consumed_records = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -232,6 +238,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     BOOST_REQUIRE_EQUAL(
       40,
       gen.batches_per_segment(10)
@@ -245,6 +252,7 @@ FIXTURE_TEST(
 
     // DeleteRecords in the region of the log that hasn't yet been uploaded.
     tests::kafka_delete_records_transport deleter(make_kafka_client().get());
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     deleter.start().get();
     auto new_start = model::offset(35);
     BOOST_REQUIRE_EQUAL(
@@ -262,6 +270,7 @@ FIXTURE_TEST(
 
     tests::kafka_list_offsets_transport lister(make_kafka_client().get());
     lister.start().get();
+    auto defered_l_close = ss::defer([&lister] { lister.stop().get(); });
     auto lwm = lister
                  .start_offset_for_partition(topic_name, model::partition_id(0))
                  .get();
@@ -285,6 +294,7 @@ FIXTURE_TEST(
     tests::kafka_list_offsets_transport rr_lister(
       rr_rp->make_kafka_client().get());
     rr_lister.start().get();
+    auto deferred_close = ss::defer([&rr_lister] { rr_lister.stop().get(); });
     auto rr_hwm = rr_lister
                     .high_watermark_for_partition(
                       topic_name, model::partition_id(0))

--- a/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
+++ b/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
@@ -100,7 +100,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
         // Produce some records to the partition.
         tests::remote_segment_generator gen(
           make_kafka_client().get(), *partition);
-
+        auto deferred_close = ss::defer([&gen] { gen.stop().get(); });
         ASSERT_EQ(
           num_records_to_produce,
           gen.records_per_batch(num_records_to_produce).produce().get());
@@ -108,6 +108,8 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
         // Assert consuming from original topic works fine.
         kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_records
           = consumer.consume_from_partition(src_tp_ns.tp, pid, model::offset(0))
               .get();
@@ -164,6 +166,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
     // Assert consuming from recovered destination topic works fine.
     kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
     auto consumed_records
       = consumer.consume_from_partition(dest_tp_ns.tp, pid, model::offset(0))
           .get();
@@ -182,7 +185,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
     auto& archiver = archiver_ref.value().get();
 
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
-
+    auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     ASSERT_EQ(
       num_records_to_produce,
       gen.num_segments(2)

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -79,6 +79,7 @@ TEST_F(e2e_fixture, test_l0_path) {
     // Produce data to the partition
     kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
     size_t total_records = 100;
     size_t records_per_batch = 1;
@@ -96,6 +97,7 @@ TEST_F(e2e_fixture, test_l0_path) {
 
     kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
     auto consumed_records = consumer
                               .consume_from_partition(
                                 topic_name,

--- a/src/v/cluster/archival/tests/async_data_uploader_test.cc
+++ b/src/v/cluster/archival/tests/async_data_uploader_test.cc
@@ -112,6 +112,7 @@ public:
         auto client = make_kafka_client().get();
         tests::kafka_produce_transport producer(std::move(client));
         producer.start().get();
+        auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
         for (size_t i = 0; i < num_batches; i++) {
             std::vector<tests::kv_t> records = generator();

--- a/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
@@ -759,6 +759,7 @@ FIXTURE_TEST(test_recover_offsets, offsets_recovery_fixture) {
     BOOST_REQUIRE_NE(new_cluster_uuid(), cluster_uuid());
     make_partitions(1).get();
     tests::kafka_produce_transport produce(make_kafka_client().get());
+    auto deferred_close = ss::defer([&produce] { produce.stop().get(); });
     produce.start().get();
     int64_t num_records = 5;
     produce

--- a/src/v/cluster/tests/remake_partition_tests.cc
+++ b/src/v/cluster/tests/remake_partition_tests.cc
@@ -66,20 +66,28 @@ public:
       size_t records_per_batch = 1,
       size_t starting_value = 0) {
         tests::kafka_produce_transport producer(co_await make_kafka_client());
+        std::exception_ptr eptr;
         co_await producer.start();
-
-        // Generate some segments.
-        size_t val_count = starting_value;
-        for (size_t i = 0; i < num_segments; i++) {
-            for (size_t r = 0; r < batches_per_segment; r++) {
-                auto kvs = tests::kv_t::sequence(
-                  val_count, records_per_batch, val_count, cardinality);
-                co_await producer.produce_to_partition(
-                  topic_name, model::partition_id(0), std::move(kvs));
-                val_count += records_per_batch;
+        try {
+            // Generate some segments.
+            size_t val_count = starting_value;
+            for (size_t i = 0; i < num_segments; i++) {
+                for (size_t r = 0; r < batches_per_segment; r++) {
+                    auto kvs = tests::kv_t::sequence(
+                      val_count, records_per_batch, val_count, cardinality);
+                    co_await producer.produce_to_partition(
+                      topic_name, model::partition_id(0), std::move(kvs));
+                    val_count += records_per_batch;
+                }
+                co_await log->flush();
+                co_await log->force_roll();
             }
-            co_await log->flush();
-            co_await log->force_roll();
+        } catch (...) {
+            eptr = std::current_exception();
+        }
+        co_await producer.stop();
+        if (eptr) {
+            std::rethrow_exception(eptr);
         }
     }
 
@@ -88,6 +96,7 @@ public:
         co_await consumer.start();
         auto consumed_kvs = co_await consumer.consume_from_partition(
           test_ntp.tp.topic, test_ntp.tp.partition, model::offset(0));
+        co_await consumer.stop();
         co_return consumed_kvs;
     }
 

--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -118,14 +118,16 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "transport",
-    srcs = [],
+    srcs = ["transport.cc"],
     hdrs = ["transport.h"],
     include_prefix = "kafka/client",
     visibility = ["//visibility:public"],
     deps = [
         ":logger",
         "//src/v/base",
+        "//src/v/bytes:iostream",
         "//src/v/bytes:scattered_message",
+        "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:api_versions",
         "//src/v/kafka/protocol:create_topics",
         "//src/v/kafka/protocol:delete_records",
@@ -147,6 +149,8 @@ redpanda_cc_library(
         "//src/v/kafka/protocol:sasl_handshake",
         "//src/v/kafka/protocol:sync_group",
         "//src/v/net",
+        "//src/v/utils:mutex",
+        "//src/v/utils:prefix_logger",
         "//src/v/utils:unresolved_address",
         "@fmt",
         "@seastar",

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -406,6 +406,7 @@ redpanda_cc_gtest(
         "//src/v/kafka/client:utils",
         "//src/v/kafka/protocol",
         "//src/v/kafka/protocol:offset_commit",
+        "//src/v/kafka/protocol:produce",
         "//src/v/model",
         "//src/v/redpanda/tests:fixture",
         "//src/v/test_utils:gtest",

--- a/src/v/kafka/client/test/cluster_test.cc
+++ b/src/v/kafka/client/test/cluster_test.cc
@@ -1,6 +1,7 @@
 
 
 #include "kafka/client/cluster.h"
+#include "kafka/protocol/produce.h"
 #include "redpanda/tests/fixture.h"
 #include "test_utils/test.h"
 
@@ -74,18 +75,30 @@ TEST_F(ClusterFixture, TestClusterRestartAndClientReconnection) {
     ASSERT_EQ(app.controller->self(), cluster.get_controller_id());
 
     // Refresh metadata to include the new topic
-    cluster.request_metadata_update().get();
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return cluster.request_metadata_update()
+          .then([&] {
+              cluster.get_topics().leader(
+                model::topic_partition(tp, model::partition_id(0)));
+              return true;
+          })
+          .handle_exception([](const std::exception_ptr&) { return false; });
+    });
+
     auto leader_id = cluster.get_topics().leader(
       model::topic_partition(tp, model::partition_id(0)));
     ASSERT_EQ(leader_id, app.controller->self());
-
     // Restart the fixture cluster (keeping existing data)
     restart(should_wipe::no);
     wait_for_controller_leadership().get();
 
     // Verify client can still dispatch requests after cluster restart
-    cluster.request_metadata_update().get();
-
+    try {
+        cluster.request_metadata_update().get();
+    } catch (const std::exception& e) {
+        FAIL() << "Cluster restart failed to allow metadata update: "
+               << e.what();
+    }
     // Check that brokers are still discoverable
     auto& brokers_after_restart = cluster.get_brokers();
     ASSERT_FALSE(brokers_after_restart.empty());
@@ -95,7 +108,132 @@ TEST_F(ClusterFixture, TestClusterRestartAndClientReconnection) {
     ASSERT_EQ(app.controller->self(), cluster.get_controller_id());
 
     // Verify topic metadata is still accessible
-    auto leader_id_after_restart = cluster.get_topics().leader(
+    // Refresh metadata to include the new topic
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return cluster.request_metadata_update()
+          .then([&] {
+              cluster.get_topics().leader(
+                model::topic_partition(tp, model::partition_id(0)));
+              return true;
+          })
+          .handle_exception([](const std::exception_ptr&) { return false; });
+    });
+}
+
+kafka::produce_request make_produce_request(
+  model::topic_partition tp, model::record_batch&& batch, acks acks) {
+    chunked_vector<kafka::produce_request::partition> partitions;
+    partitions.emplace_back(kafka::produce_request::partition{
+      .partition_index{tp.partition},
+      .records = kafka::produce_request_record_data(std::move(batch))});
+
+    chunked_vector<kafka::produce_request::topic> topics;
+    topics.emplace_back(kafka::produce_request::topic{
+      .name{std::move(tp.topic)}, .partitions{std::move(partitions)}});
+    std::optional<ss::sstring> t_id;
+    return {t_id, acks, std::move(topics)};
+}
+
+model::record_batch test_batch(int i) {
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    builder.add_raw_kv(iobuf::from("test"), serde::to_iobuf(i));
+    return std::move(builder).build();
+}
+
+ss::future<chunked_vector<model::record_batch>>
+read_partition_data(ss::lw_shared_ptr<::cluster::partition> p) {
+    storage::log_reader_config r_cfg(model::offset(0), model::offset::max());
+    r_cfg.translate_offsets = storage::translate_offsets::yes;
+    r_cfg.type_filter = model::record_batch_type::raft_data;
+    auto r = co_await p->make_reader(std::move(r_cfg));
+
+    co_return co_await model::consume_reader_to_chunked_vector(
+      std::move(r), model::no_timeout);
+};
+
+TEST_F(ClusterFixture, TestDispatchingMultipleRequests) {
+    wait_for_controller_leadership().get();
+
+    // Create and start the client cluster
+    auto cluster = create_cluster();
+    cluster.start().get();
+    auto deferred_stop = ss::defer([&] { cluster.stop().get(); });
+
+    // Create a test topic
+    model::topic tp("test-topic-mr");
+    add_topic(model::topic_namespace(model::kafka_namespace, tp)).get();
+
+    // Verify initial connection and metadata discovery
+    auto& brokers = cluster.get_brokers();
+    ASSERT_FALSE(brokers.empty());
+    brokers.find(model::node_id(1)).get();
+    ASSERT_EQ(app.controller->self(), cluster.get_controller_id());
+
+    // Refresh metadata to include the new topic
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return cluster.request_metadata_update()
+          .then([&] {
+              cluster.get_topics().leader(
+                model::topic_partition(tp, model::partition_id(0)));
+              return true;
+          })
+          .handle_exception([](const std::exception_ptr&) { return false; });
+    });
+
+    model::ntp ntp(model::kafka_namespace, tp, model::partition_id(0));
+    auto shard = app.shard_table.local().shard_for(ntp);
+
+    ASSERT_TRUE(shard.has_value());
+    /**
+     * wait for leader, Kafka API gets leadership information before it is
+     * elected.
+     */
+    RPTEST_REQUIRE_EVENTUALLY(10s, [this, shard, ntp] {
+        return app.partition_manager.invoke_on(
+          *shard, [ntp](::cluster::partition_manager& mgr) {
+              auto partition = mgr.get(ntp);
+
+              return partition->is_leader();
+          });
+    });
+    auto leader_id = cluster.get_topics().leader(
       model::topic_partition(tp, model::partition_id(0)));
-    ASSERT_EQ(leader_id_after_restart, app.controller->self());
+    ASSERT_EQ(leader_id, app.controller->self());
+    /**
+     * Run concurrent produce requests
+     */
+    auto range = std::ranges::iota_view(0, 10)
+                 | std::views::transform([&](int i) {
+                       return make_produce_request(
+                         model::topic_partition(tp, model::partition_id(0)),
+                         test_batch(i),
+                         acks_all);
+                   })
+                 | std::views::transform([&](auto&& req) {
+                       return cluster
+                         .dispatch_to(
+                           leader_id, std::forward<decltype(req)>(req))
+                         .then([](auto&&) { return; });
+                   });
+    ss::when_all_succeed(std::ranges::to<std::vector<ss::future<>>>(range))
+      .get();
+    /**
+     * check that order is preserved
+     */
+    auto batches = app.partition_manager
+                     .invoke_on(
+                       *shard,
+                       [ntp](::cluster::partition_manager& mgr) {
+                           auto partition = mgr.get(ntp);
+                           return read_partition_data(partition);
+                       })
+                     .get();
+
+    ASSERT_EQ(batches.size(), 10);
+    for (auto& b : batches) {
+        auto records = b.copy_records();
+        auto r_number = serde::from_iobuf<int>(records[0].value().copy());
+        ASSERT_EQ(static_cast<int64_t>(r_number), b.base_offset()());
+    }
 }

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -62,12 +62,6 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
     }
 
     {
-        info("Checking for known topic - expect controller not ready");
-        auto res = client.dispatch(make_list_topics_req());
-        BOOST_REQUIRE_THROW(res.get(), kc::broker_error);
-    }
-
-    {
         client.set_max_retries(size_t(5));
         info("Checking for known topic - controller ready");
         auto res = client.dispatch(make_list_topics_req()).get();

--- a/src/v/kafka/client/transport.cc
+++ b/src/v/kafka/client/transport.cc
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/transport.h"
+
+#include "bytes/iostream.h"
+#include "bytes/scattered_message.h"
+#include "kafka/client/logger.h"
+#include "kafka/protocol/api_versions.h"
+#include "kafka/protocol/flex_versions.h"
+#include "kafka/protocol/wire.h"
+#include "net/connection.h"
+namespace kafka::client {
+namespace {
+ss::future<correlation_id> read_correlation_id(ss::input_stream<char>& in) {
+    auto buf = co_await read_iobuf_exactly(in, sizeof(correlation_id));
+    protocol::decoder reader(std::move(buf));
+    co_return correlation_id(reader.read_int32());
+}
+} // namespace
+transport::transport(
+  net::base_transport::configuration c,
+  std::optional<ss::sstring> client_id) noexcept
+  : net::base_transport(std::move(c), &kclog)
+  , _client_id(std::move(client_id))
+  , _logger(
+      kclog,
+      ssx::sformat(
+        "{} - {}:{}",
+        _client_id.value_or("redpanda-client"),
+        server_address().host(),
+        server_address().port())) {}
+
+transport::transport(transport&& other) noexcept
+  // WORKAROUND: https://github.com/llvm/llvm-project/issues/63202
+  // NOLINTBEGIN(bugprone-use-after-move)
+  : net::base_transport(std::move(other))
+  , _dispatch_mutex("kafka::client::transport::dispatch_mutex")
+  , _correlation(other._correlation)
+  , _pending_requests(std::move(other._pending_requests))
+  , _client_id(std::move(other._client_id))
+  , _logger(std::move(other._logger)) {
+    other._needs_stop = false; // we are moving, so we don't need to stop
+    // NOLINTEND(bugprone-use-after-move)
+}
+
+transport::request_entry::request_entry(
+  transport* parent_transport,
+  correlation_id correlation,
+  bool is_flexible,
+  std::optional<model::timeout_clock::duration> timeout)
+  : is_flexible(is_flexible) {
+    if (timeout) {
+        timeout_timer.set_callback([parent_transport, correlation] {
+            parent_transport->on_timeout(correlation);
+        });
+        timeout_timer.arm(*timeout);
+    }
+}
+void transport::request_entry::set_response(
+  iobuf data, std::optional<tagged_fields> tags) {
+    timeout_timer.cancel();
+    response_promise.set_value(response_data{
+      .tags = std::move(tags),
+      .data = std::move(data),
+    });
+}
+void transport::request_entry::set_error(errc ec) {
+    timeout_timer.cancel();
+    response_promise.set_value(ec);
+}
+
+ss::future<> transport::read_loop() {
+    while (is_valid()) {
+        auto reply_sz = co_await protocol::parse_size(_in);
+
+        if (!reply_sz) {
+            // If we can't read the size, we are disconnected.
+            co_return;
+        }
+        auto bytes_remaining = reply_sz.value();
+
+        // TODO: add validation for correlation id here
+        auto correlation_id = co_await read_correlation_id(_in);
+        bytes_remaining -= sizeof(correlation_id);
+        auto it = _pending_requests.find(correlation_id);
+
+        if (it == _pending_requests.end()) {
+            vlog(
+              _logger.trace,
+              "No pending request for correlation_id: {}, most likely it "
+              "timed "
+              "out",
+              correlation_id);
+            continue;
+        }
+        auto entry = std::move(it->second);
+        _pending_requests.erase(it);
+        std::optional<tagged_fields> reply_tags;
+        if (entry->is_flexible) {
+            auto [tags, bytes_read] = co_await parse_tags(_in);
+            reply_tags = std::move(tags);
+            bytes_remaining -= bytes_read;
+        }
+        vlog(
+          _logger.trace,
+          "reading response for correlation_id: {}, bytes_remaining: {}",
+          correlation_id,
+          bytes_remaining);
+        auto reply_buffer = co_await read_iobuf_exactly(_in, bytes_remaining);
+
+        entry->response_promise.set_value(response_data{
+          .tags = std::move(reply_tags),
+          .data = std::move(reply_buffer),
+        });
+    }
+}
+
+void transport::on_timeout(correlation_id correlation) {
+    auto it = _pending_requests.find(correlation);
+    if (it == _pending_requests.end()) {
+        // do nothing, request already completed
+        return;
+    }
+    auto entry = std::move(it->second);
+    _pending_requests.erase(it);
+    vlog(
+      _logger.debug, "Request with correlation_id: {} timed out", correlation);
+    entry->set_error(errc::timeout);
+}
+
+ss::future<> transport::stop() {
+    vlog(_logger.trace, "Stopping client transport to: {}", server_address());
+    _needs_stop = false;
+    co_await base_transport::stop();
+    co_await wait_input_shutdown();
+}
+using namespace std::chrono_literals;
+constexpr std::chrono::seconds tcp_keepalive_idle = 360s;
+constexpr std::chrono::seconds tcp_keepalive_interval = 120s;
+constexpr unsigned int tcp_keepalive_probes = 10;
+
+ss::future<>
+transport::connect(model::timeout_clock::time_point connection_timeout) {
+    vlog(_logger.trace, "Connecting to server: {}", server_address());
+    _needs_stop = true;
+    return base_transport::connect(connection_timeout).then([this] {
+        // background
+        ssx::spawn_with_gate(_dispatch_gate, [this] {
+            set_keepalive_parameters(ss::net::tcp_keepalive_params{
+              .idle = tcp_keepalive_idle,
+              .interval = tcp_keepalive_interval,
+              .count = tcp_keepalive_probes,
+            });
+            set_keepalive(true);
+            return read_loop().then_wrapped([this](ss::future<> f) {
+                fail_outstanding_futures();
+                try {
+                    f.get();
+                } catch (...) {
+                    auto e = std::current_exception();
+                    if (net::is_disconnect_exception(e)) {
+                        vlog(
+                          _logger.info,
+                          "Disconnected from server {}: {}",
+                          server_address(),
+                          e);
+                    } else {
+                        vlog(
+                          _logger.error,
+                          "Error reading from server {}: {}",
+                          server_address(),
+                          e);
+                    }
+                }
+            });
+        });
+    });
+}
+
+void transport::fail_outstanding_futures() {
+    shutdown();
+    for (auto& [_, p] : _pending_requests) {
+        p->set_error(errc::disconnected);
+    }
+    _pending_requests.clear();
+}
+
+void transport::write_header(
+  protocol::encoder& wr,
+  api_key key,
+  api_version version,
+  correlation_id correlation) {
+    wr.write(int16_t(key()));
+    wr.write(int16_t(version()));
+    wr.write(int32_t(correlation));
+    wr.write(_client_id);
+    vassert(
+      flex_versions::is_api_in_schema(key),
+      "Attempted to send request to non-existent API: {}",
+      key);
+    if (flex_versions::is_flexible_request(key, version)) {
+        /// Tags are unused by the client but to be protocol compliant
+        /// with flex versions at least a 0 byte must be written
+        wr.write_tags(tagged_fields{});
+    }
+}
+} // namespace kafka::client

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Redpanda Data, Inc.
+ * Copyright 2025 Redpanda Data, Inc.
  *
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md
@@ -11,23 +11,22 @@
 
 #pragma once
 
+#include "base/outcome.h"
 #include "base/seastarx.h"
-#include "bytes/iostream.h"
 #include "bytes/scattered_message.h"
-#include "kafka/client/logger.h"
 #include "kafka/protocol/api_versions.h"
 #include "kafka/protocol/flex_versions.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/protocol/wire.h"
 #include "net/transport.h"
 #include "utils/mutex.h"
+#include "utils/prefix_logger.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
-
 namespace kafka::client {
 
 class kafka_request_disconnected_exception : public std::runtime_error {
@@ -36,32 +35,163 @@ public:
       : std::runtime_error(msg) {}
 };
 
+class kafka_request_timeout_exception : public std::runtime_error {
+public:
+    explicit kafka_request_timeout_exception(const std::string& msg)
+      : std::runtime_error(msg) {}
+};
+
 /**
- * \brief Kafka client.
- *
- * Restrictions:
- *  - don't dispatch concurrent requests.
+ * Kafka client transport. The transport supports sending multiple outstanding
+ * requests to the server.
+ * TODO:
+ * - observability (metrics)
+ * - limit memory usage ?
+ * - support for flexible versions
  */
 class transport : public net::base_transport {
-private:
-    /*
-     * send a request message and process the reply. note that the kafka
-     * protocol requires that replies be sent in the same order they are
-     * received at the server. in a future version of this client we will also
-     * want to do some form of request/response correlation so that multiple
-     * requests can be in flight.
+public:
+    enum class errc : int8_t {
+        none,
+        disconnected,
+        timeout,
+    };
+    /**
+     * The default timeout for requests sent to the Kafka broker.
+     * This is used when the request does not specify a timeout.
+     * The default is set to 60 seconds, which is a common timeout for Kafka
+     * requests.
      */
-    template<typename Func>
-    auto send_recv(api_key key, api_version request_version, Func&& func) {
-        // size prefixed buffer for request
+    static constexpr std::chrono::milliseconds default_timeout
+      = std::chrono::seconds(60);
+
+    transport(
+      net::base_transport::configuration c,
+      std::optional<ss::sstring> client_id) noexcept;
+    transport(const transport&) = delete;
+    transport(transport&& other) noexcept;
+    transport& operator=(const transport&) = delete;
+    transport& operator=(transport&&) = delete;
+    ~transport() override {
+        vassert(
+          _needs_stop == false, "Transport must be stopped before destruction");
+    };
+
+    const std::optional<ss::sstring>& client_id() const { return _client_id; }
+
+    template<typename RequestT>
+    requires(KafkaApi<typename RequestT::api_type>)
+    ss::future<typename RequestT::api_type::response_type> dispatch(
+      RequestT r,
+      api_version version,
+      std::optional<model::timeout_clock::duration> timeout = default_timeout) {
+        return do_send(std::move(r), version, timeout)
+          .then(
+            [this](
+              checked<typename RequestT::api_type::response_type, errc> res) {
+                if (res.has_error()) {
+                    if (res.error() == errc::disconnected) {
+                        throw kafka_request_disconnected_exception(fmt::format(
+                          "Broker {}:{} transport disconnected",
+                          server_address().host(),
+                          server_address().port()));
+                    } else if (res.error() == errc::timeout) {
+                        throw kafka_request_disconnected_exception(fmt::format(
+                          "Broker {}:{} request of type {} timed out",
+                          server_address().host(),
+                          server_address().port(),
+                          RequestT::api_type::name));
+                    }
+                }
+
+                return std::move(res.value());
+            });
+    }
+
+    template<typename RequestT>
+    requires(KafkaApi<typename RequestT::api_type>)
+    ss::future<checked<typename RequestT::api_type::response_type, errc>>
+    dispatch_errc(
+      RequestT r,
+      api_version version,
+      std::optional<model::timeout_clock::duration> timeout = default_timeout) {
+        return do_send(std::move(r), version, timeout);
+    }
+
+    ss::future<> connect(
+      model::timeout_clock::time_point connection_timeout
+      = model::no_timeout) override;
+
+    ss::future<> stop();
+
+    void fail_outstanding_futures() override;
+
+private:
+    enum class reconnect_result_t : int8_t {
+        connected,
+        timed_out,
+    };
+    ss::future<reconnect_result_t> connect_with_retires(
+      model::timeout_clock::time_point connection_timeout = model::no_timeout);
+
+    struct response_data {
+        std::optional<tagged_fields> tags;
+        iobuf data;
+    };
+
+    struct request_entry {
+        explicit request_entry(
+          transport* parent_transport,
+          correlation_id correlation,
+          bool is_flexible,
+          std::optional<model::timeout_clock::duration> timeout);
+        void set_response(iobuf data, std::optional<tagged_fields> tags);
+        void set_error(errc);
+
+        ss::promise<checked<response_data, errc>> response_promise;
+        bool is_flexible{false};
+        ss::timer<model::timeout_clock> timeout_timer;
+    };
+
+    void write_header(
+      protocol::encoder& wr,
+      api_key key,
+      api_version version,
+      correlation_id correlation);
+
+    ss::future<> read_loop();
+
+    void on_timeout(correlation_id correlation);
+
+    template<typename RequestT>
+    ss::future<checked<typename RequestT::api_type::response_type, errc>>
+    do_send(
+      RequestT request,
+      api_version version,
+      std::optional<model::timeout_clock::duration> timeout) {
+        using ret_t = checked<typename RequestT::api_type::response_type, errc>;
+        // hold the mutex here before the message is written to the output
+        // stream to ensure ordering or requests.
+        auto u = co_await _dispatch_mutex.get_units();
+        if (!is_valid() || _dispatch_gate.is_closed()) {
+            co_return ret_t(errc::disconnected);
+        }
+        auto gate_holder = _dispatch_gate.hold();
         iobuf buf;
-        auto ph = buf.reserve(sizeof(int32_t));
+        auto placeholder = buf.reserve(sizeof(int32_t));
         auto start_size = buf.size_bytes();
         protocol::encoder wr(buf);
-
+        auto key = RequestT::api_type::key;
+        auto correlation = _correlation++;
+        vlog(
+          _logger.trace,
+          "Dispatching '{}' request with version: {}, correlation: {}",
+          RequestT::api_type::name,
+          version,
+          correlation);
         // encode request
-        func(wr);
-
+        write_header(wr, RequestT::api_type::key, version, correlation);
+        request.encode(wr, version);
         vassert(
           flex_versions::is_api_in_schema(key),
           "Attempted to send request to non-existent API: {}",
@@ -71,124 +201,45 @@ private:
         /// version for the API three however makes an exception that there will
         /// be no tags in the response header.
         const auto is_flexible = flex_versions::is_flexible_request(
-                                   key, request_version)
+                                   key, version)
                                  && key() != api_versions_api::key;
 
         // finalize by filling in the size prefix
         int32_t total_size = buf.size_bytes() - start_size;
         auto be_total_size = ss::cpu_to_be(total_size);
         auto* raw_size = reinterpret_cast<const char*>(&be_total_size);
-        ph.write(raw_size, sizeof(be_total_size));
+        placeholder.write(raw_size, sizeof(be_total_size));
 
-        return _out.write(iobuf_as_scattered(std::move(buf)))
-          .then([this, is_flexible](bool) {
-              return protocol::parse_size(_in).then([this, is_flexible](
-                                                      std::optional<size_t>
-                                                        sz) {
-                  if (!sz) {
-                      return ss::make_exception_future<iobuf>(
-                        kafka_request_disconnected_exception(
-                          "Request disconnected, no response received"));
-                  }
-                  auto size = sz.value();
-                  return _in.read_exactly(sizeof(correlation_id))
-                    .then([this, size, is_flexible](
-                            ss::temporary_buffer<char>) {
-                        if (is_flexible) {
-                            return parse_tags(_in).then([size](auto p) {
-                                auto& [_, bytes_read] = p;
-                                return size
-                                       - (sizeof(correlation_id) + bytes_read);
-                            });
-                        }
-                        return ss::make_ready_future<size_t>(
-                          size - sizeof(correlation_id));
-                    })
-                    .then([this](size_t remaining) {
-                        // Finally, read the rest of the response from the
-                        // buffer
-                        return read_iobuf_exactly(_in, remaining);
-                    });
-              });
-          });
-    }
-
-public:
-    // using net::base_transport::base_transport;
-
-    transport(
-      net::base_transport::configuration c,
-      std::optional<ss::sstring> client_id)
-      : net::base_transport(c, &kclog)
-      , _client_id(std::move(client_id)) {}
-
-    /*
-     * TODO: the concept here can be improved once we convert all of the request
-     * types to encode their type relationships between api/request/response.
-     */
-    template<typename T>
-    requires(KafkaApi<typename T::api_type>)
-    ss::future<typename T::api_type::response_type>
-    dispatch(T r, api_version request_version, api_version response_version) {
-        using type = std::remove_reference_t<std::decay_t<T>>;
-        using response_type = typename T::api_type::response_type;
-        if constexpr (std::is_same_v<type, produce_request>) {
-            if (request_version < api_version(3)) {
-                return ss::make_exception_future<response_type>(
-                  std::runtime_error(fmt::format(
-                    "Cannot make produce request at version {} because "
-                    "redpanda "
-                    "does not support serialization of legacy record batches",
-                    request_version)));
-            }
+        auto [it, _] = _pending_requests.emplace(
+          correlation,
+          std::make_unique<request_entry>(
+            this, correlation, is_flexible, timeout));
+        auto response_future = it->second->response_promise.get_future();
+        co_await _out.write(iobuf_as_scattered(std::move(buf)));
+        // return all units to the semaphore before flushing the output
+        u.return_all();
+        co_await _out.flush();
+        typename RequestT::api_type::response_type resp;
+        auto response_data = co_await std::move(response_future);
+        if (response_data.has_error()) {
+            co_return ret_t(response_data.error());
         }
-        return _dispatch_mutex
-          .with([this, r = std::move(r), request_version]() mutable {
-              return send_recv(
-                T::api_type::key,
-                request_version,
-                [this, request_version, r = std::move(r)](
-                  protocol::encoder& wr) mutable {
-                    write_header(wr, T::api_type::key, request_version);
-                    r.encode(wr, request_version);
-                });
-          })
-          .then([response_version](iobuf buf) {
-              response_type r;
-              r.decode(std::move(buf), response_version);
-              return ss::make_ready_future<response_type>(std::move(r));
-          });
-    }
-
-    template<typename T>
-    requires(KafkaApi<typename T::api_type>)
-    ss::future<typename T::api_type::response_type>
-    dispatch(T r, api_version ver) {
-        return dispatch(std::move(r), ver, ver);
-    }
-
-    const std::optional<ss::sstring>& client_id() const { return _client_id; }
-
-private:
-    void write_header(protocol::encoder& wr, api_key key, api_version version) {
-        wr.write(int16_t(key()));
-        wr.write(int16_t(version()));
-        wr.write(int32_t(_correlation()));
-        wr.write(_client_id);
-        vassert(
-          flex_versions::is_api_in_schema(key),
-          "Attempted to send request to non-existent API: {}",
-          key);
-        if (flex_versions::is_flexible_request(key, version)) {
-            /// Tags are unused by the client but to be protocol compliant
-            /// with flex versions at least a 0 byte must be written
-            wr.write_tags(tagged_fields{});
-        }
-        _correlation = _correlation + correlation_id(1);
+        resp.decode(std::move(response_data.value().data), version);
+        // TODO: If we need to handle tags, we can do it here.
+        co_return resp;
     }
     mutex _dispatch_mutex{"kafka::client::transport::dispatch_mutex"};
+    bool _needs_stop = false;
     correlation_id _correlation{0};
+    // We keep the entries sorted by correlation_id, as we are going to
+    // implement the validation of correlation id in near future (Kafka protocol
+    // defines the responses to be sent in the same order as requests were
+    // sent). In this case the response should always match the first entry in
+    // the map.
+    absl::btree_map<correlation_id, std::unique_ptr<request_entry>>
+      _pending_requests;
     std::optional<ss::sstring> _client_id;
+    prefix_logger _logger;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -618,7 +618,7 @@ FIXTURE_TEST(
     auto client = make_kafka_client().get();
     client.connect().get();
     auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
-    client.stop().then([&client] { client.shutdown(); }).get();
+    client.stop().get();
     auto broker_id = std::to_string(resp.data.brokers[0].node_id());
 
     std::vector<ss::sstring> all_properties = {

--- a/src/v/kafka/server/tests/alter_user_scram_credentials_test.cc
+++ b/src/v/kafka/server/tests/alter_user_scram_credentials_test.cc
@@ -56,6 +56,7 @@ FIXTURE_TEST(
     auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     authn_kafka_client(client, user_name_256, password_256);
 
@@ -86,6 +87,7 @@ FIXTURE_TEST(
         password_256, security::scram_sha256::min_iterations);
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -156,7 +158,9 @@ FIXTURE_TEST(
     BOOST_REQUIRE(!errors_in_acl_results(acl_result));
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
+
     authn_kafka_client<security::scram_sha256_authenticator>(
       client, user_name_256, password_256);
 
@@ -184,6 +188,7 @@ FIXTURE_TEST(
 
     // now create a new client and authenticate with the created user
     auto client2 = make_kafka_client().get();
+    auto deferred_close_2 = ss::defer([&client2] { client2.stop().get(); });
     client2.connect().get();
     authn_kafka_client<security::scram_sha512_authenticator>(
       client2, user_name_512, password_512);
@@ -199,6 +204,7 @@ FIXTURE_TEST(
     create_user(user_name_256, creds_256);
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -222,8 +228,8 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
-
     kafka::alter_user_scram_credentials_request req;
     req.data.deletions.emplace_back(kafka::scram_credential_deletion{
       .name = kafka::scram_user_name{"nonexistant_user"},
@@ -247,6 +253,7 @@ FIXTURE_TEST(
     create_user(user_name_256, creds_256);
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -274,6 +281,7 @@ FIXTURE_TEST(
         password_512, security::scram_sha512::min_iterations);
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -305,6 +313,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -330,6 +339,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -355,6 +365,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -380,6 +391,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -422,6 +434,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -465,6 +478,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;
@@ -529,6 +543,7 @@ FIXTURE_TEST(
     wait_for_controller_leadership().get();
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     kafka::alter_user_scram_credentials_request req;

--- a/src/v/kafka/server/tests/api_versions_test.cc
+++ b/src/v/kafka/server/tests/api_versions_test.cc
@@ -49,14 +49,10 @@ FIXTURE_TEST(unsupported_version, redpanda_thread_fixture) {
     client.connect().get();
 
     kafka::api_versions_request request;
-    auto max_version = kafka::api_version(
-      std::numeric_limits<kafka::api_version::type>::max());
-    auto response
-      = client.dispatch(request, max_version, kafka::api_version(0)).get();
+    auto max_version = kafka::api_version(3);
+    auto response = client.dispatch(request, max_version).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_TEST(
-      response.data.error_code == kafka::error_code::unsupported_version);
     BOOST_REQUIRE(!response.data.api_keys.empty());
 
     // get the versions supported by the api versions request itself

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -155,12 +155,13 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
     add_topic(model::topic_namespace_view{model::kafka_namespace, t}).get();
     wait_for_consumer_offsets_topic(gi);
 
-    auto client = make_kafka_client().get();
+    auto client = std::make_unique<kafka::client::transport>(
+      make_kafka_client().get());
     auto client_stop = [&client] {
-        client.stop().then([&client] { client.shutdown(); }).get();
+        client->stop().then([&client] { client->shutdown(); }).get();
     };
     auto deferred = ss::defer(decltype(client_stop)(client_stop));
-    client.connect().get();
+    client->connect().get();
 
     auto gntp = app.coordinator_ntp_mapper.local().ntp_for(g);
     BOOST_REQUIRE(gntp);
@@ -179,7 +180,7 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
                       .partition_index = model::partition_id{0},
                       .committed_offset = model::offset{0}})})}};
             auto res
-              = client.dispatch(std::move(req), kafka::api_version(7)).get();
+              = client->dispatch(std::move(req), kafka::api_version(7)).get();
             if (!res.data.errored()) {
                 return true;
             }
@@ -204,8 +205,9 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
         consumer_offsets_fixture::restart(should_wipe::no);
         wait_for_consumer_offsets_topic(gi);
         wait_for_leader(*gntp).get();
-        client = make_kafka_client().get();
-        client.connect().get();
+        client = std::make_unique<kafka::client::transport>(
+          make_kafka_client().get());
+        client->connect().get();
     };
 
     BOOST_REQUIRE(can_commit_offset());

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -91,6 +91,7 @@ public:
       kafka::create_topics_request req,
       kafka::api_version version = kafka::api_version(2)) {
         auto client = make_kafka_client().get();
+        auto deferred_close = ss::defer([&client] { client.stop().get(); });
         client.connect().get();
         auto topics = req.data.topics
                         .copy(); // save a copy because we will move out of req
@@ -124,8 +125,6 @@ public:
             // that the topic creation is correctly propogated to the
             // non-controller broker.
         }
-
-        client.stop().then([&client] { client.shutdown(); }).get();
     }
 
     void verify_response(
@@ -306,6 +305,7 @@ FIXTURE_TEST(read_replica_and_remote_write, create_topic_fixture) {
         {"redpanda.remote.write", "true"}});
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client.dispatch(make_req({topic}), kafka::api_version(2)).get();
 
@@ -352,6 +352,7 @@ FIXTURE_TEST(create_multiple_topics_mixed_invalid, create_topic_fixture) {
         {"retention.bytes", "this_should_be_an_integer"}});
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client
                   .dispatch(make_req({topic_a, topic_b}), kafka::api_version(5))
@@ -389,6 +390,7 @@ FIXTURE_TEST(create_multiple_topics_all_invalid, create_topic_fixture) {
       std::map<ss::sstring, ss::sstring>{{"segment.ms", "0x2A"}});
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client
                   .dispatch(
@@ -425,6 +427,7 @@ FIXTURE_TEST(create_multiple_topics_all_invalid_name, create_topic_fixture) {
     auto topic_invalid = make_topic("$nope");
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp
       = client
@@ -467,6 +470,7 @@ FIXTURE_TEST(invalid_boolean_property, create_topic_fixture) {
         {"redpanda.remote.write", "affirmative"}});
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client.dispatch(make_req({topic}), kafka::api_version(5)).get();
 
@@ -487,6 +491,7 @@ FIXTURE_TEST(case_insensitive_boolean_property, create_topic_fixture) {
         {"redpanda.remote.write", "tRuE"}, {"redpanda.remote.read", "FALSE"}});
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client.dispatch(make_req({topic}), kafka::api_version(5)).get();
 
@@ -518,6 +523,7 @@ FIXTURE_TEST(unlicensed_permit_if_config_disabled, create_topic_fixture) {
         kafka::topic_property_record_value_schema_id_validation_compat, true)};
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     for (const auto& [name, props] : enterprise_props) {
@@ -572,6 +578,7 @@ FIXTURE_TEST(unlicensed_rejected, create_topic_fixture) {
           .racks = {model::rack_id{"A"}}})};
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     for (const auto& [name, props] : enterprise_props) {
@@ -604,6 +611,7 @@ FIXTURE_TEST(unlicensed_reject_defaults, create_topic_fixture) {
       lconf().cloud_storage_enable_remote_write.name()};
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     for (const auto& config : si_configs) {
@@ -623,6 +631,7 @@ FIXTURE_TEST(unlicensed_reject_defaults, create_topic_fixture) {
 
 FIXTURE_TEST(create_dry_run_rejects_existing, create_topic_fixture) {
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     auto topic = make_topic(ssx::sformat("topic_foo"));
@@ -657,6 +666,7 @@ FIXTURE_TEST(create_dry_run_rejects_existing, create_topic_fixture) {
 
 FIXTURE_TEST(create_topic_assigns_topic_id, create_topic_fixture) {
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     auto topic = make_topic(ssx::sformat("topic_foo"));

--- a/src/v/kafka/server/tests/delete_records_utils.h
+++ b/src/v/kafka/server/tests/delete_records_utils.h
@@ -30,7 +30,7 @@ public:
       : _transport(std::move(t)) {}
 
     ss::future<> start() { return _transport.connect(); }
-
+    ss::future<> stop() { return _transport.stop(); }
     ss::future<pid_to_offset_map_t> delete_records(
       model::topic topic_name,
       pid_to_offset_map_t offsets_per_partition,

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -48,6 +48,7 @@ public:
         }};
 
         auto client = make_kafka_client().get();
+        auto deferred_close = ss::defer([&client] { client.stop().get(); });
         client.connect().get();
         auto resp
           = client.dispatch(std::move(req), kafka::api_version(2)).get();
@@ -56,6 +57,7 @@ public:
     kafka::delete_topics_response
     send_delete_topics_request(kafka::delete_topics_request req) {
         auto client = make_kafka_client().get();
+        auto deferred_close = ss::defer([&client] { client.stop().get(); });
         client.connect().get();
 
         return client.dispatch(std::move(req), kafka::api_version(2)).get();
@@ -77,6 +79,7 @@ public:
 
     kafka::metadata_response get_topic_metadata(const model::topic& tp) {
         auto client = make_kafka_client().get();
+        auto deferred_close = ss::defer([&client] { client.stop().get(); });
         client.connect().get();
         chunked_vector<kafka::metadata_request_topic> topics;
         topics.push_back(kafka::metadata_request_topic{.name{tp}});

--- a/src/v/kafka/server/tests/describe_user_scram_credentials_test.cc
+++ b/src/v/kafka/server/tests/describe_user_scram_credentials_test.cc
@@ -89,6 +89,7 @@ FIXTURE_TEST(
     kafka::describe_user_scram_credentials_request req;
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     auto resp = client.dispatch(std::move(req), kafka::api_version(0)).get();
@@ -139,9 +140,9 @@ FIXTURE_TEST(
     BOOST_REQUIRE(!errors_in_acl_results(acl_result));
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     authn_kafka_client(client, user_name_256, password_256);
-
     kafka::describe_user_scram_credentials_request req;
 
     auto resp = client.dispatch(std::move(req), kafka::api_version(0)).get();
@@ -165,6 +166,7 @@ FIXTURE_TEST(
     auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     authn_kafka_client(client, user_name_256, password_256);
 
@@ -181,6 +183,7 @@ FIXTURE_TEST(
   describe_user_scram_credentials_fixture) {
     wait_for_controller_leadership().get();
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     kafka::describe_user_scram_credentials_request req;
     req.data.users.emplace(chunked_vector<kafka::user_name>{
@@ -200,6 +203,7 @@ FIXTURE_TEST(
   describe_user_scram_credentials_fixture) {
     wait_for_controller_leadership().get();
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     kafka::describe_user_scram_credentials_request req;
     req.data.users.emplace(chunked_vector<kafka::user_name>{
@@ -218,6 +222,7 @@ FIXTURE_TEST(
   describe_user_scram_credentials_fixture) {
     wait_for_controller_leadership().get();
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     kafka::describe_user_scram_credentials_request req;
     req.data.users.emplace(chunked_vector<kafka::user_name>{
@@ -242,6 +247,7 @@ FIXTURE_TEST(
         "password_256", security::scram_sha256::min_iterations));
     wait_for_controller_leadership().get();
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     kafka::describe_user_scram_credentials_request req;
     req.data.users.emplace(chunked_vector<kafka::user_name>{
@@ -284,6 +290,7 @@ FIXTURE_TEST(
 
     wait_for_controller_leadership().get();
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client.dispatch(std::move(req), kafka::api_version(0)).get();
     BOOST_CHECK(resp.data.errored());

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -182,6 +182,7 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
                   {std::move(msg)});
             }
         }
+        co_await producer.stop();
     }
 
     ss::future<model::topic>

--- a/src/v/kafka/server/tests/list_offsets_utils.h
+++ b/src/v/kafka/server/tests/list_offsets_utils.h
@@ -32,6 +32,7 @@ public:
       : _transport(std::move(t)) {}
 
     ss::future<> start() { return _transport.connect(); }
+    ss::future<> stop() { return _transport.stop(); }
 
     ss::future<model::offset> start_offset_for_partition(
       model::topic topic_name, model::partition_id pid);

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -63,6 +63,7 @@ protected:
         }};
 
         auto client = make_kafka_client().get();
+        auto deferred_close = ss::defer([&client] { client.stop().get(); });
         client.connect().get();
         auto resp
           = client.dispatch(std::move(req), kafka::api_version(2)).get();
@@ -88,6 +89,7 @@ FIXTURE_TEST(metadata_v9_no_topics, metadata_fixture) {
       .include_cluster_authorized_operations = false,
       .include_topic_authorized_operations = false}};
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp
       = client.dispatch(std::move(req_no_cluster), kafka::api_version(8)).get();
@@ -122,6 +124,7 @@ FIXTURE_TEST(metadata_v9_topics, metadata_fixture) {
       .include_cluster_authorized_operations = false,
       .include_topic_authorized_operations = false}};
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     auto resp = client.dispatch(std::move(req), kafka::api_version(8)).get();
     BOOST_REQUIRE(!resp.data.errored());
@@ -190,6 +193,7 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
     BOOST_REQUIRE(!errors_in_acl_results(acl_result));
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
     authn_kafka_client(client, test_username, test_password);
 
@@ -255,6 +259,7 @@ FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
     }
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     constexpr auto make_request = []() {
@@ -296,6 +301,7 @@ FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
     create_topic(test_topic_name, 1, 1);
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     const auto make_request = [&]() {
@@ -330,6 +336,7 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
     constexpr auto max_supported = kafka::metadata_handler::max_supported;
 
     auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
     const auto make_request = [&]() {

--- a/src/v/kafka/server/tests/offset_for_leader_epoch_utils.h
+++ b/src/v/kafka/server/tests/offset_for_leader_epoch_utils.h
@@ -33,6 +33,7 @@ public:
       : _transport(std::move(t)) {}
 
     ss::future<> start() { return _transport.connect(); }
+    ss::future<> stop() { return _transport.stop(); }
 
     ss::future<pid_to_offset_map_t> offsets_for_leaders(
       model::topic topic_name, pid_to_term_map_t term_per_partition);

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -177,6 +177,15 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         return kafka_probe()._bytes_by_compression.at((size_t)compression_type);
     }
 
+    ~prod_consume_fixture() {
+        ss::parallel_for_each(consumers, [](kafka::client::transport& t) {
+            return t.stop();
+        }).get();
+        ss::parallel_for_each(producers, [](kafka::client::transport& t) {
+            return t.stop();
+        }).get();
+    }
+
     std::vector<model::offset> fetch_offsets;
     std::vector<kafka::client::transport> consumers;
     std::vector<kafka::client::transport> producers;
@@ -688,7 +697,6 @@ FIXTURE_TEST(test_offset_for_leader_epoch, prod_consume_fixture) {
     };
     req.data.topics.emplace_back(std::move(t));
     auto resp = client.dispatch(std::move(req), kafka::api_version(2)).get();
-    client.stop().then([&client] { client.shutdown(); }).get();
     BOOST_REQUIRE_EQUAL(1, resp.data.topics.size());
     const auto& topic_resp = resp.data.topics[0];
     BOOST_REQUIRE_EQUAL(1, topic_resp.partitions.size());
@@ -720,6 +728,7 @@ FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
     auto log = partition->log();
 
     tests::kafka_produce_transport producer(make_kafka_client().get());
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
     producer.start().get();
     producer
       .produce_to_partition(
@@ -755,7 +764,9 @@ FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
 
     tests::kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
+    auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
     tests::kafka_delete_records_transport deleter(make_kafka_client().get());
+    auto deferred_d_close = ss::defer([&deleter] { deleter.stop().get(); });
     deleter.start().get();
 
     // At this point, we have three batches:
@@ -854,6 +865,7 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
 
     auto producer = tests::kafka_produce_transport(make_kafka_client().get());
     producer.start().get();
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
     // helper to produce a bunch of messages with some drift applied to the
     // timestamps. the drift is the same for all the messages, but a more
@@ -919,6 +931,7 @@ FIXTURE_TEST(test_compression_metrics, prod_consume_fixture) {
 
     auto producer = tests::kafka_produce_transport(make_kafka_client().get());
     producer.start().get();
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
     auto produce_messages = [&](ctype compression) {
         producer

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -79,6 +79,7 @@ public:
       : _transport(std::move(t)) {}
 
     ss::future<> start() { return _transport.connect(); }
+    ss::future<> stop() { return _transport.stop(); }
 
     // Produces the given records per partition to the given topic.
     ss::future<pid_to_offset_map_t> produce(
@@ -115,7 +116,7 @@ public:
       : _transport(std::move(t)) {}
 
     ss::future<> start() { return _transport.connect(); }
-
+    ss::future<> stop() { return _transport.stop(); }
     ss::future<pid_to_kvs_map_t> consume(
       model::topic topic_name,
       std::vector<model::partition_id> pids,

--- a/src/v/kafka/server/tests/topic_properties_helpers.h
+++ b/src/v/kafka/server/tests/topic_properties_helpers.h
@@ -50,10 +50,11 @@ public:
                 std::move(client),
                 [f = std::forward<Func>(f)](
                   kafka::client::transport& client) mutable {
-                    return client.connect().then(
-                      [&client, f = std::forward<Func>(f)]() mutable {
+                    return client.connect()
+                      .then([&client, f = std::forward<Func>(f)]() mutable {
                           return f(client);
-                      });
+                      })
+                      .finally([&client] { return client.stop(); });
                 });
           });
     }

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -54,7 +54,9 @@ public:
             }};
 
             auto client = make_kafka_client().get();
+            auto deferred_close = ss::defer([&client] { client.stop().get(); });
             client.connect().get();
+
             auto resp
               = client.dispatch(std::move(req), kafka::api_version(2)).get();
             if (
@@ -85,6 +87,7 @@ public:
     kafka::delete_topics_response
     send_delete_topics_request(kafka::delete_topics_request req) {
         auto client = make_kafka_client().get();
+        auto deferred_close = ss::defer([&client] { client.stop().get(); });
         client.connect().get();
 
         return client.dispatch(std::move(req), kafka::api_version(2)).get();
@@ -97,10 +100,11 @@ public:
                 std::move(client),
                 [f = std::forward<Func>(f)](
                   kafka::client::transport& client) mutable {
-                    return client.connect().then(
-                      [&client, f = std::forward<Func>(f)]() mutable {
+                    return client.connect()
+                      .then([&client, f = std::forward<Func>(f)]() mutable {
                           return f(client);
-                      });
+                      })
+                      .finally([&client] { return client.stop(); });
                 });
           });
     }

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -52,6 +52,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
 
     kafka_produce_transport producer(rp->make_kafka_client().get());
     producer.start().get();
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
     // []: batch
     // {}: segment
@@ -112,6 +113,8 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     // {[0 1 2 3]} {[4 5]} {[0 1 2 3 4 5]}
     kafka_produce_transport new_producer(new_rp->make_kafka_client().get());
     new_producer.start().get();
+    auto new_deferred_close = ss::defer(
+      [&new_producer] { new_producer.stop().get(); });
     new_producer.produce_to_partition(topic, pid, kv_t::sequence(0, 5)).get();
     auto new_log = new_partition->log();
     new_log->flush().get();

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -135,7 +135,6 @@ public:
       size_t base = 0) {
         tests::kafka_produce_transport producer(co_await make_kafka_client());
         co_await producer.start();
-
         // Generate some segments.
         size_t val_count = starting_value;
         for (size_t i = 0; i < num_segments; i++) {
@@ -159,6 +158,7 @@ public:
             co_await log->flush();
             co_await log->force_roll();
         }
+        co_await producer.stop();
     }
 
     ss::future<> generate_tombstones(
@@ -221,6 +221,7 @@ public:
             co_await log->flush();
             co_await log->force_roll();
         }
+        co_await producer.stop();
     }
 
     ss::future<std::vector<tests::kv_t>>
@@ -232,6 +233,7 @@ public:
         EXPECT_GE(consumed_kvs.size(), cardinality);
         auto num_duplicates = consumed_kvs.size() - cardinality;
         EXPECT_LE(num_duplicates, max_duplicates);
+        co_await consumer.stop();
         co_return consumed_kvs;
     }
 
@@ -343,6 +345,8 @@ TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
     auto restart_summary = dir_summary().get();
 
     tests::kafka_consume_transport second_consumer(make_kafka_client().get());
+    auto deferred_c_close = ss::defer(
+      [&second_consumer] { second_consumer.stop().get(); });
     second_consumer.start().get();
     auto consumed_kvs_restarted = second_consumer
                                     .consume_from_partition(
@@ -430,6 +434,8 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -940,6 +946,8 @@ TEST_F(CompactionFixtureTest, TestTombstones) {
 
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         consumer.start().get();
         auto consumed_kvs = consumer
                               .consume_from_partition(
@@ -1004,6 +1012,8 @@ TEST_P(CompactionFixtureTombstonesParamTest, TestTombstonesCompletelyEmptyLog) {
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1037,6 +1047,8 @@ TEST_P(CompactionFixtureTombstonesParamTest, TestTombstonesCompletelyEmptyLog) {
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1123,6 +1135,8 @@ TEST_P(
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1165,6 +1179,8 @@ TEST_P(
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1278,6 +1294,8 @@ TEST_P(
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1319,6 +1337,8 @@ TEST_P(
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1716,6 +1736,8 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompaction) {
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1803,6 +1825,8 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto consumed_kvs = consumer
                               .consume_from_partition(
                                 topic_name,
@@ -1915,6 +1939,8 @@ TEST_F(
     auto make_kafka_consumer = [&]() {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
+        auto deferred_c_close = ss::defer(
+          [&consumer] { consumer.stop().get(); });
         auto kvs = consumer
                      .consume_from_partition(
                        topic_name, model::partition_id(0), model::offset(0))

--- a/src/v/storage/tests/storage_e2e_fixture.h
+++ b/src/v/storage/tests/storage_e2e_fixture.h
@@ -23,17 +23,26 @@ struct storage_e2e_fixture : public redpanda_thread_fixture {
     ss::future<> produce_to_fixture(model::topic topic_name, int* incomplete) {
         tests::kafka_produce_transport producer(co_await make_kafka_client());
         co_await producer.start();
-        const int cardinality = 10;
-        auto now = ss::lowres_clock::now();
-        while (ss::lowres_clock::now() < now + 5s) {
-            for (int i = 0; i < cardinality; i++) {
-                co_await producer.produce_to_partition(
-                  topic_name,
-                  model::partition_id(0),
-                  tests::kv_t::sequence(i, 1));
+        std::exception_ptr eptr;
+        try {
+            const int cardinality = 10;
+            auto now = ss::lowres_clock::now();
+            while (ss::lowres_clock::now() < now + 5s) {
+                for (int i = 0; i < cardinality; i++) {
+                    co_await producer.produce_to_partition(
+                      topic_name,
+                      model::partition_id(0),
+                      tests::kv_t::sequence(i, 1));
+                }
             }
+            *incomplete -= 1;
+        } catch (...) {
+            eptr = std::current_exception();
         }
-        *incomplete -= 1;
+        co_await producer.stop();
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
     }
 
     ss::future<> remove_segment_permanently(

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -107,6 +107,7 @@ FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
     model::offset stop_after{num_records * 100};
     tests::kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();
+    auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
     auto produce = [&] {
         return producer
           .produce_to_partition(


### PR DESCRIPTION
Replaced the `kafka::client` transport to provide support for being able to have multiple requests in flight to a single broker. Additionally the transport implementation adds request timeouts, error code based error handling and keep alive settings. 

Fixes: CORE-12662

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- new transport for kafka client