### PR TITLE
rpk: Adds print command for node configuration

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/BUILD
+++ b/src/go/rpk/pkg/cli/redpanda/BUILD
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//src/go/rpk/pkg/adminapi",
             "//src/go/rpk/pkg/cli/redpanda/admin",
             "//src/go/rpk/pkg/cli/redpanda/tune",
             "//src/go/rpk/pkg/cloud",
@@ -49,6 +50,7 @@ go_library(
             "@com_github_spf13_cobra//:cobra",
         ],
         "@rules_go//go/platform:linux": [
+            "//src/go/rpk/pkg/adminapi",
             "//src/go/rpk/pkg/cli/redpanda/admin",
             "//src/go/rpk/pkg/cli/redpanda/tune",
             "//src/go/rpk/pkg/cloud",

--- a/src/go/rpk/pkg/cli/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/config.go
@@ -13,11 +13,13 @@
 package redpanda
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"strings"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	vnet "github.com/redpanda-data/redpanda/src/go/rpk/pkg/net"
@@ -34,8 +36,44 @@ func NewConfigCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.AddCommand(
 		set(fs, p),
 		bootstrap(fs, p),
+		printCommand(fs, p),
 		cobraext.DeprecatedCmd("init", 0),
 	)
+	return cmd
+}
+
+func printCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var host string
+	cmd := &cobra.Command{
+		Use:     "print",
+		Aliases: []string{"dump"},
+		Short:   "Display the selected node configuration",
+		Args:    cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitCloudAdmin(p)
+
+			if len(host) == 0 {
+				host, err = selectHost(p)
+				out.MaybeDie(err, "unable to select a host")
+			}
+
+			hostClient, err := adminapi.NewHostClient(fs, p, host)
+			out.MaybeDie(err, "unable to initialize the admin client: %v", err)
+
+			conf, err := hostClient.GetNodeConfig(cmd.Context())
+			out.MaybeDie(err, "unable to retrieve node %v configuration: %v", host, err)
+
+			marshaled, err := json.MarshalIndent(conf, "", "  ")
+			out.MaybeDie(err, "unable to json encode the configuration: %v", err)
+
+			fmt.Println(string(marshaled))
+		},
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "a hostname or the index (0-based) of the configured Kafka broker list")
+
 	return cmd
 }
 
@@ -317,4 +355,18 @@ func parseAdvertisedRPC(adv string, defHost string) (*config.SocketAddress, erro
 		Address: host,
 		Port:    port,
 	}, nil
+}
+
+func selectHost(p *config.RpkProfile) (string, error) {
+	addresses := p.AdminAPI.Addresses
+	if len(addresses) == 0 {
+		return "", errors.New("no Redpanda Admin API addresses configured in your rpk profile, for more information see 'rpk profile set --help'")
+	}
+
+	i, err := out.PickIndex(addresses, "Please select an Admin API address:")
+	if err != nil {
+		return "", err
+	}
+
+	return addresses[i], nil
 }


### PR DESCRIPTION
Fixes #8643

This adds in a `print` command to `rpk redpanda config` to help users see the current configuration of a node. There's already a way to print admin configs, and this commit follows its pattern. This commit makes use of the `common-go` library's `GetNodeConfig` function to accomplish this.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
### Improvements

* Adds a `print` command to retrieve a node's current configuration using `rpk`

