### PR TITLE
kc/tests: fixed test failing to build after the merge

### DIFF
--- a/src/v/kafka/client/test/cluster_test.cc
+++ b/src/v/kafka/client/test/cluster_test.cc
@@ -210,11 +210,9 @@ TEST_F(ClusterFixture, TestDispatchingMultipleRequests) {
                          test_batch(i),
                          acks_all);
                    })
-                 | std::views::transform([&](auto&& req) {
-                       return cluster
-                         .dispatch_to(
-                           leader_id, std::forward<decltype(req)>(req))
-                         .then([](auto&&) { return; });
+                 | std::views::transform([&](kafka::produce_request req) {
+                       return cluster.dispatch_to(*leader_id, std::move(req))
+                         .discard_result();
                    });
     ss::when_all_succeed(std::ranges::to<std::vector<ss::future<>>>(range))
       .get();


### PR DESCRIPTION
In one of the PRs the `topic_cache::get_leader` was changed to return an optional. Before that the method was throwing an exception when the leader was not present. The test was added before the optional change but the optional change PR was built without the test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
