### PR TITLE
[CORE-12278] schema_registry: Add scale tests for `security/acl`

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -864,7 +864,7 @@ get_security_acls(server::request_t rq, server::reply_t rp) {
         security::resource_pattern_filter::resource_subsystem::schema_registry},
       security::acl_entry_filter{principal, host, operation, permission}};
 
-    auto sr_acls = std::ranges::to<std::vector>(
+    auto sr_acls = std::ranges::to<fragmented_vector<acl>>(
       acl_store.acls(filter)
       | std::views::transform(
         [](const security::acl_binding& binding) { return acl(binding); }));
@@ -955,7 +955,7 @@ delete_security_acls(server::request_t rq, server::reply_t rp) {
     auto deleted = co_await security_frontend.delete_acls(
       std::move(filters), 5s);
 
-    auto res = std::vector<acl>{};
+    auto res = fragmented_vector<acl>{};
     std::ranges::for_each(deleted, [&res](cluster::delete_acls_result r) {
         if (r.error != cluster::errc::success) {
             throw exception(

--- a/src/v/pandaproxy/schema_registry/requests/acls.h
+++ b/src/v/pandaproxy/schema_registry/requests/acls.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "absl/strings/ascii.h"
+#include "container/fragmented_vector.h"
 #include "json/chunked_buffer.h"
 #include "json/types.h"
 #include "pandaproxy/json/rjson_parse.h"
@@ -91,7 +92,7 @@ class acl_handler : public json::base_handler<Encoding> {
 public:
     using require_fields = ss::bool_class<struct require_fields_tag>;
     using Ch = typename json::base_handler<Encoding>::Ch;
-    using rjson_parse_result = std::vector<acl>;
+    using rjson_parse_result = fragmented_vector<acl>;
 
     explicit acl_handler(require_fields require_fields)
       : json::base_handler<Encoding>{json::serialization_format::none}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -5816,14 +5816,16 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
         return sorted_response
 
     @cluster(num_nodes=3)
-    def test_basic_acl_operations(self):
+    @matrix(scale=[1, 1000])
+    def test_basic_acl_operations(self, scale: int):
         """Test basic CRUD operations for ACLs"""
         # Define the ACLs
         acls = [
             self._create_test_acl(principal="User:alice",
-                                  resource="test-subject",
+                                  resource=f"test-subject{i}",
                                   resource_type="SUBJECT",
-                                  operation="READ"),
+                                  operation="READ") for i in range(scale)
+        ] + [
             self._create_test_acl(principal="User:bob",
                                   resource="*",
                                   resource_type="REGISTRY",
@@ -5840,7 +5842,7 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
             resp = self.sr_client.get_security_acls()
             self.assert_equal(resp.status_code, 200)
             created_acls = resp.json()
-            self.assert_equal(len(created_acls), 2)
+            self.assert_equal(len(created_acls), scale + 1)
             return True
 
         wait_until(acls_exist,
@@ -5853,7 +5855,7 @@ class SchemaRegistryACLTest(SchemaRegistryEndpoints):
         resp = self.sr_client.delete_security_acls(acls)
         self.assert_equal(resp.status_code, 200)
         deleted_acls = resp.json()
-        self.assert_equal(len(deleted_acls), 2)
+        self.assert_equal(len(deleted_acls), scale + 1)
 
         # Verify ACLs are gone
         def acls_removed():


### PR DESCRIPTION
Add scale tests for `/security/acl`

There are many uses of `std::vector<security::acl_binding>`, which primarily stems from their use in:
* `cluster::create_acls_cmd_data::bindings`
* `cluster::delete_acls_result::bindings`

And is propagated through many APIs, which limits the number of creations/deletions to about 1000 before an oversize alloc.

Regardless, this PR switches to `fragmented_vector` for associated uses where possible, to avoid exacerbating the problem.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
