### PR TITLE
Kafka client direct consumer 

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -14,6 +14,16 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "errors",
+    hdrs = ["errors.h"],
+    include_prefix = "kafka/client",
+    deps = [
+        "//src/v/base",
+        "//src/v/kafka/protocol",
+    ],
+)
+
+redpanda_cc_library(
     name = "api_types",
     hdrs = ["api_types.h"],
     include_prefix = "kafka/client",

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -146,6 +146,11 @@ public:
       api_key key,
       std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
 
+    /**
+     * Returns logger prefixed with the client id.
+     */
+    prefix_logger& logger() { return _logger; }
+
 private:
     ss::future<> update_metadata();
     ss::future<> dispatch_metadata_request();

--- a/src/v/kafka/client/direct_consumer/BUILD
+++ b/src/v/kafka/client/direct_consumer/BUILD
@@ -1,0 +1,40 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+redpanda_cc_library(
+    name = "direct_consumer",
+    srcs = [
+        "data_queue.cc",
+        "direct_consumer.cc",
+        "fetcher.cc",
+    ],
+    hdrs = [
+        "api_types.h",
+        "data_queue.h",
+        "direct_consumer.h",
+        "fetcher.h",
+    ],
+    include_prefix = "kafka/client/direct_consumer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:fragmented_vector",
+        "//src/v/container:intrusive",
+        "//src/v/kafka/client:cluster",
+        "//src/v/kafka/client:errors",
+        "//src/v/kafka/client:exceptions",
+        "//src/v/kafka/client:logger",
+        "//src/v/kafka/client:types",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:fetch",
+        "//src/v/kafka/protocol:list_offset",
+        "//src/v/kafka/protocol:metadata",
+        "//src/v/kafka/protocol/schemata:fetch_response",
+        "//src/v/model",
+        "//src/v/ssx:async_algorithm",
+        "//src/v/utils:mutex",
+        "//src/v/utils:prefix_logger",
+        "@fmt",
+        "@seastar",
+    ],
+)

--- a/src/v/kafka/client/direct_consumer/api_types.h
+++ b/src/v/kafka/client/direct_consumer/api_types.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "base/outcome.h"
+#include "container/chunked_hash_map.h"
+#include "container/fragmented_vector.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/fetch_response.h"
+#include "kafka/protocol/types.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+namespace kafka::client {
+enum class offset_reset_policy : int8_t {
+    // reset to the earliest offset
+    earliest,
+    // reset to the latest offset
+    latest,
+};
+
+inline std::ostream& operator<<(std::ostream& os, offset_reset_policy p) {
+    switch (p) {
+    case offset_reset_policy::earliest:
+        return os << "earliest";
+    case offset_reset_policy::latest:
+        return os << "latest";
+    }
+}
+
+template<typename T>
+using kafka_result = result<T, kafka::error_code>;
+
+/**
+ * Control for assigned topic/partition
+ */
+struct partition_assignment {
+    model::partition_id partition_id;
+    std::optional<kafka::offset> next_offset;
+};
+
+struct topic_assignment {
+    model::topic topic;
+    chunked_vector<partition_assignment> partitions;
+};
+
+/**
+ * Data exposed to the `fetch_next()` caller
+ */
+struct fetched_partition_data {
+    model::partition_id partition_id;
+    kafka::leader_epoch leader_epoch;
+    kafka::offset high_watermark;
+    kafka::offset last_stable_offset;
+    chunked_vector<model::record_batch> data;
+    kafka::error_code error = kafka::error_code::none;
+    std::optional<chunked_vector<aborted_transaction>> aborted_transactions;
+};
+
+struct fetched_topic_data {
+    model::topic topic;
+
+    chunked_vector<fetched_partition_data> partitions;
+    size_t total_bytes{0};
+};
+
+using fetches = kafka_result<chunked_vector<fetched_topic_data>>;
+
+struct partition_offset {
+    model::partition_id partition_id;
+    kafka::error_code error_code = kafka::error_code::none;
+    kafka::leader_epoch leader_epoch;
+    kafka::offset offset;
+};
+
+struct topic_partition_offsets {
+    model::topic topic;
+    kafka::error_code error_code = kafka::error_code::none;
+    chunked_vector<partition_offset> offsets;
+};
+
+template<typename Element>
+using topic_partition_map = chunked_hash_map<
+  model::topic,
+  chunked_hash_map<model::partition_id, Element>>;
+
+} // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/data_queue.cc
+++ b/src/v/kafka/client/direct_consumer/data_queue.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/direct_consumer/data_queue.h"
+
+namespace kafka::client {
+
+data_queue::data_queue(size_t max_bytes, size_t max_count)
+  : _max_count(max_count)
+  , _max_bytes(max_bytes) {}
+
+bool data_queue::can_insert(size_t bytes) const {
+    return _queue.empty()
+           || (_current_bytes + bytes <= _max_bytes && _queue.size() < _max_count);
+}
+
+ss::future<>
+data_queue::push(chunked_vector<fetched_topic_data> data, size_t total_bytes) {
+    // optimization, if data can be inserted immediately, do it
+    if (can_insert(total_bytes)) {
+        _current_bytes += total_bytes;
+        _queue.push_back(
+          entry{.topics = std::move(data), .total_bytes = total_bytes});
+        _updated.signal();
+        return ss::now();
+    }
+    return _updated
+      .wait([this, total_bytes] { return can_insert(total_bytes); })
+      .then([total_bytes, data = std::move(data), this]() mutable {
+          _current_bytes += total_bytes;
+          _queue.push_back(
+            entry{.topics = std::move(data), .total_bytes = total_bytes});
+          _updated.signal();
+      });
+}
+
+ss::future<> data_queue::push_error(kafka::error_code ec) {
+    return _updated.wait([this] { return can_insert(0); })
+      .then([ec, this]() mutable {
+          _queue.push_back(entry{.error_code = ec});
+          _updated.signal();
+      });
+}
+
+ss::future<fetches> data_queue::pop(std::chrono::milliseconds timeout) {
+    co_await _updated.wait(timeout, [this] { return !_queue.empty(); });
+
+    auto entry = std::move(_queue.front());
+    _current_bytes -= entry.total_bytes;
+    _queue.pop_front();
+    _updated.signal();
+    if (entry.error_code != kafka::error_code::none) {
+        // If there is an error, we return an empty vector
+        co_return entry.error_code;
+    }
+    auto result = std::move(entry.topics);
+    co_return result;
+}
+
+void data_queue::stop() { _updated.broken(); }
+
+} // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/data_queue.h
+++ b/src/v/kafka/client/direct_consumer/data_queue.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/client/direct_consumer/api_types.h"
+
+namespace kafka::client {
+/**
+ * Very simple blocking queue that is used in
+ * the direct consumer to store data fetched from the broker. The queue is
+ * bounded by the number of entries and the total size of the data in the queue.
+ * The queue can store a single entry that exceeds the size limit but the
+ * prerequisite for that is that the queue is empty.
+ */
+class data_queue {
+public:
+    data_queue(size_t max_bytes = 10_MiB, size_t max_count = 10);
+    /*
+     * Returns true if the queue can accept more data.
+     */
+    bool can_insert(size_t bytes) const;
+    /**
+     * Pushes data into the queue. If the queue is full, it will block until
+     * there is enough space.
+     */
+    ss::future<>
+    push(chunked_vector<fetched_topic_data> data, size_t total_bytes);
+
+    /**
+     * Pushes an error into the queue. If the queue is full, it will block until
+     * there is enough space. The error are not accounted for the total bytes.
+     */
+    ss::future<> push_error(kafka::error_code ec);
+    /**
+     * Pops data from the queue. If the queue is empty, it will block until
+     * there is data available or the timeout is reached.
+     * If the timeout is reached, it will throw condition_variable_timed_out.
+     */
+    ss::future<fetches> pop(std::chrono::milliseconds timeout);
+
+    /**
+     * Stops the queue. All methods will return immediately after this
+     * method is called. If the methods is waiting it will throw an exception.
+     */
+    void stop();
+
+    /**
+     * Configuration setters for the queue.
+     */
+    void set_max_bytes(size_t bytes) {
+        _max_bytes = bytes;
+        _updated.signal();
+    }
+    void set_max_count(size_t count) {
+        _max_count = count;
+        _updated.signal();
+    }
+
+    size_t size() const { return _queue.size(); }
+
+    size_t current_bytes() const { return _current_bytes; }
+
+private:
+    struct entry {
+        kafka::error_code error_code{kafka::error_code::none};
+        chunked_vector<fetched_topic_data> topics;
+        size_t total_bytes{0};
+    };
+    size_t _max_count{10};
+    size_t _max_bytes{10_MiB};
+
+    size_t _current_bytes{0};
+    ss::chunked_fifo<entry> _queue;
+    ss::condition_variable _updated;
+};
+} // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/direct_consumer/direct_consumer.h"
+
+#include "kafka/client/direct_consumer/data_queue.h"
+#include "kafka/client/direct_consumer/fetcher.h"
+#include "model/validation.h"
+
+namespace kafka::client {
+
+direct_consumer::direct_consumer(cluster& cluster, configuration cfg)
+  : _cluster(&cluster)
+  , _config(cfg)
+  , _fetched_data_queue(std::make_unique<data_queue>(
+      cfg.max_buffered_bytes, cfg.max_buffered_elements)) {}
+
+ss::future<fetches>
+direct_consumer::fetch_next(std::chrono::milliseconds timeout) {
+    if (!_started) [[unlikely]] {
+        throw std::runtime_error("Direct consumer is not started");
+    }
+    auto holder = _gate.hold();
+    try {
+        co_return co_await _fetched_data_queue->pop(timeout);
+    } catch (ss::condition_variable_timed_out&) {
+        co_return chunked_vector<fetched_topic_data>{};
+    }
+}
+
+void direct_consumer::update_configuration(configuration cfg) {
+    vlog(
+      _cluster->logger().info,
+      "Updating direct consumer configuration: {}",
+      cfg);
+    _config = cfg;
+    _fetched_data_queue->set_max_bytes(cfg.max_buffered_bytes);
+    _fetched_data_queue->set_max_count(cfg.max_buffered_elements);
+}
+
+ss::future<>
+direct_consumer::update_fetchers(topic_partition_map<subscription> removals) {
+    // do not update fetchers before the consumer is started
+    if (!_started) {
+        co_return;
+    }
+    auto holder = _gate.hold();
+    /**
+     * Unassign partitions from fetchers that are no longer needed.
+     */
+    for (auto& [topic, partitions] : removals) {
+        for (auto& [p_id, subscription] : partitions) {
+            if (subscription.current_fetcher) {
+                auto& current = get_fetcher(*subscription.current_fetcher);
+                co_await current.unassign_partition(
+                  model::topic_partition_view(topic, p_id));
+            }
+        }
+    }
+    bool needs_metadata_update = false;
+    for (auto& [topic, partitions] : _subscriptions) {
+        for (auto& [p_id, sub] : partitions) {
+            auto leader_id = _cluster->get_topics().leader(
+              model::topic_partition_view(topic, p_id));
+
+            if (!leader_id) {
+                needs_metadata_update = true;
+                if (sub.current_fetcher) {
+                    // If there is a current fetcher, unassign the partition
+                    auto& current = get_fetcher(*sub.current_fetcher);
+                    auto offset = co_await current.unassign_partition(
+                      model::topic_partition_view(topic, p_id));
+                    // preserve the fetch offset for the next fetcher to use
+                    sub.fetch_offset = offset;
+                }
+                continue;
+            }
+
+            if (sub.current_fetcher != leader_id) {
+                // If the fetcher is not the same as the current one, we need to
+                // assign it
+                if (sub.current_fetcher) {
+                    auto& current = get_fetcher(*sub.current_fetcher);
+                    // If there was a previous fetcher, unassign it
+                    auto offset = co_await current.unassign_partition(
+                      model::topic_partition_view(topic, p_id));
+                    sub.fetch_offset = offset;
+                }
+                sub.current_fetcher = *leader_id;
+                auto& new_fetcher = get_fetcher(*leader_id);
+                co_await new_fetcher.assign_partition(
+                  model::topic_partition_view(topic, p_id), sub.fetch_offset);
+
+            } else if (sub.fetch_offset) {
+                // If the fetch offset is set, update it
+                auto& current = get_fetcher(*sub.current_fetcher);
+                co_await current.assign_partition(
+                  model::topic_partition_view(topic, p_id), sub.fetch_offset);
+            }
+            sub.fetch_offset.reset();
+        }
+    }
+    for (auto it = _broker_fetchers.begin(); it != _broker_fetchers.end();) {
+        auto& [id, fetcher] = *it;
+        if (fetcher->is_idle()) {
+            co_await fetcher->stop();
+            it = _broker_fetchers.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    if (needs_metadata_update) {
+        ssx::spawn_with_gate(
+          _gate, [this] { return _cluster->request_metadata_update(); });
+    }
+}
+
+fetcher& direct_consumer::get_fetcher(model::node_id id) {
+    auto it = _broker_fetchers.find(id);
+    if (it == _broker_fetchers.end()) {
+        vlog(_cluster->logger().debug, "Creating fetcher for broker: {}", id);
+        auto new_fetcher = std::make_unique<fetcher>(this, id);
+        try {
+            new_fetcher->start();
+            auto [it, _] = _broker_fetchers.emplace(id, std::move(new_fetcher));
+            return *it->second;
+        } catch (...) {
+            throw;
+        }
+    }
+    return *it->second;
+}
+
+ss::future<> direct_consumer::start() {
+    _metadata_callback_id = _cluster->register_metadata_cb(
+      [this](const metadata_response_data& d) { on_metadata_update(d); });
+    _started = true;
+    co_await update_fetchers();
+}
+
+ss::future<> direct_consumer::stop() {
+    _cluster->unregister_metadata_cb(_metadata_callback_id);
+    _fetched_data_queue->stop();
+    co_await _gate.close();
+
+    co_await ss::parallel_for_each(
+      _broker_fetchers, [](auto& pair) { return pair.second->stop(); });
+}
+
+ss::future<>
+direct_consumer::assign_partitions(chunked_vector<topic_assignment> topics) {
+    for (auto& t : topics) {
+        auto ec = model::validate_kafka_topic_name(t.topic);
+        if (ec) {
+            throw std::invalid_argument(fmt::format(
+              "Invalid topic name: {}, error: {}", t.topic, ec.message()));
+        }
+        for (auto& p : t.partitions) {
+            vlog(
+              _cluster->logger().trace,
+              "Assigning partition: {}/{} with offset: {}",
+              t.topic,
+              p.partition_id,
+              p.next_offset);
+            auto& sub = _subscriptions[t.topic][p.partition_id];
+            sub.fetch_offset = p.next_offset;
+        }
+    }
+    co_await update_fetchers();
+}
+
+ss::future<>
+direct_consumer::unassign_topics(chunked_vector<model::topic> topics) {
+    topic_partition_map<subscription> removals;
+    for (const auto& topic : topics) {
+        vlog(_cluster->logger().trace, "Unassigning topic: {}", topic);
+        auto state_it = _subscriptions.find(topic);
+        if (state_it == _subscriptions.end()) {
+            continue; // nothing to remove
+        }
+        removals[topic].reserve(state_it->second.size());
+        for (const auto& [p_id, sub] : state_it->second) {
+            removals[topic][p_id] = sub;
+        }
+        _subscriptions.erase(topic);
+    }
+    co_await update_fetchers(std::move(removals));
+}
+
+ss::future<> direct_consumer::unassign_partitions(
+  chunked_vector<model::topic_partition> partitions) {
+    topic_partition_map<subscription> removals;
+    for (const auto& tp : partitions) {
+        vlog(_cluster->logger().trace, "Unassigning partition: {}", tp);
+        auto state_it = _subscriptions.find(tp.topic);
+        if (state_it == _subscriptions.end()) {
+            continue; // nothing to remove
+        }
+        auto p_it = state_it->second.find(tp.partition);
+
+        if (p_it != state_it->second.end()) {
+            removals[tp.topic][tp.partition] = p_it->second;
+            state_it->second.erase(p_it);
+        }
+        if (state_it->second.empty()) {
+            _subscriptions.erase(state_it);
+        }
+    }
+    co_await update_fetchers(std::move(removals));
+}
+
+ss::future<> direct_consumer::handle_metadata_update() {
+    co_await update_fetchers();
+}
+
+void direct_consumer::on_metadata_update(const metadata_response_data&) {
+    ssx::spawn_with_gate(_gate, [this] { return handle_metadata_update(); });
+}
+
+direct_consumer::~direct_consumer() = default;
+
+std::ostream&
+operator<<(std::ostream& o, const direct_consumer::configuration& cfg) {
+    fmt::print(
+      o,
+      "{{ max_fetch_size: {}, partition_max_bytes: {}, reset_policy: {}, "
+      "max_wait_time: {}ms, isolation_level: {}, max_buffered_bytes: {}, "
+      "max_buffered_elements: {} }}",
+      cfg.max_fetch_size,
+      cfg.partition_max_bytes,
+      cfg.reset_policy,
+      cfg.max_wait_time.count(),
+      cfg.isolation_level,
+      cfg.max_buffered_bytes,
+      cfg.max_buffered_elements);
+
+    return o;
+}
+} // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "base/seastarx.h"
+#include "container/chunked_hash_map.h"
+#include "kafka/client/cluster.h"
+#include "kafka/client/direct_consumer/api_types.h"
+
+namespace kafka {
+struct metadata_response_data;
+namespace client {
+
+class fetcher;
+class data_queue;
+/**
+ * Simple direct Kafka consumer. (named after franz-go direct consumer which
+ * does not use consumer groups) It allows user to subscribe to a list of topic
+ * partitions. The consumer maintains broker fetch session, it reacts for the
+ * leadership changes and metadata updates. Fetch responses from all the brokers
+ * are exposed through `fetch_next()`. The fetch_next() returns whenever any
+ * ready to be consumer are available.
+ *
+ * Implementation details:
+ * NOTE:
+ * Fetcher and data queue classes should not be used directly, they are
+ * implementation details of the direct consumer, they were placed into separate
+ * files for readability.
+ *
+ * Direct consumer uses fetcher class to fetch data from the brokers. The
+ * fetcher is responsible for fetching data from a single broker. It maintains a
+ * list of partitions and corresponding fetch offsets. The fetcher loop
+ * constantly queries the broker for data and updates the fetch offsets based on
+ * the received data. Fetcher is also responsible for fetching offsets to apply
+ * the reset policy. Fetcher puts the fetched data into the parent consumer's
+ * data queue. The queue is then accessed through the `fetch_next()`
+ * method.
+ *
+ * The direct consumer maintains a list of partition subscriptions. It does not
+ * use the consumer groups to control the list of partitions to fetch from. When
+ * the subscription list is changed the consumer updates the fetchers state.
+ *
+ */
+class direct_consumer {
+public:
+    struct configuration {
+        int32_t min_bytes{1};
+        int32_t max_fetch_size{512_KiB};
+        int32_t partition_max_bytes{128_KiB};
+        offset_reset_policy reset_policy = offset_reset_policy::earliest;
+        std::chrono::milliseconds max_wait_time{100};
+        model::isolation_level isolation_level
+          = model::isolation_level::read_uncommitted;
+        // queue settings
+        size_t max_buffered_bytes{10_MiB};
+        size_t max_buffered_elements{10};
+        friend std::ostream& operator<<(std::ostream&, const configuration&);
+    };
+
+    direct_consumer(cluster& cluster, configuration cfg);
+
+    ~direct_consumer();
+    /**
+     * Starts the consumer, this method will start the fetchers and
+     * initialize the data queue.
+     * It will also register the metadata update callback.
+     * The method will return when the consumer is ready to fetch data.
+     *
+     * Not started consumer can still accept assignments, but the fetchers will
+     * only start after this method is called.
+     */
+    ss::future<> start();
+    /**
+     * Stops consumer
+     */
+    ss::future<> stop();
+
+    /**
+     * Returns all data available to fetch. If the timeout passed to this method
+     * is reached and there were no data to consume it will return an empty
+     * vector.
+     * The method returns an error whenever the consumer receives a
+     * non-retriable error from any of the brokers.
+     */
+    ss::future<fetches> fetch_next(std::chrono::milliseconds timeout);
+
+    /**
+     * Assign partitions to be fetched from, if partition is already being
+     * fetched from and is included in the vector its fetch offset will be
+     * updated
+     */
+    ss::future<> assign_partitions(chunked_vector<topic_assignment>);
+
+    /**
+     * Removes listed topics from assignment.
+     *
+     * NOTE: if the topic is not present in the current assignment it will be
+     * ignored.
+     */
+    ss::future<> unassign_topics(chunked_vector<model::topic> topics);
+
+    /**
+     * Removes listed topic partitions from assignment.
+     *
+     * NOTE: if the topic is not present in the current assignment it will be
+     * ignored.
+     */
+    ss::future<> unassign_partitions(
+      chunked_vector<model::topic_partition> topic_partitions);
+
+    /**
+     *  Updates consumer configuration, the configuration will be update when
+     * for the next fetch request.
+     */
+    void update_configuration(configuration cfg);
+
+private:
+    struct subscription {
+        std::optional<model::node_id> current_fetcher;
+        std::optional<kafka::offset> fetch_offset;
+    };
+    friend class fetcher;
+    void on_metadata_update(const metadata_response_data&);
+
+    ss::future<> handle_metadata_update();
+    ss::future<>
+    update_fetchers(topic_partition_map<subscription> removals = {});
+
+    fetcher& get_fetcher(model::node_id id);
+
+    cluster* _cluster;
+
+    offset_reset_policy _reset_policy
+      = offset_reset_policy::earliest; // default to earliest
+
+    configuration _config;
+
+    topic_partition_map<subscription> _subscriptions;
+    chunked_hash_map<model::node_id, std::unique_ptr<fetcher>> _broker_fetchers;
+    std::unique_ptr<data_queue> _fetched_data_queue;
+    ss::condition_variable _data_available;
+
+    cluster::callback_id _metadata_callback_id;
+    bool _started = false;
+    ss::gate _gate;
+};
+} // namespace client
+} // namespace kafka

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -1,0 +1,600 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/direct_consumer/fetcher.h"
+
+#include "kafka/client/direct_consumer/data_queue.h"
+#include "kafka/client/direct_consumer/direct_consumer.h"
+#include "kafka/client/errors.h"
+#include "ssx/async_algorithm.h"
+
+namespace kafka::client {
+static constexpr model::node_id client_replica_id{-1};
+static constexpr std::chrono::milliseconds error_backoff(200);
+
+data_queue& fetcher::queue() { return *_parent->_fetched_data_queue; }
+prefix_logger& fetcher::logger() { return _parent->_cluster->logger(); }
+
+fetcher::fetcher(direct_consumer* parent, model::node_id id)
+  : _parent(parent)
+  , _id(id)
+  , _state_lock("fetcher/state") {}
+
+void fetcher::start() {
+    ssx::repeat_until_gate_closed(_gate, [this] { return do_fetch(); });
+}
+
+ss::future<> fetcher::stop() {
+    vlog(logger().debug, "[broker: {}] Stopping fetcher", _id);
+    _as.request_abort();
+    _state_lock.broken();
+    _partitions_updated.broken();
+    return _gate.close();
+}
+
+ss::future<fetcher::partitions_with_epoch> fetcher::collect_partitions() {
+    auto lock = co_await _state_lock.get_units();
+    fetcher::partitions_with_epoch ret;
+    ret.partitions.reserve(_partitions.size());
+    ssx::async_counter cnt;
+    for (auto& [topic, partitions] : _partitions) {
+        partitions_to_process to_process;
+        to_process.topic = topic;
+
+        co_await ssx::async_for_each_counter(
+          cnt, partitions, [&to_process, &ret](auto& p_fs) {
+              partition_fetch_state& fetch_state = p_fs.second;
+              ret.assignment_epochs[to_process.topic][fetch_state.partition_id]
+                = fetch_state.assignment_epoch;
+              if (!fetch_state.fetch_offset.has_value()) {
+                  to_process.to_list_offsets.push_back(fetch_state);
+                  return;
+              }
+
+              to_process.to_include_in_fetch.push_back(fetch_state);
+          });
+        if (!to_process.empty()) {
+            ret.partitions.push_back(std::move(to_process));
+        }
+    }
+
+    co_return ret;
+}
+
+ss::future<fetch_request>
+fetcher::make_fetch_request(chunked_vector<partitions_to_process> to_process) {
+    // TODO: handle api versions here
+    // f.e. customize fetch request based on the version
+    fetch_request req;
+    req.data.replica_id = client_replica_id;
+    req.data.isolation_level = _parent->_config.isolation_level;
+    req.data.max_wait_ms = _parent->_config.max_wait_time;
+    req.data.max_bytes = _parent->_config.max_fetch_size;
+    req.data.min_bytes = _parent->_config.min_bytes;
+
+    // TODO: support incremental fetches, for now we always use full fetch
+    req.data.session_id = invalid_fetch_session_id;
+    req.data.session_epoch = final_fetch_session_epoch;
+
+    ssx::async_counter cnt;
+
+    for (auto& topic_partitions : to_process) {
+        fetch_topic f_topic;
+
+        if (topic_partitions.to_include_in_fetch.empty()) {
+            continue;
+        }
+        f_topic.topic = std::move(topic_partitions.topic);
+        f_topic.partitions.reserve(topic_partitions.to_include_in_fetch.size());
+        co_await ssx::async_for_each_counter(
+          cnt,
+          topic_partitions.to_include_in_fetch,
+          [this, &f_topic](const partition_fetch_state& f_state) {
+              fetch_partition f_partition;
+              f_partition.partition = f_state.partition_id;
+              f_partition.fetch_offset = kafka::offset_cast(
+                *f_state.fetch_offset);
+              f_partition.last_fetched_epoch = f_state.current_leader_epoch;
+              f_partition.partition_max_bytes
+                = _parent->_config.partition_max_bytes;
+              f_topic.partitions.push_back(std::move(f_partition));
+          });
+        req.data.topics.push_back(std::move(f_topic));
+    }
+
+    co_return req;
+}
+
+namespace {
+
+ss::future<chunked_vector<model::record_batch>>
+reader_to_chunked_vector(kafka::batch_reader reader) {
+    return model::consume_reader_to_chunked_vector(
+      model::make_record_batch_reader<kafka::batch_reader>(std::move(reader)),
+      model::no_timeout);
+}
+} // namespace
+
+bool fetcher::maybe_update_fetch_offset(
+  const model::topic& topic,
+  model::partition_id partition_id,
+  kafka::offset last_received,
+  assignment_epoch assignment_epoch) {
+    auto t_it = _partitions.find(topic);
+    if (t_it == _partitions.end()) {
+        return false;
+    }
+    auto p_it = t_it->second.find(partition_id);
+    if (p_it == t_it->second.end()) {
+        return false;
+    }
+    if (p_it->second.assignment_epoch != assignment_epoch) {
+        vlog(
+          logger().trace,
+          "[broker: {}] Ignoring {}/{} reply, assignment epoch changed, "
+          "request epoch: {}, current epoch: {}",
+          _id,
+          topic,
+          partition_id,
+          assignment_epoch,
+          p_it->second.assignment_epoch);
+        return false;
+    }
+
+    vlog(
+      logger().trace,
+      "[broker: {}] Updating {}/{} fetch offset to {}",
+      _id,
+      topic,
+      partition_id,
+      kafka::next_offset(last_received));
+    p_it->second.fetch_offset = kafka::next_offset(last_received);
+    return true;
+}
+
+ss::future<> fetcher::do_fetch() {
+    bool needs_backoff = false;
+    try {
+        co_await _partitions_updated.wait(
+          [this] { return !_partitions.empty(); });
+
+        /**
+         * Iterate once over all partitions that are assigned to the fetcher and
+         * collect necessary actions. f.e. list offsets or include in fetch
+         * request.
+         */
+        auto partitions_with_epochs = co_await collect_partitions();
+        auto assignment_epochs = std::move(
+          partitions_with_epochs.assignment_epochs);
+
+        auto list_offsets_err = co_await maybe_initialise_fetch_offsets(
+          partitions_with_epochs.partitions, assignment_epochs);
+        /**
+         */
+        if (list_offsets_err != kafka::error_code::none) {
+            vlog(
+              logger().debug,
+              "[broker: {}] list offsets error: {}",
+              _id,
+              list_offsets_err);
+            if (is_retriable_error(list_offsets_err)) {
+                needs_backoff = true;
+            } else {
+                // propagate not retriable error to the queue
+                co_await queue().push_error(list_offsets_err);
+            }
+        }
+
+        auto req = co_await make_fetch_request(
+          std::move(partitions_with_epochs.partitions));
+
+        if (_as.abort_requested()) {
+            // if the abort was requested, we should not dispatch the request
+            // and just return
+            co_return;
+        }
+        // TODO: cache the version of the fetch request
+        auto version = co_await get_fetch_request_version();
+        auto response = co_await _parent->_cluster->dispatch_to(
+          _id, std::move(req), version);
+        auto fetch_result = co_await process_fetch_response(
+          std::move(response), assignment_epochs);
+
+        if (fetch_result.has_error()) {
+            if (is_retriable_error(fetch_result.error())) {
+                needs_backoff = true;
+            } else {
+                // propagate non retriable error to the queue
+                co_await queue().push_error(fetch_result.error());
+                co_return;
+            }
+        }
+
+        auto fetch_result_value = std::move(fetch_result.value());
+        if (fetch_result_value.needs_metadata_update) {
+            // if we need to update metadata, we should do it
+            // so that we can retry fetching the partitions later
+            needs_backoff = true;
+        }
+
+        if (!fetch_result_value.topics.empty()) {
+            co_await queue().push(
+              std::move(fetch_result_value.topics),
+              fetch_result_value.total_bytes);
+        }
+
+    } catch (...) {
+        if (ssx::is_shutdown_exception(std::current_exception())) {
+            // if the exception is a shutdown exception, we should not log it
+            // and just return
+            co_return;
+        }
+        vlog(
+          logger().warn,
+          "error encountered while fetching from broker with id: {} - {}",
+          _id,
+          std::current_exception());
+        needs_backoff = true;
+    }
+    if (needs_backoff) {
+        co_await _parent->_cluster->request_metadata_update();
+        co_await ss::sleep_abortable(error_backoff, _as);
+    }
+}
+
+fetcher::assignment_epoch fetcher::find_assignment_epoch(
+  const model::topic& topic,
+  model::partition_id partition,
+  const topic_partition_map<assignment_epoch>& epochs) {
+    auto it = epochs.find(topic);
+    vassert(
+      it != epochs.end(), "assignment epoch for topic {} not found", topic);
+
+    auto p_it = it->second.find(partition);
+    vassert(
+      p_it != it->second.end(),
+      "assignment epoch for partition {}/{} not found",
+      topic,
+      partition);
+
+    return p_it->second;
+}
+
+ss::future<kafka_result<fetcher::fetch_response_content>>
+fetcher::process_fetch_response(
+  fetch_response resp, const topic_partition_map<assignment_epoch>& epochs) {
+    if (resp.data.error_code != kafka::error_code::none) {
+        co_return resp.data.error_code;
+    }
+    // Hold the lock here as the fetch response processing updates the fetch
+    // offsets, we do not want this to interfere with assignment updates.
+    auto lock = co_await _state_lock.get_units();
+
+    fetch_response_content result;
+    result.topics.reserve(resp.data.responses.size());
+    for (auto& topic_response : resp.data.responses) {
+        if (topic_response.partitions.empty()) {
+            // no partitions in the response, skip it
+            continue;
+        }
+        fetched_topic_data topic_data;
+        topic_data.topic = std::move(topic_response.topic);
+        topic_data.partitions.reserve(topic_response.partitions.size());
+
+        for (auto& part_response : topic_response.partitions) {
+            fetched_partition_data part_data;
+            part_data.error = part_response.error_code;
+            part_data.partition_id = part_response.partition_index;
+
+            if (part_response.error_code != kafka::error_code::none) {
+                if (is_retriable_error(part_response.error_code)) {
+                    vlog(
+                      logger().debug,
+                      "[broker: {}] {}/{} retriable fetch error: {}",
+                      _id,
+                      topic_data.topic,
+                      part_data.partition_id,
+                      part_response.error_code);
+
+                    result.needs_metadata_update = true;
+                    // skip partition in the result, but mark that we
+                    // need to update metadata
+                    // so that we can retry fetching it later
+                    continue;
+                }
+                vlog(
+                  logger().warn,
+                  "[broker: {}] {}/{} fetch error: {}",
+                  _id,
+                  topic_data.topic,
+                  part_data.partition_id,
+                  part_response.error_code);
+            } else {
+                part_data.high_watermark = model::offset_cast(
+                  part_response.high_watermark);
+                part_data.last_stable_offset = model::offset_cast(
+                  part_response.last_stable_offset);
+                part_data.leader_epoch
+                  = part_response.current_leader.leader_epoch;
+                part_data.aborted_transactions = std::move(
+                  part_response.aborted_transactions);
+
+                vlog(
+                  logger().trace,
+                  "[broker: {}] topic: {}, partition fetch response: {}",
+                  _id,
+                  topic_data.topic,
+                  part_response);
+
+                if (
+                  !part_response.records.has_value()
+                  || part_response.records->is_end_of_stream()) {
+                    continue;
+                }
+                topic_data.total_bytes += part_response.records->size_bytes();
+                part_data.data = co_await reader_to_chunked_vector(
+                  std::move(part_response.records.value()));
+
+                maybe_update_fetch_offset(
+                  topic_data.topic,
+                  part_data.partition_id,
+                  model::offset_cast(part_data.data.back().last_offset()),
+                  find_assignment_epoch(
+                    topic_data.topic, part_data.partition_id, epochs));
+            }
+            topic_data.partitions.push_back(std::move(part_data));
+        }
+        result.total_bytes += topic_data.total_bytes;
+        if (topic_data.partitions.empty()) {
+            continue;
+        }
+        result.topics.push_back(std::move(topic_data));
+    }
+
+    co_return result;
+}
+
+namespace {
+model::timestamp timestamp_for_offset_reset_policy(offset_reset_policy policy) {
+    switch (policy) {
+    case offset_reset_policy::earliest:
+        return list_offsets_request::earliest_timestamp;
+    case offset_reset_policy::latest:
+        return list_offsets_request::latest_timestamp;
+    }
+}
+} // namespace
+
+ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
+  const chunked_vector<partitions_to_process>& partitions,
+  const topic_partition_map<assignment_epoch>& epochs) {
+    const auto timestamp = timestamp_for_offset_reset_policy(
+      _parent->_config.reset_policy);
+
+    list_offsets_request req;
+    req.data.topics.reserve(partitions.size());
+    for (auto& topic_partitions : partitions) {
+        if (topic_partitions.to_list_offsets.empty()) {
+            // no partitions to fetch offsets for
+            continue;
+        }
+        list_offset_topic l_topic;
+        l_topic.name = topic_partitions.topic;
+        l_topic.partitions.reserve(topic_partitions.to_list_offsets.size());
+        for (auto& fetch_state : topic_partitions.to_list_offsets) {
+            // we need to fetch the offset for this partition
+            list_offset_partition l_partition;
+            l_partition.partition_index = fetch_state.partition_id;
+            l_partition.timestamp = timestamp;
+            l_partition.current_leader_epoch = fetch_state.current_leader_epoch;
+
+            l_topic.partitions.push_back(std::move(l_partition));
+        }
+
+        req.data.topics.push_back(std::move(l_topic));
+    }
+
+    if (req.data.topics.empty()) {
+        // no partitions to fetch offsets for
+        co_return error_code::none;
+    }
+
+    auto offsets = co_await do_list_offsets(std::move(req));
+    if (offsets.has_error()) {
+        if (is_retriable_error(offsets.error())) {
+            vlog(
+              logger().info,
+              "list_offsets request failed with retriable error: {}",
+              offsets.error());
+        } else {
+            vlog(
+              logger().warn,
+              "list_offsets request failed with an error: {}",
+              offsets.error());
+        }
+        co_return offsets.error();
+    }
+    // TODO: what should we do with the error code in the response?
+    kafka::error_code error = kafka::error_code::none;
+    for (auto& topic : offsets.value()) {
+        for (auto& partition_offset : topic.offsets) {
+            if (partition_offset.error_code != kafka::error_code::none) {
+                if (is_retriable_error(partition_offset.error_code)) {
+                    vlog(
+                      logger().debug,
+                      "[broker: {}] {}/{} retriable list_offsets error: {}",
+                      _id,
+                      topic.topic,
+                      partition_offset.partition_id,
+                      partition_offset.error_code);
+                }
+                // Only overwrite if we don't have an error, or if current error
+                // is retriable but new error is not retriable
+                if (error == kafka::error_code::none ||
+                  (is_retriable_error(error) && !is_retriable_error(partition_offset.error_code))) {
+                    error = partition_offset.error_code;
+                }
+                continue;
+            }
+
+            auto t_it = _partitions.find(topic.topic);
+            if (t_it == _partitions.end()) {
+                continue;
+            }
+            auto p_it = t_it->second.find(partition_offset.partition_id);
+            if (p_it == t_it->second.end()) {
+                continue;
+            }
+            auto request_epoch = find_assignment_epoch(
+              topic.topic, partition_offset.partition_id, epochs);
+            if (
+              find_assignment_epoch(
+                topic.topic, partition_offset.partition_id, epochs)
+              != p_it->second.assignment_epoch) {
+                vlog(
+                  logger().trace,
+                  "[broker: {}] Skipping partition {}/{} list offset response "
+                  "as assignment epoch has changed. request_epoch: {}, "
+                  "current_epoch: {}",
+                  _id,
+                  topic.topic,
+                  partition_offset.partition_id,
+                  partition_offset.offset,
+                  request_epoch,
+                  p_it->second.assignment_epoch);
+            }
+            vlog(
+              logger().info,
+              "[broker: {}] Resetting partition {}/{} fetch offset to: {}",
+              _id,
+              topic.topic,
+              partition_offset.partition_id,
+              partition_offset.offset);
+            p_it->second.fetch_offset = partition_offset.offset;
+        }
+    }
+
+    co_return error;
+}
+
+ss::future<api_version> fetcher::get_fetch_request_version() const {
+    auto version = co_await _parent->_cluster->supported_api_versions(
+      _id, kafka::fetch_api::key);
+    if (version) {
+        co_return std::min(version->max, kafka::fetch_api::max_valid);
+    }
+    // if the version is not supported, we fallback to the minimum version
+    // which is 1, this is the first version of the Fetch API that use the new
+    // batch format
+    co_return api_version{1};
+}
+
+ss::future<api_version> fetcher::get_list_offsets_request_version() const {
+    auto version = co_await _parent->_cluster->supported_api_versions(
+      _id, kafka::list_offsets_api::key);
+    if (version) {
+        co_return std::min(version->max, kafka::list_offsets_api::max_valid);
+    }
+    co_return kafka::list_offsets_api::min_valid;
+}
+
+ss::future<> fetcher::assign_partition(
+  model::topic_partition_view tp, std::optional<kafka::offset> offset) {
+    auto lock = co_await _state_lock.get_units();
+    vlog(
+      logger().debug,
+      "[broker: {}] Assigned partition: {} with offset: {}",
+      _id,
+      tp,
+      offset);
+
+    _partitions[tp.topic][tp.partition] = partition_fetch_state{
+      .partition_id = tp.partition,
+      .fetch_offset = offset,
+      .assignment_epoch = next_epoch(),
+    };
+
+    _partitions_updated.signal();
+    co_return;
+}
+ss::future<std::optional<kafka::offset>>
+fetcher::unassign_partition(model::topic_partition_view tp_v) {
+    auto lock = co_await _state_lock.get_units();
+    auto it = _partitions.find(tp_v.topic);
+    if (it == _partitions.end()) {
+        // partition not found, nothing to unassign
+        co_return std::nullopt;
+    }
+    auto& partitions = it->second;
+    auto p_it = partitions.find(tp_v.partition);
+    if (p_it == partitions.end()) {
+        // partition not found, nothing to unassign
+        co_return std::nullopt;
+    }
+    vlog(
+      logger().debug,
+      "[broker: {}] Removing partition: {} assignment",
+      _id,
+      tp_v);
+    // TODO: for fetch sessions we will need to mark partitions to deletion so
+    // they can be removed from the fetch session
+    auto fetch_offset = p_it->second.fetch_offset;
+    partitions.erase(p_it);
+    if (partitions.empty()) {
+        // if there are no partitions left for this topic, remove the topic
+        _partitions.erase(it);
+    }
+
+    _partitions_updated.signal();
+    co_return fetch_offset;
+}
+
+ss::future<kafka_result<chunked_vector<topic_partition_offsets>>>
+fetcher::do_list_offsets(list_offsets_request req) {
+    try {
+        auto version = co_await get_list_offsets_request_version();
+        auto reply = co_await _parent->_cluster->dispatch_to(
+          _id, std::move(req), version);
+        chunked_vector<topic_partition_offsets> offsets;
+        offsets.reserve(reply.data.topics.size());
+
+        for (auto& topic : reply.data.topics) {
+            topic_partition_offsets topics;
+            topics.topic = std::move(topic.name);
+            topics.offsets.reserve(topic.partitions.size());
+            for (auto& partition : topic.partitions) {
+                topics.offsets.push_back(partition_offset{
+                  .partition_id = partition.partition_index,
+                  .error_code = partition.error_code,
+                  .leader_epoch = partition.leader_epoch,
+                  .offset = model::offset_cast(partition.offset),
+                });
+            }
+            offsets.push_back(std::move(topics));
+        }
+        co_return offsets;
+    } catch (const broker_error& e) {
+        vlog(
+          logger().warn,
+          "list_offsets request to broker {} failed with broker error: {}",
+          _id,
+          e);
+        co_return e.error;
+    } catch (...) {
+        vlog(
+          logger().warn,
+          "list_offsets request to broker {} failed with an error: {}",
+          _id,
+          std::current_exception());
+        co_return kafka::error_code::unknown_server_error;
+    }
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "container/intrusive_list_helpers.h"
+#include "kafka/client/direct_consumer/api_types.h"
+#include "kafka/client/direct_consumer/data_queue.h"
+#include "kafka/protocol/fetch.h"
+#include "kafka/protocol/list_offset.h"
+#include "model/fundamental.h"
+#include "utils/mutex.h"
+#include "utils/prefix_logger.h"
+
+#include <seastar/core/rwlock.hh>
+namespace kafka::client {
+class direct_consumer;
+
+struct fetch_session_state {
+    enum class state {
+        none,
+        need_full_fetch,
+        incremental_fetch,
+        needs_close,
+    };
+    kafka::fetch_session_id _fetch_session_id{kafka::invalid_fetch_session_id};
+    kafka::fetch_session_epoch _fetch_session_epoch{
+      kafka::initial_fetch_session_epoch};
+
+    void update_fetch_session(kafka::fetch_session_id id) {
+        _fetch_session_id = id;
+        _fetch_session_epoch++;
+    }
+};
+
+/**
+ * Class responsible for fetching data from a single broker. It is maintaining a
+ * list of partitions and corresponding fetch offsets. The fetcher loop
+ * constantly querying the broker for data and updates the fetch offsets based
+ * on the received data. Fetcher is also responsible for fetching offsets to
+ * apply the reset policy.
+ *
+ * Fetcher put the fetched data into the parent consumer's data queue.
+ *
+ * Fetcher locks the assignment state while changing assignments, preparing the
+ * fetch request and processing the response. Every time the partition
+ * assignment is updated its corresponding assignment epoch is incremented.
+ * Partition fetch responses with stale assignment epoch are ignored. This
+ * concurrency control mechanism guarantees that the fetcher will not update its
+ * subscriptions with the stale information from the request when it was changed
+ * more than once while it was waiting for the response.
+ *
+ *
+ *
+ * TODO:
+ * - support incremental fetches
+ * - support leader epochs
+ * - support server side throttling and quotas
+ */
+class fetcher {
+public:
+    fetcher(direct_consumer* parent, model::node_id id);
+    void start();
+
+    ss::future<> stop();
+    /**
+     * Assign fetcher partitions, it can be used to assign new partitions or
+     * update the fetch offsets for the already assigned partitions.
+     */
+    ss::future<> assign_partition(
+      model::topic_partition_view, std::optional<kafka::offset>);
+    /**
+     * Unassign partition from the fetcher, it will stop fetching data for the
+     * partition and remove it from the fetcher state. After the unassignment
+     * the fetcher will not return any data for the partition.
+     *
+     * Returned offset can be used to reassign the partition later to different
+     * fetcher to continue reading from the same offset.
+     */
+
+    ss::future<std::optional<kafka::offset>>
+      unassign_partition(model::topic_partition_view);
+
+    bool is_idle() const { return _partitions.empty(); }
+
+private:
+    using assignment_epoch = named_type<uint64_t, struct fetcher_epoch_tag>;
+    struct partition_fetch_state {
+        model::partition_id partition_id;
+        std::optional<kafka::offset> fetch_offset;
+        kafka::offset high_watermark;
+        leader_epoch current_leader_epoch{kafka::invalid_leader_epoch};
+        intrusive_list_hook _hook;
+        assignment_epoch assignment_epoch{0};
+
+        bool include_in_fetch_request() const {
+            return fetch_offset.has_value();
+        }
+    };
+    using state_list
+      = intrusive_list<partition_fetch_state, &partition_fetch_state::_hook>;
+    struct partitions_to_process {
+        model::topic topic;
+        state_list to_include_in_fetch;
+        state_list to_list_offsets;
+
+        bool empty() const {
+            return to_include_in_fetch.empty() && to_list_offsets.empty();
+        }
+    };
+    struct partitions_with_epoch {
+        topic_partition_map<assignment_epoch> assignment_epochs;
+        chunked_vector<partitions_to_process> partitions;
+    };
+    struct fetch_response_content {
+        chunked_vector<fetched_topic_data> topics;
+        size_t total_bytes{0};
+        bool needs_metadata_update{false};
+    };
+
+    static assignment_epoch find_assignment_epoch(
+      const model::topic& topic,
+      model::partition_id partition,
+      const topic_partition_map<assignment_epoch>& epochs);
+
+    ss::future<api_version> get_fetch_request_version() const;
+    ss::future<api_version> get_list_offsets_request_version() const;
+    ss::future<> do_fetch();
+    ss::future<partitions_with_epoch> collect_partitions();
+    ss::future<kafka::error_code> maybe_initialise_fetch_offsets(
+      const chunked_vector<partitions_to_process>&,
+      const topic_partition_map<assignment_epoch>& epochs);
+    ss::future<fetch_request>
+      make_fetch_request(chunked_vector<partitions_to_process>);
+
+    ss::future<kafka_result<fetch_response_content>> process_fetch_response(
+      fetch_response resp, const topic_partition_map<assignment_epoch>& epochs);
+    /**
+     * Returns false if the partition was not found or the fetch offset was
+     * not updated.
+     * This indicates that the fetch response should be ignored.
+     */
+    bool maybe_update_fetch_offset(
+      const model::topic&,
+      model::partition_id,
+      kafka::offset,
+      assignment_epoch);
+
+    ss::future<kafka_result<chunked_vector<topic_partition_offsets>>>
+      do_list_offsets(list_offsets_request);
+
+    data_queue& queue();
+    prefix_logger& logger();
+    assignment_epoch next_epoch() { return ++_epoch; }
+
+    direct_consumer* _parent;
+    model::node_id _id;
+    fetch_session_state _session_state;
+    topic_partition_map<partition_fetch_state> _partitions;
+    ss::condition_variable _partitions_updated;
+    ss::gate _gate;
+    mutex _state_lock;
+    assignment_epoch _epoch{0};
+    ss::abort_source _as;
+};
+} // namespace kafka::client

--- a/src/v/kafka/client/errors.h
+++ b/src/v/kafka/client/errors.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/protocol/errors.h"
+namespace kafka::client {
+/**
+ * List of retriable errors that can be returned by the broker. This list is
+ * slightly different from the list of retriable errors defined in the protocol.
+ * (based on the franz-go retriable errors list)
+ */
+inline bool is_retriable_error(kafka::error_code ec) {
+    switch (ec) {
+    case error_code::none:
+        return false;
+    case error_code::offset_out_of_range:
+    case error_code::unknown_topic_or_partition:
+    case error_code::corrupt_message:
+    case error_code::leader_not_available:
+    case error_code::not_leader_for_partition:
+    case error_code::network_exception:
+    case error_code::coordinator_load_in_progress:
+    case error_code::coordinator_not_available:
+    case error_code::not_enough_replicas:
+    case error_code::not_enough_replicas_after_append:
+    case error_code::not_controller:
+    case error_code::fetch_session_id_not_found:
+    case error_code::invalid_fetch_session_epoch:
+    case error_code::fenced_leader_epoch:
+    case error_code::unknown_leader_epoch:
+    case error_code::listener_not_found:
+    case error_code::kafka_storage_error:
+    case error_code::offset_not_available:
+    case error_code::preferred_leader_not_available:
+    case error_code::unstable_offset_commit:
+    case error_code::throttling_quota_exceeded:
+        return true;
+    case error_code::unknown_server_error:
+    case error_code::invalid_fetch_size:
+    case error_code::request_timed_out:
+    case error_code::broker_not_available:
+    case error_code::replica_not_available:
+    case error_code::message_too_large:
+    case error_code::stale_controller_epoch:
+    case error_code::offset_metadata_too_large:
+    case error_code::not_coordinator:
+    case error_code::invalid_topic_exception:
+    case error_code::record_list_too_large:
+    case error_code::invalid_required_acks:
+    case error_code::illegal_generation:
+    case error_code::inconsistent_group_protocol:
+    case error_code::invalid_group_id:
+    case error_code::unknown_member_id:
+    case error_code::invalid_session_timeout:
+    case error_code::rebalance_in_progress:
+    case error_code::invalid_commit_offset_size:
+    case error_code::topic_authorization_failed:
+    case error_code::group_authorization_failed:
+    case error_code::cluster_authorization_failed:
+    case error_code::invalid_timestamp:
+    case error_code::unsupported_sasl_mechanism:
+    case error_code::illegal_sasl_state:
+    case error_code::unsupported_version:
+    case error_code::topic_already_exists:
+    case error_code::invalid_partitions:
+    case error_code::invalid_replication_factor:
+    case error_code::invalid_replica_assignment:
+    case error_code::invalid_config:
+    case error_code::invalid_request:
+    case error_code::unsupported_for_message_format:
+    case error_code::policy_violation:
+    case error_code::out_of_order_sequence_number:
+    case error_code::duplicate_sequence_number:
+    case error_code::invalid_producer_epoch:
+    case error_code::invalid_txn_state:
+    case error_code::invalid_producer_id_mapping:
+    case error_code::invalid_transaction_timeout:
+    case error_code::concurrent_transactions:
+    case error_code::transaction_coordinator_fenced:
+    case error_code::transactional_id_authorization_failed:
+    case error_code::security_disabled:
+    case error_code::operation_not_attempted:
+    case error_code::log_dir_not_found:
+    case error_code::sasl_authentication_failed:
+    case error_code::unknown_producer_id:
+    case error_code::reassignment_in_progress:
+    case error_code::delegation_token_auth_disabled:
+    case error_code::delegation_token_not_found:
+    case error_code::delegation_token_owner_mismatch:
+    case error_code::delegation_token_request_not_allowed:
+    case error_code::delegation_token_authorization_failed:
+    case error_code::delegation_token_expired:
+    case error_code::invalid_principal_type:
+    case error_code::non_empty_group:
+    case error_code::group_id_not_found:
+    case error_code::topic_deletion_disabled:
+    case error_code::unsupported_compression_type:
+    case error_code::stale_broker_epoch:
+    case error_code::member_id_required:
+    case error_code::group_max_size_reached:
+    case error_code::no_reassignment_in_progress:
+    case error_code::fenced_instance_id:
+    case error_code::group_subscribed_to_topic:
+    case error_code::invalid_record:
+    case error_code::resource_not_found:
+    case error_code::duplicate_resource:
+    case error_code::unacceptable_credential:
+    case error_code::transactional_id_not_found:
+        return false;
+    }
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -463,3 +463,23 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "direct_consumer_fixture_test",
+    timeout = "short",
+    srcs = [
+        "direct_consumer_fixture_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster/tests:cluster_test_fixture",
+        "//src/v/kafka/client:brokers",
+        "//src/v/kafka/client:cluster",
+        "//src/v/kafka/client/direct_consumer",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/server/tests:kafka_test_utils",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:gtest",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -428,3 +428,18 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "data_queue_test",
+    timeout = "short",
+    srcs = [
+        "data_queue_test.cc",
+    ],
+    deps = [
+        "//src/v/kafka/client/direct_consumer",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -46,6 +46,7 @@ redpanda_test_cc_library(
     include_prefix = "kafka/client/test",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/container:chunked_hash_map",
         "//src/v/kafka/client:brokers",
         "//src/v/kafka/client:logger",
     ],
@@ -443,3 +444,22 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "direct_consumer_test",
+    timeout = "short",
+    srcs = [
+        "direct_consumer_test.cc",
+    ],
+    deps = [
+        ":cluster_mock",
+        "//src/v/kafka/client:brokers",
+        "//src/v/kafka/client:cluster",
+        "//src/v/kafka/client/direct_consumer",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+

--- a/src/v/kafka/client/test/cluster_mock.cc
+++ b/src/v/kafka/client/test/cluster_mock.cc
@@ -90,6 +90,23 @@ ss::future<response_t> cluster_mock::handle_metadata_request(
           .rack = b.second.rack,
         });
     }
+
+    for (auto& [topic, partitions] : _topics) {
+        metadata_response::topic md_topic;
+        md_topic.name = topic;
+        md_topic.partitions.reserve(partitions.size());
+        for (auto& [part_id, part_meta] : partitions) {
+            md_topic.partitions.push_back(metadata_response::partition{
+              .partition_index = part_id,
+              .leader_id = part_meta.leader,
+              .leader_epoch = part_meta.leader_epoch,
+              .replica_nodes = part_meta.replicas});
+        }
+        r_data.topics.push_back(std::move(md_topic));
+    }
+
+    r_data.controller_id = _brokers.begin()->first;
+
     co_return metadata_response{.data = std::move(r_data)};
 }
 
@@ -152,6 +169,38 @@ ss::future<response_t> cluster_mock::handle(
         return do_handle<decltype(r)>(node_id, std::move(r), version, as)
           .then([](auto resp) { return response_t{std::move(resp)}; });
     });
+}
+
+void cluster_mock::add_topic(
+  model::topic topic_name, size_t partition_count, size_t replication_factor) {
+    if (_topics.contains(topic_name)) {
+        // Topic already exists, do not overwrite
+        throw std::invalid_argument(
+          fmt::format("Topic {} already exists", topic_name));
+    }
+    if (replication_factor > _brokers.size()) {
+        throw std::invalid_argument(fmt::format(
+          "Replication factor {} exceeds available brokers",
+          replication_factor));
+    }
+
+    auto cluster_nodes = get_broker_ids();
+    std::ranges::sort(cluster_nodes);
+
+    for (auto p_id : std::views::iota(size_t(0), partition_count)) {
+        partition_metadata p_md{
+          .id = model::partition_id(p_id), .leader = model::node_id(-1)};
+
+        std::copy_n(
+          cluster_nodes.begin(),
+          replication_factor,
+          std::back_inserter(p_md.replicas));
+        std::ranges::rotate(cluster_nodes, cluster_nodes.begin() + 1);
+        p_md.leader = p_md.replicas[0];
+        p_md.leader_epoch = kafka::invalid_leader_epoch;
+
+        _topics[topic_name].emplace(model::partition_id(p_id), std::move(p_md));
+    }
 }
 
 cluster_mock::cluster_mock()

--- a/src/v/kafka/client/test/cluster_mock.h
+++ b/src/v/kafka/client/test/cluster_mock.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "container/chunked_hash_map.h"
 #include "kafka/client/broker.h"
 #include "kafka/client/brokers.h"
 #include "kafka/client/logger.h"
@@ -65,6 +66,14 @@ private:
 using mock_handler = std::function<ss::future<response_t>(
   model::node_id, request_t, api_version)>;
 
+struct partition_metadata {
+    model::partition_id id;
+    model::node_id leader;
+    std::vector<model::node_id> replicas;
+    kafka::leader_epoch leader_epoch = kafka::invalid_leader_epoch;
+    model::offset start_offset = model::offset(0);
+    model::offset high_watermark = model::offset(0);
+};
 class cluster_mock {
 public:
     cluster_mock();
@@ -94,6 +103,19 @@ public:
         _broker_api_versions[id].insert_or_assign(key, range);
     }
 
+    void add_topic(
+      model::topic topic_name,
+      size_t partition_count,
+      size_t replication_factor);
+
+    std::vector<model::node_id> get_broker_ids() const {
+        return std::ranges::views::keys(_brokers)
+               | std::ranges::to<std::vector<model::node_id>>();
+    }
+
+    auto& get_topics() { return _topics; }
+
+public:
     supported_versions default_supported_versions;
 
 private:
@@ -131,7 +153,12 @@ private:
     absl::flat_hash_map<model::node_id, broker_info> _brokers;
     absl::flat_hash_map<model::node_id, supported_versions>
       _broker_api_versions;
+    chunked_hash_map<
+      model::topic,
+      chunked_hash_map<model::partition_id, partition_metadata>>
+      _topics;
 
+    std::optional<model::node_id> _controller_id;
     prefix_logger _logger;
 };
 

--- a/src/v/kafka/client/test/data_queue_test.cc
+++ b/src/v/kafka/client/test/data_queue_test.cc
@@ -1,0 +1,230 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/client/direct_consumer/data_queue.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+using namespace kafka::client;
+
+static constexpr size_t max_bytes = 1024;
+static constexpr size_t max_count = 10;
+
+chunked_vector<fetched_topic_data>
+make_data(int topic_count, int bytes_per_topic) {
+    chunked_vector<fetched_topic_data> data;
+    data.reserve(topic_count);
+    for (auto d = 0; d < topic_count; ++d) {
+        fetched_topic_data topic_data;
+        topic_data.topic = model::topic(fmt::format("topic-{}", d));
+        topic_data.total_bytes = bytes_per_topic;
+        data.push_back(std::move(topic_data));
+    }
+    return data;
+}
+
+TEST(DataQueueTest, TestIfCanInsertWorks) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+    ASSERT_TRUE(queue.can_insert(50));
+    ASSERT_TRUE(queue.can_insert(20));
+    ASSERT_TRUE(queue.can_insert(300));
+    // queue is empty, so we can insert a single entry that exceeds the size
+    // limit
+    ASSERT_TRUE(queue.can_insert(2048));
+    auto f = queue.push(make_data(1, 512), 1 * 512);
+    // future should be ready immediately
+    ASSERT_TRUE(f.available());
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 512);
+    ASSERT_TRUE(queue.can_insert(512));
+    ASSERT_FALSE(queue.can_insert(513));
+    ASSERT_FALSE(queue.can_insert(2049));
+}
+
+TEST(DataQueueTest, TestPushPop) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    queue.push(make_data(1, 512), 512).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 512);
+
+    queue.push(make_data(4, 64), 256).get();
+    ASSERT_EQ(queue.size(), 2);
+    ASSERT_EQ(queue.current_bytes(), 768);
+
+    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 256);
+
+    auto fetches_2 = queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    ASSERT_EQ(fetches.value().size(), 1);
+    ASSERT_EQ(fetches.value()[0].total_bytes, 512);
+    ASSERT_EQ(fetches_2.value().size(), 4);
+}
+
+TEST(DataQueueTest, TestPushError) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    queue.push_error(kafka::error_code::broker_not_available).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    ASSERT_TRUE(fetches.has_error());
+    ASSERT_EQ(fetches.error(), kafka::error_code::broker_not_available);
+}
+
+TEST(DataQueueTest, TestPopTimeout) {
+    data_queue queue(max_bytes, max_count);
+
+    ASSERT_THROW(
+      queue.pop(std::chrono::milliseconds(10)).get(),
+      ss::condition_variable_timed_out);
+}
+
+TEST(DataQueueTest, TestMaxCountLimit) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    for (size_t i = 0; i < max_count; ++i) {
+        queue.push(make_data(1, 10), 10).get();
+    }
+    ASSERT_EQ(queue.size(), max_count);
+    ASSERT_EQ(queue.current_bytes(), max_count * 10);
+
+    ASSERT_FALSE(queue.can_insert(10));
+
+    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(fetches.value().size(), 1);
+    ASSERT_EQ(queue.size(), max_count - 1);
+    ASSERT_EQ(queue.current_bytes(), (max_count - 1) * 10);
+
+    ASSERT_TRUE(queue.can_insert(10));
+}
+
+TEST(DataQueueTest, TestConfigurationSetters) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    queue.push(make_data(1, 500), 500).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 500);
+    ASSERT_TRUE(queue.can_insert(524));
+    ASSERT_FALSE(queue.can_insert(525));
+
+    queue.set_max_bytes(2048);
+    ASSERT_EQ(queue.current_bytes(), 500);
+    ASSERT_TRUE(queue.can_insert(1548));
+    ASSERT_FALSE(queue.can_insert(1549));
+
+    queue.set_max_count(5);
+    for (size_t i = 1; i < 5; ++i) {
+        queue.push(make_data(1, 10), 10).get();
+    }
+    ASSERT_EQ(queue.size(), 5);
+    ASSERT_EQ(queue.current_bytes(), 500 + 4 * 10);
+    ASSERT_FALSE(queue.can_insert(10));
+
+    queue.set_max_count(20);
+    ASSERT_EQ(queue.current_bytes(), 500 + 4 * 10);
+    ASSERT_TRUE(queue.can_insert(10));
+}
+
+TEST(DataQueueTest, TestBlockingPushWhenFull) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    for (size_t i = 0; i < max_count; ++i) {
+        queue.push(make_data(1, 50), 50).get();
+    }
+    ASSERT_EQ(queue.size(), max_count);
+    ASSERT_EQ(queue.current_bytes(), max_count * 50);
+
+    ASSERT_FALSE(queue.can_insert(50));
+
+    auto push_future = queue.push(make_data(1, 50), 50);
+    ASSERT_FALSE(push_future.available());
+    ASSERT_EQ(queue.size(), max_count);
+    ASSERT_EQ(queue.current_bytes(), max_count * 50);
+
+    queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), max_count - 1);
+    ASSERT_EQ(queue.current_bytes(), (max_count - 1) * 50);
+
+    push_future.get();
+    ASSERT_EQ(queue.size(), max_count);
+    ASSERT_EQ(queue.current_bytes(), max_count * 50);
+}
+
+TEST(DataQueueTest, TestEdgeCases) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    ASSERT_TRUE(queue.can_insert(2048));
+    queue.push(make_data(1, 2048), 2048).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 2048);
+    ASSERT_FALSE(queue.can_insert(1));
+
+    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(fetches.value().size(), 1);
+    ASSERT_EQ(fetches.value()[0].total_bytes, 2048);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    ASSERT_TRUE(queue.can_insert(1024));
+}
+
+TEST(DataQueueTest, TestSizeAndCurrentBytesTracking) {
+    data_queue queue(max_bytes, max_count);
+
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    queue.push(make_data(2, 100), 200).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 200);
+
+    queue.push(make_data(1, 300), 300).get();
+    ASSERT_EQ(queue.size(), 2);
+    ASSERT_EQ(queue.current_bytes(), 500);
+
+    queue.push_error(kafka::error_code::request_timed_out).get();
+    ASSERT_EQ(queue.size(), 3);
+    ASSERT_EQ(queue.current_bytes(), 500);
+
+    queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), 2);
+    ASSERT_EQ(queue.current_bytes(), 300);
+
+    queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), 1);
+    ASSERT_EQ(queue.current_bytes(), 0);
+
+    queue.pop(std::chrono::milliseconds(100)).get();
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+}

--- a/src/v/kafka/client/test/direct_consumer_fixture_test.cc
+++ b/src/v/kafka/client/test/direct_consumer_fixture_test.cc
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/tests/cluster_test_fixture.h"
+#include "kafka/client/direct_consumer/direct_consumer.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "redpanda/tests/fixture.h"
+
+#include <seastar/util/defer.hh>
+using namespace kafka::client;
+class consumer_fixture
+  : public cluster_test_fixture
+  , public ::testing::Test {
+public:
+    kafka::client::connection_configuration make_connection_config() {
+        kafka::client::connection_configuration config;
+        config.client_id = "test-client";
+        config.initial_brokers
+          = std::views::transform(
+              instance_ids(),
+              [this](model::node_id id) { return instance(id); })
+            | std::views::transform(
+              [](const redpanda_thread_fixture* f) { return f->kafka_port; })
+            | std::views::transform([](int port) {
+                  return net::unresolved_address("localhost", port);
+              })
+            | std::ranges::to<std::vector<net::unresolved_address>>();
+        return config;
+    }
+
+    ss::future<std::unique_ptr<kafka::client::cluster>>
+    create_client_cluster() {
+        auto cluster = std::make_unique<kafka::client::cluster>(
+          make_connection_config());
+        co_await cluster->start();
+        co_return cluster;
+    }
+
+    topic_assignment make_assignment(
+      const model::topic& topic,
+      std::vector<int> partitions,
+      std::optional<kafka::offset> initial_offset = std::nullopt) {
+        topic_assignment assignment;
+        assignment.topic = topic;
+        for (const auto& p : partitions) {
+            partition_assignment part;
+            part.partition_id = model::partition_id(p);
+            part.next_offset = initial_offset;
+            assignment.partitions.push_back(part);
+        }
+        return assignment;
+    }
+
+    model::node_id get_partition_leader(const model::ntp& ntp) {
+        std::optional<model::node_id> leader_id;
+        model::timeout_clock::time_point deadline = model::timeout_clock::now()
+                                                    + 10s;
+        while (!leader_id) {
+            if (model::timeout_clock::now() > deadline) {
+                throw std::runtime_error(
+                  fmt::format("Timeout while waiting for leader for {}", ntp));
+            }
+            leader_id = instance(model::node_id{0})
+                          ->app.controller->get_partition_leaders()
+                          .local()
+                          .get_leader(ntp);
+
+            ss::sleep(100ms).get();
+        }
+        return leader_id.value();
+    }
+
+    void produce_to_partition(
+      const model::topic& topic, int partition, size_t record_count) {
+        model::ntp ntp(
+          model::kafka_namespace, topic, model::partition_id(partition));
+
+        auto leader_id = get_partition_leader(ntp);
+
+        tests::kafka_produce_transport producer(
+          instance(leader_id)->make_kafka_client().get());
+        producer.start().get();
+        auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
+
+        auto records = tests::kv_t::sequence(0, record_count, partition);
+        producer
+          .produce_to_partition(topic, model::partition_id(partition), records)
+          .get();
+    }
+
+    chunked_hash_map<
+      model::topic_partition,
+      chunked_vector<model::record_batch>>
+    fetch_until_empty(direct_consumer& consumer) {
+        chunked_hash_map<
+          model::topic_partition,
+          chunked_vector<model::record_batch>>
+          ret;
+
+        while (true) {
+            auto fetched = consumer.fetch_next(1000ms).get();
+
+            if (fetched.value().empty()) {
+                break;
+            }
+            for (auto& topic_data : fetched.value()) {
+                for (auto& partition_data : topic_data.partitions) {
+                    auto& batches = ret[model::topic_partition(
+                      topic_data.topic, partition_data.partition_id)];
+
+                    std::ranges::move(
+                      partition_data.data, std::back_inserter(batches));
+                }
+            }
+        }
+        return ret;
+    }
+};
+
+TEST_F(consumer_fixture, TestBasicConsumption) {
+    create_node_application(model::node_id{0});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
+    auto* rp = instance(model::node_id{0});
+    wait_for_all_members(3s).get();
+    model::topic topic{"test-topic"};
+    rp->add_topic({model::kafka_namespace, topic}, 3, std::nullopt, 3).get();
+
+    auto cluster = create_client_cluster().get();
+
+    kafka::client::direct_consumer consumer(
+      *cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto d_stop = ss::defer([&cluster, &consumer] {
+        consumer.stop().get();
+        cluster->stop().get();
+    });
+    consumer
+      .assign_partitions(chunked_vector<topic_assignment>::single(
+        make_assignment(topic, {0, 1, 2})))
+      .get();
+    // no data should be available immediately, as the topic is empty
+    for (int i = 0; i < 10; ++i) {
+        auto fetched = consumer.fetch_next(100ms).get();
+        ASSERT_TRUE(fetched.value().empty());
+    }
+
+    // produce some data
+    produce_to_partition(topic, 0, 1000);
+    produce_to_partition(topic, 1, 400);
+    produce_to_partition(topic, 2, 20);
+    auto fetched = fetch_until_empty(consumer);
+
+    ASSERT_EQ(fetched.size(), 3);
+    ASSERT_EQ(
+      fetched[model::topic_partition(topic, model::partition_id(0))]
+        .back()
+        .last_offset(),
+      model::offset(999));
+    ASSERT_EQ(
+      fetched[model::topic_partition(topic, model::partition_id(1))]
+        .back()
+        .last_offset(),
+      model::offset(399));
+    ASSERT_EQ(
+      fetched[model::topic_partition(topic, model::partition_id(2))]
+        .back()
+        .last_offset(),
+      model::offset(19));
+    // produce again
+    produce_to_partition(topic, 2, 1000);
+    produce_to_partition(topic, 1, 400);
+    produce_to_partition(topic, 0, 20);
+    auto fetched_2 = fetch_until_empty(consumer);
+    ASSERT_EQ(fetched_2.size(), 3);
+    ASSERT_EQ(
+      fetched_2[model::topic_partition(topic, model::partition_id(0))]
+        .back()
+        .last_offset(),
+      model::offset(1019));
+    ASSERT_EQ(
+      fetched_2[model::topic_partition(topic, model::partition_id(1))]
+        .back()
+        .last_offset(),
+      model::offset(799));
+    ASSERT_EQ(
+      fetched_2[model::topic_partition(topic, model::partition_id(2))]
+        .back()
+        .last_offset(),
+      model::offset(1019));
+}

--- a/src/v/kafka/client/test/direct_consumer_test.cc
+++ b/src/v/kafka/client/test/direct_consumer_test.cc
@@ -1,0 +1,616 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/cluster.h"
+#include "kafka/client/direct_consumer/direct_consumer.h"
+#include "kafka/client/test/cluster_mock.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <seastar/util/defer.hh>
+using namespace kafka::client;
+using namespace std::chrono_literals;
+static ss::logger test_log("test-logger");
+struct consumer_test_mock : public ::testing::Test {
+    kafka::client::cluster create_client_cluster() {
+        return kafka::client::cluster(
+          kafka::client::connection_configuration{
+            .initial_brokers = {net::unresolved_address{"localhost", 9092}},
+            .client_id = "test-client",
+            .max_metadata_age = 1s,
+          },
+          std::make_unique<kafka::client::broker_mock_factory>(&cluster_mock));
+    }
+
+    void setup_brokers() {
+        cluster_mock.add_broker(
+          model::node_id(0), net::unresolved_address{"localhost", 9092});
+        cluster_mock.add_broker(
+          model::node_id(1), net::unresolved_address{"localhost", 9093});
+        cluster_mock.add_broker(
+          model::node_id(2), net::unresolved_address{"localhost", 9094});
+    }
+
+    void prepare_cluster() {
+        cluster_mock.register_default_handlers();
+        setup_brokers();
+        cluster_mock.register_handler(
+          kafka::fetch_api::key,
+          [this](model::node_id id, request_t req, kafka::api_version) {
+              return handle_fetch(
+                       id, std::get<kafka::fetch_request>(std::move(req)))
+                .then([](kafka::fetch_response resp) {
+                    return response_t{std::move(resp)};
+                });
+          });
+        cluster_mock.register_handler(
+          kafka::list_offsets_api::key,
+          [this](model::node_id id, request_t req, kafka::api_version) {
+              return handle_list_offsets(
+                       id,
+                       std::get<kafka::list_offsets_request>(std::move(req)))
+                .then([](kafka::list_offsets_response resp) {
+                    return response_t{std::move(resp)};
+                });
+          });
+    }
+
+    ss::future<kafka::list_offsets_response>
+    handle_list_offsets(model::node_id id, kafka::list_offsets_request req) {
+        kafka::list_offset_response_data resp_data;
+        for (auto& topic : req.data.topics) {
+            kafka::list_offset_topic_response topic_data;
+            topic_data.name = topic.name;
+            topic_data.partitions.reserve(topic.partitions.size());
+
+            auto t_it = cluster_mock.get_topics().find(topic.name);
+            for (auto& partition : topic.partitions) {
+                kafka::list_offset_partition_response part_data;
+                part_data.partition_index = partition.partition_index;
+                if (t_it == cluster_mock.get_topics().end()) {
+                    part_data.error_code
+                      = kafka::error_code::unknown_topic_or_partition;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+                auto p_it = t_it->second.find(partition.partition_index);
+                if (p_it == t_it->second.end()) {
+                    part_data.error_code
+                      = kafka::error_code::unknown_topic_or_partition;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+
+                if (p_it->second.leader != id) {
+                    part_data.error_code
+                      = kafka::error_code::not_leader_for_partition;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+                auto& state = p_state[topic.name][partition.partition_index];
+                if (state.error_code != kafka::error_code::none) {
+                    part_data.error_code = state.error_code;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+
+                if (
+                  partition.timestamp
+                  == kafka::list_offsets_request::earliest_timestamp) {
+                    part_data.offset
+                      = p_state[topic.name][partition.partition_index]
+                          .start_offset;
+                } else if (
+                  partition.timestamp
+                  == kafka::list_offsets_request::latest_timestamp) {
+                    part_data.offset
+                      = p_state[topic.name][partition.partition_index]
+                          .high_watermark;
+                }
+                topic_data.partitions.push_back(std::move(part_data));
+            }
+            resp_data.topics.push_back(std::move(topic_data));
+        }
+
+        co_return kafka::list_offsets_response{
+          .data = std::move(resp_data),
+        };
+    }
+
+    ss::future<kafka::fetch_response>
+    handle_fetch(model::node_id id, kafka::fetch_request req) {
+        kafka::fetch_response_data resp_data;
+        resp_data.responses.reserve(req.data.topics.size());
+        if (fetch_error.has_value()) {
+            resp_data.error_code = fetch_error.value();
+            fetch_error.reset();
+            co_return kafka::fetch_response{.data = std::move(resp_data)};
+        }
+
+        for (auto& topic : req.data.topics) {
+            kafka::fetchable_topic_response topic_data;
+            topic_data.topic = topic.topic;
+            topic_data.partitions.reserve(topic.partitions.size());
+
+            for (auto& partition : topic.partitions) {
+                auto t_it = cluster_mock.get_topics().find(topic.topic);
+                kafka::partition_data part_data;
+                part_data.partition_index = partition.partition;
+                if (t_it == cluster_mock.get_topics().end()) {
+                    part_data.error_code
+                      = kafka::error_code::unknown_topic_or_partition;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+                auto p_it = t_it->second.find(partition.partition);
+                if (p_it == t_it->second.end()) {
+                    part_data.error_code
+                      = kafka::error_code::unknown_topic_or_partition;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+
+                if (p_it->second.leader != id) {
+                    part_data.error_code
+                      = kafka::error_code::not_leader_for_partition;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+
+                auto& state = p_state[topic.topic][partition.partition];
+                vlog(
+                  test_log.info,
+                  "Handling fetch for broker: {}, topic: {}/{}, fetch_offset: "
+                  "{}, start_offset: {}, high watermark: {}",
+                  id,
+                  topic.topic,
+                  partition.partition,
+                  partition.fetch_offset,
+                  state.start_offset,
+                  state.high_watermark);
+                // handle error
+                if (state.error_code != kafka::error_code::none) {
+                    part_data.error_code = state.error_code;
+                    topic_data.partitions.push_back(std::move(part_data));
+                    continue;
+                }
+                if (partition.fetch_offset >= state.high_watermark) {
+                    // No batches available, return empty response
+                    continue;
+                }
+                auto batches_to_fetch = std::min<size_t>(
+                  10, state.high_watermark - partition.fetch_offset);
+
+                part_data.records = co_await generate_batches(
+                  partition.fetch_offset, batches_to_fetch);
+                auto& state_after = p_state[topic.topic][partition.partition];
+                part_data.high_watermark = state_after.high_watermark;
+                part_data.error_code = kafka::error_code::none;
+                part_data.current_leader.leader_id = id;
+                part_data.current_leader.leader_epoch = kafka::leader_epoch(0);
+
+                topic_data.partitions.push_back(std::move(part_data));
+            }
+            resp_data.responses.push_back(std::move(topic_data));
+        }
+
+        co_return kafka::fetch_response{.data = std::move(resp_data)};
+    }
+
+    ss::future<kafka::batch_reader>
+    generate_batches(model::offset first_offset, size_t batch_count) {
+        iobuf record_set;
+        auto writer{kafka::protocol::encoder(record_set)};
+        auto batches = co_await model::test::make_random_batches(
+          first_offset, batch_count, true, std::nullopt, 1);
+        for (auto& batch : batches) {
+            kafka::protocol::writer_serialize_batch(writer, std::move(batch));
+        }
+
+        co_return kafka::batch_reader{std::move(record_set)};
+    }
+    void set_partition_start_offset(
+      model::topic topic, int partition, model::offset start_offset) {
+        p_state[topic][model::partition_id(partition)].start_offset
+          = start_offset;
+    }
+
+    void
+    make_data_available(model::topic topic, int partition, size_t batch_cnt) {
+        model::partition_id p_id(partition);
+        auto& state = p_state[topic][p_id];
+        auto prev = state.high_watermark == model::offset{}
+                      ? state.start_offset
+                      : state.high_watermark;
+
+        state.high_watermark = prev + model::offset(batch_cnt);
+    }
+
+    ss::future<> fetch_and_append_to_map(
+      topic_partition_map<chunked_vector<model::record_batch>>& batches,
+      direct_consumer& consumer) {
+        auto data = co_await consumer.fetch_next(std::chrono::seconds(4));
+        for (auto& topic_data : data.value()) {
+            for (auto& partition_data : topic_data.partitions) {
+                auto& b_vector
+                  = batches[topic_data.topic][partition_data.partition_id];
+                vlog(
+                  test_log.info,
+                  "Fetched {} batches for topic: {}, partition: {}, "
+                  "total_batches: {}",
+                  partition_data.data.size(),
+                  topic_data.topic,
+                  partition_data.partition_id,
+                  b_vector.size());
+                std::ranges::move(
+                  partition_data.data, std::back_inserter(b_vector));
+            }
+        }
+    }
+
+    ::testing::AssertionResult validate_offsets_monotonicity(
+      const topic_partition_map<chunked_vector<model::record_batch>>& batches) {
+        for (auto& [topic, partitions] : batches) {
+            for (auto& [partition_id, batch_vector] : partitions) {
+                if (batch_vector.empty()) {
+                    continue;
+                }
+                model::offset last_end_offset;
+
+                for (const auto& b : batch_vector) {
+                    if (b.base_offset() <= last_end_offset) {
+                        return ::testing::AssertionFailure()
+                               << "Batch base offset is not greater than "
+                                  "previous batch's last offset: "
+                               << b.base_offset() << " <= " << last_end_offset;
+                    }
+                }
+            }
+        }
+        return ::testing::AssertionSuccess();
+    }
+
+    chunked_vector<topic_assignment> make_assignment(
+      const model::topic& topic, const std::vector<int>& partitions) {
+        chunked_vector<topic_assignment> assignment;
+        assignment.push_back({
+          .topic = topic,
+        });
+        for (const auto& partition : partitions) {
+            assignment.back().partitions.push_back(partition_assignment{
+              .partition_id = model::partition_id(partition),
+              .next_offset = kafka::offset(0),
+            });
+        }
+        return assignment;
+    }
+
+    void
+    set_error(const model::topic& topic, int partition, kafka::error_code ec) {
+        auto& state = p_state[topic][model::partition_id(partition)];
+        state.error_code = ec;
+    }
+
+    struct partition_state {
+        model::offset start_offset{0};
+        model::offset high_watermark{};
+        kafka::error_code error_code{kafka::error_code::none};
+    };
+    topic_partition_map<partition_state> p_state;
+    std::optional<kafka::error_code> fetch_error;
+
+    cluster_mock cluster_mock;
+};
+
+TEST_F(consumer_test_mock, TestAssignUnassignPartitions) {
+    prepare_cluster();
+    model::topic test_topic("panda-test");
+    cluster_mock.add_topic(test_topic, 16, 3);
+    topic_partition_map<chunked_vector<model::record_batch>> all_batches;
+    // 10 batches available in partition 0, 5 in partition 2
+    make_data_available(test_topic, 0, 10);
+    make_data_available(test_topic, 2, 5);
+
+    auto client_cluster = create_client_cluster();
+    client_cluster.start().get();
+    direct_consumer consumer(client_cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto deferred_stop = ss::defer([&] {
+        consumer.stop().get();
+        client_cluster.stop().get();
+    });
+
+    consumer.assign_partitions(make_assignment(test_topic, {0})).get();
+
+    fetch_and_append_to_map(all_batches, consumer).get();
+    auto data = consumer.fetch_next(std::chrono::seconds(4)).get();
+    ASSERT_EQ(all_batches.size(), 1);
+    ASSERT_TRUE(all_batches.contains(test_topic));
+    ASSERT_EQ(all_batches[test_topic].size(), 1);
+    ASSERT_EQ(all_batches[test_topic][model::partition_id(0)].size(), 10);
+
+    // add some more data to partition 0
+    make_data_available(test_topic, 0, 3);
+
+    consumer.assign_partitions(make_assignment(test_topic, {1, 2})).get();
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return fetch_and_append_to_map(all_batches, consumer).then([&] {
+            return all_batches[test_topic][model::partition_id(0)].size() == 13
+                   && all_batches[test_topic][model::partition_id(2)].size()
+                        == 5;
+        });
+    });
+    // finally add some data to partition 1
+    make_data_available(test_topic, 1, 17);
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return fetch_and_append_to_map(all_batches, consumer).then([&] {
+            return all_batches[test_topic][model::partition_id(0)].size() == 13
+                   && all_batches[test_topic][model::partition_id(1)].size()
+                        == 17
+                   && all_batches[test_topic][model::partition_id(2)].size()
+                        == 5;
+        });
+    });
+    validate_offsets_monotonicity(all_batches);
+    // unassign partition 0
+    consumer
+      .unassign_partitions(
+        {model::topic_partition(test_topic, model::partition_id(0))})
+      .get();
+
+    // make more data available in partition 0, then shouldn't be fetched
+    // because it is unassigned
+    make_data_available(test_topic, 0, 100);
+    // wait for a bit to ensure that no data is fetched
+    // request next fetch, to ensure that all in progress fetches are
+    // completed
+    consumer.fetch_next(std::chrono::milliseconds(100)).get();
+    for (int i = 0; i < 10; ++i) {
+        auto data = consumer.fetch_next(std::chrono::milliseconds(100)).get();
+        ASSERT_TRUE(data.value().empty());
+    }
+    // assign another topic
+    model::topic test_topic_2("panda-test-2");
+    cluster_mock.add_topic(test_topic_2, 2, 3);
+
+    consumer.assign_partitions(make_assignment(test_topic_2, {0, 1})).get();
+
+    make_data_available(test_topic_2, 0, 100);
+    make_data_available(test_topic_2, 1, 100);
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return fetch_and_append_to_map(all_batches, consumer).then([&] {
+            return all_batches[test_topic][model::partition_id(0)].size() == 13
+                   && all_batches[test_topic][model::partition_id(1)].size()
+                        == 17
+                   && all_batches[test_topic][model::partition_id(2)].size()
+                        == 5
+                   && all_batches[test_topic_2][model::partition_id(0)].size()
+                        == 100
+                   && all_batches[test_topic_2][model::partition_id(1)].size()
+                        == 100;
+        });
+    });
+}
+
+TEST_F(consumer_test_mock, TestLeadershipChange) {
+    prepare_cluster();
+    model::topic test_topic("panda-test");
+    cluster_mock.add_topic(test_topic, 1, 3);
+    topic_partition_map<chunked_vector<model::record_batch>> all_batches;
+    // 10 batches available in partition 0
+    make_data_available(test_topic, 0, 10);
+
+    auto client_cluster = create_client_cluster();
+    client_cluster.start().get();
+    direct_consumer consumer(client_cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto deferred_stop = ss::defer([&] {
+        consumer.stop().get();
+        client_cluster.stop().get();
+    });
+    chunked_vector<topic_assignment> assignment;
+    assignment.push_back({
+      .topic = test_topic,
+    });
+    // only partition 0 is assigned
+    assignment.back().partitions.push_back(partition_assignment{
+      .partition_id = model::partition_id(0),
+      .next_offset = kafka::offset(0),
+    });
+    consumer.assign_partitions(std::move(assignment)).get();
+
+    fetch_and_append_to_map(all_batches, consumer).get();
+    auto data = consumer.fetch_next(std::chrono::seconds(4)).get();
+    ASSERT_EQ(all_batches.size(), 1);
+    ASSERT_TRUE(all_batches.contains(test_topic));
+    ASSERT_EQ(all_batches[test_topic].size(), 1);
+    ASSERT_EQ(all_batches[test_topic][model::partition_id(0)].size(), 10);
+
+    // change leadership of partition 0 to another broker
+    vlog(
+      test_log.info,
+      "Changing leadership from {} to 2",
+      cluster_mock.get_topics()[test_topic][model::partition_id(0)].leader);
+    cluster_mock.get_topics()[test_topic][model::partition_id(0)].leader
+      = model::node_id(2);
+    // add some more data to partition 0
+    make_data_available(test_topic, 0, 23);
+
+    // wait for all data to be fetched
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return fetch_and_append_to_map(all_batches, consumer).then([&] {
+            return all_batches[test_topic][model::partition_id(0)].size() == 33;
+        });
+    });
+}
+
+TEST_F(consumer_test_mock, TestOffsetResetPolicy) {
+    prepare_cluster();
+    model::topic test_topic("panda-test");
+    cluster_mock.add_topic(test_topic, 2, 3);
+    topic_partition_map<chunked_vector<model::record_batch>> all_batches;
+    // start from offset 1000
+    set_partition_start_offset(test_topic, 0, model::offset(1000));
+    // 10 batches available in partition 0
+    make_data_available(test_topic, 0, 10);
+
+    auto client_cluster = create_client_cluster();
+    client_cluster.start().get();
+    direct_consumer consumer(client_cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto deferred_stop = ss::defer([&] {
+        consumer.stop().get();
+        client_cluster.stop().get();
+    });
+    chunked_vector<topic_assignment> assignment;
+    assignment.push_back({
+      .topic = test_topic,
+    });
+    // only partition 0 is assigned
+    assignment.back().partitions.push_back(partition_assignment{
+      .partition_id = model::partition_id(0),
+      .next_offset = std::nullopt, // no offset set, should reset to earliest
+    });
+    consumer.assign_partitions(std::move(assignment)).get();
+
+    fetch_and_append_to_map(all_batches, consumer).get();
+
+    ASSERT_EQ(all_batches.size(), 1);
+    ASSERT_TRUE(all_batches.contains(test_topic));
+    ASSERT_EQ(all_batches[test_topic].size(), 1);
+    ASSERT_EQ(all_batches[test_topic][model::partition_id(0)].size(), 10);
+
+    ASSERT_EQ(
+      all_batches[test_topic][model::partition_id(0)].front().base_offset(),
+      model::offset(1000));
+    // change offset reset policy to latest
+    // this should reset the fetch offset to the latest offset available
+    // in the partition.
+
+    // Set start offset to 400, so that the latest offset is 430
+    set_partition_start_offset(test_topic, 1, model::offset(400));
+    make_data_available(test_topic, 1, 30);
+    consumer.update_configuration(direct_consumer::configuration{
+      .reset_policy = offset_reset_policy::latest});
+    chunked_vector<topic_assignment> new_assignment;
+    new_assignment.push_back({
+      .topic = test_topic,
+    });
+    // only partition 0 is assigned
+    new_assignment.back().partitions.push_back(partition_assignment{
+      .partition_id = model::partition_id(1),
+      .next_offset = std::nullopt, // no offset set, should reset to latest
+    });
+    consumer.assign_partitions(std::move(new_assignment)).get();
+    auto data = consumer.fetch_next(std::chrono::seconds(1)).get();
+    // fetch should be empty, because the fetch offset was reset to latest
+    ASSERT_EQ(data.value().size(), 0);
+    // add more data to partition 1
+    make_data_available(test_topic, 1, 6);
+    fetch_and_append_to_map(all_batches, consumer).get();
+    ASSERT_EQ(
+      all_batches[test_topic][model::partition_id(1)].front().base_offset(),
+      model::offset(430));
+}
+TEST_F(consumer_test_mock, TestFetchErrorPropagation) {
+    prepare_cluster();
+    model::topic test_topic("panda-test");
+    cluster_mock.add_topic(test_topic, 2, 3);
+    topic_partition_map<chunked_vector<model::record_batch>> all_batches;
+
+    // 10 batches available in partition 0
+    make_data_available(test_topic, 0, 10);
+    // first try to use retriable fetch error, this one should be retried and
+    // not propagated to the consumer
+    fetch_error = kafka::error_code::listener_not_found;
+    auto client_cluster = create_client_cluster();
+    client_cluster.start().get();
+    direct_consumer consumer(client_cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto deferred_stop = ss::defer([&] {
+        consumer.stop().get();
+        client_cluster.stop().get();
+    });
+    chunked_vector<topic_assignment> assignment;
+    assignment.push_back({
+      .topic = test_topic,
+    });
+    // only partition 0 is assigned
+    assignment.back().partitions.push_back(partition_assignment{
+      .partition_id = model::partition_id(0),
+      .next_offset = std::nullopt, // no offset set, should reset to earliest
+    });
+    consumer.assign_partitions(std::move(assignment)).get();
+
+    fetch_and_append_to_map(all_batches, consumer).get();
+
+    ASSERT_EQ(all_batches.size(), 1);
+    ASSERT_TRUE(all_batches.contains(test_topic));
+    ASSERT_EQ(all_batches[test_topic].size(), 1);
+    ASSERT_EQ(all_batches[test_topic][model::partition_id(0)].size(), 10);
+
+    fetch_error = kafka::error_code::invalid_request;
+
+    // now try to use non-retriable fetch error, this one should be propagated
+    // to the consumer
+    auto data = consumer.fetch_next(std::chrono::seconds(1)).get();
+    ASSERT_TRUE(data.has_error());
+}
+
+TEST_F(consumer_test_mock, TestPartitionErrorPropagation) {
+    prepare_cluster();
+    model::topic test_topic("panda-test");
+    cluster_mock.add_topic(test_topic, 2, 3);
+    topic_partition_map<chunked_vector<model::record_batch>> all_batches;
+
+    // 10 batches available in partition 0
+    make_data_available(test_topic, 0, 10);
+    auto client_cluster = create_client_cluster();
+    client_cluster.start().get();
+    direct_consumer consumer(client_cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto deferred_stop = ss::defer([&] {
+        consumer.stop().get();
+        client_cluster.stop().get();
+    });
+    chunked_vector<topic_assignment> assignment;
+    assignment.push_back({
+      .topic = test_topic,
+    });
+    // only partition 0 is assigned
+    assignment.back().partitions.push_back(partition_assignment{
+      .partition_id = model::partition_id(0),
+      .next_offset = std::nullopt, // no offset set, should reset to earliest
+    });
+    // set retriable error for partition 0
+    set_error(test_topic, 0, kafka::error_code::not_leader_for_partition);
+    consumer.assign_partitions(std::move(assignment)).get();
+    // try fo fetch data, no data should be fetched, but the error should not be
+    // propagated to the consumer
+    auto data = consumer.fetch_next(std::chrono::seconds(1)).get();
+    ASSERT_TRUE(data.has_value());
+    ASSERT_TRUE(data.value().empty());
+    // reset the error to none, so that the next fetch will return data
+    set_error(test_topic, 0, kafka::error_code::none);
+    data = consumer.fetch_next(std::chrono::seconds(1)).get();
+    ASSERT_TRUE(data.has_value());
+    ASSERT_FALSE(data.value().empty());
+    // set non-retriable error for partition 0, it should be propagated in the
+    // partition reply
+    set_error(test_topic, 0, kafka::error_code::unknown_server_error);
+    auto expected_err = consumer.fetch_next(std::chrono::seconds(1)).get();
+    ASSERT_TRUE(expected_err.has_value());
+    ASSERT_EQ(
+      expected_err.value()[0].partitions[0].error,
+      kafka::error_code::unknown_server_error);
+}


### PR DESCRIPTION
Simple direct Kafka consumer. It allows user to subscribe to a list of topic partitions. The consumer maintains broker fetch session, it reacts for the leadership changes and metadata updates. Fetch responses from all the brokers are exposed through `fetch_next()`. The fetch_next() returns whenever any ready to be consumer are available.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none