### PR TITLE
datalake: make iceberg_rest_catalog_aws_service_name non-optional

### DIFF
--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -747,7 +747,7 @@ struct configuration final : public config_store {
     property<ss::sstring> iceberg_rest_catalog_oauth2_scope;
     enum_property<datalake_catalog_auth_mode>
       iceberg_rest_catalog_authentication_mode;
-    property<std::optional<ss::sstring>> iceberg_rest_catalog_aws_service_name;
+    property<ss::sstring> iceberg_rest_catalog_aws_service_name;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_aws_access_key;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_aws_secret_key;
     property<std::optional<ss::sstring>> iceberg_rest_catalog_aws_region;

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -861,8 +861,7 @@ ss::sstring coordinator::get_effective_default_partition_spec(
                      == config::datalake_catalog_type::rest
                    && cfg.iceberg_rest_catalog_authentication_mode()
                         == config::datalake_catalog_auth_mode::aws_sigv4
-                   && cfg.iceberg_rest_catalog_aws_service_name().value_or("")
-                        == "glue";
+                   && cfg.iceberg_rest_catalog_aws_service_name() == "glue";
     if (
       is_glue
       && current_spec == cfg.iceberg_default_partition_spec.default_value()) {

--- a/src/v/datalake/credential_manager.cc
+++ b/src/v/datalake/credential_manager.cc
@@ -52,7 +52,7 @@ create_aws_sigv4_configuration(const config::configuration& cfg) {
 
     // Service name defaults to "glue".
     s3_config.service = cloud_roles::aws_service_name{
-      cfg.iceberg_rest_catalog_aws_service_name().value_or("glue")};
+      cfg.iceberg_rest_catalog_aws_service_name()};
 
     auto region = cfg.iceberg_rest_catalog_aws_region().has_value()
                     ? cfg.iceberg_rest_catalog_aws_region()


### PR DESCRIPTION
`iceberg_rest_catalog_aws_service_name` is an escape hatch in case there's another AWS catalog or catalog mock that uses SigV4 besides Glue. It defaults to "glue" but has no effect if not using the Iceberg REST catalog with AWS SigV4 authentication. Let's make it non-optional, defaulting to "glue".

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
