### PR TITLE
iceberg/config: remove extra validation of creds source

### DIFF
--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -295,21 +295,6 @@ validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
               ? config.iceberg_rest_catalog_aws_credentials_source().value()
               : config.cloud_storage_credentials_source();
 
-        if (
-          effective_creds_source != model::cloud_credentials_source::config_file
-          && effective_creds_source
-               != model::cloud_credentials_source::aws_instance_metadata) {
-            // SigV4 only makes sense for config or instance metadata.
-            return fmt::format(
-              "SigV4 authentication (iceberg_rest_catalog_authentication_mode "
-              "= {}) "
-              "is only supported with credentials sources 'config_file' or "
-              "'aws_instance_metadata'. Current effective credentials source "
-              "is '{}'.",
-              auth_mode,
-              effective_creds_source);
-        }
-
         // When using aws_instance_metadata, AWS credentials are not required
         if (
           effective_creds_source


### PR DESCRIPTION
This removes a validation check about REST catalog auth that has a few problems:
1. The validation wasn't right because it is also acceptable to specify the key and secret as config options.
2. It introduces a dependence among configuration options that adds complexity without any real benefit. If things are configured wrong, then authentication to the catalog just won't work, and it should be obvious if the configuration values don't make sense together.
3. Dealing with the configuration dependence in tests is painful, especially in tests where many values are changed somewhat independently of each other.

This check was causing failures in ClusterConfigTest.test_valid_settings.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

