### PR TITLE
tests: add infra for analyzing shutdown hangs

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3438,6 +3438,42 @@ class RedpandaService(RedpandaServiceBase):
                 actual_config = yaml.full_load(f.read())
                 self._node_configs[node] = actual_config
 
+    def _log_node_shutdown_analysis(self, node):
+        """
+        Analyze a node's failure to shutdown within the allocated time to try
+        to diagnose the reason for shutdown hang.
+        """
+        self.logger.debug(f"Gathering logs to analyze from {node.name}...")
+        expr = "\"application.*Stopping\""
+        cmd = f"grep {expr} {RedpandaServiceBase.STDOUT_STDERR_CAPTURE} || true"
+
+        other_stopping = []
+        last_next_to_shutdown = None
+        for line in node.account.ssh_capture(cmd):
+            if "next to shutdown" in line:
+                last_next_to_shutdown = line
+            else:
+                other_stopping.append(line)
+
+        if last_next_to_shutdown is None:
+            self.logger.debug(
+                "No structured shutdown messages found. Hang may have occurred in early shutdown"
+            )
+            return
+
+        self.logger.debug(
+            f"Last structured shutdown line: {last_next_to_shutdown}")
+        next_service = last_next_to_shutdown.split()[-1]
+
+        for line in other_stopping:
+            if f"Stopping {next_service}" in line:
+                self.logger.debug(
+                    f"Found stopping message for last service {line}")
+                return
+
+        self.logger.debug(
+            f"Did not find stopping message for service {next_service}")
+
     def _log_node_process_state(self, node):
         """
         For debugging issues around starting and stopping processes: log
@@ -4223,6 +4259,7 @@ class RedpandaService(RedpandaServiceBase):
             self._set_trace_loggers_and_sleep(node, time_sec=sleep_sec)
             self.logger.warn(f"Node {node.name} status:")
             self._log_node_process_state(node)
+            self._log_node_shutdown_analysis(node)
             # Kill the process if it's still running. If redpanda still runs we
             # might fail to collect logs as the file will be modified while we
             # (ducktape) are reading/compressing it.


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/pull/25594 there was some structured logging added to help diangose shutdown hangs. It logs messages about what is being shutdown and what is next ot shutdown.

This commit adds some very basic infrastructure for searching logs and analyzing these logs in response to a redpanda service shutdown that fails due to timeout.

It looks for the last service expected to shutdown and then looks for the message indicating that this last service was shutdown. If it isn't found, then it indicates that perhaps that service is what hung.
```
[DEBUG - 2025-06-29 20:49:13,706 - redpanda - _log_node_shutdown_analysis - lineno:3462]: Last structured shutdown line: INFO  2025-06-29 20:49:13,258 [shard 0:main] main - application.h:307 - Stopping resources::cpu_profiler, ..next to shutdown is memory_sampling
[DEBUG - 2025-06-29 20:49:13,706 - redpanda - _log_node_shutdown_analysis - lineno:3467]: Found stopping message for last service INFO  2025-06-29 20:49:13,258 [shard 0:main] main - application.h:309 - Stopping memory_sampling
```
This isn't perfect by any means but can help avoid some pain in looking through logs.

NOTE: the expectation is that this PR is introducing a place to centralize anlaysis, rather than adding a "good" analysis. Better analysis will depend on the information we have, and so we should look at tackling https://redpandadata.atlassian.net/browse/CORE-12644 and making sure it integrates with this strategy.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
