### PR TITLE
wcr: skip creation of all internal topics

### DIFF
--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -233,13 +233,6 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
         topic_configuration_vector topics;
         for (size_t i = 0; i < actions.remote_topics.size(); i++) {
             auto& topic_cfg = actions.remote_topics[i];
-            if (topic_cfg.is_internal()) {
-                vlog(
-                  clusterlog.debug,
-                  "Skipping topic recovery for internal topic {}",
-                  topic_cfg.tp_ns);
-                continue;
-            }
             topics.emplace_back(std::move(topic_cfg));
             vlog(
               clusterlog.debug,

--- a/src/v/cluster/cluster_recovery_reconciler.cc
+++ b/src/v/cluster/cluster_recovery_reconciler.cc
@@ -112,6 +112,13 @@ controller_snapshot_reconciler::get_actions(
             if (_topic_table.contains(tp_ns)) {
                 continue;
             }
+            if (tp_config.is_internal()) {
+                vlog(
+                  clusterlog.debug,
+                  "Skipping topic recovery for internal topic {}",
+                  tp_ns);
+                continue;
+            }
             if (
               si_props.has_value()
               && model::is_archival_enabled(si_props.value())) {


### PR DESCRIPTION
Before this commit during `get_actions depending on topic properties we would either put a topic in `actions.remote_topics` or `actions.local_topics`. Later, if we detected that a topic is internal during processing of remote topics we would skip creating that topic.

To best of my knowledge there is only one topic that could fall into this category, `__consumer_offsets`.

The result is that post-recovery there is no automatic creation of `__consumer_offsets` topic.

While I was experimenting with disabling TS for consumer offsets topic I noticed that topic now gets automatically created during recovery. Although it is likely that this won't be the actual way we'll disable TS for consumer offsets I found that behavior surprising enough to prompt me to move the check earlier in the code such that we never attempt to create internal topics during recovery.

I believe this makes it more straightforward to understand what topics are created and not created during WCR rather than before.

We also have clusters in the wild with manually disabled TS for CO topic. When/if these get recovered they would get the same surprising behavior.

This fixes no real bugs and shouldn't introduce any new bugs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
