### PR TITLE
`storage`: fix constructor in `compaction_e2e_test.cc`

### DIFF
--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -2069,7 +2069,7 @@ TEST_F(CompactionFixtureTest, TestBatchCacheResetAfterAdjacentMerge) {
 
     ss::abort_source never_abort;
     storage::compaction_config cfg(
-      model::offset::max(), std::nullopt, never_abort);
+      model::offset::max(), std::nullopt, std::nullopt, never_abort);
 
     // self compact everything up front so that it doesn't happen inline with
     // adjacent merge compaction. this would cause batch caches to be reset


### PR DESCRIPTION
This was left unchanged due to a merge race between PRs https://github.com/redpanda-data/redpanda/pull/26732 and https://github.com/redpanda-data/redpanda/pull/26660. 

Add `std::nullopt` as an argument for `tx_retention_ms`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
