### PR TITLE
`rptest`: set `storage-gc` log level to `debug` in `random_node_operations_test`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -526,7 +526,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
           new_start_offset
           && s.offsets().get_base_offset() < *new_start_offset) {
             vlog(
-              gclog.debug,
+              gclog.trace,
               "[{}] segment {} base offs {}, new start offset {}, "
               "skipping self compaction.",
               config().ntp(),
@@ -538,7 +538,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
 
         if (s.is_compactible(cfg)) {
             vlog(
-              gclog.debug,
+              gclog.trace,
               "[{}] segment {} stable offs {}, max compactible {}, "
               "compacting.",
               config().ntp(),
@@ -1560,7 +1560,7 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
         }
 
         vlog(
-          gclog.debug,
+          gclog.trace,
           "[{}] treating segment as compacted, offsets fall above highest "
           "indexed key {}, likely because they are non-data batches: {}",
           config().ntp(),

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -82,7 +82,7 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             log_config=LoggingConfig(
                 'info', {
                     'storage-resources': 'warn',
-                    'storage-gc': 'warn',
+                    'storage-gc': 'debug',
                     'raft': 'debug',
                     'cluster': 'debug',
                     'datalake': 'trace',


### PR DESCRIPTION
To help with debugging any issues that may arise with the compaction/housekeeping subsystem.

This will result in larger logs for `random_node_operations_test`, but ostensibly not a ridiculous amount.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
