### PR TITLE
CORE-7664 c/cloudchecks: increase default timeout to 10s

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -106,7 +106,7 @@ To view the test status, poll 'rpk cluster self-test status'. Once the tests end
 		"The duration in milliseconds of individual disk test runs")
 	cmd.Flags().UintVar(&netDurationMs, "network-duration-ms", 30000,
 		"The duration in milliseconds of individual network test runs")
-	cmd.Flags().UintVar(&cloudTimeoutMs, "cloud-timeout-ms", 5000,
+	cmd.Flags().UintVar(&cloudTimeoutMs, "cloud-timeout-ms", 10000,
 		"The timeout in milliseconds for a cloud storage request")
 	cmd.Flags().UintVar(&cloudBackoffMs, "cloud-backoff-ms", 100,
 		"The backoff in milliseconds for a cloud storage request")

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -199,7 +199,7 @@ struct cloudcheck_opts
     ss::sstring name{"Cloud credentials check"};
 
     // Timeout duration for cloud storage requests.
-    ss::lowres_clock::duration timeout{std::chrono::milliseconds(5000)};
+    ss::lowres_clock::duration timeout{std::chrono::milliseconds(10000)};
 
     // Backoff duration for cloud storage requests.
     ss::lowres_clock::duration backoff{std::chrono::milliseconds(10)};

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -293,7 +293,7 @@ class SelfTestTest(EndToEndTest):
             'tests': [{
                 'type': 'cloud',
                 'backoff_ms': 100,
-                'timeout_ms': 5000
+                'timeout_ms': 10000
             }]
         }
 


### PR DESCRIPTION
Redpanda uses a default 5s timeout for DNS lookups, so if the DNS lookup for a cloud check operations times out or just takes ~5s then the self check would fail.

We should be able to gracefully retry on at least 1 DNS lookup, so increase the self check timeout to 10s to give the operations more time to complete.

This was prompted by some occasional (~1/100) failures observed in Azure CDT testing.

Fixes https://redpandadata.atlassian.net/browse/CORE-7664

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes
* Increase the default self check timeout from 5s to 10s to leave time to retry DNS lookups if they time out during a self check operation.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
