### PR TITLE
[CORE-12338] k/s/group: address inconsistency in group subscription

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -3384,11 +3384,11 @@ std::ostream& operator<<(std::ostream& o, const group::offset_metadata& md) {
 }
 
 bool group::subscribed(const model::topic& topic) const {
-    if (_subscriptions.has_value()) {
-        return _subscriptions.value().contains(topic);
+    if (!_subscriptions.has_value()) {
+        return is_consumer_group();
     }
-    // answer conservatively
-    return true;
+
+    return _subscriptions.value().contains(topic);
 }
 
 /*

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -1590,12 +1590,6 @@ class OffsetCommitter:
 
 
 class ConsumerGroupOffsetResetTest(RedpandaTest):
-    """
-    This tests simulates a large number of consumers trying to commit consumer
-    group offsets. The test doesn't produce or fetch any messages,
-    it just stress tests OffsetCommit requests and validates the final
-    state of the consumer group.
-    """
     def __init__(self, test_context):
         super(ConsumerGroupOffsetResetTest,
               self).__init__(test_context=test_context,
@@ -1647,6 +1641,12 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
     @cluster(num_nodes=3)
     @skip_debug_mode
     def test_stress_consumer_group_commits(self):
+        """
+        This tests simulates a large number of consumers trying to commit consumer
+        group offsets. The test doesn't produce or fetch any messages,
+        it just stress tests OffsetCommit requests and validates the final
+        state of the consumer group.
+        """
         self.consumer_count = 200
 
         topic = TopicSpec(name="cg-test-topic-1",
@@ -1733,3 +1733,70 @@ class ConsumerGroupOffsetResetTest(RedpandaTest):
                 err_msg=
                 f"Failed to get consumer offsets summary for node {n.account.hostname}"
             )
+
+    @cluster(num_nodes=3)
+    def test_offset_delete_manual_consumers(self):
+        """
+        Verify that OffsetDelete requests work as expected when consumers
+        are being manually managed.
+        """
+        # Magic value returned by confluent_kafka when it can't find commited offsets
+        INVALID_OFFSET = -1001
+
+        rpk = RpkTool(self.redpanda)
+
+        topic = TopicSpec(name="cg-test-topic-1", partition_count=1)
+        DefaultClient(self.redpanda).create_topic(topic)
+        self.group_id = "test-group-1"
+
+        self.consumer_count = 1
+        self.admin_client = AdminClient(
+            {"bootstrap.servers": self.redpanda.brokers()})
+
+        self.consumers = [
+            OffsetCommitter(
+                bootstrap_servers=self.redpanda.brokers(),
+                group=self.group_id,
+                topic=topic.name,
+                id=0,
+                logger=self.logger,
+                partition_id=0,
+            )
+        ]
+
+        self.wait_for_total_commits(1000)
+
+        # No consumers have subscribed. Group should be in empty state
+        desc = rpk.group_describe(self.group_id)
+        assert desc.state == "Empty", \
+                f"Expected group.state 'Empty' but got '{desc.state}', instead\n" \
+                f"Group description: {desc}"
+
+        # Try to delete offsets while there is an assigned consumer
+        # who keeps commiting offsets
+        res = rpk.offset_delete(self.group_id, {topic.name: [0]})[0]
+        assert res.status == "OK", \
+                f"Expected res.status 'OK' but got '{res.status}', instead\n" \
+                f"Response:  {res}"
+
+        def wait_for_new_commits():
+            tp = self.list_consumer_group_offsets(
+                topic.name).topic_partitions[0]
+            return tp.offset != INVALID_OFFSET
+
+        wait_until(
+            wait_for_new_commits,
+            timeout_sec=10,
+            backoff_sec=1,
+            err_msg="Timeout while waiting for consumer to commit more offsets"
+        )
+
+        self.consumers[0].stop()
+
+        res = rpk.offset_delete(self.group_id, {topic.name: [0]})
+        assert res[0].status == "OK", \
+                f"Expected res.status 'OK' but got '{res[0].status}', instead\n" \
+                f"Response:  {res[0]}"
+
+        tp = self.list_consumer_group_offsets(topic.name).topic_partitions[0]
+        assert tp.offset == INVALID_OFFSET, f"Expected offset '{INVALID_OFFSET}' but got '{tp.offset}', instead"


### PR DESCRIPTION
fixes: [CORE-12338](https://redpandadata.atlassian.net/browse/CORE-12338)

Compared to the reference implementation, the redpanda logic on whether a group is subscribed is too restrictive. Specifically in the fallback path, if the _subscriptions member is not set. We consider all such groups as subscribed.

Updated the fallback logic to consider the group subscribed if the protocol type is consumer group. Otherwise, it falls back to considering the group unsubscribed. This logic matches the reference implementation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixed an issue with consumer groups with manually assigned consumers. When an OffsetDeleteRequest was sent on such a group, a GROUP_SUBSCRIBED_TO_TOPIC error was returned.

[CORE-12338]: https://redpandadata.atlassian.net/browse/CORE-12338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ