### PR TITLE
bytes/iobuf_parser: Safe read truncated utf8

### DIFF
--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -57,11 +57,58 @@ public:
         return {val, length_size};
     }
 
-    ss::sstring read_string(size_t len) {
-        ss::sstring str = ss::uninitialized_string(len);
+    /// \brief reads size bytes into a sstring with no validation
+    /// \param size the number of bytes to read
+    /// \return a string of exactly size bytes read from the underlying iobuf
+    ss::sstring read_string_unsafe(size_t size) {
+        ss::sstring str = ss::uninitialized_string(size);
         _in.consume_to(str.size(), str.begin());
+        return str;
+    }
+
+    /// \brief reads size bytes into a sstring, throws if invalid or truncated
+    /// utf
+    /// \param size the number of bytes to read
+    /// \return a string of exactly size bytes read from the underlying iobuf
+    ss::sstring read_string(size_t size) {
+        auto str = read_string_unsafe(size);
         validate_utf8(str);
         return str;
+    }
+
+    /// \brief reads size bytes into a sstring with no validation. Does not
+    /// advance the consumption index
+    /// \param size the number of bytes to read
+    /// \return a string of exactly size bytes read from the underlying iobuf
+    ss::sstring peek_string_unsafe(size_t size) const {
+        auto in = _in;
+        ss::sstring str = ss::uninitialized_string(size);
+        in.consume_to(str.size(), str.begin());
+        return str;
+    }
+
+    /// \brief reads size bytes into a sstring, throws if invalid or truncated
+    /// utf8. Does not advance the consumption index
+    /// advance the consumption index
+    /// \param size the number of bytes to read
+    /// \return a string of exactly size bytes read from the underlying iobuf
+    ss::sstring peek_string(size_t size) const {
+        auto str = peek_string_unsafe(size);
+        validate_utf8(str);
+        return str;
+    }
+
+    /// \brief read and consume a maximum size string at utf8 boundaries. Throws
+    /// on invalid utf8, truncates incomplete utf8. Advances the consumption
+    /// index by only the valid string length.
+    /// \param max_size the maximum allowed size to consume & return
+    /// \return longest valid utf8 string of size len or less
+    ss::sstring read_string_safe(size_t max_size) {
+        auto raw_string = peek_string_unsafe(max_size);
+        const auto valid_size = validate_and_truncate(raw_string);
+        raw_string.resize(valid_size);
+        skip(valid_size);
+        return raw_string;
     }
 
     bytes read_bytes(size_t n) {

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -120,3 +120,18 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "iobuf_parser_test",
+    timeout = "short",
+    srcs = [
+        "iobuf_parser_tests.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/bytes/tests/iobuf_parser_tests.cc
+++ b/src/v/bytes/tests/iobuf_parser_tests.cc
@@ -1,0 +1,82 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf_parser.h"
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+namespace {
+[[maybe_unused]] const std::string hello = "hello";
+[[maybe_unused]] const std::string world = "world";
+[[maybe_unused]] const std::string hello_world = "helloworld";
+[[maybe_unused]] const std::string multi_byte = "۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩";
+
+// smoke test
+TEST(iobuf_parser_tests, smoke) {
+    auto buf = iobuf::from(hello);
+    buf.append_str(world);
+    auto parser = iobuf_parser{std::move(buf)};
+
+    auto output = parser.read_string_safe(hello.size() + world.size());
+
+    EXPECT_EQ(output, hello_world);
+    EXPECT_EQ(parser.bytes_left(), 0);
+};
+
+// check that read_string_safe can truncate output
+TEST(iobuf_parser_tests, test_shorter_string) {
+    auto buf = iobuf::from(hello);
+    buf.append_str(world);
+    auto parser = iobuf_parser{std::move(buf)};
+
+    // check that its okay reading over fragment boundary
+    auto output = parser.read_string_safe(hello.size() + 1);
+
+    EXPECT_EQ(output, "hellow");
+    EXPECT_EQ(parser.bytes_left(), (hello_world.size() - hello.size() - 1));
+};
+
+// test a utf8 string with an incomplete final character
+TEST(iobuf_parser_tests, test_multibyte_string) {
+    auto buf = iobuf::from(multi_byte);
+    auto parser = iobuf_parser{std::move(buf)};
+
+    // check that its okay reading over fragment boundary
+    auto output = parser.read_string_safe(multi_byte.size() - 1);
+
+    EXPECT_EQ(output.size(), multi_byte.size() - 2);
+    EXPECT_EQ(parser.bytes_left(), 2);
+};
+
+// test that a utf8 string can be partially read and continued from where it
+// left off
+TEST(iobuf_parser_tests, test_continued_read) {
+    auto buf = iobuf::from(multi_byte);
+    auto parser = iobuf_parser{std::move(buf)};
+
+    const auto clean_cut_point = 4;
+    const auto ragged_cut_point = clean_cut_point + 1;
+
+    auto first_read = multi_byte.substr(0, clean_cut_point);
+    auto second_read = multi_byte.substr(clean_cut_point, multi_byte.size());
+
+    // check that its okay reading over fragment boundary
+    auto output = parser.read_string_safe(ragged_cut_point);
+
+    EXPECT_EQ(output.size(), clean_cut_point);
+    EXPECT_EQ(output, first_read);
+    EXPECT_EQ(parser.bytes_left(), (multi_byte.size() - clean_cut_point));
+
+    output = parser.read_string_safe(parser.bytes_left());
+    EXPECT_EQ(output, second_read);
+    EXPECT_EQ(parser.bytes_left(), 0);
+};
+
+} // namespace

--- a/src/v/cloud_storage/tests/BUILD
+++ b/src/v/cloud_storage/tests/BUILD
@@ -450,6 +450,7 @@ redpanda_cc_btest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/bytes:iobuf_parser",
         "//src/v/bytes:iostream",
         "//src/v/cloud_storage",
         "//src/v/config",

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "absl/container/flat_hash_set.h"
+#include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
 #include "cloud_storage/anomalies_detector.h"
 #include "cloud_storage/base_manifest.h"
@@ -224,8 +225,8 @@ ss::input_stream<char> make_manifest_stream(std::string_view json) {
 }
 
 ss::sstring iobuf_to_string(iobuf buf) {
-    auto input_stream = make_iobuf_input_stream(std::move(buf));
-    return ss::util::read_entire_stream_contiguous(input_stream).get();
+    iobuf_parser parser{std::move(buf)};
+    return parser.read_string_unsafe(parser.bytes_left());
 }
 
 } // namespace

--- a/src/v/strings/tests/BUILD
+++ b/src/v/strings/tests/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_btest_no_seastar(
         "static_str_test.cc",
         "string_switch_test.cc",
         "utf8_control_chars.cc",
+        "utf8_substring.cc",
     ],
     deps = [
         "//src/v/strings:static_str",

--- a/src/v/strings/tests/utf8_substring.cc
+++ b/src/v/strings/tests/utf8_substring.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "strings/utf8.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(substring_tests) {
+    {
+        // compiler thinks that ascii_string is unused
+        [[maybe_unused]] const std::string_view ascii_string
+          = " !\"#$%&'()*+,-./"
+            "0123456789:;<=>?@ABCDEFHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+            "abcdefghijklmnopqrstuvwxyz{|}~";
+        BOOST_ASSERT(
+          validate_and_truncate(ascii_string) == ascii_string.size());
+    }
+
+    {
+        // get a string made of two byte glyphs
+        const std::string_view multi_byte_string = "۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩۩";
+
+        // chop the last glyph in half
+        [[maybe_unused]] const auto ragged_view = multi_byte_string.substr(
+          0, multi_byte_string.size() - 1);
+
+        // make sure that the entire glyph was removed
+        BOOST_ASSERT(
+          validate_and_truncate(ragged_view) == multi_byte_string.size() - 2);
+    }
+
+    {
+        // invalid character start sequence
+        static constexpr const char invalid_array[2] = {(char)-128, '\0'};
+        auto invalid_str = static_cast<const char*>(invalid_array);
+        std::string hello{"hello"};
+        std::string world{"world"};
+        hello.append(invalid_str);
+        hello.append(world);
+        BOOST_CHECK_THROW(validate_and_truncate(hello), invalid_utf8_exception);
+    }
+}

--- a/src/v/strings/utf8.h
+++ b/src/v/strings/utf8.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/likely.h"
+#include "base/seastarx.h"
 
 #include <boost/locale.hpp>
 #include <boost/locale/encoding_utf.hpp>
@@ -112,6 +113,29 @@ void validate_no_control(std::string_view s, ExceptionThrower auto thrower) {
 
 inline void validate_no_control(std::string_view s) {
     validate_no_control(s, default_control_character_thrower{});
+}
+
+/// \brief Truncates incomplete character sequences from the provided string.
+/// Throws on invalid character sequences hence also validates
+/// \param s a string view to validate_and_truncate
+/// \return the length of the longest valid utf8 substring starting at s.begin()
+inline size_t validate_and_truncate(std::string_view s) {
+    auto begin = s.cbegin();
+    auto end = s.cend();
+
+    size_t valid_length{0};
+    while (begin != end) {
+        const boost::locale::utf::code_point c
+          = boost::locale::utf::utf_traits<char>::decode(begin, end);
+        if (c == boost::locale::utf::illegal) {
+            throw invalid_utf8_exception("Cannot decode string as UTF8");
+        }
+        if (c == boost::locale::utf::incomplete) {
+            return valid_length;
+        }
+        valid_length = (begin - s.cbegin());
+    }
+    return valid_length;
 }
 
 template<typename Thrower>


### PR DESCRIPTION
Allows safely reading a fragment of a utf8 string from and iobuf. Naive truncation of a utf8 string could cut in the middle of a character sequence.

This adds a utf utility to find the longest valid string under a given size, and iobuf_parser::read_incomplete_string to read and consume a size limited utf string from an iobuf

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
