### PR TITLE
[CORE-12593] rp/admin/server: Fix an issue with the audit log escape hatch

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -204,6 +204,14 @@ security::audit::authentication_event_options make_authn_event_options(
       .error_reason = reason};
 }
 
+std::string_view strip_query_param(const ss::sstring& url) {
+    auto pos = url.find('?');
+    if (pos == ss::sstring::npos) {
+        return {url};
+    }
+    return {url.begin(), pos};
+};
+
 bool escape_hatch_request(ss::httpd::const_req req) {
     /// The following "break glass" mechanism allows the cluster config
     /// API to be hit in the case the user desires to disable auditing
@@ -212,14 +220,14 @@ bool escape_hatch_request(ss::httpd::const_req req) {
     static const auto allowed_requests = std::to_array(
       {ss::httpd::cluster_config_json::get_cluster_config_status,
        ss::httpd::cluster_config_json::get_cluster_config_schema,
-       ss::httpd::cluster_config_json::patch_cluster_config});
+       ss::httpd::cluster_config_json::patch_cluster_config,
+       ss::httpd::cluster_config_json::get_cluster_config});
 
-    return std::any_of(
-      allowed_requests.cbegin(),
-      allowed_requests.cend(),
+    return std::ranges::any_of(
+      allowed_requests,
       [method = req._method,
-       url = req.get_url()](const ss::httpd::path_description& d) {
-          return d.path == url
+       url = req._url](const ss::httpd::path_description& d) {
+          return d.path == strip_query_param(url)
                  && d.operations.method == ss::httpd::str2type(method);
       });
 }

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2314,3 +2314,53 @@ class AuditLogTestReproducer(AuditLogTestBase):
         )
         assert len(records) > 0, \
             f'Did not receive any audit records for topic {created_topic}'
+
+
+class AuditLogTestEscapeHatch(RedpandaTest):
+    def __init__(self, test_context, **kwargs):
+
+        super(AuditLogTestEscapeHatch,
+              self).__init__(test_context,
+                             extra_rp_conf={"audit_enabled": False},
+                             log_config=LoggingConfig('info',
+                                                      logger_levels={
+                                                          'auditing': 'trace',
+                                                      }),
+                             **kwargs)
+
+    @skip_fips_mode
+    @cluster(
+        num_nodes=3,
+        log_allow_list=AUDIT_LOG_ALLOW_LIST + [
+            r".*Request authenticate user to modify or view cluster configuration was not audited due to audit queues being full",
+            r".*Request to authorize user to modify or view cluster configuration was not audited due to audit queues being full"
+        ])
+    def test_escape_hatch(self):
+        rpk = RpkTool(self.redpanda)
+        admin = Admin(self.redpanda, default_node=self.redpanda.nodes[0])
+
+        test_topic = "test-topic"
+
+        rpk.create_topic(test_topic)
+
+        # Enable audit logging without a valid authentication set up.
+        admin.patch_cluster_config(upsert={"audit_enabled": True})
+        time.sleep(5)
+
+        audit_enabled = admin.get_cluster_config(key="audit_enabled")
+        assert audit_enabled, "Expected audit_enabled to be True"
+
+        with expect_exception(
+                RpkException, lambda e:
+                "Broker not available - audit system failure" in str(e)):
+            rpk.add_partitions(test_topic, 1)
+
+        # Verify that we can disable the audit logging
+        admin.patch_cluster_config(upsert={"audit_enabled": False})
+        time.sleep(5)
+
+        audit_enabled = admin.get_cluster_config(key="audit_enabled")
+        assert audit_enabled, "Expected audit_enabled to be False"
+
+        # Ensure that this doesn't throw
+        rpk.add_partitions(test_topic, 1)


### PR DESCRIPTION
Fixes: [CORE-12593](https://redpandadata.atlassian.net/browse/CORE-12593)

Audit log's escape hatch was not working and the full url would not match against the endpoint path.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fix an issue where audit log could lock down a cluster, if miss-configured. Now it is always possible to disable it.


[CORE-12593]: https://redpandadata.atlassian.net/browse/CORE-12593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ