### PR TITLE
tx/tm_stm: fix clean up of old pids

### DIFF
--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -194,10 +194,9 @@ TEST_F_CORO(tm_stm_test_fixture, test_tm_stm_re_tx) {
 
     model::producer_identity pid2{1, 1};
     model::producer_identity expected_pid(3, 5);
-    co_await retry_with_term([tx_id, pid1, expected_pid, pid2](
+    co_await retry_with_term([tx_id, expected_pid, pid2](
                                stm_cssshptrr_t stm, model::term_id term) {
-        return stm->update_tx_producer(
-          term, tx_id, 0s, pid2, expected_pid, pid1);
+        return stm->update_tx_producer(term, tx_id, 0s, pid2, expected_pid);
     }).then(assert_success);
     auto tx7 = co_await get_tx(tx_id);
     ASSERT_EQ_CORO(tx7.pid, pid2);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -365,16 +365,14 @@ ss::future<tm_stm::op_status> tm_stm::update_tx_producer(
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
   model::producer_identity pid,
-  model::producer_identity last_pid,
-  model::producer_identity rolled_pid) {
+  model::producer_identity last_pid) {
     vlog(
       _ctx_log.trace,
       "[tx_id={}] Registering existing transaction with new pid: {}, previous "
-      "pid: {}, rolled_pid: {}",
+      "pid: {}",
       tx_id,
       pid,
-      last_pid,
-      rolled_pid);
+      last_pid);
 
     auto tx_opt = co_await get_tx(tx_id);
     if (!tx_opt.has_value()) {
@@ -392,11 +390,9 @@ ss::future<tm_stm::op_status> tm_stm::update_tx_producer(
     tx.last_update_ts = clock_type::now();
 
     auto r = co_await update_tx(std::move(tx), expected_term);
-
     if (!r.has_value()) {
         co_return tm_stm::op_status::unknown;
     }
-    _pid_tx_id.erase(rolled_pid);
     co_return tm_stm::op_status::success;
 }
 

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -571,6 +571,13 @@ ss::future<tm_stm::op_status> tm_stm::add_group(
     co_return tm_stm::op_status::success;
 }
 void tm_stm::upsert_transaction(tx_metadata tx) {
+    vlog(
+      _ctx_log.trace,
+      "[tx_id={}] upserting transaction: {}, transactions: {} pid_map: {}",
+      tx.id,
+      tx,
+      _transactions.size(),
+      _pid_tx_id.size());
     auto [tx_it, inserted] = _transactions.try_emplace(tx.id, tx);
     // erase any existing mappings
     _pid_tx_id.erase(tx.last_pid);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -572,8 +572,11 @@ ss::future<tm_stm::op_status> tm_stm::add_group(
 }
 void tm_stm::upsert_transaction(tx_metadata tx) {
     auto [tx_it, inserted] = _transactions.try_emplace(tx.id, tx);
-    _pid_tx_id[tx.pid] = tx.id;
+    // erase any existing mappings
     _pid_tx_id.erase(tx.last_pid);
+    _pid_tx_id.erase(tx_it->second.tx.pid);
+    // Update the latest tx_id to pid mapping
+    _pid_tx_id[tx.pid] = tx.id;
     if (!inserted) {
         tx_it->second.tx = std::move(tx);
     }

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -723,7 +723,7 @@ tm_stm::apply_tm_update(model::record_batch_header hdr, model::record_batch b) {
     // now this is fine as there was no validation on apply in the first place
     // before the refactoring happened. We will add validation after we will
     // make sure the transaction FSM transitions are all valid
-    upsert_transaction(tx);
+    upsert_transaction(std::move(tx));
 
     return ss::now();
 }

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -294,17 +294,12 @@ public:
       update_transaction_status(
         model::term_id, kafka::transactional_id, tx_status);
 
-    // todo: cleanup last_pid and rolled_pid. It seems like they are doing
-    // the same thing but in practice they are not. last_pid is not updated
-    // in all cases whereas rolled_pid is need to cleanup all the state
-    // from previous epochs.
     ss::future<tm_stm::op_status> update_tx_producer(
       model::term_id,
       kafka::transactional_id,
       std::chrono::milliseconds,
       model::producer_identity pid_to_register,
-      model::producer_identity last_pid,
-      model::producer_identity rolled_pid);
+      model::producer_identity last_pid);
     ss::future<tm_stm::op_status> register_new_producer(
       model::term_id,
       kafka::transactional_id,

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1054,7 +1054,6 @@ tx_gateway_frontend::increase_producer_epoch(
     const bool expected_epoch_matches = expected_pid
                                           ? expected_pid->epoch == tx_pid.epoch
                                           : true;
-    auto dropped_pid = model::no_pid;
     // exhausted epoch, allocate new producer id
     if (tx_pid.has_exhausted_epoch() && expected_epoch_matches) {
         allocate_id_reply pid_reply
@@ -1068,7 +1067,6 @@ tx_gateway_frontend::increase_producer_epoch(
               pid_reply.ec);
             co_return init_tm_tx_reply{tx::errc::not_coordinator};
         }
-        dropped_pid = tx_pid;
         tx_pid = model::producer_identity(
           pid_reply.id, model::no_producer_epoch);
     }
@@ -1080,7 +1078,6 @@ tx_gateway_frontend::increase_producer_epoch(
     }
     // expected producer id wasn't provided,
     if (!expected_pid) {
-        dropped_pid = tx_pid;
         tx_pid = model::producer_identity::with_next_epoch(tx_pid);
         last_tx_pid = model::no_pid;
     } else if (
@@ -1091,7 +1088,6 @@ tx_gateway_frontend::increase_producer_epoch(
         // initialized. Bump the current and last epochs. The no current epoch
         // case means this is a new producer; producerEpoch will be -1 and
         // bumpedEpoch will be 0
-        dropped_pid = tx_pid;
         last_tx_pid = tx_pid;
         tx_pid = model::producer_identity::with_next_epoch(tx_pid);
     } else if (last_tx_pid == expected_pid) {
@@ -1118,7 +1114,7 @@ tx_gateway_frontend::increase_producer_epoch(
     reply.pid = tx_pid;
 
     auto op_status = co_await stm->update_tx_producer(
-      term, tx_id, transaction_timeout_ms, tx_pid, last_tx_pid, dropped_pid);
+      term, tx_id, transaction_timeout_ms, tx_pid, last_tx_pid);
     if (op_status == tm_stm::op_status::success) {
         reply.ec = tx::errc::none;
     } else if (op_status == tm_stm::op_status::conflict) {


### PR DESCRIPTION
There is reverse pid mapping from pid to tx_id to help lookup transactional ids during abort requests initiated by partitions that are pid based.

This map can grow unbounded in some cases where old epochs are not deleted. The invariant is that `_transactions` and `_pid_to_tx_id` is 1:1, or in other words only retain the latest pid entry for a given transaction. This PR ensures that.

Hard to write a test for this but verified manually.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes
### Bug Fixes
* Fixes unbounded memory usage in some transaction use caes
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
