### PR TITLE
Audit log reject policy

### DIFF
--- a/src/v/config/BUILD
+++ b/src/v/config/BUILD
@@ -13,6 +13,7 @@ redpanda_cc_library(
         "rjson_serialization.cc",
         "throughput_control_group.cc",
         "tls_config.cc",
+        "types.cc",
         "validators.cc",
     ],
     hdrs = [

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1964,6 +1964,16 @@ configuration::configuration()
         .visibility = visibility::user,
       },
       {})
+  , audit_failure_policy(
+      *this,
+      "audit_failure_policy",
+      "Defines the policy for rejecting audit log messages when the audit log "
+      "queue is full. If set to 'permit', then new audit messages are dropped "
+      "and the operation is permitted.  If set to 'reject', then the operation "
+      "is rejected.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      audit_failure_policy::reject,
+      {audit_failure_policy::reject, audit_failure_policy::permit})
   , cloud_storage_enabled(
       *this,
       true,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -389,6 +389,7 @@ struct configuration final : public config_store {
     property<std::vector<ss::sstring>> audit_enabled_event_types;
     property<std::vector<ss::sstring>> audit_excluded_topics;
     property<std::vector<ss::sstring>> audit_excluded_principals;
+    enum_property<audit_failure_policy> audit_failure_policy;
 
     // Archival storage
     enterprise<property<bool>> cloud_storage_enabled;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -23,6 +23,7 @@
 #include <boost/lexical_cast.hpp>
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
 #include <unordered_map>
 
 namespace YAML {
@@ -738,6 +739,25 @@ struct convert<config::tls_name_format> {
             return false;
         }
         std::istringstream iss(value);
+        iss >> rhs;
+        return true;
+    }
+};
+
+template<>
+struct convert<config::audit_failure_policy> {
+    static Node encode(const config::audit_failure_policy& rhs) {
+        return Node(fmt::format("{}", rhs));
+    }
+
+    static bool decode(const Node& node, config::audit_failure_policy& rhs) {
+        static constexpr auto acceptable_values
+          = config::acceptable_audit_log_failure_policy_values();
+        auto valid = node.as<std::string>();
+        if (!std::ranges::contains(acceptable_values, valid)) {
+            return false;
+        }
+        std::istringstream iss(valid);
         iss >> rhs;
         return true;
     }

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -699,6 +699,8 @@ consteval std::string_view property_type_name() {
         return "string";
     } else if constexpr (std::is_same_v<type, config::tls_name_format>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, config::audit_failure_policy>) {
+        return "string";
     } else {
         static_assert(
           base::unsupported_type<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -284,4 +284,9 @@ void rjson_serialize(
     stringize(w, format);
 }
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, config::audit_failure_policy policy) {
+    stringize(w, policy);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -148,4 +148,7 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>&, config::tls_name_format);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>&, config::audit_failure_policy);
+
 } // namespace json

--- a/src/v/config/types.cc
+++ b/src/v/config/types.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "config/types.h"
+
+namespace config {
+
+std::ostream& operator<<(std::ostream& os, audit_failure_policy policy) {
+    return os << to_string_view(policy);
+}
+
+std::istream& operator>>(std::istream& is, audit_failure_policy& policy) {
+    ss::sstring s;
+    is >> s;
+    policy = string_switch<audit_failure_policy>(s)
+               .match(
+                 to_string_view(audit_failure_policy::reject),
+                 audit_failure_policy::reject)
+               .match(
+                 to_string_view(audit_failure_policy::permit),
+                 audit_failure_policy::permit);
+    return is;
+}
+} // namespace config

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -233,4 +233,31 @@ inline std::istream& operator>>(std::istream& is, tls_name_format& format) {
     return is;
 }
 
+enum class audit_failure_policy : uint8_t {
+    // If the audit log is full or misconfigured, reject any request that cannot
+    // be audited
+    reject,
+    // If the audit log is full or misconfigured, permit requests that cannot be
+    // audited to proceed, but log a warning that the audit message was dropped
+    permit,
+};
+
+constexpr std::string_view to_string_view(audit_failure_policy policy) {
+    switch (policy) {
+    case audit_failure_policy::reject:
+        return "reject";
+    case audit_failure_policy::permit:
+        return "permit";
+    }
+}
+
+static constexpr auto acceptable_audit_log_failure_policy_values() {
+    return std::to_array(
+      {to_string_view(audit_failure_policy::reject),
+       to_string_view(audit_failure_policy::permit)});
+}
+
+std::ostream& operator<<(std::ostream&, audit_failure_policy);
+std::istream& operator>>(std::istream&, audit_failure_policy&);
+
 } // namespace config

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -17,6 +17,7 @@
 #include "cluster/metadata_cache.h"
 #include "cluster/security_frontend.h"
 #include "config/configuration.h"
+#include "config/types.h"
 #include "kafka/client/client.h"
 #include "kafka/client/config_utils.h"
 #include "kafka/data/record_batcher.h"
@@ -32,6 +33,7 @@
 #include "security/audit/schemas/types.h"
 #include "security/audit/schemas/utils.h"
 #include "security/ephemeral_credential_store.h"
+#include "ssx/semaphore.h"
 #include "storage/parser_utils.h"
 #include "utils/retry.h"
 
@@ -101,8 +103,12 @@ public:
     ss::future<> shutdown();
 
     /// Produces to the audit topic partition specified with each batch.
-    /// Blocks if semaphore is exhausted.
-    ss::future<> produce(chunked_vector<partition_batch>, audit_probe&);
+    /// Blocks if semaphore is exhausted, or until the timeout expires, if one
+    /// is provided
+    ss::future<> produce(
+      chunked_vector<partition_batch>,
+      audit_probe&,
+      std::optional<ss::timer<>::duration> timeout = std::nullopt);
 
     /// Returns true if the configuration phase has completed which includes:
     /// - Connecting to the broker(s) w/ ephemeral creds
@@ -111,8 +117,11 @@ public:
     bool is_initialized() const { return _is_initialized; }
 
 private:
-    ss::future<>
-    do_produce(model::record_batch, model::partition_id, audit_probe&);
+    ss::future<> do_produce(
+      model::record_batch,
+      model::partition_id,
+      audit_probe&,
+      ss::timer<>::time_point timeout = ss::timer<>::time_point::max());
     ss::future<> update_status(kafka::error_code);
     ss::future<> update_status(kafka::produce_response);
     ss::future<> configure();
@@ -158,7 +167,9 @@ public:
     /// Produce to the audit topic within the context of the internal locks,
     /// ensuring toggling of the audit master switch happens in lock step with
     /// calls to produce()
-    ss::future<> produce(chunked_vector<partition_batch> records);
+    ss::future<> produce(
+      chunked_vector<partition_batch> records,
+      std::optional<ss::timer<>::duration> timeout = std::nullopt);
 
     /// Allocates and connects, or deallocates and shuts down the audit client
     void toggle(bool enabled);
@@ -492,7 +503,9 @@ ss::future<> audit_client::shutdown() {
 }
 
 ss::future<> audit_client::produce(
-  chunked_vector<partition_batch> records, audit_probe& probe) {
+  chunked_vector<partition_batch> records,
+  audit_probe& probe,
+  std::optional<ss::timer<>::duration> timeout) {
     auto total_size = absl::c_accumulate(
       records, size_t{0}, [](size_t acc, const partition_batch& b) {
           return acc + b.batch.size_bytes();
@@ -504,7 +517,9 @@ ss::future<> audit_client::produce(
       records.size(),
       total_size);
 
-    auto reserved = co_await ss::get_units(_send_sem, total_size);
+    auto timepoint = timeout.has_value() ? ss::timer<>::clock::now() + *timeout
+                                         : ss::timer<>::time_point::max();
+    auto reserved = co_await ss::get_units(_send_sem, total_size, timepoint);
 
     absl::c_for_each(records, [&reserved](partition_batch& pb) {
         try {
@@ -533,18 +548,24 @@ ss::future<> audit_client::produce(
           [this,
            &probe,
            max_concurrency,
-           records = std::move(records)]() mutable {
+           records = std::move(records),
+           timepoint]() mutable {
               return ss::do_with(
                 std::move(records),
-                [this, &probe, max_concurrency](auto& records) mutable {
+                timepoint,
+                [this, &probe, max_concurrency](
+                  auto& records, ss::timer<>::time_point& timeout) mutable {
                     return ss::max_concurrent_for_each(
                       std::make_move_iterator(records.begin()),
                       std::make_move_iterator(records.end()),
                       max_concurrency,
-                      [this,
-                       &probe](partition_batch rec) mutable -> ss::future<> {
+                      [this, &probe, &timeout](
+                        partition_batch rec) mutable -> ss::future<> {
                           return do_produce(
-                                   std::move(rec.batch), rec.pid, probe)
+                                   std::move(rec.batch),
+                                   rec.pid,
+                                   probe,
+                                   timeout)
                             .finally([units = std::move(rec.send_units)] {});
                       });
                 });
@@ -558,12 +579,15 @@ ss::future<> audit_client::produce(
 }
 
 ss::future<> audit_client::do_produce(
-  model::record_batch batch, model::partition_id pid, audit_probe& probe) {
+  model::record_batch batch,
+  model::partition_id pid,
+  audit_probe& probe,
+  ss::timer<>::time_point timeout) {
     // Effectively retry forever, but start a fresh request from batch data held
     // in memory when each produce_record_batch's retries are exhausted. This
     // way the kafka client should periodically refresh its internal metadata.
     std::optional<kafka::error_code> ec;
-    while (!_as.abort_requested()) {
+    while (!_as.abort_requested() && ss::timer<>::clock::now() < timeout) {
         auto r = co_await _client.produce_record_batch(
           model::topic_partition{model::kafka_audit_logging_topic, pid},
           batch.copy());
@@ -617,11 +641,13 @@ audit_sink::update_auth_status(auth_misconfigured_t auth_misconfigured) {
       });
 }
 
-ss::future<> audit_sink::produce(chunked_vector<partition_batch> records) {
+ss::future<> audit_sink::produce(
+  chunked_vector<partition_batch> records,
+  std::optional<ss::timer<>::duration> timeout) {
     /// No locks/gates since the calls to this method are done in controlled
     /// context of other synchronization primitives
     vassert(_client, "produce() called on a null client");
-    co_await _client->produce(std::move(records), _audit_mgr->probe());
+    co_await _client->produce(std::move(records), _audit_mgr->probe(), timeout);
 }
 
 ss::future<> audit_sink::publish_app_lifecycle_event(
@@ -640,7 +666,22 @@ ss::future<> audit_sink::publish_app_lifecycle_event(
             .make_batch_of_one(std::nullopt, std::move(b));
     chunked_vector<partition_batch> rs;
     rs.emplace_back(_audit_mgr->compute_partition_id(), std::move(batch));
-    co_await produce(std::move(rs));
+    // If the audit log reject policy is set to drop, then we will call produce
+    // with a 5s timeout.  This is to prevent the audit log from blocking either
+    // the Redpanda startup or shutdown process.  If the policy is set to
+    // reject, then no timeout is set
+    auto timeout = _audit_mgr->_audit_log_reject_policy()
+                       == config::audit_failure_policy::permit
+                     ? std::make_optional(5s)
+                     : std::nullopt;
+    try {
+        co_await produce(std::move(rs), timeout);
+    } catch (ss::semaphore_timed_out& e) {
+        vlog(
+          adtlog.error,
+          "Failed to produce application lifecycle event: {}",
+          e.what());
+    }
 }
 
 void audit_sink::toggle(bool enabled) {
@@ -726,6 +767,8 @@ audit_log_manager::audit_log_manager(
   kafka::client::configuration& client_config,
   ss::sharded<cluster::metadata_cache>* metadata_cache)
   : _audit_enabled(config::shard_local_cfg().audit_enabled.bind())
+  , _audit_log_reject_policy(
+      config::shard_local_cfg().audit_failure_policy.bind())
   , _queue_drain_interval_ms(
       config::shard_local_cfg().audit_queue_drain_interval_ms.bind())
   , _audit_event_types(
@@ -998,7 +1041,10 @@ audit_log_manager::should_enqueue_audit_event() const {
     if (_as.abort_requested()) {
         /// Prevent auditing new messages when shutdown starts that way the
         /// queue may be entirely flushed before shutdown
-        return std::make_optional(audit_event_passthrough::no);
+        return std::make_optional(
+          _audit_log_reject_policy() == config::audit_failure_policy::reject
+            ? audit_event_passthrough::no
+            : audit_event_passthrough::yes);
     }
     const auto& feature_table = _controller->get_feature_table();
     if (!feature_table.local().is_active(features::feature::audit_logging)) {
@@ -1016,7 +1062,10 @@ audit_log_manager::should_enqueue_audit_event() const {
         vlog(
           adtlog.warn,
           "Audit message rejected due to misconfigured authorization");
-        return std::make_optional(audit_event_passthrough::no);
+        return std::make_optional(
+          _audit_log_reject_policy() == config::audit_failure_policy::reject
+            ? audit_event_passthrough::no
+            : audit_event_passthrough::yes);
     }
     return std::nullopt;
 }

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -243,6 +243,8 @@ private:
 
     template<InheritsFromOCSFBase T, typename... Args>
     bool do_enqueue_audit_event(Args&&... args) {
+        static constexpr auto rate_limit = std::chrono::seconds(5);
+        static thread_local ss::logger::rate_limit rate(rate_limit);
         auto& map = _queue.get<underlying_unordered_map>();
         const auto hash_key = T::hash(args...);
         auto it = map.find(hash_key);
@@ -260,6 +262,17 @@ private:
                   msg_size,
                   _queue_bytes_sem.available_units());
                 probe().audit_error();
+                if (
+                  _audit_log_reject_policy()
+                  == config::audit_failure_policy::permit) {
+                    vloglr(
+                      adtlog,
+                      ss::log_level::warn,
+                      rate,
+                      "Audit event {} dropped due to full queue",
+                      *msg);
+                    return true;
+                }
                 return false;
             }
             auto& list = _queue.get<underlying_list>();
@@ -354,6 +367,7 @@ private:
 
     /// configuration options
     config::binding<bool> _audit_enabled;
+    config::binding<config::audit_failure_policy> _audit_log_reject_policy;
     config::binding<std::chrono::milliseconds> _queue_drain_interval_ms;
     config::binding<std::vector<ss::sstring>> _audit_event_types;
     size_t _max_queue_size_bytes;

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -93,6 +93,11 @@ class ClassUID(int, Enum):
     WEB_RESOURCE_ACCESS_ACTIVITY = 6004
 
 
+class AuditFailurePolicy(str, Enum):
+    PERMIT = 'permit'
+    REJECT = 'reject'
+
+
 class MTLSProvider(TLSProvider):
     """
     Defines an mTLS provider
@@ -237,10 +242,12 @@ class RangeTestItem(BaseTestItem):
 
 class AuditLogConfig:
     """Configuration for the audit log system"""
-    def __init__(self,
-                 enabled: bool = True,
-                 num_partitions: int = 8,
-                 event_types=['management', 'admin']):
+    def __init__(
+            self,
+            enabled: bool = True,
+            num_partitions: int = 8,
+            event_types=['management', 'admin'],
+            failure_policy: AuditFailurePolicy = AuditFailurePolicy.REJECT):
         """Initializes the config
 
         Parameters
@@ -257,6 +264,7 @@ class AuditLogConfig:
         self.enabled = enabled
         self.num_partitions = num_partitions
         self.event_types = event_types
+        self.failure_policy = failure_policy
 
     def to_conf(self) -> {str, str}:
         """Converts conf to dict
@@ -269,7 +277,8 @@ class AuditLogConfig:
         return {
             'audit_enabled': self.enabled,
             'audit_log_num_partitions': self.num_partitions,
-            'audit_enabled_event_types': self.event_types
+            'audit_enabled_event_types': self.event_types,
+            'audit_failure_policy': self.failure_policy.value
         }
 
 
@@ -339,9 +348,10 @@ class AuditLogTestBase(RedpandaTest):
         default_credentials(),
             audit_log_client_config: Optional[redpanda.AuditLogConfig] = None,
             extra_rp_conf=None,
+            permit_no_auth: bool = False,
             **kwargs):
-        assert (security.check_configuration()
-                ), "No auth enabled, test harness misconfigured"
+        assert (security.check_configuration() or
+                permit_no_auth), "No auth enabled, test harness misconfigured"
         self.audit_log_config = audit_log_config
 
         self.extra_rp_conf = self.audit_log_config.to_conf()
@@ -356,13 +366,13 @@ class AuditLogTestBase(RedpandaTest):
                 self.security.principal_mapping_rules
             ]
 
-        super(AuditLogTestBase,
-              self).__init__(test_context=test_context,
-                             extra_rp_conf=self.extra_rp_conf,
-                             log_config=self.log_config,
-                             security=self.security,
-                             audit_log_config=self.audit_log_client_config,
-                             **kwargs)
+        super(AuditLogTestBase, self).__init__(
+            test_context=test_context,
+            extra_rp_conf=self.extra_rp_conf,
+            log_config=self.log_config,
+            security=self.security if self.security else SecurityConfig(),
+            audit_log_config=self.audit_log_client_config,
+            **kwargs)
 
         self.rpk = self.get_rpk()
         self.super_rpk = self.get_super_rpk()
@@ -409,7 +419,7 @@ class AuditLogTestBase(RedpandaTest):
         else:
             return RpkTool(self.redpanda)
 
-    def setUp(self):
+    def setUp(self, wait_for_audit_log: bool = True):
         """Initializes the Redpanda node and waits for audit log to be present
         """
         super().setUp()
@@ -421,7 +431,8 @@ class AuditLogTestBase(RedpandaTest):
         self.logger.debug(
             f'Running OCSF Server Version {self.ocsf_server.get_api_version(None)}'
         )
-        self.wait_for_audit_log()
+        if wait_for_audit_log:
+            self.wait_for_audit_log()
 
     def wait_for_audit_log(self):
         """Waits for audit log to appear in the list of topics
@@ -2364,3 +2375,84 @@ class AuditLogTestEscapeHatch(RedpandaTest):
 
         # Ensure that this doesn't throw
         rpk.add_partitions(test_topic, 1)
+
+
+class AuditLogTestBypassBase(AuditLogTestBase):
+    """
+    Base test class that sets up the auditing tests with bad configuration.
+    """
+    def __init__(
+            self,
+            test_context,
+            security: AuditLogTestSecurityConfig = AuditLogTestSecurityConfig(
+            ),
+            extra_rp_conf=None,
+            expect_topic: bool = True,
+            permit_no_auth: bool = True,
+            **kwargs):
+
+        self.extra_rp_conf = AuditLogConfig(
+            enabled=True,
+            failure_policy=AuditFailurePolicy.PERMIT,
+            event_types=[
+                'management', 'produce', 'consume', 'describe', 'heartbeat',
+                'authenticate', 'admin', 'schema_registry'
+            ]).to_conf()
+        if extra_rp_conf is not None:
+            self.extra_rp_conf = self.extra_rp_conf | extra_rp_conf
+
+        self.expect_topic = expect_topic
+        super(AuditLogTestBypassBase, self).__init__(
+            test_context=test_context,
+            log_config=LoggingConfig('info',
+                                     logger_levels={'auditing': 'trace'}),
+            security=security,
+            permit_no_auth=permit_no_auth,
+            extra_rp_conf=self.extra_rp_conf,
+            **kwargs)
+
+    def setUp(self):
+        super().setUp(wait_for_audit_log=self.expect_topic)
+
+    @cluster(
+        num_nodes=4,
+        log_allow_list=[
+            'Failed to produce application lifecycle event: Semaphore timed out: audit_log_producer_semaphore'
+        ])
+    def test_bypass(self):
+        """
+        Validates that the Redpanda cluster is able to operate even with a misconfigured
+        audit log client
+        """
+
+        # Below is a simple set of actions that are performed to validate that Kafka commands function even when the audit log is not functioning
+        self.super_rpk.create_topic('test')
+        self.super_rpk.produce('test', key='test key', msg='test message')
+        self.super_rpk.consume('test', n=1)
+
+
+class AuditLogTestNoSecurityConfigured(AuditLogTestBypassBase):
+    """
+    Validates that the 'drop' configuration works when security credentials are not properly configured.
+    """
+    def __init__(self, test_context):
+        super(AuditLogTestNoSecurityConfigured,
+              self).__init__(test_context=test_context,
+                             expect_topic=False,
+                             permit_no_auth=True)
+
+
+class AuditLogTestSmallBuffers(AuditLogTestBypassBase):
+    """
+    Validates that the 'drop' configuraiton works when the audit log buffers are too small
+    """
+    def __init__(self, test_context):
+        super(AuditLogTestSmallBuffers, self).__init__(
+            test_context=test_context,
+            expect_topic=True,
+            security=AuditLogTestSecurityConfig.default_credentials(),
+            extra_rp_conf={
+                'audit_client_max_buffer_size': 1,
+                'audit_queue_max_buffer_size_per_shard': 1
+            },
+            permit_no_auth=False)


### PR DESCRIPTION
Adds a new cluster configuration `audit_failure_policy` that is an enum that controls how the audit system handles situations when an audit message is unable to be written to the audit log.

* `reject` - The command is rejected (default, current behavior)
* `permit` - The command is permitted, but the audit message is dropped

Fixes: CORE-12663

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Adds `audit_failure_policy` that allows users to set the behavior of the audit log if the system is unable to produce the audit message to the audit log