### PR TITLE
[CORE-12761] - Remove feature for DR and use development config

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -89,7 +89,7 @@ frontend::frontend(
 ss::future<errc> frontend::upsert_cluster_link(
   ::cluster_link::model::metadata meta,
   model::timeout_clock::time_point timeout) {
-    if (!cluster_link_active(true)) {
+    if (!cluster_link_active()) {
         co_return errc::feature_disabled;
     }
     cluster_link_cmd c{cluster::cluster_link_upsert_cmd{0, std::move(meta)}};
@@ -99,7 +99,7 @@ ss::future<errc> frontend::upsert_cluster_link(
 ss::future<errc> frontend::remove_cluster_link(
   ::cluster_link::model::name_t name,
   model::timeout_clock::time_point timeout) {
-    if (!cluster_link_active(false)) {
+    if (!cluster_link_active()) {
         co_return errc::feature_disabled;
     }
     cluster_link_cmd c{cluster::cluster_link_remove_cmd(std::move(name), 0)};
@@ -108,7 +108,7 @@ ss::future<errc> frontend::remove_cluster_link(
 
 ss::future<errc> frontend::add_mirror_topic(
   id_t id, add_mirror_topic_cmd cmd, model::timeout_clock::time_point timeout) {
-    if (!cluster_link_active(false)) {
+    if (!cluster_link_active()) {
         co_return errc::feature_disabled;
     }
     cluster_link_cmd c{
@@ -120,7 +120,7 @@ ss::future<errc> frontend::update_mirror_topic_state(
   id_t id,
   update_mirror_topic_state_cmd cmd,
   model::timeout_clock::time_point timeout) {
-    if (!cluster_link_active(false)) {
+    if (!cluster_link_active()) {
         co_return errc::feature_disabled;
     }
     cluster_link_cmd c{
@@ -128,10 +128,7 @@ ss::future<errc> frontend::update_mirror_topic_state(
     co_return co_await do_mutation(std::move(c), timeout);
 }
 
-bool frontend::cluster_link_active(bool check_license) const {
-    return _features->is_active(features::feature::cluster_linking_dr)
-           && !(check_license && _features->should_sanction());
-}
+bool frontend::cluster_link_active() const { return true; }
 
 frontend::notification_id
 frontend::register_for_updates(notification_callback cb) {

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -17,6 +17,7 @@
 #include "cluster/partition_leaders_table.h"
 #include "cluster/types.h"
 #include "cluster_link/model/types.h"
+#include "config/configuration.h"
 #include "model/validation.h"
 #include "rpc/connection_cache.h"
 
@@ -128,7 +129,9 @@ ss::future<errc> frontend::update_mirror_topic_state(
     co_return co_await do_mutation(std::move(c), timeout);
 }
 
-bool frontend::cluster_link_active() const { return true; }
+bool frontend::cluster_link_active() const {
+    return config::shard_local_cfg().development_enable_cluster_link();
+}
 
 frontend::notification_id
 frontend::register_for_updates(notification_callback cb) {

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -58,7 +58,7 @@ public:
       ::cluster_link::model::update_mirror_topic_state_cmd,
       model::timeout_clock::time_point);
 
-    bool cluster_link_active(bool check_license) const;
+    bool cluster_link_active() const;
 
     notification_id register_for_updates(notification_callback);
     void unregister_for_updates(notification_id);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4331,6 +4331,12 @@ configuration::configuration()
       "Enable cloud topics.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , development_enable_cluster_link(
+      *this,
+      "development_enable_cluster_link",
+      "Enable cluster linking.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -790,6 +790,7 @@ struct configuration final : public config_store {
 
 public:
     development_feature_property<bool> development_enable_cloud_topics;
+    development_feature_property<bool> development_enable_cluster_link;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -110,8 +110,6 @@ std::string_view to_string_view(feature f) {
         return "topic_ids";
     case feature::kafka_data_rpc:
         return "kafka_data_rpc";
-    case feature::cluster_linking_dr:
-        return "cluster_linking_dr";
     case feature::topic_locations_in_outbound_migrations:
         return "topic_locations_in_outbound_migrations";
     case feature::schema_registry_authz:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -38,7 +38,6 @@ struct feature_table_snapshot;
 /// only used at runtime.  Therefore it is safe to re-use an integer that
 /// has been made available by another feature being retired.
 enum class feature : std::uint64_t {
-    cluster_linking_dr = 1ULL << 1U,
     topic_locations_in_outbound_migrations = 1ULL << 2U,
     schema_registry_authz = 1ULL << 3U,
     consumer_groups_migrations = 1ULL << 7U,
@@ -454,12 +453,6 @@ inline constexpr std::array feature_schema{
     "kafka_data_rpc",
     feature::kafka_data_rpc,
     feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
-  feature_spec{
-    release_version::v25_2_1,
-    "cluster_linking_dr",
-    feature::cluster_linking_dr,
-    feature_spec::available_policy::explicit_only,
     feature_spec::prepare_policy::always},
   feature_spec{
     release_version::v25_2_1,


### PR DESCRIPTION
Removes the feature flag for DR and instead uses a development config option

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
