### PR TITLE
CORE-9669 cloud_metadata: add group offsets upload fallback 

### DIFF
--- a/src/v/cluster/cloud_metadata/uploader.cc
+++ b/src/v/cluster/cloud_metadata/uploader.cc
@@ -174,12 +174,20 @@ ss::future<error_outcome> uploader::upload_next_metadata(
             auto reply = co_await _offsets_uploader->request_upload(req, 30s);
             if (reply.ec != cluster::errc::success) {
                 vlog(
-                  clusterlog.debug,
-                  "Error while requesting offsets upload of {}",
-                  req.offsets_ntp);
-                continue;
+                  clusterlog.warn,
+                  "Failed to upload group offsets for {} ({}), falling "
+                  "back to existing cluster metadata manifest data",
+                  req.offsets_ntp,
+                  reply.ec);
+                if (
+                  static_cast<size_t>(i)
+                  < manifest.offsets_snapshots_by_partition.size()) {
+                    uploaded_offset_paths[i] = std::move(
+                      manifest.offsets_snapshots_by_partition[i]);
+                }
+            } else {
+                uploaded_offset_paths[i] = std::move(reply.uploaded_paths);
             }
-            uploaded_offset_paths[i] = std::move(reply.uploaded_paths);
         }
         manifest.offsets_snapshots_by_partition = std::move(
           uploaded_offset_paths);

--- a/tests/rptest/tests/consumer_group_recovery_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_test.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from dataclasses import astuple, dataclass
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
 
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -39,6 +40,8 @@ class TopicPartitionOffset:
 
 
 class ConsumerOffsetsRecoveryTest(PreallocNodesTest):
+    UPLOAD_INTERVAL_SEC = 1
+
     def __init__(self, test_ctx, *args):
         self._ctx = test_ctx
         self.initial_partition_count = 3
@@ -48,10 +51,14 @@ class ConsumerOffsetsRecoveryTest(PreallocNodesTest):
             *args,
             extra_rp_conf={
                 "kafka_nodelete_topics": [],
-                "group_topic_partitions": self.initial_partition_count,
-                'controller_snapshot_max_age_sec': 1,
-                "enable_cluster_metadata_upload_loop": True,
-                "cloud_storage_cluster_metadata_upload_interval_ms": 1000,
+                "group_topic_partitions":
+                self.initial_partition_count,
+                'controller_snapshot_max_age_sec':
+                1,
+                "enable_cluster_metadata_upload_loop":
+                True,
+                "cloud_storage_cluster_metadata_upload_interval_ms":
+                ConsumerOffsetsRecoveryTest.UPLOAD_INTERVAL_SEC * 1000,
             },
             node_prealloc_count=1,
             si_settings=SISettings(
@@ -113,7 +120,9 @@ class ConsumerOffsetsRecoveryTest(PreallocNodesTest):
         return True
 
     @cluster(num_nodes=4)
-    def test_consumer_offsets_partition_recovery(self):
+    @matrix(force_offset_upload_failures=[False, True])
+    def test_consumer_offsets_partition_recovery(
+            self, force_offset_upload_failures: bool):
         partition_count = 16
         topic = TopicSpec(partition_count=partition_count,
                           replication_factor=3)
@@ -155,7 +164,16 @@ class ConsumerOffsetsRecoveryTest(PreallocNodesTest):
         groups_pre_restore = self.describe_all_groups()
         self.logger.debug(f"Groups pre-restore {groups_pre_restore}")
 
-        self.redpanda.stop()
+        if force_offset_upload_failures:
+            # Force a scenario where the controller leader initiates an offset
+            # upload request that fails because the consumer group partition
+            # leader is unavailable
+            for n in reversed(self.redpanda.nodes):
+                self.redpanda.stop_node(n)
+                time.sleep(1 + ConsumerOffsetsRecoveryTest.UPLOAD_INTERVAL_SEC)
+        else:
+            self.redpanda.stop()
+
         for n in self.redpanda.nodes:
             self.redpanda.remove_local_data(n)
 


### PR DESCRIPTION
Whole cluster recovery relies on a periodic (default: 1h) upload of the
group offsets snapshots created for each consumer group partition. This
is coordinated by the controller leader but the uploads send requests to
the consumer group partition leaders.

Uploading the group offsets for a partition may fail, for example, if
the partition leader is temporarily unavailable. In this case, it is
preferrable to fall back to using the old manifest's snapshots for this
partition instead of uploading a new cluster manifest with the partition
omitted, since having stale data for the groups is preferrable to having
no data at all.

Fixes https://redpandadata.atlassian.net/browse/CORE-9669

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes
### Improvements

* Fall back to the previously uploaded cluster manifest's group offset snapshot if uploading the group offsets fails for a consumer offsets topic partition.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
