### PR TITLE
cloud_storage: hold gate in remote

### DIFF
--- a/src/v/cloud_io/tests/s3_imposter.h
+++ b/src/v/cloud_io/tests/s3_imposter.h
@@ -115,7 +115,6 @@ public:
     const cloud_storage_clients::bucket_name bucket_name
       = random_test_bucket_name();
 
-protected:
     cloud_storage_clients::s3_url_style url_style;
     cloud_storage_clients::s3_configuration conf;
 

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -95,7 +95,10 @@ ss::future<> remote::start() { co_await _materialized->start(); }
 
 ss::future<> remote::stop() {
     cst_log.debug("Stopping remote...");
+    _as.request_abort();
+    auto gate_close = _gate.close();
     co_await _materialized->stop();
+    co_await std::move(gate_close);
     cst_log.debug("Stopped remote...");
 }
 
@@ -150,6 +153,8 @@ ss::future<download_result> remote::do_download_manifest(
   base_manifest& manifest,
   retry_chain_node& parent,
   bool expect_missing) {
+    _as.check();
+    auto holder = _gate.hold();
     auto path = cloud_storage_clients::object_key(format_key.second().native());
     iobuf buffer;
     const auto dl_result = co_await io().download_object(
@@ -211,6 +216,8 @@ ss::future<upload_result> remote::upload_manifest(
   const base_manifest& manifest,
   const remote_manifest_path& key,
   retry_chain_node& parent) {
+    _as.check();
+    auto holder = _gate.hold();
     auto buf = co_await manifest.serialize_buf();
     auto success_cb = [this, t = manifest.get_manifest_type()]() {
         switch (t) {
@@ -284,6 +291,8 @@ ss::future<upload_result> remote::upload_controller_snapshot(
   const ss::file& file,
   retry_chain_node& parent,
   lazy_abort_source& lazy_abort_source) {
+    _as.check();
+    auto holder = _gate.hold();
     auto reset_str = [&file] {
         using provider_t = std::unique_ptr<stream_provider>;
         ss::file_input_stream_options opts;
@@ -322,23 +331,28 @@ ss::future<upload_result> remote::upload_segment(
   retry_chain_node& parent,
   lazy_abort_source& lazy_abort_source,
   std::optional<size_t> max_retries) {
-    return io().upload_stream(
-      {
-        .bucket = bucket,
-        .key = cloud_storage_clients::object_key{segment_path()},
-        .parent_rtc = parent,
-        .success_cb = [this] { _probe.successful_upload(); },
-        .success_size_cb =
-          [this](size_t sz) { _probe.register_upload_size(sz); },
-        .failure_cb = [this] { _probe.failed_upload(); },
-        .backoff_cb = [this] { _probe.upload_backoff(); },
-        .on_req_cb = make_notify_cb(api_activity_type::segment_upload, parent),
-      },
-      content_length,
-      reset_str,
-      lazy_abort_source,
-      "segment",
-      max_retries);
+    _as.check();
+    auto holder = _gate.hold();
+    return io()
+      .upload_stream(
+        {
+          .bucket = bucket,
+          .key = cloud_storage_clients::object_key{segment_path()},
+          .parent_rtc = parent,
+          .success_cb = [this] { _probe.successful_upload(); },
+          .success_size_cb =
+            [this](size_t sz) { _probe.register_upload_size(sz); },
+          .failure_cb = [this] { _probe.failed_upload(); },
+          .backoff_cb = [this] { _probe.upload_backoff(); },
+          .on_req_cb = make_notify_cb(
+            api_activity_type::segment_upload, parent),
+        },
+        content_length,
+        reset_str,
+        lazy_abort_source,
+        "segment",
+        max_retries)
+      .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
 ss::future<upload_result> remote::upload_index(
@@ -346,19 +360,23 @@ ss::future<upload_result> remote::upload_index(
   const cloud_storage_clients::object_key& key,
   const offset_index& index,
   retry_chain_node& parent) {
+    _as.check();
+    auto holder = _gate.hold();
     auto buf = index.to_iobuf();
-    return io().upload_object({
-      .transfer_details = {
-        .bucket = bucket,
-        .key = key,
-        .parent_rtc = parent,
-        .success_cb = [this] { _probe.index_upload(); },
-        .failure_cb = [this] { _probe.failed_index_upload(); },
-        .on_req_cb = make_notify_cb(api_activity_type::object_upload, parent),
-      },
-      .display_str = to_string(upload_type::segment_index),
-      .payload = std::move(buf),
-    });
+    return io()
+      .upload_object({
+        .transfer_details = {
+          .bucket = bucket,
+          .key = key,
+          .parent_rtc = parent,
+          .success_cb = [this] { _probe.index_upload(); },
+          .failure_cb = [this] { _probe.failed_index_upload(); },
+          .on_req_cb = make_notify_cb(api_activity_type::object_upload, parent),
+        },
+        .display_str = to_string(upload_type::segment_index),
+        .payload = std::move(buf),
+      })
+      .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
 ss::future<download_result> remote::download_stream(
@@ -369,32 +387,36 @@ ss::future<download_result> remote::download_stream(
   const std::string_view stream_label,
   const download_metrics& metrics,
   std::optional<cloud_storage_clients::http_byte_range> byte_range) {
-    return io().download_stream(
-      {
-        // TODO: these metrics are for segments. Though this method appears to
-        // only be used for inventory downlaods.
-        .bucket = bucket,
-        .key = cloud_storage_clients::object_key{path()},
-        .parent_rtc = parent,
-        .success_cb = [this] { _probe.successful_download(); },
-        .success_size_cb =
-          [this](size_t sz) { _probe.register_download_size(sz); },
-        .failure_cb = [&metrics] { metrics.failed_download_metric(); },
-        .backoff_cb = [&metrics] { metrics.download_backoff_metric(); },
-        .client_acquire_cb = [this] { _probe.client_acquisition(); },
-        // TODO: pass type in as an argument.
-        .on_req_cb = make_notify_cb(
-          api_activity_type::segment_download, parent),
-        .measure_latency_cb =
-          [&metrics] { return metrics.download_latency_measurement(); },
-      },
-      cons_str,
-      stream_label,
-      false,
-      byte_range,
-      [this](size_t ms) {
-          _materialized->get_read_path_probe().download_throttled(ms);
-      });
+    _as.check();
+    auto holder = _gate.hold();
+    return io()
+      .download_stream(
+        {
+          // TODO: these metrics are for segments. Though this method appears to
+          // only be used for inventory downlaods.
+          .bucket = bucket,
+          .key = cloud_storage_clients::object_key{path()},
+          .parent_rtc = parent,
+          .success_cb = [this] { _probe.successful_download(); },
+          .success_size_cb =
+            [this](size_t sz) { _probe.register_download_size(sz); },
+          .failure_cb = [&metrics] { metrics.failed_download_metric(); },
+          .backoff_cb = [&metrics] { metrics.download_backoff_metric(); },
+          .client_acquire_cb = [this] { _probe.client_acquisition(); },
+          // TODO: pass type in as an argument.
+          .on_req_cb = make_notify_cb(
+            api_activity_type::segment_download, parent),
+          .measure_latency_cb =
+            [&metrics] { return metrics.download_latency_measurement(); },
+        },
+        cons_str,
+        stream_label,
+        false,
+        byte_range,
+        [this](size_t ms) {
+            _materialized->get_read_path_probe().download_throttled(ms);
+        })
+      .then([h = std::move(holder)](download_result r) { return r; });
 }
 
 ss::future<download_result> remote::download_segment(
@@ -403,28 +425,32 @@ ss::future<download_result> remote::download_segment(
   const try_consume_stream& cons_str,
   retry_chain_node& parent,
   std::optional<cloud_storage_clients::http_byte_range> byte_range) {
-    return io().download_stream(
-      {
-        .bucket = bucket,
-        .key = cloud_storage_clients::object_key{segment_path()},
-        .parent_rtc = parent,
-        .success_cb = [this] { _probe.successful_download(); },
-        .success_size_cb =
-          [this](size_t sz) { _probe.register_download_size(sz); },
-        .failure_cb = [this] { _probe.failed_download(); },
-        .backoff_cb = [this] { _probe.download_backoff(); },
-        .client_acquire_cb = [this] { _probe.client_acquisition(); },
-        .on_req_cb = make_notify_cb(
-          api_activity_type::segment_download, parent),
-        .measure_latency_cb = [this] { return _probe.segment_download(); },
-      },
-      cons_str,
-      "segment",
-      false,
-      byte_range,
-      [this](size_t ms) {
-          _materialized->get_read_path_probe().download_throttled(ms);
-      });
+    _as.check();
+    auto holder = _gate.hold();
+    return io()
+      .download_stream(
+        {
+          .bucket = bucket,
+          .key = cloud_storage_clients::object_key{segment_path()},
+          .parent_rtc = parent,
+          .success_cb = [this] { _probe.successful_download(); },
+          .success_size_cb =
+            [this](size_t sz) { _probe.register_download_size(sz); },
+          .failure_cb = [this] { _probe.failed_download(); },
+          .backoff_cb = [this] { _probe.download_backoff(); },
+          .client_acquire_cb = [this] { _probe.client_acquisition(); },
+          .on_req_cb = make_notify_cb(
+            api_activity_type::segment_download, parent),
+          .measure_latency_cb = [this] { return _probe.segment_download(); },
+        },
+        cons_str,
+        "segment",
+        false,
+        byte_range,
+        [this](size_t ms) {
+            _materialized->get_read_path_probe().download_throttled(ms);
+        })
+      .then([h = std::move(holder)](download_result r) { return r; });
 }
 
 ss::future<download_result> remote::download_index(
@@ -432,6 +458,8 @@ ss::future<download_result> remote::download_index(
   const remote_segment_path& index_path,
   offset_index& ix,
   retry_chain_node& parent) {
+    _as.check();
+    auto holder = _gate.hold();
     iobuf buffer;
     const auto dl_result = co_await io().download_object(
       {.transfer_details = {
@@ -454,16 +482,20 @@ ss::future<download_result> remote::download_index(
 
 ss::future<download_result>
 remote::download_object(download_request download_request) {
+    _as.check();
+    auto holder = _gate.hold();
     auto details = std::move(download_request.transfer_details);
     if (!details.on_req_cb.has_value()) {
         details.on_req_cb = make_notify_cb(
           api_activity_type::object_download, details.parent_rtc);
     }
-    return io().download_object({
-      .transfer_details = std::move(details),
-      .display_str = to_string(download_request.type),
-      .payload = download_request.payload,
-    });
+    return io()
+      .download_object({
+        .transfer_details = std::move(details),
+        .display_str = to_string(download_request.type),
+        .payload = download_request.payload,
+      })
+      .then([h = std::move(holder)](download_result r) { return r; });
 }
 
 ss::future<download_result> remote::object_exists(
@@ -471,6 +503,8 @@ ss::future<download_result> remote::object_exists(
   const cloud_storage_clients::object_key& path,
   retry_chain_node& parent,
   existence_check_type object_type) {
+    _as.check();
+    auto holder = _gate.hold();
     co_return co_await io().object_exists(
       bucket, path, parent, fmt::to_string(object_type));
 }
@@ -479,6 +513,8 @@ ss::future<download_result> remote::segment_exists(
   const cloud_storage_clients::bucket_name& bucket,
   const remote_segment_path& segment_path,
   retry_chain_node& parent) {
+    _as.check();
+    auto holder = _gate.hold();
     co_return co_await io().object_exists(
       bucket,
       cloud_storage_clients::object_key{segment_path},
@@ -490,12 +526,16 @@ ss::future<upload_result> remote::delete_object(
   const cloud_storage_clients::bucket_name& bucket,
   const cloud_storage_clients::object_key& path,
   retry_chain_node& parent) {
-    return io().delete_object({
-      .bucket = bucket,
-      .key = path,
-      .parent_rtc = parent,
-      .on_req_cb = make_notify_cb(api_activity_type::segment_delete, parent),
-    });
+    _as.check();
+    auto holder = _gate.hold();
+    return io()
+      .delete_object({
+        .bucket = bucket,
+        .key = path,
+        .parent_rtc = parent,
+        .on_req_cb = make_notify_cb(api_activity_type::segment_delete, parent),
+      })
+      .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
 template<typename R>
@@ -507,11 +547,15 @@ ss::future<upload_result> remote::delete_objects(
   const cloud_storage_clients::bucket_name& bucket,
   R keys,
   retry_chain_node& parent) {
-    return io().delete_objects(
-      bucket,
-      std::move(keys),
-      parent,
-      make_notify_cb(api_activity_type::segment_delete, parent));
+    _as.check();
+    auto holder = _gate.hold();
+    return io()
+      .delete_objects(
+        bucket,
+        std::move(keys),
+        parent,
+        make_notify_cb(api_activity_type::segment_delete, parent))
+      .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
 template ss::future<upload_result>
@@ -534,37 +578,49 @@ ss::future<remote::list_result> remote::list_objects(
   std::optional<cloud_storage_clients::client::item_filter> item_filter,
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token) {
-    return io().list_objects(
-      bucket,
-      parent,
-      prefix,
-      delimiter,
-      item_filter,
-      max_keys,
-      continuation_token);
+    _as.check();
+    auto holder = _gate.hold();
+    return io()
+      .list_objects(
+        bucket,
+        parent,
+        prefix,
+        delimiter,
+        item_filter,
+        max_keys,
+        continuation_token)
+      .then([h = std::move(holder)](list_result r) { return r; });
 }
 
 ss::future<upload_result> remote::upload_object(upload_request req) {
+    _as.check();
+    auto holder = _gate.hold();
     auto details = std::move(req.transfer_details);
     if (!details.on_req_cb.has_value()) {
         details.on_req_cb = make_notify_cb(
           api_activity_type::object_upload, details.parent_rtc);
     }
-    return io().upload_object({
-      .transfer_details = std::move(details),
-      .display_str = to_string(req.type),
-      .payload = std::move(req.payload),
-      .accept_no_content_response = false,
-    });
+    return io()
+      .upload_object({
+        .transfer_details = std::move(details),
+        .display_str = to_string(req.type),
+        .payload = std::move(req.payload),
+        .accept_no_content_response = false,
+      })
+      .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
 ss::future<api_activity_notification>
 remote::subscribe(remote::event_filter& filter) {
+    _as.check();
+    auto holder = _gate.hold();
     vassert(filter._hook.is_linked() == false, "Filter is already in use");
     filter._hook = {};
     _filters.push_back(filter);
     filter._promise.emplace();
-    return filter._promise->get_future();
+    return filter._promise->get_future().then(
+      [h = std::move(holder)](api_activity_notification r) { return r; });
+    ;
 }
 
 std::function<void(size_t)>

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -477,8 +477,8 @@ public:
 
     // If you need to spawn a background task that relies on
     // this object staying alive, spawn it with this gate.
-    seastar::gate& gate() { return io().gate(); };
-    ss::abort_source& as() { return io().as(); }
+    seastar::gate& gate() { return _gate; };
+    ss::abort_source& as() { return _as; }
 
     remote_probe& get_probe() { return _probe; }
 
@@ -491,6 +491,9 @@ private:
       api_activity_notification, const retry_chain_node& caller);
     std::function<void(size_t)>
     make_notify_cb(api_activity_type t, retry_chain_node& retry);
+
+    ss::gate _gate;
+    ss::abort_source _as;
 
     ss::sharded<cloud_io::remote>& _io;
     std::unique_ptr<materialized_resources> _materialized;

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -45,6 +45,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/util/later.hh>
 
 #include <boost/range/irange.hpp>
 
@@ -1410,3 +1411,67 @@ INSTANTIATE_TEST_SUITE_P(
       .url_style = cloud_storage_clients::s3_url_style::virtual_host},
     remote_test_parameters{
       .url_style = cloud_storage_clients::s3_url_style::path}));
+
+TEST(RemoteTest, TestShutdownOnRetry) {
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    ss::sharded<cloud_io::remote> io;
+    ss::sharded<remote> remote;
+
+    s3_imposter_fixture s3;
+    bool stopped_remote = false;
+    auto shutdown = ss::defer([&] {
+        if (stopped_remote) {
+            pool.local().shutdown_connections();
+            io.local().request_stop();
+            remote.stop().get();
+        }
+        io.stop().get();
+        pool.stop().get();
+    });
+
+    pool.start(10, ss::sharded_parameter([&s3] { return s3.conf; })).get();
+    io.start(
+        std::ref(pool),
+        ss::sharded_parameter([&s3] { return s3.conf; }),
+        ss::sharded_parameter([&] { return config_file; }),
+        ss::sharded_parameter([] { return ss::default_scheduling_group(); }))
+      .get();
+    remote.start(std::ref(io), ss::sharded_parameter([&s3] { return s3.conf; }))
+      .get();
+
+    s3.fail_request_if(
+      [](const auto&) { return true; },
+      {.status = ss::http::reply::status_type::service_unavailable});
+
+    retry_chain_node fib(never_abort, 100ms, 20ms);
+    partition_manifest dummy_dst_manifest(manifest_ntp, manifest_revision);
+    std::vector<ss::future<download_result>> futs;
+    futs.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        futs.emplace_back(remote.local().download_manifest(
+          s3.bucket_name, json_manifest_format_path, dummy_dst_manifest, fib));
+    }
+
+    // Give some time for the downloads to start.
+    ss::sleep(30ms).get();
+
+    // Now simulate the broker shutting down, but don't get to the point where
+    // cloud_io::remote is shut down.
+    pool.local().shutdown_connections();
+    io.local().request_stop();
+    remote.stop().get();
+    stopped_remote = true;
+
+    // Regression test for CORE-10019. Previously the downloads could result in
+    // a heap-use-after-free.
+    auto results = ss::when_all(futs.begin(), futs.end()).get();
+    for (auto& res_fut : results) {
+        if (res_fut.failed()) {
+            if (ssx::is_shutdown_exception(res_fut.get_exception())) {
+                continue;
+            }
+            FAIL() << "Expected shutdown exception";
+        }
+        EXPECT_EQ(res_fut.get(), download_result::timedout);
+    }
+}


### PR DESCRIPTION
Previously we held a gate in cloud_io::remote, but not cloud_storage::remote. This led to a heap-use-after-free where cloud_storage::remote is successfully destructed, but cloud_io::remote is in the middle of a retry -- in this case, it calls an input callback that relies on cloud_storage::remote::_probe.

This commit fixes this by adding a gate and abort source to cloud_storage::remote and holding the gate in all async calls.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Fixes [CORE-10019](https://redpandadata.atlassian.net/browse/CORE-10019)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixes a heap-use-after-free that could trigger during a race between cloud storage IO and the broker shutting down.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-10019]: https://redpandadata.atlassian.net/browse/CORE-10019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ