### PR TITLE
CORE-7664 [v24.3.x] CORE-7664 c/cloudchecks: increase default timeout to 10s

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -106,7 +106,7 @@ To view the test status, poll 'rpk cluster self-test status'. Once the tests end
 		"The duration in milliseconds of individual disk test runs")
 	cmd.Flags().UintVar(&netDurationMs, "network-duration-ms", 30000,
 		"The duration in milliseconds of individual network test runs")
-	cmd.Flags().UintVar(&cloudTimeoutMs, "cloud-timeout-ms", 5000,
+	cmd.Flags().UintVar(&cloudTimeoutMs, "cloud-timeout-ms", 10000,
 		"The timeout in milliseconds for a cloud storage request")
 	cmd.Flags().UintVar(&cloudBackoffMs, "cloud-backoff-ms", 100,
 		"The backoff in milliseconds for a cloud storage request")

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -200,7 +200,7 @@ struct cloudcheck_opts
     ss::sstring name{"Cloud credentials check"};
 
     // Timeout duration for cloud storage requests.
-    ss::lowres_clock::duration timeout{std::chrono::milliseconds(5000)};
+    ss::lowres_clock::duration timeout{std::chrono::milliseconds(10000)};
 
     // Backoff duration for cloud storage requests.
     ss::lowres_clock::duration backoff{std::chrono::milliseconds(10)};

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -291,7 +291,7 @@ class SelfTestTest(EndToEndTest):
             'tests': [{
                 'type': 'cloud',
                 'backoff_ms': 100,
-                'timeout_ms': 5000
+                'timeout_ms': 10000
             }]
         }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26765
