### PR TITLE
[v25.1.x] rptest: test that data is readable after upgrades

### DIFF
--- a/tests/rptest/tests/datalake/datalake_upgrade_test.py
+++ b/tests/rptest/tests/datalake/datalake_upgrade_test.py
@@ -6,6 +6,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+
+import json
 from rptest.services.cluster import cluster
 
 from rptest.services.redpanda import SISettings
@@ -79,3 +81,60 @@ class DatalakeUpgradeTest(RedpandaTest):
                         {"iceberg_target_lag_ms": 10000})
                     lag_set = True
                 run_workload()
+
+            # Run some spot checks to ensure that the data is readable.
+            result = dl.spark().run_query_fetch_one(f"""
+                                                    SELECT count(*)
+                                                    FROM redpanda.{self.topic_name}
+                                                    WHERE redpanda.offset < 10
+                                                      AND redpanda.partition = 0
+                                                    """)
+            assert result[0] == 10, f"Expected 10 rows, got {result[0]}"
+
+            result = dl.spark().run_query_fetch_one(f"""
+                                                    SELECT count(*)
+                                                    FROM redpanda.{self.topic_name}
+                                                    WHERE redpanda.timestamp >= '2025-01-01 00:00:00'
+                                                    """)
+            assert result[
+                0] == total_count, f"Expected {total_count} rows, got {result[0]}"
+
+            # Check that all fields are queryable and the structure of the row
+            # matches the expected structure.
+            with dl.spark().run_query(f"""
+                                      SELECT *
+                                      FROM redpanda.{self.topic_name}
+                                      """) as cursor:
+                assert cursor.description == [
+                    ('redpanda', 'STRUCT_TYPE', None, None, None, None, True),
+                    ('value', 'BINARY_TYPE', None, None, None, None, True)
+                ], f"Unexpected cursor description: {cursor.description}"
+
+                rows = cursor.fetchall()
+                assert rows
+
+                # We're not checking internal redpanda fields as it is close to
+                # impossible with our current client PyHive which returns a string
+                # representation of the struct. It also loses some type information
+                # and binary data which looks like numbers is represented as numbers.
+                # If assert below begin to fail maybe we have changed the client and
+                # now it is possible to check the types.
+                assert isinstance(rows[0][0],
+                                  str), f"Unexpected type {type(rows[0][0])}"
+                assert isinstance(rows[0][1],
+                                  bytes), f"Unexpected type {type(rows[0][1])}"
+
+            # Check nested fields of redpanda struct. Fetch all rows
+            with dl.spark().run_query(f"""
+                                    SELECT to_json(redpanda)
+                                    FROM redpanda.{self.topic_name}
+                                    """) as cursor:
+                rows = cursor.fetchall()
+                assert rows
+
+                # Fetch all rows to make sure the underlying query engine does
+                # not fail internally but it should be enough to check a single
+                # row from the result set.
+                assert json.loads(rows[0][0]).keys() == {
+                    "partition", "offset", "timestamp", "headers", "key"
+                }, f"Unexpected JSON keys: {json.loads(rows[0][0]).keys()}"

--- a/tests/rptest/tests/datalake/datalake_upgrade_test.py
+++ b/tests/rptest/tests/datalake/datalake_upgrade_test.py
@@ -11,6 +11,7 @@ import json
 from rptest.services.cluster import cluster
 
 from rptest.services.redpanda import SISettings
+from rptest.services.redpanda_installer import RedpandaVersionTriple
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.datalake.datalake_services import DatalakeServices
@@ -34,8 +35,8 @@ class DatalakeUpgradeTest(RedpandaTest):
         self.topic_name = "upgrade_topic"
 
         # Initial version that supported Iceberg.
-        self.initial_version = (24, 3)
-        self.min_version_with_lag_support = (25, 1)
+        self.initial_version: RedpandaVersionTriple = (24, 3, 1)
+        self.min_version_with_lag_support: RedpandaVersionTriple = (25, 1, 1)
 
     def setUp(self):
         self.redpanda._installer.install(self.redpanda.nodes,
@@ -51,8 +52,10 @@ class DatalakeUpgradeTest(RedpandaTest):
         of Redpanda (e.g. ensuring that data format changes or additional
         Iceberg fields don't block progress).
         """
+        versions = self.load_version_range(self.initial_version)
+        lag_set = self.initial_version >= self.min_version_with_lag_support
+
         total_count = 0
-        versions = self.load_version_range(self.initial_version)[1:]
         with DatalakeServices(self.test_ctx,
                               redpanda=self.redpanda,
                               catalog_type=filesystem_catalog_type(),
@@ -68,8 +71,6 @@ class DatalakeUpgradeTest(RedpandaTest):
                 total_count += count
                 dl.wait_for_translation(self.topic_name, msg_count=total_count)
 
-            lag_set = self.initial_version >= self.min_version_with_lag_support  # type: ignore
-            versions = self.load_version_range(self.initial_version)
             for v in self.upgrade_through_versions(versions_in=versions,
                                                    already_running=True):
                 self.logger.info(f"Updated to {v}")

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -152,7 +152,7 @@ class RedpandaTest(RedpandaTestBase):
 
     def upgrade_through_versions(
         self,
-        versions_in: list[RedpandaVersion],
+        versions_in: Sequence[RedpandaVersion],
         already_running: bool = False,
         auto_assign_node_id: bool = False,
         mid_upgrade_check: Callable[[Mapping[Any, RedpandaVersion]],


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26540
