### PR TITLE
[backport v25.1.x] datalake: add default partition spec kludge for AWS Glue

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4096,7 +4096,9 @@ configuration::configuration()
       "iceberg_default_partition_spec",
       "Default value for the redpanda.iceberg.partition.spec topic property "
       "that determines the partition spec for the Iceberg table corresponding "
-      "to the topic.",
+      "to the topic. If this property is not set and AWS Glue is being used as "
+      "the Iceberg REST catalog, the default value will be overridden by an "
+      "empty partition spec, for compatibility with AWS Glue.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       "(hour(redpanda.timestamp))",
       &validate_iceberg_partition_spec)

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -442,9 +442,8 @@ struct coordinator::main_table_schema_provider
 
     ss::sstring
     get_partition_spec(const cluster::topic_metadata& topic_md) const final {
-        return topic_md.get_configuration()
-          .properties.iceberg_partition_spec.value_or(
-            parent.default_partition_spec_());
+        return parent.get_effective_default_partition_spec(
+          topic_md.get_configuration().properties.iceberg_partition_spec);
     }
 
     const coordinator& parent;
@@ -496,7 +495,7 @@ struct coordinator::dlq_table_schema_provider
     }
 
     ss::sstring get_partition_spec(const cluster::topic_metadata&) const final {
-        return parent.default_partition_spec_();
+        return parent.get_effective_default_partition_spec(std::nullopt);
     }
 
     const coordinator& parent;
@@ -827,4 +826,28 @@ coordinator::update_lifecycle_state(
     co_return ss::stop_iteration::no;
 }
 
+ss::sstring coordinator::get_effective_default_partition_spec(
+  const std::optional<ss::sstring>& partition_spec) const {
+    const auto& cfg = config::shard_local_cfg();
+    auto current_spec = partition_spec.value_or(default_partition_spec_());
+
+    bool is_glue = cfg.iceberg_catalog_type()
+                     == config::datalake_catalog_type::rest
+                   && cfg.iceberg_rest_catalog_authentication_mode()
+                        == config::datalake_catalog_auth_mode::aws_sigv4
+                   && cfg.iceberg_rest_catalog_aws_service_name().value_or("")
+                        == "glue";
+    if (
+      is_glue
+      && current_spec == cfg.iceberg_default_partition_spec.default_value()) {
+        // Glue can't partition on nested fields like redpanda.timestamp.
+        vlog(
+          datalake_log.warn,
+          "Overriding default partition spec to '()' for AWS Glue "
+          "compatibility");
+        return "()";
+    }
+
+    return current_spec;
+}
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -142,6 +142,11 @@ private:
       std::string_view method_name,
       const table_schema_provider&);
 
+    // Get the effective default partition spec.
+    // This is an AWS Glue compatibility kludge.
+    ss::sstring get_effective_default_partition_spec(
+      const std::optional<ss::sstring>& partition_spec) const;
+
     ss::shared_ptr<coordinator_stm> stm_;
     cluster::topic_table& topic_table_;
     type_resolver& type_resolver_;


### PR DESCRIPTION
AWS Glue does not support partitioning on nested fields, which means it does not support partitioning on the default `(hour(redpanda.timestamp))` partition spec. In fact, trying to use a partition spec on a nested fields causes 500 errors from Glue on catalog operations. To work around this, default the partition spec to empty `()` when we detect we're using AWS Glue as the Iceberg REST catalog.

Backport note: fixed a trivial conflict in coordinator.cc.

(cherry picked from commit 962b5afc95fc7774639f4d36836e7ef035034216)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
