### PR TITLE
test_utils: continue running tests after exceptions

### DIFF
--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -9,7 +9,9 @@
  * by the Apache License, Version 2.0
  */
 #include "test_utils/gtest_utils.h"
-#include "test_utils/test.h"
+
+#include <seastar/core/thread.hh>
+#include <seastar/testing/test_runner.hh>
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/src/v/test_utils/gtest_utils.cc
+++ b/src/v/test_utils/gtest_utils.cc
@@ -28,7 +28,22 @@ void rp_test_listener::OnTestIterationStart(
 
 void rp_test_listener::OnTestPartResult(
   const ::testing::TestPartResult& result) {
-    if (result.type() == testing::TestPartResult::kFatalFailure) {
+    if (result.fatally_failed()) {
+        const bool failed_with_exception = result.file_name() == nullptr
+                                           && result.line_number() == -1;
+        if (failed_with_exception) {
+            // If the test failed because an exception was thrown, we don't want
+            // to throw another exception here. The test is already failed and
+            // any additional exceptions are propagated to the runner process
+            // which would exit. This is a workaround for the issue
+            // https://github.com/google/googletest/issues/4791.
+            return;
+        }
+
+        // Throw an exception to fail the test on first assert (even if it is
+        // from a helper function).
+        // See
+        // https://google.github.io/googletest/advanced.html#asserting-on-subroutines-with-an-exception.
         throw testing::AssertionException(result);
     }
 }

--- a/src/v/test_utils/tests/gtest_listener_test.cc
+++ b/src/v/test_utils/tests/gtest_listener_test.cc
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 /// Helper function to print and error message and exit with code 1.
 /// We can't use gtest assertions because the way test is set up is meant to
 /// fail and we hide that failure.
@@ -41,6 +43,16 @@ TEST(AssertInHelper, AssertInHelperThrows) {
     }
 }
 
+TEST(ThrowFromBody, ThrowFromBodyDoesNotAbort) {
+    throw std::runtime_error("throwing from test body");
+}
+
+bool global_did_run_after_throw = false;
+
+TEST(ThrowFromBody, ThisTestRunsAfterThrow) {
+    global_did_run_after_throw = true;
+}
+
 /// In this test we want to check that the listener intercepts asserts and
 /// throws exception resulting in not just test failure but test termination.
 int main(int argc, char** argv) {
@@ -51,10 +63,13 @@ int main(int argc, char** argv) {
 
     // Hide stdout to avoid confusing users.
     testing::internal::CaptureStdout();
-
     int result = RUN_ALL_TESTS();
     if (result == 0) {
         fail_test("Expected the test to fail but it passed.");
+    }
+
+    if (!global_did_run_after_throw) {
+        fail_test("Expected the test after throw to run but it did not.");
     }
 
     return 0;


### PR DESCRIPTION
Previously gtest would fail fatally (with reports from LSAN even) when we would use our gtest_main implementation. We don't want that. Instead, we want to fail only a single test and continue with the rest.

This in part is caused by the code we added in 6f707f5c22 to trigger fatal failures on failed asserts from test helpers and some gtest internals.

When throwing an exception, gtest handles it and reports a fatal test result but then we throw again which aborts entire test run as it is not prepared to handle such exceptions.

Fix the problem by avoiding throwing on test failures caused by exceptions. The check is not ideal but it does work and a test is included.

We should propose a proper mechanism upstream for handling this problem in the long run.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
