### PR TITLE
test_utils: refactor macro to avoid clang-tidy warns

### DIFF
--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -64,21 +64,35 @@ private:
         static ::testing::TestInfo* const test_info_ [[maybe_unused]];         \
     };                                                                         \
                                                                                \
+    constexpr auto GTEST_CONCAT_TOKEN_(                                        \
+      GTEST_TEST_CLASS_NAME_(test_suite_name, test_name), _init)               \
+      = []() noexcept {                                                        \
+            try {                                                              \
+                /* NOLINTNEXTLINE(cppcoreguidelines-owning-memory) */          \
+                auto test_factory = new ::testing::internal::TestFactoryImpl<  \
+                  GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)>;         \
+                return ::testing::internal::MakeAndRegisterTestInfo(           \
+                  #test_suite_name,                                            \
+                  #test_name,                                                  \
+                  nullptr,                                                     \
+                  nullptr,                                                     \
+                  ::testing::internal::CodeLocation(__FILE__, __LINE__),       \
+                  (parent_id),                                                 \
+                  ::testing::internal::SuiteApiResolver<                       \
+                    parent_class>::GetSetUpCaseOrSuite(__FILE__, __LINE__),    \
+                  ::testing::internal::SuiteApiResolver<                       \
+                    parent_class>::GetTearDownCaseOrSuite(__FILE__, __LINE__), \
+                  test_factory);                                               \
+            } catch (...) {                                                    \
+                std::print(std::cerr, "Unknown exception during test init.");  \
+                std::terminate();                                              \
+            }                                                                  \
+        };                                                                     \
     ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(                         \
       test_suite_name, test_name)::test_info_                                  \
-      = ::testing::internal::MakeAndRegisterTestInfo(                          \
-        #test_suite_name,                                                      \
-        #test_name,                                                            \
-        nullptr,                                                               \
-        nullptr,                                                               \
-        ::testing::internal::CodeLocation(__FILE__, __LINE__),                 \
-        (parent_id),                                                           \
-        ::testing::internal::SuiteApiResolver<                                 \
-          parent_class>::GetSetUpCaseOrSuite(__FILE__, __LINE__),              \
-        ::testing::internal::SuiteApiResolver<                                 \
-          parent_class>::GetTearDownCaseOrSuite(__FILE__, __LINE__),           \
-        new ::testing::internal::TestFactoryImpl<GTEST_TEST_CLASS_NAME_(       \
-          test_suite_name, test_name)>);                                       \
+      = GTEST_CONCAT_TOKEN_(                                                   \
+        GTEST_TEST_CLASS_NAME_(test_suite_name, test_name), _init());          \
+                                                                               \
     seastar::future<> GTEST_TEST_CLASS_NAME_(                                  \
       test_suite_name, test_name)::TestBodyWrapped()
 


### PR DESCRIPTION
1. Wrap test_info_ init in a noexcept lambda to avoid https://clang.llvm.org/extra/clang-tidy/checks/cert/err58-cpp.html.

2. Ignore https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/owning-memory.html

Less yellow squiggly lines in IDEs and less noise in clang-tidy output.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
