### PR TITLE
tests: dt matrix must be json de/en-codable

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -361,13 +361,13 @@ def get_cloud_storage_type_and_url_style(
 ) -> List[CloudStorageTypeAndUrlStyle]:
     """
     Returns a list of compatible cloud storage types and url styles.
-    I.e, Returns [(CloudStorageType.S3, 'virtual_host'),
-                  (CloudStorageType.S3, 'path'),
-                  (CloudStorageType.ABS, 'virtual_host')]
+    I.e, Returns [[CloudStorageType.S3, 'virtual_host'],
+                  [CloudStorageType.S3, 'path'],
+                  [CloudStorageType.ABS, 'virtual_host']]
     """
     return [
         tus for tus_list in map(
-            lambda t: [(t, us) for us in get_cloud_storage_url_style(t)],
+            lambda t: [[t, us] for us in get_cloud_storage_url_style(t)],
             get_cloud_storage_type()) for tus in tus_list
     ]
 


### PR DESCRIPTION
In a test execution without parametrizing the tests, the matrix can return any type that's compatible with python. However, when a test is being parametrized, ducktape expects a json string. Having tuples work with python but ducktape cannot json-decode it leading ducktape to not be able to load that test. For instance, the test_tiered_storage test calls a function to parametrize the matrix and that must return a json decodeable output. This was blocking this test from being retried with the error:

```
[WARNING:2025-06-06 23:26:21,518]: No tests loaded for /root/tests/rptest/tests - tiered_storage_model_test.py - TieredStorageTest - test_tiered_storage - {'cloud_storage_type_and_url_style': [1, 'path'], 'test_case': {'name': '(TS_Read == True, TS_TxRangeMaterialized == True, SpilloverManifestUploaded == True)'}}
[WARNING:2025-06-06 23:26:21,518]: Didn't find any tests in /root/tests/rptest/tests/tiered_storage_model_test.py
```

jira: [DEVPROD-3062]

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

[DEVPROD-3062]: https://redpandadata.atlassian.net/browse/DEVPROD-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ