### PR TITLE
Introduced tiered storage reads scheduling group

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -74,7 +74,7 @@ int_flag(
 
 int_flag(
     name = "scheduling_groups",
-    build_setting_default = 16,
+    build_setting_default = 17,
     make_variable = "SCHEDULING_GROUPS",
 )
 

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -94,6 +94,12 @@ public:
          * replication part is done in this scheduling group.
          */
         _produce = co_await ss::create_scheduling_group("produce", 1000);
+        /**
+         * Group used to handle tiered storage reads.
+         * Lower priority than raft writes, to mitigate promotion to tiered
+         * storage cache starving out producers.
+         */
+        _ts_read = co_await ss::create_scheduling_group("ts_read", 500);
     }
 
     ss::future<> destroy_groups() {
@@ -111,6 +117,7 @@ public:
         co_await destroy_scheduling_group(_transforms);
         co_await destroy_scheduling_group(_datalake);
         co_await destroy_scheduling_group(_produce);
+        co_await destroy_scheduling_group(_ts_read);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -147,6 +154,8 @@ public:
      */
     ss::scheduling_group produce_sg() { return _produce; }
 
+    ss::scheduling_group ts_read_sg() { return _ts_read; }
+
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
         return {
@@ -164,7 +173,8 @@ public:
           std::cref(_fetch),
           std::cref(_transforms),
           std::cref(_datalake),
-          std::cref(_produce)};
+          std::cref(_produce),
+          std::cref(_ts_read)};
     }
 
 private:
@@ -184,4 +194,5 @@ private:
     ss::scheduling_group _transforms;
     ss::scheduling_group _datalake;
     ss::scheduling_group _produce;
+    ss::scheduling_group _ts_read;
 };


### PR DESCRIPTION
Added a CPU scheduling group for tiered storage. This is a replacement for the `shadow-indexing` `io_priority_class`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none