### PR TITLE
ct/l1: metastore replace_objects interface

### DIFF
--- a/src/v/cloud_topics/level_one/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore.h
@@ -87,6 +87,17 @@ public:
     virtual ss::future<std::expected<void, errc>>
     add_objects(const chunked_vector<object_metadata>&) = 0;
 
+    // Adds the given objects to the metastore, expecting that the new extents
+    // replace an extent or set of extents covering the same range.
+    // It is expected that the set of new extents per partition covers a
+    // contiguous range of that partition's offset space.
+    //
+    // While these constraints aren't the only way we could ensure
+    // correctness, these simplify accounting and makes it easier to validate
+    // that we haven't lost data.
+    virtual ss::future<std::expected<void, errc>>
+    replace_objects(const chunked_vector<object_metadata>&) = 0;
+
     // Finds the first object of a given partition with data greater than or
     // equal to the given offset. If no such offset exists, returns
     // `out_of_range`.

--- a/src/v/cloud_topics/level_one/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/simple_metastore.cc
@@ -60,6 +60,23 @@ simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
     co_return std::expected<void, metastore::errc>{};
 }
 
+ss::future<std::expected<void, metastore::errc>>
+simple_metastore::replace_objects(
+  const chunked_vector<object_metadata>& objects) {
+    chunked_vector<new_object> new_objects;
+    for (const auto& o : objects) {
+        new_objects.emplace_back(make_new_object(o));
+    }
+    auto update_res = replace_objects_update::build(
+      state_, std::move(new_objects));
+    if (!update_res.has_value()) {
+        co_return std::unexpected(metastore::errc::invalid_request);
+    }
+    auto apply_res = update_res->apply(state_);
+    vassert(apply_res.has_value(), "Apply must succeed if can_apply() is true");
+    co_return std::expected<void, metastore::errc>{};
+}
+
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 simple_metastore::get_first_ge(
   const model::topic_id_partition& tpr, kafka::offset o) {

--- a/src/v/cloud_topics/level_one/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/simple_metastore.h
@@ -27,6 +27,9 @@ public:
     ss::future<std::expected<void, errc>>
     add_objects(const chunked_vector<object_metadata>&) override;
 
+    ss::future<std::expected<void, errc>>
+    replace_objects(const chunked_vector<object_metadata>&) override;
+
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;
 

--- a/src/v/cloud_topics/level_one/state.h
+++ b/src/v/cloud_topics/level_one/state.h
@@ -63,9 +63,10 @@ struct partition_state
     // allows us to perform efficient lookups by offset.
     // Using a set here allows us to:
     // - perform efficient lookups by offset
-    // - remove elements from the begining e.g. for prefix truncation
+    // - remove elements from the beginning e.g. for prefix truncation
     // - replace ranges in the middle with new extents e.g. for compaction
-    absl::btree_set<extent> extents;
+    using extent_set_t = absl::btree_set<extent>;
+    extent_set_t extents;
 
     // The start offset of the partition. This may not align with the front of
     // `extents` if the offset was set through the Kafka API.

--- a/src/v/cloud_topics/level_one/state_update.cc
+++ b/src/v/cloud_topics/level_one/state_update.cc
@@ -13,6 +13,33 @@
 
 namespace experimental::cloud_topics::l1 {
 
+namespace {
+
+using extent_iter_t = partition_state::extent_set_t::const_iterator;
+struct extent_range {
+    extent_iter_t base_it;
+    extent_iter_t last_it;
+};
+std::optional<extent_range> get_range(
+  const partition_state::extent_set_t& extents,
+  kafka::offset base,
+  kafka::offset last) {
+    auto base_it = std::ranges::lower_bound(
+      extents, base, std::less<>{}, &extent::base_offset);
+    if (base_it == extents.end() || base_it->base_offset != base) {
+        return std::nullopt;
+    }
+    // Check that the range's last offset aligns with an existing extent.
+    auto last_it = std::ranges::lower_bound(
+      extents, last, std::less<>{}, &extent::last_offset);
+    if (last_it == extents.end() || last_it->last_offset != last) {
+        return std::nullopt;
+    }
+    return extent_range{base_it, last_it};
+}
+
+} // namespace
+
 void new_object::collect_extents_by_tidp(sorted_extents_by_tidp_t* ret) const {
     for (const auto& [tid, p_extents] : extent_metas) {
         for (const auto& [p, extent_meta] : p_extents) {
@@ -108,6 +135,117 @@ add_objects_update::apply(state& state) {
         }
     }
     return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+replace_objects_update::can_apply(const state& state) {
+    if (new_objects.empty()) {
+        return std::unexpected(stm_update_error{"No objects requested"});
+    }
+    new_object::sorted_extents_by_tidp_t new_extents_by_tp;
+    for (const auto& o : new_objects) {
+        if (state.objects.contains(o.oid)) {
+            return std::unexpected(
+              stm_update_error{fmt::format("Object {} already exists", o.oid)});
+        }
+        o.collect_extents_by_tidp(&new_extents_by_tp);
+    }
+
+    for (const auto& [tidp, new_prt_extents] : new_extents_by_tp) {
+        auto req_base = new_prt_extents.begin()->base_offset;
+        auto req_last = std::prev(new_prt_extents.end())->last_offset;
+
+        auto p_state = state.partition_state(tidp);
+        if (!p_state) {
+            return std::unexpected(stm_update_error(
+              fmt::format("Partition {} not tracked by state", tidp)));
+        }
+
+        // Check that the new range's offset aligns with existing extents.
+        const auto& prt = p_state->get();
+        auto iters = get_range(prt.extents, req_base, req_last);
+        if (!iters.has_value()) {
+            return std::unexpected(stm_update_error(fmt::format(
+              "Partition {} doesn't contain extents that span exactly [{}, {}]",
+              tidp,
+              req_base,
+              req_last)));
+        }
+
+        // Check that the new range of extents is contiguous, which in turn
+        // ensures the resulting total set of extents will be contiguous.
+        const auto& [base_it, last_it] = *iters;
+        auto expected_next = base_it->base_offset;
+        for (const auto& new_extent : new_prt_extents) {
+            if (new_extent.base_offset != expected_next) {
+                return std::unexpected(stm_update_error(fmt::format(
+                  "Input object breaks partition {} offset ordering: expected "
+                  "next: {}, actual: {}",
+                  tidp,
+                  expected_next,
+                  new_extent.base_offset)));
+            }
+            expected_next = kafka::next_offset(new_extent.last_offset);
+        }
+    }
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+replace_objects_update::apply(state& state) {
+    auto allowed = can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    new_object::sorted_extents_by_tidp_t new_extents_by_tp;
+    for (const auto& o : new_objects) {
+        o.collect_extents_by_tidp(&new_extents_by_tp);
+        state.objects.emplace(
+          o.oid,
+          object_entry{
+            .total_data_size = 0,
+            .removed_data_size = 0,
+            .footer_pos = o.footer_pos,
+          });
+    }
+    for (const auto& [tidp, new_extents] : new_extents_by_tp) {
+        auto& p_state
+          = state.topic_to_state[tidp.topic_id].pid_to_state[tidp.partition];
+        auto requested_base = new_extents.begin()->base_offset;
+        auto requested_last = new_extents.rbegin()->last_offset;
+        auto iters = get_range(p_state.extents, requested_base, requested_last);
+        auto [base_it, last_it] = *iters;
+        auto end_it = std::next(last_it);
+        for (auto iter = base_it; iter != end_it; ++iter) {
+            auto& old_extent = *iter;
+            state.objects[old_extent.oid].removed_data_size += old_extent.len;
+        }
+
+        p_state.extents.erase(base_it, end_it);
+        for (const auto& e : new_extents) {
+            p_state.extents.emplace(e);
+        }
+        // NOTE: we don't need to update the start or next offsets since we've
+        // validated that the new extents replace exact ranges.
+
+        for (const auto& extent : new_extents) {
+            state.objects[extent.oid].total_data_size += extent.len;
+        }
+    }
+    return std::monostate{};
+}
+
+std::expected<replace_objects_update, stm_update_error>
+replace_objects_update::build(
+  const state& state, chunked_vector<new_object> objects) {
+    replace_objects_update update{
+      .new_objects = std::move(objects),
+    };
+    auto allowed = update.can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    return update;
 }
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/state_update.h
+++ b/src/v/cloud_topics/level_one/state_update.h
@@ -22,6 +22,7 @@ namespace experimental::cloud_topics::l1 {
 
 enum class update_key : uint8_t {
     add_objects = 0,
+    replace_objects = 1,
 };
 
 using stm_update_error = named_type<ss::sstring, struct update_error_tag>;
@@ -80,6 +81,26 @@ struct add_objects_update
     chunked_vector<new_object> new_objects;
 };
 
+struct replace_objects_update
+  : public serde::envelope<
+      replace_objects_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool
+    operator==(const replace_objects_update&, const replace_objects_update&)
+      = default;
+    auto serde_fields() { return std::tie(new_objects); }
+
+    static constexpr auto key{update_key::replace_objects};
+    static std::expected<replace_objects_update, stm_update_error>
+    build(const state&, chunked_vector<new_object>);
+
+    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> apply(state&);
+
+    chunked_vector<new_object> new_objects;
+};
+
 } // namespace experimental::cloud_topics::l1
 
 template<>
@@ -92,6 +113,8 @@ struct fmt::formatter<experimental::cloud_topics::l1::update_key> final
         switch (k) {
         case experimental::cloud_topics::l1::update_key::add_objects:
             return formatter<string_view>::format("add_objects", ctx);
+        case experimental::cloud_topics::l1::update_key::replace_objects:
+            return formatter<string_view>::format("replace_objects", ctx);
         }
     }
 };

--- a/src/v/cloud_topics/level_one/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/tests/simple_metastore_test.cc
@@ -317,3 +317,257 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampOutOfRange) {
     ASSERT_FALSE(get_res.has_value());
     ASSERT_EQ(metastore::errc::out_of_range, get_res.error());
 }
+
+TEST(StateUpdateTest, TestReplaceBasic) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    om_list_t new_os;
+    new_os.emplace_back(
+      om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    auto replace_res = m.replace_objects(new_os).get();
+    ASSERT_TRUE(replace_res.has_value());
+
+    // Sanity check that replacement leaves us with expected offsets.
+    auto offsets_res
+      = m.get_offsets(model::topic_id_partition::from(tid_a)).get();
+    ASSERT_TRUE(offsets_res.has_value());
+    ASSERT_EQ(0_o, offsets_res->start_offset);
+    ASSERT_EQ(11_o, offsets_res->next_offset);
+}
+
+TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(om_builder(oid1, 100)
+                      .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                      .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100)
+                      .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                      .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
+                      .build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    om_list_t new_os;
+    new_os.emplace_back(
+      om_builder(oid3, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+    auto replace_res = m.replace_objects(new_os).get();
+    ASSERT_TRUE(replace_res.has_value());
+
+    // Replaced offsets should be served from oid3.
+    auto tpr = model::topic_id_partition::from(tid_a);
+    for (const auto& o : std::views::iota(0, 21)) {
+        auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid3);
+        ASSERT_EQ(get_res->footer_pos, 100);
+    }
+    // Others should be served from oid1 or oid2.
+    tpr = model::topic_id_partition::from(tid_b);
+    for (const auto& o : std::views::iota(0, 11)) {
+        auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid1);
+        ASSERT_EQ(get_res->footer_pos, 100);
+    }
+    for (const auto& o : std::views::iota(11, 21)) {
+        auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid2);
+        ASSERT_EQ(get_res->footer_pos, 100);
+    }
+    // Sanity check that replacement leaves us with expected offsets.
+    for (const auto& tid : {tid_a, tid_b}) {
+        auto offsets_res
+          = m.get_offsets(model::topic_id_partition::from(tid)).get();
+        ASSERT_TRUE(offsets_res.has_value());
+        ASSERT_EQ(0_o, offsets_res->start_offset);
+        ASSERT_EQ(21_o, offsets_res->next_offset);
+    }
+}
+
+TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(om_builder(oid1, 100)
+                      .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                      .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100)
+                      .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                      .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
+                      .build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // For one partition, replace the entire range. For another, replace part
+    // of the range. As long as they're both aligned this should succeed.
+    om_list_t new_os;
+    new_os.emplace_back(om_builder(oid3, 100)
+                          .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
+                          .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
+                          .build());
+    auto replace_res = m.replace_objects(new_os).get();
+    ASSERT_TRUE(replace_res.has_value());
+
+    // Replaced offsets should be served from oid3.
+    auto tpr = model::topic_id_partition::from(tid_a);
+    for (const auto& o : std::views::iota(0, 21)) {
+        auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid3);
+        ASSERT_EQ(get_res->footer_pos, 100);
+    }
+    tpr = model::topic_id_partition::from(tid_b);
+    for (const auto& o : std::views::iota(11, 21)) {
+        auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid3);
+        ASSERT_EQ(get_res->footer_pos, 100);
+    }
+    // Others should be served from oid1 or oid2.
+    for (const auto& o : std::views::iota(0, 11)) {
+        auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid1);
+        ASSERT_EQ(get_res->footer_pos, 100);
+    }
+    // Sanity check that replacement leaves us with expected offsets.
+    for (const auto& tid : {tid_a, tid_b}) {
+        auto offsets_res
+          = m.get_offsets(model::topic_id_partition::from(tid)).get();
+        ASSERT_TRUE(offsets_res.has_value());
+        ASSERT_EQ(0_o, offsets_res->start_offset);
+        ASSERT_EQ(21_o, offsets_res->next_offset);
+    }
+}
+
+TEST(StateUpdateTest, TestReplaceEmptyRequest) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Add a replacement object that has no objects.
+    om_list_t new_os;
+    auto replace_res = m.replace_objects(new_os).get();
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+}
+
+TEST(StateUpdateTest, TestReplaceEmptyState) {
+    simple_metastore m;
+    {
+        // Add a replacement object that has no objects.
+        om_list_t new_os;
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+    {
+        // Now try with an actual object. It should be rejected.
+        om_list_t new_os;
+        new_os.emplace_back(
+          om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+}
+
+TEST(StateUpdateTest, TestReplaceMisaligned) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    for (const auto& [base_o, last_o] :
+         std::initializer_list<std::pair<kafka::offset, kafka::offset>>{
+           {0_o, 11_o}, {1_o, 11_o}, {1_o, 10_o}, {1_o, 9_o}}) {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid2, 100)
+                              .add(tid_a, base_o, last_o, 2000_t, 0, 99)
+                              .build());
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+}
+
+TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    {
+        // Even though one extent overlaps, the complete range for tid_a does
+        // not align.
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid2, 100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .add(tid_a, 11_o, 12_o, 2000_t, 0, 99)
+                              .build());
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+    {
+        // Even though tid_a overlaps exactly, tid_b does not exist.
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid2, 100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+}
+
+TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(om_builder(oid1, 100)
+                      .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                      .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid2, 100)
+                      .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                      .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
+                      .build());
+    auto add_res = m.add_objects(os).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    {
+        om_list_t new_os;
+        new_os.emplace_back(
+          om_builder(oid3, 100).add(tid_a, 0_o, 19_o, 2000_t, 0, 99).build());
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+    {
+        // Even though tid_a overlaps exactly, tid_b is misaligned.
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid3, 100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .add(tid_b, 0_o, 19_o, 2000_t, 0, 99)
+                              .build());
+        auto replace_res = m.replace_objects(new_os).get();
+        ASSERT_FALSE(replace_res.has_value());
+        EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
+    }
+}

--- a/src/v/cloud_topics/level_one/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/tests/state_update_test.cc
@@ -12,10 +12,10 @@
 #include "absl/strings/str_split.h"
 #include "cloud_topics/level_one/state_update.h"
 #include "cloud_topics/types.h"
+#include "gmock/gmock.h"
 #include "model/fundamental.h"
 #include "utils/uuid.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace experimental::cloud_topics;
@@ -24,6 +24,7 @@ using namespace experimental::cloud_topics::l1;
 namespace {
 const object_id oid1{uuid_t::create()};
 const object_id oid2{uuid_t::create()};
+const object_id oid3{uuid_t::create()};
 const std::string_view tidp_a = "deadbeef-aaaa-0000-0000-000000000000/0";
 const std::string_view tidp_b = "deadbeef-bbbb-0000-0000-000000000000/0";
 const std::string_view tidp_c = "deadbeef-cccc-0000-0000-000000000000/0";
@@ -78,6 +79,18 @@ public:
 
 private:
     add_objects_update out;
+};
+
+struct replace_objects_builder {
+public:
+    replace_objects_builder& add(new_object o) {
+        out.new_objects.emplace_back(std::move(o));
+        return *this;
+    }
+    replace_objects_update build() { return std::move(out); }
+
+private:
+    replace_objects_update out;
 };
 } // namespace
 
@@ -194,4 +207,174 @@ TEST(StateUpdateTest, TestDuplicateAddMultipleUpdates) {
       dupe_res.error()(), testing::HasSubstr("Input object breaks partition"))
       << dupe_res.error();
     EXPECT_EQ(1, s.objects.size());
+}
+
+namespace {
+
+MATCHER_P3(MatchesRange, oid, base, last, "") {
+    return arg.oid == oid && arg.base_offset == base && arg.last_offset == last;
+}
+} // namespace
+
+TEST(StateUpdateTest, TestReplaceBasic) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 300)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
+                        .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
+                        .build())
+                 .add(new_obj_builder(oid2, 100)
+                        .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                        .add(tidp_c, 11_o, 20_o, 1999_t, 0, 99)
+                        .build())
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    // Fully replace partition a, partially replace c.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid3, 100)
+                            .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
+                            .add(tidp_c, 0_o, 10_o, 1999_t, 100, 199)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    // Fully replaced.
+    const auto& prt_a
+      = s.partition_state(model::topic_id_partition::from(tidp_a))->get();
+    EXPECT_THAT(prt_a.extents, ElementsAre(MatchesRange(oid3, 0_o, 20_o)));
+
+    // Not replaced.
+    const auto& prt_b
+      = s.partition_state(model::topic_id_partition::from(tidp_b))->get();
+    EXPECT_THAT(prt_b.extents, ElementsAre(MatchesRange(oid1, 0_o, 10_o)));
+
+    // Partially replaced.
+    const auto& prt_c
+      = s.partition_state(model::topic_id_partition::from(tidp_c))->get();
+    EXPECT_THAT(
+      prt_c.extents,
+      ElementsAre(
+        MatchesRange(oid3, 0_o, 10_o), MatchesRange(oid2, 11_o, 20_o)));
+
+    EXPECT_EQ(s.objects.at(oid1).removed_data_size, 198);
+    EXPECT_EQ(s.objects.at(oid2).removed_data_size, 99);
+    EXPECT_EQ(s.objects.at(oid3).removed_data_size, 0);
+}
+
+TEST(StateUpdateTest, TestReplaceEmptyState) {
+    state s;
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid1, 100)
+                            .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex("Partition .+ not tracked by state"));
+}
+
+TEST(StateUpdateTest, TestReplaceDuplicate) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid1, 100)
+                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex("Object .+ already exists"));
+}
+
+TEST(StateUpdateTest, TestReplaceMisaligned) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid2, 100)
+                            .add(tidp_a, 0_o, 9_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex(
+        "Partition .+ doesn't contain extents that span exactly"));
+}
+
+TEST(StateUpdateTest, TestReplaceBadOrdering) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    // Make the replacement overlap with itself.
+    auto replace = replace_objects_builder()
+                     .add(new_obj_builder(oid2, 100)
+                            .add(tidp_a, 0_o, 7_o, 1999_t, 0, 99)
+                            .build())
+                     .add(new_obj_builder(oid3, 100)
+                            .add(tidp_a, 5_o, 10_o, 1999_t, 0, 99)
+                            .build())
+                     .build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::ContainsRegex("breaks partition .+ offset ordering"));
+}
+
+TEST(StateUpdateTest, TestEmptyReplace) {
+    using testing::ElementsAre;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .build();
+    state s;
+    auto add_res = add.apply(s);
+    ASSERT_TRUE(add_res.has_value());
+
+    auto replace = replace_objects_builder().build();
+
+    auto replace_res = replace.apply(s);
+    ASSERT_FALSE(replace_res.has_value());
+    EXPECT_THAT(
+      std::string(replace_res.error()()),
+      testing::StrEq("No objects requested"));
 }


### PR DESCRIPTION
Adds an interface to the metastore that allows callers to replace extents with new extents that point to new objects.

Note, this commit only includes the interface for a simple replacement of extents with no constraints other than offset boundary checks. This may be used during leveling, but is not sufficient for compaction without additional accounting, to come in a later change.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
