### PR TITLE
rptest: speed up cluster metadata listing

### DIFF
--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -852,7 +852,7 @@ class BucketViewState:
     partial results if listed is False
     """
     def __init__(self):
-        self.listed: bool = False
+        self.listed: set[Optional[str]] = set()
         self.segment_objects: int = 0
         self.ignored_objects: int = 0
         self.tx_manifests: int = 0
@@ -946,12 +946,12 @@ class BucketView:
 
     @property
     def cluster_metadata(self) -> dict[str, ClusterMetadata]:
-        self._ensure_listing()
+        self._ensure_listing("cluster_metadata")
         return self._state.cluster_metadata
 
     @property
     def latest_cluster_metadata_manifest(self) -> dict:
-        self._ensure_listing()
+        self._ensure_listing("cluster_metadata")
         latest_cluster_metadata = ClusterMetadata(dict(), dict())
         highest_meta_id = -1
         for _, meta in self.cluster_metadata.items():
@@ -1040,13 +1040,18 @@ class BucketView:
         self.logger.debug(f"cloud_log_size_sum()={total}")
         return total
 
-    def _ensure_listing(self):
-        if not self._state.listed is True:
-            self._do_listing()
-            self._state.listed = True
+    def _ensure_listing(self, prefix: Optional[str] = None):
+        if None in self._state.listed:
+            # 'None' indicates there was a previous listing with no prefix,
+            # which means there is a superset of the prefix.
+            return
 
-    def _do_listing(self):
-        for o in self.client.list_objects(self.bucket):
+        if prefix not in self._state.listed:
+            self._do_listing(prefix=prefix)
+            self._state.listed.add(prefix)
+
+    def _do_listing(self, prefix: Optional[str] = None):
+        for o in self.client.list_objects(self.bucket, prefix=prefix):
             self.logger.debug(f"Loading object {o.key}")
             if self.path_matcher.is_partition_manifest(o):
                 ntpr = parse_s3_manifest_path(o.key)


### PR DESCRIPTION
The cluster_metadata_upload_test waits 30 seconds for a bucket listing to show valid cluster metadata. On ABS (empirically slow in CI), the presence of several partition manifests delays the discovery of cluster metadata for that entire duration. If this happens after the metadata uploader has removed some stale cluster metadata already, the test fails to download/validate the cluster metadata snapshot on its first and only try, and the entire test fails.

This updates the test to filter the cluster metadata listing by cluster_metadata to speed the listing up.

Fixes CORE-8227

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
