### PR TITLE
strings/utf8: unneeded copy in validate_utf8

### DIFF
--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -25,7 +25,7 @@ namespace {
 struct header_parsing_error_utf8 : public default_control_character_thrower {
     using default_control_character_thrower::default_control_character_thrower;
 
-    [[noreturn]] [[gnu::cold]] void conversion_error() override {
+    [[noreturn]] [[gnu::cold]] void conversion_error() const override {
         throw invalid_utf8_exception("Invalid UTF8 in header");
     }
 };
@@ -33,7 +33,7 @@ struct header_parsing_error_utf8 : public default_control_character_thrower {
 struct header_parsing_error_control : public default_control_character_thrower {
     using default_control_character_thrower::default_control_character_thrower;
 
-    [[noreturn]] [[gnu::cold]] void conversion_error() override {
+    [[noreturn]] [[gnu::cold]] void conversion_error() const override {
         throw control_character_present_exception(
           "Control character in header");
     }

--- a/src/v/pandaproxy/parsing/exceptions.h
+++ b/src/v/pandaproxy/parsing/exceptions.h
@@ -49,7 +49,7 @@ struct pp_parsing_error : public default_control_character_thrower {
       : default_control_character_thrower()
       , _parameter_name(parameter_name) {}
 
-    [[noreturn]] [[gnu::cold]] void conversion_error() override {
+    [[noreturn]] [[gnu::cold]] void conversion_error() const override {
         throw parse::error(
           parse::error_code::invalid_param,
           fmt::format(

--- a/src/v/pandaproxy/schema_registry/requests/acls.cc
+++ b/src/v/pandaproxy/schema_registry/requests/acls.cc
@@ -25,7 +25,7 @@ namespace pandaproxy::schema_registry {
 struct acl_control_character_thrower {
     explicit acl_control_character_thrower(std::string_view field)
       : field_name(field) {}
-    [[noreturn]] void conversion_error() {
+    [[noreturn]] void conversion_error() const {
         throw exception(
           error_code::acl_invalid,
           fmt::format("Control characters not allowed in '{}'", field_name));

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -107,7 +107,7 @@ public:
           : default_control_character_thrower()
           , _parameter_name(parameter_name) {}
 
-        [[noreturn]] [[gnu::cold]] void conversion_error() override {
+        [[noreturn]] [[gnu::cold]] void conversion_error() const override {
             throw ss::httpd::bad_request_exception(fmt::format(
               "Parameter '{}' contained invalid control characters",
               _parameter_name));

--- a/src/v/strings/tests/utf8_control_chars.cc
+++ b/src/v/strings/tests/utf8_control_chars.cc
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(control_chars_default_thrower) {
 }
 
 struct my_check_exception {
-    [[noreturn]] [[gnu::cold]] void conversion_error() {
+    [[noreturn]] [[gnu::cold]] void conversion_error() const {
         throw std::invalid_argument("invalid argument");
     }
 };

--- a/src/v/strings/utf8.cc
+++ b/src/v/strings/utf8.cc
@@ -12,19 +12,3 @@
 #include "strings/utf8.h"
 
 thread_local bool permit_unsafe_log_operation::_flag = false;
-
-bool is_valid_utf8(std::string_view s) {
-    bool is_valid = true;
-    class default_utf8_checker {
-    public:
-        explicit default_utf8_checker(bool* is_valid)
-          : _is_valid(is_valid) {}
-
-        void conversion_error() { *_is_valid = false; }
-
-    private:
-        bool* _is_valid;
-    };
-    validate_utf8(s, default_utf8_checker{&is_valid});
-    return is_valid;
-}

--- a/src/v/strings/utf8.h
+++ b/src/v/strings/utf8.h
@@ -16,6 +16,7 @@
 
 #include <boost/locale.hpp>
 #include <boost/locale/encoding_utf.hpp>
+#include <boost/locale/utf.hpp>
 
 #include <string>
 #include <string_view>
@@ -74,10 +75,10 @@ struct invalid_utf8_exception : public invalid_character_exception {
 };
 
 template<typename T>
-concept ExceptionThrower = requires(T obj) { obj.conversion_error(); };
+concept ExceptionThrower = requires(const T obj) { obj.conversion_error(); };
 
 struct default_utf8_thrower {
-    [[noreturn]] [[gnu::cold]] void conversion_error() {
+    [[noreturn]] [[gnu::cold]] void conversion_error() const {
         throw invalid_utf8_exception("Cannot decode string as UTF8");
     }
 };
@@ -90,7 +91,7 @@ struct control_character_present_exception
 
 struct default_control_character_thrower {
     virtual ~default_control_character_thrower() = default;
-    [[noreturn]] [[gnu::cold]] virtual void conversion_error() {
+    [[noreturn]] [[gnu::cold]] virtual void conversion_error() const {
         throw control_character_present_exception(
           "String contains control character");
     }
@@ -138,13 +139,25 @@ inline size_t validate_and_truncate(std::string_view s) {
     return valid_length;
 }
 
+inline bool is_valid_utf8(std::string_view s) {
+    auto begin = s.cbegin();
+    auto end = s.cend();
+
+    while (begin != end) {
+        const boost::locale::utf::code_point c
+          = boost::locale::utf::utf_traits<char>::decode(begin, end);
+        if (!boost::locale::utf::is_valid_codepoint(c)) {
+            return false;
+        }
+        // continue
+    }
+    return true;
+}
+
 template<typename Thrower>
 requires ExceptionThrower<Thrower>
-inline void validate_utf8(std::string_view s, Thrower&& thrower) {
-    try {
-        boost::locale::conv::utf_to_utf<char>(
-          s.data(), s.data() + s.size(), boost::locale::conv::stop);
-    } catch (const boost::locale::conv::conversion_error& ex) {
+inline void validate_utf8(std::string_view s, const Thrower& thrower) {
+    if (!is_valid_utf8(s)) {
         thrower.conversion_error();
     }
 }
@@ -152,5 +165,3 @@ inline void validate_utf8(std::string_view s, Thrower&& thrower) {
 inline void validate_utf8(std::string_view s) {
     validate_utf8(s, default_utf8_thrower{});
 }
-
-bool is_valid_utf8(std::string_view s);


### PR DESCRIPTION
boost::locale::conv::utf_to_utf returns a re-encoded string which is
promptly discarded. This change performs the inner utf8 validation
without storing an additional string.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
