### PR TITLE
schema_registry: Synchronize swagger with docs

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -30,7 +30,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -73,7 +73,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -104,13 +104,13 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -136,7 +136,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -173,7 +173,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -199,7 +199,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -242,7 +242,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -289,7 +289,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -345,7 +345,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -383,7 +383,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -412,7 +412,7 @@
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -435,7 +435,8 @@
             "name": "format",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -459,13 +460,19 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -509,13 +516,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -557,13 +564,13 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
           },
           "500": {
-            "description": "Internal Server error",
+            "description": "Internal Server Error",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -580,7 +587,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "subjectPrefix",
@@ -645,7 +652,8 @@
             "name": "format",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           },
           {
             "name": "schema_def",
@@ -668,7 +676,7 @@
             }
           },
           "404": {
-            "description": "Not found",
+            "description": "Not Found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -687,6 +695,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -726,7 +740,7 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -755,7 +769,7 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           }
         ],
         "produces": [
@@ -774,7 +788,7 @@
             }
           },
           "404": {
-            "description": "Subject not found",
+            "description": "Not Found: Subject not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -875,13 +889,14 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "format",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -897,7 +912,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -910,6 +925,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -952,7 +973,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -974,8 +995,9 @@
     },
     "/subjects/{subject}/versions/{version}/schema": {
       "get": {
-        "summary": "Retrieve a schema for the subject and version.",
+        "summary": "Retrieve the raw schema for the subject.",
         "operationId": "get_subject_versions_version_schema",
+        "description": "Returns the specified version of the schema in its original format, without backslashes.",
         "parameters": [
           {
             "name": "subject",
@@ -993,13 +1015,14 @@
             "name": "deleted",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "format",
             "in": "query",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "Redpanda version 25.2 or later. For Avro and Protobuf schemas only. Supported values: an empty string `''` returns the schema in its current format (default), and `serialized` (Protobuf only) returns the schema in its Base64-encoded wire binary format. Unsupported values return a 501 error."
           }
         ],
         "produces": [
@@ -1015,7 +1038,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1028,6 +1051,12 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "501": {
+            "description": "Not Implemented: The specified format parameter value is not supported",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1069,7 +1098,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1124,7 +1153,7 @@
             }
           },
           "404": {
-            "description": "Schema not found",
+            "description": "Not Found: Schema not found",
             "schema": {
               "$ref": "#/definitions/error_body"
             }
@@ -1176,6 +1205,7 @@
           {
             "name": "verbose",
             "in": "query",
+            "description": "If true, includes more verbose information about the compatibility check, for example the reason the check failed.",
             "required": false,
             "type": "boolean"
           }
@@ -1230,7 +1260,7 @@
     "/security/acls": {
       "get": {
         "summary": "List ACLs",
-        "description": "Returns a list of rules that match the specified filters.",
+        "description": "Returns a list of ACL rules that match the specified filters.",
         "operationId": "get_security_acls",
         "produces": [
           "application/json"
@@ -1240,33 +1270,33 @@
             "name": "principal",
             "in": "query",
             "type": "string",
-            "description": "The name of the principal (e.g., User:alice or RedpandaRole:bob). Use \"*\" to represent wildcard."
+            "description": "The name of the principal, for example, User:alice or RedpandaRole:admin. Use \"*\" to represent a wildcard."
           },
           {
             "name": "resource",
             "in": "query",
             "type": "string",
-            "description": "The name of the resource. Use \"*\" to represent wildcard."
+            "description": "The name of the resource. Use \"*\" to represent a wildcard."
           },
           {
             "name": "resource_type",
             "in": "query",
             "type": "string",
             "enum": ["REGISTRY", "SUBJECT"],
-            "description": "Type of the resource being secured."
+            "description": "The type of resource being secured. The REGISTRY type maps to top-level operations such as `GET /mode` and `GET /config`. The SUBJECT type maps to operations on the subject level, such as `GET /subjects` and `GET /config/{subject}`."
           },
           {
             "name": "pattern_type",
             "in": "query",
             "type": "string",
             "enum": ["LITERAL", "PREFIXED"],
-            "description": "Pattern match type for the resource. Only applies when resource_type is SUBJECT."
+            "description": "Pattern match type for the resource. Only applies when `resource_type` is SUBJECT."
           },
           {
             "name": "host",
             "in": "query",
             "type": "string",
-            "description": "Originating host for which this rule applies. Use \"*\" to represent wildcard."
+            "description": "Originating host for which this rule applies. Use \"*\" to represent a wildcard."
           },
           {
             "name": "operation",
@@ -1328,7 +1358,7 @@
       },
       "post": {
         "summary": "Create ACLs",
-        "description": "Create new rules.",
+        "description": "Create new ACL rules.",
         "operationId": "post_security_acls",
         "parameters": [
           {
@@ -1381,8 +1411,11 @@
       },
       "delete": {
         "summary": "Delete ACLs",
-        "description": "Delete ACL rules exactly matching the given definitions.",
+        "description": "Delete ACL rules that match the specified definitions exactly.",
         "operationId": "delete_security_acls",
+        "consumes": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "acls",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -114,7 +114,7 @@
           "items": {
             "type": "string"
           }
-        },
+        }
       }
     },
     "security_acl": {
@@ -131,11 +131,11 @@
       "properties": {
         "principal": {
           "type": "string",
-          "description": "The name of the principal (e.g., User:alice or RedpandaRole:admin). Use \"*\" to represent wildcard."
+          "description": "The name of the principal, for example, User:alice or RedpandaRole:admin. Use \"*\" to represent a wildcard."
         },
         "resource": {
           "type": "string",
-          "description": "The name of the resource. Use \"*\" to represent wildcard."
+          "description": "The name of the resource. Use \"*\" to represent a wildcard."
         },
         "resource_type": {
           "type": "string",
@@ -143,7 +143,7 @@
             "REGISTRY",
             "SUBJECT"
           ],
-          "description": "Type of the resource being secured."
+          "description": "The type of resource being secured."
         },
         "pattern_type": {
           "type": "string",
@@ -151,11 +151,11 @@
             "LITERAL",
             "PREFIXED"
           ],
-          "description": "Pattern match type for the resource. Only applies when resource_type is SUBJECT."
+          "description": "Pattern match type for the resource. Only applies when `resource_type` is SUBJECT."
         },
         "host": {
           "type": "string",
-          "description": "Originating host for which this rule applies. Use \"*\" to represent wildcard."
+          "description": "Originating host for which this rule applies. Use \"*\" to represent a wildcard."
         },
         "operation": {
           "type": "string",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "Pandaproxy Schema Registry",
+    "title": "Redpanda Schema Registry API",
     "version": "1.1.0"
   },
   "host": "{{Host}}",


### PR DESCRIPTION
The docs team have a copy of this that they've improved.

Let's synchronize them.

https://github.com/redpanda-data/docs/pull/1206
https://github.com/redpanda-data/docs/pull/1204

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
