### PR TITLE
serde/json: require commas in arrays and objects

### DIFF
--- a/src/v/serde/json/parser.cc
+++ b/src/v/serde/json/parser.cc
@@ -380,6 +380,8 @@ public:
             ++_buf;                       // consume ']'
             _suspension_stack.pop_back(); // pop the array member state
             co_return suspend_with_token(token::end_array);
+        } else if (expect_separator) {
+            co_return fuse_with_failure();
         }
 
         co_return co_await parse_json_value();
@@ -416,6 +418,8 @@ public:
             ++_buf;                       // consume '}'
             _suspension_stack.pop_back(); // pop the object key state
             co_return suspend_with_token(token::end_object);
+        } else if (expect_separator) {
+            co_return fuse_with_failure();
         }
 
         co_return co_await parse_string(true);

--- a/src/v/serde/json/tests/parser_test.cc
+++ b/src/v/serde/json/tests/parser_test.cc
@@ -368,3 +368,32 @@ TEST_CORO(json_parser, skip_value_bad_precondition) {
             StrEq("skip_value called with unexpected token: end_array")));
     });
 }
+
+TEST_CORO(json_parser, invalid_array_missing_comma) {
+    auto p = parser(iobuf::from(R"([42.1"zz"])"));
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::start_array);
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::value_double);
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::error);
+}
+
+TEST_CORO(json_parser, invalid_object_missing_comma) {
+    auto p = parser(iobuf::from(R"({"a": 1 "b": 2})"));
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::start_object);
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::key);
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::value_int);
+
+    EXPECT_TRUE(co_await p.next());
+    EXPECT_EQ(p.token(), token::error);
+}


### PR DESCRIPTION
Oops.

Fixes CORE-12755

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

