### PR TITLE
serde/json: do not throw on empty docs

### DIFF
--- a/src/v/serde/json/parser.cc
+++ b/src/v/serde/json/parser.cc
@@ -211,6 +211,11 @@ public:
     ss::future<token> parse_json_document() {
         TRACE("parse_json_document\n");
 
+        if (_buf.empty()) {
+            TRACE("parse_json_document: empty buffer\n");
+            co_return fuse_with_failure();
+        }
+
         switch (_buf.peek()) {
         case '{':
             co_return parse_object();
@@ -223,6 +228,11 @@ public:
 
     ss::future<token> parse_json_value() {
         TRACE("parse_json_value, peek: {}\n", _buf.peek());
+
+        if (_buf.empty()) {
+            TRACE("parse_json_value: empty buffer\n");
+            co_return fuse_with_failure();
+        }
 
         switch (_buf.peek()) {
         case '{':

--- a/src/v/serde/json/tests/parser_test.cc
+++ b/src/v/serde/json/tests/parser_test.cc
@@ -31,3 +31,45 @@ TEST_CORO(json_test_suite, parse) {
     EXPECT_EQ(parser.token(), token::eof) << "Expected to reach EOF but got: "
                                           << std::to_underlying(parser.token());
 }
+
+struct token_seq_test_case {
+    std::string_view input;
+    std::vector<token> expected_tokens;
+};
+
+ss::future<> run_test_case(const token_seq_test_case& tc) {
+    auto parser = experimental::serde::json::parser(iobuf::from(tc.input));
+    for (const auto& expected : tc.expected_tokens) {
+        ASSERT_TRUE_CORO(co_await parser.next())
+          << "Expected next() to return true for input: " << tc.input;
+        ASSERT_EQ_CORO(parser.token(), expected)
+          << "Unexpected token for input: " << tc.input;
+    }
+    ASSERT_FALSE_CORO(co_await parser.next())
+      << "Expected next() to return false after all tokens for input: "
+      << tc.input;
+}
+
+TEST_CORO(json_parser, parse_empty) {
+    constexpr auto empty_documents = std::to_array<std::string_view>(
+      {"", " ", "\n", "\t", "\r\n"});
+
+    for (const auto& doc : empty_documents) {
+        SCOPED_TRACE(fmt::format("Testing empty document: {}", doc));
+        ASSERT_NO_FATAL_FAILURE_CORO(co_await run_test_case({
+          .input = doc,
+          .expected_tokens = {token::error},
+        }));
+    }
+};
+
+TEST_CORO(json_parser, leading_trailing_whitespace) {
+    ASSERT_NO_FATAL_FAILURE_CORO(co_await run_test_case({
+        .input = "   [   ]   ",
+        .expected_tokens = {
+            token::start_array,
+            token::end_array,
+            token::eof,
+        },
+    }));
+}


### PR DESCRIPTION
Return an error instead.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
