### PR TITLE
[CORE-10012] rptests/tests: Fix consumer group stress test

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1559,6 +1559,7 @@ class OffsetCommitter:
                 'auto.offset.reset': 'earliest',
                 'enable.auto.offset.store': True,
                 'enable.auto.commit': False,
+                'fetch.wait.max.ms': 50,
             },
             logger=self.logger)
 

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1604,7 +1604,7 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
                                  "group_topic_partitions": 1,
                                  "compacted_log_segment_size": 1024 * 1024,
                                  "log_compaction_interval_ms": 1000,
-                                 "group_offset_retention_sec": 20,
+                                 "group_offset_retention_sec": None
                              },
                              log_config=LoggingConfig(
                                  'info', {
@@ -1698,7 +1698,7 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
             self.logger.info(
                 f"Partition {tp.topic}/{tp.partition} committed offset={tp.offset}"
             )
-            assert tp.offset == expected, f"Offset mismatch for partition {tp.topic}{tp.partition}, expected: {expected} got: {tp.offset}"
+            assert tp.offset == expected, f"Offset mismatch for partition {tp.topic}/{tp.partition}, expected: {expected} got: {tp.offset}"
 
         olv = OfflineLogViewer(self.redpanda)
 


### PR DESCRIPTION
Fixes: [CORE-10012](https://redpandadata.atlassian.net/browse/CORE-10012)

Sometimes, this test would take more than 10 minutes to run, which is the default value of `group_offset_retention_check_ms`. This would trigger the `group_offset_retention_sec`, which was set to only 20sec in this test. Then when the client tries to get the offsets, after the consumers have been stopped, it would return an error value (-1001).

To address missing offsets in such cases, offset retention period has been disabled.

The slowdown happens because some commit requests block for a long time when the leadership transfer happens. It appears that they block due to blocked fetch requests in the librdkafka request queue. When reducing the value of fetch.wait.max, the problem seems to go away.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none



[CORE-10012]: https://redpandadata.atlassian.net/browse/CORE-10012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ