### PR TITLE
`cloud_storage_clients`: fix `s3_client` default self configuration for `MinIO`

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -588,6 +588,15 @@ s3_client::self_configure() {
     // ListObjects request used for self configuration still manages to succeed,
     // leading to a similarily bad state as Oracle. Override for this case as
     // well.
+    auto backend = config::shard_local_cfg().cloud_storage_backend();
+    if (
+      backend == model::cloud_storage_backend::oracle_s3_compat
+      || backend == model::cloud_storage_backend::minio) {
+        result.url_style = s3_url_style::path;
+        co_return result;
+    }
+
+    // Also handle possibly inferred backend.
     auto inferred_backend = infer_backend_from_uri(_requestor._ap);
     if (
       inferred_backend == model::cloud_storage_backend::oracle_s3_compat

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -580,8 +580,18 @@ s3_client::self_configure() {
     // but self-configuration will misconfigure to virtual-host style due to a
     // ListObjects request that happens to succeed. Override for this
     // specific case.
+    //
+    // Similarily, MinIO supports `virtual_host` only iff the property
+    // MINIO_DOMAIN is set, see:
+    // (https://min.io/docs/minio/linux/reference/minio-server/settings/core.html#envvar.MINIO_DOMAIN).
+    // If it is not, API calls with `virtual_host` will fail, though the
+    // ListObjects request used for self configuration still manages to succeed,
+    // leading to a similarily bad state as Oracle. Override for this case as
+    // well.
     auto inferred_backend = infer_backend_from_uri(_requestor._ap);
-    if (inferred_backend == model::cloud_storage_backend::oracle_s3_compat) {
+    if (
+      inferred_backend == model::cloud_storage_backend::oracle_s3_compat
+      || inferred_backend == model::cloud_storage_backend::minio) {
         result.url_style = s3_url_style::path;
         co_return result;
     }


### PR DESCRIPTION
`virtual_host` style is only supported by MinIO iff the property [`MINIO_DOMAIN` ](https://min.io/docs/minio/linux/reference/minio-server/settings/core.html#envvar.MINIO_DOMAIN)is set. If it is not, API calls will fail- with the exception of `ListObjects`, which is the request type used to self configure the `s3_client` in the case that `cloud_storage_url_style` is not set. We also attempt self configuration first with `virtual_host`, then with `path`.

This leads to a bad state in which `MinIO` will continue to fail until the user overrides `cloud_storage_url_style` manually to `path`. To prevent this bad self-configuration, particularly for users who do not have `MINIO_DOMAIN` configured, handle the `minio` backend case explicitly by hard-coding its self configuration result to `path`. If a user feels strongly about the `cloud_storage_url_style` being used, they can always override it at the cluster level.

Also, if a user manually set the `cloud_storage_backend`, it should be considered the source of truth for self configuration. Check its value and use the same `path` override for `oracle_s3_compat` and `minio` in this early return path within `s3_client::self_configure()` before checking inferred backend or performing a manual `ListObjects` request to self-configure.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
