### PR TITLE
`storage`: remove `ntp` from `is_compactible_control_batch()` path

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -148,9 +148,8 @@ model::record_batch copy_data_segment_reducer::make_placeholder_batch(
 
 ss::future<std::optional<model::record_batch>>
 copy_data_segment_reducer::filter(model::record_batch batch) {
-    // do not compact raft configuration and archival metadata as they shift
-    // offset translation
-    if (!is_compactible(_ntp, batch)) {
+    // do not filter non-removable batch types under any circumstances
+    if (!is_filterable(batch.header().type)) {
         co_return std::move(batch);
     }
 
@@ -293,7 +292,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
     const auto records_to_remove = record_count_before
                                    - to_copy->record_count();
     _stats.records_discarded += records_to_remove;
-    bool compactible_batch = is_compactible(_ntp, to_copy.value());
+    bool compactible_batch = is_compactible(_ntp, to_copy.value().header());
     if (!compactible_batch) {
         ++_stats.non_compactible_batches;
     }
@@ -426,9 +425,9 @@ bool tx_reducer::can_discard_consumer_offsets_batch(
         return false;
     }
     // Remove all transaction related batches (including data) because the
-    // committed data has already been rewritten as separate raft_data batches,
-    // so no need to retain originally written group_prepare_tx batches while
-    // the transaction is in progress.
+    // committed data has already been rewritten as separate raft_data
+    // batches, so no need to retain originally written group_prepare_tx
+    // batches while the transaction is in progress.
     return is_compactible_control_batch(_ntp, b.header().type);
 }
 
@@ -474,10 +473,11 @@ ss::future<ss::stop_iteration> map_building_reducer::maybe_index_record_in_map(
 ss::future<ss::stop_iteration>
 map_building_reducer::operator()(model::record_batch batch) {
     bool fully_indexed_batch = true;
-    // There is no point to indexing records in uncompactible batches, since
-    // their inclusion in the segment post compaction is irrespective of the map
-    // state (see copy_data_segment_reducer::filter()).
-    if (!is_compactible(_ntp, batch)) {
+    auto& header = batch.header();
+    if (!is_compactible(_ntp, header)) {
+        // There is no point to indexing records in uncompactible batches, since
+        // their inclusion in the segment post compaction is irrespective of the
+        // map state (see copy_data_segment_reducer::filter()).
         co_return ss::stop_iteration::no;
     }
     auto b = co_await decompress_batch(std::move(batch));
@@ -485,8 +485,8 @@ map_building_reducer::operator()(model::record_batch batch) {
       [this,
        &fully_indexed_batch,
        base_offset = b.base_offset(),
-       type = b.header().type,
-       is_control = b.header().attrs.is_control()](
+       type = header.type,
+       is_control = header.attrs.is_control()](
         const model::record& r) -> ss::future<ss::stop_iteration> {
           return maybe_index_record_in_map(
             r, base_offset, type, is_control, fully_indexed_batch);

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -428,7 +428,7 @@ bool tx_reducer::can_discard_consumer_offsets_batch(
     // committed data has already been rewritten as separate raft_data
     // batches, so no need to retain originally written group_prepare_tx
     // batches while the transaction is in progress.
-    return is_compactible_control_batch(b.header().type);
+    return is_removable_control_batch(b.header().type);
 }
 
 ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -292,7 +292,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
     const auto records_to_remove = record_count_before
                                    - to_copy->record_count();
     _stats.records_discarded += records_to_remove;
-    bool compactible_batch = is_compactible(_ntp, to_copy.value().header());
+    bool compactible_batch = is_compactible(to_copy.value().header());
     if (!compactible_batch) {
         ++_stats.non_compactible_batches;
     }
@@ -428,7 +428,7 @@ bool tx_reducer::can_discard_consumer_offsets_batch(
     // committed data has already been rewritten as separate raft_data
     // batches, so no need to retain originally written group_prepare_tx
     // batches while the transaction is in progress.
-    return is_compactible_control_batch(_ntp, b.header().type);
+    return is_compactible_control_batch(b.header().type);
 }
 
 ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
@@ -474,7 +474,7 @@ ss::future<ss::stop_iteration>
 map_building_reducer::operator()(model::record_batch batch) {
     bool fully_indexed_batch = true;
     auto& header = batch.header();
-    if (!is_compactible(_ntp, header)) {
+    if (!is_compactible(header)) {
         // There is no point to indexing records in uncompactible batches, since
         // their inclusion in the segment post compaction is irrespective of the
         // map state (see copy_data_segment_reducer::filter()).

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -158,7 +158,6 @@ public:
     };
 
     copy_data_segment_reducer(
-      model::ntp ntp,
       filter_t f,
       segment_appender* a,
       bool internal_topic,
@@ -169,8 +168,7 @@ public:
       compacted_index_writer* cidx = nullptr,
       bool inject_failure = false,
       ss::abort_source* as = nullptr)
-      : _ntp(std::move(ntp))
-      , _should_keep_fn(std::move(f))
+      : _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
       , _compaction_placeholder_enabled(compaction_placeholder_enabled)
       , _appender(a)
@@ -198,7 +196,6 @@ private:
     // Creates a placeholder batch with same offset range as the input header.
     model::record_batch make_placeholder_batch(model::record_batch_header&);
 
-    model::ntp _ntp;
     filter_t _should_keep_fn;
 
     // Offset to keep in case the index is empty as of getting to this offset.
@@ -266,12 +263,10 @@ private:
 class tx_reducer : public compaction_reducer {
 public:
     explicit tx_reducer(
-      model::ntp ntp,
       ss::lw_shared_ptr<storage::stm_manager> stm_mgr,
       fragmented_vector<model::tx_range>&& txs,
       compacted_index_writer* w) noexcept
-      : _ntp(std::move(ntp))
-      , _delegate(index_rebuilder_reducer(w))
+      : _delegate(index_rebuilder_reducer(w))
       , _aborted_txs(model::tx_range_cmp(), std::move(txs))
       , _stm_mgr(stm_mgr)
       , _transactional_stm_type(stm_mgr->transactional_stm_type()) {
@@ -308,7 +303,6 @@ private:
     void refresh_ongoing_aborted_txs(const model::record_batch&);
     bool has_transactional_data() const;
 
-    model::ntp _ntp;
     index_rebuilder_reducer _delegate;
     // A min heap of aborted transactions based on begin offset.
     using underlying_t = std::priority_queue<
@@ -339,9 +333,8 @@ private:
 class map_building_reducer : public compaction_reducer {
 public:
     explicit map_building_reducer(
-      model::ntp ntp, key_offset_map* map, model::offset start_offset_inclusive)
-      : _ntp(std::move(ntp))
-      , _map(map)
+      key_offset_map* map, model::offset start_offset_inclusive)
+      : _map(map)
       , _start_offset(start_offset_inclusive) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
@@ -355,7 +348,6 @@ private:
       bool is_control,
       bool& fully_indexed_batch);
 
-    model::ntp _ntp;
     key_offset_map* _map;
     model::offset _start_offset;
     bool _fully_indexed_segment = true;

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -347,8 +347,9 @@ std::ostream& operator<<(std::ostream& o, const index_state& s) {
              << s.num_compactible_records_appended
              << ", clean_compact_timestamp:" << s.clean_compact_timestamp
              << ", may_have_tombstone_records:" << s.may_have_tombstone_records
-             << ", self_compact_timestamp:" << s.self_compact_timestamp << ", "
-             << s.index << "}";
+             << ", self_compact_timestamp:" << s.self_compact_timestamp
+             << ", has_transaction_batches:" << s.has_transaction_batches
+             << ", " << s.index << "}";
 }
 
 void index_state::serde_write(iobuf& out) const {
@@ -371,6 +372,7 @@ void index_state::serde_write(iobuf& out) const {
     write(tmp, clean_compact_timestamp);
     write(tmp, may_have_tombstone_records);
     write(tmp, self_compact_timestamp);
+    write(tmp, has_transaction_batches);
 
     crc::crc32c crc;
     crc_extend_iobuf(crc, tmp);
@@ -488,6 +490,11 @@ void read_nested(
     } else {
         st.self_compact_timestamp = std::nullopt;
     }
+    if (hdr._version >= index_state::has_transaction_batches_version) {
+        read_nested(p, st.has_transaction_batches, 0U);
+    } else {
+        st.has_transaction_batches = false;
+    }
 }
 
 index_state index_state::copy() const { return *this; }
@@ -554,7 +561,8 @@ index_state::index_state(const index_state& o) noexcept
   , num_compactible_records_appended(o.num_compactible_records_appended)
   , clean_compact_timestamp(o.clean_compact_timestamp)
   , may_have_tombstone_records(o.may_have_tombstone_records)
-  , self_compact_timestamp(o.self_compact_timestamp) {}
+  , self_compact_timestamp(o.self_compact_timestamp)
+  , has_transaction_batches(o.has_transaction_batches) {}
 
 namespace serde_compat {
 uint64_t index_state_serde::checksum(const index_state& r) {

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -200,10 +200,11 @@ struct index_state
     // the index.
     std::optional<model::timestamp> broker_timestamp{std::nullopt};
 
-    // The number of compactible records appended to the segment. This may not
-    // necessarily indicate the exact number of compactible records, e.g. if
-    // the segment was truncated, the count will remain the same. As such, this
-    // value may be an overestimate of the exact number of compactible records.
+    // The number of records appended to the segment that could be considered
+    // for removal via compaction. This may not necessarily indicate the exact
+    // number of compactible records, e.g. if the segment was truncated, the
+    // count will remain the same. As such, this value may be an overestimate of
+    // the exact number of compactible records.
     //
     // Returns std::nullopt if this index was written in a version that didn't
     // support this field, and we can't conclude anything.

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -137,7 +137,9 @@ struct index_state
     static constexpr auto num_compactible_records_version = 7;
     static constexpr auto clean_compact_timestamp_version = 8;
     static constexpr auto may_have_tombstone_records_version = 9;
+    // Added in the same version.
     static constexpr auto self_compact_timestamp_version = 10;
+    static constexpr auto has_transaction_batches_version = 10;
 
     static index_state
     make_empty_index(model::offset base_offset, offset_delta_time with_offset);
@@ -226,6 +228,12 @@ struct index_state
     // This preserveration is important for transactional batch removal, as its
     // delete horizon is set by `self_compact_timestamp + delete.retention.ms`.
     std::optional<model::timestamp> self_compact_timestamp{std::nullopt};
+
+    // has_transaction_batches is `false` by default, but set in
+    // segment::append() when transactional batches are added. It remains `true`
+    // until compaction deduplication/segment data copying is performed and all
+    // transaction batches are removed.
+    bool has_transaction_batches{false};
 
     size_t size() const;
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -492,7 +492,7 @@ ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
         co_return;
     }
     // do not index not compactible batches
-    if (!internal::is_compactible(path().get_ntp(), b)) {
+    if (!internal::is_compactible(path().get_ntp(), b.header())) {
         co_return;
     }
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -631,22 +631,33 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
 }
 
 ss::future<append_result> segment::append(const model::record_batch& b) {
-    if (has_compaction_index() && b.contains_transactional_data()) {
-        // With transactional batches, we do not know ahead of time whether the
-        // batch will be committed or aborted. We may not have this information
-        // during the lifetime of this segment as the batch may be aborted in
-        // the next segment. We mark this index as `incomplete` and rebuild it
-        // later from scratch during compaction.
-        try {
-            auto index = std::exchange(_compaction_index, std::nullopt).value();
-            index->set_flag(compacted_index::footer_flags::incomplete);
+    if (b.contains_transactional_data()) {
+        if (!_idx.has_transaction_batches()) {
             vlog(
-              gclog.info,
-              "Marking compaction index {} as incomplete",
-              index->filename());
-            co_await index->close();
-        } catch (...) {
-            co_return ss::coroutine::exception(std::current_exception());
+              gclog.trace,
+              "Marking index for segment {} as has transaction batches",
+              filename());
+            _idx.set_has_transaction_batches(true);
+        }
+        if (has_compaction_index()) {
+            // With transactional batches, we do not know ahead of time whether
+            // the batch will be committed or aborted. We may not have this
+            // information during the lifetime of this segment as the batch may
+            // be aborted in the next segment. We mark this index as
+            // `incomplete` and rebuild it later from scratch during compaction.
+            try {
+                auto compacted_index
+                  = std::exchange(_compaction_index, std::nullopt).value();
+                compacted_index->set_flag(
+                  compacted_index::footer_flags::incomplete);
+                vlog(
+                  gclog.info,
+                  "Marking compaction index {} as incomplete",
+                  compacted_index->filename());
+                co_await compacted_index->close();
+            } catch (...) {
+                co_return ss::coroutine::exception(std::current_exception());
+            }
         }
     }
     co_return co_await do_append(b);

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -492,7 +492,7 @@ ss::future<> segment::compaction_index_batch(const model::record_batch& b) {
         co_return;
     }
     // do not index not compactible batches
-    if (!internal::is_compactible(path().get_ntp(), b.header())) {
+    if (!internal::is_compactible(b.header())) {
         co_return;
     }
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -205,8 +205,10 @@ ss::future<index_state> deduplicate_segment(
         return is_latest_record_for_key(map, b, r);
     };
 
+    const auto& ntp = seg->path().get_ntp();
     auto record_filter = [f = std::move(is_latest_record),
                           &feature_table,
+                          &ntp,
                           segment_last_offset,
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
@@ -218,6 +220,7 @@ ss::future<index_state> deduplicate_segment(
         return internal::should_keep(
           b,
           r,
+          ntp,
           is_last_record_in_batch,
           f,
           probe,
@@ -229,7 +232,7 @@ ss::future<index_state> deduplicate_segment(
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
-      seg->path().get_ntp(),
+      ntp,
       std::move(record_filter),
       &appender,
       seg->path().is_internal_topic(),

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -197,6 +197,7 @@ ss::future<index_state> deduplicate_segment(
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
+    bool has_transaction_batches = false;
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -209,7 +210,8 @@ ss::future<index_state> deduplicate_segment(
                           segment_last_offset,
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
-                          &probe](
+                          &probe,
+                          &has_transaction_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -222,7 +224,8 @@ ss::future<index_state> deduplicate_segment(
           feature_table,
           segment_last_offset,
           past_tombstone_delete_horizon,
-          may_have_tombstone_records);
+          may_have_tombstone_records,
+          has_transaction_batches);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -264,6 +267,9 @@ ss::future<index_state> deduplicate_segment(
 
     // Set may_have_tombstone_records
     new_idx.may_have_tombstone_records = may_have_tombstone_records;
+
+    // Set has_transaction_batches
+    new_idx.has_transaction_batches = has_transaction_batches;
 
     if (
       seg->index().may_have_tombstone_records()

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -205,10 +205,8 @@ ss::future<index_state> deduplicate_segment(
         return is_latest_record_for_key(map, b, r);
     };
 
-    const auto& ntp = seg->path().get_ntp();
     auto record_filter = [f = std::move(is_latest_record),
                           &feature_table,
-                          &ntp,
                           segment_last_offset,
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
@@ -220,7 +218,6 @@ ss::future<index_state> deduplicate_segment(
         return internal::should_keep(
           b,
           r,
-          ntp,
           is_last_record_in_batch,
           f,
           probe,
@@ -232,7 +229,6 @@ ss::future<index_state> deduplicate_segment(
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
-      ntp,
       std::move(record_filter),
       &appender,
       seg->path().is_internal_topic(),
@@ -297,8 +293,7 @@ ss::future<bool> index_chunk_of_segment_for_map(
     auto start_offset_inclusive = model::next_offset(last_indexed_offset);
     auto rdr = internal::create_segment_full_reader(
       seg, compact_cfg, pb, std::move(read_holder), start_offset_inclusive);
-    internal::map_building_reducer reducer(
-      seg->path().get_ntp(), &map, start_offset_inclusive);
+    internal::map_building_reducer reducer(&map, start_offset_inclusive);
 
     bool fully_indexed_segment = co_await std::move(rdr).consume(
       reducer, model::no_timeout);

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -140,8 +140,7 @@ void segment_index::maybe_track(
           to_optional_model_timestamp(new_broker_ts),
           path().is_internal_topic()
             || hdr.type == model::record_batch_type::raft_data,
-          internal::is_compactible(_path.get_ntp(), hdr) ? hdr.record_count
-                                                         : 0)) {
+          internal::is_filterable(hdr.type) ? hdr.record_count : 0)) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -38,7 +38,8 @@ segment_index::segment_index(
   std::optional<model::timestamp> broker_timestamp,
   std::optional<model::timestamp> clean_compact_timestamp,
   bool may_have_tombstone_records,
-  std::optional<model::timestamp> self_compact_timestamp)
+  std::optional<model::timestamp> self_compact_timestamp,
+  bool has_transaction_batches)
   : _path(std::move(path))
   , _step(step)
   , _feature_table(std::ref(feature_table))
@@ -49,6 +50,7 @@ segment_index::segment_index(
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
     _state.self_compact_timestamp = self_compact_timestamp;
+    _state.has_transaction_batches = has_transaction_batches;
 }
 
 segment_index::segment_index(
@@ -84,6 +86,7 @@ void segment_index::reset() {
     auto self_compact_timestamp = _state.self_compact_timestamp;
     auto clean_compact_timestamp = _state.clean_compact_timestamp;
     auto may_have_tombstone_records = _state.may_have_tombstone_records;
+    auto has_transaction_batches = _state.has_transaction_batches;
 
     _state = index_state::make_empty_index(
       base, storage::internal::should_apply_delta_time_offset(_feature_table));
@@ -91,6 +94,7 @@ void segment_index::reset() {
     _state.self_compact_timestamp = self_compact_timestamp;
     _state.clean_compact_timestamp = clean_compact_timestamp;
     _state.may_have_tombstone_records = may_have_tombstone_records;
+    _state.has_transaction_batches = has_transaction_batches;
 
     _acc = 0;
 }

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -127,7 +127,8 @@ public:
       std::optional<model::timestamp> broker_timestamp = std::nullopt,
       std::optional<model::timestamp> clean_compact_timestamp = std::nullopt,
       bool may_have_tombstone_records = true,
-      std::optional<model::timestamp> self_compact_timestamp = std::nullopt);
+      std::optional<model::timestamp> self_compact_timestamp = std::nullopt,
+      bool has_transaction_batches = true);
 
     ~segment_index() noexcept = default;
     segment_index(segment_index&&) noexcept = default;
@@ -253,6 +254,17 @@ public:
     // Get the self compacted timestamp.
     std::optional<model::timestamp> self_compact_timestamp() const {
         return _state.self_compact_timestamp;
+    }
+
+    void set_has_transaction_batches(bool b) {
+        if (_state.has_transaction_batches != b) {
+            _needs_persistence = true;
+        }
+        _state.has_transaction_batches = b;
+    }
+
+    bool has_transaction_batches() const {
+        return _state.has_transaction_batches;
     }
 
     ss::future<bool> materialize_index();

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -423,8 +423,10 @@ ss::future<storage::index_state> do_copy_segment_data(
         return ss::make_ready_future<bool>(keep);
     };
 
+    const auto& ntp = seg->path().get_ntp();
     auto record_filter = [f = std::move(offset_in_compacted_list),
                           &feature_table,
+                          &ntp,
                           segment_last_offset,
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
@@ -436,6 +438,7 @@ ss::future<storage::index_state> do_copy_segment_data(
         return internal::should_keep(
           b,
           r,
+          ntp,
           is_last_record_in_batch,
           f,
           pb,
@@ -447,7 +450,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     };
 
     auto copy_reducer = copy_data_segment_reducer(
-      seg->path().get_ntp(),
+      ntp,
       std::move(record_filter),
       appender.get(),
       seg->path().is_internal_topic(),

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -412,6 +412,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     const bool past_tombstone_delete_horizon
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
+    bool has_transaction_batches = false;
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -427,7 +428,8 @@ ss::future<storage::index_state> do_copy_segment_data(
                           segment_last_offset,
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
-                          &pb](
+                          &pb,
+                          &has_transaction_batches](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -440,7 +442,8 @@ ss::future<storage::index_state> do_copy_segment_data(
           feature_table,
           segment_last_offset,
           past_tombstone_delete_horizon,
-          may_have_tombstone_records);
+          may_have_tombstone_records,
+          has_transaction_batches);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -492,6 +495,9 @@ ss::future<storage::index_state> do_copy_segment_data(
 
     // Set may_have_tombstone_records
     new_index.may_have_tombstone_records = may_have_tombstone_records;
+
+    // Set has_transaction_batches
+    new_index.has_transaction_batches = has_transaction_batches;
 
     if (
       seg->index().may_have_tombstone_records()
@@ -966,6 +972,12 @@ make_concatenated_segment(
           .self_compact_timestamp()
           .value();
 
+    // If any of the segments contain a transactional batch, then the new index
+    // should reflect that.
+    auto new_has_transaction_batches = std::ranges::any_of(
+      segments,
+      [](const auto& s) { return s->index().has_transaction_batches(); });
+
     segment_index index(
       index_path,
       offsets.get_base_offset(),
@@ -975,7 +987,8 @@ make_concatenated_segment(
       new_broker_timestamp,
       new_clean_compact_timestamp,
       new_may_have_tombstone_records,
-      new_self_compact_timestamp);
+      new_self_compact_timestamp,
+      new_has_transaction_batches);
 
     co_return std::make_tuple(
       ss::make_lw_shared<segment>(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -423,10 +423,8 @@ ss::future<storage::index_state> do_copy_segment_data(
         return ss::make_ready_future<bool>(keep);
     };
 
-    const auto& ntp = seg->path().get_ntp();
     auto record_filter = [f = std::move(offset_in_compacted_list),
                           &feature_table,
-                          &ntp,
                           segment_last_offset,
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
@@ -438,7 +436,6 @@ ss::future<storage::index_state> do_copy_segment_data(
         return internal::should_keep(
           b,
           r,
-          ntp,
           is_last_record_in_batch,
           f,
           pb,
@@ -450,7 +447,6 @@ ss::future<storage::index_state> do_copy_segment_data(
     };
 
     auto copy_reducer = copy_data_segment_reducer(
-      ntp,
       std::move(record_filter),
       appender.get(),
       seg->path().is_internal_topic(),
@@ -656,8 +652,7 @@ ss::future<> build_compaction_index(
   storage_resources& resources) {
     auto w = storage::make_file_backed_compacted_index(
       p, false, resources, cfg.sanitizer_config);
-    auto reducer = tx_reducer(
-      p.get_ntp(), stm_manager, std::move(aborted_txs), w.get());
+    auto reducer = tx_reducer(stm_manager, std::move(aborted_txs), w.get());
     auto index_builder = co_await ss::coroutine::as_future<tx_reducer::stats>(
       std::move(rdr)
         .consume(std::move(reducer), model::no_timeout)

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -257,12 +257,6 @@ inline bool is_compactible_control_batch(
     // tx_fence batches  in consumer offsets are special and should be
     // compacted. They were used historically to mark the begin of a transaction
     // but later switched to group_fence_tx.
-
-    // Note: This ugly hack of propagating the consumer offsets flag is
-    // temporary until we fix the compaction to compact away all the control
-    // batches (including the ones in data partitions), at which point we solely
-    // can make this decision on whether the batch is a control batch or not and
-    // avoid propagating the flag everywhere.
     return unlikely(
              batch_type == model::record_batch_type::tx_fence
              && model::is_consumer_offsets_topic(ntp))
@@ -272,23 +266,37 @@ inline bool is_compactible_control_batch(
            || batch_type == model::record_batch_type::group_commit_tx;
 }
 
-inline bool
-is_compactible(const model::ntp& ntp, const model::record_batch_header& h) {
-    if (
-      (h.attrs.is_control() && !is_compactible_control_batch(ntp, h.type))
-      || h.type == model::record_batch_type::compaction_placeholder) {
-        // Keep control batches to ensure we maintain transaction boundaries
-        // (unless it is CO topic). They should be rare.
+// Returns `true` or `false` indicating whether the batch type of the header
+// passed contains records that may be removed by compaction- whether that is by
+// de-duplication, or by other logic, i.e we need to consider transactional
+// batch removal past `delete.retention.ms`. Batches which should NEVER be
+// removed from the log via compaction filtering include compaction placeholder
+// batches, as well as all batches that shift offset translation. These batches
+// shouldn't even be considered in `should_keep()`, they should be kept
+// unconditionally.
+inline bool is_filterable(model::record_batch_type t) {
+    if (t == model::record_batch_type::compaction_placeholder) {
         return false;
     }
     static const auto filtered_types = model::offset_translator_batch_types();
-    auto n = std::count(filtered_types.begin(), filtered_types.end(), h.type);
+    auto n = std::count(filtered_types.begin(), filtered_types.end(), t);
     return n == 0;
 }
 
+// Returns `true` or `false` indicating whether the batch type of the header
+// passed contains records that may be de-duplicated by compaction
+// (de-duplication refers to the removal of records performed _only_ due to
+// records with the same key existing for a later record in the log). This is a
+// more stringent condition than `is_filterable()`- this condition determines
+// whether records from a batch should be indexed in a .compaction_index file,
+// and whether only the latest record for a given key should be kept in
+// `should_keep()`.
 inline bool
-is_compactible(const model::ntp& ntp, const model::record_batch& b) {
-    return is_compactible(ntp, b.header());
+is_compactible(const model::ntp& ntp, const model::record_batch_header& h) {
+    if (h.attrs.is_control() && !is_compactible_control_batch(ntp, h.type)) {
+        return false;
+    }
+    return is_filterable(h.type);
 }
 
 offset_delta_time should_apply_delta_time_offset(
@@ -348,6 +356,7 @@ template<typename Func>
 ss::future<bool> should_keep(
   const model::record_batch& b,
   const model::record& r,
+  const model::ntp& ntp,
   bool is_last_record_in_batch,
   Func&& is_latest_key,
   probe& pb,
@@ -388,8 +397,10 @@ ss::future<bool> should_keep(
     }
 
     auto& header = b.header();
-    if (header.attrs.is_control()) {
-        has_tx_batches = true;
+    if (!is_compactible(ntp, header)) {
+        if (header.attrs.is_control()) {
+            has_tx_batches = true;
+        }
         co_return true;
     }
 

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -352,6 +352,32 @@ auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
       });
 }
 
+// Returns `true` or `false` depending on whether the provided record/control
+// batch is instantly removable by compaction.
+// This will return `true` for:
+//   1. Compactible control batches (such as those found in the
+//      __consumer_offsets topic).
+//   2. Tombstone records past the removal horizon set by
+//      `delete.retention.ms`
+// In all other cases, return `false`.
+inline bool can_discard(
+  const model::record_batch& b,
+  const model::record& r,
+  const model::ntp& ntp,
+  bool past_tombstone_delete_horizon) {
+    // Compactible control batches are always removable
+    if (is_compactible_control_batch(ntp, b.header().type)) {
+        return true;
+    }
+
+    // Deal with tombstone record removal
+    if (r.is_tombstone() && past_tombstone_delete_horizon) {
+        return true;
+    }
+
+    return false;
+}
+
 template<typename Func>
 ss::future<bool> should_keep(
   const model::record_batch& b,
@@ -390,18 +416,21 @@ ss::future<bool> should_keep(
         co_return true;
     }
 
-    // Deal with tombstone record removal
-    if (r.is_tombstone() && past_tombstone_delete_horizon) {
-        pb.add_removed_tombstone();
-        co_return false;
-    }
-
     auto& header = b.header();
     if (!is_compactible(ntp, header)) {
         if (header.attrs.is_control()) {
             has_tx_batches = true;
         }
         co_return true;
+    }
+
+    // Before considering `is_latest_key()`, unconditionally remove
+    // records/batches which are always considered removable.
+    if (can_discard(b, r, ntp, past_tombstone_delete_horizon)) {
+        if (r.is_tombstone()) {
+            pb.add_removed_tombstone();
+        }
+        co_return false;
     }
 
     auto keep = co_await is_latest_key(b, r);

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -354,7 +354,8 @@ ss::future<bool> should_keep(
   ss::sharded<features::feature_table>& feature_table,
   model::offset segment_last_offset,
   bool past_tombstone_delete_horizon,
-  bool& may_have_tombstone_records) {
+  bool& may_have_tombstone_records,
+  bool& has_tx_batches) {
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     auto is_last_batch = b.last_offset() == segment_last_offset;
@@ -373,6 +374,10 @@ ss::future<bool> should_keep(
             may_have_tombstone_records = true;
         }
 
+        if (b.contains_transactional_data()) {
+            has_tx_batches = true;
+        }
+
         co_return true;
     }
 
@@ -382,10 +387,20 @@ ss::future<bool> should_keep(
         co_return false;
     }
 
+    auto& header = b.header();
+    if (header.attrs.is_control()) {
+        has_tx_batches = true;
+        co_return true;
+    }
+
     auto keep = co_await is_latest_key(b, r);
 
     if (r.is_tombstone() && keep) {
         may_have_tombstone_records = true;
+    }
+
+    if (b.contains_transactional_data() && keep) {
+        has_tx_batches = true;
     }
 
     co_return keep;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -250,7 +250,7 @@ struct clean_segment_value
 };
 
 inline bool
-is_compactible_control_batch(const model::record_batch_type batch_type) {
+is_removable_control_batch(const model::record_batch_type batch_type) {
     // Control batches in consumer offsets are special compared to
     // the ones in data partitions can be safely compacted away.
     //
@@ -362,7 +362,7 @@ inline bool can_discard(
   const model::record& r,
   bool past_tombstone_delete_horizon) {
     // Compactible control batches are always removable
-    if (is_compactible_control_batch(b.header().type)) {
+    if (is_removable_control_batch(b.header().type)) {
         return true;
     }
 

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -249,17 +249,15 @@ struct clean_segment_value
     auto serde_fields() { return std::tie(segment_name); }
 };
 
-inline bool is_compactible_control_batch(
-  const model::ntp& ntp, const model::record_batch_type batch_type) {
+inline bool
+is_compactible_control_batch(const model::record_batch_type batch_type) {
     // Control batches in consumer offsets are special compared to
     // the ones in data partitions can be safely compacted away.
     //
     // tx_fence batches  in consumer offsets are special and should be
-    // compacted. They were used historically to mark the begin of a transaction
-    // but later switched to group_fence_tx.
-    return unlikely(
-             batch_type == model::record_batch_type::tx_fence
-             && model::is_consumer_offsets_topic(ntp))
+    // removed during compaction. They were used historically to mark the begin
+    // of a transaction but later switched to group_fence_tx.
+    return batch_type == model::record_batch_type::tx_fence
            || batch_type == model::record_batch_type::group_fence_tx
            || batch_type == model::record_batch_type::group_prepare_tx
            || batch_type == model::record_batch_type::group_abort_tx
@@ -291,9 +289,8 @@ inline bool is_filterable(model::record_batch_type t) {
 // whether records from a batch should be indexed in a .compaction_index file,
 // and whether only the latest record for a given key should be kept in
 // `should_keep()`.
-inline bool
-is_compactible(const model::ntp& ntp, const model::record_batch_header& h) {
-    if (h.attrs.is_control() && !is_compactible_control_batch(ntp, h.type)) {
+inline bool is_compactible(const model::record_batch_header& h) {
+    if (h.attrs.is_control()) {
         return false;
     }
     return is_filterable(h.type);
@@ -363,10 +360,9 @@ auto with_segment_reader_handle(segment_reader_handle handle, Func func) {
 inline bool can_discard(
   const model::record_batch& b,
   const model::record& r,
-  const model::ntp& ntp,
   bool past_tombstone_delete_horizon) {
     // Compactible control batches are always removable
-    if (is_compactible_control_batch(ntp, b.header().type)) {
+    if (is_compactible_control_batch(b.header().type)) {
         return true;
     }
 
@@ -382,7 +378,6 @@ template<typename Func>
 ss::future<bool> should_keep(
   const model::record_batch& b,
   const model::record& r,
-  const model::ntp& ntp,
   bool is_last_record_in_batch,
   Func&& is_latest_key,
   probe& pb,
@@ -417,7 +412,7 @@ ss::future<bool> should_keep(
     }
 
     auto& header = b.header();
-    if (!is_compactible(ntp, header)) {
+    if (!is_compactible(header)) {
         if (header.attrs.is_control()) {
             has_tx_batches = true;
         }
@@ -426,7 +421,7 @@ ss::future<bool> should_keep(
 
     // Before considering `is_latest_key()`, unconditionally remove
     // records/batches which are always considered removable.
-    if (can_discard(b, r, ntp, past_tombstone_delete_horizon)) {
+    if (can_discard(b, r, past_tombstone_delete_horizon)) {
         if (r.is_tombstone()) {
             pb.add_removed_tombstone();
         }


### PR DESCRIPTION
### **DNM this for `v25.2`.**

Based on https://github.com/redpanda-data/redpanda/pull/26661. Only last 2 commits are new.

This `ntp` plumbing was only in place to ensure `tx_fence` batches were considered compactible in the `__consumer_offsets` topic and not in user topics.

However, `tx_fence` batches should be considered safely removable during compaction, as the presence of the transactional bit in a Raft data batch can accomplish the same "fencing" marker as the `tx_fence` batch itself.

Also, rename `is_compactible_control_batch()` to `is_removable_control_batch()`- "compactible", as a concept, should be reserved for the idea that a record is discardable due to the existence of a later record with the same key and a higher offset in the `log`.

Since we are discarding these batches unconditionally without any consideration or requirement for the above condition, `is_removable()` is a better term to distinguish the nuance in behavior here.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
