### PR TITLE
[CORE-12729] debug/bundle: forward kubernetes env vars to rpk

### DIFF
--- a/src/v/debug_bundle/debug_bundle_service.cc
+++ b/src/v/debug_bundle/debug_bundle_service.cc
@@ -72,11 +72,17 @@ bool contains_sensitive_info(const ss::sstring& arg) {
     }
     return false;
 }
-void print_arguments(const std::vector<ss::sstring>& args) {
+void print_arguments(
+  const std::vector<ss::sstring>& args, const std::vector<ss::sstring>& env) {
     auto msg = boost::algorithm::join_if(args, " ", [](const ss::sstring& arg) {
         return !contains_sensitive_info(arg);
     });
-    vlog(lg.debug, "Starting RPK debug bundle: {}", msg);
+    ss::sstring cmd{};
+    if (!env.empty()) {
+        cmd += ss::format("{} ", fmt::join(env, " "));
+    }
+    cmd += ss::format("{}", msg);
+    vlog(lg.debug, "Starting RPK debug bundle: {}", cmd);
 }
 
 std::string form_debug_bundle_file_name(job_id_t job_id) {
@@ -329,14 +335,17 @@ ss::future<> service::stop() {
 }
 
 ss::future<result<void>> service::initiate_rpk_debug_bundle_collection(
-  job_id_t job_id, debug_bundle_parameters params) {
+  job_id_t job_id,
+  debug_bundle_parameters params,
+  std::vector<ss::sstring> env) {
     auto hold = _gate.hold();
     if (ss::this_shard_id() != service_shard) {
         co_return co_await container().invoke_on(
           service_shard,
-          [job_id, params = std::move(params)](service& s) mutable {
+          [job_id, params = std::move(params), env = std::move(env)](
+            service& s) mutable {
               return s.initiate_rpk_debug_bundle_collection(
-                job_id, std::move(params));
+                job_id, std::move(params), std::move(env));
           });
     }
     auto units = co_await _process_control_mutex.get_units();
@@ -394,14 +403,14 @@ ss::future<result<void>> service::initiate_rpk_debug_bundle_collection(
     }
     auto args = std::move(args_res.assume_value());
     if (lg.is_enabled(ss::log_level::debug)) {
-        print_arguments(args);
+        print_arguments(args, env);
     }
 
     try {
         _rpk_process = std::make_unique<debug_bundle_process>(
           job_id,
           co_await external_process::external_process::create_external_process(
-            std::move(args)),
+            std::move(args), std::move(env)),
           std::move(debug_bundle_file_path),
           std::move(process_output_path));
     } catch (const std::exception& e) {

--- a/src/v/debug_bundle/debug_bundle_service.h
+++ b/src/v/debug_bundle/debug_bundle_service.h
@@ -66,6 +66,7 @@ public:
      *
      * @param job_id The job ID
      * @param params the parameters
+     * @param env optional list of enviromental variables as KEY=VALUE
      * @return Result with possible error codes:
      * * error_code::debug_bundle_process_running
      * * error_code::invalid_parameters
@@ -73,7 +74,9 @@ public:
      * * error_code::internal_error
      */
     ss::future<result<void>> initiate_rpk_debug_bundle_collection(
-      job_id_t job_id, debug_bundle_parameters params);
+      job_id_t job_id,
+      debug_bundle_parameters params,
+      std::vector<ss::sstring> env = {});
 
     /**
      * @brief Attempts to cancel a running "rpk debug bundle" process

--- a/src/v/redpanda/admin/debug_bundle.cc
+++ b/src/v/redpanda/admin/debug_bundle.cc
@@ -32,6 +32,7 @@
 #include <fmt/core.h>
 #include <rapidjson/error/en.h>
 
+#include <algorithm>
 #include <charconv>
 #include <chrono>
 #include <sstream>
@@ -105,6 +106,27 @@ std::unique_ptr<ss::http::reply> make_error_body(
 std::unique_ptr<ss::http::reply> make_error_body(
   const debug_bundle::error_info& err, std::unique_ptr<ss::http::reply> rep) {
     return make_error_body(err.code(), err.message(), std::move(rep));
+}
+
+std::vector<ss::sstring> get_enviromental_vars() {
+    constexpr auto env_vars = std::to_array(
+      {"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT"});
+
+    const auto env_with_value = [](const char* var) {
+        auto value = std::getenv(var);
+        auto sv = (value == nullptr) ? ss::sstring{} : ss::sstring{value};
+        return std::make_pair(var, sv);
+    };
+
+    const auto has_value = [](const auto& p) { return !p.second.empty(); };
+
+    const auto format_var = [](const auto& p) {
+        return ss::format("{}={}", p.first, p.second);
+    };
+
+    return env_vars | std::views::transform(env_with_value)
+           | std::views::filter(has_value) | std::views::transform(format_var)
+           | std::ranges::to<std::vector>();
 }
 
 } // namespace
@@ -199,11 +221,13 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::post_debug_bundle(
           std::move(params).assume_error(), std::move(rep));
     }
 
+    std::vector<ss::sstring> env_vars = ::get_enviromental_vars();
     auto res = co_await _debug_bundle_service.local()
                  .initiate_rpk_debug_bundle_collection(
                    job_id.assume_value(),
                    std::move(params).assume_value().value_or(
-                     debug_bundle::debug_bundle_parameters{}));
+                     debug_bundle::debug_bundle_parameters{}),
+                   std::move(env_vars));
     if (res.has_error()) {
         co_return make_error_body(res.assume_error(), std::move(rep));
     }

--- a/tests/rptest/tests/debug_bundle_test.py
+++ b/tests/rptest/tests/debug_bundle_test.py
@@ -51,6 +51,11 @@ log_config = LoggingConfig('info',
                                'debug-bundle-service': 'trace'
                            })
 
+KUBERNETES_VARIABLES = {
+    "KUBERNETES_SERVICE_HOST": "INVALID_HOST",
+    "KUBERNETES_SERVICE_PORT": "INVALID_PORT",
+}
+
 
 class DebugBundleTestBase(RedpandaTest):
     debug_bundle_dir_config = "debug_bundle_storage_dir"
@@ -482,12 +487,18 @@ class DebugBundleTest(DebugBundleTestBase):
             node=node)
 
     @cluster(num_nodes=1)
-    def test_debug_bundle_parameters(self):
+    @matrix(env_variables=[{}, KUBERNETES_VARIABLES])
+    def test_debug_bundle_parameters(self, env_variables):
         """
         This test will verify that the debug bundle parameters are
         correctly parsed and passed to rpk
         """
         topic_name = "test_topic"
+
+        if env_variables:
+            self.redpanda.set_environment(env_variables)
+            self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
+                                                use_maintenance_mode=False)
 
         controller_logs_size_limit_bytes = 300 * 1024 * 1024
         cpu_profiler_wait_seconds = 15
@@ -524,7 +535,10 @@ class DebugBundleTest(DebugBundleTestBase):
 
         self._run_debug_bundle(job_id=job_id, node=node, config=params)
 
-        search_str = f'Starting RPK debug bundle: {self.redpanda.find_path_to_rpk()} debug bundle'
+        search_str = f'Starting RPK debug bundle:'
+        for k, v in env_variables.items():
+            search_str += f' {k}={v}'
+        search_str += f' {self.redpanda.find_path_to_rpk()} debug bundle'
         search_str += f' --output /var/lib/redpanda/data/debug-bundle/{str(job_id)}.zip'
         search_str += f' --verbose'
         search_str += f' --controller-logs-size-limit {controller_logs_size_limit_bytes}B'


### PR DESCRIPTION
Fixes: [CORE-12729](https://redpandadata.atlassian.net/browse/CORE-12729)

rpk is using the kubernetes environment variables while creating the debug bundle. Added forwarding the kubernetes environment variables when invoking rpk debug bundle through the admin api.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

* none



[CORE-12729]: https://redpandadata.atlassian.net/browse/CORE-12729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ