### PR TITLE
SR AuthZ: reduce set of valid acl ops

### DIFF
--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -328,85 +328,11 @@ inline int32_t to_bit_field(const std::vector<security::acl_operation>& ops) {
     return static_cast<int32_t>(bitfield.to_ulong());
 }
 
-/**
- *  list of acl operations for specific resource
- */
-template<typename T>
-const std::vector<security::acl_operation>& get_allowed_operations() {
-    static const std::vector<security::acl_operation> topic_resource_ops{
-      security::acl_operation::read,
-      security::acl_operation::write,
-      security::acl_operation::create,
-      security::acl_operation::describe,
-      security::acl_operation::remove,
-      security::acl_operation::alter,
-      security::acl_operation::describe_configs,
-      security::acl_operation::alter_configs,
-    };
-
-    static const std::vector<security::acl_operation> group_resource_ops{
-      security::acl_operation::read,
-      security::acl_operation::describe,
-      security::acl_operation::remove,
-    };
-
-    static const std::vector<security::acl_operation>
-      transactional_id_resource_ops{
-        security::acl_operation::write,
-        security::acl_operation::describe,
-      };
-
-    static const std::vector<security::acl_operation> cluster_resource_ops{
-      security::acl_operation::create,
-      security::acl_operation::cluster_action,
-      security::acl_operation::describe_configs,
-      security::acl_operation::alter_configs,
-      security::acl_operation::idempotent_write,
-      security::acl_operation::alter,
-      security::acl_operation::describe,
-    };
-
-    static const std::vector<security::acl_operation> sr_subject_resource_ops{
-      security::acl_operation::read,
-      security::acl_operation::write,
-      security::acl_operation::remove,
-      security::acl_operation::describe,
-      security::acl_operation::alter_configs,
-      security::acl_operation::describe_configs,
-    };
-
-    static const std::vector<security::acl_operation> sr_registry_resource_ops{
-      security::acl_operation::read,
-      security::acl_operation::describe,
-      security::acl_operation::alter_configs,
-      security::acl_operation::describe_configs,
-    };
-
-    auto resource_type = security::get_resource_type<T>();
-
-    switch (resource_type) {
-    case security::resource_type::cluster:
-        return cluster_resource_ops;
-    case security::resource_type::group:
-        return group_resource_ops;
-    case security::resource_type::topic:
-        return topic_resource_ops;
-    case security::resource_type::transactional_id:
-        return transactional_id_resource_ops;
-    case security::resource_type::sr_subject:
-        return sr_subject_resource_ops;
-    case security::resource_type::sr_registry:
-        return sr_registry_resource_ops;
-    };
-
-    __builtin_unreachable();
-}
-
 template<typename T>
 std::vector<security::acl_operation>
 authorized_operations(request_context& ctx, const T& resource) {
     std::vector<security::acl_operation> allowed_operations;
-    auto& ops = get_allowed_operations<T>();
+    auto& ops = security::get_allowed_operations<T>();
 
     std::copy_if(
       ops.begin(),

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -349,7 +349,7 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
 
     const metadata_response_data default_response;
     const auto cluster_ops = kafka::details::to_bit_field(
-      kafka::details::get_allowed_operations<security::acl_cluster_name>());
+      security::get_allowed_operations<security::acl_cluster_name>());
 
     for (api_version ver{1}; ver < max_supported; ++ver) {
         auto resp = client.dispatch(make_request(), ver).get();

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1272,7 +1272,7 @@
             "name": "operation",
             "in": "query",
             "type": "string",
-            "enum": ["ALL", "READ", "WRITE", "REMOVE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER", "ALTER_CONFIGS"],
+            "enum": ["ALL", "READ", "WRITE", "DELETE", "DESCRIBE", "DESCRIBE_CONFIGS", "ALTER_CONFIGS"],
             "description": "The operation to allow or deny."
           },
           {

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -166,7 +166,6 @@
             "DELETE",
             "DESCRIBE",
             "DESCRIBE_CONFIGS",
-            "ALTER",
             "ALTER_CONFIGS"
           ],
           "description": "The operation to allow or deny."

--- a/src/v/pandaproxy/schema_registry/requests/acls.cc
+++ b/src/v/pandaproxy/schema_registry/requests/acls.cc
@@ -18,6 +18,8 @@
 #include "security/acl.h"
 #include "strings/utf8.h"
 
+#include <algorithm>
+
 namespace pandaproxy::schema_registry {
 
 struct acl_control_character_thrower {
@@ -47,7 +49,24 @@ T parse_security_enum(std::string_view value, std::string_view type_name) {
 } // namespace
 
 security::acl_operation to_acl_operation(std::string_view op) {
-    return parse_security_enum<security::acl_operation>(op, "ACL operation");
+    auto res = parse_security_enum<security::acl_operation>(
+      op, "ACL operation");
+
+    static const auto valid_ops = [] {
+        auto ops = std::vector<security::acl_operation>{};
+        ops.push_back(security::acl_operation::all);
+        ops.append_range(security::get_allowed_operations<subject>());
+        ops.append_range(security::get_allowed_operations<registry_resource>());
+        std::ranges::sort(ops);
+        ops.erase(std::ranges::unique(ops).begin(), ops.end());
+        return ops;
+    }();
+    if (!std::ranges::contains(valid_ops, res)) {
+        throw exception(
+          error_code::acl_invalid,
+          fmt::format("Invalid acl operation: {}", op));
+    }
+    return res;
 }
 
 security::resource_type to_resource_type(std::string_view type) {

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -12,6 +12,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "security/acl_store.h"
 #include "security/logger.h"
 #include "serde/envelope.h"
@@ -798,5 +799,88 @@ void acl_binding_filter::testing_serde_full_read_v2(
       in, bytes_left_limit);
     *this = acl_binding_filter{res._pattern, res._acl};
 }
+
+template<typename T>
+const std::vector<acl_operation>& get_allowed_operations() {
+    static const std::vector<acl_operation> topic_resource_ops{
+      acl_operation::read,
+      acl_operation::write,
+      acl_operation::create,
+      acl_operation::describe,
+      acl_operation::remove,
+      acl_operation::alter,
+      acl_operation::describe_configs,
+      acl_operation::alter_configs,
+    };
+
+    static const std::vector<acl_operation> group_resource_ops{
+      acl_operation::read,
+      acl_operation::describe,
+      acl_operation::remove,
+    };
+
+    static const std::vector<acl_operation> transactional_id_resource_ops{
+      acl_operation::write,
+      acl_operation::describe,
+    };
+
+    static const std::vector<acl_operation> cluster_resource_ops{
+      acl_operation::create,
+      acl_operation::cluster_action,
+      acl_operation::describe_configs,
+      acl_operation::alter_configs,
+      acl_operation::idempotent_write,
+      acl_operation::alter,
+      acl_operation::describe,
+    };
+
+    static const std::vector<acl_operation> sr_subject_resource_ops{
+      acl_operation::read,
+      acl_operation::write,
+      acl_operation::remove,
+      acl_operation::describe,
+      acl_operation::alter_configs,
+      acl_operation::describe_configs,
+    };
+
+    static const std::vector<acl_operation> sr_registry_resource_ops{
+      acl_operation::read,
+      acl_operation::describe,
+      acl_operation::alter_configs,
+      acl_operation::describe_configs,
+    };
+
+    auto resource_type = get_resource_type<T>();
+
+    switch (resource_type) {
+    case resource_type::cluster:
+        return cluster_resource_ops;
+    case resource_type::group:
+        return group_resource_ops;
+    case resource_type::topic:
+        return topic_resource_ops;
+    case resource_type::transactional_id:
+        return transactional_id_resource_ops;
+    case resource_type::sr_subject:
+        return sr_subject_resource_ops;
+    case resource_type::sr_registry:
+        return sr_registry_resource_ops;
+    };
+
+    __builtin_unreachable();
+}
+
+template const std::vector<acl_operation>&
+get_allowed_operations<model::topic>();
+template const std::vector<acl_operation>&
+get_allowed_operations<kafka::group_id>();
+template const std::vector<acl_operation>&
+get_allowed_operations<acl_cluster_name>();
+template const std::vector<acl_operation>&
+get_allowed_operations<kafka::transactional_id>();
+template const std::vector<acl_operation>&
+get_allowed_operations<pandaproxy::schema_registry::subject>();
+template const std::vector<acl_operation>&
+get_allowed_operations<pandaproxy::schema_registry::registry_resource>();
 
 } // namespace security

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -858,4 +858,10 @@ struct acl_binding_filter_v2 : public acl_binding_filter {
 
 } // namespace testing
 
+/**
+ *  list of acl operations for specific resource
+ */
+template<typename T>
+const std::vector<acl_operation>& get_allowed_operations();
+
 } // namespace security

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5753,9 +5753,11 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
     """
 
     VALID_OPERATIONS = [
-        "READ", "WRITE", "CREATE", "DELETE", "ALTER", "DESCRIBE",
-        "CLUSTER_ACTION", "DESCRIBE_CONFIGS", "ALTER_CONFIGS",
-        "IDEMPOTENT_WRITE", "ALL"
+        "ALL", "READ", "WRITE", "DELETE", "DESCRIBE", "DESCRIBE_CONFIGS",
+        "ALTER_CONFIGS"
+    ]
+    DISALLOWED_OPERATIONS = [
+        "CREATE", "ALTER", "CLUSTER_ACTION", "IDEMPOTENT_WRITE"
     ]
 
     VALID_PATTERN_TYPES = ["LITERAL", "PREFIXED"]
@@ -5950,9 +5952,12 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
         resp = self.sr_client.post_security_acls(invalid_pattern_acl)
         self.assert_equal(resp.status_code, 400)
 
-        invalid_operation_acl = [self._create_test_acl(operation="INVALID_OP")]
-        resp = self.sr_client.post_security_acls(invalid_operation_acl)
-        self.assert_equal(resp.status_code, 400)
+        for operation in self.DISALLOWED_OPERATIONS + ["INVALID_OP"]:
+            invalid_operation_acl = [
+                self._create_test_acl(operation=operation)
+            ]
+            resp = self.sr_client.post_security_acls(invalid_operation_acl)
+            self.assert_equal(resp.status_code, 400)
 
     @cluster(num_nodes=3)
     def test_case_handling(self):


### PR DESCRIPTION
Throw an invalid acl exception and return 400 if the user specifies the
acl operation as CREATE, CLUSTER_ACTION, IDEMPOTENT_WRITE.

These are valid Kafka acl operations, but they are unused in the schema
registry, therefore they should be rejected on the API.

cc @r-vasquez 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
