### PR TITLE
serde/json: omit input strings to fix test report XML

### DIFF
--- a/src/v/serde/json/detail/tests/string_test.cc
+++ b/src/v/serde/json/detail/tests/string_test.cc
@@ -50,8 +50,9 @@ struct test_case {
 };
 
 std::ostream& operator<<(std::ostream& os, const test_case& tc) {
-    os << "input: " << tc.input
-       << ", expected_err: " << static_cast<int>(tc.expected_err)
+    // Don't print the input string as it's generally not valid UTF-8
+    // and it breaks test reports.
+    os << ", expected_err: " << static_cast<int>(tc.expected_err)
        << ", expected_pos: " << tc.expected_pos;
 
     if (!tc.expected_output.empty()) {


### PR DESCRIPTION
The test cases, which contain many examples of invalid UTF-8, break the XML generated by bazel. This applies the easiest fix: just don't try to print the input string.

I hemmed and hawed over the best way to escape and print the input string for a while... but it's easiest just not to print
it into the report at all. Shrug.

I verified the output report is valid xml with `xmllint`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
