### PR TITLE
config: allow implicitly null for optional enum config

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -938,7 +938,7 @@ private:
         }();
 
         return fmt::format(
-          "Must be one of {}{}", fmt::join(enum_values(), ","), or_null_str);
+          "Must be one of {}{}", fmt::join(enum_values(), ", "), or_null_str);
     }
 
     std::vector<T> _values;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -881,6 +881,14 @@ public:
           meta,
           def,
           [this](T new_value) -> std::optional<ss::sstring> {
+              if constexpr (reflection::is_std_optional<T>) {
+                  // Accept nullopt as a valid value for optional enums even if
+                  // it is not explicitly listed in the enum values.
+                  if (!new_value.has_value()) {
+                      return std::nullopt;
+                  }
+              }
+
               auto found = std::ranges::find_if(
                 _values, [&new_value](const T& v) { return v == new_value; });
               if (found == _values.end()) {

--- a/src/v/config/tests/enum_property_test.cc
+++ b/src/v/config/tests/enum_property_test.cc
@@ -17,6 +17,8 @@ namespace {
 struct test_config : public config::config_store {
     config::enum_property<ss::sstring> enum_str;
     config::enum_property<std::optional<ss::sstring>> opt_enum_str;
+    config::enum_property<std::optional<ss::sstring>>
+      opt_enum_implicit_null_str;
 
     test_config()
       : enum_str(
@@ -32,7 +34,14 @@ struct test_config : public config::config_store {
           "A string with only certain values allowed",
           {},
           "foo",
-          {std::nullopt, "foo", "bar", "baz"}) {}
+          {std::nullopt, "foo", "bar", "baz"})
+      , opt_enum_implicit_null_str(
+          *this,
+          "opt_enum_implicit_null_str",
+          "A string with only certain values allowed",
+          {},
+          "foo",
+          {"foo", "bar", "baz"}) {}
 };
 
 SEASTAR_THREAD_TEST_CASE(enum_property_validation) {
@@ -64,6 +73,10 @@ SEASTAR_THREAD_TEST_CASE(enum_property_validation) {
 
     // Optional variant should also always consider null to be valid.
     verr = cfg.opt_enum_str.validate(YAML::Load("~"));
+    BOOST_CHECK(!verr.has_value());
+
+    // Optional variant should also always consider null to be valid.
+    verr = cfg.opt_enum_implicit_null_str.validate(YAML::Load("~"));
     BOOST_CHECK(!verr.has_value());
 }
 

--- a/src/v/config/tests/enum_property_test.cc
+++ b/src/v/config/tests/enum_property_test.cc
@@ -63,12 +63,12 @@ SEASTAR_THREAD_TEST_CASE(enum_property_validation) {
         verr = cfg.enum_str.validate(YAML::Load(v));
         BOOST_REQUIRE(verr.has_value());
         BOOST_REQUIRE_EQUAL(
-          verr.value().error_message(), "Must be one of foo,bar,baz");
+          verr.value().error_message(), "Must be one of foo, bar, baz");
 
         verr = cfg.opt_enum_str.validate(YAML::Load(v));
         BOOST_REQUIRE(verr.has_value());
         BOOST_REQUIRE_EQUAL(
-          verr.value().error_message(), "Must be one of foo,bar,baz or null");
+          verr.value().error_message(), "Must be one of foo, bar, baz or null");
     }
 
     // Optional variant should also always consider null to be valid.


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
