### PR TITLE
CORE-7664 c/self_check: fix list pagination handling

### DIFF
--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -235,6 +235,10 @@ public:
     /// requests. It is also important to note that the value for max_keys will
     /// be capped by the cloud provider default (which may vary between
     /// providers, e.g AWS has a limit of 1000 keys per ListObjects request).
+    /// The result may also contain less than max_keys (or even no results) even
+    /// though there is data if the continuation_token is followed. Use the
+    /// is_truncated field in the result to see if there is more data to be
+    /// fetched.
     /// \param continuation_token The token hopefully passed back to the user
     /// from a prior list_objects() request, in the case that they are handling
     /// a truncated result manually.

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -160,7 +160,7 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
       = (is_uploaded) ? self_test_prefix
                       : std::optional<cloud_storage_clients::object_key>{};
     auto list_test_result_pair = co_await do_run_test(
-      &cloudcheck::verify_list, bucket, list_prefix, 1);
+      &cloudcheck::verify_list, bucket, list_prefix);
     auto& [object_list, list_test_result] = list_test_result_pair;
     if (is_uploaded && object_list) {
         // Check that uploaded object exists in object_list contents.
@@ -311,8 +311,7 @@ ss::future<cloudcheck::verify_upload_result> cloudcheck::verify_upload(
 
 ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
   cloud_storage_clients::bucket_name bucket,
-  std::optional<cloud_storage_clients::object_key> prefix,
-  size_t max_keys) {
+  std::optional<cloud_storage_clients::object_key> prefix) {
     auto result = self_test_result{
       .name = _opts.name, .info = "List", .test_type = "cloud"};
 
@@ -326,7 +325,7 @@ ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
         auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
         const cloud_storage::remote::list_result object_list
           = co_await _cloud_storage_api.local().list_objects(
-            bucket, rtc, prefix, std::nullopt, std::nullopt, max_keys);
+            bucket, rtc, prefix, std::nullopt, std::nullopt, std::nullopt);
 
         if (!object_list) {
             result.error = "Failed to list objects in cloud storage.";

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -106,8 +106,7 @@ private:
     // Verify that listing (List: read operation) from cloud storage works.
     ss::future<verify_list_result> verify_list(
       cloud_storage_clients::bucket_name bucket,
-      std::optional<cloud_storage_clients::object_key> prefix,
-      size_t max_keys = num_default_objects);
+      std::optional<cloud_storage_clients::object_key> prefix);
 
     struct verify_head_result {
         self_test_result test_result;

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -345,5 +345,18 @@ class SelfTestTest(EndToEndTest):
                 if result['test_type'] in unknown_checks_map[node]:
                     assert 'error' in result
                 else:
-                    assert 'error' not in result
+                    if 'error' in result:
+                        if (result['error'] ==
+                                'Uploaded key/payload could not be found in cloud storage item list.'
+                                and result.get('test_type', '') == 'cloud'
+                                and result.get('info', '') == 'List'):
+                            # On Azure we had flakiness for these versions where a later List Blob
+                            # request would not see the upload result of a Put Blob because of a
+                            # bug in the redpanda's self check logic. To avoid this flakiness,
+                            # explicitly ignore these errors in this case.
+                            pass
+                        else:
+                            # Any other error is not allowed
+                            assert False, f"Unexpected error in result: {result}"
+
                     assert 'warning' not in result


### PR DESCRIPTION
Azure ABS treats pagination quite "flexibly" and the ABS API sometimes responds to List Blob requests with an empty list of results + a continuation token for more results, prompting the user to try again for more data.

This lead to a bug in redpanda's self check logic, where the self check would fail when as part of one of the checks, it saw that the incomplete List Blob response did not contain the earlier uploaded object that it would have expected to see in the List Blob response.

This was highlighted by flakiness in Azure CDT.

Ref: https://learn.microsoft.com/en-us/answers/questions/1330367/rest-api-not-returning-blobs-within-container

I've tested on https://github.com/redpanda-data/redpanda/pull/26629 with some added logging that we were hitting the problem described above:

```
TRACE 2025-06-27 12:04:21,860 [shard 0:st  ] http - [/panda-container-cd8b4f32-534e-11f0-a04e-858e833bec81?restype=container&comp=list&prefix=self-test-3-9aa0852c-a4c0-4e18-87ec-78320635c8fb/&maxresults=1&showonly=files] - client.cc:125 - client.make_request GET /panda-container-cd8b4f32-534e-11f0-a04e-858e833bec81?restype=container&comp=list&prefix=self-test-3-9aa0852c-a4c0-4e18-87ec-78320635c8fb/&maxresults=1&showonly=files HTTP/1.1
Host: cdtstrg171828976234.blob.core.windows.net
x-ms-date: Fri, 27 Jun 2025 12:04:21 GMT
x-ms-version: 2023-01-03
Authorization: [secret]
INFO  2025-06-27 12:04:21,865 [shard 0:st  ] cluster - cloudcheck.cc:183 - Self test 'List' returned: size=0, truncated=true, next_continuation_token=...
```

With the fix in this PR, the CI failures described above are gone. (Note that there is another issue causing flakiness for this test, where DNS lookups are taking 5 seconds while trying to connect to ABS, which I am still investigating.)

Ref https://redpandadata.atlassian.net/browse/CORE-7664

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

### Bug Fixes
* This fixes a bug in Redpanda's self-check functionality, where the self-check would occasionally fail with 'Uploaded key/payload could not be found in cloud storage item list.' despite the object being successfully uploaded. This issue occurred when testing against an Azure ABS tiered storage endpoint.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
