### PR TITLE
[CORE-12756] `storage`: reset batch cache during adjacent merge compaction

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1132,6 +1132,10 @@ ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
     // clean up replacement segment
     co_await from->remove_persistent_state();
 
+    // Clear the target segment's batch cache to ensure no stale data is present
+    // in the cache after the transfer.
+    co_await to->reset_batch_cache_index();
+
     co_return std::move(locks);
 }
 

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -2010,3 +2010,79 @@ TEST_F(
     ASSERT_EQ(num_data_records(on_disk_batches_after), cardinality);
     ASSERT_NE(on_disk_batches_before, on_disk_batches_after);
 }
+
+TEST_F(CompactionFixtureTest, TestBatchCacheResetAfterAdjacentMerge) {
+    // This test case reproduces a specific set of circumstances under which,
+    // previously, batches removed by adjacent merge compaction remained in
+    // the batch cache on the merge range's base segment after compaction has
+    // finished.
+    auto num_segments = 10;
+    auto cardinality = 10;
+    auto batches_per_segment = 10;
+    auto records_per_batch = 1;
+    map_t latest_kv_map;
+    generate_data(
+      num_segments,
+      cardinality,
+      batches_per_segment,
+      records_per_batch,
+      0,
+      false,
+      &latest_kv_map)
+      .get();
+
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+
+    auto target_segs_v = disk_log.segments() | std::views::take(num_segments);
+
+    ASSERT_TRUE(std::ranges::all_of(
+      target_segs_v, [](const auto& s) { return !s->has_appender(); }));
+
+    storage::segment_set segs{storage::segment_set::underlying_t{
+      target_segs_v.begin(), target_segs_v.end()}};
+
+    ss::abort_source never_abort;
+    storage::compaction_config cfg(
+      model::offset::max(), std::nullopt, never_abort);
+
+    // self compact everything up front so that it doesn't happen inline with
+    // adjacent merge compaction. this would cause batch caches to be reset
+    // immediately
+    for (auto& s : segs) {
+        disk_log.segment_self_compact(cfg, s).get();
+    }
+
+    auto consume = [&disk_log](storage::log_reader_config cfg) {
+        return disk_log.make_reader(cfg)
+          .then([](model::record_batch_reader reader) {
+              return model::consume_reader_to_memory(
+                std::move(reader), model::no_timeout);
+          })
+          .get();
+    };
+
+    // read some batches in segments[0]. merge compaction will remove these.
+    auto& first_seg = *target_segs_v.front();
+    auto base = model::next_offset(first_seg.offsets().get_base_offset());
+    auto end = first_seg.offsets().get_committed_offset();
+
+    storage::log_reader_config reader_cfg(base, end);
+    reader_cfg.skip_readers_cache = true;
+
+    auto before_merge = consume(reader_cfg);
+    ASSERT_EQ(before_merge.size(), cardinality);
+
+    disk_log.adjacent_merge_compact(segs, cfg).get();
+
+    ASSERT_EQ(disk_log.segment_count(), 2);
+
+    // at this point, all the batches in segment[0] will have been compacted
+    // away, with those offsets no longer appearing on disk. ensure that they do
+    // not appear in the batch cache.
+
+    reader_cfg.start_offset = before_merge.front().base_offset();
+    reader_cfg.max_offset = before_merge.back().last_offset();
+
+    auto after_merge = consume(reader_cfg);
+    ASSERT_TRUE(after_merge.empty());
+}


### PR DESCRIPTION
JIRA: https://redpandadata.atlassian.net/browse/CORE-12756

Previously, there existed a bug in which the target `segment` would retain its batch cache index after an adjacent merge operation, leading to potentially stale data in the batch cache.

This is because there are two `segment`s of note during adjacent merge compaction- the replacement `segment`, and the target `segment`. The replacement `segment` is the result of the concatenation of several other `segment`s, as well as a self compaction performed upon that data. This means that the replacement `segment` clears its batch cache during adjacent merge compaction. However, the target `segment`, whose underlying data is transferred to/from replacement's, did not previously have its batch cache cleared, leading to potentially stale reads after an adjacent merge operation.

Clear the target's batch cache within `transfer_segment()` to avoid this invalid state.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a `segment` produced by adjacent merge compaction did not have its batch cache reset, leading to potentially stale reads in the `storage` layer.