### PR TITLE
storage: Fix weak pointer use-after-free in batch cache

### DIFF
--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -176,22 +176,22 @@ batch_cache::entry batch_cache::put(
         return entry(0, r->weak_from_this());
     }
 
-    if (
-      !index._small_batches_range || !index._small_batches_range->valid()
-      || !index._small_batches_range->fits(input)) {
+    // Check if we need to create a new range or use existing one
+    auto small_range_ptr = index._small_batches_range.get();
+    if (!small_range_ptr || !small_range_ptr->valid() || !small_range_ptr->fits(input)) {
         auto r = new range(index);
         _lru.push_back(*r);
         _size_bytes += r->memory_size();
         index._small_batches_range = r->weak_from_this();
+        small_range_ptr = r;
     }
 
-    auto initial_sz = index._small_batches_range->memory_size();
-    auto offset = index._small_batches_range->add(input, dirty);
+    auto initial_sz = small_range_ptr->memory_size();
+    auto offset = small_range_ptr->add(input, dirty);
     // calculate size difference to update batch cache size
-    int64_t diff = (int64_t)index._small_batches_range->memory_size()
-                   - initial_sz;
+    int64_t diff = (int64_t)small_range_ptr->memory_size() - initial_sz;
     _size_bytes += diff;
-    return entry(offset, index._small_batches_range->weak_from_this());
+    return entry(offset, small_range_ptr->weak_from_this());
 }
 
 batch_cache::~batch_cache() noexcept {
@@ -467,7 +467,9 @@ void batch_cache_index::mark_clean(model::offset up_to_inclusive) {
     auto last = std::next(find_first(up_to_inclusive));
 
     std::for_each(first, last, [up_to_inclusive](index_type::value_type& e) {
-        e.second.range()->mark_clean(up_to_inclusive);
+        if (auto ptr = e.second.range().get()) {
+            ptr->mark_clean(up_to_inclusive);
+        }
     });
 
     _dirty_tracker.mark_clean(up_to_inclusive);

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -178,7 +178,9 @@ batch_cache::entry batch_cache::put(
 
     // Check if we need to create a new range or use existing one
     auto small_range_ptr = index._small_batches_range.get();
-    if (!small_range_ptr || !small_range_ptr->valid() || !small_range_ptr->fits(input)) {
+    if (
+      !small_range_ptr || !small_range_ptr->valid()
+      || !small_range_ptr->fits(input)) {
         auto r = new range(index);
         _lru.push_back(*r);
         _size_bytes += r->memory_size();

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -278,24 +278,26 @@ public:
         entry(const entry&) = delete;
         entry& operator=(const entry&) = delete;
 
-        model::record_batch batch() { 
+        model::record_batch batch() {
             auto ptr = _range.get();
             if (unlikely(!ptr)) {
-                throw std::runtime_error("batch_cache::entry: weak pointer expired");
+                throw std::runtime_error(
+                  "batch_cache::entry: weak pointer expired");
             }
-            return ptr->batch(_range_offset); 
+            return ptr->batch(_range_offset);
         }
         model::record_batch_header header() const {
             auto ptr = _range.get();
             if (unlikely(!ptr)) {
-                throw std::runtime_error("batch_cache::entry: weak pointer expired");
+                throw std::runtime_error(
+                  "batch_cache::entry: weak pointer expired");
             }
             return ptr->header(_range_offset);
         }
 
         range_ptr& range() { return _range; }
         const range_ptr& range() const { return _range; }
-        bool valid() const { 
+        bool valid() const {
             auto ptr = _range.get();
             return ptr && ptr->valid();
         }

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -28,6 +28,7 @@
 #include <seastar/core/weak_ptr.hh>
 
 #include <limits>
+#include <stdexcept>
 #include <type_traits>
 
 class batch_cache_test_fixture;
@@ -277,14 +278,27 @@ public:
         entry(const entry&) = delete;
         entry& operator=(const entry&) = delete;
 
-        model::record_batch batch() { return _range->batch(_range_offset); }
+        model::record_batch batch() { 
+            auto ptr = _range.get();
+            if (unlikely(!ptr)) {
+                throw std::runtime_error("batch_cache::entry: weak pointer expired");
+            }
+            return ptr->batch(_range_offset); 
+        }
         model::record_batch_header header() const {
-            return _range->header(_range_offset);
+            auto ptr = _range.get();
+            if (unlikely(!ptr)) {
+                throw std::runtime_error("batch_cache::entry: weak pointer expired");
+            }
+            return ptr->header(_range_offset);
         }
 
         range_ptr& range() { return _range; }
         const range_ptr& range() const { return _range; }
-        bool valid() const { return _range->valid(); }
+        bool valid() const { 
+            auto ptr = _range.get();
+            return ptr && ptr->valid();
+        }
 
     private:
         uint32_t _range_offset;


### PR DESCRIPTION
## Summary

Fixes multiple weak pointer use-after-free vulnerabilities in the batch cache that could cause crashes and memory corruption when the memory reclaimer runs concurrently with batch operations.

## Problem Description

The batch cache uses `ss::weak_ptr<range>` to reference cache ranges, but several operations were directly dereferencing weak pointers without checking if they were still valid. This created race conditions where:

1. A weak pointer is obtained to a cache range
2. The memory reclaimer deallocates the range 
3. Code attempts to access the deallocated range via the weak pointer
4. Results in use-after-free, crashes, or memory corruption

## Unsafe Operations Fixed

### 1. **batch_cache::entry methods** (`src/v/storage/batch_cache.h:280-287`)
```cpp
// UNSAFE: Direct dereference without validation
model::record_batch batch() { return _range->batch(_range_offset); }
bool valid() const { return _range->valid(); }
```

### 2. **Small batches range usage** (`src/v/storage/batch_cache.cc:180-194`)
```cpp
// UNSAFE: Multiple operations on weak pointer without atomic checks
if (\!index._small_batches_range || \!index._small_batches_range->valid()) {
    // ... weak pointer could become invalid here
}
auto initial_sz = index._small_batches_range->memory_size(); // Potential use-after-free
```

### 3. **mark_clean operation** (`src/v/storage/batch_cache.cc:470`)
```cpp
// UNSAFE: Direct dereference without validation
e.second.range()->mark_clean(up_to_inclusive);
```

## Solution

All weak pointer operations now:
- Use `.get()` to safely obtain raw pointers with null checking
- Handle expired weak pointers gracefully with clear error messages
- Use raw pointers for multiple operations on the same object to ensure atomicity
- Provide defensive programming against concurrent reclamation

## Changes

- **batch_cache.h**: Added null checks and error handling to entry methods
- **batch_cache.cc**: Fixed unsafe weak pointer usage in batch allocation and cleanup
- **batch_cache.h**: Added `#include <stdexcept>` for exception handling

## Impact

- **Prevents crashes** during concurrent memory reclamation
- **Eliminates use-after-free** vulnerabilities  
- **Improves system stability** under memory pressure
- **Maintains existing API** while adding safety