### PR TITLE
[CORE-12207] test: make test timeout adaptive to making progress

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -216,11 +216,13 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
         self.rpk = RpkTool(self.redpanda)
         self.s3_bucket_name = si_settings.cloud_storage_bucket
 
-    def segments_removed(self, limit: int):
-        segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+    def query_segments(self):
+        return self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
             "kafka", self.topic_name, 0)
-        self.logger.debug(f"Current segments: {segs}")
 
+    def segments_removed(self, limit: int):
+        segs = self.query_segments()
+        self.logger.debug(f"Current segments: {segs}")
         return len(segs) <= limit
 
     @cluster(num_nodes=1)
@@ -353,10 +355,31 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
                             bytes_to_produce=self.total_segments *
                             self.segment_size)
 
-        wait_until(lambda: self.segments_removed(1),
-                   timeout_sec=30,
-                   backoff_sec=1,
-                   err_msg=f"Segments were not removed")
+        # initial number of segments
+        num_segs = len(self.query_segments())
+        assert num_segs > 1
+
+        # we have seen long delays before the first removal occurs. so we break
+        # that out and give it a bit of an extra wiggle room
+        wait_until(lambda: self.segments_removed(num_segs - 1),
+                   timeout_sec=60,
+                   backoff_sec=2,
+                   err_msg=f"Initial segments were not removed")
+
+        # the expectation of retention is to remove up to the active segment.
+        # we allow 0 to also succeed because I guess technically it would still
+        # be valid since this test is all about time-based retention.
+        while num_segs > 1:
+            # we don't do a single wait for all but one segment to be removed.
+            # instead we let the test reset the timeout if at least one segment
+            # removal is observed
+            wait_until(lambda: self.segments_removed(num_segs - 1),
+                       timeout_sec=30,
+                       backoff_sec=5,
+                       err_msg=f"Segments were not removed")
+            tmp = len(self.query_segments())
+            assert tmp < num_segs
+            num_segs = tmp
 
 
 class ShadowIndexingCloudRetentionTest(RedpandaTest):


### PR DESCRIPTION
According to @oleiman it looks to me like 14s elapsed between finishing the segment upload request and receiving a response. so not an issue of excessive load on the client pool but rather an extremely long running upload request.

Which is a significant chunk of time taken out of the 30 second timeout for the test. Additionally this is on ARM which had a bug that was pegging the CPU at 100%.

See JIRA ticket for more details.

Note that from the broker logs the test _almost succeeded_ all 8/9 segments were deleted, and the 9th was uploaded but the last check happened about 10 seconds before those last removals so the test ended up failing.

In this PR we add adaptive wait so that as long as retention removal is making progress we reset the timeout.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
