### PR TITLE
CORE-12276 SR AuthZ: implement authz for /schemas/ids/{id}

### DIFF
--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -29,15 +29,23 @@ concept no_auth = std::is_same_v<T, auth::none>
 template<typename T>
 concept requires_auth = !no_auth<T>;
 
+struct auth_params {
+    security::acl_principal principal;
+    security::acl_host host;
+    security::acl_operation op;
+
+    auth_params(const server::request_t& rq, const auth& auth)
+      : principal{security::principal_type::user, rq.user.name}
+      , host{rq.req->get_client_address().addr()}
+      , op{auth.get_op().value_or(security::acl_operation::all)} {}
+};
+
 } // namespace detail
 
-void handle_authz(
-  const server::request_t& rq,
-  const auth& auth,
-  request_auth_result& auth_result) {
-    auth_result.pass();
+namespace {
 
-    // Extract the resource from the request
+auth::resource
+extract_resource_from_request(const server::request_t& rq, const auth& auth) {
     auto resource = auth.get_resource();
     ss::visit(
       resource,
@@ -45,34 +53,45 @@ void handle_authz(
           sub = parse::request_param<subject>(*rq.req, "subject");
       },
       [](const auto&) {});
+    return resource;
+}
 
-    security::acl_principal principal{
-      security::principal_type::user, rq.user.name};
-    security::acl_host host{rq.req->get_client_address().addr()};
-    security::acl_operation op = auth.get_op().value_or(
-      security::acl_operation::all);
+void handle_authz_result(const security::auth_result& authz_result) {
+    if (authz_result.is_authorized()) {
+        // TODO(CORE-12275): audit success
+    } else {
+        // TODO(CORE-12275): audit failure
+        throw ss::httpd::base_exception(
+          "Forbidden (missing required ACLs)",
+          ss::http::reply::status_type::forbidden);
+    }
+}
+
+} // namespace
+
+void handle_authz(
+  const server::request_t& rq,
+  const auth& auth,
+  request_auth_result& auth_result) {
+    auth_result.pass();
+
+    detail::auth_params params{rq, auth};
+
+    auto resource = extract_resource_from_request(rq, auth);
 
     // Check Authorization
     auto authz_result = ss::visit(
       resource,
       [&](const detail::requires_auth auto& resource_name) {
           return rq.service().authorizor().authorized(
-            resource_name, op, principal, host);
+            resource_name, params.op, params.principal, params.host);
       },
       [&](const detail::no_auth auto&) {
           return security::auth_result::authz_disabled(
-            principal, host, op, registry_resource{});
+            params.principal, params.host, params.op, registry_resource{});
       });
 
-    if (authz_result.is_authorized()) {
-        // TODO(CORE-12275): audit success
-    } else {
-        // TODO(CORE-12275): audit failure
-
-        throw ss::httpd::base_exception(
-          "Forbidden (missing required ACLs)",
-          ss::http::reply::status_type::forbidden);
-    }
+    handle_authz_result(authz_result);
 }
 
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -94,4 +94,19 @@ void handle_authz(
     handle_authz_result(authz_result);
 }
 
+void handle_deferred_authz(
+  const server::request_t& rq,
+  const auth& auth,
+  request_auth_result& auth_result,
+  const chunked_vector<subject>& resource_names) {
+    auth_result.pass();
+
+    detail::auth_params params{rq, auth};
+
+    auto authz_result = rq.service().authorizor().any_authorized(
+      resource_names, params.op, params.principal, params.host);
+
+    handle_authz_result(authz_result);
+}
+
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/authorization.h
+++ b/src/v/pandaproxy/schema_registry/authorization.h
@@ -24,4 +24,10 @@ void handle_authz(
   const auth& auth,
   request_auth_result& auth_result);
 
+void handle_deferred_authz(
+  const server::request_t& rq,
+  const auth& auth,
+  request_auth_result& auth_result,
+  const chunked_vector<subject>& resource_names);
+
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <ranges>
 
 namespace ppj = pandaproxy::json;
 
@@ -347,7 +348,7 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_schemas_ids_id(
   server::request_t rq,
   server::reply_t rp,
-  auth auth,
+  auth auth_obj,
   std::optional<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
@@ -356,12 +357,10 @@ ss::future<server::reply_t> get_schemas_ids_id(
     // Check if we need to validate the auth result
     // Note: we may not need to if ACLs or authentication are disabled
     if (auth_result.has_value()) {
-        // TODO(CORE-12276): Authorization check
-        // if auth::op::read for any subject that references this is satisfied
-        //    create an auth with the resource, pass it below
-        // else
-        //    fail
-        enterprise::handle_authz(rq, auth, *auth_result);
+        auto subs = co_await rq.service().schema_store().get_schema_subjects(
+          id, include_deleted::yes);
+        auto subjects = std::ranges::to<chunked_vector<subject>>(subs);
+        enterprise::handle_deferred_authz(rq, auth_obj, *auth_result, subjects);
     }
 
     // With deferred schema validation, there might be a schema that

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -85,7 +85,11 @@ public:
                   return h(std::move(rq), std::move(rp));
               },
               [&](const auth::deferred_function_handler& h) {
-                  return h(std::move(rq), std::move(rp), _auth, auth_result);
+                  return h(
+                    std::move(rq),
+                    std::move(rp),
+                    _auth,
+                    std::move(auth_result));
               });
         } catch (const kafka::client::partition_error& ex) {
             if (

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -214,7 +214,7 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       ss::httpd::schema_registry_json::get_schemas_ids_id,
       wrap(
         auth::level::user,
-        std::nullopt,
+        acl_operation::read,
         auth::deferred{},
         get_schemas_ids_id)});
 

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -381,10 +381,10 @@ void admin_server::register_security_routes() {
     register_route<user, true>(
       ss::httpd::security_json::list_user_roles,
       [this](
-        std::unique_ptr<ss::http::request> req, request_auth_result auth_result)
+        std::unique_ptr<ss::http::request> req,
+        const request_auth_result& auth_result)
         -> ss::future<ss::json::json_return_type> {
-          return list_user_roles_handler(
-            std::move(req), std::move(auth_result));
+          return list_user_roles_handler(std::move(req), auth_result);
       });
 
     register_route<superuser>(
@@ -621,7 +621,8 @@ admin_server::oidc_revoke_handler(std::unique_ptr<ss::http::request>) {
 }
 
 ss::future<ss::json::json_return_type> admin_server::list_user_roles_handler(
-  std::unique_ptr<ss::http::request> req, request_auth_result auth_result) {
+  std::unique_ptr<ss::http::request> req,
+  const request_auth_result& auth_result) {
     ss::sstring filter = req->get_query_param("filter");
 
     security::role_member member{

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -205,7 +205,7 @@ private:
     template<typename R>
     auto exception_intercepter(
       const ss::sstring& url, const request_auth_result& auth_state) {
-        return [this, url, auth_state](std::exception_ptr eptr) mutable {
+        return [this, url, &auth_state](std::exception_ptr eptr) mutable {
             log_exception(url, auth_state, eptr);
             return ss::make_exception_future<R>(eptr);
         };
@@ -465,7 +465,7 @@ private:
     ss::future<ss::json::json_return_type>
     oidc_revoke_handler(std::unique_ptr<ss::http::request> req);
     ss::future<ss::json::json_return_type> list_user_roles_handler(
-      std::unique_ptr<ss::http::request>, request_auth_result);
+      std::unique_ptr<ss::http::request>, const request_auth_result&);
 
     ss::future<std::unique_ptr<ss::http::reply>> create_role_handler(
       std::unique_ptr<ss::http::request> req,

--- a/src/v/security/audit/schemas/application_activity.h
+++ b/src/v/security/audit/schemas/application_activity.h
@@ -128,7 +128,8 @@ public:
         auto crud = op_to_crud(auth_result.operation);
         auto actor = result_to_actor(auth_result);
         new_ars.emplace_back(resource_detail{
-          .name = auth_result.resource_name,
+          .name = auth_result.resource_name.value_or(
+            ss::sstring{"[no-resource]"}),
           .type = fmt::format("{}", auth_result.resource_type)});
 
         return {

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -17,6 +17,7 @@
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "security/acl.h"
 #include "security/role.h"
 #include "security/role_store.h"
 
@@ -75,8 +76,12 @@ public:
         }
     }
 
-    constexpr void record_authz_result(authz_result r) {
-        ++_authz_results[static_cast<size_t>(r)];
+    constexpr void record_authz_result(const auth_result& r) {
+        authz_result r_val = r.is_authorized() ? authz_result::allow
+                             : r.empty_matches ? authz_result::empty
+                                               : authz_result::deny;
+
+        ++_authz_results[static_cast<size_t>(r_val)];
     }
 
 private:
@@ -166,11 +171,41 @@ auth_result authorizer::authorized(
   acl_operation operation,
   const acl_principal& principal,
   const acl_host& host) const {
-    auth_result r = do_authorized(resource_name, operation, principal, host);
-    _probe->record_authz_result(
-      r.is_authorized() ? authz_result::allow
-      : r.empty_matches ? authz_result::empty
-                        : authz_result::deny);
+    auth_result r = [&]() {
+        if (_superusers.contains(principal)) {
+            return auth_result::superuser_authorized(
+              principal, host, operation, resource_name);
+        }
+        return do_authorized(resource_name, operation, principal, host);
+    }();
+
+    _probe->record_authz_result(r);
+    return r;
+}
+
+template<typename T>
+auth_result authorizer::any_authorized(
+  const chunked_vector<T>& resource_names,
+  acl_operation operation,
+  const acl_principal& principal,
+  const acl_host& host) const {
+    auth_result r = [&]() {
+        constexpr auto resoure_type = get_resource_type<T>();
+        for (const auto& resource_name : resource_names) {
+            auto res = do_authorized(resource_name, operation, principal, host);
+            if (res.is_authorized()) {
+                return res;
+            }
+        }
+        if (_superusers.contains(principal)) {
+            return auth_result::superuser_authorized_without_resource(
+              principal, host, operation, resoure_type);
+        }
+        return auth_result::no_acl_match_without_resource(
+          principal, host, operation, resoure_type);
+    }();
+
+    _probe->record_authz_result(r);
     return r;
 }
 
@@ -322,6 +357,12 @@ template auth_result authorizer::authorized(
 
 template auth_result authorizer::authorized(
   const pandaproxy::schema_registry::registry_resource&,
+  acl_operation,
+  const acl_principal&,
+  const acl_host&) const;
+
+template auth_result authorizer::any_authorized(
+  const chunked_vector<pandaproxy::schema_registry::subject>&,
   acl_operation,
   const acl_principal&,
   const acl_host&) const;

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -51,8 +51,9 @@ struct auth_result {
     security::acl_host host;
     // The type of resource
     security::resource_type resource_type;
-    // The name of the resource
-    ss::sstring resource_name;
+    // The name of the resource (may be missing on endpoints that dynamically
+    // select which resources apply to the endpoint)
+    std::optional<ss::sstring> resource_name;
     // The operation request
     security::acl_operation operation;
 
@@ -95,6 +96,21 @@ struct auth_result {
           .host = host,
           .resource_type = get_resource_type<T>(),
           .resource_name = resource(),
+          .operation = operation};
+    }
+
+    static auth_result superuser_authorized_without_resource(
+      const security::acl_principal& principal,
+      security::acl_host host,
+      security::acl_operation operation,
+      security::resource_type resource_type) {
+        return {
+          .authorized = true,
+          .is_superuser = true,
+          .principal = principal,
+          .host = host,
+          .resource_type = resource_type,
+          .resource_name = std::optional<ss::sstring>{},
           .operation = operation};
     }
 
@@ -176,6 +192,23 @@ struct auth_result {
           .resource_name = resource(),
           .operation = operation};
     }
+
+    static auth_result no_acl_match_without_resource(
+      const security::acl_principal& principal,
+      security::acl_host host,
+      security::acl_operation operation,
+      security::resource_type resource_type) {
+        return {
+          .authorized = false,
+          .empty_matches = true,
+          .resource_pattern = std::nullopt,
+          .acl = std::nullopt,
+          .principal = principal,
+          .host = host,
+          .resource_type = resource_type,
+          .resource_name = std::optional<ss::sstring>{},
+          .operation = operation};
+    }
 };
 
 /*
@@ -229,6 +262,17 @@ public:
     template<typename T>
     auth_result authorized(
       const T& resource_name,
+      acl_operation operation,
+      const acl_principal& principal,
+      const acl_host& host) const;
+
+    /*
+     * Authorize an operation on any resource. The type of the resource is
+     * deduced by the type `T` of the name of the resouce (e.g. `model::topic`).
+     */
+    template<typename T>
+    auth_result any_authorized(
+      const chunked_vector<T>& resource_names,
       acl_operation operation,
       const acl_principal& principal,
       const acl_host& host) const;

--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -216,6 +216,17 @@ void request_auth_result::require_authenticated() {
 
 void request_auth_result::pass() { _checked = true; }
 
+request_auth_result::request_auth_result(request_auth_result&& other) noexcept
+  : _username{std::move(other._username)}
+  , _password{std::move(other._password)}
+  , _sasl_mechanism{std::move(other._sasl_mechanism)}
+  , _authenticated{other._authenticated}
+  , _superuser{other._superuser}
+  , _auth_required{other._auth_required}
+  , _checked{other._checked} {
+    other.pass();
+}
+
 /**
  * It is important to protect against someone calling authenticate()
  * but then not calling any of the authorization helpers: this indicates

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -80,6 +80,11 @@ public:
       , _superuser(is_superuser)
       , _auth_required(is_auth_required) {};
 
+    request_auth_result operator=(request_auth_result&&) = delete;
+    request_auth_result operator=(const request_auth_result&) = delete;
+    request_auth_result(const request_auth_result&) = delete;
+
+    request_auth_result(request_auth_result&&) noexcept;
     ~request_auth_result() noexcept(false);
 
     /**

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 #include <fmt/ostream.h>
 
+#include <algorithm>
+
 namespace security {
 
 static const acl_entry allow_read_acl(
@@ -1677,6 +1679,86 @@ BOOST_AUTO_TEST_CASE(authz_filter_out_non_kafka_resources) {
     result = auth.authorized(
       ppsr::registry_resource(), acl_operation::read, user, host);
     BOOST_REQUIRE(!result.is_authorized());
+}
+
+BOOST_AUTO_TEST_CASE(any_authorized_first_resource_authorized) {
+    namespace sr = pandaproxy::schema_registry;
+    acl_principal user(principal_type::user, "alice");
+    acl_host host("192.168.2.1");
+    auto auth = make_test_instance();
+
+    // Set up ACL that allows read on subject-1 but not subject-2
+    const acl_entry allow_read(
+      user, acl_wildcard_host, acl_operation::read, acl_permission::allow);
+
+    std::vector<acl_binding> bindings;
+    resource_pattern sub1_resource(
+      resource_type::sr_subject,
+      sr::subject{"subject-1"},
+      pattern_type::literal);
+    bindings.emplace_back(sub1_resource, allow_read);
+    auth.add_bindings(bindings);
+
+    chunked_vector<sr::subject> topics;
+    topics.emplace_back("subject-1");
+    topics.emplace_back("subject-2");
+
+    // Test with first resource authorized
+    auto result = auth.any_authorized(topics, acl_operation::read, user, host);
+    BOOST_REQUIRE(result.authorized);
+    BOOST_CHECK_EQUAL(result.acl, allow_read);
+    BOOST_CHECK_EQUAL(result.principal, user);
+    BOOST_CHECK_EQUAL(result.resource_name, "subject-1");
+
+    // Test with second resource authorized
+    std::ranges::reverse(topics);
+    result = auth.any_authorized(topics, acl_operation::read, user, host);
+    BOOST_REQUIRE(result.authorized);
+    BOOST_CHECK_EQUAL(result.acl, allow_read);
+    BOOST_CHECK_EQUAL(result.principal, user);
+    BOOST_CHECK_EQUAL(result.resource_name, "subject-1");
+
+    // Test with no resource given (and not superuser)
+    result = auth.any_authorized(
+      chunked_vector<sr::subject>{}, acl_operation::read, user, host);
+    BOOST_REQUIRE(!result.authorized);
+    BOOST_CHECK_EQUAL(result.principal, user);
+    BOOST_CHECK_EQUAL(result.resource_type, resource_type::sr_subject);
+    BOOST_CHECK_EQUAL(result.resource_name, std::optional<ss::sstring>{});
+}
+
+BOOST_AUTO_TEST_CASE(any_authorized_superuser_authorized) {
+    namespace sr = pandaproxy::schema_registry;
+
+    config::mock_property<std::vector<ss::sstring>> superuser_config_prop(
+      std::vector<ss::sstring>{});
+    role_store roles;
+    authorizer auth(superuser_config_prop.bind(), &roles);
+
+    acl_principal superuser(principal_type::user, "superuser1");
+    acl_host host("192.168.2.1");
+
+    superuser_config_prop.update({superuser.name()});
+
+    chunked_vector<sr::subject> topics;
+    topics.emplace_back("subject-1");
+    topics.emplace_back("subject-2");
+
+    auto result = auth.any_authorized(
+      topics, acl_operation::read, superuser, host);
+    BOOST_CHECK(result.authorized);
+    BOOST_CHECK(!result.acl.has_value());
+    BOOST_CHECK_EQUAL(result.resource_type, resource_type::sr_subject);
+    BOOST_CHECK_EQUAL(result.principal, superuser);
+    BOOST_CHECK_EQUAL(result.resource_name, "subject-1");
+
+    result = auth.any_authorized(
+      chunked_vector<sr::subject>{}, acl_operation::read, superuser, host);
+    BOOST_CHECK(result.authorized);
+    BOOST_CHECK(!result.acl.has_value());
+    BOOST_CHECK_EQUAL(result.principal, superuser);
+    BOOST_CHECK_EQUAL(result.resource_type, resource_type::sr_subject);
+    BOOST_CHECK_EQUAL(result.resource_name, std::optional<ss::sstring>{});
 }
 
 } // namespace security

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6659,6 +6659,11 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
                                                       auth=self.super_auth)
         self.assert_equal(result.status_code, 200)
 
+        # Check deferred endpoints
+        schema_id = result.json()['id']
+        result = self._get_schemas_ids_id(schema_id, auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+
     @cluster(num_nodes=1)
     def test_resource_patterns(self):
         """Test that prefixed and global pattern matching of resources works"""
@@ -6690,3 +6695,88 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         self._post_acl(acl_3)
 
         check_post_schemas(can_post_1=False, can_post_2=False)
+
+    @cluster(num_nodes=1)
+    def test_get_schemas_ids_id_authorization(self):
+        """
+        Test GET /schemas/ids/{id} endpoint authorization logic.
+        This endpoint allows access if the user has READ permission on ANY subject
+        that references the schema.
+        """
+
+        # Create test subjects referencing the same schema
+        subject_1 = "test-subject-1"
+        subject_2 = "test-subject-2"
+        subject_3 = "test-subject-3"
+
+        schema_id = self._create_schema(subject_1)
+
+        response = self._post_subjects_subject_versions(
+            subject_2, data=self.schema_data_1, auth=self.super_auth)
+        self.assert_equal(response.status_code, 200)
+        self.assert_equal(response.json()["id"], schema_id)
+
+        response = self._post_subjects_subject_versions(
+            subject_3, data=self.schema_data_1, auth=self.super_auth)
+        self.assert_equal(response.status_code, 200)
+        self.assert_equal(response.json()["id"], schema_id)
+
+        # No ACLs - should be denied
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+        # Grant READ to subject_1 - should succeed
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Switch access to subject_2 - should still work (any subject access sufficient)
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ", "DENY"))
+        self._post_acl(
+            self._create_acl(subject_2, "SUBJECT", "LITERAL", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Remove all access - should be denied
+        self._post_acl(
+            self._create_acl(subject_2, "SUBJECT", "LITERAL", "READ", "DENY"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+        # Grant access to subject 3 using a prefixed ACL - should succeed
+        self._post_acl(
+            self._create_acl("test-subject-", "SUBJECT", "PREFIXED", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Delete the only subject that granted access to the endpoint
+        # Should still succeed since soft-deleted subjects also count
+        result = self._delete_subject(subject_3, auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+    @cluster(num_nodes=1)
+    def test_get_schemas_ids_no_match(self):
+        """
+        Test that access is denied when no subject referencing the schema allows access.
+
+        Even with a wildcard (*) ALLOW rule, if all specific subjects that reference
+        the schema are explicitly denied, the endpoint should return 403.
+        """
+        subject_1 = "test-subject-1"
+        schema_id = self._create_schema(subject_1)
+
+        # Verify wildcard (*) ALLOW grants access
+        self._post_acl(self._create_acl("*", "SUBJECT", "LITERAL", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Add specific DENY to override wildcard ALLOW - should be denied (no subject grants access)
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ", "DENY"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)


### PR DESCRIPTION
Implements CORE-12276

/schemas/ids/{id} - Permission is granted if this schema id exists
(including soft-deleted) on a subject with a matching permission set.

Operation is authorized if the principal has auth::op::read for any
subject that references the schema id.

See the commit messages for implementation details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
