### PR TITLE
cs: Use configurable timeouts for downloads in remote seg/part

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -40,7 +40,6 @@ namespace cloud_storage {
 
 // These timeout/backoff settings are for S3 requests
 using namespace std::chrono_literals;
-inline const ss::lowres_clock::duration cache_hydration_timeout = 60s;
 inline const ss::lowres_clock::duration cache_hydration_backoff = 250ms;
 
 // This backoff is for failure of the local cache to retain recently

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1305,7 +1305,6 @@ bool remote_partition::bounds_timestamp(model::timestamp t) const {
     }
 }
 
-static constexpr ss::lowres_clock::duration finalize_timeout = 20s;
 static constexpr ss::lowres_clock::duration finalize_backoff = 1s;
 
 /// When a remote_partition is being destroyed for the last time, we save this
@@ -1330,7 +1329,10 @@ ss::future<> finalize_in_background(
   remote& api, finalize_data data, remote_path_provider path_provider) {
     ss::abort_source& as = api.as();
 
-    retry_chain_node local_rtc(as, finalize_timeout, finalize_backoff);
+    retry_chain_node local_rtc(
+      as,
+      config::shard_local_cfg().cloud_storage_manifest_upload_timeout_ms(),
+      finalize_backoff);
 
     // Start with an empty manifest.
     partition_manifest remote_manifest(data.ntp, data.revision);

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -466,7 +466,9 @@ ss::future<> remote_segment::put_chunk_in_cache(
 
 ss::future<> remote_segment::do_hydrate_segment() {
     retry_chain_node local_rtc(
-      cache_hydration_timeout, cache_hydration_backoff, &_rtc);
+      config::shard_local_cfg().cloud_storage_segment_upload_timeout_ms(),
+      cache_hydration_backoff,
+      &_rtc);
 
     // RAII reservation object represents the disk space this put will consume
     auto reservation = co_await _cache.reserve_space(
@@ -498,7 +500,9 @@ ss::future<> remote_segment::do_hydrate_segment() {
 
 ss::future<> remote_segment::do_hydrate_index() {
     retry_chain_node local_rtc(
-      cache_hydration_timeout, cache_hydration_backoff, &_rtc);
+      config::shard_local_cfg().cloud_storage_segment_upload_timeout_ms(),
+      cache_hydration_backoff,
+      &_rtc);
 
     offset_index ix(
       _base_rp_offset,
@@ -530,7 +534,9 @@ ss::future<> remote_segment::do_hydrate_index() {
 ss::future<> remote_segment::do_hydrate_txrange() {
     ss::gate::holder guard(_gate);
     retry_chain_node local_rtc(
-      cache_hydration_timeout, cache_hydration_backoff, &_rtc);
+      config::shard_local_cfg().cloud_storage_segment_upload_timeout_ms(),
+      cache_hydration_backoff,
+      &_rtc);
     if (_sname_format == segment_name_format::v3 && _metadata_size_hint == 0) {
         // The tx-manifest is empty, no need to download it, and
         // avoid putting this empty manifest into the cache.
@@ -1067,7 +1073,9 @@ ss::future<> remote_segment::hydrate_chunk(chunk_start_offset_t start_offset) {
     }
 
     retry_chain_node rtc{
-      cache_hydration_timeout, cache_hydration_backoff, &_rtc};
+      config::shard_local_cfg().cloud_storage_segment_upload_timeout_ms(),
+      cache_hydration_backoff,
+      &_rtc};
 
     auto byte_range = _chunks_api->get_byte_range_for_chunk(
       start_offset, _size - 1);

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -457,14 +457,14 @@ auto client_pool::acquire_with_timeout(
               if (ctx.has_value()) {
                   vlog(
                     pool_log.debug,
-                    "{} - Lease expired after {}. Shutting down client...",
+                    "{} - Lease expired after {}ms. Shutting down client...",
                     ctx.value(),
-                    to);
+                    to / 1ms);
               } else {
                   vlog(
                     pool_log.debug,
-                    "Lease expired after {}. Shutting down client...",
-                    to);
+                    "Lease expired after {}ms. Shutting down client...",
+                    to / 1ms);
               }
               if (probe) {
                   probe->register_timeout();

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2155,13 +2155,13 @@ configuration::configuration()
       "cloud_storage_segment_upload_timeout_ms",
       "Log segment upload timeout (ms)",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      30s)
+      90s)
   , cloud_storage_manifest_upload_timeout_ms(
       *this,
       "cloud_storage_manifest_upload_timeout_ms",
       "Manifest upload timeout (ms).",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      10s)
+      30s)
   , cloud_storage_garbage_collect_timeout_ms(
       *this,
       "cloud_storage_garbage_collect_timeout_ms",


### PR DESCRIPTION
Since adding active request timeouts in cloud_io, we have observed an increased rate of upload and download failures. For the most part, these requests timeouts are subject to cluster configs:

- cloud_storage_manifest_upload_timeout_ms
- cloud_storage_segment_upload_timeout_ms

This commit modifies remote_segment and remote_partition to apply the configurable appropriate configurable timeout to segment & manifest downloads, which were previously subject to hard-coded timeouts.

This pattern is not without precedent insomuch as many manifest downloads are subject to manifest_uplaod_timeout already.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Make segment download timeouts configurable in cloud cache hydration

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
