### PR TITLE
tests: fixed pattern used to detect log about stuck reconciliation

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -49,7 +49,7 @@ STARTUP_SEQUENCE_ABORTED = [
 # Example
 # ERROR 2025-05-12 11:08:51,283 [shard 1:main] cluster - controller_backend.cc:909 - [{kafka/topic-sgnmkqspsy/0}] reconciliation seems stuck (last retried 109s. ago), state: {pending_notifies: 1,  properties_changed_at: {nullopt}, removed_at: {nullopt}, cur_operation: {{revision: 264, type: update, assignment: { id: 0, group_id: 1, replicas: {{node_id: 1, shard: 0}, {node_id: 4, shard: 0}, {node_id: 2, shard: 0}} }, retries: 2, last_error: cluster::errc::waiting_for_recovery (Waiting for partition to recover)}}}
 RECONCILIATION_TIMEOUT_LOG = [
-    "controller_backend.* reconciliation seems stuck \(last retried.*"
+    ".*cluster - controller_backend.* reconciliation seems stuck.*"
 ]
 
 
@@ -416,7 +416,8 @@ class PartitionBalancerTest(PartitionBalancerService):
         wait_for_recovery_throttle_rate(self.redpanda, new_value)
 
     @skip_debug_mode
-    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=6,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + RECONCILIATION_TIMEOUT_LOG)
     def test_movement_cancellations(self):
         self.start_redpanda(num_nodes=4)
 
@@ -472,7 +473,8 @@ class PartitionBalancerTest(PartitionBalancerService):
             ), f"bad rack placement {racks} for partition id: {p.id} (replicas: {p.replicas})"
 
     @skip_debug_mode
-    @cluster(num_nodes=8, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=8,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + RECONCILIATION_TIMEOUT_LOG)
     def test_rack_awareness(self):
         extra_rp_conf = self._extra_rp_conf | {"enable_rack_awareness": True}
         self.redpanda = make_redpanda_service(self.test_context,
@@ -507,7 +509,8 @@ class PartitionBalancerTest(PartitionBalancerService):
             self.run_validation(consumer_timeout_sec=CONSUMER_TIMEOUT)
 
     @skip_debug_mode
-    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=7,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + RECONCILIATION_TIMEOUT_LOG)
     def test_rack_constraint_repair(self):
         """
         Test partition balancer rack constraint repair with the following scenario:
@@ -579,7 +582,8 @@ class PartitionBalancerTest(PartitionBalancerService):
     @skip_debug_mode
     @cluster(num_nodes=7,
              log_allow_list=CHAOS_LOG_ALLOW_LIST +
-             RACE_BETWEEN_DELETION_AND_ADDING_PARTITION)
+             RACE_BETWEEN_DELETION_AND_ADDING_PARTITION +
+             RECONCILIATION_TIMEOUT_LOG)
     def test_fuzz_admin_ops(self):
         self.start_redpanda(num_nodes=5)
 
@@ -914,7 +918,8 @@ class PartitionBalancerTest(PartitionBalancerService):
         self.wait_until_status(is_ready_and_stable)
 
     @skip_debug_mode
-    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
+    @cluster(num_nodes=7,
+             log_allow_list=CHAOS_LOG_ALLOW_LIST + RECONCILIATION_TIMEOUT_LOG)
     @matrix(kill_same_node=[True, False])
     def test_maintenance_mode(self, kill_same_node):
         """


### PR DESCRIPTION
Partition balancer test may suspend the node to make it unavailable. This way of unavailability is important to be covered in tests as it is often triggering various race conditions. In this case it is expected to see logs about stuck reconciliation as the node was suspended for a time long enough to trigger the log.
Fixes: CORE-11846
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 