### PR TITLE
cloud_topics: centralize object naming

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -179,3 +179,21 @@ redpanda_cc_library(
         "@fmt",
     ],
 )
+
+redpanda_cc_library(
+    name = "object_utils",
+    srcs = [
+        "object_utils.cc",
+    ],
+    hdrs = [
+        "object_utils.h",
+    ],
+    include_prefix = "cloud_topics",
+    deps = [
+        ":types",
+        "//src/v/cloud_storage_clients",
+        "//src/v/ssx:sformat",
+        "//src/v/utils:uuid",
+        "@fmt",
+    ],
+)

--- a/src/v/cloud_topics/batcher/BUILD
+++ b/src/v/cloud_topics/batcher/BUILD
@@ -44,6 +44,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:remote",
         "//src/v/cloud_topics:extent_meta",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:object_utils",
         "//src/v/cloud_topics/batcher:aggregator",
         "//src/v/cloud_topics/core:serializer",
         "//src/v/ssx:sformat",

--- a/src/v/cloud_topics/batcher/batcher.cc
+++ b/src/v/cloud_topics/batcher/batcher.cc
@@ -18,6 +18,7 @@
 #include "cloud_topics/core/write_request.h"
 #include "cloud_topics/errc.h"
 #include "cloud_topics/logger.h"
+#include "cloud_topics/object_utils.h"
 #include "cloud_topics/types.h"
 #include "config/configuration.h"
 #include "ssx/sformat.h"
@@ -72,9 +73,6 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
       "upload_object is called, upload size: {}",
       human::bytes(content_length));
 
-    // TODO: this should be replaced with the proper name
-    auto name = ssx::sformat("{}", id);
-
     auto err = errc::success;
     try {
         // Clock type is not parametrized further down the call chain.
@@ -85,7 +83,7 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
           retry_strategy::disallow,
           &_rtc);
 
-        auto path = cloud_storage_clients::object_key(name);
+        auto path = object_path_factory::level_zero_path(id);
 
         cloud_io::basic_transfer_details<Clock> td{
           .bucket = _bucket,

--- a/src/v/cloud_topics/object_utils.cc
+++ b/src/v/cloud_topics/object_utils.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/object_utils.h"
+
+#include "ssx/sformat.h"
+#include "utils/uuid.h"
+
+namespace experimental::cloud_topics {
+
+cloud_storage_clients::object_key
+object_path_factory::level_zero_path(object_id id) {
+    return cloud_storage_clients::object_key(ssx::sformat("{}", id));
+}
+
+cloud_storage_clients::object_key object_path_factory::level_one_path() {
+    return cloud_storage_clients::object_key(
+      ssx::sformat("l1_{}", uuid_t::create()));
+}
+
+} // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/object_utils.h
+++ b/src/v/cloud_topics/object_utils.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_storage_clients/types.h"
+#include "cloud_topics/types.h"
+
+namespace experimental::cloud_topics {
+
+/*
+ * Utilities for working with the object storage paths.
+ */
+class object_path_factory {
+public:
+    /*
+     * Generate the path of a level-zero object.
+     */
+    static cloud_storage_clients::object_key level_zero_path(object_id id);
+
+    /*
+     * Generate the path of a level-one object.
+     */
+    static cloud_storage_clients::object_key level_one_path();
+};
+
+} // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cloud_io:remote",
         "//src/v/cloud_storage",
+        "//src/v/cloud_topics:object_utils",
         "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_zero:ctp_stm_api",
         "//src/v/cluster",

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "cloud_storage/configuration.h"
 #include "cloud_topics/level_zero/ctp_stm_api.h"
+#include "cloud_topics/object_utils.h"
 #include "cloud_topics/types.h"
 #include "cluster/partition.h"
 #include "kafka/data/partition_proxy.h"
@@ -201,9 +202,6 @@ ss::future<std::optional<reconciler::object>> reconciler::build_object() {
 }
 
 ss::future<cloud_io::upload_result> reconciler::upload_object(iobuf payload) {
-    const cloud_storage_clients::object_key key(
-      fmt::format("l1_{}", uuid_t::create()));
-
     retry_chain_node rtc(
       _as,
       ss::lowres_clock::now() + std::chrono::seconds(20),
@@ -212,7 +210,7 @@ ss::future<cloud_io::upload_result> reconciler::upload_object(iobuf payload) {
     co_return co_await _cloud_io->local().upload_object({
       .transfer_details = {
         .bucket = _bucket,
-        .key = key,
+        .key = object_path_factory::level_one_path(),
         .parent_rtc = rtc,
       },
       .display_str = "l1_object",

--- a/src/v/cloud_topics/tests/BUILD
+++ b/src/v/cloud_topics/tests/BUILD
@@ -40,3 +40,16 @@ redpanda_cc_gtest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "object_utils_test",
+    timeout = "short",
+    srcs = [
+        "object_utils_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics:object_utils",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/cloud_topics/tests/object_utils_test.cc
+++ b/src/v/cloud_topics/tests/object_utils_test.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/object_utils.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#define UUID_REGEX                                                             \
+    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+TEST(ObjectPathFactory, LevelZeroPathFormat) {
+    auto path
+      = experimental::cloud_topics::object_path_factory::level_zero_path(
+        experimental::cloud_topics::object_id{uuid_t::create()});
+    EXPECT_THAT(path().string(), ::testing::MatchesRegex("^" UUID_REGEX "$"));
+}
+
+TEST(ObjectPathFactory, LevelOnePathFormat) {
+    auto path
+      = experimental::cloud_topics::object_path_factory::level_one_path();
+    EXPECT_THAT(
+      path().string(), ::testing::MatchesRegex("^l1_" UUID_REGEX "$"));
+}


### PR DESCRIPTION
Centralizes cloud topic object naming utilities. This was done in local storage (see segment_path_utils) with good success. It's useful because object naming changes during development, and may generally change overtime. Those changes should be centralized to avoid mistakes and life easier.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
