### PR TITLE
`cloud_io`: fix typo in `cloud_io::remote::stop()`

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -194,7 +194,7 @@ ss::future<> remote::stop() {
     co_await _resources->stop();
     co_await _gate.close();
     co_await _auth_refresh_bg_op.stop();
-    vlog(log.debug, "Stopeed remote...");
+    vlog(log.debug, "Stopped remote...");
 }
 
 size_t remote::concurrency() const { return _pool.local().max_size(); }


### PR DESCRIPTION
cloud_io: fix typo in cloud_io::remote::stop()

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
