### PR TITLE
rptest: adjust cluster metadata upload frequency

### DIFF
--- a/tests/rptest/tests/cluster_metadata_upload_test.py
+++ b/tests/rptest/tests/cluster_metadata_upload_test.py
@@ -56,7 +56,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
                                  fast_uploads=True)
         extra_rp_conf = {
             'controller_snapshot_max_age_sec': 1,
-            'cloud_storage_cluster_metadata_upload_interval_ms': 1000,
+            'cloud_storage_cluster_metadata_upload_interval_ms': 2500,
             'enable_cluster_metadata_upload_loop': True,
         }
         super().__init__(test_context,
@@ -93,7 +93,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
                                          {"state": "active"})
 
         wait_until(lambda: self.bucket_has_metadata(1),
-                   timeout_sec=10,
+                   timeout_sec=30,
                    backoff_sec=1)
 
         # Stop the cluster so we can check consistency of the bucket without
@@ -133,7 +133,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
             return new_highest_manifest_id > orig_highest_manifest_id + by_at_least
 
         wait_until(lambda: meta_id_has_grown(5),
-                   timeout_sec=10,
+                   timeout_sec=30,
                    backoff_sec=0.1)
         # The topic manifest may not have been uploaded yet, but that's fine
         # since this test focuses on cluster metadata only.
@@ -151,7 +151,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
         admin = self.redpanda._admin
         admin.put_feature("controller_snapshots", {"state": "active"})
         wait_until(lambda: self.bucket_has_metadata(1),
-                   timeout_sec=10,
+                   timeout_sec=30,
                    backoff_sec=1)
         orig_cluster_uuid_resp: str = admin.get_cluster_uuid(
             self.redpanda.nodes[0])
@@ -172,7 +172,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
         # The new cluster should begin uploading new metadata without clearing
         # out the metadata from the old cluster.
         wait_until(lambda: self.bucket_has_metadata(2),
-                   timeout_sec=10,
+                   timeout_sec=30,
                    backoff_sec=1)
         self.redpanda.stop()
 


### PR DESCRIPTION
The test was timing out while waiting for the cluster to have metadata in S3 because each check was hitting a warning:

[DEBUG - 2025-06-27 06:41:36,069 - si_utils - _load_cluster_metadata_manifest - lineno:1199]: Exception loading cluster_metadata/ac55dd59-f0bc-4195-8b3f-2ca54470d8ae/manifests/36/cluster_manifest.json: An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist.

This is because the upload loop cleans up old metadata on each round of uploading. To mitigate, this updates the upload frequency to happen less often to give the test more time to see metadata.

Adjusts some timeouts accordingly to give a bit more wiggle room for the slower uploads.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
