### PR TITLE
[CORE-12752] schema_registry: Rename ACL Operation from REMOVE to DELETE

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -163,7 +163,7 @@
             "ALL",
             "READ",
             "WRITE",
-            "REMOVE",
+            "DELETE",
             "DESCRIBE",
             "DESCRIBE_CONFIGS",
             "ALTER",

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -174,7 +174,7 @@ constexpr std::string_view to_string_view(acl_operation op) {
     case acl_operation::create:
         return "create";
     case acl_operation::remove:
-        return "remove";
+        return "delete";
     case acl_operation::alter:
         return "alter";
     case acl_operation::describe:

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5702,7 +5702,7 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
     """
 
     VALID_OPERATIONS = [
-        "READ", "WRITE", "CREATE", "REMOVE", "ALTER", "DESCRIBE",
+        "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE",
         "CLUSTER_ACTION", "DESCRIBE_CONFIGS", "ALTER_CONFIGS",
         "IDEMPOTENT_WRITE", "ALL"
     ]
@@ -6413,7 +6413,7 @@ class DeleteSubject(ACLTestEndpoint):
 
     def create_acl(self):
         return self.test._create_acl(self.test.subject, "SUBJECT", "LITERAL",
-                                     "REMOVE")
+                                     "DELETE")
 
 
 class DeleteSubjectVersion(ACLTestEndpoint):
@@ -6429,7 +6429,7 @@ class DeleteSubjectVersion(ACLTestEndpoint):
 
     def create_acl(self):
         return self.test._create_acl(self.test.subject, "SUBJECT", "LITERAL",
-                                     "REMOVE")
+                                     "DELETE")
 
 
 class CompatibilitySubjectVersion(ACLTestEndpoint):


### PR DESCRIPTION
Rename the operation for improved consistenmcy with the wider ecosystem

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
