### PR TITLE
ct: add version to l1 objects

### DIFF
--- a/src/v/cloud_topics/object_utils.cc
+++ b/src/v/cloud_topics/object_utils.cc
@@ -22,7 +22,7 @@ object_path_factory::level_zero_path(object_id id) {
 
 cloud_storage_clients::object_key object_path_factory::level_one_path() {
     return cloud_storage_clients::object_key(
-      ssx::sformat("l1_{}", uuid_t::create()));
+      ssx::sformat("l1_v0_{}", uuid_t::create()));
 }
 
 } // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/tests/object_utils_test.cc
+++ b/src/v/cloud_topics/tests/object_utils_test.cc
@@ -26,5 +26,5 @@ TEST(ObjectPathFactory, LevelOnePathFormat) {
     auto path
       = experimental::cloud_topics::object_path_factory::level_one_path();
     EXPECT_THAT(
-      path().string(), ::testing::MatchesRegex("^l1_" UUID_REGEX "$"));
+      path().string(), ::testing::MatchesRegex("^l1_v0_" UUID_REGEX "$"));
 }


### PR DESCRIPTION
We could take the lack of version to mean v0, but might as well be
specific.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
