### PR TITLE
CORE-10102 dt/keycloak: increase start timeout to 300s

### DIFF
--- a/tests/rptest/services/keycloak.py
+++ b/tests/rptest/services/keycloak.py
@@ -321,7 +321,7 @@ class KeycloakService(Service):
         with node.account.monitor_log(KC_LOG_FILE) as monitor:
             node.account.ssh(f"{KC} build", allow_fail=False)
             node.account.ssh_capture(self._start_cmd(), allow_fail=False)
-            monitor.wait_until("Running the server in", timeout_sec=120)
+            monitor.wait_until("Running the server in", timeout_sec=300)
 
         self.logger.debug(f"Keycloak PIDs: {self.pids(node)}")
 


### PR DESCRIPTION
The audit logging tests have been flaky because of timeouts on starting up the keycloak service in CI in ducktape.

Looking through recent passing and failing tests, it is clear that the startup time of keycloak varies significantly between 20s and 120s+. Unfortunately keycloak is an external service and the logs are not helpful to debug where exactly this wide variance is stemming from, and therefore it is difficult to see if and how it may be reduced. (See some examples in the attached ticket.)

This commit gives keycloak more time to start to ensure that it can start up even at the upper end of its range, to reduce flakiness for the tests that use keycloak.

Fixes https://redpandadata.atlassian.net/browse/CORE-10102

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
