### PR TITLE
cluster/security_frontend: Minor bug fix

### DIFF
--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -173,9 +173,8 @@ ss::future<std::vector<errc>> security_frontend::create_acls(
     auto leader = _leaders.local().get_leader(model::controller_ntp);
 
     if (!leader) {
-        std::vector<errc> res;
-        res.assign(bindings.size(), errc::no_leader_controller);
-        co_return res;
+        co_return std::vector<errc>(
+          bindings.size(), errc::no_leader_controller);
     }
 
     if (leader == _self) {
@@ -207,9 +206,7 @@ ss::future<std::vector<errc>> security_frontend::dispatch_create_acls_to_leader(
       .then(&rpc::get_ctx_data<create_acls_reply>)
       .then([num_bindings](result<create_acls_reply> r) {
           if (r.has_error()) {
-              std::vector<errc> res;
-              res.assign(num_bindings, map_errc(r.error()));
-              return res;
+              return std::vector<errc>(num_bindings, map_errc(r.error()));
           }
           return std::move(r.value().results);
       });
@@ -322,13 +319,11 @@ ss::future<std::vector<delete_acls_result>> security_frontend::delete_acls(
     auto leader = _leaders.local().get_leader(model::controller_ntp);
 
     if (!leader) {
-        std::vector<delete_acls_result> res;
-        res.assign(
+        co_return std::vector<delete_acls_result>(
           filters.size(),
           delete_acls_result{
             .error = errc::no_leader_controller,
           });
-        co_return res;
     }
 
     if (leader == _self) {
@@ -361,8 +356,7 @@ security_frontend::dispatch_delete_acls_to_leader(
       .then(&rpc::get_ctx_data<delete_acls_reply>)
       .then([num_filters](result<delete_acls_reply> r) {
           if (r.has_error()) {
-              std::vector<delete_acls_result> res;
-              res.assign(
+              return std::vector<delete_acls_result>(
                 num_filters,
                 delete_acls_result{
                   .error = map_errc(r.error()),


### PR DESCRIPTION
Correctly return the mapped error if the RPC fails for `security_frontend::dispatch_delete_acls_to_leader`

I also switched to using the vector constructor.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [x] v24.2.x

## Release Notes

### Bug Fixes

* Return the correct error response if the RPC to the leader for deleting ACLs fails.

