### PR TITLE
kafka/produce: create partition proxy further up

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -352,7 +352,7 @@ partition_produce_stages produce_topic_partition(
              timeout,
              source_shard = ss::this_shard_id()](
               cluster::partition_manager& mgr) mutable {
-                auto partition = mgr.get(ntp);
+                auto partition = kafka::make_partition_proxy(ntp, mgr);
                 if (!partition) {
                     return finalize_request_with_error_code(
                       error_code::not_leader_for_partition,
@@ -389,7 +389,7 @@ partition_produce_stages produce_topic_partition(
 
                 return std::move(f).then(
                   [ntp{std::move(ntp)},
-                   partition{std::move(partition)},
+                   partition{std::move(*partition)},
                    dispatch = std::move(dispatch),
                    bid,
                    acks,
@@ -402,10 +402,9 @@ partition_produce_stages produce_topic_partition(
                           return finalize_request_with_error_code(
                             err, std::move(dispatch), ntp, source_shard);
                       }
-                      auto proxy = kafka::make_partition_proxy(partition);
                       auto stages = partition_append(
                         ntp.tp.partition,
-                        std::move(proxy),
+                        std::move(partition),
                         bid,
                         std::move(batch),
                         acks,


### PR DESCRIPTION
We should only interact with partition proxy and not switch halfway
between. This make no functional difference, but may someday if we don't
have direct partition objects in the kafka layer (virtualized partitions)
or if we have a different notion of leadership (cloud topics).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
