### PR TITLE
[UX-287] rpk: use common-go rpsr package

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -294,6 +294,7 @@ use_repo(
     "com_github_prometheus_common",
     "com_github_redpanda_data_common_go_proto",
     "com_github_redpanda_data_common_go_rpadmin",
+    "com_github_redpanda_data_common_go_rpsr",
     "com_github_redpanda_data_redpanda_src_transform_sdk_go_transform",
     "com_github_rs_xid",
     "com_github_safchain_ethtool",

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829
 	github.com/redpanda-data/common-go/rpadmin v0.1.14
+	github.com/redpanda-data/common-go/rpsr v0.1.0
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.5.10
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
@@ -57,13 +58,13 @@ require (
 	github.com/twmb/franz-go v1.19.4
 	github.com/twmb/franz-go/pkg/kadm v1.16.0
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
-	github.com/twmb/franz-go/pkg/sr v1.4.0
+	github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765
 	github.com/twmb/franz-go/plugin/kzap v1.1.2
 	github.com/twmb/tlscfg v1.2.1
 	github.com/twmb/types v1.1.6
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250207012021-f9890c6ad9f3
-	golang.org/x/sync v0.14.0
+	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.32.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250409194420-de1ac958c67a

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -224,6 +224,8 @@ github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829 h1:f
 github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829/go.mod h1:6WXvgZCZIkbQCNsvU5zTx/+ub5eXTuCcl90i5xkhMw0=
 github.com/redpanda-data/common-go/rpadmin v0.1.14 h1:G/rlh9cHsGhTsNpkwrISdpGA8fPZ7ul57rzxbPiJhs0=
 github.com/redpanda-data/common-go/rpadmin v0.1.14/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
+github.com/redpanda-data/common-go/rpsr v0.1.0 h1:kFjUlMTP76r8qCcDKAgTJYk6GqTjpeJlL/8hQiHlLSg=
+github.com/redpanda-data/common-go/rpsr v0.1.0/go.mod h1:VdvwMZ0z+htjbgo1kvYyUK1IjN0Ihx8dlD8dmkRat1M=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -279,8 +281,8 @@ github.com/twmb/franz-go/pkg/kadm v1.16.0 h1:STMs1t5lYR5mR974PSiwNzE5TvsosByTp+r
 github.com/twmb/franz-go/pkg/kadm v1.16.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
-github.com/twmb/franz-go/pkg/sr v1.4.0 h1:5XLiFsxAEbCgwjuBPlvVGQagHuKUS3Zyq/2abxxQS9w=
-github.com/twmb/franz-go/pkg/sr v1.4.0/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765 h1:+l/P3ExNaY1T5Tft/+zK5r7hiEilgHWS5Cjjh2iZ4ME=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
 github.com/twmb/franz-go/plugin/kzap v1.1.2 h1:0arX5xJ0soUPX1LlDay6ZZoxuWkWk1lggQ5M/IgRXAE=
 github.com/twmb/franz-go/plugin/kzap v1.1.2/go.mod h1:53Cl9Uz1pbdOPDvUISIxLrZIWSa2jCuY1bTMauRMBmo=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=
@@ -351,8 +353,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
-golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/src/go/rpk/pkg/cli/topic/BUILD
+++ b/src/go/rpk/pkg/cli/topic/BUILD
@@ -30,6 +30,7 @@ go_library(
         "@com_github_docker_go_units//:go-units",
         "@com_github_hashicorp_go_multierror//:go-multierror",
         "@com_github_redpanda_data_common_go_rpadmin//:rpadmin",
+        "@com_github_redpanda_data_common_go_rpsr//:rpsr",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_twmb_franz_go//pkg/kerr",

--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/redpanda-data/common-go/rpsr"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
@@ -67,7 +68,7 @@ type consumer struct {
 	partStarts map[string]map[int32]int64
 
 	cl   *kgo.Client
-	srCl *sr.Client
+	srCl *rpsr.Client
 }
 
 func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -840,7 +841,7 @@ func (c *consumer) formatSchemaRegistryFlag() error {
 	return nil
 }
 
-func handleDecode(ctx context.Context, cl *sr.Client, record []byte, serdeCache map[int]*serde.Serde) ([]byte, error) {
+func handleDecode(ctx context.Context, cl *rpsr.Client, record []byte, serdeCache map[int]*serde.Serde) ([]byte, error) {
 	var serdeHeader sr.ConfluentHeader
 	id, toDecode, err := serdeHeader.DecodeID(record)
 	if err != nil {
@@ -854,7 +855,7 @@ func handleDecode(ctx context.Context, cl *sr.Client, record []byte, serdeCache 
 		if err != nil {
 			return nil, fmt.Errorf("unable to get schema with index %v from the schema registry: %v", id, err)
 		}
-		rpkSerde, err = serde.NewSerde(ctx, cl, &schema, id, "")
+		rpkSerde, err = serde.NewSerde(ctx, cl.Client, &schema, id, "")
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/rpk/pkg/cli/topic/produce.go
+++ b/src/go/rpk/pkg/cli/topic/produce.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/redpanda-data/common-go/rpsr"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
@@ -162,7 +163,7 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			defer cl.Flush(context.Background())
 
 			var defaultKeySerde, defaultValSerde *serde.Serde
-			var srCl *sr.Client
+			var srCl *rpsr.Client
 			if isSchemaRegistry {
 				srCl, err = schemaregistry.NewClient(fs, p)
 				out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
@@ -171,11 +172,11 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				out.MaybeDie(err, "unable to query schemas from the registry: %v", err)
 
 				if keySchema != nil {
-					defaultKeySerde, err = serde.NewSerde(cmd.Context(), srCl, keySchema, keySchemaID, protoKeyFQN)
+					defaultKeySerde, err = serde.NewSerde(cmd.Context(), srCl.Client, keySchema, keySchemaID, protoKeyFQN)
 					out.MaybeDie(err, "unable to build serializer for the key schema: %v", err)
 				}
 				if valSchema != nil {
-					defaultValSerde, err = serde.NewSerde(cmd.Context(), srCl, valSchema, schemaID, protoFQN)
+					defaultValSerde, err = serde.NewSerde(cmd.Context(), srCl.Client, valSchema, schemaID, protoFQN)
 					out.MaybeDie(err, "unable to build serializer for the value schema: %v", err)
 				}
 			}
@@ -283,7 +284,7 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return cmd
 }
 
-func querySchemas(ctx context.Context, cl *sr.Client, keySchemaID, valSchemaID int) (keySchema *sr.Schema, valSchema *sr.Schema, err error) {
+func querySchemas(ctx context.Context, cl *rpsr.Client, keySchemaID, valSchemaID int) (keySchema *sr.Schema, valSchema *sr.Schema, err error) {
 	if keySchemaID > 0 {
 		keySch, err := cl.SchemaByID(ctx, keySchemaID)
 		if err != nil {
@@ -318,7 +319,7 @@ func parseSchemaIDFlag(flag string) (int, bool, error) {
 // serdeFromTopicName returns a new serde.Serde based on the topicName strategy.
 // First, it searches if the serde is cached, if not, it will query the latest
 // schema with subject name: <topic>-<suffix> and cache the result.
-func serdeFromTopicName(ctx context.Context, cl *sr.Client, topic, suffix, protoFQN string, serdeCache map[string]*serde.Serde) (*serde.Serde, error) {
+func serdeFromTopicName(ctx context.Context, cl *rpsr.Client, topic, suffix, protoFQN string, serdeCache map[string]*serde.Serde) (*serde.Serde, error) {
 	var newSerde *serde.Serde
 	schSubjectName := topic + "-" + suffix
 	if s, ok := serdeCache[schSubjectName]; ok {
@@ -328,7 +329,7 @@ func serdeFromTopicName(ctx context.Context, cl *sr.Client, topic, suffix, proto
 		if err != nil {
 			return nil, fmt.Errorf("unable to get schema with name %q using TopicName strategy: %v", schSubjectName, err)
 		}
-		newSerde, err = serde.NewSerde(ctx, cl, &schema.Schema, schema.ID, protoFQN)
+		newSerde, err = serde.NewSerde(ctx, cl.Client, &schema.Schema, schema.ID, protoFQN)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build serializer for the schema: %v", err)
 		}

--- a/src/go/rpk/pkg/schemaregistry/BUILD
+++ b/src/go/rpk/pkg/schemaregistry/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//src/go/rpk/pkg/net",
         "//src/go/rpk/pkg/oauth",
         "//src/go/rpk/pkg/oauth/providers/auth0",
+        "@com_github_redpanda_data_common_go_rpsr//:rpsr",
         "@com_github_spf13_afero//:afero",
         "@com_github_twmb_franz_go//pkg/kgo",
         "@com_github_twmb_franz_go_pkg_sr//:sr",

--- a/src/go/rpk/pkg/schemaregistry/client.go
+++ b/src/go/rpk/pkg/schemaregistry/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/redpanda-data/common-go/rpsr"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/net"
@@ -16,7 +17,7 @@ import (
 	"github.com/twmb/franz-go/plugin/kzap"
 )
 
-func NewClient(fs afero.Fs, p *config.RpkProfile) (*sr.Client, error) {
+func NewClient(fs afero.Fs, p *config.RpkProfile) (*rpsr.Client, error) {
 	api := &p.SR
 
 	d := p.Defaults()
@@ -85,7 +86,11 @@ func NewClient(fs afero.Fs, p *config.RpkProfile) (*sr.Client, error) {
 	default:
 		// do nothing
 	}
-	return sr.NewClient(opts...)
+	srCl, err := sr.NewClient(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return rpsr.NewClient(srCl)
 }
 
 // IsSoftDeleteError checks whether the error is a SoftDeleteError. This error

--- a/src/go/rpk/pkg/serde/avro_test.go
+++ b/src/go/rpk/pkg/serde/avro_test.go
@@ -291,7 +291,7 @@ func Test_encodeDecodeAvroRecordWithReferences(t *testing.T) {
 			require.NoError(t, err)
 
 			tt.schema.Type = sr.TypeAvro
-			serde, err := NewSerde(context.Background(), client, tt.schema, tt.schemaID, "")
+			serde, err := NewSerde(context.Background(), client.Client, tt.schema, tt.schemaID, "")
 			require.NoError(t, err)
 
 			got, err := serde.EncodeRecord([]byte(tt.record))

--- a/src/go/rpk/pkg/serde/jsonschema_test.go
+++ b/src/go/rpk/pkg/serde/jsonschema_test.go
@@ -384,7 +384,7 @@ func Test_encodeDecodeJsonsRecordWithReferences(t *testing.T) {
 			require.NoError(t, err)
 
 			tt.schema.Type = sr.TypeJSON
-			serde, err := NewSerde(context.Background(), client, tt.schema, tt.schemaID, "")
+			serde, err := NewSerde(context.Background(), client.Client, tt.schema, tt.schemaID, "")
 			require.NoError(t, err)
 
 			got, err := serde.EncodeRecord([]byte(tt.record))

--- a/src/go/rpk/pkg/serde/proto_test.go
+++ b/src/go/rpk/pkg/serde/proto_test.go
@@ -489,7 +489,7 @@ func Test_encodeProtoRecordWithReferences(t *testing.T) {
 			require.NoError(t, err)
 
 			tt.schema.Type = sr.TypeProtobuf
-			serde, err := NewSerde(context.Background(), cl, tt.schema, tt.schemaID, tt.msgType)
+			serde, err := NewSerde(context.Background(), cl.Client, tt.schema, tt.schemaID, tt.msgType)
 			require.NoError(t, err)
 
 			got, err := serde.EncodeRecord([]byte(tt.record))


### PR DESCRIPTION
This initial step is to replace our direct use of Franz-Go rp package for our wrapped client in the common-go rpsr package.

This new wrapped package will let us use SR ACLs.

Fixes UX-287

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
