### PR TITLE
[v24.3.x] `storage`: reset batch cache during adjacent merge compaction (MANUAL BACKPORT)

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1098,6 +1098,10 @@ ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
     // clean up replacement segment
     co_await from->remove_persistent_state();
 
+    // Clear the target segment's batch cache to ensure no stale data is present
+    // in the cache after the transfer.
+    to->release_batch_cache_index();
+
     co_return std::move(locks);
 }
 


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26732. `cherry-pick` conflict due to missing tests in `compaction_e2e_test.cc` in previous version of `redpanda`.

Fixes https://github.com/redpanda-data/redpanda/issues/26739.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in which a `segment` produced by adjacent merge compaction did not have its batch cache reset, leading to potentially stale reads in the `storage` layer.
