### PR TITLE
.gitignore: ignore bazel_cc_flags.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,6 @@ tests/java/iceberg-rest-catalog/.gradle
 # Ctest
 /Testing
 
+# produced in CI for bazel
+# needs to be ignored to not leave a dirty git state
+bazel_cc_flags.json


### PR DESCRIPTION
CI produces this file during the build. It needs to be ignored so that git does not leave a dirty state leading goreleaser to fail.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

jira: [DEVPROD-3156]

## Release Notes

* none


[DEVPROD-3156]: https://redpandadata.atlassian.net/browse/DEVPROD-3156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ