### PR TITLE
schema_registry: change acl op for `GET /subjects`

### DIFF
--- a/src/v/pandaproxy/schema_registry/authorization.cc
+++ b/src/v/pandaproxy/schema_registry/authorization.cc
@@ -209,7 +209,7 @@ void handle_get_subjects_authz(
   chunked_vector<subject>& subjects) {
     const auto& operation_name
       = ss::httpd::schema_registry_json::get_subjects.operations.nickname;
-    constexpr auto op = security::acl_operation::read;
+    constexpr auto op = security::acl_operation::describe;
 
     if (!auth_result.has_value()) {
         // ACLs or authentication is disabled

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2555,7 +2555,7 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
         denied_subjects = subjects[1::2]
 
         self._post_acl([
-            self._create_acl(subject, "SUBJECT", "LITERAL", "READ")
+            self._create_acl(subject, "SUBJECT", "LITERAL", "DESCRIBE")
             for subject in allowed_subjects
         ])
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -7128,20 +7128,20 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
 
         # Grant READ to subject_1 only - should only return subject_1
         self._post_acl(
-            self._create_acl(subject_1, "SUBJECT", "LITERAL", "READ"))
+            self._create_acl(subject_1, "SUBJECT", "LITERAL", "DESCRIBE"))
         result = self.sr_client.get_subjects(auth=self.user_auth)
         self.assert_equal(result.status_code, 200)
         self.assert_equal(result.json(), [subject_1])
 
         # Grant wildcard (*) access - should return all subjects
-        self._post_acl(self._create_acl("*", "SUBJECT", "LITERAL", "READ"))
+        self._post_acl(self._create_acl("*", "SUBJECT", "LITERAL", "DESCRIBE"))
         result = self.sr_client.get_subjects(auth=self.user_auth)
         self.assert_equal(result.status_code, 200)
         self.assert_equal(set(result.json()), {subject_1, subject_2})
 
         # Deny all access - should return no subjects
         self._post_acl(
-            self._create_acl("*", "SUBJECT", "LITERAL", "READ", "DENY"))
+            self._create_acl("*", "SUBJECT", "LITERAL", "DESCRIBE", "DENY"))
         result = self.sr_client.get_subjects(auth=self.user_auth)
         self.assert_equal(result.status_code, 200)
         self.assert_equal(result.json(), [])


### PR DESCRIPTION
Require describe instead of read on this endpoint.

To match the intended acl operation as described in https://github.com/redpanda-data/redpanda/pull/26758.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
