### PR TITLE
cluster/partition: remove optional around cloud topics app

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -53,10 +53,9 @@ partition::partition(
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<archival::upload_housekeeping_service>& upload_hks,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
-  std::optional<
-    std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>> dp)
+  ss::sharded<experimental::cloud_topics::app>& ct_app)
   : _raft(std::move(r))
-  , _data_plane_api(dp)
+  , _cloud_topics_app(ct_app)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
   , _archival_conf(std::move(archival_conf))
@@ -1845,10 +1844,9 @@ ss::future<result<ssx::rwlock_unit>> partition::hold_writes_enabled() {
     co_return *std::move(maybe_units);
 }
 
-std::optional<
-  std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+ss::sharded<experimental::cloud_topics::app>&
 partition::get_cloud_topics_data_api() noexcept {
-    return _data_plane_api;
+    return _cloud_topics_app;
 }
 
 } // namespace cluster

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -57,11 +57,8 @@ public:
       ss::lw_shared_ptr<const archival::configuration>,
       ss::sharded<features::feature_table>&,
       ss::sharded<archival::upload_housekeeping_service>&,
-      std::optional<cloud_storage_clients::bucket_name> read_replica_bucket
-      = std::nullopt,
-      std::optional<
-        std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>> dp
-      = std::nullopt);
+      std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
+      ss::sharded<experimental::cloud_topics::app>& ct_app);
 
     ~partition() = default;
 
@@ -406,8 +403,7 @@ public:
 
     // Returns a pointer to the data plane api if cloud topics is enabled for
     // this partition. Otherwise, nullopt is returned
-    std::optional<
-      std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
+    ss::sharded<experimental::cloud_topics::app>&
     get_cloud_topics_data_api() noexcept;
 
 private:
@@ -436,9 +432,7 @@ private:
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::shared_ptr<experimental::cloud_topics::dl_stm_api> _dl_stm_api;
-    std::optional<
-      std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
-      _data_plane_api;
+    ss::sharded<experimental::cloud_topics::app>& _cloud_topics_app;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -60,9 +60,7 @@ partition_manager::partition_manager(
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<archival::upload_housekeeping_service>& upload_hks,
   config::binding<std::chrono::milliseconds> partition_shutdown_timeout,
-  std::optional<
-    std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
-    dp_api)
+  ss::sharded<experimental::cloud_topics::app>& cloud_topics_app)
   : _storage(storage.local())
   , _raft_manager(raft)
   , _partition_recovery_mgr(recovery_mgr)
@@ -72,7 +70,7 @@ partition_manager::partition_manager(
   , _feature_table(feature_table)
   , _upload_hks(upload_hks)
   , _partition_shutdown_timeout(std::move(partition_shutdown_timeout))
-  , _data_plane_api(dp_api) {
+  , _cloud_topics_app(cloud_topics_app) {
     _leader_notify_handle
       = _raft_manager.local().register_leadership_notification(
         [this](
@@ -304,7 +302,7 @@ ss::future<consensus_ptr> partition_manager::manage(
       _feature_table,
       _upload_hks,
       read_replica_bucket,
-      _data_plane_api);
+      _cloud_topics_app);
 
     _ntp_table.emplace(log->config().ntp(), p);
     _raft_table.emplace(group, p);

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -53,8 +53,7 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<archival::upload_housekeeping_service>&,
       config::binding<std::chrono::milliseconds>,
-      std::optional<
-        std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>);
+      ss::sharded<experimental::cloud_topics::app>&);
 
     ~partition_manager();
 
@@ -308,10 +307,8 @@ private:
 
     state_machine_registry _stm_registry;
 
-    // The value is set only if cloud topics are enabled
-    std::optional<
-      std::reference_wrapper<ss::sharded<experimental::cloud_topics::app>>>
-      _data_plane_api;
+    // The sharded app may not be initialized if cloud topics isn't enabled.
+    ss::sharded<experimental::cloud_topics::app>& _cloud_topics_app;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
     friend std::ostream& operator<<(

--- a/src/v/kafka/data/partition_proxy.cc
+++ b/src/v/kafka/data/partition_proxy.cc
@@ -26,15 +26,13 @@ partition_proxy make_with_impl(Args&&... args) {
 partition_proxy
 make_partition_proxy(const ss::lw_shared_ptr<cluster::partition>& partition) {
     if (partition->get_ntp_config().cloud_topic_enabled()) {
-        auto ct_data_plane = partition->get_cloud_topics_data_api();
-        if (
-          ct_data_plane.has_value()
-          && !ct_data_plane->get().local_is_initialized()) {
+        auto& ct_data_plane = partition->get_cloud_topics_data_api();
+        if (!ct_data_plane.local_is_initialized()) {
             throw std::runtime_error(
               "Cloud topic partition can't be created because the cloud-topics "
               "subsystem is not initialized");
         }
-        auto api = ct_data_plane->get().local().get_data_plane_api();
+        auto api = ct_data_plane.local().get_data_plane_api();
         return make_with_impl<cloud_topic_partition>(partition, api);
     }
     return make_with_impl<replicated_partition>(partition);


### PR DESCRIPTION
It's always used and set. However when it's set it may not be
initialized.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
