### PR TITLE
serde/json: zap leftover comment

### DIFF
--- a/src/v/serde/json/parser.cc
+++ b/src/v/serde/json/parser.cc
@@ -509,10 +509,6 @@ public:
                == detail::numeric_parser::result::need_more_data) {
             if (_buf.empty()) {
                 if (_suspension_stack.empty()) {
-                    // If we reach the end of the input parsing a number, and
-                    // we're at the top-level, it's valid if the number literal
-                    // is valid. To force the number parser to finalize the
-                    // number, feed it a space. Bit of a hack :).
                     TRACE(
                       "parse_number: EOF at top level, trying to finalize\n");
                     numeric_parser.finalize(numeric_parse_result);


### PR DESCRIPTION
I forgot to delete a comment about the space trick when I moved that trick into the numeric parser. Oops.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
