### PR TITLE
`storage`: add removed state tracking functions to `log` [SC&R #6]

### DIFF
--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -266,4 +266,9 @@ failure_injectable_log::earliest_removable_timestamp(model::offset o) const {
     return _underlying_log->earliest_removable_timestamp(o);
 }
 
+std::optional<model::offset>
+failure_injectable_log::max_removed_offset() const {
+    return _underlying_log->max_removed_offset();
+}
+
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -261,4 +261,9 @@ failure_injectable_log::earliest_dirty_segment_ts() const {
     return _underlying_log->earliest_dirty_segment_ts();
 }
 
+std::optional<model::timestamp>
+failure_injectable_log::earliest_removable_timestamp(model::offset o) const {
+    return _underlying_log->earliest_removable_timestamp(o);
+}
+
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -139,6 +139,8 @@ public:
     virtual std::optional<model::timestamp>
       earliest_removable_timestamp(model::offset) const final;
 
+    virtual std::optional<model::offset> max_removed_offset() const final;
+
 private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -136,6 +136,9 @@ public:
     virtual std::optional<model::timestamp>
     earliest_dirty_segment_ts() const final;
 
+    virtual std::optional<model::timestamp>
+      earliest_removable_timestamp(model::offset) const final;
+
 private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -507,6 +507,7 @@ ss::future<compaction_result> disk_log_impl::segment_self_compact(
       *_readers_cache,
       _manager.resources(),
       _feature_table,
+      _kvstore,
       force_compaction);
 }
 
@@ -1113,7 +1114,8 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
             *_readers_cache,
             _manager.resources(),
             _feature_table,
-            _segment_rewrite_lock);
+            _segment_rewrite_lock,
+            _kvstore);
     } catch (const generation_id_mismatch_exception& e) {
         // Early abort
         vlog(gclog.info, "{}", e.what());
@@ -1625,8 +1627,8 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
           *compacted_idx_writer,
           *_probe,
           storage::internal::should_apply_delta_time_offset(_feature_table),
-          _feature_table);
-
+          _feature_table,
+          _kvstore);
     } catch (...) {
         eptr = std::current_exception();
     }
@@ -4385,11 +4387,13 @@ ss::future<> disk_log_impl::copy_kvstore_state(
       ks, internal::start_offset_key(ntp));
     std::optional<iobuf> clean_segment = source_kvs.get(
       ks, internal::clean_segment_key(ntp));
+    std::optional<iobuf> max_removed_offset = source_kvs.get(
+      ks, internal::max_removed_offset_key(ntp));
 
     co_await storage.invoke_on(target_shard, [&](storage::api& api) {
         const auto ks = kvstore::key_space::storage;
         std::vector<ss::future<>> write_futures;
-        write_futures.reserve(2);
+        write_futures.reserve(3);
         if (start_offset) {
             write_futures.push_back(api.kvs().put(
               ks, internal::start_offset_key(ntp), start_offset->copy()));
@@ -4397,6 +4401,12 @@ ss::future<> disk_log_impl::copy_kvstore_state(
         if (clean_segment) {
             write_futures.push_back(api.kvs().put(
               ks, internal::clean_segment_key(ntp), clean_segment->copy()));
+        }
+        if (max_removed_offset) {
+            write_futures.push_back(api.kvs().put(
+              ks,
+              internal::max_removed_offset_key(ntp),
+              max_removed_offset->copy()));
         }
         return ss::when_all_succeed(std::move(write_futures));
     });
@@ -4407,7 +4417,8 @@ ss::future<> disk_log_impl::remove_kvstore_state(
     const auto ks = kvstore::key_space::storage;
     return ss::when_all_succeed(
              kvs.remove(ks, internal::start_offset_key(ntp)),
-             kvs.remove(ks, internal::clean_segment_key(ntp)))
+             kvs.remove(ks, internal::clean_segment_key(ntp)),
+             kvs.remove(ks, internal::max_removed_offset_key(ntp)))
       .discard_result();
 }
 
@@ -4552,6 +4563,10 @@ disk_log_impl::earliest_removable_timestamp(model::offset o) const {
     }
 
     return earliest_removable_ts;
+}
+
+std::optional<model::offset> disk_log_impl::max_removed_offset() const {
+    return internal::read_max_removed_offset(_kvstore, config().ntp());
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4504,4 +4504,54 @@ disk_log_impl::earliest_dirty_segment_ts() const {
     return *std::ranges::min_element(dirty_segments_ts);
 }
 
+std::optional<model::timestamp>
+disk_log_impl::earliest_removable_timestamp(model::offset o) const {
+    if (!config().is_compacted()) {
+        return std::nullopt;
+    }
+
+    // If there is no value for `delete_retention_ms`, don't bother scanning
+    // over the list of _segs.
+    if (!config().delete_retention_ms().has_value()) {
+        return std::nullopt;
+    }
+
+    model::timestamp earliest_removable_ts = model::timestamp::max();
+
+    auto it = _segs.lower_bound(o);
+    if (it == _segs.end()) {
+        return std::nullopt;
+    }
+
+    for (; it != _segs.end(); ++it) {
+        auto& seg = *it;
+        auto can_remove_tombstones
+          = config().tombstone_retention_ms().has_value()
+            && seg->has_clean_compact_timestamp()
+            && seg->index().may_have_tombstone_records();
+
+        auto can_remove_tx_batches = config().tx_retention_ms().has_value()
+                                     && seg->has_self_compact_timestamp()
+                                     && seg->index().has_transaction_batches();
+
+        if (can_remove_tombstones) {
+            earliest_removable_ts = std::min(
+              earliest_removable_ts,
+              seg->index().clean_compact_timestamp().value());
+        }
+
+        if (can_remove_tx_batches) {
+            earliest_removable_ts = std::min(
+              earliest_removable_ts,
+              seg->index().self_compact_timestamp().value());
+        }
+    }
+
+    if (earliest_removable_ts == model::timestamp::max()) {
+        return std::nullopt;
+    }
+
+    return earliest_removable_ts;
+}
+
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -303,6 +303,8 @@ public:
     std::optional<model::timestamp>
       earliest_removable_timestamp(model::offset) const final;
 
+    std::optional<model::offset> max_removed_offset() const final;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -292,6 +292,17 @@ public:
       storage::compaction_config cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
 
+    // Returns the timestamp of the earliest removable data in the log above
+    // the offset o. "Removable" refers to data that, through the
+    // `copy_data_segment_reducer::filter()` process during compaction, can be
+    // removed due to reasons other than de-duplication. Concretely, "removable"
+    // data can be either a tombstone record in a segment with a
+    // clean_compact_timestamp set, or a transactional batch in a segment with
+    // self_compact_timestamp set. Returns std::nullopt if neither of the above
+    // are found.
+    std::optional<model::timestamp>
+      earliest_removable_timestamp(model::offset) const final;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -242,6 +242,8 @@ public:
     virtual std::optional<model::timestamp>
       earliest_removable_timestamp(model::offset) const = 0;
 
+    virtual std::optional<model::offset> max_removed_offset() const = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -239,6 +239,9 @@ public:
     virtual std::optional<model::timestamp>
     earliest_dirty_segment_ts() const = 0;
 
+    virtual std::optional<model::timestamp>
+      earliest_removable_timestamp(model::offset) const = 0;
+
 private:
     ntp_config _config;
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -734,23 +734,13 @@ ss::future<ss::shared_ptr<log>> log_manager::manage(
 }
 
 ss::future<> log_manager::maybe_clear_kvstore(const ntp_config& cfg) {
-    return ss::file_exists(cfg.work_directory())
-      .then([this,
-             offset_key = internal::start_offset_key(cfg.ntp()),
-             segment_key = internal::clean_segment_key(cfg.ntp())](
-              bool dir_exists) {
-          if (dir_exists) {
-              return ss::now();
-          }
-          // directory was deleted, make sure we do not have any state in KV
-          // store.
-          // NOTE: this only removes state in the storage key space.
-          return _kvstore.remove(kvstore::key_space::storage, offset_key)
-            .then([this, segment_key] {
-                return _kvstore.remove(
-                  kvstore::key_space::storage, segment_key);
-            });
-      });
+    if (co_await ss::file_exists(cfg.work_directory())) {
+        co_return;
+    }
+    // directory was deleted, make sure we do not have any state in KV
+    // store.
+    // NOTE: this only removes state in the storage key space.
+    co_await disk_log_impl::remove_kvstore_state(cfg.ntp(), _kvstore);
 }
 
 ss::future<ss::shared_ptr<log>> log_manager::do_manage(

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -183,6 +183,7 @@ ss::future<index_state> deduplicate_segment(
   probe& probe,
   offset_delta_time should_offset_delta_times,
   ss::sharded<features::feature_table>& feature_table,
+  kvstore& kvs,
   bool inject_reader_failure) {
     auto read_holder = co_await seg->read_lock();
     if (seg->is_closed()) {
@@ -198,6 +199,7 @@ ss::future<index_state> deduplicate_segment(
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
     bool has_transaction_batches = false;
+    model::offset max_removed_offset = model::offset::min();
 
     auto is_latest_record = [&map](
                               const model::record_batch& b,
@@ -213,7 +215,8 @@ ss::future<index_state> deduplicate_segment(
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
                           &probe,
-                          &has_transaction_batches](
+                          &has_transaction_batches,
+                          &max_removed_offset](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -228,7 +231,8 @@ ss::future<index_state> deduplicate_segment(
           segment_last_offset,
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
-          has_transaction_batches);
+          has_transaction_batches,
+          max_removed_offset);
     };
 
     auto copy_reducer = internal::copy_data_segment_reducer(
@@ -278,6 +282,13 @@ ss::future<index_state> deduplicate_segment(
       seg->index().may_have_tombstone_records()
       && !may_have_tombstone_records) {
         probe.add_segment_marked_tombstone_free();
+    }
+
+    auto curr_max_removed_offset = internal::read_max_removed_offset(kvs, ntp)
+                                     .value_or(model::offset::min());
+    if (max_removed_offset > curr_max_removed_offset) {
+        co_await internal::write_max_removed_offset(
+          kvs, ntp, max_removed_offset);
     }
 
     co_return std::move(new_idx);

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -58,6 +58,7 @@ ss::future<index_state> deduplicate_segment(
   storage::probe& probe,
   offset_delta_time should_offset_delta_times,
   ss::sharded<features::feature_table>&,
+  kvstore&,
   bool inject_reader_failure = false);
 
 // Creates a reader for the segment starting from the last_indexed_offset

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -34,6 +34,7 @@
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
 #include "storage/index_state.h"
+#include "storage/kvstore.h"
 #include "storage/lock_manager.h"
 #include "storage/log_reader.h"
 #include "storage/logger.h"
@@ -368,7 +369,8 @@ ss::future<storage::index_state> do_copy_segment_data(
   ss::rwlock::holder rw_lock_holder,
   storage_resources& resources,
   offset_delta_time apply_offset,
-  ss::sharded<features::feature_table>& feature_table) {
+  ss::sharded<features::feature_table>& feature_table,
+  kvstore& kvs) {
     // preserve base_offset, broker_timestamp, and clean_compact_timestamp from
     // the segment's index
     auto old_base_offset = seg->index().base_offset();
@@ -413,6 +415,7 @@ ss::future<storage::index_state> do_copy_segment_data(
       = internal::is_past_tombstone_delete_horizon(seg, cfg);
     bool may_have_tombstone_records = false;
     bool has_transaction_batches = false;
+    model::offset max_removed_offset = model::offset::min();
 
     auto offset_in_compacted_list =
       [compacted_offsets = std::move(compacted_offsets)](
@@ -431,7 +434,8 @@ ss::future<storage::index_state> do_copy_segment_data(
                           past_tombstone_delete_horizon,
                           &may_have_tombstone_records,
                           &pb,
-                          &has_transaction_batches](
+                          &has_transaction_batches,
+                          &max_removed_offset](
                            const model::record_batch& b,
                            const model::record& r,
                            bool is_last_record_in_batch) {
@@ -446,7 +450,8 @@ ss::future<storage::index_state> do_copy_segment_data(
           segment_last_offset,
           past_tombstone_delete_horizon,
           may_have_tombstone_records,
-          has_transaction_batches);
+          has_transaction_batches,
+          max_removed_offset);
     };
 
     auto copy_reducer = copy_data_segment_reducer(
@@ -506,6 +511,12 @@ ss::future<storage::index_state> do_copy_segment_data(
       seg->index().may_have_tombstone_records()
       && !may_have_tombstone_records) {
         pb.add_segment_marked_tombstone_free();
+    }
+
+    auto curr_max_removed_offset = read_max_removed_offset(kvs, ntp).value_or(
+      model::offset::min());
+    if (max_removed_offset > curr_max_removed_offset) {
+        co_await write_max_removed_offset(kvs, ntp, max_removed_offset);
     }
 
     co_return std::move(new_index);
@@ -578,7 +589,8 @@ ss::future<compaction_result> do_self_compact_segment(
   storage_resources& resources,
   offset_delta_time apply_offset,
   ss::rwlock::holder read_holder,
-  ss::sharded<features::feature_table>& feature_table) {
+  ss::sharded<features::feature_table>& feature_table,
+  kvstore& kvs) {
     auto size_before = s->size_bytes();
 
     if (cfg.asrc) {
@@ -611,7 +623,8 @@ ss::future<compaction_result> do_self_compact_segment(
       std::move(read_holder),
       resources,
       apply_offset,
-      feature_table);
+      feature_table,
+      kvs);
     vlog(
       gclog.trace, "finished copying segment data for {}", s->reader().path());
 
@@ -778,6 +791,7 @@ ss::future<compaction_result> self_compact_segment(
   storage::readers_cache& readers_cache,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
+  kvstore& kvs,
   bool force_compaction) {
     if (s->has_appender()) {
         throw std::runtime_error(fmt::format(
@@ -827,7 +841,8 @@ ss::future<compaction_result> self_compact_segment(
       resources,
       apply_offset,
       std::move(read_holder),
-      feature_table);
+      feature_table,
+      kvs);
 
     if (res.did_compact()) {
         pb.add_compaction_removed_bytes(
@@ -1164,7 +1179,8 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
   storage::readers_cache& readers_cache,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
-  mutex& segment_rewrite_lock) {
+  mutex& segment_rewrite_lock,
+  kvstore& kvs) {
     vassert(
       segment_rewrite_lock.is_held(), "Segment rewrite lock should be held.");
 
@@ -1206,6 +1222,7 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
       readers_cache,
       resources,
       feature_table,
+      kvs,
       true);
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 
@@ -1320,6 +1337,13 @@ bytes clean_segment_key(model::ntp ntp) {
     return iobuf_to_bytes(buf);
 }
 
+bytes max_removed_offset_key(model::ntp ntp) {
+    iobuf buf;
+    reflection::serialize(
+      buf, kvstore_key_type::max_removed_offset, std::move(ntp));
+    return iobuf_to_bytes(buf);
+}
+
 offset_delta_time should_apply_delta_time_offset(
   ss::sharded<features::feature_table>& feature_table) {
     return offset_delta_time{
@@ -1392,6 +1416,26 @@ bool has_removable_transaction_batches(
   ss::lw_shared_ptr<segment> seg, const compaction_config& cfg) {
     return seg->index().has_transaction_batches()
            && is_past_transaction_batch_delete_horizon(seg, cfg);
+}
+
+std::optional<model::offset>
+read_max_removed_offset(kvstore& kvs, const model::ntp& ntp) {
+    auto value = kvs.get(
+      kvstore::key_space::storage, internal::max_removed_offset_key(ntp));
+    if (value) {
+        auto offset = reflection::adl<model::offset>{}.from(std::move(*value));
+        return offset;
+    }
+    return std::nullopt;
+}
+
+ss::future<>
+write_max_removed_offset(kvstore& kvs, const model::ntp& ntp, model::offset o) {
+    vlog(gclog.debug, "{}: Updated max_removed_offset as {}", ntp, o);
+    co_await kvs.put(
+      kvstore::key_space::storage,
+      internal::max_removed_offset_key(ntp),
+      reflection::to_iobuf(o));
 }
 
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1347,10 +1347,11 @@ bool is_past_tombstone_delete_horizon(
     if (
       seg->has_clean_compact_timestamp()
       && cfg.tombstone_retention_ms.has_value()) {
-        auto tombstone_delete_horizon = model::timestamp(
-          seg->index().clean_compact_timestamp()->value()
-          + cfg.tombstone_retention_ms->count());
-        return (model::timestamp::now() > tombstone_delete_horizon);
+        const auto now = model::to_time_point(model::timestamp::now());
+        return (now
+                - model::to_time_point(
+                  seg->index().clean_compact_timestamp().value()))
+               > cfg.tombstone_retention_ms.value();
     }
 
     return false;
@@ -1372,6 +1373,25 @@ ss::future<bool> mark_segment_as_finished_self_compaction(
     }
 
     return ss::make_ready_future<bool>(false);
+}
+
+bool is_past_transaction_batch_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg) {
+    if (seg->has_self_compact_timestamp() && cfg.tx_retention_ms.has_value()) {
+        const auto now = model::to_time_point(model::timestamp::now());
+        return (now
+                - model::to_time_point(
+                  seg->index().self_compact_timestamp().value()))
+               > cfg.tx_retention_ms.value();
+    }
+
+    return false;
+}
+
+bool has_removable_transaction_batches(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg) {
+    return seg->index().has_transaction_batches()
+           && is_past_transaction_batch_delete_horizon(seg, cfg);
 }
 
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -58,6 +58,7 @@ ss::future<compaction_result> self_compact_segment(
   storage::readers_cache&,
   storage::storage_resources&,
   ss::sharded<features::feature_table>& feature_table,
+  kvstore& kvs,
   bool force_compaction = false);
 
 /// \brief, rebuilds a given segment's compacted index. This method acquires
@@ -112,7 +113,8 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
   storage::readers_cache& readers_cache,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table,
-  mutex& segment_rewrite_lock);
+  mutex& segment_rewrite_lock,
+  kvstore& kvs);
 
 ss::future<> write_concatenated_compacted_index(
   std::filesystem::path,
@@ -218,7 +220,8 @@ ss::future<storage::index_state> do_copy_segment_data(
   storage::compaction_config,
   storage::probe&,
   ss::rwlock::holder,
-  storage_resources&);
+  storage_resources&,
+  kvstore&);
 
 ss::future<> do_swap_data_file_handles(
   std::filesystem::path compacted,
@@ -235,10 +238,12 @@ float random_jitter(jitter_percents);
 enum class kvstore_key_type : int8_t {
     start_offset = 0,
     clean_segment = 1,
+    max_removed_offset = 2,
 };
 
 bytes start_offset_key(model::ntp ntp);
 bytes clean_segment_key(model::ntp ntp);
+bytes max_removed_offset_key(model::ntp ntp);
 
 struct clean_segment_value
   : serde::envelope<
@@ -396,7 +401,8 @@ ss::future<bool> should_keep(
   model::offset segment_last_offset,
   bool past_tombstone_delete_horizon,
   bool& may_have_tombstone_records,
-  bool& has_tx_batches) {
+  bool& has_tx_batches,
+  model::offset& max_removed_offset) {
     auto compaction_placeholder_enabled = feature_table.local().is_active(
       features::feature::compaction_placeholder_batch);
     auto is_last_batch = b.last_offset() == segment_last_offset;
@@ -435,6 +441,8 @@ ss::future<bool> should_keep(
     if (can_discard(b, r, ntp, past_tombstone_delete_horizon)) {
         if (r.is_tombstone()) {
             pb.add_removed_tombstone();
+            max_removed_offset = b.base_offset()
+                                 + model::offset_delta(r.offset_delta());
         }
         co_return false;
     }
@@ -451,5 +459,11 @@ ss::future<bool> should_keep(
 
     co_return keep;
 }
+
+std::optional<model::offset>
+read_max_removed_offset(kvstore&, const model::ntp&);
+
+ss::future<>
+write_max_removed_offset(kvstore&, const model::ntp&, model::offset);
 
 } // namespace storage::internal

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -323,6 +323,12 @@ bool is_past_tombstone_delete_horizon(
 bool may_have_removable_tombstones(
   ss::lw_shared_ptr<segment> seg, const compaction_config& cfg);
 
+bool is_past_transaction_batch_delete_horizon(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg);
+
+bool has_removable_transaction_batches(
+  ss::lw_shared_ptr<segment> seg, const compaction_config& cfg);
+
 // Mark a segment as completed window compaction, and whether it is "clean" (in
 // which case the `clean_compact_timestamp` is set in the segment's index).
 // Also potentially issues a call to seg->index()->flush(), if the

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -1387,6 +1387,19 @@ TEST_P(
               num_tombstones_produced + num_records_produced);
         }
     }
+
+    if (wait_for_retention_ms) {
+        auto max_removed_pre_restart = log->max_removed_offset();
+        ASSERT_GT(max_removed_pre_restart, model::offset{0});
+
+        restart(should_wipe::no);
+        wait_for_leader(ntp).get();
+        partition = app.partition_manager.local().get(ntp).get();
+        log = partition->log().get();
+
+        auto max_removed_post_restart = log->max_removed_offset();
+        ASSERT_EQ(max_removed_pre_restart, max_removed_post_restart);
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/storage/tests/segment_concatenation_test.cc
+++ b/src/v/storage/tests/segment_concatenation_test.cc
@@ -122,6 +122,7 @@ void concatenate_segments_from_log(
   storage::disk_log_impl& log,
   int expected_segments_to_compact,
   ss::sharded<features::feature_table>& feature_table,
+  storage::kvstore& kvs,
   bool maybe_compress) {
     storage::compaction_config cfg(
       model::offset::max(), std::nullopt, std::nullopt, never_abort);
@@ -177,7 +178,8 @@ void concatenate_segments_from_log(
           log.readers(),
           log.resources(),
           feature_table,
-          fake_segment_rewrite_lock)
+          fake_segment_rewrite_lock,
+          kvs)
           .get();
 
     EXPECT_EQ(target->file_size(), expected_target_file_size);
@@ -213,7 +215,11 @@ TEST_P(MakeConcatenatedSegmentFixture, ConcatenateSegments) {
     }
 
     concatenate_segments_from_log(
-      disk_log, num_segments, b.feature_table(), maybe_compress);
+      disk_log,
+      num_segments,
+      b.feature_table(),
+      b.storage().kvs(),
+      maybe_compress);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -360,7 +360,8 @@ TEST(BuildOffsetMap, TestBuildSimpleMap) {
           pb,
           disk_log.readers(),
           disk_log.resources(),
-          feature_table)
+          feature_table,
+          b.storage().kvs())
           .get();
     }
 
@@ -480,6 +481,7 @@ TEST(DeduplicateSegmentsTest, TestBadReader) {
         disk_log.get_probe(),
         storage::internal::should_apply_delta_time_offset(b.feature_table()),
         b.feature_table(),
+        b.storage().kvs(),
         /*inject_reader_failure=*/true)
         .get(),
       std::runtime_error);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -6446,3 +6446,159 @@ TEST_F(storage_test_fixture, delete_retention_ms_without_ts) {
     ASSERT_TRUE(tx_retention_ms.has_value());
     ASSERT_EQ(tx_retention_ms.value(), delete_retention_ms);
 };
+
+TEST_F(storage_test_fixture, earliest_removable_timestamp) {
+    using namespace storage;
+    struct test_case {
+        struct segment_spec {
+            int num_records;
+            bool has_tombstones;
+            bool has_txs;
+            std::optional<model::timestamp> self_compact_timestamp;
+            std::optional<model::timestamp> clean_compact_timestamp;
+
+            void set_segment_state(ss::lw_shared_ptr<segment> s) const {
+                s->index().set_may_have_tombstone_records(has_tombstones);
+                s->index().set_has_transaction_batches(has_txs);
+
+                if (self_compact_timestamp.has_value()) {
+                    s->index().maybe_set_self_compact_timestamp(
+                      self_compact_timestamp.value());
+                }
+                if (clean_compact_timestamp.has_value()) {
+                    s->index().maybe_set_clean_compact_timestamp(
+                      clean_compact_timestamp.value());
+                }
+            }
+        };
+
+        model::offset o;
+        std::optional<model::timestamp> expected_removable_timestamp;
+        std::vector<segment_spec> segments;
+        ss::sstring desc;
+    };
+
+    // clang-format off
+    std::vector<test_case>
+        test_cases = {
+      test_case{
+	.o = model::offset{0},
+	.expected_removable_timestamp = std::nullopt,
+	.segments = {test_case::segment_spec{.num_records = 100,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = std::nullopt,
+					     .clean_compact_timestamp = std::nullopt},
+		     test_case::segment_spec{.num_records = 100,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = std::nullopt,
+					     .clean_compact_timestamp = std::nullopt}},
+	.desc = "No segments with currently removable tombstones or transactions"},
+      test_case{
+	.o = model::offset{50},
+	.expected_removable_timestamp = std::nullopt,
+	.segments = {test_case::segment_spec{.num_records = 10,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = model::timestamp{1},
+					     .clean_compact_timestamp = model::timestamp{1}},
+		     test_case::segment_spec{.num_records = 100,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = std::nullopt,
+					     .clean_compact_timestamp = std::nullopt}},
+	.desc = "No segments with currently removable tombstones or transactions above the provided offset"},
+      test_case{
+	.o = model::offset{50},
+	.expected_removable_timestamp = std::nullopt,
+	.segments = {test_case::segment_spec{.num_records = 10,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = model::timestamp{1},
+					     .clean_compact_timestamp = model::timestamp{1}},
+		     test_case::segment_spec{.num_records = 100,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = std::nullopt,
+					     .clean_compact_timestamp = std::nullopt}},
+	.desc = "No segments with currently removable tombstones or transactions above the provided offset"},
+      test_case{
+	.o = model::offset{20},
+	.expected_removable_timestamp = std::nullopt,
+	.segments = {test_case::segment_spec{.num_records = 30,
+					     .has_tombstones = false,
+					     .has_txs = false,
+					     .self_compact_timestamp = model::timestamp{1},
+					     .clean_compact_timestamp = model::timestamp{2}}},
+	.desc = "Segment without any removable data."},
+      test_case{
+	.o = model::offset{20},
+	.expected_removable_timestamp = model::timestamp{1},
+	.segments = {test_case::segment_spec{.num_records = 30,
+					     .has_tombstones = true,
+					     .has_txs = false,
+					     .self_compact_timestamp = std::nullopt,
+					     .clean_compact_timestamp = model::timestamp{1}}},
+	.desc = "Segment with a removable tombstone."},
+      test_case{
+	.o = model::offset{20},
+	.expected_removable_timestamp = model::timestamp{1},
+	.segments = {test_case::segment_spec{.num_records = 30,
+					     .has_tombstones = false,
+					     .has_txs = true,
+					     .self_compact_timestamp = model::timestamp{1},
+					     .clean_compact_timestamp = std::nullopt}},
+	.desc = "Segment with removable transaction data."},
+      test_case{
+	.o = model::offset{0},
+	.expected_removable_timestamp = model::timestamp{3},
+	.segments = {test_case::segment_spec{.num_records = 10,
+					     .has_tombstones = false,
+					     .has_txs = false,
+					     .self_compact_timestamp = model::timestamp{1},
+					     .clean_compact_timestamp = model::timestamp{2}},
+		     test_case::segment_spec{.num_records = 10,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = model::timestamp{3},
+					     .clean_compact_timestamp = model::timestamp{4}},
+		     test_case::segment_spec{.num_records = 10,
+					     .has_tombstones = true,
+					     .has_txs = true,
+					     .self_compact_timestamp = model::timestamp{5},
+					     .clean_compact_timestamp = model::timestamp{6}}},
+	.desc = "Multiple segments with removable data should return the earliest timestamp."},
+    };
+    // clang-format on
+
+    using overrides_t = ntp_config::default_overrides;
+    overrides_t ov;
+    auto delete_retention_ms = 10ms;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    ov.delete_retention_ms = tristate<std::chrono::milliseconds>(
+      delete_retention_ms);
+    for (const auto& test : test_cases) {
+        disk_log_builder b;
+        auto ntp_cfg = ntp_config(
+          storage::log_builder_ntp(),
+          b.get_log_config().base_dir,
+          std::make_unique<overrides_t>(ov));
+
+        b | start(std::move(ntp_cfg));
+        auto cleanup = ss::defer([&] { b.stop().get(); });
+
+        auto& disk_log = b.get_disk_log_impl();
+        auto offset = 0;
+        for (const auto& segment_spec : test.segments) {
+            b | add_segment(offset)
+              | add_random_batch(offset, segment_spec.num_records);
+            segment_spec.set_segment_state(disk_log.segments().back());
+            disk_log.force_roll().get();
+            offset += segment_spec.num_records;
+        }
+        auto earliest_removable_ts = disk_log.earliest_removable_timestamp(
+          test.o);
+        ASSERT_EQ(test.expected_removable_timestamp, earliest_removable_ts);
+    }
+}


### PR DESCRIPTION
This PR is the 6th in the series of safe compaction & recovery [SC&R] PRs.

It adds the following:
* Two new helper functions to `segment_utils.cc`, `has_removable_transaction_batches()` and `is_past_transaction_batch_delete_horizon()`, analogous to their tombstone counter parts.
* A new function `log::earliest_removable_timestamp()`, which scans over the `segment`s in the `log` (above a certain offset) and returns the earliest set timestamp which sets a time horizon for the removal of either a tombstone record (i.e `clean_compact_timestamp`) or a transactional batch (i.e `self_compact_timestamp`). This will be used in the future to set a cap on how long a recovery process can take before there is a possibility for divergence amongst replicas.
* A new function `log::max_removed_offset()`, which book-keeps the highest offset of a removed tombstone or transactional batch (for now, this is only set for removed tombstones). This will be used in the future to detect if recovery of a learner is beginning below removed state on a leader, which will also require a forced remake of the partition on the learner node. Because this state cannot be reproduced by a scan over the `segment`s in the `log`, it is persisted in the `kvstore` on the leader node.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
