### PR TITLE
iceberg/config: add example iceberg_rest_catalog_aws_credentials_source

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4124,7 +4124,9 @@ configuration::configuration()
       "aws_sigv4 authentication mode. Accepted values: config_file, "
       "aws_instance_metadata, sts, gcp_instance_metadata, "
       "azure_vm_instance_metadata, azure_aks_oidc_federation.",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      {.needs_restart = needs_restart::yes,
+       .example = "config_file",
+       .visibility = visibility::user},
       std::nullopt,
       {
         model::cloud_credentials_source::config_file,


### PR DESCRIPTION
This gives the ClusterConfigTest a valid value to set the property to.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
