### PR TITLE
pandaproxy: remove ephemeral credentials

### DIFF
--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -10,16 +10,12 @@
 #include "pandaproxy/rest/proxy.h"
 
 #include "cluster/controller.h"
-#include "cluster/ephemeral_credential_frontend.h"
-#include "cluster/members_table.h"
-#include "cluster/security_frontend.h"
 #include "config/configuration.h"
-#include "kafka/client/config_utils.h"
+#include "kafka/client/configuration.h"
 #include "pandaproxy/api/api-doc/rest.json.hh"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/handlers.h"
-#include "security/ephemeral_credential_store.h"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/memory.hh>
@@ -29,9 +25,6 @@
 namespace pandaproxy::rest {
 
 using server = proxy::server;
-
-const security::acl_principal principal{
-  security::principal_type::ephemeral_user, "__pandaproxy"};
 
 class wrap {
 public:
@@ -172,40 +165,20 @@ ss::future<> proxy::do_start() {
 }
 
 ss::future<> proxy::configure() {
-    auto sasl_config = co_await kafka::client::create_client_credentials(
-      *_controller, config::shard_local_cfg(), _client_cfg, principal);
+    std::optional<kafka::client::sasl_configuration> sasl_config;
+    if (
+      _client_cfg.scram_username.is_overriden()
+      || _client_cfg.scram_password.is_overriden()
+      || _client_cfg.sasl_mechanism.is_overriden()) {
+        sasl_config = kafka::client::sasl_configuration{
+          .mechanism = _client_cfg.sasl_mechanism(),
+          .username = _client_cfg.scram_username(),
+          .password = _client_cfg.scram_password()};
+    }
     co_await _client.invoke_on_all(
       [sasl_config = std::move(sasl_config)](kafka::client::client& c) {
           c.set_credentials(sasl_config);
       });
-
-    const auto& store = _controller->get_ephemeral_credential_store().local();
-    bool has_ephemeral_credentials = store.has(store.find(principal));
-    co_await container().invoke_on_all(
-      _ctx.smp_sg, [has_ephemeral_credentials](proxy& p) {
-          p._has_ephemeral_credentials = has_ephemeral_credentials;
-      });
-
-    security::acl_entry acl_entry{
-      principal,
-      security::acl_host::wildcard_host(),
-      security::acl_operation::all,
-      security::acl_permission::allow};
-
-    co_await _controller->get_security_frontend().local().create_acls(
-      {security::acl_binding{
-         security::resource_pattern{
-           security::resource_type::topic,
-           security::resource_pattern::wildcard,
-           security::pattern_type::literal},
-         acl_entry},
-       security::acl_binding{
-         security::resource_pattern{
-           security::resource_type::group,
-           security::resource_pattern::wildcard,
-           security::pattern_type::literal},
-         acl_entry}},
-      5s);
 }
 
 ss::future<> proxy::mitigate_error(std::exception_ptr eptr) {
@@ -214,39 +187,7 @@ ss::future<> proxy::mitigate_error(std::exception_ptr eptr) {
         return ss::now();
     }
     vlog(plog.debug, "mitigate_error: {}", eptr);
-    return ss::make_exception_future<>(eptr).handle_exception_type(
-      [this, eptr](const kafka::client::broker_error& ex) {
-          if (
-            ex.error == kafka::error_code::sasl_authentication_failed
-            && _has_ephemeral_credentials) {
-              return inform(ex.node_id).then([this]() {
-                  // This fully mitigates, don't rethrow.
-                  return _client.local().connect();
-              });
-          }
-          // Rethrow unhandled exceptions
-          return ss::make_exception_future<>(eptr);
-      });
-}
-
-ss::future<> proxy::inform(model::node_id id) {
-    vlog(plog.trace, "inform: {}", id);
-
-    // Inform a particular node
-    if (id != kafka::client::unknown_node_id) {
-        return do_inform(id);
-    }
-
-    // Inform all nodes
-    return seastar::parallel_for_each(
-      _controller->get_members_table().local().node_ids(),
-      [this](model::node_id id) { return do_inform(id); });
-}
-
-ss::future<> proxy::do_inform(model::node_id id) {
-    auto& fe = _controller->get_ephemeral_credential_frontend().local();
-    auto ec = co_await fe.inform(id, principal);
-    vlog(plog.info, "Informed: broker: {}, ec: {}", id, ec);
+    return ss::make_exception_future<>(eptr);
 }
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -49,8 +49,6 @@ public:
 private:
     ss::future<> do_start();
     ss::future<> configure();
-    ss::future<> inform(model::node_id);
-    ss::future<> do_inform(model::node_id);
 
     configuration _config;
     kafka::client::configuration _client_cfg;
@@ -64,7 +62,6 @@ private:
     server _server;
     one_shot _ensure_started;
     cluster::controller* _controller;
-    bool _has_ephemeral_credentials{false};
     bool _is_started{false};
 };
 

--- a/tests/rptest/tests/admin_api_auth_test.py
+++ b/tests/rptest/tests/admin_api_auth_test.py
@@ -11,7 +11,7 @@ import requests
 
 from rptest.services.admin import Admin
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.tests.pandaproxy_test import PandaProxyEndpoints
+from rptest.tests.schema_registry_test import SchemaRegistryEndpoints
 from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SaslCredentials, SecurityConfig
@@ -221,7 +221,7 @@ class AdminApiAuthEnablementTest(RedpandaTest):
                 {"superusers": [self.redpanda.SUPERUSER_CREDENTIALS.username]})
 
 
-class AdminApiListUsersTest(PandaProxyEndpoints):
+class AdminApiListUsersTest(SchemaRegistryEndpoints):
     def __init__(self, context):
         security = SecurityConfig()
         security.kafka_enable_authorization = True
@@ -237,10 +237,10 @@ class AdminApiListUsersTest(PandaProxyEndpoints):
 
     @cluster(num_nodes=3)
     def test_list_users(self):
-        # Create ephemeral users for each pandaproxy instance
+        # Create ephemeral users for each schema registry instance
         pp_hosts = [node.account.hostname for node in self.redpanda.nodes]
         for host in pp_hosts:
-            res = requests.get(f"http://{host}:8082/status/ready")
+            res = requests.get(f"http://{host}:8081/status/ready")
             assert res.status_code == requests.codes.ok
 
         users = self.superuser_admin.list_users()

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -1729,55 +1729,6 @@ class PandaProxyBasicAuthTest(PandaProxyEndpoints):
                                                   super_password))
 
 
-class PandaProxyAutoAuthTest(PandaProxyTestMethods):
-    """
-    Test pandaproxy against a redpanda cluster with Auto Auth enabled.
-
-    This derived class inherits all the tests from PandaProxyTestMethods.
-    """
-    def __init__(self, context):
-        security = SecurityConfig()
-        security.kafka_enable_authorization = True
-        security.endpoint_authn_method = 'sasl'
-        security.auto_auth = True
-
-        super(PandaProxyAutoAuthTest, self).__init__(context,
-                                                     security=security)
-
-    @cluster(num_nodes=3)
-    @parametrize(move_controller_leader=False)
-    @parametrize(move_controller_leader=True)
-    def test_restarts(self, move_controller_leader: bool):
-        nodes = self.redpanda.nodes
-        node_count = len(nodes)
-        restart_node_idx = 0
-
-        admin = Admin(self.redpanda)
-
-        def check_connection(hostname: str):
-            result_raw = self._get_topics(hostname=hostname)
-            self.logger.info(result_raw.status_code)
-            self.logger.info(result_raw.json())
-            assert result_raw.status_code == requests.codes.ok
-            assert result_raw.json() == []
-
-        def restart_node():
-            victim = nodes[restart_node_idx]
-
-            if move_controller_leader:
-                admin.partition_transfer_leadership(namespace="redpanda",
-                                                    topic="controller",
-                                                    partition=0)
-            self.logger.info(f"Restarting node: {restart_node_idx}")
-            self.redpanda.restart_nodes(victim)
-
-        for _ in range(5):
-            for n in self.redpanda.nodes:
-                check_connection(n.account.hostname)
-            restart_node()
-            restart_node_idx = (restart_node_idx + 1) % node_count
-
-
 class PandaProxyClientStopTest(PandaProxyEndpoints):
     username = 'red'
     password = 'panda'

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -1358,10 +1358,6 @@ class SchemaRegistryEndpoints(RedpandaTest):
                            payload_class=payload_class,
                            compression_type=compression_type)
 
-    def _get_topics(self):
-        return requests.get(
-            f"http://{self.redpanda.nodes[0].account.hostname}:8082/topics")
-
     def _create_topic(self,
                       topic=create_topic_names(1),
                       partition_count=1,
@@ -1378,11 +1374,10 @@ class SchemaRegistryEndpoints(RedpandaTest):
                                config=config)
 
         def has_topic():
-            self_topics = self._get_topics()
+            self_topics = set(rpk_tools.list_topics())
             self.logger.info(
-                f"name: {topic}, self._get_topics().status_code: {self_topics.status_code}, self_topics.json(): {self_topics.json()}"
-            )
-            return topic in self_topics.json()
+                f"name: {topic}, self._get_topics(): {self_topics}")
+            return topic in self_topics
 
         wait_until(has_topic,
                    timeout_sec=10,


### PR DESCRIPTION
We should not use ephemeral credentials in pandaproxy, but instead *always* use the credentials in the request. Otherwise, it's possible to have elevated privileges through pandaproxy, if it's not configured to use authentication.

Currently, we use the overridden credentials in the broker config as the default credentials in pandaproxy, but if that's not configured then we did create "ephemeral" credentials with full access to all topics (and only if auth is enabled on the kafka interface). Those credentials are used by default if the request does not specify credentials, and with this change we will no longer use ephemeral credentials by default if the kafka API has auth enabled, which is a win for security as it's an easy footgun to misconfigure pandaproxy to allow root level access to the kafka api.

NOTE: It's still possible to get the same end behavior but a user has to explicitly configure credentials with full access in the broker configuration.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* If credentials were not specified for the pandaproxy kafka client, then superuser access was granted on all requests. This behavior is now removed - if no credentials are specified then requests will be made unauthenticated. If HTTP Basic Auth is enabled for Pandaproxy, then no changes are made to requests that forward the credentials to the kafka interface.

