### PR TITLE
serde/json: hide the space trick inside the numeric parser

### DIFF
--- a/src/v/serde/json/detail/numeric.h
+++ b/src/v/serde/json/detail/numeric.h
@@ -54,6 +54,15 @@ public:
     /// can be called to get the result.
     size_t advance(ss::temporary_buffer<char>& buf, result& err);
 
+    /// Signal to the parser that there will be no more input.
+    /// After this method returns the parser will be done or in an error state.
+    /// Equivalent to calling advance with input a single space character.
+    size_t finalize(result& err) {
+        const char space = ' ';
+        ss::temporary_buffer<char> space_buf(&space, 1);
+        return advance(space_buf, err);
+    }
+
     bool is_int() const {
         if (_state == state::finished_with_int) {
             return true;

--- a/src/v/serde/json/parser.cc
+++ b/src/v/serde/json/parser.cc
@@ -515,9 +515,7 @@ public:
                     // number, feed it a space. Bit of a hack :).
                     TRACE(
                       "parse_number: EOF at top level, trying to finalize\n");
-                    char space = ' ';
-                    ss::temporary_buffer<char> space_buf(&space, 1);
-                    numeric_parser.advance(space_buf, numeric_parse_result);
+                    numeric_parser.finalize(numeric_parse_result);
                     // If the number is done produce it, else fall through
                     // to the incomplete case.
                     if (


### PR DESCRIPTION
To parse top-level numbers we're using a trick where we pass a phantom space into the numeric parser when the JSON parser detects there's no more input. This forces the numeric parser to finish parsing. Originally, the trick lived in the JSON parser but maybe it's nicer to hide it inside the numeric parser.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
