### PR TITLE
iceberg/config: mark iceberg auth options as restored (default)

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
@@ -158,10 +158,6 @@ TEST(cluster_recovery_reconciler_test, test_config_ignore_list) {
       "cloud_storage_azure_shared_key",
       "cloud_storage_azure_adls_endpoint",
       "cloud_storage_azure_adls_port",
-      "iceberg_rest_catalog_aws_access_key",
-      "iceberg_rest_catalog_aws_secret_key",
-      "iceberg_rest_catalog_aws_region",
-      "iceberg_rest_catalog_aws_credentials_source",
     };
     auto ignore_list = controller_snapshot_reconciler::properties_ignore_list();
     ASSERT_EQ(ignore_list, expected_ignore_list);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4082,9 +4082,7 @@ configuration::configuration()
       "AWS access key for Iceberg REST catalog SigV4 authentication. If not "
       "set, falls back to cloud_storage_access_key when using aws_sigv4 "
       "authentication mode.",
-      {.needs_restart = needs_restart::yes,
-       .visibility = visibility::user,
-       .gets_restored = gets_restored::no},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_aws_secret_key(
@@ -4095,8 +4093,7 @@ configuration::configuration()
       "authentication mode.",
       {.needs_restart = needs_restart::yes,
        .visibility = visibility::user,
-       .secret = is_secret::yes,
-       .gets_restored = gets_restored::no},
+       .secret = is_secret::yes},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_aws_region(
@@ -4105,9 +4102,7 @@ configuration::configuration()
       "AWS region for Iceberg REST catalog SigV4 authentication. If not set, "
       "falls back to cloud_storage_region when using aws_sigv4 authentication "
       "mode.",
-      {.needs_restart = needs_restart::yes,
-       .visibility = visibility::user,
-       .gets_restored = gets_restored::no},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
   , iceberg_rest_catalog_aws_credentials_source(
@@ -4119,9 +4114,7 @@ configuration::configuration()
       "aws_sigv4 authentication mode. Accepted values: config_file, "
       "aws_instance_metadata, sts, gcp_instance_metadata, "
       "azure_vm_instance_metadata, azure_aks_oidc_federation.",
-      {.needs_restart = needs_restart::yes,
-       .visibility = visibility::user,
-       .gets_restored = gets_restored::no},
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt,
       {
         model::cloud_credentials_source::config_file,


### PR DESCRIPTION
The commit introducing these configs marked them as not restored, mistakenly assuming that was correct because the cloud storage configs they derived from were marked as not restored.

This change corrects the error.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
