### PR TITLE
[CORE-12439] - Cluster Link Task Infrastructure

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -321,7 +321,7 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
                   // update an existing link with a different UUID.
                   vlog(
                     cluster::clusterlog.info,
-                    "Attempting to upsert a panda link with name {} with a "
+                    "Attempting to upsert a cluster link with name {} with a "
                     "different UUID ({}) than the existing one ({})",
                     cmd.value.name,
                     cmd.value.uuid,
@@ -331,7 +331,7 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
               if (cmd.value.connection.bootstrap_servers.empty()) {
                   vlog(
                     cluster::clusterlog.info,
-                    "Attempting to update a panda link without bootstrap "
+                    "Attempting to update a cluster link without bootstrap "
                     "servers");
                   return errc::invalid_update;
               }
@@ -341,14 +341,14 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
           if (cmd.value.name().empty()) {
               vlog(
                 cluster::clusterlog.info,
-                "Attempting to create a panda link without a name");
+                "Attempting to create a cluster link without a name");
               return errc::invalid_create;
           }
           constexpr static size_t max_name_size = 128;
           if (cmd.value.name().size() > max_name_size) {
               vlog(
                 cluster::clusterlog.info,
-                "Attempting to create a panda link with too large of a "
+                "Attempting to create a cluster link with too large of a "
                 "name "
                 "{} > {}",
                 cmd.value.name().size(),
@@ -360,20 +360,22 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
               })) {
               vlog(
                 cluster::clusterlog.info,
-                "Attempting to create a panda link with a name containing "
+                "Attempting to create a cluster link with a name containing "
                 "invalid characters");
               return errc::invalid_create;
           }
           if (cmd.value.connection.bootstrap_servers.empty()) {
               vlog(
                 cluster::clusterlog.info,
-                "Attempting to create a panda link without bootstrap servers");
+                "Attempting to create a cluster link without bootstrap "
+                "servers");
               return errc::invalid_create;
           }
           if (_table->size() >= _max_links) {
               vlog(
                 cluster::clusterlog.info,
-                "Attempting to create a panda link when the maximum number of "
+                "Attempting to create a cluster link when the maximum number "
+                "of "
                 "links ({}) is already reached",
                 _max_links);
               return errc::limit_exceeded;

--- a/src/v/cluster/cluster_link/table.cc
+++ b/src/v/cluster/cluster_link/table.cc
@@ -70,7 +70,7 @@ void table::reset_links(map_t links) {
         auto it = snap_name_index.emplace(metadata.name, id);
         if (!it.second) {
             throw std::logic_error(fmt::format(
-              "panda link id={} is attempting to use a name {} which is "
+              "cluster link id={} is attempting to use a name {} which is "
               "already registered to {}",
               id,
               metadata.name,
@@ -80,7 +80,7 @@ void table::reset_links(map_t links) {
             auto topic_it = snap_topic_name_index.emplace(t.first, id);
             if (!topic_it.second) {
                 throw std::logic_error(fmt::format(
-                  "panda link id={} is attempting to use a topic {} which is "
+                  "cluster link id={} is attempting to use a topic {} which is "
                   "already registered to {}",
                   id,
                   t.first,
@@ -264,7 +264,7 @@ cluster::cluster_link::errc table::upsert_link(id_t id, metadata meta) {
         if (name_it->second != id) {
             vlog(
               cluster::clusterlog.error,
-              "panda link id={} is attempting to use a name {} which is "
+              "cluster link id={} is attempting to use a name {} which is "
               "already registered to {}",
               id,
               meta.name,

--- a/src/v/cluster/cluster_link/table.h
+++ b/src/v/cluster/cluster_link/table.h
@@ -20,7 +20,7 @@
 
 namespace cluster::cluster_link {
 /**
- * @brief Table that holds information about panda links
+ * @brief Table that holds information about cluster links
  */
 class table : public ss::peering_sharded_service<table> {
 public:
@@ -73,9 +73,9 @@ public:
     void unregister_for_updates(notification_id);
 
 private:
-    /// Snapshot copy of all the panda links
+    /// Snapshot copy of all the cluster links
     map_t all_links() const;
-    /// Restores a panda link table from a snapshot
+    /// Restores a cluster link table from a snapshot
     void reset_links(map_t);
 
     /// Upserts a link, if the ID classes, throws a std::logic_error

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -150,7 +150,7 @@ inline constexpr int8_t create_data_migration_cmd_type = 0;
 inline constexpr int8_t update_data_migration_state_cmd_type = 1;
 inline constexpr int8_t remove_data_migration_cmd_type = 2;
 
-// panda link commands
+// cluster link commands
 inline constexpr int8_t cluster_link_upsert_cmd_type = 0;
 inline constexpr int8_t cluster_link_remove_cmd_type = 1;
 inline constexpr int8_t cluster_link_add_mirror_topic_cmd_type = 2;

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -54,6 +54,7 @@ redpanda_cc_library(
         "//src/v/cluster",
         "//src/v/cluster_link/model",
         "//src/v/container:fragmented_vector",
+        "//src/v/kafka/data/rpc",
         "//src/v/model",
         "//src/v/ssx:future_util",
         "//src/v/ssx:work_queue",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -42,6 +42,7 @@ redpanda_cc_library(
         "link.h",
         "manager.h",
         "task.h",
+        "types.h",
     ],
     implementation_deps = [
         ":logger",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -17,6 +17,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "errc",
+    srcs = [
+        "errc.cc",
+    ],
+    hdrs = [
+        "errc.h",
+    ],
+    include_prefix = "cluster_link",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+    ],
+)
+
+redpanda_cc_library(
     name = "impl",
     srcs = [
         "link.cc",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -57,6 +57,7 @@ redpanda_cc_library(
         "//src/v/model",
         "//src/v/ssx:future_util",
         "//src/v/ssx:work_queue",
+        "//src/v/utils:mutex",
         "//src/v/utils:notification_list",
         "//src/v/utils:prefix_logger",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -36,10 +36,12 @@ redpanda_cc_library(
     srcs = [
         "link.cc",
         "manager.cc",
+        "task.cc",
     ],
     hdrs = [
         "link.h",
         "manager.h",
+        "task.h",
     ],
     implementation_deps = [
         ":logger",
@@ -47,12 +49,19 @@ redpanda_cc_library(
     include_prefix = "cluster_link",
     visibility = ["//src/v/cluster_link:__subpackages__"],
     deps = [
+        ":errc",
+        "//src/v/base",
         "//src/v/cluster",
         "//src/v/cluster_link/model",
         "//src/v/container:fragmented_vector",
         "//src/v/model",
+        "//src/v/ssx:future_util",
         "//src/v/ssx:work_queue",
+        "//src/v/utils:notification_list",
+        "//src/v/utils:prefix_logger",
         "@abseil-cpp//absl/container:flat_hash_map",
+        "@fmt",
+        "@seastar",
     ],
 )
 

--- a/src/v/cluster_link/errc.cc
+++ b/src/v/cluster_link/errc.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/errc.h"
+
+namespace cluster_link {
+namespace {
+struct error_category final : public std::error_category {
+    const char* name() const noexcept override { return "cluster_link"; }
+
+    std::string message(int ev) const override {
+        switch (static_cast<errc>(ev)) {
+        case errc::success:
+            return "success";
+        case errc::invalid_task_state_change:
+            return "invalid task state change";
+        case errc::task_not_running:
+            return "task not running";
+        case errc::task_already_running:
+            return "task already running";
+        case errc::failed_to_start_task:
+            return "failed to start task";
+        case errc::task_already_registered_on_link:
+            return "task already registered on link";
+        }
+
+        return "(unknown error code)";
+    }
+};
+
+const error_category cluster_link_error_category{};
+} // namespace
+
+std::error_code make_error_code(errc ec) noexcept {
+    return {static_cast<int>(ec), cluster_link_error_category};
+}
+
+const std::error_category& error_category() noexcept {
+    return cluster_link_error_category;
+}
+
+err_info::err_info(errc ec)
+  : _ec(ec)
+  , _msg(make_error_code(_ec).message()) {}
+
+err_info::err_info(errc ec, std::string msg)
+  : _ec(ec)
+  , _msg(std::move(msg)) {}
+
+errc err_info::code() const noexcept { return _ec; }
+
+const std::string& err_info::message() const noexcept { return _msg; }
+
+} // namespace cluster_link

--- a/src/v/cluster_link/errc.h
+++ b/src/v/cluster_link/errc.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/outcome.h"
+
+#include <system_error>
+
+namespace cluster_link {
+enum class errc : int {
+    success = 0,
+    invalid_task_state_change,
+    task_not_running,
+    task_already_running,
+    failed_to_start_task,
+    task_already_registered_on_link,
+};
+
+std::error_code make_error_code(errc) noexcept;
+
+const std::error_category& error_category() noexcept;
+
+class err_info {
+public:
+    explicit err_info(errc ec);
+    err_info(errc, std::string);
+    errc code() const noexcept;
+    const std::string& message() const noexcept;
+
+private:
+    errc _ec;
+    std::string _msg;
+};
+
+template<typename T>
+using result = result<T, err_info>;
+} // namespace cluster_link
+
+namespace std {
+template<>
+struct is_error_code_enum<cluster_link::errc> : true_type {};
+} // namespace std

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -218,6 +218,16 @@ void link::unregister_for_task_state_changes(
     _task_state_change_notifications.unregister_cb(id);
 }
 
+model::link_task_status_report link::get_task_status_report() const {
+    model::link_task_status_report report;
+    report.link_name = _config.name;
+    report.task_status_reports.reserve(_tasks.size());
+    for (const auto& [name, t] : _tasks) {
+        report.task_status_reports.emplace(name, t->get_status_report());
+    }
+    return report;
+}
+
 bool link::should_start_task(task* t) const {
     if (t->get_state() != model::task_state::not_running) {
         // Can only start tasks that are currently not running

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -15,8 +15,12 @@
 
 namespace cluster_link {
 
-link::link(model::metadata config)
-  : _config(std::move(config)) {}
+using kafka::data::rpc::partition_leader_cache;
+
+link::link(
+  model::metadata config, partition_leader_cache* partition_leader_cache)
+  : _config(std::move(config))
+  , _partition_leader_cache(partition_leader_cache) {}
 
 ss::future<> link::start() {
     vlog(

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -30,6 +30,28 @@ ss::future<> link::stop() {
     return ss::now();
 }
 
+ss::future<result<void>> link::register_task(std::unique_ptr<task> t) {
+    vlog(
+      cllog.debug,
+      "Registering task {} for cluster link {} ({})",
+      t->name(),
+      _config.name,
+      _config.uuid);
+    if (_tasks.contains(t->name())) {
+        auto msg = ssx::sformat(
+          "Task named '{}' already exists for link {}",
+          t->name(),
+          _config.name);
+        vlog(cllog.warn, "{}", msg);
+        co_return err_info(
+          errc::task_already_registered_on_link, std::move(msg));
+    }
+
+    auto name = t->name();
+    _tasks.emplace(std::move(name), std::move(t));
+    co_return outcome::success();
+}
+
 void link::update_config(model::metadata config) {
     vlog(
       cllog.debug,
@@ -38,7 +60,15 @@ void link::update_config(model::metadata config) {
       _config.uuid,
       config);
     _config = std::move(config);
+
+    for (auto& [_, t] : _tasks) {
+        t->update_config(_config);
+    }
 }
 
 const model::metadata& link::config() const { return _config; }
+
+bool link::task_is_registered(std::string_view name) const noexcept {
+    return _tasks.contains(ss::sstring{name});
+}
 } // namespace cluster_link

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -12,32 +12,117 @@
 #include "cluster_link/link.h"
 
 #include "cluster_link/logger.h"
+#include "model/namespace.h"
+
+#include <seastar/coroutine/as_future.hh>
 
 namespace cluster_link {
+namespace {
+ss::future<result<void>> start_task(task* t) {
+    result<void> res = outcome::success();
+    try {
+        co_return co_await t->start();
+    } catch (const std::exception& e) {
+        res = err_info(
+          errc::failed_to_start_task,
+          ssx::sformat("Failed to start task {}: {}", t->name(), e.what()));
+    }
+
+    co_return res;
+}
+ss::future<result<void>> stop_task(task* t) {
+    result<void> res = outcome::success();
+    try {
+        co_return co_await t->stop();
+    } catch (const std::exception& e) {
+        res = err_info(
+          errc::failed_to_start_task,
+          ssx::sformat("Failed to stop task {}: {}", t->name(), e.what()));
+    }
+
+    co_return res;
+}
+} // namespace
 
 using kafka::data::rpc::partition_leader_cache;
 using kafka::data::rpc::partition_manager;
 
 link::link(
   ::model::node_id self,
+  ss::lowres_clock::duration task_reconciler_interval,
   model::metadata config,
   partition_leader_cache* partition_leader_cache,
   partition_manager* partition_manager)
   : _self(self)
   , _config(std::move(config))
   , _partition_leader_cache(partition_leader_cache)
-  , _partition_manager(partition_manager) {}
+  , _partition_manager(partition_manager)
+  , _task_reconciler_interval(task_reconciler_interval) {}
 
 ss::future<> link::start() {
     vlog(
       cllog.info, "Starting cluster link {} ({})", _config.name, _config.uuid);
-    return ss::now();
+    for (auto& [_, t] : _tasks) {
+        if (should_start_task(t.get())) {
+            vlog(
+              cllog.info,
+              "Starting task {} for cluster link {} ({})",
+              t->name(),
+              _config.name,
+              _config.uuid);
+            auto res = co_await start_task(t.get());
+            if (!res) {
+                vlog(
+                  cllog.error,
+                  "Failed to start task {}: {}",
+                  t->name(),
+                  res.assume_error().message());
+            }
+        } else {
+            vlog(
+              cllog.debug,
+              "Skipping task {} for cluster link {} ({})",
+              t->name(),
+              _config.name,
+              _config.uuid);
+        }
+    }
+    _task_reconciler.set_callback([this] {
+        ssx::spawn_with_gate(_gate, [this] { return run_task_reconciler(); });
+    });
+    _task_reconciler.arm_periodic(_task_reconciler_interval);
+    _is_running = true;
 }
 
 ss::future<> link::stop() {
     vlog(
       cllog.info, "Stopping cluster link {} ({})", _config.name, _config.uuid);
-    return ss::now();
+    _is_running = false;
+    _task_reconciler.cancel();
+    _as.request_abort();
+    co_await _gate.close();
+
+    for (auto& [_, t] : _tasks) {
+        vlog(
+          cllog.info,
+          "Stopping task {} for cluster link {}",
+          t->name(),
+          _config.name);
+        auto res = co_await stop_task(t.get());
+        if (!res) {
+            if (res.assume_error().code() == errc::task_not_running) {
+                // that's ok, keep going
+                continue;
+            }
+            vlog(
+              cllog.error,
+              "Failed to stop task {}: {}",
+              t->name(),
+              res.assume_error().message());
+        }
+    }
+
+    vlog(cllog.info, "Stopped link {} ({})", _config.name, _config.uuid);
 }
 
 ss::future<result<void>> link::register_task(std::unique_ptr<task> t) {
@@ -57,9 +142,36 @@ ss::future<result<void>> link::register_task(std::unique_ptr<task> t) {
           errc::task_already_registered_on_link, std::move(msg));
     }
 
+    result<void> res = outcome::success();
+    // Do not need to unregister the task callback as the task lifetime is
+    // managed by the link
+    t->register_for_updates([this](
+                              std::string_view task_name,
+                              task::state_change change) {
+        vlog(
+          cllog.debug, "Task {} reported state change: {}", task_name, change);
+        _task_state_change_notifications.notify(
+          _config.name, task_name, change);
+    });
+    // If we register a task after the link has started, then check to see
+    // if it should start and do so
+    if (_is_running && should_start_task(t.get())) {
+        vlog(cllog.info, "Starting task {}", t->name());
+        res = co_await start_task(t.get());
+        if (!res) {
+            vlog(
+              cllog.error,
+              "Failed to start task {}: {}",
+              t->name(),
+              res.assume_error().message());
+        }
+    }
+    // Even if the task failed to start, still emplace it into the list, the
+    // task reconcilier will re-attempt later
     auto name = t->name();
     _tasks.emplace(std::move(name), std::move(t));
-    co_return outcome::success();
+
+    co_return res;
 }
 
 void link::update_config(model::metadata config) {
@@ -70,9 +182,23 @@ void link::update_config(model::metadata config) {
       _config.uuid,
       config);
     _config = std::move(config);
-
     for (auto& [_, t] : _tasks) {
+        vlog(cllog.trace, "Updating config for task {}", t->name());
         t->update_config(_config);
+    }
+}
+
+ss::future<>
+link::handle_on_leadership_change(::model::ntp ntp, ntp_leader is_ntp_leader) {
+    vlog(
+      cllog.trace,
+      "Cluster link {} handling leadership change for {}: {}",
+      _config.name,
+      ntp,
+      is_ntp_leader);
+
+    if (ntp == ::model::controller_ntp) {
+        co_await handle_controller_leadership_change(is_ntp_leader);
     }
 }
 
@@ -80,5 +206,162 @@ const model::metadata& link::config() const { return _config; }
 
 bool link::task_is_registered(std::string_view name) const noexcept {
     return _tasks.contains(ss::sstring{name});
+}
+
+link::task_state_notification_id
+link::register_for_task_state_changes(task_state_change_cb cb) {
+    return _task_state_change_notifications.register_cb(std::move(cb));
+}
+
+void link::unregister_for_task_state_changes(
+  task_state_notification_id id) noexcept {
+    _task_state_change_notifications.unregister_cb(id);
+}
+
+bool link::should_start_task(task* t) const {
+    if (t->get_state() != model::task_state::not_running) {
+        // Can only start tasks that are currently not running
+        return false;
+    }
+    if (t->locked_to_controller() == task::is_locked_to_controller::yes) {
+        auto controller_leader_node = _partition_leader_cache->get_leader_node(
+          ::model::controller_ntp);
+        if (!controller_leader_node || *controller_leader_node != _self) {
+            return false;
+        }
+        auto controller_leader_shard = _partition_manager->shard_owner(
+          ::model::controller_ntp);
+        return controller_leader_shard.has_value()
+               && *controller_leader_shard == ss::this_shard_id();
+    }
+    return true;
+}
+
+bool link::should_stop_task(task* t) const {
+    if (t->get_state() == model::task_state::not_running) {
+        // Can only stop tasks that are currently running
+        return false;
+    }
+    if (t->locked_to_controller() == task::is_locked_to_controller::yes) {
+        auto controller_leader_node = _partition_leader_cache->get_leader_node(
+          ::model::controller_ntp);
+        if (!controller_leader_node || *controller_leader_node != _self) {
+            return true;
+        }
+        auto controller_leader_shard = _partition_manager->shard_owner(
+          ::model::controller_ntp);
+        return !controller_leader_shard.has_value()
+               || *controller_leader_shard != ss::this_shard_id();
+    }
+    return false;
+}
+
+ss::future<>
+link::handle_controller_leadership_change(ntp_leader is_ntp_leader) {
+    vlog(
+      cllog.trace,
+      "Cluster link {} handling controller leadership change: {}",
+      _config.name,
+      is_ntp_leader);
+    // Lock the reconciler mutex here to ensure it doesn't run while we are
+    // handling controller leaderhip changes
+    auto fut = co_await ss::coroutine::as_future(
+      _task_reconciler_mutex.get_units(_as));
+    if (fut.failed()) {
+        // abort source triggered, exit early
+        co_return;
+    }
+    auto units = std::move(fut).get();
+
+    for (auto& [_, t] : _tasks) {
+        if (t->locked_to_controller() == task::is_locked_to_controller::no) {
+            continue;
+        }
+        if (
+          t->get_state() == model::task_state::not_running
+          && is_ntp_leader == ntp_leader::yes) {
+            vlog(
+              cllog.info,
+              "Starting task {} for cluster link {}",
+              t->name(),
+              _config.name);
+            auto res = co_await start_task(t.get());
+            if (!res) {
+                vlog(
+                  cllog.error,
+                  "Failed to start task {}: {}",
+                  t->name(),
+                  res.assume_error().message());
+            }
+        }
+        if (
+          t->get_state() != model::task_state::not_running
+          && is_ntp_leader == ntp_leader::no) {
+            vlog(
+              cllog.info,
+              "Stopping task {} for cluster link {}",
+              t->name(),
+              _config.name);
+            auto res = co_await stop_task(t.get());
+            if (!res) {
+                vlog(
+                  cllog.error,
+                  "Failed to stop task {}: {}",
+                  t->name(),
+                  res.assume_error().message());
+            }
+        }
+    }
+}
+
+ss::future<> link::run_task_reconciler() {
+    auto fut = co_await ss::coroutine::as_future(
+      _task_reconciler_mutex.get_units(_as));
+    if (fut.failed()) {
+        // abort source triggered, exit early
+        co_return;
+    }
+    auto units = std::move(fut).get();
+
+    vlog(
+      cllog.trace, "Running task reconciler for cluster link {}", _config.name);
+    // Iterate over all tasks and reconcile their state
+    for (auto& [name, t] : _tasks) {
+        if (_is_running && should_start_task(t.get())) {
+            vlog(
+              cllog.info,
+              "Reconciler starting task {} for cluster link {}",
+              name,
+              _config.name);
+            auto res = co_await start_task(t.get());
+            if (!res) {
+                vlog(
+                  cllog.error,
+                  "Failed to start task {}: {}",
+                  name,
+                  res.assume_error().message());
+            }
+        }
+
+        if (should_stop_task(t.get())) {
+            vlog(
+              cllog.debug,
+              "Reconciler stopping task {} for cluster link {}",
+              name,
+              _config.name);
+            auto res = co_await stop_task(t.get());
+            if (!res) {
+                if (res.assume_error().code() == errc::task_not_running) {
+                    // that's ok, keep going
+                    continue;
+                }
+                vlog(
+                  cllog.error,
+                  "Failed to stop task {}: {}",
+                  name,
+                  res.assume_error().message());
+            }
+        }
+    }
 }
 } // namespace cluster_link

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -16,11 +16,15 @@
 namespace cluster_link {
 
 using kafka::data::rpc::partition_leader_cache;
+using kafka::data::rpc::partition_manager;
 
 link::link(
-  model::metadata config, partition_leader_cache* partition_leader_cache)
+  model::metadata config,
+  partition_leader_cache* partition_leader_cache,
+  partition_manager* partition_manager)
   : _config(std::move(config))
-  , _partition_leader_cache(partition_leader_cache) {}
+  , _partition_leader_cache(partition_leader_cache)
+  , _partition_manager(partition_manager) {}
 
 ss::future<> link::start() {
     vlog(

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -19,10 +19,12 @@ using kafka::data::rpc::partition_leader_cache;
 using kafka::data::rpc::partition_manager;
 
 link::link(
+  ::model::node_id self,
   model::metadata config,
   partition_leader_cache* partition_leader_cache,
   partition_manager* partition_manager)
-  : _config(std::move(config))
+  : _self(self)
+  , _config(std::move(config))
   , _partition_leader_cache(partition_leader_cache)
   , _partition_manager(partition_manager) {}
 

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -19,19 +19,21 @@ link::link(model::metadata config)
   : _config(std::move(config)) {}
 
 ss::future<> link::start() {
-    vlog(cllog.info, "Starting panda link {} ({})", _config.name, _config.uuid);
+    vlog(
+      cllog.info, "Starting cluster link {} ({})", _config.name, _config.uuid);
     return ss::now();
 }
 
 ss::future<> link::stop() {
-    vlog(cllog.info, "Stopping panda link {} ({})", _config.name, _config.uuid);
+    vlog(
+      cllog.info, "Stopping cluster link {} ({})", _config.name, _config.uuid);
     return ss::now();
 }
 
 void link::update_config(model::metadata config) {
     vlog(
       cllog.debug,
-      "Updating panda link {} ({}): {}",
+      "Updating cluster link {} ({}): {}",
       _config.name,
       _config.uuid,
       config);

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -13,6 +13,7 @@
 
 #include "cluster_link/model/types.h"
 #include "cluster_link/task.h"
+#include "kafka/data/rpc/deps.h"
 
 namespace cluster_link {
 /**
@@ -20,7 +21,9 @@ namespace cluster_link {
  */
 class link {
 public:
-    explicit link(model::metadata config);
+    explicit link(
+      model::metadata config,
+      kafka::data::rpc::partition_leader_cache* partition_leader_cache);
     link(const link&) = delete;
     link(link&&) = delete;
     link& operator=(const link&) = delete;
@@ -41,5 +44,6 @@ public:
 private:
     chunked_hash_map<ss::sstring, std::unique_ptr<task>> _tasks;
     model::metadata _config;
+    kafka::data::rpc::partition_leader_cache* _partition_leader_cache;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -63,6 +63,8 @@ public:
     void
     unregister_for_task_state_changes(task_state_notification_id id) noexcept;
 
+    model::link_task_status_report get_task_status_report() const;
+
 private:
     bool should_start_task(task* t) const;
     bool should_stop_task(task* t) const;

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster_link/model/types.h"
+#include "cluster_link/task.h"
 
 namespace cluster_link {
 /**
@@ -29,11 +30,16 @@ public:
     virtual ss::future<> start();
     virtual ss::future<> stop();
 
+    ss::future<result<void>> register_task(std::unique_ptr<task>);
+
     void update_config(model::metadata);
 
     const model::metadata& config() const;
 
+    bool task_is_registered(std::string_view) const noexcept;
+
 private:
+    chunked_hash_map<ss::sstring, std::unique_ptr<task>> _tasks;
     model::metadata _config;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -23,7 +23,8 @@ class link {
 public:
     explicit link(
       model::metadata config,
-      kafka::data::rpc::partition_leader_cache* partition_leader_cache);
+      kafka::data::rpc::partition_leader_cache* partition_leader_cache,
+      kafka::data::rpc::partition_manager* partition_manager);
     link(const link&) = delete;
     link(link&&) = delete;
     link& operator=(const link&) = delete;
@@ -45,5 +46,6 @@ private:
     chunked_hash_map<ss::sstring, std::unique_ptr<task>> _tasks;
     model::metadata _config;
     kafka::data::rpc::partition_leader_cache* _partition_leader_cache;
+    kafka::data::rpc::partition_manager* _partition_manager;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -13,7 +13,10 @@
 
 #include "cluster_link/model/types.h"
 #include "cluster_link/task.h"
+#include "cluster_link/types.h"
 #include "kafka/data/rpc/deps.h"
+#include "utils/mutex.h"
+#include "utils/notification_list.h"
 
 namespace cluster_link {
 /**
@@ -23,6 +26,7 @@ class link {
 public:
     explicit link(
       ::model::node_id self,
+      ss::lowres_clock::duration task_reconciler_interval,
       model::metadata config,
       kafka::data::rpc::partition_leader_cache* partition_leader_cache,
       kafka::data::rpc::partition_manager* partition_manager);
@@ -39,9 +43,33 @@ public:
 
     void update_config(model::metadata);
 
+    ss::future<>
+    handle_on_leadership_change(::model::ntp ntp, ntp_leader is_ntp_leader);
+
     const model::metadata& config() const;
 
     bool task_is_registered(std::string_view) const noexcept;
+
+    using task_state_notification_id
+      = named_type<size_t, struct task_state_notification_id_tag>;
+    /// Callback for when a task changes state.  Callback reports the link name,
+    /// task name, and the state change information
+    using task_state_change_cb = ss::noncopyable_function<void(
+      model::name_t, std::string_view, task::state_change)>;
+
+    task_state_notification_id
+    register_for_task_state_changes(task_state_change_cb cb);
+
+    void
+    unregister_for_task_state_changes(task_state_notification_id id) noexcept;
+
+private:
+    bool should_start_task(task* t) const;
+    bool should_stop_task(task* t) const;
+    ss::future<> handle_controller_leadership_change(ntp_leader is_ntp_leader);
+    ss::future<>
+    do_handle_controller_leadership_change(ntp_leader is_ntp_leader);
+    ss::future<> run_task_reconciler();
 
 private:
     ::model::node_id _self;
@@ -49,5 +77,13 @@ private:
     model::metadata _config;
     kafka::data::rpc::partition_leader_cache* _partition_leader_cache;
     kafka::data::rpc::partition_manager* _partition_manager;
+    notification_list<task_state_change_cb, task_state_notification_id>
+      _task_state_change_notifications;
+    ss::lowres_clock::duration _task_reconciler_interval;
+    mutex _task_reconciler_mutex{"cluster_link::link::task_reconciler"};
+    ss::timer<ss::lowres_clock> _task_reconciler;
+    ss::gate _gate;
+    ss::abort_source _as;
+    bool _is_running{false};
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -22,6 +22,7 @@ namespace cluster_link {
 class link {
 public:
     explicit link(
+      ::model::node_id self,
       model::metadata config,
       kafka::data::rpc::partition_leader_cache* partition_leader_cache,
       kafka::data::rpc::partition_manager* partition_manager);
@@ -43,6 +44,7 @@ public:
     bool task_is_registered(std::string_view) const noexcept;
 
 private:
+    ::model::node_id _self;
     chunked_hash_map<ss::sstring, std::unique_ptr<task>> _tasks;
     model::metadata _config;
     kafka::data::rpc::partition_leader_cache* _partition_leader_cache;

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -20,10 +20,13 @@ using namespace std::chrono_literals;
 namespace cluster_link {
 manager::manager(
   ::model::node_id self,
+  std::unique_ptr<kafka::data::rpc::partition_leader_cache>
+    partition_leader_cache,
   std::unique_ptr<link_registry> registry,
   std::unique_ptr<link_factory> link_factory,
   ss::lowres_clock::duration task_reconciler_interval)
   : _self(self)
+  , _partition_leader_cache(std::move(partition_leader_cache))
   , _registry(std::move(registry))
   , _link_factory(std::move(link_factory))
   , _queue(
@@ -119,7 +122,9 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
           id,
           link_metadata);
         try {
-            auto new_link = _link_factory->create_link(link_metadata.copy());
+            auto units = co_await _link_task_reconciler_mutex.get_units(_as);
+            auto new_link = _link_factory->create_link(
+              link_metadata.copy(), _partition_leader_cache.get());
             vassert(
               new_link, "Link factory returned a null link for id={}", id);
             // Register tasks for the link
@@ -152,6 +157,9 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
             }
             co_await new_link->start();
             _links.emplace(id, std::move(new_link));
+        } catch (const ss::semaphore_aborted&) {
+            vlog(cllog.debug, "Semaphore aborted, stopping link creation");
+            co_return;
         } catch (const std::exception& e) {
             vlog(
               cllog.warn,

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -238,4 +238,16 @@ ss::future<> manager::handle_on_leadership_change(
         return pair.second->handle_on_leadership_change(ntp, is_ntp_leader);
     });
 }
+
+model::cluster_link_task_status_report manager::get_task_status_report() const {
+    model::cluster_link_task_status_report report;
+    report.link_reports.reserve(_links.size());
+    for (const auto& [_, link] : _links) {
+        auto link_report = link->get_task_status_report();
+        auto name = link_report.link_name;
+        report.link_reports.emplace(std::move(name), std::move(link_report));
+    }
+
+    return report;
+}
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -22,11 +22,13 @@ manager::manager(
   ::model::node_id self,
   std::unique_ptr<kafka::data::rpc::partition_leader_cache>
     partition_leader_cache,
+  std::unique_ptr<kafka::data::rpc::partition_manager> partition_manager,
   std::unique_ptr<link_registry> registry,
   std::unique_ptr<link_factory> link_factory,
   ss::lowres_clock::duration task_reconciler_interval)
   : _self(self)
   , _partition_leader_cache(std::move(partition_leader_cache))
+  , _partition_manager(std::move(partition_manager))
   , _registry(std::move(registry))
   , _link_factory(std::move(link_factory))
   , _queue(
@@ -124,7 +126,9 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
         try {
             auto units = co_await _link_task_reconciler_mutex.get_units(_as);
             auto new_link = _link_factory->create_link(
-              link_metadata.copy(), _partition_leader_cache.get());
+              link_metadata.copy(),
+              _partition_leader_cache.get(),
+              _partition_manager.get());
             vassert(
               new_link, "Link factory returned a null link for id={}", id);
             // Register tasks for the link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -13,13 +13,16 @@
 
 #include "cluster_link/logger.h"
 
+#include <seastar/coroutine/as_future.hh>
+
 using namespace std::chrono_literals;
 
 namespace cluster_link {
 manager::manager(
   ::model::node_id self,
   std::unique_ptr<link_registry> registry,
-  std::unique_ptr<link_factory> link_factory)
+  std::unique_ptr<link_factory> link_factory,
+  ss::lowres_clock::duration task_reconciler_interval)
   : _self(self)
   , _registry(std::move(registry))
   , _link_factory(std::move(link_factory))
@@ -27,7 +30,8 @@ manager::manager(
       [](const std::exception_ptr& ex) {
           vlog(cllog.warn, "unexpected cluster link manager error: {}", ex);
       },
-      ssx::work_queue::is_paused_t::yes) {}
+      ssx::work_queue::is_paused_t::yes)
+  , _task_reconciler_interval(task_reconciler_interval) {}
 
 ss::future<> manager::start() {
     vlog(cllog.info, "Starting cluster link manager");
@@ -35,6 +39,10 @@ ss::future<> manager::start() {
     for (auto id : ids) {
         co_await handle_on_link_change(id);
     }
+    _link_task_reconciler_timer.set_callback([this] {
+        ssx::spawn_with_gate(_g, [this] { return link_task_reconciler(); });
+    });
+    _link_task_reconciler_timer.arm_periodic(_task_reconciler_interval);
     _queue.resume();
 }
 
@@ -42,9 +50,14 @@ ss::future<> manager::stop() {
     vlog(cllog.info, "Stopping cluster link manager");
 
     co_await _queue.shutdown();
+    _link_task_reconciler_timer.cancel();
+    _as.request_abort();
+    co_await _g.close();
     for (auto& [_, link] : _links) {
         co_await link->stop();
     }
+
+    vlog(cllog.info, "Cluster link manager stopped");
 }
 
 void manager::on_link_change(model::id_t id) {
@@ -109,6 +122,34 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
             auto new_link = _link_factory->create_link(link_metadata.copy());
             vassert(
               new_link, "Link factory returned a null link for id={}", id);
+            // Register tasks for the link
+            for (auto& task_factory : _task_factories) {
+                auto task = task_factory->create_task();
+                vassert(
+                  task,
+                  "Task factory for task {} returned a null task for link "
+                  "id={}",
+                  task_factory->created_task_name(),
+                  id);
+                try {
+                    auto ec = co_await new_link->register_task(std::move(task));
+                    if (!ec) {
+                        vlog(
+                          cllog.warn,
+                          "Failed to register task '{}': {}",
+                          task_factory->created_task_name(),
+                          ec.assume_error().message());
+                    }
+                } catch (const std::exception& e) {
+                    vlog(
+                      cllog.warn,
+                      "Failed to register task {} for link {}: \"{}\". "
+                      "Continuing with link creation",
+                      task_factory->created_task_name(),
+                      id,
+                      e);
+                }
+            }
             co_await new_link->start();
             _links.emplace(id, std::move(new_link));
         } catch (const std::exception& e) {
@@ -121,6 +162,50 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
               retry_delay.count());
             _queue.submit_delayed(
               retry_delay, [this, id] { return handle_on_link_change(id); });
+        }
+    }
+}
+
+ss::future<> manager::link_task_reconciler() {
+    vlog(cllog.trace, "Reconciling tasks for all cluster links");
+
+    auto fut = co_await ss::coroutine::as_future(
+      _link_task_reconciler_mutex.get_units(_as));
+    if (fut.failed()) {
+        // abort source triggered, exit early
+        co_return;
+    }
+    auto units = std::move(fut).get();
+
+    for (const auto& [_, link] : _links) {
+        vlog(
+          cllog.trace,
+          "Reconciling tasks for cluster link {} ({})",
+          link->config().name,
+          link->config().uuid);
+        for (const auto& task_factory : _task_factories) {
+            auto task_name = task_factory->created_task_name();
+            if (!link->task_is_registered(task_name)) {
+                vlog(
+                  cllog.debug,
+                  "Registering task {} for cluster link {} ({})",
+                  task_name,
+                  link->config().name,
+                  link->config().uuid);
+                auto task = task_factory->create_task();
+                vassert(
+                  task,
+                  "Task factory for task {} returned a null task for link {}",
+                  task_name,
+                  link->config().name);
+                auto ec = co_await link->register_task(std::move(task));
+                if (!ec) {
+                    vlog(
+                      cllog.error,
+                      "Error occurred while registering the task: {}",
+                      ec.assume_error().message());
+                }
+            }
         }
     }
 }

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -72,6 +72,9 @@ void manager::on_link_change(model::id_t id) {
 
 void manager::on_leadership_change(::model::ntp ntp, ntp_leader is_ntp_leader) {
     vlog(cllog.trace, "NTP={} leadership changed to {}", ntp, is_ntp_leader);
+    _queue.submit([this, ntp{std::move(ntp)}, is_ntp_leader]() mutable {
+        return handle_on_leadership_change(std::move(ntp), is_ntp_leader);
+    });
 }
 
 ss::future<> manager::handle_on_link_change(model::id_t id) {
@@ -221,5 +224,18 @@ ss::future<> manager::link_task_reconciler() {
             }
         }
     }
+}
+
+ss::future<> manager::handle_on_leadership_change(
+  ::model::ntp ntp, ntp_leader is_ntp_leader) {
+    vlog(
+      cllog.trace,
+      "Handling leadership change for NTP={}, is_ntp_leader={}",
+      ntp,
+      is_ntp_leader);
+
+    co_await ss::parallel_for_each(_links, [ntp, is_ntp_leader](auto& pair) {
+        return pair.second->handle_on_leadership_change(ntp, is_ntp_leader);
+    });
 }
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -25,12 +25,12 @@ manager::manager(
   , _link_factory(std::move(link_factory))
   , _queue(
       [](const std::exception_ptr& ex) {
-          vlog(cllog.warn, "unexpected panda link manager error: {}", ex);
+          vlog(cllog.warn, "unexpected cluster link manager error: {}", ex);
       },
       ssx::work_queue::is_paused_t::yes) {}
 
 ss::future<> manager::start() {
-    vlog(cllog.info, "Starting panda link manager");
+    vlog(cllog.info, "Starting cluster link manager");
     auto ids = _registry->get_all_link_ids();
     for (auto id : ids) {
         co_await handle_on_link_change(id);
@@ -39,7 +39,8 @@ ss::future<> manager::start() {
 }
 
 ss::future<> manager::stop() {
-    vlog(cllog.info, "Stopping panda link manager");
+    vlog(cllog.info, "Stopping cluster link manager");
+
     co_await _queue.shutdown();
     for (auto& [_, link] : _links) {
         co_await link->stop();
@@ -47,7 +48,7 @@ ss::future<> manager::stop() {
 }
 
 void manager::on_link_change(model::id_t id) {
-    vlog(cllog.trace, "Panda link with id={} has changed", id);
+    vlog(cllog.trace, "Cluster link with id={} has changed", id);
     _queue.submit([this, id] { return handle_on_link_change(id); });
 }
 
@@ -58,15 +59,15 @@ void manager::on_leadership_change(::model::ntp ntp, ntp_leader is_ntp_leader) {
 ss::future<> manager::handle_on_link_change(model::id_t id) {
     static constexpr auto retry_delay = 10s;
 
-    vlog(cllog.trace, "Handling panda link change for id={}", id);
+    vlog(cllog.trace, "Handling cluster link change for id={}", id);
     auto link_opt = _registry->find_link_by_id(id);
     if (!link_opt) {
-        vlog(cllog.debug, "Detected panda link id={} has been removed", id);
+        vlog(cllog.debug, "Detected cluster link id={} has been removed", id);
         auto it = _links.find(id);
         if (it != _links.end()) {
             // Stop and remove the link
             try {
-                vlog(cllog.debug, "Stopping panda link with id={}", id);
+                vlog(cllog.debug, "Stopping cluster link with id={}", id);
                 co_await it->second->stop();
                 _links.erase(it);
             } catch (const std::exception& e) {
@@ -93,7 +94,7 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
         // Link already exists, update its configur
         vlog(
           cllog.debug,
-          "Updating panda link id={} with new config: {}",
+          "Updating cluster link id={} with new config: {}",
           id,
           link_metadata);
         it->second->update_config(link_metadata.copy());

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -126,6 +126,7 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
         try {
             auto units = co_await _link_task_reconciler_mutex.get_units(_as);
             auto new_link = _link_factory->create_link(
+              _self,
               link_metadata.copy(),
               _partition_leader_cache.get(),
               _partition_manager.get());

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -108,6 +108,8 @@ public:
           std::make_unique<T>(std::forward<Args>(args)...));
     }
 
+    model::cluster_link_task_status_report get_task_status_report() const;
+
 private:
     /// Called periodically to reconcile registered tasks on created links
     ss::future<> link_task_reconciler();

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -60,7 +60,10 @@ public:
     link_factory& operator=(link_factory&&) = delete;
     virtual ~link_factory() = default;
 
-    virtual std::unique_ptr<link> create_link(model::metadata config) = 0;
+    virtual std::unique_ptr<link> create_link(
+      model::metadata config,
+      kafka::data::rpc::partition_leader_cache* partition_leader_cache)
+      = 0;
 };
 
 /**
@@ -73,6 +76,8 @@ class manager {
 public:
     manager(
       ::model::node_id self,
+      std::unique_ptr<kafka::data::rpc::partition_leader_cache>
+        partition_leader_cache,
       std::unique_ptr<link_registry> registry,
       std::unique_ptr<link_factory> link_factory,
       ss::lowres_clock::duration task_reconciler_interval);
@@ -106,6 +111,8 @@ private:
 
 private:
     ::model::node_id _self;
+    std::unique_ptr<kafka::data::rpc::partition_leader_cache>
+      _partition_leader_cache;
     std::unique_ptr<link_registry> _registry;
     std::unique_ptr<link_factory> _link_factory;
     ssx::work_queue _queue;

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -97,6 +97,8 @@ public:
     void on_leadership_change(::model::ntp ntp, ntp_leader is_ntp_leader);
     /// Handles creation and start of a link
     ss::future<> handle_on_link_change(model::id_t id);
+    /// Handles leadership changes for a given NTP
+    ss::future<> handle_on_leadership_change(::model::ntp, ntp_leader);
 
     /// Registers a task factory that will be used to create tasks when links
     /// are created

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -14,9 +14,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "cluster_link/link.h"
 #include "cluster_link/model/types.h"
+#include "cluster_link/task.h"
 #include "container/fragmented_vector.h"
 #include "model/fundamental.h"
 #include "ssx/work_queue.h"
+#include "utils/mutex.h"
 
 namespace cluster_link {
 
@@ -72,7 +74,8 @@ public:
     manager(
       ::model::node_id self,
       std::unique_ptr<link_registry> registry,
-      std::unique_ptr<link_factory> link_factory);
+      std::unique_ptr<link_factory> link_factory,
+      ss::lowres_clock::duration task_reconciler_interval);
     manager(const manager&) = delete;
     manager(manager&&) = delete;
     manager& operator=(const manager&) = delete;
@@ -89,12 +92,32 @@ public:
     /// Handles creation and start of a link
     ss::future<> handle_on_link_change(model::id_t id);
 
+    /// Registers a task factory that will be used to create tasks when links
+    /// are created
+    template<typename T, typename... Args>
+    void register_task_factory(Args&&... args) {
+        _task_factories.emplace_back(
+          std::make_unique<T>(std::forward<Args>(args)...));
+    }
+
+private:
+    /// Called periodically to reconcile registered tasks on created links
+    ss::future<> link_task_reconciler();
+
 private:
     ::model::node_id _self;
     std::unique_ptr<link_registry> _registry;
     std::unique_ptr<link_factory> _link_factory;
     ssx::work_queue _queue;
 
+    chunked_vector<std::unique_ptr<task_factory>> _task_factories;
     absl::flat_hash_map<id_t, std::unique_ptr<link>> _links;
+
+    ss::lowres_clock::duration _task_reconciler_interval;
+    mutex _link_task_reconciler_mutex{
+      "cluster_link::manager::link_task_reconciler"};
+    ss::timer<ss::lowres_clock> _link_task_reconciler_timer;
+    ss::abort_source _as;
+    ss::gate _g;
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -62,7 +62,8 @@ public:
 
     virtual std::unique_ptr<link> create_link(
       model::metadata config,
-      kafka::data::rpc::partition_leader_cache* partition_leader_cache)
+      kafka::data::rpc::partition_leader_cache* partition_leader_cache,
+      kafka::data::rpc::partition_manager* partition_manager)
       = 0;
 };
 
@@ -78,6 +79,7 @@ public:
       ::model::node_id self,
       std::unique_ptr<kafka::data::rpc::partition_leader_cache>
         partition_leader_cache,
+      std::unique_ptr<kafka::data::rpc::partition_manager> partition_manager,
       std::unique_ptr<link_registry> registry,
       std::unique_ptr<link_factory> link_factory,
       ss::lowres_clock::duration task_reconciler_interval);
@@ -113,6 +115,7 @@ private:
     ::model::node_id _self;
     std::unique_ptr<kafka::data::rpc::partition_leader_cache>
       _partition_leader_cache;
+    std::unique_ptr<kafka::data::rpc::partition_manager> _partition_manager;
     std::unique_ptr<link_registry> _registry;
     std::unique_ptr<link_factory> _link_factory;
     ssx::work_queue _queue;

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -15,15 +15,13 @@
 #include "cluster_link/link.h"
 #include "cluster_link/model/types.h"
 #include "cluster_link/task.h"
+#include "cluster_link/types.h"
 #include "container/fragmented_vector.h"
 #include "model/fundamental.h"
 #include "ssx/work_queue.h"
 #include "utils/mutex.h"
 
 namespace cluster_link {
-
-/// Indicates if the current node is the leader for a given NTP
-using ntp_leader = ss::bool_class<struct is_ntp_leader_tag>;
 
 /**
  * @brief Abstract class that provides accessors to cluster link table

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -61,6 +61,7 @@ public:
     virtual ~link_factory() = default;
 
     virtual std::unique_ptr<link> create_link(
+      ::model::node_id self,
       model::metadata config,
       kafka::data::rpc::partition_leader_cache* partition_leader_cache,
       kafka::data::rpc::partition_manager* partition_manager)

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -24,7 +24,7 @@ namespace cluster_link {
 using ntp_leader = ss::bool_class<struct is_ntp_leader_tag>;
 
 /**
- * @brief Abstract class that provides accessors to panda link table
+ * @brief Abstract class that provides accessors to cluster link table
  *
  */
 class link_registry {
@@ -62,10 +62,10 @@ public:
 };
 
 /**
- * @brief Class used to manage panda links
+ * @brief Class used to manage cluster links
  *
  * This class will be notified of changes in Redpanda to create, modify, or
- * remove panda links and to handle leadership changes of partitions.
+ * remove cluster links and to handle leadership changes of partitions.
  */
 class manager {
 public:
@@ -82,7 +82,7 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    /// Used to notify that a panda link has been updated
+    /// Used to notify that a cluster link has been updated
     void on_link_change(model::id_t id);
     /// Used to notify manager in a change of NTP leadership
     void on_leadership_change(::model::ntp ntp, ntp_leader is_ntp_leader);

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -160,3 +160,59 @@ auto fmt::formatter<cluster_link::model::update_mirror_topic_state_cmd>::format(
     return fmt::format_to(
       ctx.out(), "{{topic={}, state={}}}", m.topic, m.state);
 }
+
+auto fmt::formatter<cluster_link::model::task_status_report>::format(
+  const cluster_link::model::task_status_report& r, format_context& ctx) const
+  -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{task_name={}, task_state={}, task_state_reason={}}}",
+      r.task_name,
+      r.task_state,
+      r.task_state_reason);
+}
+
+auto fmt::formatter<decltype(cluster_link::model::link_task_status_report::
+                               task_status_reports)::value_type>::
+  format(
+    const decltype(cluster_link::model::link_task_status_report::
+                     task_status_reports)::value_type& m,
+    format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{task_name: {}, task_status_report: {}}}",
+      m.first,
+      m.second);
+}
+
+auto fmt::formatter<cluster_link::model::link_task_status_report>::format(
+  const cluster_link::model::link_task_status_report& r,
+  format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{link_name={}, task_status_reports={}}}",
+      r.link_name,
+      fmt::join(
+        r.task_status_reports.begin(), r.task_status_reports.end(), ","));
+}
+
+auto fmt::formatter<
+  decltype(cluster_link::model::cluster_link_task_status_report::link_reports)::
+    value_type>::
+  format(
+    const decltype(cluster_link::model::cluster_link_task_status_report::
+                     link_reports)::value_type& m,
+    format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(), "{{topic: {}, metadata: {}}}", m.first, m.second);
+}
+
+auto fmt::formatter<cluster_link::model::cluster_link_task_status_report>::
+  format(
+    const cluster_link::model::cluster_link_task_status_report& r,
+    format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{link_reports={}}}",
+      fmt::join(r.link_reports.begin(), r.link_reports.end(), ","));
+}

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -49,6 +49,12 @@ auto fmt::formatter<cluster_link::model::mirror_topic_state>::format(
     return fmt::format_to(ctx.out(), "{}", to_string_view(s));
 }
 
+auto fmt::formatter<cluster_link::model::task_state>::format(
+  cluster_link::model::task_state st, format_context& ctx) const
+  -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", to_string_view(st));
+}
+
 auto fmt::formatter<cluster_link::model::scram_credentials>::format(
   const cluster_link::model::scram_credentials& c, format_context& ctx)
   -> decltype(ctx.out()) {

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -251,6 +251,56 @@ struct update_mirror_topic_state_cmd
 
     auto serde_fields() { return std::tie(topic, state); }
 };
+
+/// Status report for a task
+struct task_status_report
+  : serde::envelope<
+      task_status_report,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ss::sstring task_name;
+    task_state task_state;
+    ss::sstring task_state_reason;
+
+    friend bool operator==(const task_status_report&, const task_status_report&)
+      = default;
+
+    auto serde_fields() {
+        return std::tie(task_name, task_state, task_state_reason);
+    }
+};
+
+/// The status report of a link
+struct link_task_status_report
+  : serde::envelope<
+      link_task_status_report,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    name_t link_name;
+    chunked_hash_map<ss::sstring, task_status_report> task_status_reports;
+
+    friend bool
+    operator==(const link_task_status_report&, const link_task_status_report&)
+      = default;
+
+    auto serde_fields() { return std::tie(link_name, task_status_reports); }
+};
+
+/// A map of task status reports per link
+struct cluster_link_task_status_report
+  : serde::envelope<
+      cluster_link_task_status_report,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    chunked_hash_map<name_t, link_task_status_report> link_reports;
+
+    friend bool operator==(
+      const cluster_link_task_status_report&,
+      const cluster_link_task_status_report&)
+      = default;
+
+    auto serde_fields() { return std::tie(link_reports); }
+};
 } // namespace cluster_link::model
 
 template<>
@@ -347,4 +397,48 @@ struct fmt::formatter<cluster_link::model::update_mirror_topic_state_cmd>
     auto format(
       const cluster_link::model::update_mirror_topic_state_cmd& m,
       format_context& ctx) -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::task_status_report>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::task_status_report& m,
+      format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<decltype(cluster_link::model::link_task_status_report::
+                                 task_status_reports)::value_type>
+  : fmt::formatter<string_view> {
+    auto format(
+      const decltype(cluster_link::model::link_task_status_report::
+                       task_status_reports)::value_type& m,
+      format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::link_task_status_report>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::link_task_status_report& m,
+      format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<
+  decltype(cluster_link::model::cluster_link_task_status_report::link_reports)::
+    value_type> : fmt::formatter<string_view> {
+    auto format(
+      const decltype(cluster_link::model::cluster_link_task_status_report::
+                       link_reports)::value_type& m,
+      format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::cluster_link_task_status_report>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::cluster_link_task_status_report& m,
+      format_context& ctx) const -> decltype(ctx.out());
 };

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -55,6 +55,38 @@ static constexpr std::string_view to_string_view(mirror_topic_state s) {
     return "unknown";
 }
 
+enum class task_state : uint8_t {
+    /// The task is currently active and processing
+    active,
+    /// The task has been paused by the user
+    paused,
+    /// The link to the source cluster is unavailable.  This could be a
+    /// temporary condition that can be resolved by changing configuration of
+    /// the task or on the source cluster.  This state is informative and the
+    /// task will continue to run at its set interval
+    link_unavailable,
+    /// The task is not configured to run
+    not_running,
+    /// The task has encountered an unexpected fault
+    faulted,
+};
+
+static constexpr std::string_view to_string_view(task_state st) {
+    switch (st) {
+    case task_state::active:
+        return "active";
+    case task_state::paused:
+        return "paused";
+    case task_state::link_unavailable:
+        return "link_unavailable";
+    case task_state::not_running:
+        return "not_running";
+    case task_state::faulted:
+        return "faulted";
+    }
+    return "unknown";
+}
+
 /**
  * @brief SCRAM credentials to use for authentication
  */
@@ -225,6 +257,13 @@ template<>
 struct fmt::formatter<cluster_link::model::mirror_topic_state>
   : fmt::formatter<string_view> {
     auto format(cluster_link::model::mirror_topic_state s, format_context& ctx)
+      -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::task_state>
+  : fmt::formatter<string_view> {
+    auto format(cluster_link::model::task_state, format_context& ctx) const
       -> decltype(ctx.out());
 };
 

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -23,11 +23,11 @@
 #include <seastar/util/bool_class.hh>
 
 namespace cluster_link::model {
-/// ID of the panda link - used internally based off of controller offset
+/// ID of the cluster link - used internally based off of controller offset
 using id_t = named_type<int64_t, struct id_tag>;
-/// UUID of the panda link - used externally
+/// UUID of the cluster link - used externally
 using uuid_t = named_type<uuid_t, struct uuid_tag>;
-/// Name of the panda link
+/// Name of the cluster link
 using name_t = named_type<ss::sstring, struct name_tag>;
 
 enum class mirror_topic_state : uint8_t {
@@ -142,9 +142,9 @@ struct link_state
     link_state& operator=(const link_state&) = delete;
     ~link_state() noexcept = default;
 
-    /// Type to indicate if the panda link is paused
+    /// Type to indicate if the cluster link is paused
     using paused_t = ss::bool_class<struct paused_tag>;
-    /// Flag indicating if the panda link has been paused
+    /// Flag indicating if the cluster link has been paused
     paused_t paused{paused_t::no};
     using mirror_topics_t
       = chunked_hash_map<::model::topic, mirror_topic_metadata>;
@@ -161,11 +161,11 @@ struct link_state
 };
 struct metadata
   : serde::envelope<metadata, serde::version<0>, serde::compat_version<0>> {
-    /// Name of the panda link
+    /// Name of the cluster link
     name_t name;
-    /// Unique identifier for the panda link
+    /// Unique identifier for the cluster link
     uuid_t uuid;
-    /// Connection settings for the panda link
+    /// Connection settings for the cluster link
     connection_config connection;
     /// The state of the link
     link_state state;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -23,6 +23,7 @@
 namespace cluster_link {
 
 using ::cluster::cluster_link::frontend;
+using kafka::data::rpc::partition_leader_cache;
 
 class link_registry_adapter : public link_registry {
 public:
@@ -49,8 +50,11 @@ private:
 
 class default_link_factory : public link_factory {
 public:
-    std::unique_ptr<link> create_link(model::metadata config) override {
-        return std::make_unique<link>(std::move(config));
+    std::unique_ptr<link> create_link(
+      model::metadata config,
+      partition_leader_cache* partition_leader_cache) override {
+        return std::make_unique<link>(
+          std::move(config), partition_leader_cache);
     }
 };
 
@@ -58,11 +62,13 @@ service::service(
   ::model::node_id self,
   ss::sharded<frontend>* plf,
   ss::sharded<cluster::partition_manager>* partition_manager,
-  ss::sharded<raft::group_manager>* group_manager)
+  ss::sharded<raft::group_manager>* group_manager,
+  ss::sharded<cluster::partition_leaders_table>* partition_leaders_table)
   : _self(self)
   , _plf(plf)
   , _partition_manager(partition_manager)
-  , _group_manager(group_manager) {}
+  , _group_manager(group_manager)
+  , _partition_leaders_table(partition_leaders_table) {}
 
 service::~service() = default;
 
@@ -70,6 +76,7 @@ ss::future<> service::start() {
     vlog(cllog.info, "Starting cluster link service");
     _manager = std::make_unique<manager>(
       _self,
+      partition_leader_cache::make_default(_partition_leaders_table),
       std::make_unique<link_registry_adapter>(&_plf->local()),
       std::make_unique<default_link_factory>(),
       30s); // Temporary until we have a proper configuration for this

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -24,6 +24,7 @@ namespace cluster_link {
 
 using ::cluster::cluster_link::frontend;
 using kafka::data::rpc::partition_leader_cache;
+using kafka::data::rpc::partition_manager;
 
 class link_registry_adapter : public link_registry {
 public:
@@ -52,9 +53,10 @@ class default_link_factory : public link_factory {
 public:
     std::unique_ptr<link> create_link(
       model::metadata config,
-      partition_leader_cache* partition_leader_cache) override {
+      partition_leader_cache* partition_leader_cache,
+      partition_manager* partition_manager) override {
         return std::make_unique<link>(
-          std::move(config), partition_leader_cache);
+          std::move(config), partition_leader_cache, partition_manager);
     }
 };
 
@@ -63,12 +65,16 @@ service::service(
   ss::sharded<frontend>* plf,
   ss::sharded<cluster::partition_manager>* partition_manager,
   ss::sharded<raft::group_manager>* group_manager,
-  ss::sharded<cluster::partition_leaders_table>* partition_leaders_table)
+  ss::sharded<cluster::partition_leaders_table>* partition_leaders_table,
+  ss::sharded<cluster::shard_table>* shard_table,
+  ss::smp_service_group smp_group)
   : _self(self)
   , _plf(plf)
   , _partition_manager(partition_manager)
   , _group_manager(group_manager)
-  , _partition_leaders_table(partition_leaders_table) {}
+  , _partition_leaders_table(partition_leaders_table)
+  , _shard_table(shard_table)
+  , _smp_group(smp_group) {}
 
 service::~service() = default;
 
@@ -77,6 +83,8 @@ ss::future<> service::start() {
     _manager = std::make_unique<manager>(
       _self,
       partition_leader_cache::make_default(_partition_leaders_table),
+      partition_manager::make_default(
+        _shard_table, _partition_manager, _smp_group),
       std::make_unique<link_registry_adapter>(&_plf->local()),
       std::make_unique<default_link_factory>(),
       30s); // Temporary until we have a proper configuration for this

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -71,7 +71,8 @@ ss::future<> service::start() {
     _manager = std::make_unique<manager>(
       _self,
       std::make_unique<link_registry_adapter>(&_plf->local()),
-      std::make_unique<default_link_factory>());
+      std::make_unique<default_link_factory>(),
+      30s); // Temporary until we have a proper configuration for this
 
     // Register notifications before the manager starts.  The manager will have
     // a constructed the underlying workqueue to start in a paused state and

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -51,13 +51,18 @@ private:
 
 class default_link_factory : public link_factory {
 public:
+    static constexpr auto link_reconciler_period = 5min;
     std::unique_ptr<link> create_link(
       ::model::node_id self,
       model::metadata config,
       partition_leader_cache* partition_leader_cache,
       partition_manager* partition_manager) override {
         return std::make_unique<link>(
-          self, std::move(config), partition_leader_cache, partition_manager);
+          self,
+          link_reconciler_period,
+          std::move(config),
+          partition_leader_cache,
+          partition_manager);
     }
 };
 

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -52,11 +52,12 @@ private:
 class default_link_factory : public link_factory {
 public:
     std::unique_ptr<link> create_link(
+      ::model::node_id self,
       model::metadata config,
       partition_leader_cache* partition_leader_cache,
       partition_manager* partition_manager) override {
         return std::make_unique<link>(
-          std::move(config), partition_leader_cache, partition_manager);
+          self, std::move(config), partition_leader_cache, partition_manager);
     }
 };
 

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -67,7 +67,7 @@ service::service(
 service::~service() = default;
 
 ss::future<> service::start() {
-    vlog(cllog.info, "Starting panda link service");
+    vlog(cllog.info, "Starting cluster link service");
     _manager = std::make_unique<manager>(
       _self,
       std::make_unique<link_registry_adapter>(&_plf->local()),
@@ -81,7 +81,7 @@ ss::future<> service::start() {
 }
 
 ss::future<> service::stop() {
-    vlog(cllog.info, "Stopping panda link service");
+    vlog(cllog.info, "Stopping cluster link service");
     unregister_notifications();
     co_await _manager->stop();
 }

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -33,7 +33,8 @@ public:
       ::model::node_id self,
       ss::sharded<::cluster::cluster_link::frontend>* plf,
       ss::sharded<cluster::partition_manager>* partition_manager,
-      ss::sharded<raft::group_manager>* group_manager);
+      ss::sharded<raft::group_manager>* group_manager,
+      ss::sharded<cluster::partition_leaders_table>* partition_leaders_table);
 
     service(const service&) = delete;
     service(service&&) = delete;
@@ -62,6 +63,7 @@ private:
     ss::sharded<::cluster::cluster_link::frontend>* _plf;
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<raft::group_manager>* _group_manager;
+    ss::sharded<cluster::partition_leaders_table>* _partition_leaders_table;
     std::unique_ptr<manager> _manager;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -34,7 +34,9 @@ public:
       ss::sharded<::cluster::cluster_link::frontend>* plf,
       ss::sharded<cluster::partition_manager>* partition_manager,
       ss::sharded<raft::group_manager>* group_manager,
-      ss::sharded<cluster::partition_leaders_table>* partition_leaders_table);
+      ss::sharded<cluster::partition_leaders_table>* partition_leaders_table,
+      ss::sharded<cluster::shard_table>* shard_table,
+      ss::smp_service_group smp_group);
 
     service(const service&) = delete;
     service(service&&) = delete;
@@ -64,6 +66,8 @@ private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<raft::group_manager>* _group_manager;
     ss::sharded<cluster::partition_leaders_table>* _partition_leaders_table;
+    ss::sharded<cluster::shard_table>* _shard_table;
+    ss::smp_service_group _smp_group;
     std::unique_ptr<manager> _manager;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -25,7 +25,7 @@
 
 namespace cluster_link {
 /**
- * @brief API access for panda link service
+ * @brief API access for cluster link service
  */
 class service {
 public:

--- a/src/v/cluster_link/task.cc
+++ b/src/v/cluster_link/task.cc
@@ -138,6 +138,14 @@ void task::unregister_for_updates(notification_id id) {
 
 model::task_state task::get_state() const noexcept { return _state; }
 
+model::task_status_report task::get_status_report() const {
+    model::task_status_report report;
+    report.task_name = name();
+    report.task_state = get_state();
+    report.task_state_reason = _last_state_change_response;
+    return report;
+}
+
 result<model::task_state>
 task::change_state(model::task_state new_state, ss::sstring reason) {
     vlog(
@@ -162,6 +170,7 @@ task::change_state(model::task_state new_state, ss::sstring reason) {
 
     auto prev_state = _state;
     _state = new_state;
+    _last_state_change_response = reason;
     run_callbacks(
       {.prev = prev_state, .cur = new_state, .reason = std::move(reason)});
     return prev_state;

--- a/src/v/cluster_link/task.cc
+++ b/src/v/cluster_link/task.cc
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/task.h"
+
+#include "cluster_link/errc.h"
+#include "cluster_link/logger.h"
+#include "ssx/future-util.h"
+
+namespace cluster_link {
+
+class task::runner {
+public:
+    explicit runner(task* task)
+      : _task(task) {}
+
+    runner(const runner&) = delete;
+    runner& operator=(const runner&) = delete;
+    runner(runner&&) = delete;
+    runner& operator=(runner&&) = delete;
+
+    virtual ~runner() = default;
+
+    ss::future<> start() {
+        vlog(_task->logger().debug, "Beginning task runner");
+        _timer.set_callback([this] {
+            ssx::spawn_with_gate(_gate, [this] {
+                return run_task().finally(
+                  [this] { _timer.arm(_task->_run_interval); });
+            });
+        });
+        // Before arming the timer, run the task once initially
+        co_await run_task();
+        _timer.arm(_task->_run_interval);
+    }
+    ss::future<> stop() {
+        vlog(_task->logger().debug, "Stopping task runner");
+        _timer.cancel();
+        co_await _gate.close();
+        vlog(_task->logger().debug, "Task runner stopped");
+    }
+
+    void set_task_interval(ss::lowres_clock::duration interval) {
+        vlog(
+          _task->logger().trace, "set_task_interval called with {}", interval);
+        auto cur_timeout = _timer.get_timeout();
+
+        // Re-arm the timer to run with the new interval, calculate the new
+        // timepoint for when the timer should run
+        _timer.cancel();
+        _timer.arm((cur_timeout - _task->_run_interval) + interval);
+    }
+
+private:
+    ss::future<> run_task() {
+        vlog(_task->logger().trace, "run_task started");
+        try {
+            vlog(_task->logger().trace, "running task");
+            co_await _task->run_impl();
+        } catch (const std::exception& e) {
+            vlog(_task->logger().error, "task failed: {}", e.what());
+            auto res = _task->change_state(
+              model::task_state::faulted,
+              ssx::sformat(
+                "{} failed with error: {}", _task->name(), e.what()));
+            vassert(res.has_value(), "Failed to change state to faulted");
+        }
+    }
+
+private:
+    ss::gate _gate;
+    ss::timer<ss::lowres_clock> _timer;
+
+    task* _task;
+};
+
+task::task(ss::lowres_clock::duration run_interval, ss::sstring name)
+  : _run_interval(run_interval)
+  , _name(std::move(name))
+  , _logger(cllog, _name) {}
+
+task::~task() = default;
+
+ss::future<result<void>> task::start() {
+    vlog(logger().trace, "start called");
+    if (_task_runner) {
+        vlog(logger().debug, "task already started");
+        co_return err_info(errc::task_already_running);
+    }
+    BOOST_OUTCOME_CO_TRYX(change_state(
+      model::task_state::active, ssx::sformat("{} has started", name())));
+
+    _task_runner = std::make_unique<runner>(this);
+    co_await _task_runner->start();
+
+    co_return outcome::success();
+}
+
+ss::future<result<void>> task::stop() {
+    vlog(logger().trace, "stop called");
+    auto res = change_state(
+      model::task_state::not_running, ssx::sformat("{} has stopped", name()));
+    vassert(res.has_value(), "Failed to change state to not_running");
+    if (_task_runner) {
+        co_await _task_runner->stop();
+        _task_runner.reset();
+    }
+    co_return outcome::success();
+}
+
+ss::future<result<void>> task::pause() {
+    vlog(logger().trace, "pause called");
+    BOOST_OUTCOME_CO_TRYX(change_state(
+      model::task_state::paused, ssx::sformat("{} has paused", name())));
+    if (_task_runner) {
+        co_await _task_runner->stop();
+        _task_runner.reset();
+    }
+    co_return outcome::success();
+}
+
+const ss::sstring& task::name() const noexcept { return _name; }
+
+task::notification_id task::register_for_updates(task_status_cb cb) {
+    return _callbacks.register_cb(std::move(cb));
+}
+void task::unregister_for_updates(notification_id id) {
+    _callbacks.unregister_cb(id);
+}
+
+model::task_state task::get_state() const noexcept { return _state; }
+
+result<model::task_state>
+task::change_state(model::task_state new_state, ss::sstring reason) {
+    vlog(
+      logger().trace,
+      "requesting state change from {} to {}: {}",
+      _state,
+      new_state,
+      reason);
+    if (_state == new_state) {
+        return _state;
+    }
+
+    if (!valid_previous_state(new_state)) {
+        return err_info(
+          errc::invalid_task_state_change,
+          fmt::format(
+            "Cannot change state from {} to {}: {}",
+            _state,
+            new_state,
+            reason));
+    }
+
+    auto prev_state = _state;
+    _state = new_state;
+    run_callbacks(
+      {.prev = prev_state, .cur = new_state, .reason = std::move(reason)});
+    return prev_state;
+}
+
+void task::set_run_interval(ss::lowres_clock::duration interval) {
+    vlog(logger().trace, "set_run_interval called with {}", interval);
+
+    if (_task_runner) {
+        _task_runner->set_task_interval(interval);
+    }
+    _run_interval = interval;
+}
+
+prefix_logger& task::logger() { return _logger; }
+
+void task::run_callbacks(const state_change& change) {
+    _callbacks.notify(name(), change);
+}
+
+bool task::valid_previous_state(model::task_state st) const {
+    switch (st) {
+    case model::task_state::paused:
+        return _state == model::task_state::active
+               || _state == model::task_state::link_unavailable
+               || _state == model::task_state::faulted;
+    case model::task_state::link_unavailable:
+        return _state == model::task_state::active;
+    // Always valid to change to not_running, active or faulted
+    case model::task_state::not_running:
+    case model::task_state::active:
+    case model::task_state::faulted:
+        return true;
+    }
+}
+} // namespace cluster_link
+
+auto fmt::formatter<cluster_link::task::state_change>::format(
+  const cluster_link::task::state_change& t, format_context& ctx) const
+  -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(), "{{prev={}, cur={}, reason={}}}", t.prev, t.cur, t.reason);
+}

--- a/src/v/cluster_link/task.h
+++ b/src/v/cluster_link/task.h
@@ -79,6 +79,9 @@ public:
     /// Returns the current state of the task
     model::task_state get_state() const noexcept;
 
+    /// Returns the status report for this task
+    model::task_status_report get_status_report() const;
+
 protected:
     /// Used by the implementation to change the state of the task
     /// \return The previous state
@@ -100,6 +103,7 @@ private:
     ss::lowres_clock::duration _run_interval;
     task_status_cb _status_cb;
     model::task_state _state{model::task_state::not_running};
+    ss::sstring _last_state_change_response;
 
     notification_list<task_status_cb, notification_id> _callbacks;
 

--- a/src/v/cluster_link/task.h
+++ b/src/v/cluster_link/task.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "cluster_link/errc.h"
+#include "cluster_link/model/types.h"
+#include "utils/notification_list.h"
+#include "utils/prefix_logger.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/format.h>
+
+namespace cluster_link {
+
+/**
+ * @brief Abstract class that defines a task in cluster linking
+ */
+class task {
+    class runner;
+
+public:
+    using is_locked_to_controller
+      = ss::bool_class<struct is_locked_to_controller_tag>;
+
+    /// Creates a task with a specified run interval and name
+    task(ss::lowres_clock::duration run_interval, ss::sstring name);
+    task(const task&) = delete;
+    task& operator=(const task&) = delete;
+    task(task&&) = delete;
+    task& operator=(task&&) = delete;
+    virtual ~task();
+
+    /// Starts/resumes the task
+    /// Is virtual so these methods can be overriden by test classes
+    virtual ss::future<result<void>> start();
+    /// Stops the task from running
+    /// Is virtual so these methods can be overriden by test classes
+    virtual ss::future<result<void>> stop();
+    /// Pauses the task, prevening it from running until resumed
+    ss::future<result<void>> pause();
+    /// Returns the name of the task
+    const ss::sstring& name() const noexcept;
+    /// Indicates if this task should only run on the controller node
+    virtual is_locked_to_controller locked_to_controller() const noexcept = 0;
+    /// Updates config of the task
+    virtual void update_config(const model::metadata&) = 0;
+
+    struct state_change {
+        model::task_state prev;
+        model::task_state cur;
+        ss::sstring reason;
+    };
+
+    using notification_id = named_type<size_t, struct task_notification_tag>;
+    /// Callback to be notified when a task changes state.  The parameters are
+    /// the task name, the state change info, and a reason
+    using task_status_cb
+      = ss::noncopyable_function<void(std::string_view, state_change)>;
+
+    /// Registers for notification of task state change
+    notification_id register_for_updates(task_status_cb);
+    /// Unregisters state change notification
+    void unregister_for_updates(notification_id);
+
+    /// Returns the current state of the task
+    model::task_state get_state() const noexcept;
+
+protected:
+    /// Used by the implementation to change the state of the task
+    /// \return The previous state
+    result<model::task_state> change_state(model::task_state, ss::sstring = "");
+    /// Changes the run interval
+    void set_run_interval(ss::lowres_clock::duration);
+    /// Returns the logger
+    prefix_logger& logger();
+    /// Implementation of the task logic that will run periodically
+    virtual ss::future<> run_impl() = 0;
+
+private:
+    /// Executes all callbacks on state change
+    void run_callbacks(const state_change&);
+    /// Validates that the state change is valid
+    bool valid_previous_state(model::task_state st) const;
+
+private:
+    ss::lowres_clock::duration _run_interval;
+    task_status_cb _status_cb;
+    model::task_state _state{model::task_state::not_running};
+
+    notification_list<task_status_cb, notification_id> _callbacks;
+
+    ss::sstring _name;
+    prefix_logger _logger;
+
+    std::unique_ptr<runner> _task_runner{nullptr};
+};
+
+class task_factory {
+public:
+    task_factory() = default;
+    task_factory(const task_factory&) = delete;
+    task_factory& operator=(const task_factory&) = delete;
+    task_factory(task_factory&&) = delete;
+    task_factory& operator=(task_factory&&) = delete;
+    virtual ~task_factory() = default;
+
+    /// Returns the name of the task that this factory creates
+    virtual std::string_view created_task_name() const noexcept = 0;
+
+    virtual std::unique_ptr<task> create_task() = 0;
+};
+} // namespace cluster_link
+
+template<>
+struct fmt::formatter<cluster_link::task::state_change>
+  : fmt::formatter<string_view> {
+    auto
+    format(const cluster_link::task::state_change& t, format_context& ctx) const
+      -> decltype(ctx.out());
+};

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -1,4 +1,18 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "test_deps",
+    hdrs = [
+        "deps.h",
+    ],
+    include_prefix = "cluster_link/tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/kafka/data/rpc",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "link_test",
@@ -7,6 +21,7 @@ redpanda_cc_gtest(
         "link_test.cc",
     ],
     deps = [
+        ":test_deps",
         "//src/v/cluster",
         "//src/v/cluster/cluster_link/tests:test_lib",
         "//src/v/cluster_link:impl",

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -17,3 +17,16 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "errc_test",
+    timeout = "short",
+    srcs = [
+        "errc_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster_link:errc",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -65,3 +65,20 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "task_manager_integration_test",
+    timeout = "short",
+    srcs = [
+        "task_manager_integration_test.cc",
+    ],
+    deps = [
+        ":test_deps",
+        "//src/v/cluster_link:impl",
+        "//src/v/cluster_link/model",
+        "//src/v/kafka/data/rpc",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -2,12 +2,18 @@ load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "test_deps",
+    srcs = [
+        "deps.cc",
+    ],
     hdrs = [
         "deps.h",
     ],
     include_prefix = "cluster_link/tests",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/cluster",
+        "//src/v/cluster/cluster_link/tests:test_lib",
+        "//src/v/cluster_link:impl",
         "//src/v/kafka/data/rpc",
         "//src/v/model",
         "@seastar",

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -30,3 +30,17 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "base_task_test",
+    timeout = "short",
+    srcs = [
+        "base_task_test.cc",
+    ],
+    deps = [
+        "//src/v/cluster_link:impl",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/tests/base_task_test.cc
+++ b/src/v/cluster_link/tests/base_task_test.cc
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/task.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/util/defer.hh>
+
+#include <gmock/gmock.h>
+
+using namespace std::chrono_literals;
+using namespace ::testing;
+
+namespace cluster_link {
+
+namespace {
+template<typename T>
+auto IsInRange(T lo, T hi) {
+    return AllOf(Ge((lo)), Le((hi)));
+}
+} // namespace
+
+static constexpr auto initial_run_interval = 500ms;
+
+struct test_metadata : public model::metadata {
+    ss::lowres_clock::duration run_interval{initial_run_interval};
+};
+class test_task : public task {
+public:
+    static constexpr auto name = "test_task";
+    explicit test_task(ss::lowres_clock::duration run_interval)
+      : task(run_interval, name) {}
+
+    task::is_locked_to_controller
+    locked_to_controller() const noexcept override {
+        return task::is_locked_to_controller::no;
+    }
+
+    void update_config(const model::metadata& meta) override {
+        auto cfg = static_cast<const test_metadata*>(&meta);
+        vassert(cfg != nullptr, "meta is not of type test_metadata");
+        set_run_interval(cfg->run_interval);
+    }
+
+    ss::future<> run_impl() override {
+        _count++;
+        return ss::now();
+    }
+
+    unsigned count() const noexcept { return _count; }
+
+private:
+    unsigned _count{0};
+};
+
+class test_task_factory : public task_factory {
+public:
+    std::string_view created_task_name() const noexcept override {
+        return test_task::name;
+    }
+    std::unique_ptr<task> create_task() override {
+        return std::make_unique<test_task>(initial_run_interval);
+    }
+};
+
+class test_task_fixture : public seastar_test {
+public:
+    ss::future<void> SetUpAsync() override {
+        _task_factory = std::make_unique<test_task_factory>();
+        return ss::now();
+    }
+    ss::future<void> TearDownAsync() override {
+        _task_factory.reset(nullptr);
+        return ss::now();
+    }
+
+    std::unique_ptr<task> create_task() { return _task_factory->create_task(); }
+
+private:
+    std::unique_ptr<task_factory> _task_factory{nullptr};
+};
+
+TEST_F_CORO(test_task_fixture, test_task_run) {
+    auto task = create_task();
+    auto test_task_inst = dynamic_cast<test_task*>(task.get());
+    ASSERT_EQ_CORO(task->get_state(), model::task_state::not_running);
+
+    auto res = co_await task->pause();
+    EXPECT_FALSE(res.has_value())
+      << "Was able to pause task when in not_running state";
+    EXPECT_EQ(res.assume_error().code(), errc::invalid_task_state_change);
+    ASSERT_EQ_CORO(task->get_state(), model::task_state::not_running);
+
+    res = co_await task->start();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to start task: " << res.assume_error().message();
+    EXPECT_EQ(task->get_state(), model::task_state::active);
+
+    res = co_await task->start();
+    ASSERT_FALSE_CORO(res.has_value())
+      << "Was able to start task when already running";
+    EXPECT_EQ(res.assume_error().code(), errc::task_already_running);
+
+    auto cur_val = test_task_inst->count();
+    auto prev_val = cur_val;
+    co_await ss::sleep(initial_run_interval * 2);
+    cur_val = test_task_inst->count();
+    EXPECT_THAT(cur_val, IsInRange(prev_val + 1, prev_val + 2));
+
+    res = co_await task->stop();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to stop task: " << res.assume_error().message();
+    EXPECT_EQ(task->get_state(), model::task_state::not_running);
+}
+
+class test_task_started_fixture : public test_task_fixture {
+public:
+    ss::future<void> SetUpAsync() override {
+        co_await test_task_fixture::SetUpAsync();
+        _task = create_task();
+        auto res = co_await _task->start();
+        ASSERT_TRUE_CORO(res.has_value())
+          << "Failed to start task: " << res.assume_error().message();
+        ASSERT_EQ_CORO(_task->get_state(), model::task_state::active);
+    }
+
+    ss::future<void> TearDownAsync() override {
+        auto res = co_await _task->stop();
+        ASSERT_TRUE_CORO(res.has_value())
+          << "Failed to stop task: " << res.assume_error().message();
+        _task.reset(nullptr);
+        co_await test_task_fixture::TearDownAsync();
+    }
+
+    test_task* get_task() { return dynamic_cast<test_task*>(_task.get()); }
+
+private:
+    std::unique_ptr<task> _task{nullptr};
+};
+
+TEST_F_CORO(test_task_started_fixture, test_pause_resume) {
+    // make sure the task is running
+    co_await ss::sleep(initial_run_interval);
+    auto pre_count = get_task()->count();
+    EXPECT_GT(pre_count, 0);
+
+    auto res = co_await get_task()->pause();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to pause task: " << res.assume_error().message();
+    ASSERT_EQ_CORO(get_task()->get_state(), model::task_state::paused);
+
+    co_await ss::sleep(initial_run_interval * 2);
+    auto cur_count = get_task()->count();
+    EXPECT_THAT(cur_count, IsInRange(pre_count, pre_count + 1));
+
+    res = co_await get_task()->start();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to resume task: " << res.assume_error().message();
+
+    co_await ss::sleep(initial_run_interval * 2);
+    pre_count = cur_count;
+    cur_count = get_task()->count();
+    EXPECT_THAT(cur_count, IsInRange(pre_count + 2, pre_count + 3));
+}
+
+TEST_F_CORO(test_task_started_fixture, test_change_run_interval) {
+    test_metadata meta;
+    meta.run_interval = initial_run_interval * 2;
+    co_await ss::sleep(initial_run_interval);
+    auto pre_count = get_task()->count();
+    get_task()->update_config(meta);
+    co_await ss::sleep(initial_run_interval);
+    auto cur_count = get_task()->count();
+    EXPECT_THAT(cur_count, IsInRange(pre_count, pre_count + 1));
+
+    co_await ss::sleep(initial_run_interval);
+    cur_count = get_task()->count();
+    EXPECT_THAT(cur_count, IsInRange(pre_count + 1, pre_count + 2));
+}
+
+TEST_F_CORO(test_task_started_fixture, test_callbacks) {
+    model::task_state prev_state = model::task_state::not_running,
+                      cur_state = model::task_state::not_running;
+    auto cb = [&](std::string_view name, task::state_change change) {
+        prev_state = change.prev;
+        cur_state = change.cur;
+        EXPECT_EQ(name, test_task::name);
+    };
+    auto id = get_task()->register_for_updates(std::move(cb));
+    auto remove_cb = ss::defer([&] { get_task()->unregister_for_updates(id); });
+    auto res = co_await get_task()->pause();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to pause task: " << res.assume_error().message();
+    EXPECT_EQ(prev_state, model::task_state::active);
+    EXPECT_EQ(cur_state, model::task_state::paused);
+
+    res = co_await get_task()->start();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to resume task: " << res.assume_error().message();
+    EXPECT_EQ(prev_state, model::task_state::paused);
+    EXPECT_EQ(cur_state, model::task_state::active);
+}
+
+class evil_task : public task {
+public:
+    static constexpr auto name = "evil_task";
+    explicit evil_task(ss::lowres_clock::duration run_interval)
+      : task(run_interval, name) {}
+
+    task::is_locked_to_controller
+    locked_to_controller() const noexcept override {
+        return task::is_locked_to_controller::no;
+    }
+
+    void update_config(const model::metadata&) override {}
+
+    ss::future<> run_impl() override {
+        throw std::runtime_error("evil task failed");
+    }
+};
+
+class evil_task_fixture : public seastar_test {};
+
+TEST_F_CORO(evil_task_fixture, test_failing_task) {
+    auto task = std::make_unique<evil_task>(initial_run_interval);
+    auto res = co_await task->start();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to start task: " << res.assume_error().message();
+    co_await ss::sleep(initial_run_interval * 2);
+    EXPECT_EQ(task->get_state(), model::task_state::faulted);
+
+    res = co_await task->stop();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to stop task: " << res.assume_error().message();
+}
+
+class link_unavailable_task : public task {
+public:
+    static constexpr auto name = "link_unavailable_task";
+    explicit link_unavailable_task(ss::lowres_clock::duration run_interval)
+      : task(run_interval, name) {}
+
+    task::is_locked_to_controller
+    locked_to_controller() const noexcept override {
+        return task::is_locked_to_controller::no;
+    }
+
+    void update_config(const model::metadata&) override {}
+
+    ss::future<> run_impl() override {
+        if (get_state() == model::task_state::active) {
+            vlog(logger().info, "Simulating link unavailability");
+            auto res = change_state(
+              model::task_state::link_unavailable, "Simulated link down");
+            vassert(
+              res.has_value()
+                && res.assume_value() == model::task_state::active,
+              "Failed to change state to link_unavailable");
+        } else if (get_state() == model::task_state::link_unavailable) {
+            vlog(logger().info, "Simulating link availability");
+            auto res = change_state(
+              model::task_state::active, "Simulated link up");
+            vassert(
+              res.has_value()
+                && res.assume_value() == model::task_state::link_unavailable,
+              "Failed to change state to active");
+        }
+
+        return ss::now();
+    }
+};
+
+class link_unavailable_fixture : public seastar_test {};
+
+TEST_F_CORO(link_unavailable_fixture, test_link_unavailable_task) {
+    auto task = std::make_unique<link_unavailable_task>(initial_run_interval);
+    auto res = co_await task->start();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to start task: " << res.assume_error().message();
+
+    co_await ss::sleep(initial_run_interval / 2);
+    EXPECT_EQ(task->get_state(), model::task_state::link_unavailable);
+
+    co_await ss::sleep(initial_run_interval);
+    EXPECT_EQ(task->get_state(), model::task_state::active);
+
+    co_await ss::sleep(initial_run_interval);
+    EXPECT_EQ(task->get_state(), model::task_state::link_unavailable);
+
+    res = co_await task->stop();
+    ASSERT_TRUE_CORO(res.has_value())
+      << "Failed to stop task: " << res.assume_error().message();
+}
+} // namespace cluster_link

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster_link/tests/deps.h"
+
+#include "cluster/cluster_link/tests/utils.h"
+#include "cluster_link/types.h"
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::tests {
+
+cluster_link_manager_test_fixture::cluster_link_manager_test_fixture(
+  ::model::node_id self)
+  : _self(self) {}
+
+ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
+  std::unique_ptr<link_factory> lf) {
+    co_await _table.start_single();
+
+    _fpmp = std::make_unique<fake_partition_manager_proxy>();
+    auto fplc = std::make_unique<fake_partition_leader_cache_impl>();
+    _fplci = fplc.get();
+
+    _lf = lf.get();
+    co_await _manager.start_single(
+      _self,
+      ss::sharded_parameter([&fplc]() { return std::move(fplc); }),
+      ss::sharded_parameter([this]() {
+          auto fpm = std::make_unique<fake_partition_manager>(
+            partition_manager_proxy());
+          _fpm = fpm.get();
+          return fpm;
+      }),
+      ss::sharded_parameter([this]() {
+          return std::make_unique<test_link_registry>(&_table.local());
+      }),
+      ss::sharded_parameter([&lf]() { return std::move(lf); }),
+      1s);
+
+    auto notif_id = _table.local().register_for_updates(
+      [this](model::id_t id) { _manager.local().on_link_change(id); });
+    _notification_cleanups.emplace_back(
+      [this, notif_id] { _table.local().unregister_for_updates(notif_id); });
+
+    co_await _manager.invoke_on_all([](manager& m) { return m.start(); });
+}
+
+ss::future<> cluster_link_manager_test_fixture::reset() {
+    _notification_cleanups.clear();
+    _lf = nullptr;
+    co_await _manager.stop();
+    _fpm = nullptr;
+    _fplci = nullptr;
+    _fpmp.reset();
+    co_await _table.stop();
+}
+
+void cluster_link_manager_test_fixture::elect_leader(
+  const ::model::ntp& ntp,
+  ::model::node_id node_id,
+  std::optional<ss::shard_id> shard_id) {
+    partition_leader_cache()->set_leader_node(ntp, node_id);
+    if (node_id == _self) {
+        auto shard = shard_id.value_or(ss::this_shard_id());
+        partition_manager()->set_shard_owner(ntp, shard);
+        _manager.local().on_leadership_change(
+          ntp, shard == ss::this_shard_id() ? ntp_leader::yes : ntp_leader::no);
+    } else {
+        partition_manager()->remove_shard_owner(ntp);
+        _manager.local().on_leadership_change(ntp, ntp_leader::no);
+    }
+}
+
+ss::future<>
+cluster_link_manager_test_fixture::upsert_link(model::metadata metadata) {
+    auto id = model::id_t(_next_link_id++);
+    return ss::do_with(
+      id,
+      std::move(metadata),
+      [this](model::id_t& id, model::metadata& metadata) {
+          return _table.invoke_on_all(
+            [id, &metadata](cluster::cluster_link::table& table) {
+                return table
+                  .apply_update(
+                    cluster::cluster_link::testing::create_upsert_command(
+                      ::model::offset{id()}, metadata.copy()))
+                  .then([](std::error_code ec) {
+                      vassert(
+                        ec.value() == 0,
+                        "Failed to upsert link: {}",
+                        ec.message());
+                  });
+            });
+      });
+}
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/data/rpc/deps.h"
+
+#include <seastar/util/defer.hh>
+namespace cluster_link::tests {
+class fake_partition_leader_cache_impl {
+public:
+    std::optional<::model::node_id> get_leader_node(
+      ::model::topic_namespace_view tp_ns, ::model::partition_id pid) const {
+        auto ntp = ::model::ntp(tp_ns.ns, tp_ns.tp, pid);
+        auto it = _leader_map.find(ntp);
+        if (it == _leader_map.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+    void set_leader_node(const ::model::ntp& ntp, ::model::node_id node_id) {
+        _leader_map.insert_or_assign(ntp, node_id);
+    }
+
+private:
+    chunked_hash_map<::model::ntp, ::model::node_id> _leader_map;
+};
+
+class fake_partition_leader_cache
+  : public kafka::data::rpc::partition_leader_cache {
+public:
+    explicit fake_partition_leader_cache(fake_partition_leader_cache_impl* impl)
+      : _impl(impl) {}
+    std::optional<::model::node_id> get_leader_node(
+      ::model::topic_namespace_view tp_ns,
+      ::model::partition_id pid) const final {
+        return _impl->get_leader_node(tp_ns, pid);
+    }
+
+private:
+    fake_partition_leader_cache_impl* _impl;
+};
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -15,7 +15,87 @@
 
 #include <seastar/util/defer.hh>
 namespace cluster_link::tests {
-class fake_partition_leader_cache_impl {
+class fake_partition_manager_proxy {
+public:
+    std::optional<ss::shard_id> shard_owner(const ::model::ktp& ktp) {
+        auto it = _shard_locations.find(ktp);
+        if (it == _shard_locations.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+    std::optional<ss::shard_id> shard_owner(const ::model::ntp& ntp) {
+        auto it = _shard_locations.find(ntp);
+        if (it == _shard_locations.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    void set_shard_owner(const ::model::ntp& ntp, ss::shard_id shard_id) {
+        _shard_locations.insert_or_assign(ntp, shard_id);
+    }
+
+    void remove_shard_owner(const ::model::ntp& ntp) {
+        _shard_locations.erase(ntp);
+    }
+
+    template<typename R, typename N>
+    ss::future<::result<R, cluster::errc>> invoke_on_shard_impl(
+      ss::shard_id,
+      const N&,
+      ss::noncopyable_function<
+        ss::future<::result<R, cluster::errc>>(kafka::partition_proxy*)>) {
+        throw std::runtime_error("not implemented");
+    }
+
+private:
+    ::model::ntp_map_type<ss::shard_id> _shard_locations;
+};
+
+class fake_partition_manager : public kafka::data::rpc::partition_manager {
+public:
+    explicit fake_partition_manager(fake_partition_manager_proxy* impl)
+      : _impl(impl) {}
+
+    std::optional<ss::shard_id> shard_owner(const ::model::ktp& ktp) override {
+        return _impl->shard_owner(ktp);
+    }
+
+    std::optional<ss::shard_id> shard_owner(const ::model::ntp& ntp) override {
+        return _impl->shard_owner(ntp);
+    }
+
+    void set_shard_owner(const ::model::ntp& ntp, ss::shard_id shard_id) {
+        _impl->set_shard_owner(ntp, shard_id);
+    }
+
+    void remove_shard_owner(const ::model::ntp& ntp) {
+        _impl->remove_shard_owner(ntp);
+    }
+
+    ss::future<::result<::model::offset, cluster::errc>> invoke_on_shard(
+      ss::shard_id shard_id,
+      const ::model::ktp& ktp,
+      ss::noncopyable_function<
+        ss::future<::result<::model::offset, cluster::errc>>(
+          kafka::partition_proxy*)> fn) final {
+        return _impl->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+    }
+    ss::future<::result<::model::offset, cluster::errc>> invoke_on_shard(
+      ss::shard_id shard_id,
+      const ::model::ntp& ntp,
+      ss::noncopyable_function<
+        ss::future<::result<::model::offset, cluster::errc>>(
+          kafka::partition_proxy*)> fn) final {
+        return _impl->invoke_on_shard_impl(shard_id, ntp, std::move(fn));
+    }
+
+private:
+    fake_partition_manager_proxy* _impl;
+};
+class fake_partition_leader_cache_impl
+  : public kafka::data::rpc::partition_leader_cache {
 public:
     std::optional<::model::node_id> get_leader_node(
       ::model::topic_namespace_view tp_ns, ::model::partition_id pid) const {

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -11,10 +11,35 @@
 
 #pragma once
 
+#include "cluster/cluster_link/table.h"
+#include "cluster_link/manager.h"
 #include "kafka/data/rpc/deps.h"
 
 #include <seastar/util/defer.hh>
 namespace cluster_link::tests {
+
+class test_link_registry : public link_registry {
+public:
+    explicit test_link_registry(cluster::cluster_link::table* table)
+      : _table(table) {}
+
+    std::optional<std::reference_wrapper<const model::metadata>>
+    find_link_by_id(model::id_t id) const override {
+        return _table->find_link_by_id(id);
+    }
+
+    std::optional<std::reference_wrapper<const model::metadata>>
+    find_link_by_name(const model::name_t& name) const override {
+        return _table->find_link_by_name(name);
+    }
+
+    chunked_vector<model::id_t> get_all_link_ids() const override {
+        return _table->get_all_link_ids();
+    }
+
+private:
+    cluster::cluster_link::table* _table;
+};
 class fake_partition_manager_proxy {
 public:
     std::optional<ss::shard_id> shard_owner(const ::model::ktp& ktp) {
@@ -127,5 +152,60 @@ public:
 
 private:
     fake_partition_leader_cache_impl* _impl;
+};
+
+class cluster_link_manager_test_fixture {
+public:
+    explicit cluster_link_manager_test_fixture(::model::node_id self);
+    ~cluster_link_manager_test_fixture() = default;
+
+    cluster_link_manager_test_fixture(const cluster_link_manager_test_fixture&)
+      = delete;
+    cluster_link_manager_test_fixture&
+    operator=(const cluster_link_manager_test_fixture&)
+      = delete;
+    cluster_link_manager_test_fixture(cluster_link_manager_test_fixture&&)
+      = delete;
+    cluster_link_manager_test_fixture&
+    operator=(cluster_link_manager_test_fixture&&)
+      = delete;
+
+    ss::future<> wire_up_and_start(std::unique_ptr<link_factory>);
+
+    ss::future<> reset();
+
+    fake_partition_manager_proxy* partition_manager_proxy() {
+        return _fpmp.get();
+    }
+
+    ss::sharded<manager>& get_manager() { return _manager; }
+
+    void elect_leader(
+      const ::model::ntp& ntp,
+      ::model::node_id node_id,
+      std::optional<ss::shard_id> shard_id);
+
+    fake_partition_leader_cache_impl* partition_leader_cache() {
+        return _fplci;
+    }
+
+    fake_partition_manager* partition_manager() { return _fpm; }
+
+    ss::future<> upsert_link(model::metadata metadata);
+
+    link_factory* get_link_factory() { return _lf; }
+
+private:
+    chunked_vector<ss::deferred_action<ss::noncopyable_function<void()>>>
+      _notification_cleanups;
+    ss::sharded<cluster::cluster_link::table> _table;
+    std::unique_ptr<fake_partition_manager_proxy> _fpmp;
+    fake_partition_manager* _fpm{nullptr};
+    fake_partition_leader_cache_impl* _fplci{nullptr};
+    link_factory* _lf{nullptr};
+    ss::sharded<manager> _manager;
+
+    ::model::node_id _self;
+    model::id_t _next_link_id{0};
 };
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/errc_test.cc
+++ b/src/v/cluster_link/tests/errc_test.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/errc.h"
+
+#include <gtest/gtest.h>
+
+namespace cluster_link {
+
+TEST(cluster_link_errc_fixture, errc_all_values_message_test) {
+    struct errc_expected {
+        errc value;
+        const char* expected_message;
+    };
+
+    const auto test_cases = std::to_array<errc_expected>({
+      {.value = errc::success, .expected_message = "success"},
+      {.value = errc::invalid_task_state_change,
+       .expected_message = "invalid task state change"},
+      {.value = errc::task_not_running, .expected_message = "task not running"},
+      {.value = errc::task_already_running,
+       .expected_message = "task already running"},
+      {.value = errc::failed_to_start_task,
+       .expected_message = "failed to start task"},
+      {.value = errc::task_already_registered_on_link,
+       .expected_message = "task already registered on link"},
+    });
+
+    for (const auto& tc : test_cases) {
+        auto ec = make_error_code(tc.value);
+        EXPECT_EQ(ec.value(), static_cast<int>(tc.value));
+        EXPECT_EQ(ec.category().name(), std::string("cluster_link"));
+        EXPECT_EQ(ec.message(), std::string(tc.expected_message));
+    }
+}
+
+TEST(cluster_link_errc_fixture, errc_unknown_value_message_test) {
+    // Use a value not defined in errc
+    int unknown_value = 9999;
+    auto ec = std::error_code(unknown_value, error_category());
+    EXPECT_EQ(ec.message(), "(unknown error code)");
+}
+
+TEST(cluster_link_errc_fixture, err_info_test) {
+    err_info info(errc::invalid_task_state_change, "Custom error message");
+    EXPECT_EQ(info.code(), errc::invalid_task_state_change);
+    EXPECT_EQ(info.message(), "Custom error message");
+
+    err_info default_info(errc::success);
+    EXPECT_EQ(default_info.code(), errc::success);
+    EXPECT_EQ(default_info.message(), "success");
+}
+} // namespace cluster_link

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -14,6 +14,7 @@
 #include "cluster/cluster_link/tests/utils.h"
 #include "cluster_link/link.h"
 #include "cluster_link/manager.h"
+#include "cluster_link/tests/deps.h"
 #include "test_utils/test.h"
 
 #include <seastar/util/defer.hh>
@@ -22,12 +23,14 @@
 
 using namespace std::chrono_literals;
 
-namespace cluster_link {
+namespace cluster_link::tests {
 
 using ::cluster::cluster_link::table;
+using kafka::data::rpc::partition_leader_cache;
 
 class link_test;
 namespace {
+
 class test_link_registry : public link_registry {
 public:
     explicit test_link_registry(table* table)
@@ -53,7 +56,10 @@ private:
 
 class test_link : public link {
 public:
-    test_link(link_test* link_test, model::metadata metadata);
+    test_link(
+      link_test* link_test,
+      model::metadata metadata,
+      partition_leader_cache* partition_leader_cache);
 
     ss::future<> start() override;
     ss::future<> stop() override;
@@ -66,8 +72,11 @@ class test_link_factory : public link_factory {
 public:
     explicit test_link_factory(link_test* link_test)
       : _link_test(link_test) {}
-    std::unique_ptr<link> create_link(model::metadata metadata) override {
-        return std::make_unique<test_link>(_link_test, std::move(metadata));
+    std::unique_ptr<link> create_link(
+      model::metadata metadata,
+      partition_leader_cache* partition_leader_cache) override {
+        return std::make_unique<test_link>(
+          _link_test, std::move(metadata), partition_leader_cache);
     }
 
 private:
@@ -79,9 +88,13 @@ class link_test : public seastar_test {
 public:
     static constexpr auto task_reconciler_interval = 1s;
     virtual ss::future<> SetUpAsync() override {
+        _partition_leader_cache_impl
+          = std::make_unique<fake_partition_leader_cache_impl>();
         co_await _table.start();
         _manager = std::make_unique<manager>(
           ::model::node_id(0),
+          std::make_unique<fake_partition_leader_cache>(
+            _partition_leader_cache_impl.get()),
           std::make_unique<test_link_registry>(&_table.local()),
           std::make_unique<test_link_factory>(this),
           task_reconciler_interval);
@@ -90,6 +103,7 @@ public:
     virtual ss::future<> TearDownAsync() override {
         _manager.reset(nullptr);
         co_await _table.stop();
+        _partition_leader_cache_impl.reset();
     }
 
     ss::future<> upsert_link(model::id_t id, model::metadata metadata) {
@@ -137,6 +151,8 @@ public:
     void unregister_callback(notification_id id) { _callbacks.erase(id); }
 
 protected:
+    std::unique_ptr<fake_partition_leader_cache_impl>
+      _partition_leader_cache_impl;
     ss::sharded<table> _table;
     std::unique_ptr<manager> _manager;
     absl::flat_hash_map<uuid_t, test_link*> _links;
@@ -159,8 +175,11 @@ public:
 };
 
 namespace {
-test_link::test_link(link_test* link_test, model::metadata metadata)
-  : link(std::move(metadata))
+test_link::test_link(
+  link_test* link_test,
+  model::metadata metadata,
+  partition_leader_cache* partition_leader_cache)
+  : link(std::move(metadata), partition_leader_cache)
   , _link_test(link_test) {}
 
 ss::future<> test_link::start() {
@@ -271,4 +290,4 @@ TEST_F_CORO(link_test_manager_started, test_remove_non_existant_link) {
     _manager->on_link_change(model::id_t(1));
     return ss::now();
 }
-} // namespace cluster_link
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -59,6 +59,7 @@ class test_link : public link {
 public:
     test_link(
       ::model::node_id self,
+      ss::lowres_clock::duration task_reconciler_interval,
       link_test* link_test,
       model::metadata metadata,
       partition_leader_cache* partition_leader_cache,
@@ -73,8 +74,11 @@ private:
 
 class test_link_factory : public link_factory {
 public:
-    explicit test_link_factory(link_test* link_test)
-      : _link_test(link_test) {}
+    test_link_factory(
+      link_test* link_test, ss::lowres_clock::duration task_reconciler_interval)
+      : _link_test(link_test)
+      , _task_reconciler_interval(task_reconciler_interval) {}
+
     std::unique_ptr<link> create_link(
       ::model::node_id self,
       model::metadata metadata,
@@ -82,6 +86,7 @@ public:
       partition_manager* partition_manager) override {
         return std::make_unique<test_link>(
           self,
+          _task_reconciler_interval,
           _link_test,
           std::move(metadata),
           partition_leader_cache,
@@ -90,6 +95,7 @@ public:
 
 private:
     link_test* _link_test;
+    ss::lowres_clock::duration _task_reconciler_interval;
 };
 } // namespace
 
@@ -168,7 +174,7 @@ public:
           std::make_unique<fake_partition_manager>(
             _partition_manager_proxy.get()),
           std::make_unique<test_link_registry>(&_table.local()),
-          std::make_unique<test_link_factory>(this),
+          std::make_unique<test_link_factory>(this, 1s),
           task_reconciler_interval);
     }
 
@@ -207,11 +213,17 @@ public:
 namespace {
 test_link::test_link(
   ::model::node_id self,
+  ss::lowres_clock::duration task_reconciler_interval,
   link_test* link_test,
   model::metadata metadata,
   partition_leader_cache* partition_leader_cache,
   partition_manager* partition_manager)
-  : link(self, std::move(metadata), partition_leader_cache, partition_manager)
+  : link(
+      self,
+      task_reconciler_interval,
+      std::move(metadata),
+      partition_leader_cache,
+      partition_manager)
   , _link_test(link_test) {}
 
 ss::future<> test_link::start() {

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -77,12 +77,14 @@ private:
 
 class link_test : public seastar_test {
 public:
+    static constexpr auto task_reconciler_interval = 1s;
     virtual ss::future<> SetUpAsync() override {
         co_await _table.start();
         _manager = std::make_unique<manager>(
           ::model::node_id(0),
           std::make_unique<test_link_registry>(&_table.local()),
-          std::make_unique<test_link_factory>(this));
+          std::make_unique<test_link_factory>(this),
+          task_reconciler_interval);
     }
 
     virtual ss::future<> TearDownAsync() override {

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -93,28 +93,17 @@ private:
 };
 } // namespace
 
-class link_test : public seastar_test {
+class link_test_base : public seastar_test {
 public:
-    static constexpr auto task_reconciler_interval = 1s;
     virtual ss::future<> SetUpAsync() override {
         _partition_leader_cache_impl
           = std::make_unique<fake_partition_leader_cache_impl>();
         _partition_manager_proxy
           = std::make_unique<fake_partition_manager_proxy>();
         co_await _table.start();
-        _manager = std::make_unique<manager>(
-          ::model::node_id(0),
-          std::make_unique<fake_partition_leader_cache>(
-            _partition_leader_cache_impl.get()),
-          std::make_unique<fake_partition_manager>(
-            _partition_manager_proxy.get()),
-          std::make_unique<test_link_registry>(&_table.local()),
-          std::make_unique<test_link_factory>(this),
-          task_reconciler_interval);
     }
 
     virtual ss::future<> TearDownAsync() override {
-        _manager.reset(nullptr);
         co_await _table.stop();
         _partition_manager_proxy.reset();
         _partition_leader_cache_impl.reset();
@@ -134,16 +123,6 @@ public:
         if (id.has_value()) {
             _manager->on_link_change(id.value());
         }
-    }
-
-    void add_link_to_list(uuid_t id, test_link* link) {
-        _links.emplace(id, link);
-        run_callbacks(id);
-    }
-
-    void remove_link(uuid_t id) {
-        _links.erase(id);
-        run_callbacks(id);
     }
 
     void run_callbacks(uuid_t id) {
@@ -169,11 +148,47 @@ protected:
       _partition_leader_cache_impl;
     std::unique_ptr<fake_partition_manager_proxy> _partition_manager_proxy;
     ss::sharded<table> _table;
+
     std::unique_ptr<manager> _manager;
-    absl::flat_hash_map<uuid_t, test_link*> _links;
+
     absl::flat_hash_map<notification_id, ss::noncopyable_function<void(uuid_t)>>
       _callbacks;
     notification_id _latest_id{0};
+};
+
+class link_test : public link_test_base {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+    virtual ss::future<> SetUpAsync() override {
+        co_await link_test_base::SetUpAsync();
+        _manager = std::make_unique<manager>(
+          ::model::node_id(0),
+          std::make_unique<fake_partition_leader_cache>(
+            _partition_leader_cache_impl.get()),
+          std::make_unique<fake_partition_manager>(
+            _partition_manager_proxy.get()),
+          std::make_unique<test_link_registry>(&_table.local()),
+          std::make_unique<test_link_factory>(this),
+          task_reconciler_interval);
+    }
+
+    virtual ss::future<> TearDownAsync() override {
+        _manager.reset(nullptr);
+        co_await link_test_base::TearDownAsync();
+    }
+
+    void add_link_to_list(uuid_t id, test_link* link) {
+        _links.emplace(id, link);
+        run_callbacks(id);
+    }
+
+    void remove_link_from_list(uuid_t id) {
+        _links.erase(id);
+        run_callbacks(id);
+    }
+
+protected:
+    absl::flat_hash_map<uuid_t, test_link*> _links;
 };
 
 class link_test_manager_started : public link_test {
@@ -205,7 +220,7 @@ ss::future<> test_link::start() {
 }
 
 ss::future<> test_link::stop() {
-    _link_test->remove_link(config().uuid);
+    _link_test->remove_link_from_list(config().uuid);
     co_await link::stop();
 }
 } // namespace

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -311,4 +311,128 @@ TEST_F_CORO(link_test_manager_started, test_remove_non_existant_link) {
     _manager->on_link_change(model::id_t(1));
     return ss::now();
 }
+
+class evil_link : public link {
+public:
+    using link::link;
+
+    ss::future<> start() override {
+        static bool has_been_called = false;
+        if (has_been_called) {
+            has_been_called = false;
+            _running = true;
+            return ss::now();
+        } else {
+            has_been_called = true;
+            throw std::runtime_error("Evil link start method failed");
+        }
+    }
+
+    ss::future<> stop() override {
+        static bool has_been_called = false;
+        if (has_been_called) {
+            has_been_called = false;
+            _running = false;
+            return ss::now();
+        } else {
+            has_been_called = true;
+            throw std::runtime_error("Evil link stop method failed");
+        }
+    }
+
+    bool running() const { return _running; }
+
+private:
+    bool _running{false};
+};
+
+class evil_link_factory : public link_factory {
+public:
+    std::unique_ptr<link> create_link(
+      ::model::node_id self,
+      model::metadata metadata,
+      partition_leader_cache* partition_leader_cache,
+      partition_manager* partition_manager) override {
+        return std::make_unique<evil_link>(
+          self,
+          1s,
+          std::move(metadata),
+          partition_leader_cache,
+          partition_manager);
+    }
+};
+
+class evil_link_test : public link_test_base {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+    virtual ss::future<> SetUpAsync() override {
+        co_await link_test_base::SetUpAsync();
+        auto elf = std::make_unique<evil_link_factory>();
+        _elf = elf.get();
+        _manager = std::make_unique<manager>(
+          ::model::node_id(0),
+          std::make_unique<fake_partition_leader_cache>(
+            _partition_leader_cache_impl.get()),
+          std::make_unique<fake_partition_manager>(
+            _partition_manager_proxy.get()),
+          std::make_unique<test_link_registry>(&_table.local()),
+          std::move(elf),
+          task_reconciler_interval);
+        co_await _manager->start();
+    }
+
+    virtual ss::future<> TearDownAsync() override {
+        co_await _manager->stop();
+        _elf = nullptr;
+        _manager.reset(nullptr);
+
+        co_await link_test_base::TearDownAsync();
+    }
+
+protected:
+    evil_link_factory* _elf;
+};
+
+TEST_F_CORO(evil_link_test, test_evil_link_start_stop) {
+    auto name = model::name_t("link1");
+    model::metadata link{
+      .name = name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+    model::id_t link_id(1);
+
+    co_await upsert_link(link_id, link.copy());
+
+    // Enough time for the upsert callback to fire but no link should be present
+    co_await ss::sleep(500ms);
+
+    auto report = _manager->get_task_status_report();
+
+    EXPECT_TRUE(report.link_reports.empty())
+      << "Link should not be present yet";
+
+    // Link reconciler loop takes 10 seconds to run
+    co_await ss::sleep(11s);
+
+    report = _manager->get_task_status_report();
+    auto link_report = report.link_reports.find(name);
+    EXPECT_NE(link_report, report.link_reports.end())
+      << "Link should be present after reconciler loop";
+
+    co_await remove_link(name);
+    // Allow callback time to execute
+    co_await ss::sleep(500ms);
+
+    report = _manager->get_task_status_report();
+    link_report = report.link_reports.find(name);
+    EXPECT_NE(link_report, report.link_reports.end())
+      << "Link should be present after reconciler loop";
+
+    // Link reconciler loop takes 10 seconds to run
+    co_await ss::sleep(11s);
+    report = _manager->get_task_status_report();
+    EXPECT_TRUE(report.link_reports.empty())
+      << "Link should be removed after reconciler loop";
+}
+
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -27,6 +27,7 @@ namespace cluster_link::tests {
 
 using ::cluster::cluster_link::table;
 using kafka::data::rpc::partition_leader_cache;
+using kafka::data::rpc::partition_manager;
 
 class link_test;
 namespace {
@@ -59,7 +60,8 @@ public:
     test_link(
       link_test* link_test,
       model::metadata metadata,
-      partition_leader_cache* partition_leader_cache);
+      partition_leader_cache* partition_leader_cache,
+      partition_manager* partition_manager);
 
     ss::future<> start() override;
     ss::future<> stop() override;
@@ -74,9 +76,13 @@ public:
       : _link_test(link_test) {}
     std::unique_ptr<link> create_link(
       model::metadata metadata,
-      partition_leader_cache* partition_leader_cache) override {
+      partition_leader_cache* partition_leader_cache,
+      partition_manager* partition_manager) override {
         return std::make_unique<test_link>(
-          _link_test, std::move(metadata), partition_leader_cache);
+          _link_test,
+          std::move(metadata),
+          partition_leader_cache,
+          partition_manager);
     }
 
 private:
@@ -90,11 +96,15 @@ public:
     virtual ss::future<> SetUpAsync() override {
         _partition_leader_cache_impl
           = std::make_unique<fake_partition_leader_cache_impl>();
+        _partition_manager_proxy
+          = std::make_unique<fake_partition_manager_proxy>();
         co_await _table.start();
         _manager = std::make_unique<manager>(
           ::model::node_id(0),
           std::make_unique<fake_partition_leader_cache>(
             _partition_leader_cache_impl.get()),
+          std::make_unique<fake_partition_manager>(
+            _partition_manager_proxy.get()),
           std::make_unique<test_link_registry>(&_table.local()),
           std::make_unique<test_link_factory>(this),
           task_reconciler_interval);
@@ -103,6 +113,7 @@ public:
     virtual ss::future<> TearDownAsync() override {
         _manager.reset(nullptr);
         co_await _table.stop();
+        _partition_manager_proxy.reset();
         _partition_leader_cache_impl.reset();
     }
 
@@ -153,6 +164,7 @@ public:
 protected:
     std::unique_ptr<fake_partition_leader_cache_impl>
       _partition_leader_cache_impl;
+    std::unique_ptr<fake_partition_manager_proxy> _partition_manager_proxy;
     ss::sharded<table> _table;
     std::unique_ptr<manager> _manager;
     absl::flat_hash_map<uuid_t, test_link*> _links;
@@ -178,8 +190,9 @@ namespace {
 test_link::test_link(
   link_test* link_test,
   model::metadata metadata,
-  partition_leader_cache* partition_leader_cache)
-  : link(std::move(metadata), partition_leader_cache)
+  partition_leader_cache* partition_leader_cache,
+  partition_manager* partition_manager)
+  : link(std::move(metadata), partition_leader_cache, partition_manager)
   , _link_test(link_test) {}
 
 ss::future<> test_link::start() {

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -32,29 +32,6 @@ using kafka::data::rpc::partition_manager;
 class link_test;
 namespace {
 
-class test_link_registry : public link_registry {
-public:
-    explicit test_link_registry(table* table)
-      : _table(table) {}
-
-    std::optional<std::reference_wrapper<const model::metadata>>
-    find_link_by_id(model::id_t id) const override {
-        return _table->find_link_by_id(id);
-    }
-
-    std::optional<std::reference_wrapper<const model::metadata>>
-    find_link_by_name(const model::name_t& name) const override {
-        return _table->find_link_by_name(name);
-    }
-
-    chunked_vector<model::id_t> get_all_link_ids() const override {
-        return _table->get_all_link_ids();
-    }
-
-private:
-    table* _table;
-};
-
 class test_link : public link {
 public:
     test_link(

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -58,6 +58,7 @@ private:
 class test_link : public link {
 public:
     test_link(
+      ::model::node_id self,
       link_test* link_test,
       model::metadata metadata,
       partition_leader_cache* partition_leader_cache,
@@ -75,10 +76,12 @@ public:
     explicit test_link_factory(link_test* link_test)
       : _link_test(link_test) {}
     std::unique_ptr<link> create_link(
+      ::model::node_id self,
       model::metadata metadata,
       partition_leader_cache* partition_leader_cache,
       partition_manager* partition_manager) override {
         return std::make_unique<test_link>(
+          self,
           _link_test,
           std::move(metadata),
           partition_leader_cache,
@@ -188,11 +191,12 @@ public:
 
 namespace {
 test_link::test_link(
+  ::model::node_id self,
   link_test* link_test,
   model::metadata metadata,
   partition_leader_cache* partition_leader_cache,
   partition_manager* partition_manager)
-  : link(std::move(metadata), partition_leader_cache, partition_manager)
+  : link(self, std::move(metadata), partition_leader_cache, partition_manager)
   , _link_test(link_test) {}
 
 ss::future<> test_link::start() {

--- a/src/v/cluster_link/tests/task_manager_integration_test.cc
+++ b/src/v/cluster_link/tests/task_manager_integration_test.cc
@@ -1,0 +1,672 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/link.h"
+#include "cluster_link/model/types.h"
+#include "cluster_link/task.h"
+#include "cluster_link/tests/deps.h"
+#include "kafka/data/rpc/deps.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::tests {
+
+namespace {
+
+void validate_report(
+  const model::cluster_link_task_status_report& report,
+  const model::name_t& link_name,
+  std::string_view task_name,
+  model::task_state expected_state) {
+    const auto link_task_state_report = report.link_reports.find(link_name);
+    ASSERT_NE(link_task_state_report, report.link_reports.end())
+      << "Link report for link " << link_name << " not found";
+
+    const auto task_report = link_task_state_report->second.task_status_reports
+                               .find(ss::sstring{task_name});
+    ASSERT_NE(
+      task_report, link_task_state_report->second.task_status_reports.end())
+      << "Task report for task " << task_name << " not found in link "
+      << link_name;
+
+    ASSERT_EQ(task_report->second.task_state, expected_state);
+}
+} // namespace
+
+using kafka::data::rpc::partition_leader_cache;
+using kafka::data::rpc::partition_manager;
+
+class test_task : public task {
+public:
+    static constexpr auto name = "test_task";
+    test_task(
+      ss::lowres_clock::duration run_interval,
+      is_locked_to_controller is_locked)
+      : task(run_interval, name)
+      , _is_locked_to_controller(is_locked) {}
+
+    task::is_locked_to_controller
+    locked_to_controller() const noexcept override {
+        return _is_locked_to_controller;
+    }
+
+    void update_config(const model::metadata&) override {}
+
+    ss::future<> run_impl() override { return ss::now(); }
+
+private:
+    is_locked_to_controller _is_locked_to_controller
+      = is_locked_to_controller::no;
+};
+
+class test_task_factory : public task_factory {
+public:
+    explicit test_task_factory(
+      task::is_locked_to_controller is_locked_to_controller)
+      : _is_locked_to_controller(is_locked_to_controller) {}
+    std::string_view created_task_name() const noexcept override {
+        return test_task::name;
+    }
+
+    std::unique_ptr<task> create_task() override {
+        return std::make_unique<test_task>(100ms, _is_locked_to_controller);
+    }
+
+private:
+    task::is_locked_to_controller _is_locked_to_controller;
+};
+
+class test_link_factory : public link_factory {
+public:
+    explicit test_link_factory(
+      ss::lowres_clock::duration task_reconciler_interval)
+      : _task_reconciler_interval(task_reconciler_interval) {}
+    std::unique_ptr<link> create_link(
+      ::model::node_id self,
+      model::metadata metadata,
+      partition_leader_cache* leader_cache,
+      partition_manager* pm) override {
+        auto name = metadata.name;
+        auto created_link = std::make_unique<link>(
+          self,
+          _task_reconciler_interval,
+          std::move(metadata),
+          leader_cache,
+          pm);
+
+        _links.emplace(std::move(name), created_link.get());
+        return created_link;
+    }
+
+    std::optional<link*> get_link(const model::name_t& name) const {
+        auto it = _links.find(name);
+        if (it != _links.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+private:
+    ss::lowres_clock::duration _task_reconciler_interval;
+    chunked_hash_map<model::name_t, link*> _links;
+};
+
+struct test_parameters {
+    task::is_locked_to_controller is_locked_to_controller;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const test_parameters& tp) {
+        return os << "{is_locked_to_controller: " << tp.is_locked_to_controller
+                  << "}";
+    }
+};
+
+class task_manager_integration_test
+  : public ::testing::TestWithParam<test_parameters> {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+    void SetUp() override {
+        _clmtf = std::make_unique<cluster_link_manager_test_fixture>(self());
+        _clmtf
+          ->wire_up_and_start(
+            std::make_unique<test_link_factory>(task_reconciler_interval))
+          .get();
+    }
+    void TearDown() override {
+        _clmtf->reset().get();
+        _clmtf.reset();
+    }
+
+    cluster_link_manager_test_fixture* fixture() { return _clmtf.get(); }
+
+    ss::future<std::optional<model::cluster_link_task_status_report>>
+    await_status_report(
+      ss::lowres_clock::duration timeout,
+      ss::lowres_clock::duration backoff,
+      std::function<bool(size_t)> predicate) {
+        auto timeout_time = ss::lowres_clock::now() + timeout;
+        while (ss::lowres_clock::now() < timeout_time) {
+            auto report
+              = fixture()->get_manager().local().get_task_status_report();
+            if (predicate(report.link_reports.size())) {
+                co_return report;
+            }
+            co_await ss::sleep(backoff);
+        }
+
+        co_return std::nullopt;
+    }
+
+    ::model::node_id self() { return ::model::node_id(0); }
+
+private:
+    std::unique_ptr<cluster_link_manager_test_fixture> _clmtf;
+};
+
+TEST_P(task_manager_integration_test, create_task_no_controller) {
+    /// This test validates when no controller leader is present that:
+    /// - Tasks that are locked to the controller are not started
+    /// - Tasks that are not locked to the controller are started
+    fixture()
+      ->get_manager()
+      .invoke_on_all([](manager& m) {
+          m.register_task_factory<test_task_factory>(
+            GetParam().is_locked_to_controller);
+      })
+      .get();
+    {
+        auto report = fixture()->get_manager().local().get_task_status_report();
+        ASSERT_TRUE(report.link_reports.empty());
+    }
+
+    auto link_name = model::name_t("test_link");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    fixture()->upsert_link(std::move(m1)).get();
+    auto report = await_status_report(5s, 100ms, [](size_t size) {
+                      return size > 0;
+                  }).get();
+    ASSERT_TRUE(report.has_value()) << "Never received a task report";
+
+    validate_report(
+      *report,
+      link_name,
+      test_task::name,
+      GetParam().is_locked_to_controller == task::is_locked_to_controller::yes
+        ? model::task_state::not_running
+        : model::task_state::active);
+}
+
+TEST_P(task_manager_integration_test, create_task_with_controller) {
+    /// This test validates when a controller leader is present that:
+    /// - Tasks that are locked to the controller are started
+    /// - Tasks that are not locked to the controller are started
+    fixture()
+      ->get_manager()
+      .invoke_on_all([](manager& m) {
+          m.register_task_factory<test_task_factory>(
+            GetParam().is_locked_to_controller);
+      })
+      .get();
+    fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+    auto link_name = model::name_t("test_link");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    fixture()->upsert_link(std::move(m1)).get();
+    auto report = await_status_report(5s, 100ms, [](size_t size) {
+                      return size > 0;
+                  }).get();
+    ASSERT_TRUE(report.has_value()) << "Never received a task report";
+
+    validate_report(
+      *report, link_name, test_task::name, model::task_state::active);
+}
+
+TEST_P(task_manager_integration_test, controller_leadership_moved_on) {
+    /// This test validates that when the controller leadership moves onto the
+    /// shard that tasks that are
+    /// - Locked to the controller are started
+    /// - Not locked to the controller are started
+
+    // This test starts off with no controller leader elected, creates the task,
+    // and then 'elects' a controller leader
+
+    fixture()
+      ->get_manager()
+      .invoke_on_all([](manager& m) {
+          m.register_task_factory<test_task_factory>(
+            GetParam().is_locked_to_controller);
+      })
+      .get();
+
+    auto link_name = model::name_t("test_link");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    fixture()->upsert_link(std::move(m1)).get();
+    auto report = await_status_report(5s, 100ms, [](size_t size) {
+                      return size > 0;
+                  }).get();
+    ASSERT_TRUE(report.has_value()) << "Never received a task report";
+
+    validate_report(
+      *report,
+      link_name,
+      test_task::name,
+      GetParam().is_locked_to_controller == task::is_locked_to_controller::yes
+        ? model::task_state::not_running
+        : model::task_state::active);
+
+    // Register for a callback from the task to alert us if the task changes
+    // state.  If the task is not locked to the controller, then no state change
+    // should be reported, however if it is locked to the controller, then the
+    // state should change from not_running to active
+    ss::condition_variable cv;
+
+    task::state_change change;
+    auto notif_id
+      = dynamic_cast<test_link_factory*>(fixture()->get_link_factory())
+          ->get_link(link_name)
+          .value()
+          ->register_for_task_state_changes(
+            [&cv, &change, &link_name, task_name = test_task::name](
+              model::name_t cb_link_name,
+              std::string_view cb_task_name,
+              task::state_change state_change) {
+                if (cb_link_name == link_name && cb_task_name == task_name) {
+                    change = std::move(state_change);
+                    cv.signal();
+                }
+            });
+    auto remove_callback = ss::defer([this, notif_id, &link_name] {
+        dynamic_cast<test_link_factory*>(fixture()->get_link_factory())
+          ->get_link(link_name)
+          .value()
+          ->unregister_for_task_state_changes(notif_id);
+    });
+
+    fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+    try {
+        cv.wait(1s).get();
+        EXPECT_EQ(change.prev, model::task_state::not_running);
+        EXPECT_EQ(change.cur, model::task_state::active);
+    } catch (const ss::condition_variable_timed_out&) {
+        if (
+          GetParam().is_locked_to_controller
+          == task::is_locked_to_controller::yes) {
+            FAIL() << "Task should have started after controller leadership "
+                      "moved to "
+                      "this shard";
+        } else {
+            // this is expected - should already have been running and have no
+            // state change
+        }
+    }
+}
+
+TEST_P(task_manager_integration_test, controller_leadership_move_off) {
+    /// This test validates that when the controller leadership moves off of the
+    /// shard that
+    /// - Tasks that are locked to the controller are stopped
+    /// - Tasks that are not locked to the controller are still running
+
+    // This test starts of with a controller leader elected, creates the tasks
+    // and then moves leadership
+
+    fixture()
+      ->get_manager()
+      .invoke_on_all([](manager& m) {
+          m.register_task_factory<test_task_factory>(
+            GetParam().is_locked_to_controller);
+      })
+      .get();
+
+    fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+    auto link_name = model::name_t("test_link");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    fixture()->upsert_link(std::move(m1)).get();
+
+    auto report = await_status_report(5s, 100ms, [](size_t size) {
+                      return size > 0;
+                  }).get();
+    ASSERT_TRUE(report.has_value()) << "Never received a task report";
+
+    validate_report(
+      *report, link_name, test_task::name, model::task_state::active);
+
+    // Register for a callback from the task to alert us if the task changes
+    // state.  If the task is not locked to the controller, then no state change
+    // should be reported, however if it is locked to the controller, then the
+    // state should change from active to not_running
+    ss::condition_variable cv;
+
+    task::state_change change;
+    auto notif_id
+      = dynamic_cast<test_link_factory*>(fixture()->get_link_factory())
+          ->get_link(link_name)
+          .value()
+          ->register_for_task_state_changes(
+            [&cv, &change, &link_name, task_name = test_task::name](
+              model::name_t cb_link_name,
+              std::string_view cb_task_name,
+              task::state_change state_change) {
+                if (cb_link_name == link_name && cb_task_name == task_name) {
+                    change = std::move(state_change);
+                    cv.signal();
+                }
+            });
+    auto remove_callback = ss::defer([this, notif_id, &link_name] {
+        dynamic_cast<test_link_factory*>(fixture()->get_link_factory())
+          ->get_link(link_name)
+          .value()
+          ->unregister_for_task_state_changes(notif_id);
+    });
+
+    fixture()->elect_leader(::model::controller_ntp, self() + 1, std::nullopt);
+
+    try {
+        cv.wait(1s).get();
+        EXPECT_EQ(change.prev, model::task_state::active);
+        EXPECT_EQ(change.cur, model::task_state::not_running);
+    } catch (const ss::condition_variable_timed_out&) {
+        if (
+          GetParam().is_locked_to_controller
+          == task::is_locked_to_controller::yes) {
+            FAIL() << "Task should have halted after controller leadership "
+                      "moved to "
+                      "this shard";
+        } else {
+            // this is expected - should already have been running and have no
+            // state change
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  tracks_with_controller_leader,
+  task_manager_integration_test,
+  ::testing::Values(
+    test_parameters{
+      .is_locked_to_controller = task::is_locked_to_controller::yes},
+    test_parameters{
+      .is_locked_to_controller = task::is_locked_to_controller::no}));
+
+/// Class that doesn't start/stop on the first try
+class evil_task : public task {
+public:
+    static constexpr auto name = "evil_task";
+
+    using task::task;
+
+    is_locked_to_controller locked_to_controller() const noexcept override {
+        return is_locked_to_controller::yes;
+    }
+
+    void update_config(const model::metadata&) override {}
+
+    ss::future<> run_impl() override { return ss::now(); }
+
+    ss::future<result<void>> start() override {
+        static unsigned num_calls = 0;
+        if (num_calls < 2) {
+            num_calls++;
+            throw std::runtime_error("Evil task start method failed");
+        } else {
+            num_calls = 0; // reset for next start
+            co_return co_await task::start();
+        }
+    }
+
+    ss::future<result<void>> stop() override {
+        static unsigned num_calls = 0;
+        if (num_calls < 2) {
+            num_calls++;
+            throw std::runtime_error("Evil task stop method failed");
+        } else {
+            num_calls = 0; // reset for next start
+            co_return co_await task::stop();
+        }
+    }
+};
+
+class evil_task_factory : public task_factory {
+public:
+    using task_factory::task_factory;
+
+    std::string_view created_task_name() const noexcept override {
+        return evil_task::name;
+    }
+
+    std::unique_ptr<task> create_task() override {
+        return std::make_unique<evil_task>(100ms, evil_task::name);
+    }
+};
+
+class evil_task_manager_integration_test : public seastar_test {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+
+    ss::future<> SetUpAsync() override {
+        _clmtf = std::make_unique<cluster_link_manager_test_fixture>(self());
+        co_await _clmtf->wire_up_and_start(
+          std::make_unique<test_link_factory>(task_reconciler_interval));
+    }
+
+    ss::future<> TearDownAsync() override {
+        co_await _clmtf->reset();
+        _clmtf.reset();
+    }
+
+    cluster_link_manager_test_fixture* fixture() { return _clmtf.get(); }
+
+    ::model::node_id self() { return ::model::node_id(0); }
+
+    ss::future<std::optional<model::cluster_link_task_status_report>>
+    await_status_report(
+      ss::lowres_clock::duration timeout,
+      ss::lowres_clock::duration backoff,
+      std::function<bool(const model::cluster_link_task_status_report&)>
+        predicate) {
+        auto timeout_time = ss::lowres_clock::now() + timeout;
+        while (ss::lowres_clock::now() < timeout_time) {
+            auto report
+              = fixture()->get_manager().local().get_task_status_report();
+            if (predicate(report)) {
+                co_return report;
+            }
+            co_await ss::sleep(backoff);
+        }
+
+        co_return std::nullopt;
+    }
+
+private:
+    std::unique_ptr<cluster_link_manager_test_fixture> _clmtf;
+};
+
+TEST_F_CORO(
+  evil_task_manager_integration_test, evil_task_start_stop_leader_move_off) {
+    /// This test verifies that when a task is supposed to start/stop but fails,
+    /// the task reconciliation mechanism can recover from the failure.
+
+    co_await fixture()->get_manager().invoke_on_all(
+      [](manager& m) { m.register_task_factory<evil_task_factory>(); });
+
+    fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+
+    auto link_name = model::name_t("link1");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    co_await fixture()->upsert_link(std::move(m1));
+
+    auto report = co_await await_status_report(
+      5s, 100ms, [](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.size() > 0;
+      });
+
+    // Expect that the status report should not be running yet
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::not_running);
+
+    // Await the task reconciler interval time (plus a fudge) to allow the loop
+    // to run to start the task
+    co_await ss::sleep(task_reconciler_interval * 2 + 100ms);
+
+    report = co_await await_status_report(
+      5s, 100ms, [](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.size() > 0;
+      });
+
+    // Expect that the status report should be running now
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::active);
+
+    // Now move the controller leadership off this shard
+    fixture()->elect_leader(::model::controller_ntp, self() + 1, std::nullopt);
+
+    report = co_await await_status_report(
+      5s, 100ms, [](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.size() > 0;
+      });
+
+    // Expect that the status report should be running now
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::active);
+
+    // Await the task reconciler interval time (plus a fudge) to allow the loop
+    // to run to stop the task
+    co_await ss::sleep(task_reconciler_interval * 2 + 100ms);
+
+    report = co_await await_status_report(
+      5s, 100ms, [](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.size() > 0;
+      });
+
+    // Expect that the status report should be running now
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::not_running);
+}
+
+TEST_F_CORO(
+  evil_task_manager_integration_test, evil_task_start_stop_leader_move_on) {
+    /// This test verifies that when a task is supposed to start/stop but fails,
+    /// the task reconciliation mechanism can recover from the failure.
+
+    co_await fixture()->get_manager().invoke_on_all(
+      [](manager& m) { m.register_task_factory<evil_task_factory>(); });
+
+    auto link_name = model::name_t("link1");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    co_await fixture()->upsert_link(std::move(m1));
+
+    auto report = co_await await_status_report(
+      5s, 100ms, [](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.size() > 0;
+      });
+
+    // Expect that the status report should not be running yet
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::not_running);
+
+    fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+
+    // Await the task reconciler interval time (plus a fudge) to allow the loop
+    // to run to start the task
+    co_await ss::sleep(task_reconciler_interval * 2 + 100ms);
+
+    report = co_await await_status_report(
+      5s, 100ms, [](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.size() > 0;
+      });
+
+    // Expect that the status report should be running now
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::active);
+}
+
+TEST_F_CORO(
+  evil_task_manager_integration_test, evil_task_register_after_start) {
+    /// This test verifies the of registering a task after a link is created
+
+    fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+
+    auto link_name = model::name_t("link1");
+
+    model::metadata m1{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::connection_config{}};
+
+    co_await fixture()->upsert_link(std::move(m1));
+
+    co_await fixture()->get_manager().invoke_on_all(
+      [](manager& m) { m.register_task_factory<evil_task_factory>(); });
+
+    auto report = co_await await_status_report(
+      5s,
+      100ms,
+      [&link_name](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.contains(link_name)
+                 && report.link_reports.at(link_name)
+                      .task_status_reports.contains(evil_task::name);
+      });
+
+    // Expect that the status report should not be running yet
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::not_running);
+
+    // Await the task reconciler interval time (plus a fudge) to allow the loop
+    // to run to start the task
+    co_await ss::sleep(task_reconciler_interval * 2 + 100ms);
+
+    report = co_await await_status_report(
+      5s,
+      100ms,
+      [&link_name](const model::cluster_link_task_status_report& report) {
+          return report.link_reports.contains(link_name)
+                 && report.link_reports.at(link_name)
+                      .task_status_reports.contains(evil_task::name);
+      });
+
+    // Expect that the status report should be running now
+    validate_report(
+      *report, link_name, evil_task::name, model::task_state::active);
+}
+
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/types.h
+++ b/src/v/cluster_link/types.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/bool_class.hh>
+
+namespace cluster_link {
+/// Indicates if the current node is the leader for a given NTP
+using ntp_leader = ss::bool_class<struct is_ntp_leader_tag>;
+} // namespace cluster_link


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds the initial Cluster Link Task framework.  A cluster link task is a background fiber that runs at a set interval collecting metadata from the source cluster and acting on it.  Future tasks will be:

* Auto topic creation
* ACL monitoring
* CG offset monitoring
 
to name a few.

Tasks are constructed from factories which are registered with the cluster link manager.  When a new link is created, these factories are used to create new tasks and add them to the link.  The link then may start the task.  Tasks may indicate that they are locked to the controller leader, meaning they should only run on the controller leader broker (for example, auto topic creation).

Tasks have the following states:

* active - the task is running
* paused - the task has been paused by the user
* task_failed - the task has failed and cannot run
* link_unavailable - the connection to the remote cluster is unavailable
* not_running - not running

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
