### PR TITLE
Added defensive checks when materializing batch records

### DIFF
--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -134,11 +134,23 @@ static model::record do_parse_one_record_from_buffer(
     auto [key_length, kv] = parser.read_varlong();
     iobuf key;
     if (key_length > 0) {
+        if (key_length > record_size) [[unlikely]] {
+            throw std::out_of_range(fmt::format(
+              "Expected key length {} but record has only {} bytes in total",
+              key_length,
+              record_size));
+        }
         key = parser_data(parser, key_length);
     }
     auto [value_length, vv] = parser.read_varlong();
     iobuf value;
     if (value_length > 0) {
+        if (value_length > record_size) [[unlikely]] {
+            throw std::out_of_range(fmt::format(
+              "Expected value length {} but record has only {} bytes in total",
+              value_length,
+              record_size));
+        }
         value = parser_data(parser, value_length);
     }
     auto headers = parse_record_headers(parser, parser_data);
@@ -165,6 +177,12 @@ parse_record_meta_from_buffer(iobuf_parser_base& parser) {
       sizeof(model::record_attributes::type) == 1,
       "model attributes expected to be one byte");
     auto [record_size, rv] = parser.read_varlong();
+    if (static_cast<size_t>(record_size) > parser.bytes_left()) [[unlikely]] {
+        throw std::out_of_range(fmt::format(
+          "Expected record size {} but only {} bytes left",
+          record_size,
+          parser.bytes_left()));
+    }
     auto attr = parser.consume_type<model::record_attributes::type>();
     return std::make_pair(record_size, attr);
 }


### PR DESCRIPTION
`model::record_batch` records are stored as a raw binary data in an `iobuf`. The records are materialized when they need to be interpreted f.e. during state machine apply operation. Previously there were no checks when materializing records validating if the buffer sizes parsed out of the binary representation makes sense. Added basic validation to prevent Redpanad from allocating very large memory range just to find out that the records binary data is corrupted.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none