### PR TITLE
Fixed oversized allocation in CPU profiler admin API endpoint

### DIFF
--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -858,7 +858,7 @@
                     "description": "Number of samples that were dropped due to space limitations during the measurement period."
                 },
                 "samples": {
-                    "type": "array",
+                    "type": "chunked_array",
                     "items": {
                         "type": "cpu_profile_sample"
                     }

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -33,6 +33,7 @@
 #include "utils/arch.h"
 #include "version/version.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
@@ -621,7 +622,7 @@ admin_server::cpu_profile_handler(std::unique_ptr<ss::http::request> req) {
         shard_samples.dropped_samples = shard_profile.dropped_samples;
 
         // build up the samples list
-        std::vector<cpu_profile_sample> samples;
+        seastar::chunked_fifo<cpu_profile_sample> samples;
         samples.reserve(shard_profile.samples.size());
         for (auto& sample : shard_profile.samples) {
             ss::httpd::debug_json::cpu_profile_sample json_sample;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR switches the type of `samples` from `array` to `chunked_array`. This doesn't effect the json structure being returned by the endpoint. It just effects what data structures seastar is using internally to hold the list before it's sent back to the client.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
