### PR TITLE
[v25.1.x] `storage`: set cached disk usage after compaction rounds & more cached disk usage improvements (MANUAL BACKPORT) 

### DIFF
--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -78,6 +78,7 @@ public:
     virtual void set_flag(compacted_index::footer_flags) = 0;
     virtual void print(std::ostream&) const = 0;
     const ss::sstring& filename() const { return _name; }
+    virtual size_t size_bytes() const = 0;
 
 private:
     friend std::ostream&

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1064,7 +1064,12 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     }
     // transfer segment state from replacement to target
     locks = co_await internal::transfer_segment(
-      target, replacement, cfg, *_probe, std::move(locks));
+      target,
+      replacement,
+      cfg,
+      *_probe,
+      std::move(locks),
+      ret.cmp_idx_size_after);
 
     auto segment_to_remove = segments.back();
     // We are going to remove one of the segments, but its bytes have not
@@ -1576,7 +1581,8 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     co_await seg->index().drop_all_data();
 
     // Rename the data file.
-    co_await internal::do_swap_data_file_handles(tmpname, seg, cfg, *_probe);
+    co_await internal::do_swap_data_file_handles(
+      tmpname, seg, cfg, *_probe, compacted_idx_writer->size_bytes());
 
     // Persist the state of our indexes in their new names.
     seg->index().swap_index_state(std::move(new_idx));

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -530,7 +530,6 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
           segment->reader().filename(),
           result);
         if (result.did_compact()) {
-            segment->clear_cached_disk_usage();
             _compaction_ratio.update(result.compaction_ratio());
             const ssize_t removed_bytes = ssize_t(result.size_before)
                                           - ssize_t(result.size_after);

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -255,13 +255,22 @@ ss::future<> segment::do_release_appender(
         std::optional<std::unique_ptr<compacted_index_writer>>&
           compacted_index) {
           return appender->close()
-            .then([this] { return _idx.flush(); })
-            .then([this, &compacted_index] {
+            .then([this] {
+                clear_cached_disk_usage();
+                return _idx.flush();
+            })
+            .then([&compacted_index] {
                 if (compacted_index) {
                     return compacted_index.value()->close();
                 }
-                clear_cached_disk_usage();
                 return ss::now();
+            })
+            .then([this, &compacted_index, &appender] {
+                std::optional<size_t> cmp_idx_size{std::nullopt};
+                if (compacted_index) {
+                    cmp_idx_size = compacted_index.value()->size_bytes();
+                }
+                set_cached_disk_usage(appender->size_bytes(), cmp_idx_size);
             });
       });
 }

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -189,6 +189,14 @@ void segment::clear_cached_disk_usage() {
     _compaction_index_size.reset();
 }
 
+void segment::set_cached_disk_usage(
+  size_t new_seg_size, std::optional<size_t> new_compacted_index_size) {
+    _data_disk_usage_size = new_seg_size;
+    if (new_compacted_index_size.has_value()) {
+        _compaction_index_size = new_compacted_index_size.value();
+    }
+}
+
 ss::future<size_t> segment::remove_persistent_state() {
     vassert(is_closed(), "Cannot clear state from unclosed segment");
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -120,7 +120,9 @@ ss::future<usage> segment::persistent_size() {
      * segment appender will transparently extend the size of the segment file
      * using fallocate, always stat the on disk size for the head partition.
      */
-    if (!_appender && _data_disk_usage_size.has_value()) {
+    if (_appender) {
+        u.data = _appender->size_bytes();
+    } else if (_data_disk_usage_size.has_value()) {
         u.data = _data_disk_usage_size.value();
     } else {
         try {
@@ -139,7 +141,9 @@ ss::future<usage> segment::persistent_size() {
      * however, we pay for that stat() with no guarantee that the information
      * will be used.
      */
-    if (_compaction_index_size.has_value()) {
+    if (_compaction_index) {
+        u.compaction = _compaction_index.value()->size_bytes();
+    } else if (_compaction_index_size.has_value()) {
         u.compaction = _compaction_index_size.value();
     } else {
         auto path = reader().path().to_compacted_index();

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -37,6 +37,10 @@ struct segment_closed_exception final : std::exception {
     }
 };
 
+namespace testing_details {
+class segment_accessor;
+}; // namespace testing_details
+
 class segment {
 public:
     using generation_id = named_type<uint64_t, struct segment_gen_tag>;
@@ -361,6 +365,7 @@ private:
     std::optional<ss::lowres_clock::time_point> _first_write;
 
     friend std::ostream& operator<<(std::ostream&, const segment&);
+    friend class testing_details::segment_accessor;
 };
 
 /**

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -275,15 +275,15 @@ public:
     }
 
     void clear_cached_disk_usage();
-    // Sets the cached disk usage for the `segment` and `compacted_index`. These
-    // are usually the values from the underlying `segment_{appender/reader}`
-    // for either of these objects. The base `segment_index` sets its disk usage
-    // in `flush_to_file()`.
+    // Sets the cached disk usage for the `segment` and optionally the
+    // `compacted_index`. These are usually the values from the underlying
+    // `segment_{appender/reader}` for either of these objects. The base
+    // `segment_index` sets its disk usage in `flush_to_file()`.
     //
-    // This function is used within the compaction subsystem to cut down on
-    // future calls to `stat()`, since the cached disk usage is cleared during
-    // every round of compaction, and we know from in-memory state how large
-    // these objects are going to be on disk.
+    // This function is widely used within the compaction subsystem to cut down
+    // on future calls to `stat()`, since the cached disk usage is cleared
+    // during every round of compaction, and we know from in-memory state how
+    // large these objects are going to be on disk.
     void set_cached_disk_usage(
       size_t new_seg_size, std::optional<size_t> new_compacted_index_size);
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -271,6 +271,17 @@ public:
     }
 
     void clear_cached_disk_usage();
+    // Sets the cached disk usage for the `segment` and `compacted_index`. These
+    // are usually the values from the underlying `segment_{appender/reader}`
+    // for either of these objects. The base `segment_index` sets its disk usage
+    // in `flush_to_file()`.
+    //
+    // This function is used within the compaction subsystem to cut down on
+    // future calls to `stat()`, since the cached disk usage is cleared during
+    // every round of compaction, and we know from in-memory state how large
+    // these objects are going to be on disk.
+    void set_cached_disk_usage(
+      size_t new_seg_size, std::optional<size_t> new_compacted_index_size);
 
     /// Fallback timestamp method, for use if the timestamps in the index
     /// appear to be invalid (e.g. too far in the future)

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -326,7 +326,12 @@ ss::future<> segment_appender::close() {
     _closed = true;
     return hard_flush()
       .then([this] { return do_truncation(_committed_offset); })
-      .then([this] { return _out.close(); });
+      .then([this] {
+          _fallocation_offset = _committed_offset;
+          _flushed_offset = _committed_offset;
+          _stable_offset = _committed_offset;
+          return _out.close();
+      });
 }
 
 ss::future<> segment_appender::do_next_adaptive_fallocation() {

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -89,6 +89,10 @@ public:
         return _committed_offset + _bytes_flush_pending;
     }
 
+    // The size of the underlying file on disk, which is the
+    // _fallocation_offset.
+    size_t size_bytes() const { return _fallocation_offset; }
+
     /**
      * @brief Appends a batch.
      *

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -181,6 +181,7 @@ ss::future<bool> segment_index::materialize_index() {
 ss::future<bool> segment_index::materialize_index_from_file(ss::file f) {
     auto size = co_await f.size();
     auto buf = co_await f.dma_read_bulk<char>(0, size);
+    _disk_usage_size = size;
     if (buf.empty()) {
         co_return false;
     }
@@ -229,6 +230,9 @@ ss::future<> segment_index::flush_to_file(ss::file backing_file) {
     for (const auto& f : b) {
         co_await out.write(f.get(), f.size());
     }
+
+    _disk_usage_size = b.size_bytes();
+
     co_await out.flush();
 }
 

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -132,6 +132,15 @@ ss::future<> segment_reader::put() {
     }
 }
 
+ss::future<size_t> segment_reader::fsize() {
+    ss::gate::holder guard{_gate};
+
+    auto handle = co_await get();
+    auto r = co_await _data_file.size();
+    co_await handle.close();
+    co_return r;
+}
+
 ss::future<struct stat> segment_reader::stat() {
     ss::gate::holder guard{_gate};
 

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -51,8 +51,8 @@ segment_reader::~segment_reader() noexcept {
 ss::future<> segment_reader::load_size() {
     ss::gate::holder guard{_gate};
 
-    auto s = co_await stat();
-    set_file_size(s.st_size);
+    auto s = co_await fsize();
+    set_file_size(s);
 };
 
 ss::future<segment_reader_handle>

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -132,6 +132,9 @@ public:
     /// close the underlying file handle
     ss::future<> close();
 
+    // Performs a syscall to get the size of _data_file on disk.
+    ss::future<size_t> fsize();
+
     /// perform syscall stat
     ss::future<struct stat> stat();
 

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -281,8 +281,8 @@ static ss::future<segment_set> unsafe_do_recover(
           to_recover.begin(),
           to_recover.end(),
           [](ss::lw_shared_ptr<segment>& segment) {
-              auto stat = segment->reader().stat().get();
-              if (stat.st_size != 0) {
+              auto size = segment->reader().fsize().get();
+              if (size != 0) {
                   return true;
               }
               vlog(stlog.info, "Removing empty segment: {}", segment);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -268,23 +268,25 @@ ss::future<size_t> write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
-    size_t cmp_idx_size{0};
-    std::exception_ptr eptr;
+    // integrity verified in `do_detect_compaction_index_state`
+    auto fut = co_await ss::coroutine::as_future(
+      do_write_clean_compacted_index(reader, cfg, resources));
+
     try {
-        // integrity verified in `do_detect_compaction_index_state`
-        cmp_idx_size = co_await do_write_clean_compacted_index(
-          reader, cfg, resources);
+        co_await reader.close();
     } catch (...) {
-        eptr = std::current_exception();
+        auto e = std::current_exception();
+        vlog(
+          gclog.debug,
+          "Caught exception {} while closing compacted_index_reader",
+          e);
     }
 
-    co_await reader.close();
-
-    if (eptr) {
-        std::rethrow_exception(eptr);
+    if (fut.failed()) {
+        std::rethrow_exception(fut.get_exception());
     }
 
-    co_return cmp_idx_size;
+    co_return fut.get();
 }
 
 ss::future<compacted_index::recovery_state>

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -545,7 +545,7 @@ ss::future<> do_swap_data_file_handles(
  * Executes segment compaction, returns size of compacted segment or an empty
  * optional if segment wasn't compacted
  */
-ss::future<std::optional<size_t>> do_self_compact_segment(
+ss::future<compaction_result> do_self_compact_segment(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
@@ -554,6 +554,8 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
   offset_delta_time apply_offset,
   ss::rwlock::holder read_holder,
   ss::sharded<features::feature_table>& feature_table) {
+    auto size_before = s->size_bytes();
+
     if (cfg.asrc) {
         cfg.asrc->check();
     }
@@ -598,7 +600,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
           "generation: {}, skipping compaction",
           s->get_generation_id(),
           segment_generation);
-        co_return std::nullopt;
+        co_return compaction_result(size_before);
     }
 
     if (s->is_closed()) {
@@ -616,7 +618,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     s->release_batch_cache_index();
     co_await s->index().flush();
     s->advance_generation();
-    co_return s->size_bytes();
+    co_return compaction_result(size_before, s->size_bytes());
 }
 
 ss::future<> build_compaction_index(
@@ -785,9 +787,8 @@ ss::future<compaction_result> self_compact_segment(
         || (state == compacted_index::recovery_state::already_compacted);
     vassert(is_valid_index_state, "Unexpected state {}", state);
 
-    auto sz_before = s->size_bytes();
     auto apply_offset = should_apply_delta_time_offset(feature_table);
-    auto sz_after = co_await do_self_compact_segment(
+    auto res = co_await do_self_compact_segment(
       s,
       cfg,
       pb,
@@ -797,15 +798,14 @@ ss::future<compaction_result> self_compact_segment(
       std::move(read_holder),
       feature_table);
 
-    // compaction wasn't executed, return
-    if (!sz_after) {
-        co_return compaction_result(sz_before);
+    if (res.did_compact()) {
+        pb.segment_compacted();
+        pb.add_compaction_removed_bytes(
+          ssize_t(res.size_before) - ssize_t(res.size_after));
+        s->mark_as_finished_self_compaction();
     }
 
-    pb.segment_compacted();
-    pb.add_compaction_removed_bytes(ssize_t(sz_before) - ssize_t(*sz_after));
-    s->mark_as_finished_self_compaction();
-    co_return compaction_result(sz_before, *sz_after);
+    co_return res;
 }
 
 ss::future<

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -225,23 +225,23 @@ ss::future<> copy_filtered_entries(
   compacted_index_reader reader,
   roaring::Roaring to_copy_index,
   std::unique_ptr<compacted_index_writer> writer) {
-    return ss::do_with(
-      std::move(writer),
-      [bm = std::move(to_copy_index),
-       reader](std::unique_ptr<compacted_index_writer>& writer) mutable {
-          reader.reset();
-          return reader
-            .consume(
-              index_filtered_copy_reducer(std::move(bm), *writer),
-              model::no_timeout)
-            // must be last
-            .finally([&writer] {
-                writer->set_flag(
-                  compacted_index::footer_flags::self_compaction);
-                // do not handle exception on the close
-                return writer->close();
-            });
-      });
+    std::exception_ptr eptr;
+    try {
+        reader.reset();
+        co_await reader.consume(
+          index_filtered_copy_reducer(std::move(to_copy_index), *writer),
+          model::no_timeout);
+        writer->set_flag(compacted_index::footer_flags::self_compaction);
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    // do not handle exception on the close
+    co_await writer->close();
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }
 
 static ss::future<> do_write_clean_compacted_index(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -265,13 +265,21 @@ ss::future<> write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
-    // integrity verified in `do_detect_compaction_index_state`
-    return do_write_clean_compacted_index(reader, cfg, resources)
-      .finally([reader]() mutable {
-          return reader.close().then_wrapped(
-            [reader](ss::future<>) { /*ignore*/ });
-      });
+    std::exception_ptr eptr;
+    try {
+        // integrity verified in `do_detect_compaction_index_state`
+        co_await do_write_clean_compacted_index(reader, cfg, resources);
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    co_await reader.close();
+
+    if (eptr) {
+        std::rethrow_exception(eptr);
+    }
 }
+
 ss::future<compacted_index::recovery_state>
 do_detect_compaction_index_state(segment_full_path p, compaction_config cfg) {
     using flags = compacted_index::footer_flags;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -221,7 +221,7 @@ natural_index_of_entries_to_keep(compacted_index_reader reader) {
     return reader.consume(compaction_key_reducer(), model::no_timeout);
 }
 
-ss::future<> copy_filtered_entries(
+ss::future<size_t> copy_filtered_entries(
   compacted_index_reader reader,
   roaring::Roaring to_copy_index,
   std::unique_ptr<compacted_index_writer> writer) {
@@ -242,9 +242,11 @@ ss::future<> copy_filtered_entries(
     if (eptr) {
         std::rethrow_exception(eptr);
     }
+
+    co_return writer->size_bytes();
 }
 
-static ss::future<> do_write_clean_compacted_index(
+static ss::future<size_t> do_write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
@@ -255,20 +257,23 @@ static ss::future<> do_write_clean_compacted_index(
       cfg.files_to_cleanup, {tmpname}};
     auto truncating_writer = make_file_backed_compacted_index(
       tmpname.string(), cfg.iopc, true, resources, cfg.sanitizer_config);
-    co_await copy_filtered_entries(
+    auto cmp_idx_size = co_await copy_filtered_entries(
       reader, std::move(bitmap), std::move(truncating_writer));
     co_await ss::rename_file(std::string(tmpname), ss::sstring(reader.path()));
     staging_to_clean.clear();
+    co_return cmp_idx_size;
 };
 
-ss::future<> write_clean_compacted_index(
+ss::future<size_t> write_clean_compacted_index(
   compacted_index_reader reader,
   compaction_config cfg,
   storage_resources& resources) {
+    size_t cmp_idx_size{0};
     std::exception_ptr eptr;
     try {
         // integrity verified in `do_detect_compaction_index_state`
-        co_await do_write_clean_compacted_index(reader, cfg, resources);
+        cmp_idx_size = co_await do_write_clean_compacted_index(
+          reader, cfg, resources);
     } catch (...) {
         eptr = std::current_exception();
     }
@@ -278,6 +283,8 @@ ss::future<> write_clean_compacted_index(
     if (eptr) {
         std::rethrow_exception(eptr);
     }
+
+    co_return cmp_idx_size;
 }
 
 ss::future<compacted_index::recovery_state>
@@ -335,7 +342,7 @@ generate_compacted_list(model::offset o, compacted_index_reader reader) {
       .finally([reader] {});
 }
 
-ss::future<> do_compact_segment_index(
+ss::future<size_t> do_compact_segment_index(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage_resources& resources) {
@@ -569,7 +576,7 @@ ss::future<compaction_result> do_self_compact_segment(
 
     // broker_timestamp is used for retention.ms, but it's only in the index,
     // not it in the segment itself. save it to restore it later
-    co_await do_compact_segment_index(s, cfg, resources);
+    auto cmp_idx_size = co_await do_compact_segment_index(s, cfg, resources);
     // copy the bytes after segment is good - note that we
     // need to do it with the READ-lock, not the write lock
     auto staging_file = s->reader().path().to_staging();
@@ -618,7 +625,7 @@ ss::future<compaction_result> do_self_compact_segment(
     s->release_batch_cache_index();
     co_await s->index().flush();
     s->advance_generation();
-    co_return compaction_result(size_before, s->size_bytes());
+    co_return compaction_result(size_before, s->size_bytes(), cmp_idx_size);
 }
 
 ss::future<> build_compaction_index(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -522,7 +522,8 @@ ss::future<> do_swap_data_file_handles(
   std::filesystem::path compacted,
   ss::lw_shared_ptr<storage::segment> s,
   storage::compaction_config cfg,
-  probe& pb) {
+  probe& pb,
+  std::optional<size_t> new_cmp_idx_size) {
     co_await s->reader().close();
 
     ss::sstring old_name = compacted.string();
@@ -541,6 +542,11 @@ ss::future<> do_swap_data_file_handles(
       config::shard_local_cfg().storage_read_readahead_count(),
       cfg.sanitizer_config);
     co_await r->load_size();
+
+    // We know the size of the segment and compacted index files. To save on
+    // future file_stat() calls due to these values being unset, set the cached
+    // disk usage here.
+    s->set_cached_disk_usage(r->file_size(), new_cmp_idx_size);
 
     // update partition size probe
     pb.delete_segment(*s.get());
@@ -617,7 +623,8 @@ ss::future<compaction_result> do_self_compact_segment(
     co_await s->index().drop_all_data();
 
     auto compacted_file = s->reader().path().to_staging();
-    co_await do_swap_data_file_handles(compacted_file, s, cfg, pb);
+    co_await do_swap_data_file_handles(
+      compacted_file, s, cfg, pb, cmp_idx_size);
     staging_to_clean.clear();
 
     s->index().swap_index_state(std::move(idx));
@@ -1094,14 +1101,16 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> from,
   compaction_config cfg,
   probe& probe,
-  std::vector<ss::rwlock::holder> locks) {
+  std::vector<ss::rwlock::holder> locks,
+  std::optional<size_t> new_cmp_idx_size) {
     co_await from->close();
 
     co_await to->index().drop_all_data();
 
     // segment data file
     auto from_path = from->reader().path();
-    co_await do_swap_data_file_handles(from_path, to, cfg, probe);
+    co_await do_swap_data_file_handles(
+      from_path, to, cfg, probe, new_cmp_idx_size);
 
     // offset index
     to->index().swap_index_state(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -105,7 +105,8 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> from,
   compaction_config cfg,
   probe& probe,
-  std::vector<ss::rwlock::holder>);
+  std::vector<ss::rwlock::holder>,
+  std::optional<size_t> new_cmp_idx_size);
 
 /*
  * Acquire write locks on multiple segments. The process will proceed until
@@ -204,7 +205,8 @@ ss::future<> do_swap_data_file_handles(
   std::filesystem::path compacted,
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
-  probe&);
+  probe&,
+  std::optional<size_t>);
 
 // Generates a random jitter percentage [as a fraction] with in the passed
 // percents range.

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -158,14 +158,17 @@ uint64_t segment_size_from_config(const storage::ntp_config&);
 ss::future<roaring::Roaring>
   natural_index_of_entries_to_keep(compacted_index_reader);
 
-ss::future<> copy_filtered_entries(
+// Returns the size of the built compacted index in bytes.
+ss::future<size_t> copy_filtered_entries(
   storage::compacted_index_reader input,
   roaring::Roaring to_copy_index_filter,
   storage::compacted_index_writer output);
 
 /// \brief writes a new `*.compacted_index` file and *closes* the
 /// input compacted_index_reader file
-ss::future<> write_clean_compacted_index(
+///
+/// Returns the size of the built compacted index in bytes.
+ss::future<size_t> write_clean_compacted_index(
   storage::compacted_index_reader,
   storage::compaction_config,
   storage_resources& resources);

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -423,7 +423,7 @@ std::ostream& operator<<(std::ostream& o, const spill_key_index& k) {
 
 size_t spill_key_index::size_bytes() const {
     if (_appender.has_value()) {
-        return _appender->file_byte_offset();
+        return _appender->size_bytes();
     }
     return 0;
 }

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -421,6 +421,13 @@ std::ostream& operator<<(std::ostream& o, const spill_key_index& k) {
     return o;
 }
 
+size_t spill_key_index::size_bytes() const {
+    if (_appender.has_value()) {
+        return _appender->file_byte_offset();
+    }
+    return 0;
+}
+
 } // namespace storage::internal
 
 namespace storage {

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -83,6 +83,7 @@ public:
     ss::future<> close() final;
     void print(std::ostream&) const final;
     void set_flag(compacted_index::footer_flags) final;
+    size_t size_bytes() const final;
 
 private:
     /**

--- a/src/v/storage/tests/common.h
+++ b/src/v/storage/tests/common.h
@@ -29,4 +29,16 @@ public:
         return m._logs_list;
     }
 };
+
+class segment_accessor {
+public:
+    static std::optional<size_t> data_disk_usage_size(storage::segment& s) {
+        return s._data_disk_usage_size;
+    }
+
+    static std::optional<size_t> compaction_index_size(storage::segment& s) {
+        return s._compaction_index_size;
+    }
+};
+
 } // namespace storage::testing_details

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5982,6 +5982,8 @@ FIXTURE_TEST(
     // Test self-compaction
     {
         auto& s = segs[0];
+        // Freshly rolled segment should have cached sizes set.
+        check_cached_sizes(s);
         disk_log.segment_self_compact(cfg, s).get();
         check_cached_sizes(s);
     }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5163,6 +5163,10 @@ public:
         return std::ranges::max(diffs);
     }
 
+    static std::optional<size_t> disk_usage_size(segment_index& index) {
+        return index._disk_usage_size;
+    }
+
 private:
     segment_index& _index;
     size_t _size;
@@ -5914,4 +5918,95 @@ FIXTURE_TEST(log_compaction_enable_sliding_window, storage_test_fixture) {
     // capacity 0 is used.
     storage::testing_details::log_manager_accessor::housekeeping_scan(mgr)
       .get();
+}
+
+FIXTURE_TEST(
+  segment_cached_disk_usage_set_after_compaction, storage_test_fixture) {
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "a", 0);
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(0));
+        log->force_roll(ss::default_priority_class()).get();
+    };
+
+    add_segment_func();
+    add_segment_func();
+
+    ss::abort_source as;
+    storage::compaction_config cfg(
+      model::offset::max(), std::nullopt, ss::default_priority_class(), as);
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+
+    auto check_cached_sizes = [](auto& seg) {
+        auto disk
+          = storage::testing_details::segment_accessor::data_disk_usage_size(
+            *seg);
+        auto cidx
+          = storage::testing_details::segment_accessor::compaction_index_size(
+            *seg);
+        auto sidx = storage::segment_index_observer::disk_usage_size(
+          seg->index());
+        BOOST_REQUIRE(disk.has_value());
+        BOOST_REQUIRE(cidx.has_value());
+        BOOST_REQUIRE(sidx.has_value());
+
+        BOOST_REQUIRE_EQUAL(
+          disk.value(), ss::file_size(seg->path().string()).get());
+        BOOST_REQUIRE_EQUAL(
+          cidx.value(),
+          ss::file_size(seg->path().to_compacted_index().string()).get());
+        BOOST_REQUIRE_EQUAL(
+          sidx.value(), ss::file_size(seg->path().to_index().string()).get());
+    };
+
+    auto& segs = log->segments();
+
+    // Test self-compaction
+    {
+        auto& s = segs[0];
+        disk_log.segment_self_compact(cfg, s).get();
+        check_cached_sizes(s);
+    }
+
+    // Test adjacent compaction
+    {
+        disk_log.adjacent_merge_compact(cfg).get();
+        for (auto& s : segs) {
+            if (s->finished_self_compaction()) {
+                check_cached_sizes(s);
+            }
+        }
+    }
+
+    // Test sliding window compaction
+    {
+        bool did_compact = disk_log.sliding_window_compact(cfg).get();
+        while (did_compact) {
+            did_compact = disk_log.sliding_window_compact(cfg).get();
+        }
+        for (auto& s : segs) {
+            if (s->finished_self_compaction()) {
+                BOOST_REQUIRE(s->has_clean_compact_timestamp());
+                check_cached_sizes(s);
+            }
+        }
+    }
 }

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -580,10 +580,14 @@ struct compaction_result {
       , size_before(sz)
       , size_after(sz) {}
 
-    compaction_result(size_t before, size_t after)
+    compaction_result(
+      size_t before,
+      size_t after,
+      std::optional<size_t> cmp_idx_size_after = std::nullopt)
       : executed_compaction(true)
       , size_before(before)
-      , size_after(after) {}
+      , size_after(after)
+      , cmp_idx_size_after(cmp_idx_size_after) {}
 
     bool did_compact() const { return executed_compaction; }
 
@@ -595,6 +599,8 @@ struct compaction_result {
     bool executed_compaction;
     size_t size_before;
     size_t size_after;
+    // The size of the new compacted index, if one was made.
+    std::optional<size_t> cmp_idx_size_after{std::nullopt};
     friend std::ostream& operator<<(std::ostream&, const compaction_result&);
 };
 


### PR DESCRIPTION
Combined backport of https://github.com/redpanda-data/redpanda/pull/26513 and https://github.com/redpanda-data/redpanda/pull/26521.

Cherry-pick conflicts due to many changes and refactors throughout compaction subsystem not present in `v25.1.x`

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Cut down the amount of time spent in `fstat()` syscalls during storage layer housekeeping & cut down the amount of time spent in `fstat()` syscalls in the storage layer EVEN MORE IN GENERAL!
