### PR TITLE
ducktape: fix flaky high watermark check in recovery_mode_test

### DIFF
--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -535,7 +535,12 @@ class DisablingPartitionsTest(RedpandaTest):
 
         assert all_disabled_shut_down()
 
-        assert get_hwms() == hwms3
+        # Even though we waited for leadership, a non-member of a partition
+        # may need a bit more time to learn about the new leader.
+        wait_until(lambda: get_hwms() == hwms3,
+                   10,
+                   backoff_sec=1,
+                   err_msg="Failed waiting to match high watermarks")
 
         self.logger.info("enabling partitions back")
 


### PR DESCRIPTION
In one test case, one partition of a topic is disabled and the cluster is restarted to check that the partition remains disabled across restarts. The test also checks the high watermarks set by producing to the topic. However, after restart, the cluster must elect new leaders for the active partitions. The test waits for this, but the node that is not a part of the partition (there are 4 nodes, partitions are 3x replicated) may not be updated about the leadership change until somewhat later than the other nodes. If the describe topic command that retrieves the high watermark goes to the non-member of the partition, it can fail saying the partition is leaderless or is in the middle of an election. This addresses the flakiness by weakening the watermark check after restart to an eventual check. This should give time for leadership information to be propagated around the cluster.

Fixes CORE-10110

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
