### PR TITLE
`cloud_storage_clients`: log on `_unknown` in `status_to_error_code()` for `s3_client`

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -409,6 +409,8 @@ status_to_error_code(boost::beast::http::status s) {
       || s == boost::beast::http::status::internal_server_error) {
         return cloud_storage_clients::s3_error_code::slow_down;
     }
+    vlog(
+      s3_log.debug, "Returning s3_error_code::_unknown for http::status {}", s);
     return cloud_storage_clients::s3_error_code::_unknown;
 }
 


### PR DESCRIPTION
Opening up mainly for `ci-repeat`s.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
