### PR TITLE
Change batch size estimate in fetch handler

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3796,14 +3796,7 @@ configuration::configuration()
       0.5,
       {.min = 0.0, .max = 1.0})
   , kafka_memory_batch_size_estimate_for_fetch(
-      *this,
-      "kafka_memory_batch_size_estimate_for_fetch",
-      "The size of the batch used to estimate memory consumption for fetch "
-      "requests, in bytes. Smaller sizes allow more concurrent fetch requests "
-      "per shard. Larger sizes prevent running out of memory because of too "
-      "many concurrent fetch requests.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1_MiB)
+      *this, "kafka_memory_batch_size_estimate_for_fetch")
   , cpu_profiler_enabled(
       *this,
       "cpu_profiler_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -702,7 +702,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> max_in_flight_pandaproxy_requests_per_shard;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
-    property<size_t> kafka_memory_batch_size_estimate_for_fetch;
+    deprecated_property kafka_memory_batch_size_estimate_for_fetch;
     // debug controls
     property<bool> cpu_profiler_enabled;
     bounded_property<std::chrono::milliseconds> cpu_profiler_sample_period_ms;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -241,47 +241,46 @@ void read_result::memory_units_t::adopt(memory_units_t&& o) {
  * available resources: if none, there is no memory for the operation;
  * if less than \p max_bytes, the fetch should be capped to that size.
  *
- * \param max_bytes The limit of how much data is going to be fetched
- * \param obligatory_batch_read Set to true for the first ntp in the fetch
- *   fetch request, at least one batch must be fetched for that ntp. Also it
- *   is assumed that a batch size has already been consumed from kafka
- *   memory semaphore for it.
+ * \param max_units The maximum number of units the function will attempt to
+ * allocate.
+ * \param min_units The minimum number of units the function will attempt to
+ * allocate. If it can't allocate at least this many units no units will be
+ * allocated.
+ * \param require_min_units If true then at least \ref min_units will be
+ * allocated regardless of the units available in \ref memory_sem and \ref
+ * memory_fetch_sem.
  */
 static read_result::memory_units_t reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
-  const size_t max_bytes,
-  const size_t max_batch_size,
-  const bool obligatory_batch_read) {
-    read_result::memory_units_t memory_units;
-    const size_t memory_kafka_now = memory_sem.current();
-    const size_t memory_fetch = memory_fetch_sem.current();
-    const size_t batch_size_estimate = max_batch_size;
+  size_t max_units,
+  const size_t min_units,
+  const bool require_min_units) {
+    const size_t available_units = std::min(
+      memory_sem.current(), memory_fetch_sem.current());
+    // Note that it's not currently enforced that max_units >= min_units. Hence
+    // we set max_units to the larger of the two here to ensure that is the
+    // case.
+    max_units = std::max(max_units, min_units);
 
-    if (obligatory_batch_read) {
-        // cap what we want at what we have, but no further down than a single
-        // batch size - with \ref obligatory_batch_read, it must be fetched
-        // regardless
-        const size_t fetch_size = std::max(
-          batch_size_estimate,
-          std::min({max_bytes, memory_kafka_now, memory_fetch}));
-        memory_units.fetch = ss::consume_units(memory_fetch_sem, fetch_size);
-        memory_units.kafka = ss::consume_units(memory_sem, fetch_size);
-    } else {
-        // max_bytes is how much we prepare to read from this ntp, but no less
-        // than one full batch
-        const size_t requested_fetch_size = std::max(
-          max_bytes, batch_size_estimate);
-        // cap what we want at what we have
-        const size_t fetch_size = std::min(
-          {requested_fetch_size, memory_kafka_now, memory_fetch});
-        // only reserve memory if we have space for at least one batch,
-        // otherwise this ntp will be skipped
-        if (fetch_size >= batch_size_estimate) {
-            memory_units.fetch = ss::consume_units(
-              memory_fetch_sem, fetch_size);
-            memory_units.kafka = ss::consume_units(memory_sem, fetch_size);
-        }
+    size_t units_to_alloc = 0;
+    if (require_min_units) {
+        // if \ref require_min_units is true then we must read at least \ref
+        // min_units. So allocate at least that many even if it causes the
+        // semaphores to become negative.
+        units_to_alloc = std::max(
+          min_units, std::min(max_units, available_units));
+    } else if (available_units >= min_units) {
+        // only reserve memory if we have space for at least \ref min_units,
+        // otherwise allocate none.
+        units_to_alloc = std::min(available_units, max_units);
+    }
+
+    read_result::memory_units_t memory_units;
+    if (units_to_alloc > 0) {
+        memory_units.fetch = ss::consume_units(
+          memory_fetch_sem, units_to_alloc);
+        memory_units.kafka = ss::consume_units(memory_sem, units_to_alloc);
     }
 
     return memory_units;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -251,12 +251,12 @@ static read_result::memory_units_t reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,
+  const size_t max_batch_size,
   const bool obligatory_batch_read) {
     read_result::memory_units_t memory_units;
     const size_t memory_kafka_now = memory_sem.current();
     const size_t memory_fetch = memory_fetch_sem.current();
-    const size_t batch_size_estimate
-      = config::shard_local_cfg().kafka_memory_batch_size_estimate_for_fetch();
+    const size_t batch_size_estimate = max_batch_size;
 
     if (obligatory_batch_read) {
         // cap what we want at what we have, but no further down than a single
@@ -336,6 +336,7 @@ static ss::future<read_result> do_read_from_ntp(
           memory_sem,
           memory_fetch_sem,
           ntp_config.cfg.max_bytes,
+          ntp_config.cfg.max_batch_size,
           obligatory_batch_read);
         if (!memory_units.fetch) {
             ntp_config.cfg.skip_read = true;
@@ -462,9 +463,14 @@ read_result::memory_units_t reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,
+  const size_t max_batch_size,
   const bool obligatory_batch_read) {
     return kafka::reserve_memory_units(
-      memory_sem, memory_fetch_sem, max_bytes, obligatory_batch_read);
+      memory_sem,
+      memory_fetch_sem,
+      max_bytes,
+      max_batch_size,
+      obligatory_batch_read);
 }
 
 } // namespace testing
@@ -1447,6 +1453,27 @@ class simple_fetch_planner final : public fetch_planner::impl {
                     error_code::invalid_topic_exception);
               }
 
+              const auto& topic_md = metadata_cache.get_topic_metadata_ref(
+                model::topic_namespace_view{model::kafka_namespace, topic});
+
+              if (!topic_md) {
+                  return fail_all_partitions(
+                    error_code::unknown_topic_or_partition);
+              }
+
+              const auto& topic_cfg = topic_md->get().get_configuration();
+              // Max batch size or `message.max.bytes` is a user configurable
+              // topic property that defines the max size of a batch that can be
+              // produced to any partition in the topic.
+              //
+              // It is used later in the fetch path to establish the minimum
+              // number of memory semaphore units that need to be allocated
+              // before reading a single batch from any of the topic's
+              // partitions.
+              const auto max_batch_size
+                = topic_cfg.properties.batch_max_bytes.value_or(
+                  metadata_cache.get_default_batch_max_bytes());
+
               for (const kafka::fetch_session_partition& fp : partitions) {
                   // if this is not an initial fetch we are allowed to skip
                   // partitions that already have an error or we have enough
@@ -1509,6 +1536,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       .start_offset = fp.fetch_offset,
                       .max_offset = model::model_limits<model::offset>::max(),
                       .max_bytes = max_bytes,
+                      .max_batch_size = max_batch_size,
                       .timeout = octx.deadline.value_or(model::no_timeout),
                       .current_leader_epoch = fp.current_leader_epoch,
                       .isolation_level = octx.request.data.isolation_level,

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -168,6 +168,7 @@ struct fetch_config {
     model::offset start_offset;
     model::offset max_offset;
     size_t max_bytes;
+    size_t max_batch_size;
     model::timeout_clock::time_point timeout;
     kafka::leader_epoch current_leader_epoch;
     model::isolation_level isolation_level;
@@ -182,11 +183,12 @@ struct fetch_config {
     friend std::ostream& operator<<(std::ostream& o, const fetch_config& cfg) {
         fmt::print(
           o,
-          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}, "skip_read": {}, "current_leader_epoch:" {}, "follower_read:" {}, "consumer_rack_id": {}, "abortable": {}, "aborted": {}, "client_address": {}}})",
+          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "max_batch_size": {}, "strict_max_bytes": {}, "skip_read": {}, "current_leader_epoch:" {}, "follower_read:" {}, "consumer_rack_id": {}, "abortable": {}, "aborted": {}, "client_address": {}}})",
           cfg.start_offset,
           cfg.max_offset,
           cfg.isolation_level,
           cfg.max_bytes,
+          cfg.max_batch_size,
           cfg.strict_max_bytes,
           cfg.skip_read,
           cfg.current_leader_epoch,
@@ -449,6 +451,7 @@ read_result::memory_units_t reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,
+  const size_t max_batch_size,
   const bool obligatory_batch_read);
 
 ss::future<> do_fetch(op_context& octx);

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -164,6 +164,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
           .start_offset = model::offset(0),
           .max_offset = model::model_limits<model::offset>::max(),
           .max_bytes = max_bytes,
+          .max_batch_size = 1_MiB,
           .timeout = model::no_timeout,
           .isolation_level = model::isolation_level::read_uncommitted,
         };

--- a/src/v/kafka/server/tests/fetch_unit_test.cc
+++ b/src/v/kafka/server/tests/fetch_unit_test.cc
@@ -37,6 +37,8 @@ BOOST_AUTO_TEST_CASE(reserve_memory_units_test) {
     using namespace std::chrono_literals;
     using r = reserve_mem_units_test_result;
 
+    static constexpr size_t batch_size = 1_MiB;
+
     // reserve memory units, return how many memory units have been reserved
     // from each memory semaphore
     ssx::semaphore memory_sem{100_MiB, "test_memory_sem"};
@@ -46,11 +48,13 @@ BOOST_AUTO_TEST_CASE(reserve_memory_units_test) {
         size_t max_bytes,
         bool obligatory_batch_read) -> reserve_mem_units_test_result {
         auto mu = kafka::testing::reserve_memory_units(
-          memory_sem, memory_fetch_sem, max_bytes, obligatory_batch_read);
+          memory_sem,
+          memory_fetch_sem,
+          max_bytes,
+          batch_size,
+          obligatory_batch_read);
         return {mu.kafka.count(), mu.fetch.count()};
     };
-
-    static constexpr size_t batch_size = 1_MiB;
 
     // below are test prerequisites, tests are done based on these assumptions
     // if these are not valid, the test needs a change


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR changes the batch size estimate from using the `kafka_memory_batch_size_estimate_for_fetch` cluster config to using the `message.max.bytes` topic config within the fetch handler. The main result of doing this will be that fetch concurrency will decrease when `message.max.bytes` increases. This in turn should reduce the number of times the fetch memory semaphore has to be overdrawn during obligatory batch reads.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
### Features
* Deprecates the `kafka_memory_batch_size_estimate_for_fetch` cluster config and introduces new batch size estimate logic to replace its use.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
