### PR TITLE
[CORE-12276, CORE-12277] SR AuthZ: implement deferred handlers

### DIFF
--- a/src/v/pandaproxy/schema_registry/auth.h
+++ b/src/v/pandaproxy/schema_registry/auth.h
@@ -47,12 +47,9 @@ public:
 
     using regular_function_handler = ss::noncopyable_function<
       ss::future<server::reply_t>(server::request_t, server::reply_t)>;
-    using deferred_function_handler
-      = ss::noncopyable_function<ss::future<server::reply_t>(
-        server::request_t,
-        server::reply_t,
-        auth,
-        std::optional<request_auth_result>)>;
+    using deferred_function_handler = ss::noncopyable_function<ss::future<
+      server::reply_t>(
+      server::request_t, server::reply_t, std::optional<request_auth_result>)>;
     using function_handler
       = std::variant<regular_function_handler, deferred_function_handler>;
 

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -60,18 +60,30 @@ void throw_unauthorized() {
       ss::http::reply::status_type::forbidden);
 }
 
+void check_authenticated(request_auth_result& auth_result) {
+    try {
+        auth_result.require_authenticated();
+    } catch (...) {
+        // TODO(CORE-12275): audit failure
+        throw;
+    }
+}
+
 } // namespace
 
 void handle_authz(
   const server::request_t& rq,
   const auth& auth,
   request_auth_result& auth_result) {
-    auth_result.pass();
-
     auto params = detail::auth_params{rq};
     auto op = auth.get_op().value_or(security::acl_operation::all);
 
     auto resource = extract_resource_from_request(rq, auth);
+
+    ss::visit(
+      resource,
+      [&](const auth::none&) { auth_result.pass(); },
+      [&](const auto&) { check_authenticated(auth_result); });
 
     // Check Authorization
     auto authz_result = ss::visit(

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -105,4 +105,48 @@ void handle_authz(
     }
 }
 
+void handle_get_schemas_ids_id_authz(
+  const server::request_t& rq,
+  std::optional<request_auth_result>& auth_result,
+  const chunked_vector<subject>& subjects) {
+    if (!auth_result.has_value()) {
+        // ACLs or authentication is disabled
+        return;
+    }
+
+    check_authenticated(*auth_result);
+
+    if (subjects.empty()) {
+        // If there are no subjects associated with the schema id, it does
+        // not exist.
+        // Throw unauthorized here to avoid leaking information about whether a
+        // schema id exists or not.
+        // TODO(CORE-12275): audit failure with [] (empty list of auth_result)
+        throw_unauthorized();
+    }
+
+    auto params = detail::auth_params{rq};
+
+    auto authorizing_result = std::optional<security::auth_result>{};
+    auto all_results = chunked_vector<security::auth_result>{};
+    for (const auto& sub : subjects) {
+        auto res = rq.service().authorizor().authorized(
+          sub, security::acl_operation::read, params.principal, params.host);
+
+        if (res.is_authorized()) {
+            authorizing_result = std::move(res);
+            break;
+        } else {
+            all_results.push_back(std::move(res));
+        }
+    }
+
+    if (authorizing_result.has_value()) {
+        // TODO(CORE-12275): audit success with *authorizing_result
+    } else {
+        // TODO(CORE-12275): audit failure with all_results
+        throw_unauthorized();
+    }
+}
+
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -149,4 +149,44 @@ void handle_get_schemas_ids_id_authz(
     }
 }
 
+void handle_get_subjects_authz(
+  const server::request_t& rq,
+  std::optional<request_auth_result>& auth_result,
+  chunked_vector<subject>& subjects) {
+    if (!auth_result.has_value()) {
+        // ACLs or authentication is disabled
+        return;
+    }
+
+    check_authenticated(*auth_result);
+
+    auto params = detail::auth_params{rq};
+
+    auto passing_results = chunked_vector<security::auth_result>{};
+    auto failing_results = chunked_vector<security::auth_result>{};
+
+    auto new_end = std::ranges::remove_if(subjects, [&](const auto& subject) {
+        auto res = rq.service().authorizor().authorized(
+          subject,
+          security::acl_operation::read,
+          params.principal,
+          params.host);
+        if (res.is_authorized()) {
+            passing_results.push_back(std::move(res));
+            return false; // keep
+        } else {
+            failing_results.push_back(std::move(res));
+            return true; // remove
+        }
+    });
+    subjects.erase_to_end(new_end.begin());
+
+    // TODO(CORE-12275): audit success with passing_results (since we always
+    // return a successful response)
+
+    if (!failing_results.empty()) {
+        // TODO(CORE-12275): audit failure with failing_results
+    }
+}
+
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -29,15 +29,21 @@ concept no_auth = std::is_same_v<T, auth::none>
 template<typename T>
 concept requires_auth = !no_auth<T>;
 
+struct auth_params {
+    security::acl_principal principal;
+    security::acl_host host;
+
+    explicit auth_params(const server::request_t& rq)
+      : principal{security::principal_type::user, rq.user.name}
+      , host{rq.req->get_client_address().addr()} {}
+};
+
 } // namespace detail
 
-void handle_authz(
-  const server::request_t& rq,
-  const auth& auth,
-  request_auth_result& auth_result) {
-    auth_result.pass();
+namespace {
 
-    // Extract the resource from the request
+auth::resource
+extract_resource_from_request(const server::request_t& rq, const auth& auth) {
     auto resource = auth.get_resource();
     ss::visit(
       resource,
@@ -45,33 +51,45 @@ void handle_authz(
           sub = parse::request_param<subject>(*rq.req, "subject");
       },
       [](const auto&) {});
+    return resource;
+}
 
-    security::acl_principal principal{
-      security::principal_type::user, rq.user.name};
-    security::acl_host host{rq.req->get_client_address().addr()};
-    security::acl_operation op = auth.get_op().value_or(
-      security::acl_operation::all);
+void throw_unauthorized() {
+    throw ss::httpd::base_exception(
+      "Forbidden (missing required ACLs)",
+      ss::http::reply::status_type::forbidden);
+}
+
+} // namespace
+
+void handle_authz(
+  const server::request_t& rq,
+  const auth& auth,
+  request_auth_result& auth_result) {
+    auth_result.pass();
+
+    auto params = detail::auth_params{rq};
+    auto op = auth.get_op().value_or(security::acl_operation::all);
+
+    auto resource = extract_resource_from_request(rq, auth);
 
     // Check Authorization
     auto authz_result = ss::visit(
       resource,
       [&](const detail::requires_auth auto& resource_name) {
           return rq.service().authorizor().authorized(
-            resource_name, op, principal, host);
+            resource_name, op, params.principal, params.host);
       },
       [&](const detail::no_auth auto&) {
           return security::auth_result::authz_disabled(
-            principal, host, op, registry_resource{});
+            params.principal, params.host, op, registry_resource{});
       });
 
     if (authz_result.is_authorized()) {
         // TODO(CORE-12275): audit success
     } else {
         // TODO(CORE-12275): audit failure
-
-        throw ss::httpd::base_exception(
-          "Forbidden (missing required ACLs)",
-          ss::http::reply::status_type::forbidden);
+        throw_unauthorized();
     }
 }
 

--- a/src/v/pandaproxy/schema_registry/authorization.h
+++ b/src/v/pandaproxy/schema_registry/authorization.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "container/fragmented_vector.h"
 #include "pandaproxy/schema_registry/auth.h"
 #include "pandaproxy/schema_registry/fwd.h"
 #include "pandaproxy/server.h"
@@ -23,5 +24,10 @@ void handle_authz(
   const server::request_t& rq,
   const auth& auth,
   request_auth_result& auth_result);
+
+void handle_get_schemas_ids_id_authz(
+  const server::request_t& rq,
+  std::optional<request_auth_result>& auth_result,
+  const chunked_vector<subject>& subjects);
 
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/authorization.h
+++ b/src/v/pandaproxy/schema_registry/authorization.h
@@ -30,4 +30,9 @@ void handle_get_schemas_ids_id_authz(
   std::optional<request_auth_result>& auth_result,
   const chunked_vector<subject>& subjects);
 
+void handle_get_subjects_authz(
+  const server::request_t& rq,
+  std::optional<request_auth_result>& auth_result,
+  chunked_vector<subject>& subjects);
+
 } // namespace pandaproxy::schema_registry::enterprise

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -347,22 +347,16 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_schemas_ids_id(
   server::request_t rq,
   server::reply_t rp,
-  auth auth,
+  auth,
   std::optional<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
     const auto format = parse_output_format(*rq.req);
 
-    // Check if we need to validate the auth result
-    // Note: we may not need to if ACLs or authentication are disabled
-    if (auth_result.has_value()) {
-        // TODO(CORE-12276): Authorization check
-        // if auth::op::read for any subject that references this is satisfied
-        //    create an auth with the resource, pass it below
-        // else
-        //    fail
-        enterprise::handle_authz(rq, auth, *auth_result);
-    }
+    auto subjects = co_await rq.service().schema_store().get_schema_subjects(
+      id, include_deleted::yes);
+
+    enterprise::handle_get_schemas_ids_id_authz(rq, auth_result, subjects);
 
     // With deferred schema validation, there might be a schema that
     // had invalid references. These might have already been posted, so

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -419,7 +419,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<server::reply_t> get_subjects(
   server::request_t rq,
   server::reply_t rp,
-  auth auth,
+  auth,
   std::optional<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto inc_del{
@@ -428,19 +428,16 @@ ss::future<server::reply_t> get_subjects(
     auto subject_prefix{
       parse::query_param<std::optional<ss::sstring>>(*rq.req, "subjectPrefix")};
 
-    // Check if we need to validate the auth result
-    // Note: we may not need to if ACLs or authentication are disabled
-    if (auth_result.has_value()) {
-        // TODO(CORE-12277): Authorization check
-        enterprise::handle_authz(rq, auth, *auth_result);
-    }
-
     // List-type request: must ensure we see latest writes
     co_await rq.service().writer().read_sync();
 
-    auto resp = ppj::rjson_serialize_iobuf(
-      co_await rq.service().schema_store().get_subjects(
-        inc_del, subject_prefix));
+    auto res = co_await rq.service().schema_store().get_subjects(
+      inc_del, subject_prefix);
+
+    // Handle AuthZ - Filters res for the subjects the user is allowed to see
+    enterprise::handle_get_subjects_authz(rq, auth_result, res);
+
+    auto resp = ppj::rjson_serialize_iobuf(std::move(res));
     log_response(*rq.req, resp);
     rp.rep->write_body("json", ppj::as_body_writer(std::move(resp)));
     co_return rp;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -347,7 +347,6 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t> get_schemas_ids_id(
   server::request_t rq,
   server::reply_t rp,
-  auth,
   std::optional<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto id = parse::request_param<schema_id>(*rq.req, "id");
@@ -419,7 +418,6 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<server::reply_t> get_subjects(
   server::request_t rq,
   server::reply_t rp,
-  auth,
   std::optional<request_auth_result> auth_result) {
     parse_accept_header(rq, rp);
     auto inc_del{

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -56,7 +56,6 @@ ss::future<ctx_server<service>::reply_t> get_schemas_types(
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  auth auth,
   std::optional<request_auth_result> auth_result);
 
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_versions(
@@ -68,7 +67,6 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
 ss::future<ctx_server<service>::reply_t> get_subjects(
   ctx_server<service>::request_t rq,
   ctx_server<service>::reply_t rp,
-  auth auth,
   std::optional<request_auth_result> auth_result);
 
 ss::future<ctx_server<service>::reply_t> get_subject_versions(

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -85,7 +85,11 @@ public:
                   return h(std::move(rq), std::move(rp));
               },
               [&](const auth::deferred_function_handler& h) {
-                  return h(std::move(rq), std::move(rp), _auth, auth_result);
+                  return h(
+                    std::move(rq),
+                    std::move(rp),
+                    _auth,
+                    std::move(auth_result));
               });
         } catch (const kafka::client::partition_error& ex) {
             if (

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -86,10 +86,7 @@ public:
               },
               [&](const auth::deferred_function_handler& h) {
                   return h(
-                    std::move(rq),
-                    std::move(rp),
-                    _auth,
-                    std::move(auth_result));
+                    std::move(rq), std::move(rp), std::move(auth_result));
               });
         } catch (const kafka::client::partition_error& ex) {
             if (

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -381,10 +381,10 @@ void admin_server::register_security_routes() {
     register_route<user, true>(
       ss::httpd::security_json::list_user_roles,
       [this](
-        std::unique_ptr<ss::http::request> req, request_auth_result auth_result)
+        std::unique_ptr<ss::http::request> req,
+        const request_auth_result& auth_result)
         -> ss::future<ss::json::json_return_type> {
-          return list_user_roles_handler(
-            std::move(req), std::move(auth_result));
+          return list_user_roles_handler(std::move(req), auth_result);
       });
 
     register_route<superuser>(
@@ -621,7 +621,8 @@ admin_server::oidc_revoke_handler(std::unique_ptr<ss::http::request>) {
 }
 
 ss::future<ss::json::json_return_type> admin_server::list_user_roles_handler(
-  std::unique_ptr<ss::http::request> req, request_auth_result auth_result) {
+  std::unique_ptr<ss::http::request> req,
+  const request_auth_result& auth_result) {
     ss::sstring filter = req->get_query_param("filter");
 
     security::role_member member{

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -465,7 +465,7 @@ private:
     ss::future<ss::json::json_return_type>
     oidc_revoke_handler(std::unique_ptr<ss::http::request> req);
     ss::future<ss::json::json_return_type> list_user_roles_handler(
-      std::unique_ptr<ss::http::request>, request_auth_result);
+      std::unique_ptr<ss::http::request>, const request_auth_result&);
 
     ss::future<std::unique_ptr<ss::http::reply>> create_role_handler(
       std::unique_ptr<ss::http::request> req,

--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -216,6 +216,17 @@ void request_auth_result::require_authenticated() {
 
 void request_auth_result::pass() { _checked = true; }
 
+request_auth_result::request_auth_result(request_auth_result&& other) noexcept
+  : _username{std::move(other._username)}
+  , _password{std::move(other._password)}
+  , _sasl_mechanism{std::move(other._sasl_mechanism)}
+  , _authenticated{other._authenticated}
+  , _superuser{other._superuser}
+  , _auth_required{other._auth_required}
+  , _checked{other._checked} {
+    other.pass();
+}
+
 /**
  * It is important to protect against someone calling authenticate()
  * but then not calling any of the authorization helpers: this indicates

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -80,6 +80,11 @@ public:
       , _superuser(is_superuser)
       , _auth_required(is_auth_required) {};
 
+    request_auth_result operator=(request_auth_result&&) = delete;
+    request_auth_result operator=(const request_auth_result&) = delete;
+
+    request_auth_result(const request_auth_result&) = default;
+    request_auth_result(request_auth_result&&) noexcept;
     ~request_auth_result() noexcept(false);
 
     /**

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6608,6 +6608,9 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         result = self._get_security_acls()
         self.assert_equal(result.status_code, 401)
 
+        result = self._get_schemas_ids_id(1)
+        self.assert_equal(result.status_code, 401)
+
     @cluster(num_nodes=1)
     def test_acl_endpoints(self):
         """Test the ACL GET/POST/DELETE endpoints which are protected by the kafka cluster resource"""
@@ -6669,6 +6672,11 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
                                                       auth=self.super_auth)
         self.assert_equal(result.status_code, 200)
 
+        # Check deferred endpoints
+        schema_id = result.json()['id']
+        result = self._get_schemas_ids_id(schema_id, auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+
     @cluster(num_nodes=1)
     def test_resource_patterns(self):
         """Test that prefixed and global pattern matching of resources works"""
@@ -6700,3 +6708,98 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         self._post_acl(acl_3)
 
         check_post_schemas(can_post_1=False, can_post_2=False)
+
+    @cluster(num_nodes=1)
+    def test_get_schemas_ids_id_authorization(self):
+        """
+        Test GET /schemas/ids/{id} endpoint authorization logic.
+        This endpoint allows access if the user has READ permission on ANY subject
+        that references the schema.
+        """
+
+        # Create test subjects referencing the same schema
+        subject_1 = "test-subject-1"
+        subject_2 = "test-subject-2"
+        subject_3 = "test-subject-3"
+
+        schema_id = self._create_schema(subject_1)
+
+        response = self._post_subjects_subject_versions(
+            subject_2, data=self.schema_data_1, auth=self.super_auth)
+        self.assert_equal(response.status_code, 200)
+        self.assert_equal(response.json()["id"], schema_id)
+
+        response = self._post_subjects_subject_versions(
+            subject_3, data=self.schema_data_1, auth=self.super_auth)
+        self.assert_equal(response.status_code, 200)
+        self.assert_equal(response.json()["id"], schema_id)
+
+        # Unknown schema id - should be 403 (don't leak presence info)
+        result = self._get_schemas_ids_id(99999, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+        # No ACLs - should be denied
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+        # Grant READ to subject_1 - should succeed
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Switch access to subject_2 - should still work (any subject access sufficient)
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ", "DENY"))
+        self._post_acl(
+            self._create_acl(subject_2, "SUBJECT", "LITERAL", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Remove all access - should be denied
+        self._post_acl(
+            self._create_acl(subject_2, "SUBJECT", "LITERAL", "READ", "DENY"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+        # Grant access to subject 3 using a prefixed ACL - should succeed
+        self._post_acl(
+            self._create_acl("test-subject-", "SUBJECT", "PREFIXED", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Delete the only subject that granted access to the endpoint
+        # Should still succeed since soft-deleted subjects also count
+        result = self._delete_subject(subject_3, auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Remove access to all subjects - should be denied
+        self._post_acl(
+            self._create_acl("*", "SUBJECT", "LITERAL", "READ", "DENY"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)
+
+    @cluster(num_nodes=1)
+    def test_get_schemas_ids_no_match(self):
+        """
+        Test that access is denied when no subject referencing the schema allows access.
+
+        Even with a wildcard (*) ALLOW rule, if all specific subjects that reference
+        the schema are explicitly denied, the endpoint should return 403.
+        """
+        subject_1 = "test-subject-1"
+        schema_id = self._create_schema(subject_1)
+
+        # Verify wildcard (*) ALLOW grants access
+        self._post_acl(self._create_acl("*", "SUBJECT", "LITERAL", "READ"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+
+        # Add specific DENY to override wildcard ALLOW - should be denied (no subject grants access)
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ", "DENY"))
+        result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
+        self.assert_equal(result.status_code, 403)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6587,16 +6587,26 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         self.assert_equal(result.status_code, 200)
 
     @cluster(num_nodes=1)
-    def test_public_endpoints(self):
-        """Test the endpoints that don't require any ACLs for access"""
+    def test_unauthenticated(self):
+        """Test the behaviour of endpoints when they are requested unauthenticated"""
 
-        # GET_SCHEMAS_TYPES
+        # Test public endpoints - GET_SCHEMAS_TYPES and SCHEMA_REGISTRY_STATUS_READY
         result = self._get_schemas_types()
         self.assert_equal(result.status_code, 200)
 
-        # SCHEMA_REGISTRY_STATUS_READY
         result = self._get_status_ready()
         self.assert_equal(result.status_code, 200)
+
+        # Test non-public endpoints - should return 401
+        result = self._get_config()
+        self.assert_equal(result.status_code, 401)
+
+        result = self._post_subjects_subject_versions("test-subject",
+                                                      data=self.schema_data_1)
+        self.assert_equal(result.status_code, 401)
+
+        result = self._get_security_acls()
+        self.assert_equal(result.status_code, 401)
 
     @cluster(num_nodes=1)
     def test_acl_endpoints(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -6611,6 +6611,9 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         result = self._get_schemas_ids_id(1)
         self.assert_equal(result.status_code, 401)
 
+        result = self._get_subjects()
+        self.assert_equal(result.status_code, 401)
+
     @cluster(num_nodes=1)
     def test_acl_endpoints(self):
         """Test the ACL GET/POST/DELETE endpoints which are protected by the kafka cluster resource"""
@@ -6676,6 +6679,10 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         schema_id = result.json()['id']
         result = self._get_schemas_ids_id(schema_id, auth=self.super_auth)
         self.assert_equal(result.status_code, 200)
+
+        result = self._get_subjects(auth=self.super_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json(), [subject])
 
     @cluster(num_nodes=1)
     def test_resource_patterns(self):
@@ -6803,3 +6810,44 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
             self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ", "DENY"))
         result = self._get_schemas_ids_id(schema_id, auth=self.user_auth)
         self.assert_equal(result.status_code, 403)
+
+    @cluster(num_nodes=1)
+    def test_get_subjects_authorization(self):
+        """
+        Test GET /subjects endpoint authorization logic.
+        This endpoint filters subjects based on individual READ permissions,
+        only returning subjects the user is authorized to access.
+        """
+
+        # Create multiple test subjects with different schemas
+        subject_1 = "test-subject-1"
+        subject_2 = "test-subject-2"
+
+        # Create subjects with schemas (using superuser)
+        self._create_schema(subject_1)
+        self._create_schema(subject_2)
+
+        # No ACLs - should return empty list
+        result = self._get_subjects(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json(), [])
+
+        # Grant READ to subject_1 only - should only return subject_1
+        self._post_acl(
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ"))
+        result = self._get_subjects(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json(), [subject_1])
+
+        # Grant wildcard (*) access - should return all subjects
+        self._post_acl(self._create_acl("*", "SUBJECT", "LITERAL", "READ"))
+        result = self._get_subjects(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(set(result.json()), {subject_1, subject_2})
+
+        # Deny all access - should return no subjects
+        self._post_acl(
+            self._create_acl("*", "SUBJECT", "LITERAL", "READ", "DENY"))
+        result = self._get_subjects(auth=self.user_auth)
+        self.assert_equal(result.status_code, 200)
+        self.assert_equal(result.json(), [])


### PR DESCRIPTION
Implements CORE-12276 and CORE-12277

* `GET /schemas/ids/{id}` - Permission is granted if this schema id exists (including soft-deleted) on a subject with a matching permission set. Operation is authorized if the principal has auth::op::read for any subject that references the schema id.

* `GET /subjects` - List the subjects that the user has op::describe for.

See the commit messages for implementation details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
