### PR TITLE
[CORE-12697] Implement support for license format v1

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -306,7 +306,7 @@ make_builtin_trial_license(security::license::clock::time_point start_time) {
 
     return security::license{
       .format_version = 0,
-      .type = security::license_type::free_trial,
+      ._type = security::license_type::free_trial,
       .organization = "Redpanda Built-In Evaluation Period",
       .expiry = expiry,
       .checksum = "",

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -168,6 +168,13 @@
                     "type": "string",
                     "description": "type of license"
                 },
+                "products": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Products covered by this license"
+                },
                 "expires": {
                     "type": "long",
                     "description": "Expiration date of the license in Unix epoch seconds"

--- a/src/v/redpanda/admin/api-doc/features.json
+++ b/src/v/redpanda/admin/api-doc/features.json
@@ -166,7 +166,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "description": "type of license, currently only free_trial or enterprise"
+                    "description": "type of license"
                 },
                 "expires": {
                     "type": "long",

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2463,6 +2463,7 @@ void admin_server::register_features_routes() {
               lc.type = license->get_type();
               lc.expires = license->expiry.count();
               lc.sha256 = license->checksum;
+              lc.products = license->products;
               res.license = lc;
           }
           return ss::make_ready_future<ss::json::json_return_type>(

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2460,7 +2460,7 @@ void admin_server::register_features_routes() {
                   lc.format_version = license->format_version;
                   lc.org = license->organization;
               }
-              lc.type = security::license_type_to_string(license->type);
+              lc.type = license->get_type();
               lc.expires = license->expiry.count();
               lc.sha256 = license->checksum;
               res.license = lc;

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -75,7 +75,7 @@ license_type integer_to_license_type(int type) {
         return license_type::enterprise;
     default:
         throw license_invalid_exception(
-          fmt::format("Unknown license_type: {}", type));
+          ss::format("Unknown license_type: {}", type));
     }
 }
 
@@ -99,7 +99,7 @@ license_components parse_license(std::string_view license) {
         license.substr(itr + strlen(signature_delimiter)))};
 }
 
-const std::string license_data_validator_schema = R"(
+const char* const license_data_validator_schema_v0 = R"(
 {
     "type": "object",
     "properties": {
@@ -126,26 +126,58 @@ const std::string license_data_validator_schema = R"(
 }
 )";
 
-void parse_data_section(license& lc, const json::Document& doc) {
-    json::validator license_data_validator(license_data_validator_schema);
-    if (!doc.Accept(license_data_validator.schema_validator)) {
-        throw license_malformed_exception(
-          "License data section failed to match schema");
-    }
+struct license_data_parser {
+    using data_parser = void (*)(license& lc, const json::Document& doc);
+
+    const char* schema;
+    data_parser parser;
+};
+
+// parse_data_section_v* functions are responsible for parsing all values of the
+// license relevant to each version, apart from 'format_version' and 'checksum'
+void parse_data_section_v0(license& lc, const json::Document& doc) {
     lc.expiry = std::chrono::seconds(
       doc.FindMember("expiry")->value.GetInt64());
     if (lc.is_expired()) {
         throw license_invalid_exception("Expiry date behind todays date");
-    }
-    lc.format_version = doc.FindMember("version")->value.GetInt();
-    if (lc.format_version < 0) {
-        throw license_invalid_exception("Invalid format_version, is < 0");
     }
     lc.organization = doc.FindMember("org")->value.GetString();
     if (lc.organization == "") {
         throw license_invalid_exception("Cannot have empty string for org");
     }
     lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
+}
+
+license_data_parser get_parser(const uint8_t version) {
+    switch (version) {
+    case 0:
+        return license_data_parser{
+          .schema = license_data_validator_schema_v0,
+          .parser = parse_data_section_v0};
+    default:
+        throw license_invalid_exception(
+          ss::format("Unsupported version {}", version));
+    }
+}
+
+void parse_data_section(license& lc, const json::Document& doc) {
+    const auto it_version = doc.FindMember("version");
+    if (it_version == doc.MemberEnd()) {
+        throw license_invalid_exception("Missing required parameter 'version'");
+    }
+    lc.format_version = it_version->value.GetInt();
+    const auto ldf = get_parser(lc.format_version);
+
+    json::validator license_data_validator(ldf.schema);
+    if (!doc.Accept(license_data_validator.schema_validator)) {
+        json::StringBuffer sb;
+        json::Writer<json::StringBuffer> writer(sb);
+        license_data_validator.schema_validator.GetError().Accept(writer);
+        throw license_malformed_exception(ss::format(
+          "License data section failed to match schema with error: {}",
+          sb.GetString()));
+    }
+    ldf.parser(lc, doc);
 }
 
 ss::sstring calculate_sha256_checksum(std::string_view raw_license) {
@@ -167,7 +199,7 @@ std::ostream& operator<<(std::ostream& os, const license& lic) {
 
 license make_license(std::string_view raw_license) {
     try {
-        license lc;
+        license lc{};
         auto components = parse_license(raw_license);
         if (!crypto::verify_license(components.data, components.signature)) {
             throw license_verifcation_exception("RSA signature invalid");

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -141,6 +141,12 @@ const char* const license_data_validator_schema_v1 = R"(
         },
         "expiry": {
             "type": "number"
+        },
+        "products": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "required": [
@@ -186,6 +192,13 @@ void parse_data_section_v1(license& lc, const json::Document& doc) {
         throw license_invalid_exception("Cannot have empty string for org");
     }
     lc._type_str = doc.FindMember("type")->value.GetString();
+
+    const auto it_products = doc.FindMember("products");
+    if (it_products != doc.MemberEnd()) {
+        lc.products = it_products->value.GetArray()
+                      | std::views::transform(&json::Value::GetString)
+                      | std::ranges::to<decltype(lc.products)>();
+    }
 }
 
 license_data_parser get_parser(const uint8_t version) {
@@ -290,11 +303,14 @@ fmt::formatter<security::license, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     return fmt::format_to(
       ctx.out(),
-      "[Version: {0}, Organization: {1}, Type: {2}, Expiry(epoch): {3}]",
+      "[Version: {0}, Organization: {1}, Type: {2}, Expiry(epoch): {3}{4}]",
       r.format_version,
       r.organization,
       r.get_type(),
-      r.expiry.count());
+      r.expiry.count(),
+      r.products.empty()
+        ? ""
+        : fmt::format(", Products: {}", fmt::join(r.products, ",")));
 }
 
 } // namespace fmt

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -155,7 +155,7 @@ const char* const license_data_validator_schema_v1 = R"(
         "type",
         "expiry"
     ],
-    "additionalProperties": false
+    "additionalProperties": true
 }
 )";
 

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -126,6 +126,33 @@ const char* const license_data_validator_schema_v0 = R"(
 }
 )";
 
+const char* const license_data_validator_schema_v1 = R"(
+{
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "number"
+        },
+        "org": {
+            "type": "string"
+        },
+        "type": {
+            "type": "number"
+        },
+        "expiry": {
+            "type": "number"
+        }
+    },
+    "required": [
+        "version",
+        "org",
+        "type",
+        "expiry"
+    ],
+    "additionalProperties": false
+}
+)";
+
 struct license_data_parser {
     using data_parser = void (*)(license& lc, const json::Document& doc);
 
@@ -148,12 +175,29 @@ void parse_data_section_v0(license& lc, const json::Document& doc) {
     lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
 }
 
+void parse_data_section_v1(license& lc, const json::Document& doc) {
+    lc.expiry = std::chrono::seconds(
+      doc.FindMember("expiry")->value.GetInt64());
+    if (lc.is_expired()) {
+        throw license_invalid_exception("Expiry date behind todays date");
+    }
+    lc.organization = doc.FindMember("org")->value.GetString();
+    if (lc.organization == "") {
+        throw license_invalid_exception("Cannot have empty string for org");
+    }
+    lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
+}
+
 license_data_parser get_parser(const uint8_t version) {
     switch (version) {
     case 0:
         return license_data_parser{
           .schema = license_data_validator_schema_v0,
           .parser = parse_data_section_v0};
+    case 1:
+        return license_data_parser{
+          .schema = license_data_validator_schema_v1,
+          .parser = parse_data_section_v1};
     default:
         throw license_invalid_exception(
           ss::format("Unsupported version {}", version));

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -27,7 +27,8 @@ namespace security {
 
 namespace crypto {
 
-static const ::crypto::key public_key = []() {
+namespace {
+const ::crypto::key public_key = []() {
     static const ss::sstring public_key_material
       = "-----BEGIN PUBLIC KEY-----\n"
         "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt0Y2jGOLI70xkF4rmpNM\n"
@@ -47,11 +48,11 @@ static const ::crypto::key public_key = []() {
 /// The redpanda license is comprised of 2 sections seperated by a delimiter.
 /// The first section is the data section (base64 encoded), the second being the
 /// signature, which is a PCKS1.5 sigature of the contents of the data section.
-static bool
-verify_license(const ss::sstring& data, const ss::sstring& signature) {
+bool verify_license(const ss::sstring& data, const ss::sstring& signature) {
     return ::crypto::verify_signature(
       ::crypto::digest_type::SHA256, public_key, data, signature);
 }
+} // namespace
 
 } // namespace crypto
 
@@ -65,7 +66,8 @@ ss::sstring license_type_to_string(license_type type) {
     __builtin_unreachable();
 }
 
-static license_type integer_to_license_type(int type) {
+namespace {
+license_type integer_to_license_type(int type) {
     switch (type) {
     case 0:
         return license_type::free_trial;
@@ -77,17 +79,12 @@ static license_type integer_to_license_type(int type) {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const license& lic) {
-    fmt::print(os, "{}", lic);
-    return os;
-}
-
 struct license_components {
     ss::sstring data;
     ss::sstring signature;
 };
 
-static license_components parse_license(std::string_view license) {
+license_components parse_license(std::string_view license) {
     static constexpr auto signature_delimiter = ".";
     const auto itr = license.find(signature_delimiter);
     if (itr == ss::sstring::npos) {
@@ -102,7 +99,7 @@ static license_components parse_license(std::string_view license) {
         license.substr(itr + strlen(signature_delimiter)))};
 }
 
-static const std::string license_data_validator_schema = R"(
+const std::string license_data_validator_schema = R"(
 {
     "type": "object",
     "properties": {
@@ -129,7 +126,7 @@ static const std::string license_data_validator_schema = R"(
 }
 )";
 
-static void parse_data_section(license& lc, const json::Document& doc) {
+void parse_data_section(license& lc, const json::Document& doc) {
     json::validator license_data_validator(license_data_validator_schema);
     if (!doc.Accept(license_data_validator.schema_validator)) {
         throw license_malformed_exception(
@@ -151,7 +148,7 @@ static void parse_data_section(license& lc, const json::Document& doc) {
     lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
 }
 
-static ss::sstring calculate_sha256_checksum(std::string_view raw_license) {
+ss::sstring calculate_sha256_checksum(std::string_view raw_license) {
     bytes checksum;
     hash_sha256 h;
     h.update(raw_license);
@@ -159,6 +156,13 @@ static ss::sstring calculate_sha256_checksum(std::string_view raw_license) {
     checksum.resize(digest.size());
     std::copy_n(digest.begin(), digest.size(), checksum.begin());
     return to_hex(checksum);
+}
+
+} // namespace
+
+std::ostream& operator<<(std::ostream& os, const license& lic) {
+    fmt::print(os, "{}", lic);
+    return os;
 }
 
 license make_license(std::string_view raw_license) {

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -56,6 +56,7 @@ bool verify_license(const ss::sstring& data, const ss::sstring& signature) {
 
 } // namespace crypto
 
+namespace {
 ss::sstring license_type_to_string(license_type type) {
     switch (type) {
     case license_type::free_trial:
@@ -66,7 +67,6 @@ ss::sstring license_type_to_string(license_type type) {
     __builtin_unreachable();
 }
 
-namespace {
 license_type integer_to_license_type(int type) {
     switch (type) {
     case 0:
@@ -137,7 +137,7 @@ const char* const license_data_validator_schema_v1 = R"(
             "type": "string"
         },
         "type": {
-            "type": "number"
+            "type": "string"
         },
         "expiry": {
             "type": "number"
@@ -172,7 +172,7 @@ void parse_data_section_v0(license& lc, const json::Document& doc) {
     if (lc.organization == "") {
         throw license_invalid_exception("Cannot have empty string for org");
     }
-    lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
+    lc._type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
 }
 
 void parse_data_section_v1(license& lc, const json::Document& doc) {
@@ -185,7 +185,7 @@ void parse_data_section_v1(license& lc, const json::Document& doc) {
     if (lc.organization == "") {
         throw license_invalid_exception("Cannot have empty string for org");
     }
-    lc.type = integer_to_license_type(doc.FindMember("type")->value.GetInt());
+    lc._type_str = doc.FindMember("type")->value.GetString();
 }
 
 license_data_parser get_parser(const uint8_t version) {
@@ -262,6 +262,15 @@ license make_license(std::string_view raw_license) {
     }
 }
 
+ss::sstring license::get_type() const {
+    switch (format_version) {
+    case 0:
+        return license_type_to_string(_type);
+    default:
+        return _type_str;
+    }
+}
+
 bool license::is_expired() const noexcept {
     return clock::now() > expiration();
 }
@@ -281,10 +290,10 @@ fmt::formatter<security::license, char, void>::format<
   fmt::basic_format_context<fmt::appender, char>& ctx) const {
     return fmt::format_to(
       ctx.out(),
-      "[Version: {0}, Organization: {1}, Type: {2} Expiry(epoch): {3}]",
+      "[Version: {0}, Organization: {1}, Type: {2}, Expiry(epoch): {3}]",
       r.format_version,
       r.organization,
-      license_type_to_string(r.type),
+      r.get_type(),
       r.expiry.count());
 }
 

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -72,12 +72,19 @@ struct license
     ss::sstring checksum;
     // This variable should not be used directly. Use get_type accessor, instead
     ss::sstring _type_str;
+    std::vector<ss::sstring> products;
 
     ss::sstring get_type() const;
 
     auto serde_fields() {
         return std::tie(
-          format_version, _type, organization, expiry, checksum, _type_str);
+          format_version,
+          _type,
+          organization,
+          expiry,
+          checksum,
+          _type_str,
+          products);
     }
 
     /// true if todays date is greater then \ref expiry

--- a/src/v/security/license.h
+++ b/src/v/security/license.h
@@ -59,26 +59,25 @@ public:
 
 enum class license_type : uint8_t { free_trial = 0, enterprise = 1 };
 
-ss::sstring license_type_to_string(license_type type);
-
-inline std::ostream& operator<<(std::ostream& os, license_type lt) {
-    os << license_type_to_string(lt);
-    return os;
-}
-
 struct license
-  : serde::envelope<license, serde::version<1>, serde::compat_version<0>> {
+  : serde::envelope<license, serde::version<2>, serde::compat_version<0>> {
     using clock = std::chrono::system_clock;
 
     /// Expected encoded contents
     uint8_t format_version;
-    license_type type;
+    // This variable should not be used directly. Use get_type accessor, instead
+    license_type _type;
     ss::sstring organization;
     std::chrono::seconds expiry;
     ss::sstring checksum;
+    // This variable should not be used directly. Use get_type accessor, instead
+    ss::sstring _type_str;
+
+    ss::sstring get_type() const;
 
     auto serde_fields() {
-        return std::tie(format_version, type, organization, expiry, checksum);
+        return std::tie(
+          format_version, _type, organization, expiry, checksum, _type_str);
     }
 
     /// true if todays date is greater then \ref expiry

--- a/src/v/security/tests/license_test.cc
+++ b/src/v/security/tests/license_test.cc
@@ -18,6 +18,24 @@
 
 using namespace std::chrono_literals;
 
+namespace {
+
+std::optional<security::license> make_license(const char* env_var) {
+    const char* sample_valid_license = std::getenv(env_var);
+    if (sample_valid_license == nullptr) {
+        const char* is_on_ci = std::getenv("CI");
+        if (is_on_ci) {
+            throw std::runtime_error{fmt::format(
+              "Expecting the {} env var in the CI enviornment", env_var)};
+        }
+        return std::nullopt;
+    }
+    const ss::sstring license_str{sample_valid_license};
+    return security::make_license(license_str);
+}
+
+} // namespace
+
 namespace security {
 
 BOOST_AUTO_TEST_CASE(test_license_invalid_signature) {
@@ -67,17 +85,11 @@ BOOST_AUTO_TEST_CASE(test_license_invalid_content) {
 }
 
 BOOST_AUTO_TEST_CASE(test_license_valid_content) {
-    const char* sample_valid_license = std::getenv("REDPANDA_SAMPLE_LICENSE");
-    if (sample_valid_license == nullptr) {
-        const char* is_on_ci = std::getenv("CI");
-        BOOST_TEST_REQUIRE(
-          !is_on_ci,
-          "Expecting the REDPANDA_SAMPLE_LICENSE env var in the CI "
-          "enviornment");
+    auto opt_license = ::make_license("REDPANDA_SAMPLE_LICENSE");
+    if (!opt_license.has_value()) {
         return;
     }
-    const ss::sstring license_str{sample_valid_license};
-    const auto license = make_license(license_str);
+    const license license = std::move(opt_license.value());
     BOOST_CHECK_EQUAL(license.format_version, 0);
     BOOST_CHECK_EQUAL(license.type, license_type::enterprise);
     BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");

--- a/src/v/security/tests/license_test.cc
+++ b/src/v/security/tests/license_test.cc
@@ -97,6 +97,7 @@ BOOST_AUTO_TEST_CASE(test_license_valid_content) {
     BOOST_CHECK_EQUAL(license.expiry.count(), 4813252273);
     BOOST_CHECK(
       license.expiration() == license::clock::time_point{4813252273s});
+    BOOST_CHECK_EQUAL(license.products, std::vector<ss::sstring>{});
     BOOST_CHECK_EQUAL(
       license.checksum,
       "2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf");
@@ -115,8 +116,30 @@ BOOST_AUTO_TEST_CASE(test_license_valid_content_v1) {
     BOOST_CHECK_EQUAL(license.expiry.count(), 4344165449);
     BOOST_CHECK(
       license.expiration() == license::clock::time_point{4344165449s});
+    BOOST_CHECK_EQUAL(license.products, std::vector<ss::sstring>{});
     BOOST_CHECK_EQUAL(
       license.checksum,
       "baba05c0557197d210966555bda6abf3fb54435959dbb5c8e7fd7c5805b29069");
+}
+
+BOOST_AUTO_TEST_CASE(test_license_valid_content_v1_products) {
+    auto opt_license = ::make_license("REDPANDA_SAMPLE_LICENSE_V1_PRODUCTS");
+    if (!opt_license.has_value()) {
+        return;
+    }
+    const license license = std::move(opt_license.value());
+    BOOST_CHECK_EQUAL(license.format_version, 1);
+    BOOST_CHECK_EQUAL(license.get_type(), "testing_license");
+    BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");
+    BOOST_CHECK(!license.is_expired());
+    BOOST_CHECK_EQUAL(license.expiry.count(), 4344165449);
+    BOOST_CHECK(
+      license.expiration() == license::clock::time_point{4344165449s});
+    BOOST_CHECK_EQUAL(
+      license.products,
+      (std::vector<ss::sstring>{"some_prod", "some_other_prod"}));
+    BOOST_CHECK_EQUAL(
+      license.checksum,
+      "0937a2d8e4437a63373c1c1cb0f5f62c5cae9366fea1b00467b4c4eaab8ca4cf");
 }
 } // namespace security

--- a/src/v/security/tests/license_test.cc
+++ b/src/v/security/tests/license_test.cc
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(test_license_valid_content) {
     }
     const license license = std::move(opt_license.value());
     BOOST_CHECK_EQUAL(license.format_version, 0);
-    BOOST_CHECK_EQUAL(license.type, license_type::enterprise);
+    BOOST_CHECK_EQUAL(license.get_type(), "enterprise");
     BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");
     BOOST_CHECK(!license.is_expired());
     BOOST_CHECK_EQUAL(license.expiry.count(), 4813252273);
@@ -100,5 +100,23 @@ BOOST_AUTO_TEST_CASE(test_license_valid_content) {
     BOOST_CHECK_EQUAL(
       license.checksum,
       "2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf");
+}
+
+BOOST_AUTO_TEST_CASE(test_license_valid_content_v1) {
+    auto opt_license = ::make_license("REDPANDA_SAMPLE_LICENSE_V1");
+    if (!opt_license.has_value()) {
+        return;
+    }
+    const license license = std::move(opt_license.value());
+    BOOST_CHECK_EQUAL(license.format_version, 1);
+    BOOST_CHECK_EQUAL(license.get_type(), "testing_license");
+    BOOST_CHECK_EQUAL(license.organization, "redpanda-testing");
+    BOOST_CHECK(!license.is_expired());
+    BOOST_CHECK_EQUAL(license.expiry.count(), 4344165449);
+    BOOST_CHECK(
+      license.expiration() == license::clock::time_point{4344165449s});
+    BOOST_CHECK_EQUAL(
+      license.checksum,
+      "baba05c0557197d210966555bda6abf3fb54435959dbb5c8e7fd7c5805b29069");
 }
 } // namespace security

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -935,8 +935,11 @@ class Admin:
                 and resp['license']['type'] == 'enterprise' \
                 and resp['license']['org'] == 'redpanda-testing'
 
-    def put_license(self, license):
-        return self._request("PUT", "features/license", data=license)
+    def put_license(self, license, node=None):
+        return self._request("PUT",
+                             "features/license",
+                             data=license,
+                             node=node)
 
     def get_enterprise_features(self):
         return self._request("GET", "features/enterprise")

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -10,7 +10,7 @@
 import time
 import json
 
-from rptest.utils.rpenv import sample_license
+from rptest.utils.rpenv import sample_license, sample_license_v1
 from rptest.services.admin import Admin
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.tests.redpanda_test import RedpandaTest
@@ -227,6 +227,53 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
             '2730125070a934ca1067ed073d7159acc9975dc61015892308aae186f7455daf'
         }
 
+        assert self.admin.put_license(license).status_code == 200
+
+        def obtain_configured_license():
+            lic = self.admin.get_license()
+            return (self.admin.is_sample_license(lic), lic)
+
+        resp = wait_until_result(obtain_configured_license,
+                                 timeout_sec=5,
+                                 backoff_sec=1)
+        assert resp['license'] is not None
+        assert expected_license_contents == resp['license'], resp['license']
+
+        license_v1 = sample_license_v1()
+        if license_v1 is None:
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE_V1_PRODUCTS env var not found"
+            )
+            return
+        expected_license_contents_v1 = {
+            'format_version':
+            1,
+            'org':
+            'redpanda-testing',
+            'type':
+            'testing_license',
+            'products': ['some_prod', 'some_other_prod'],
+            'expires':
+            4344165449,
+            'sha256':
+            '0937a2d8e4437a63373c1c1cb0f5f62c5cae9366fea1b00467b4c4eaab8ca4cf'
+        }
+
+        assert self.admin.put_license(license_v1).status_code == 200
+
+        def obtain_configured_license_v1():
+            lic = self.admin.get_license()
+            if lic is None or 'license' not in lic:
+                return False
+            return (lic['license']['format_version'] == 1, lic)
+
+        resp = wait_until_result(obtain_configured_license_v1,
+                                 timeout_sec=5,
+                                 backoff_sec=1)
+        assert resp['license'] is not None
+        assert expected_license_contents_v1 == resp['license'], resp['license']
+
+        # Set back to v0 for sanity check
         assert self.admin.put_license(license).status_code == 200
 
         def obtain_configured_license():

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -13,7 +13,8 @@ import time
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
-from rptest.utils.rpenv import sample_license
+from rptest.util import expect_exception
+from rptest.utils.rpenv import sample_license, sample_license_v1
 from rptest.services.admin import Admin
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
@@ -68,3 +69,197 @@ class UpgradeMigratingLicenseVersion(RedpandaTest):
                    timeout_sec=30,
                    backoff_sec=1,
                    err_msg="Timeout waiting for license to exist in cluster")
+
+
+class UpgradeFormatLicenseVersion(RedpandaTest):
+    """
+    Verify that the cluster can interpret licenses between versions
+    """
+    def __init__(self, test_context):
+        super(UpgradeFormatLicenseVersion,
+              self).__init__(test_context=test_context,
+                             num_brokers=2,
+                             si_settings=SISettings(test_context))
+        self.installer = self.redpanda._installer
+        self.admin = Admin(self.redpanda)
+
+    def setUp(self):
+        # 25.2.x is when license formating went live
+        # Setting to previous version
+        self.installer.install(self.redpanda.nodes, (25, 1))
+        super(UpgradeFormatLicenseVersion, self).setUp()
+
+    @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_license_versioning_upgrade(self):
+        license_v0 = sample_license()
+        license_v1 = sample_license_v1()
+        if license_v0 is None:
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE env var not found")
+            return
+        if license_v1 is None:
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE_V1_PRODUCTS env var not found"
+            )
+            return
+
+        # V1 format should be rejected, as this is an older version
+        with expect_exception(
+                HTTPError,
+                lambda e: "400 Client Error: Bad Request" in str(e)):
+            self.admin.put_license(license_v1)
+
+        # V0 format should be accepted
+        res = self.admin.put_license(license_v0)
+        assert res.status_code == 200, \
+                f"Expected status_code {200} but got {res.status_code} instead.\nContent: {res.content}"
+
+        # Update all nodes to newest version
+        self.installer.install(self.redpanda.nodes, (25, 2))
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        _ = wait_for_num_versions(self.redpanda, 1)
+
+        # Attempt to read license written by older version
+        def v0_license_loaded_ok():
+            license = self.admin.get_license()
+            return self.admin.is_sample_license(license)
+
+        wait_until(
+            v0_license_loaded_ok,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout waiting for license v0 to exist in cluster")
+
+        res = self.admin.put_license(license_v1)
+        assert res.status_code == 200, \
+                f"Expected status_code {200} but got {res.status_code} instead.\nContent: {res.content}"
+
+        # Verify newer format license
+        def v1_license_loaded_ok():
+            lic = self.admin.get_license()
+            if lic is None or 'license' not in lic:
+                return False
+            return (lic['license']['format_version'] == 1, lic)
+
+        wait_until(
+            v1_license_loaded_ok,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout waiting for license v1 to exist in cluster")
+
+    @cluster(num_nodes=2, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_license_versioning_partial_upgrade(self):
+        license_v1 = sample_license_v1()
+        if license_v1 is None:
+            self.logger.info(
+                "Skipping test, REDPANDA_SAMPLE_LICENSE_V1_PRODUCTS env var not found"
+            )
+            return
+
+        node_v25_2 = self.redpanda.nodes[0]
+        node_v25_2_id = self.redpanda.node_id(node_v25_2)
+        node_v25_1 = self.redpanda.nodes[1]
+        node_v25_1_id = self.redpanda.node_id(node_v25_1)
+
+        # Update only the first node to newest version
+        self.installer.install([node_v25_2], (25, 2))
+        self.redpanda.restart_nodes([node_v25_2])
+        _ = wait_for_num_versions(self.redpanda, 2)
+
+        # Verify that we are working with the expected versions in each node
+        version = self.redpanda.get_version(node_v25_2)
+        assert "v25.2" in version, \
+                f"Expected a 'v25.2' version for node {node_v25_2_id}. Got '{version}' instead"
+        version = self.redpanda.get_version(node_v25_1)
+        assert "v25.1" in version, \
+                f"Expected a 'v25.1' version for node {node_v25_1_id}. Got '{version}' instead"
+
+        def change_controller(target_controller):
+            self.admin.partition_transfer_leadership(
+                namespace="redpanda",
+                topic="controller",
+                target_id=self.redpanda.node_id(target_controller),
+                partition=0)
+
+            return self.admin.await_stable_leader(topic='controller',
+                                                  partition=0,
+                                                  namespace="redpanda")
+
+        # Set controller to the upgraded node
+        controller_id = change_controller(node_v25_2)
+        assert controller_id == node_v25_2_id, \
+                f"Expected node {node_v25_2_id} to be controller. Got node {controller_id} instead"
+
+        # V1 format should be rejected on any older node
+        with expect_exception(
+                HTTPError,
+                lambda e: "400 Client Error: Bad Request" in str(e)):
+            self.admin.put_license(license_v1, node=node_v25_1)
+
+        # V1 format should be accepted on upgraded node
+        res = self.admin.put_license(license_v1, node=node_v25_2)
+        assert res.status_code == 200, \
+                f"Expected status_code {200} but got {res.status_code} instead.\nContent: {res.content}"
+
+        expected_license_contents = {
+            'format_version':
+            1,
+            'org':
+            'redpanda-testing',
+            'type':
+            'testing_license',
+            'products': ['some_prod', 'some_other_prod'],
+            'expires':
+            4344165449,
+            'sha256':
+            '0937a2d8e4437a63373c1c1cb0f5f62c5cae9366fea1b00467b4c4eaab8ca4cf'
+        }
+
+        # Wait until license has been loaded in all nodes
+        def v1_license_loaded_ok():
+            def verify_license(lic):
+                if lic is None or 'license' not in lic:
+                    return False
+                correct_version = lic['license'][
+                    'format_version'] == expected_license_contents[
+                        'format_version']
+                correct_sha256 = lic['license'][
+                    'sha256'] == expected_license_contents['sha256']
+                return correct_version and correct_sha256
+
+            lics = [
+                self.admin.get_license(node=node)
+                for node in self.redpanda.nodes
+            ]
+            return all([verify_license(lic) for lic in lics])
+
+        wait_until(
+            v1_license_loaded_ok,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=
+            "Timeout waiting for license v1 to propagate through cluster")
+
+        # Validate the full license against upgraded node
+        license_v1 = self.admin.get_license(node=node_v25_2)
+        assert expected_license_contents == license_v1['license'], \
+            f"Invalid license loaded.\n" \
+            f"Found: {license_v1['license']}\n" \
+            f"Expected: {expected_license_contents}"
+
+        # Now check how it behaves on a node that is not aware of V1
+        lic = self.admin.get_license(node=node_v25_1)['license']
+
+        # Validate that backwards compatible fields are maintained
+        for key in ['format_version', 'org', 'expires', 'sha256']:
+            assert lic[key] == expected_license_contents[key], \
+                f"Invalid value for key: '{key}'\n" \
+                f"Found: {lic[key]}\n" \
+                f"Expected: {expected_license_contents[key]}"
+
+        # 'type' is now a string. 'type' should be in the defaulted value, i.e. free trial
+        assert lic['type'] == "free_trial", \
+                    f"Expected 'type' as 'free_trial'. Got '{lic['type']}'."
+
+        # 'products' is a new field in V1. 'products' should not be part of the license
+        assert 'products' not in lic, f"Expected 'products' not in license. License: {lic}"

--- a/tests/rptest/utils/rpenv.py
+++ b/tests/rptest/utils/rpenv.py
@@ -29,6 +29,23 @@ def sample_license(assert_exists=False):
     return license
 
 
+def sample_license_v1(assert_exists=False):
+    """
+    Returns the sample license from the env if it exists, asserts if its
+    missing and the environment is CI
+    """
+    license = os.environ.get("REDPANDA_SAMPLE_LICENSE_V1_PRODUCTS", None)
+    if license is None:
+        is_ci = os.environ.get("CI", "false")
+        assert is_ci == "false"
+        assert not assert_exists, (
+            "No enterprise license found in the environment variable REDPANDA_SAMPLE_LICENSE_V1_PRODUCTS. "
+            "Please follow these instructions to get a sample license for local development: "
+            "https://redpandadata.atlassian.net/l/cp/4eeNEgZW")
+        return None
+    return license
+
+
 class IsCIOrNotEmpty:
     """
     Comparison with this object is true if the environemnt is CI, or if the


### PR DESCRIPTION
Implements: [CORE-12697](https://redpandadata.atlassian.net/browse/CORE-12697)

Implement license v1 format. This includes:
- Change type of `type` to a string
- Allow optional list of products
- Allow additional parameters

If `products` is included in the license, it will also be returned by the `get_license` admin endpoint.

Note on backport: This is a feature aimed at 25.2.x. However it is merged after the 25.2.x branch has been cut.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12697]: https://redpandadata.atlassian.net/browse/CORE-12697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ