### PR TITLE
`raft`: add `remake_learner_state` to `consensus` protocol [SC&R #5]

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -145,6 +145,7 @@ cluster::errc map_update_interruption_error_code(std::error_code ec) {
         case raft::errc::group_not_exists:
         case raft::errc::replicate_first_stage_exception:
         case raft::errc::invalid_input_records:
+        case raft::errc::not_learner:
             return errc::replication_error;
         }
         __builtin_unreachable();

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -646,6 +646,8 @@ ss::future<> controller::start(
       std::ref(_partition_manager),
       std::ref(_as));
 
+    co_await set_raft_manager_remake_cb();
+
     co_await _members_backend.invoke_on(
       members_manager::shard, &members_backend::start);
     co_await _config_manager.invoke_on(
@@ -909,6 +911,7 @@ ss::future<> controller::stop() {
     co_await _data_migration_frontend.stop();
     co_await _topic_mount_handler.stop();
     co_await _config_manager.stop();
+    co_await clear_raft_manager_remake_cb();
     co_await _api.stop();
     co_await _shard_balancer.stop();
     co_await _backend.stop();
@@ -1250,6 +1253,27 @@ controller::validate_configuration_invariants() {
         // configuration_invariants in kvstore later.
     }
     co_return invariants;
+}
+
+ss::future<std::error_code> controller::trigger_remake_cb(raft::group_id g) {
+    auto ec = co_await _api.local().remake_partition(g);
+    if (ec) {
+        vlog(clusterlog.warn, "Unable to remake group {}, {}", g, ec);
+    }
+    co_return ec;
+}
+
+ss::future<> controller::set_raft_manager_remake_cb() {
+    co_await _raft_manager.invoke_on_all([this](raft::group_manager& gm) {
+        gm.set_remake_cb(
+          [this](raft::group_id g) -> ss::future<std::error_code> {
+              return trigger_remake_cb(g);
+          });
+    });
+}
+
+ss::future<> controller::clear_raft_manager_remake_cb() {
+    co_await _raft_manager.invoke_on_all(&raft::group_manager::clear_remake_cb);
 }
 
 } // namespace cluster

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -270,6 +270,15 @@ public:
 private:
     friend controller_probe;
 
+    using remake_cb_t
+      = ss::noncopyable_function<ss::future<std::error_code>(model::ntp)>;
+
+    ss::future<std::error_code> trigger_remake_cb(raft::group_id g);
+
+    ss::future<> set_raft_manager_remake_cb();
+
+    ss::future<> clear_raft_manager_remake_cb();
+
     /**
      * Create a \c bootstrap_cluster_cmd, replicate-and-wait it to the current
      * quorum, retry infinitely if replicate-and-wait fails.

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -579,17 +579,31 @@ controller_api::get_global_reconciliation_state(
     co_return state;
 }
 
-ss::future<std::error_code>
-controller_api::remake_partition(const model::ntp& ntp) {
-    auto shard_for_opt = shard_for(ntp);
+ss::future<std::error_code> controller_api::remake_partition(raft::group_id g) {
+    auto shard_for_opt = shard_for(g);
     if (!shard_for_opt.has_value()) {
         co_return errc::partition_not_exists;
     }
 
     auto shard = shard_for_opt.value();
+    auto ntp_opt = co_await _partition_manager.invoke_on(
+      shard, [g](cluster::partition_manager& pm) -> std::optional<model::ntp> {
+          auto p = pm.partition_for(g);
+          if (!p) {
+              return std::nullopt;
+          }
+          return p->ntp();
+      });
+
+    if (!ntp_opt.has_value()) {
+        co_return errc::partition_not_exists;
+    }
+
+    auto ntp = std::move(ntp_opt).value();
+
     co_return co_await _backend.invoke_on(
       shard, [&ntp](cluster::controller_backend& b) {
-          return b.remake_partition(ntp);
+          return b.remake_partition(std::move(ntp));
       });
 }
 

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -88,7 +88,8 @@ public:
     std::optional<ss::shard_id> shard_for(const raft::group_id& group) const;
     std::optional<ss::shard_id> shard_for(const model::ntp& ntp) const;
 
-    ss::future<std::error_code> remake_partition(const model::ntp& ntp);
+    // Remakes the partition for the provided raft group.
+    ss::future<std::error_code> remake_partition(raft::group_id g);
 
 private:
     ss::future<std::optional<backend_operation>>

--- a/src/v/cluster/tests/remake_partition_tests.cc
+++ b/src/v/cluster/tests/remake_partition_tests.cc
@@ -113,7 +113,9 @@ FIXTURE_TEST(remake_partition_test, remake_partition_fixture) {
     add_topic(model::topic_namespace_view{test_ntp}).get();
     wait_for_leader(test_ntp).get();
 
-    auto ec = controller->get_api().local().remake_partition(test_ntp).get();
+    auto group
+      = controller->get_partition_manager().local().get(test_ntp)->group();
+    auto ec = controller->get_api().local().remake_partition(group).get();
     BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
 
     // Wait till partition is recreated
@@ -229,7 +231,8 @@ FIXTURE_TEST(remake_partition_with_produce_test, remake_partition_fixture) {
         BOOST_REQUIRE_EQUAL(records.size(), total_num_records);
     }
 
-    auto ec = controller->get_api().local().remake_partition(test_ntp).get();
+    auto group = p->group();
+    auto ec = controller->get_api().local().remake_partition(group).get();
     BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
 
     // Wait till partition is recreated

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2138,6 +2138,7 @@ kafka::error_code map_store_offset_error_code(std::error_code ec) {
         case raft::errc::group_not_exists:
         case raft::errc::replicate_first_stage_exception:
         case raft::errc::transfer_to_current_leader:
+        case raft::errc::not_learner:
             return error_code::unknown_server_error;
         }
     }

--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -185,6 +185,20 @@ buffered_protocol::transfer_leadership(
       &consensus_client_protocol::transfer_leadership);
 }
 
+ss::future<result<remake_learner_state_reply>>
+buffered_protocol::remake_learner_state(
+  model::node_id target_node,
+  remake_learner_state_request req,
+  rpc::client_opts opts) {
+    return apply_with_gate(
+      _gate,
+      _base_protocol,
+      target_node,
+      std::move(req),
+      std::move(opts),
+      &consensus_client_protocol::remake_learner_state);
+}
+
 ss::future<bool> buffered_protocol::ensure_disconnect(model::node_id node_id) {
     return _base_protocol.ensure_disconnect(node_id);
 }

--- a/src/v/raft/buffered_protocol.h
+++ b/src/v/raft/buffered_protocol.h
@@ -152,6 +152,9 @@ public:
 
     ss::future<> reset_backoff(model::node_id n) final;
 
+    ss::future<result<remake_learner_state_reply>> remake_learner_state(
+      model::node_id, remake_learner_state_request, rpc::client_opts) final;
+
     ss::future<> stop();
 
 private:

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1709,6 +1709,18 @@ ss::future<> consensus::write_last_applied(model::offset o) {
       storage::kvstore::key_space::consensus, std::move(key), std::move(val));
 }
 
+ss::future<> consensus::truncate_state(model::offset truncate_at) {
+    co_await _log->truncate(storage::truncate_config(truncate_at));
+    _probe->log_truncated();
+    // update flushed offset
+    _flushed_offset = std::min(
+      model::prev_offset(truncate_at), _flushed_offset);
+
+    co_await _configuration_manager.truncate(truncate_at);
+    _probe->configuration_update();
+    update_follower_stats(_configuration_manager.get_latest());
+}
+
 model::offset consensus::read_last_applied() const {
     const auto key = last_applied_key();
     auto value = _storage.kvs().get(
@@ -2235,7 +2247,6 @@ consensus::do_append_entries(append_entries_request&& r) {
           last_visible_index(),
           _last_leader_visible_offset,
           truncate_at);
-        _probe->log_truncated();
 
         _majority_replicated_index = std::min(
           model::prev_offset(truncate_at), _majority_replicated_index);
@@ -2248,17 +2259,7 @@ consensus::do_append_entries(append_entries_request&& r) {
           model::prev_offset(truncate_at), _flushed_offset);
 
         try {
-            co_await _log->truncate(storage::truncate_config(truncate_at));
-            // update flushed offset once again after truncation as flush is
-            // executed concurrently to append entries and it may race with
-            // the truncation
-            _flushed_offset = std::min(
-              model::prev_offset(truncate_at), _flushed_offset);
-
-            co_await _configuration_manager.truncate(truncate_at);
-            _probe->configuration_update();
-            update_follower_stats(_configuration_manager.get_latest());
-
+            co_await truncate_state(truncate_at);
             auto lstats = _log->offsets();
             if (unlikely(lstats.dirty_offset != adjusted_prev_log_index)) {
                 vlog(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -4290,4 +4290,85 @@ size_t consensus::bytes_to_deliver_to_learners() const {
     return total;
 }
 
+ss::future<remake_learner_state_reply>
+consensus::remake_learner_state(vnode target) {
+    _probe->recovery_reset();
+    remake_learner_state_request req{
+      .node_id = _self,
+      .target_node_id = target,
+      .group = _group,
+      .term = _term};
+    vlog(_ctxlog.info, "Issuing remake group request {}", req);
+    static constexpr auto timeout = 10s;
+    result<remake_learner_state_reply> reply
+      = co_await _client_protocol.remake_learner_state(
+        target.id(), req, rpc::client_opts(timeout));
+    if (!reply) {
+        vlog(
+          _ctxlog.warn,
+          "Unable to issue remake group request {}, {}",
+          req,
+          reply.error());
+        co_return remake_learner_state_reply{};
+    }
+
+    co_return reply.value();
+}
+
+ss::future<remake_learner_state_reply>
+consensus::do_remake_learner_state(remake_learner_state_request req) {
+    remake_learner_state_reply reply{};
+    using is_success = remake_learner_state_reply::is_success;
+    try {
+        auto units = co_await _op_lock.get_units();
+
+        // Perform validation of request under _op_lock
+        auto maybe_err = [&]() -> std::optional<raft::errc> {
+            if (req.term != _term) {
+                return raft::errc::not_leader;
+            }
+            if (req.source_node() != _leader_id) {
+                return raft::errc::leadership_transfer_in_progress;
+            }
+            if (req.target_node() != _self) {
+                return raft::errc::invalid_target_node;
+            }
+            if (!is_learner()) {
+                return raft::errc::not_learner;
+            }
+            if (req.group != _group) {
+                return raft::errc::group_not_exists;
+            }
+
+            return std::nullopt;
+        }();
+
+        if (maybe_err.has_value()) {
+            reply.success = is_success::no;
+            vlog(
+              _ctxlog.warn,
+              "Unable to process remake group request {}, raft::errc {}",
+              req,
+              maybe_err.value());
+        } else {
+            auto cluster_err = co_await _remake_notification(req.group);
+            reply.success = cluster_err ? is_success::no : is_success::yes;
+            vlog(
+              _ctxlog.warn,
+              "Unable to process remake group request {}, cluster::errc {}",
+              req,
+              cluster_err);
+        }
+    } catch (...) {
+        vlog(
+          _ctxlog.warn,
+          "Unable to process remake group request {}, caught exception: {}",
+          req,
+          std::current_exception());
+        reply.success = is_success::no;
+    }
+
+    co_return reply;
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -106,7 +106,8 @@ consensus::consensus(
   config::binding<std::chrono::milliseconds> disk_timeout,
   config::binding<bool> enable_longest_log_detection,
   consensus_client_protocol client,
-  consensus::leader_cb_t cb,
+  remake_cb_t remake_cb,
+  consensus::leader_cb_t leader_cb,
   storage::api& storage,
   std::optional<std::reference_wrapper<coordinated_recovery_throttle>>
     recovery_throttle,
@@ -123,7 +124,8 @@ consensus::consensus(
   , _disk_timeout(std::move(disk_timeout))
   , _enable_longest_log_detection(std::move(enable_longest_log_detection))
   , _client_protocol(client)
-  , _leader_notification(std::move(cb))
+  , _remake_notification(std::move(remake_cb))
+  , _leader_notification(std::move(leader_cb))
   , _fstats(_self)
   , _batcher(this, config::shard_local_cfg().raft_replicate_batch_window_size())
   , _event_manager(this)

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -418,6 +418,8 @@ public:
 
     model::offset read_last_applied() const;
 
+    ss::future<> truncate_state(model::offset);
+
     probe& get_probe() { return *_probe; };
 
     ss::shared_ptr<storage::log> log() { return _log; }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -184,6 +184,10 @@ public:
     bool is_leader() const {
         return is_elected_leader() && _term == _confirmed_term;
     }
+    // If this node is not yet a voter, it is a learner.
+    bool is_learner() const {
+        return !_configuration_manager.get_latest().is_voter(_self);
+    }
     bool is_candidate() const { return _vstate == vote_state::candidate; }
     std::optional<model::node_id> get_leader_id() const {
         return _leader_id ? std::make_optional(_leader_id->id()) : std::nullopt;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -568,6 +568,10 @@ public:
     ss::future<remake_learner_state_reply>
       do_remake_learner_state(remake_learner_state_request);
 
+    const configuration_manager& config_manager() const {
+        return _configuration_manager;
+    }
+
 private:
     friend replication_monitor;
     friend replicate_entries_stm;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -561,6 +561,13 @@ public:
         _inject_error_in_append_entries = inject_error;
     }
 
+    // Function invoked on leader side to clear state on learner node.
+    ss::future<remake_learner_state_reply> remake_learner_state(vnode target);
+
+    // Function invoked on learner side to clear local state.
+    ss::future<remake_learner_state_reply>
+      do_remake_learner_state(remake_learner_state_request);
+
 private:
     friend replication_monitor;
     friend replicate_entries_stm;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -93,6 +93,8 @@ public:
     };
     enum class vote_state { follower, candidate, leader };
     using leader_cb_t = ss::noncopyable_function<void(leadership_status)>;
+    using remake_cb_t
+      = ss::noncopyable_function<ss::future<std::error_code>(group_id)>;
 
     consensus(
       model::node_id,
@@ -104,6 +106,7 @@ public:
       config::binding<std::chrono::milliseconds> disk_timeout,
       config::binding<bool> enable_longest_log_detection,
       consensus_client_protocol,
+      remake_cb_t,
       leader_cb_t,
       storage::api&,
       std::optional<std::reference_wrapper<coordinated_recovery_throttle>>,
@@ -820,6 +823,7 @@ private:
     config::binding<std::chrono::milliseconds> _disk_timeout;
     config::binding<bool> _enable_longest_log_detection;
     consensus_client_protocol _client_protocol;
+    remake_cb_t _remake_notification;
     leader_cb_t _leader_notification;
 
     // consensus state

--- a/src/v/raft/consensus_client_protocol.h
+++ b/src/v/raft/consensus_client_protocol.h
@@ -57,6 +57,11 @@ public:
 
         virtual ss::future<> reset_backoff(model::node_id) = 0;
 
+        virtual ss::future<result<remake_learner_state_reply>>
+          remake_learner_state(
+            model::node_id, remake_learner_state_request, rpc::client_opts)
+          = 0;
+
         virtual ~impl() noexcept = default;
     };
 
@@ -116,6 +121,14 @@ public:
 
     ss::future<> reset_backoff(model::node_id target_node) {
         return _impl->reset_backoff(target_node);
+    }
+
+    ss::future<result<remake_learner_state_reply>> remake_learner_state(
+      model::node_id target_node,
+      remake_learner_state_request r,
+      rpc::client_opts opts) {
+        return _impl->remake_learner_state(
+          target_node, std::move(r), std::move(opts));
     }
 
 private:

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -40,6 +40,7 @@ enum class errc : int16_t {
     group_not_exists,
     replicate_first_stage_exception,
     invalid_input_records,
+    not_learner,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -96,6 +97,8 @@ struct errc_category final : public std::error_category {
                    "first phase";
         case errc::invalid_input_records:
             return "attempt to replicate invalid input records";
+        case errc::not_learner:
+            return "raft::errc::not_learner";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -139,8 +139,9 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
       _configuration.raft_io_timeout_ms,
       _configuration.enable_longest_log_detection,
       consensus_client_protocol(_buffered_protocol),
+      [this](raft::group_id g) { return trigger_remake_notification(g); },
       [this](raft::leadership_status st) {
-          trigger_leadership_notification(std::move(st));
+          return trigger_leadership_notification(std::move(st));
       },
       _storage,
       enable_learner_recovery_throttle
@@ -194,6 +195,16 @@ ss::future<xshard_transfer_state> group_manager::do_shutdown(
       group_id);
     _groups.erase(it);
     co_return transfer_state;
+}
+
+ss::future<std::error_code>
+group_manager::trigger_remake_notification(raft::group_id g) {
+    if (!_remake_cb || _remake_cb_gate.is_closed()) {
+        co_return raft::errc::shutting_down;
+    }
+
+    auto holder = _remake_cb_gate.hold();
+    co_return co_await (*_remake_cb)(g);
 }
 
 void group_manager::trigger_leadership_notification(

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -117,6 +117,7 @@ public:
     }
 
 private:
+    ss::future<std::error_code> trigger_remake_notification(raft::group_id);
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();
 

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -99,6 +99,23 @@ public:
         return _recovery_scheduler.get_status();
     }
 
+    using remake_cb_t
+      = ss::noncopyable_function<ss::future<std::error_code>(raft::group_id)>;
+    // Remake callback is set in controller.cc to tie together `group_manager`
+    // to `controller_backend/api`.
+    void set_remake_cb(remake_cb_t cb) {
+        vassert(
+          _remake_cb == nullptr, "_remake_cb should only be registered once.");
+        _remake_cb = std::make_unique<remake_cb_t>(std::move(cb));
+    }
+
+    // Lifetime of `group_manager` & `controller_backend/api` is not tied. We
+    // need to clear this callback to avoid calls to stopped services.
+    ss::future<> clear_remake_cb() {
+        co_await _remake_cb_gate.close();
+        _remake_cb = nullptr;
+    }
+
 private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();
@@ -116,6 +133,7 @@ private:
     ss::shared_ptr<raft::buffered_protocol> _buffered_protocol;
     raft::heartbeat_manager _heartbeats;
     ss::gate _gate;
+    ss::gate _remake_cb_gate;
     std::vector<ss::lw_shared_ptr<raft::consensus>> _groups;
     notification_list<leader_cb_t, group_manager_notification_id>
       _notifications;
@@ -130,6 +148,7 @@ private:
     ss::timer<> _metrics_timer;
     size_t _learners_gap_bytes{0};
     bool _is_ready;
+    std::unique_ptr<remake_cb_t> _remake_cb;
 };
 
 } // namespace raft

--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -170,6 +170,12 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _append_entries_buffer_flush; },
           sm::description("Number of append entries buffer flushes"),
           labels),
+        sm::make_gauge(
+          "recovery_resets",
+          [this] { return _recovery_resets; },
+          sm::description("Number of times that a learner was forcefully reset "
+                          "during recovery due to potential divergence"),
+          labels),
       },
       {},
       {sm::shard_label, sm::label("partition")});

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -74,6 +74,7 @@ public:
     }
 
     uint32_t get_recovery_resets() const { return _recovery_resets; }
+    uint32_t get_log_truncations() { return _log_truncations; }
 
 private:
     uint64_t _vote_requests = 0;

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -60,6 +60,7 @@ public:
     void heartbeat_request_error() { ++_heartbeat_request_error; };
     void replicate_request_error() { ++_replicate_request_error; };
     void recovery_request_error() { ++_recovery_request_error; };
+    void recovery_reset() { ++_recovery_resets; };
 
     void full_heartbeat() { ++_full_heartbeat_requests; }
     void lw_heartbeat() { ++_lw_heartbeat_requests; }
@@ -71,6 +72,8 @@ public:
         _metrics.clear();
         _public_metrics.clear();
     }
+
+    uint32_t get_recovery_resets() const { return _recovery_resets; }
 
 private:
     uint64_t _vote_requests = 0;
@@ -94,6 +97,7 @@ private:
     uint64_t _lw_heartbeat_requests = 0;
     uint64_t _offset_translator_inconsistency_error = 0;
     uint64_t _append_entries_buffer_flush = 0;
+    uint32_t _recovery_resets = 0;
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };

--- a/src/v/raft/raftgen.json
+++ b/src/v/raft/raftgen.json
@@ -45,6 +45,11 @@
             "name": "append_entries_full_serde",
             "input_type": "append_entries_request_serde_wrapper",
             "output_type": "append_entries_reply"
+        },
+        {
+            "name": "remake_learner_state",
+            "input_type": "remake_learner_state_request",
+            "output_type": "remake_learner_state_reply"
         }
     ]
 }

--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -163,4 +163,21 @@ rpc_client_protocol::transfer_leadership(
       });
 }
 
+ss::future<result<remake_learner_state_reply>>
+rpc_client_protocol::remake_learner_state(
+  model::node_id n, remake_learner_state_request r, rpc::client_opts opts) {
+    auto timeout = opts.timeout;
+    return _connection_cache.local()
+      .with_node_client<raftgen_client_protocol>(
+        _self,
+        ss::this_shard_id(),
+        n,
+        timeout,
+        [r = std::move(r),
+         opts = std::move(opts)](raftgen_client_protocol client) mutable {
+            return client.remake_learner_state(std::move(r), std::move(opts));
+        })
+      .then(&rpc::get_ctx_data<remake_learner_state_reply>);
+}
+
 } // namespace raft

--- a/src/v/raft/rpc_client_protocol.h
+++ b/src/v/raft/rpc_client_protocol.h
@@ -51,6 +51,11 @@ public:
 
     ss::future<> reset_backoff(model::node_id n);
 
+    ss::future<result<remake_learner_state_reply>> remake_learner_state(
+      model::node_id,
+      remake_learner_state_request r,
+      rpc::client_opts opts) final;
+
 private:
     model::node_id _self;
     ss::sharded<rpc::connection_cache>& _connection_cache;

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -248,6 +248,20 @@ public:
           });
     }
 
+    [[gnu::always_inline]] ss::future<remake_learner_state_reply>
+    remake_learner_state(
+      remake_learner_state_request r, rpc::streaming_context&) final {
+        return _probe.remake_learner_state().then(
+          [this, r = std::move(r)]() mutable {
+              return dispatch_request(
+                std::move(r),
+                &service::make_failed_remake_learner_state_reply,
+                [](remake_learner_state_request&& r, consensus_ptr c) {
+                    return c->do_remake_learner_state(std::move(r));
+                });
+          });
+    }
+
 private:
     using consensus_ptr = seastar::lw_shared_ptr<consensus>;
 
@@ -303,6 +317,12 @@ private:
     make_failed_transfer_leadership_reply() {
         return ss::make_ready_future<transfer_leadership_reply>(
           transfer_leadership_reply{});
+    }
+
+    static ss::future<remake_learner_state_reply>
+    make_failed_remake_learner_state_reply() {
+        return ss::make_ready_future<remake_learner_state_reply>(
+          remake_learner_state_reply{});
     }
 
     template<typename Req, typename ErrorFactory, typename Func>

--- a/src/v/raft/tests/buffered_protocol_test.cc
+++ b/src/v/raft/tests/buffered_protocol_test.cc
@@ -64,6 +64,11 @@ public:
     ss::future<> reset_backoff(model::node_id) final {
         return ss::make_ready_future<>();
     }
+    ss::future<result<remake_learner_state_reply>> remake_learner_state(
+      model::node_id, remake_learner_state_request, rpc::client_opts) final {
+        return ss::make_ready_future<result<raft::remake_learner_state_reply>>(
+          raft::remake_learner_state_reply{});
+    }
 };
 
 class BufferedProtocolFixture : public seastar_test {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -358,6 +358,13 @@ in_memory_test_protocol::transfer_leadership(
       id, std::move(req), std::move(opts));
 }
 
+ss::future<result<remake_learner_state_reply>>
+in_memory_test_protocol::remake_learner_state(
+  model::node_id id, remake_learner_state_request req, rpc::client_opts opts) {
+    return dispatch<remake_learner_state_request, remake_learner_state_reply>(
+      id, std::move(req), std::move(opts));
+}
+
 raft_node_instance::raft_node_instance(
   model::node_id id,
   model::revision_id revision,

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -476,6 +476,7 @@ raft_node_instance::initialise(std::vector<raft::vnode> initial_nodes) {
       config::mock_binding<std::chrono::milliseconds>(1s),
       config::mock_binding<bool>(_enable_longest_log_detection),
       consensus_client_protocol(_buffered_protocol),
+      [this](group_id g) { return remake_learner_callback(g); },
       [this](leadership_status ls) { leadership_notification_callback(ls); },
       _storage.local(),
       _recovery_throttle.local(),
@@ -531,6 +532,18 @@ ss::future<> raft_node_instance::stop() {
 ss::future<> raft_node_instance::remove_data() {
     return ss::recursive_remove_directory(
       std::filesystem::path(_base_directory));
+}
+
+ss::future<std::error_code>
+raft_node_instance::remake_learner_callback(group_id g) {
+    _logger.info("remake learner notification for group: {}", g);
+    try {
+        co_await _raft->truncate_state(model::offset{0});
+        co_await _raft->remove_persistent_state();
+    } catch (...) {
+        co_return errc::timeout;
+    }
+    co_return errc::success;
 }
 
 void raft_node_instance::leadership_notification_callback(

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -194,6 +194,16 @@ ss::future<> channel::do_dispatch_message(msg msg) {
             msg.resp_data.set_value(std::move(resp_buf));
             break;
         }
+        case msg_type::remake_learner_state: {
+            auto req = co_await serde::read_async<remake_learner_state_request>(
+              req_parser);
+            auto resp = co_await get_service().remake_learner_state(
+              std::move(req), ctx);
+            iobuf resp_buf;
+            co_await serde::write_async(resp_buf, std::move(resp));
+            msg.resp_data.set_value(std::move(resp_buf));
+            break;
+        }
         }
     } catch (...) {
         msg.resp_data.set_to_current_exception();
@@ -256,6 +266,8 @@ static constexpr msg_type map_msg_type() {
         return msg_type::timeout_now;
     } else if constexpr (std::is_same_v<ReqT, transfer_leadership_request>) {
         return msg_type::transfer_leadership;
+    } else if constexpr (std::is_same_v<ReqT, remake_learner_state_request>) {
+        return msg_type::remake_learner_state;
     }
     __builtin_unreachable();
 }
@@ -862,6 +874,9 @@ std::ostream& operator<<(std::ostream& o, msg_type type) {
         return o;
     case msg_type::transfer_leadership:
         o << "transfer_leadership";
+        return o;
+    case msg_type::remake_learner_state:
+        o << "remake_learner_state";
         return o;
     }
 }

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -54,6 +54,7 @@ enum class msg_type {
     install_snapshot,
     timeout_now,
     transfer_leadership,
+    remake_learner_state
 };
 
 struct msg {

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -249,6 +249,7 @@ public:
 
     ss::future<> remove_data();
 
+    ss::future<std::error_code> remake_learner_callback(group_id g);
     void leadership_notification_callback(leadership_status);
 
     model::ntp ntp() const {

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -111,7 +111,8 @@ using reply_variant = std::variant<
   heartbeat_reply_v2,
   install_snapshot_reply,
   timeout_now_reply,
-  transfer_leadership_reply>;
+  transfer_leadership_reply,
+  remake_learner_state_reply>;
 
 using reply_interceptor_t = ss::noncopyable_function<ss::future<reply_variant>(
   reply_variant, model::node_id)>;
@@ -146,6 +147,9 @@ public:
 
     // TODO: move those methods out of Raft protocol.
     ss::future<> reset_backoff(model::node_id) final { co_return; }
+
+    ss::future<result<remake_learner_state_reply>> remake_learner_state(
+      model::node_id, remake_learner_state_request, rpc::client_opts) final;
 
     ss::future<bool> ensure_disconnect(model::node_id) final {
         co_return true;

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -108,3 +108,56 @@ TEST_F(state_removal_test, remove_persistent_state_test_with_snapshot) {
     ASSERT_FALSE(snapshot_exists(*node));
     ASSERT_EQ(node->raft()->get_snapshot_size(), 0);
 };
+
+TEST_F(state_removal_test, reset_learner_state) {
+    create_simple_group(2).get();
+    auto leader_id = wait_for_leader(10s).get();
+
+    auto res = replicate_random_batches().get();
+    ASSERT_TRUE(res.has_value());
+
+    wait_for_committed_offset(res.value().last_offset, 5s).get();
+    assert_logs_equal().get();
+
+    auto& leader = node(leader_id);
+    auto follower_id_opt = random_follower_id();
+    ASSERT_TRUE(follower_id_opt.has_value());
+    auto& follower = node(follower_id_opt.value());
+
+    // `const_cast` hacks to ensure this follower is _actually_ a learner
+    // by removing its voter status.
+    auto& config_manager = const_cast<configuration_manager&>(
+      follower.raft()->config_manager());
+    auto& configuration = const_cast<group_configuration&>(
+      config_manager.get_latest());
+    auto& config = const_cast<group_nodes&>(configuration.current_config());
+    config.voters.clear();
+    auto reply
+      = leader.raft()->remake_learner_state(follower.get_vnode()).get();
+    ASSERT_TRUE(reply.success);
+    ASSERT_EQ(leader.raft()->get_probe().get_recovery_resets(), 1);
+    ASSERT_GE(follower.raft()->get_probe().get_log_truncations(), 1);
+};
+
+TEST_F(state_removal_test, reset_non_learner_state) {
+    create_simple_group(2).get();
+    auto leader_id = wait_for_leader(10s).get();
+
+    auto res = replicate_random_batches().get();
+    ASSERT_TRUE(res.has_value());
+
+    wait_for_committed_offset(res.value().last_offset, 5s).get();
+    assert_logs_equal().get();
+
+    auto& leader = node(leader_id);
+    auto follower_id_opt = random_follower_id();
+    ASSERT_TRUE(follower_id_opt.has_value());
+    auto& follower = node(follower_id_opt.value());
+    // This follower node isn't a learner.
+    auto reply
+      = leader.raft()->remake_learner_state(follower.get_vnode()).get();
+    ASSERT_FALSE(reply.success);
+    // Recovery reset was issueed, but follower was not truncated.
+    ASSERT_EQ(leader.raft()->get_probe().get_recovery_resets(), 1);
+    ASSERT_EQ(follower.raft()->get_probe().get_log_truncations(), 0);
+};

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -757,6 +757,58 @@ struct xshard_transfer_state {
     std::optional<model::term_id> leader_term;
 };
 
+struct remake_learner_state_request
+  : serde::envelope<
+      remake_learner_state_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const remake_learner_state_request& r) {
+        fmt::print(
+          o,
+          "{{node_id: {}, target_node_id: {}, group: {}, term: {}}}",
+          r.node_id,
+          r.target_node_id,
+          r.group,
+          r.term);
+        return o;
+    }
+
+    auto serde_fields() {
+        return std::tie(node_id, target_node_id, group, term);
+    }
+
+    raft::group_id target_group() const { return group; }
+    vnode source_node() const { return node_id; }
+    vnode target_node() const { return target_node_id; }
+
+    vnode node_id;
+    vnode target_node_id;
+    raft::group_id group;
+    model::term_id term;
+};
+
+struct remake_learner_state_reply
+  : serde::envelope<
+      remake_learner_state_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    using is_success = ss::bool_class<struct remake_learner_state_tag>;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const remake_learner_state_reply& r) {
+        fmt::print(o, "success: {}", r.success);
+        return o;
+    }
+
+    auto serde_fields() { return std::tie(success); }
+
+    is_success success = is_success::no;
+};
+
 } // namespace raft
 
 namespace reflection {


### PR DESCRIPTION
This PR is the 5th in the series of safe compaction & recovery [SC&R] PRs.

It adds the `remake_learner_state` primitive to the `raft/consensus` protocol for issuing `remake_partition()` requests (added in https://github.com/redpanda-data/redpanda/pull/26562) from a leader node on a learner node in the case that the leader detects the current round of recovery has entered a potentially divergent state.

This PR adds the types, classes and performs some plumbing through the `consensus` layer to wire everything up, but does not yet use any of the types defined here.

Future PRs in this series will tie everything together by using to be added state in the `log` and the now present `do_remake_learner_state()` commands present in the `consensus` object to ensure divergence free recovery.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
