### PR TITLE
cloud_storage: Use scheduling group in the read path

### DIFF
--- a/src/v/cloud_io/io_resources.cc
+++ b/src/v/cloud_io/io_resources.cc
@@ -240,6 +240,10 @@ ss::future<> io_resources::start() {
     co_return;
 }
 
+ss::scheduling_group io_resources::get_scheduling_group() const {
+    return _scheduling_group;
+}
+
 size_t io_resources::max_parallel_hydrations() const {
     auto max_connections
       = config::shard_local_cfg().cloud_storage_max_connections();

--- a/src/v/cloud_io/io_resources.h
+++ b/src/v/cloud_io/io_resources.h
@@ -18,6 +18,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/scheduling.hh>
 
 namespace cloud_io {
 
@@ -45,6 +46,8 @@ public:
 
     /// How many partition_record_batch_reader_impl instances exist
     size_t current_ongoing_hydrations() const;
+
+    ss::scheduling_group get_scheduling_group() const;
 
 private:
     config::binding<std::optional<uint32_t>>

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -35,7 +35,6 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/smp.hh>
-#include <seastar/core/with_scheduling_group.hh>
 #include <seastar/util/defer.hh>
 
 #include <boost/lexical_cast.hpp>

--- a/src/v/cloud_storage/materialized_manifest_cache.cc
+++ b/src/v/cloud_storage/materialized_manifest_cache.cc
@@ -32,7 +32,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/smp.hh>
-#include <seastar/core/with_scheduling_group.hh>
 #include <seastar/util/defer.hh>
 
 #include <boost/algorithm/string/classification.hpp>

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -156,6 +156,10 @@ public:
     /// \brief Start the remote
     ss::future<> start();
 
+    const cloud_io::io_resources& resources() const {
+        return _io.local().resources();
+    }
+
     /// \brief Stop the remote
     ///
     /// Wait until all background operations complete

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -16,6 +16,7 @@
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/download_exception.h"
 #include "cloud_storage/logger.h"
+#include "cloud_storage/materialized_resources.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote_segment_index.h"
 #include "cloud_storage/segment_chunk_data_source.h"
@@ -176,8 +177,11 @@ remote_segment::remote_segment(
     }
 
     // run hydration loop in the background
+    auto sg = _api.resources().get_scheduling_group();
     _hydration_loop_running = true;
-    ssx::background = run_hydrate_bg();
+
+    ssx::background = ss::with_scheduling_group(
+      sg, [this] { return run_hydrate_bg(); });
 }
 
 const model::ntp& remote_segment::get_ntp() const { return _ntp; }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1626,8 +1626,7 @@ void application::wire_up_redpanda_services(
           ss::sharded_parameter([&cloud_configs] {
               return cloud_configs.local().cloud_credentials_source;
           }),
-          ss::sharded_parameter(
-            [this] { return sched_groups.archival_upload(); }))
+          ss::sharded_parameter([this] { return sched_groups.ts_read_sg(); }))
           .get();
         cloud_io.invoke_on_all(&cloud_io::remote::start).get();
         bucket_name = cloud_configs.local().bucket_name;


### PR DESCRIPTION
This PR contains changes needed to use a scheduling group for TS downloads.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none