### PR TITLE
bazel: update to libxml2 v2.14.4

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -100,9 +100,9 @@ def data_dependency():
     http_archive(
         name = "libxml2",
         build_file = "//bazel/thirdparty:libxml2.BUILD",
-        sha256 = "f33a6353a80ccdb483abc3f895d4283f799b8ee9fae778da7a97b73604929138",
-        strip_prefix = "libxml2-2.13.8",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.13.8.tar.gz",
+        sha256 = "fe59cb94cf6f2ca18d57f3a99e9509d2dd555bbd930e00f637eb3b8ba886c468",
+        strip_prefix = "libxml2-2.14.4",
+        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.14.4.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
jira: [DEVPROD-3082]

Addresses CVE-2025-6021
See release notes https://gitlab.gnome.org/GNOME/libxml2/-/releases

Depends on PR https://github.com/redpanda-data/vtools/pull/3756

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

[DEVPROD-3082]: https://redpandadata.atlassian.net/browse/DEVPROD-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ