### PR TITLE
rpk: add Schema Registry ACL support

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829
 	github.com/redpanda-data/common-go/rpadmin v0.1.14
-	github.com/redpanda-data/common-go/rpsr v0.1.0
+	github.com/redpanda-data/common-go/rpsr v0.1.1
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.5.10
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
@@ -58,13 +58,13 @@ require (
 	github.com/twmb/franz-go v1.19.4
 	github.com/twmb/franz-go/pkg/kadm v1.16.0
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
-	github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765
+	github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250711145744-a849b8be17b7
 	github.com/twmb/franz-go/plugin/kzap v1.1.2
 	github.com/twmb/tlscfg v1.2.1
 	github.com/twmb/types v1.1.6
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250207012021-f9890c6ad9f3
-	golang.org/x/sync v0.15.0
+	golang.org/x/sync v0.16.0
 	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.32.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250409194420-de1ac958c67a

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -224,8 +224,8 @@ github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829 h1:f
 github.com/redpanda-data/common-go/proto v0.0.0-20250422172326-6a3bcb14b829/go.mod h1:6WXvgZCZIkbQCNsvU5zTx/+ub5eXTuCcl90i5xkhMw0=
 github.com/redpanda-data/common-go/rpadmin v0.1.14 h1:G/rlh9cHsGhTsNpkwrISdpGA8fPZ7ul57rzxbPiJhs0=
 github.com/redpanda-data/common-go/rpadmin v0.1.14/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
-github.com/redpanda-data/common-go/rpsr v0.1.0 h1:kFjUlMTP76r8qCcDKAgTJYk6GqTjpeJlL/8hQiHlLSg=
-github.com/redpanda-data/common-go/rpsr v0.1.0/go.mod h1:VdvwMZ0z+htjbgo1kvYyUK1IjN0Ihx8dlD8dmkRat1M=
+github.com/redpanda-data/common-go/rpsr v0.1.1 h1:3935qYNvAhbs8s3TrmXzXMs/Tc0+ukNjgsVxskh99kI=
+github.com/redpanda-data/common-go/rpsr v0.1.1/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -281,8 +281,8 @@ github.com/twmb/franz-go/pkg/kadm v1.16.0 h1:STMs1t5lYR5mR974PSiwNzE5TvsosByTp+r
 github.com/twmb/franz-go/pkg/kadm v1.16.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
-github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765 h1:+l/P3ExNaY1T5Tft/+zK5r7hiEilgHWS5Cjjh2iZ4ME=
-github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250620172413-c17130ef7765/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250711145744-a849b8be17b7 h1:9DDDjtNqzD3na5J8GPnHz//BGzMvpPEn57f32YeHEG0=
+github.com/twmb/franz-go/pkg/sr v1.4.1-0.20250711145744-a849b8be17b7/go.mod h1:O4o4mUMNfmyEt2HcuM+qZdc6KrcStvjgxWR6Cfvmukw=
 github.com/twmb/franz-go/plugin/kzap v1.1.2 h1:0arX5xJ0soUPX1LlDay6ZZoxuWkWk1lggQ5M/IgRXAE=
 github.com/twmb/franz-go/plugin/kzap v1.1.2/go.mod h1:53Cl9Uz1pbdOPDvUISIxLrZIWSa2jCuY1bTMauRMBmo=
 github.com/twmb/tlscfg v1.2.1 h1:IU2efmP9utQEIV2fufpZjPq7xgcZK4qu25viD51BB44=
@@ -353,8 +353,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
-golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/src/go/rpk/pkg/cli/security/acl/BUILD
+++ b/src/go/rpk/pkg/cli/security/acl/BUILD
@@ -15,11 +15,14 @@ go_library(
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/kafka",
         "//src/go/rpk/pkg/out",
+        "//src/go/rpk/pkg/schemaregistry",
+        "@com_github_redpanda_data_common_go_rpsr//:rpsr",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
         "@com_github_twmb_franz_go_pkg_kmsg//:kmsg",
         "@com_github_twmb_types//:types",
+        "@org_uber_go_zap//:zap",
     ],
 )
 
@@ -29,6 +32,7 @@ go_test(
     srcs = ["common_test.go"],
     embed = [":acl"],
     deps = [
+        "@com_github_redpanda_data_common_go_rpsr//:rpsr",
         "@com_github_stretchr_testify//require",
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
         "@com_github_twmb_franz_go_pkg_kmsg//:kmsg",

--- a/src/go/rpk/pkg/cli/security/acl/acl.go
+++ b/src/go/rpk/pkg/cli/security/acl/acl.go
@@ -105,9 +105,10 @@ flag with the --allow-principal flag, and the --deny-host flag with the
 
 RESOURCES
 
-A resource is what an ACL allows or denies access to. There are four resources
-within Redpanda: topics, groups, the cluster itself, and transactional IDs.
-Names for each of these resources can be specified with their respective flags.
+A resource is what an ACL allows or denies access to. There are six resources
+within Redpanda: topics, groups, the cluster itself, transactional IDs,
+schema registry, and schema registry subjects. Names for each of these resources
+can be specified with their respective flags.
 
 Resources combine with the operation that is allowed or denied on that
 resource. The next section describes which operations are required for which
@@ -128,7 +129,8 @@ Redpanda has the following operations:
     ALL                 Allows all operations below.
     READ                Allows reading a given resource.
     WRITE               Allows writing to a given resource.
-    CREATE              Allows creating a given resource.
+    CREATE              Allows creating a given resource (Except for Redpanda
+                        Schema Registry).
     DELETE              Allows deleting a given resource.
     ALTER               Allows altering non-configurations.
     DESCRIBE            Allows querying non-configurations.
@@ -169,7 +171,8 @@ const helpACLOperations = `Brokers support many operations for many resources:
     ALL                 Allows all operations below.
     READ                Allows reading a given resource.
     WRITE               Allows writing to a given resource.
-    CREATE              Allows creating a given resource.
+    CREATE              Allows creating a given resource. (Except for Redpanda
+                        Schema Registry).
     DELETE              Allows deleting a given resource.
     ALTER               Allows altering non-configurations.
     DESCRIBE            Allows querying non-configurations.
@@ -278,4 +281,45 @@ ADMIN
     DescribeTransactions   DESCRIBE on TRANSACTIONAL_ID for transactional.id
                            DESCRIBE on TOPIC for topics
     ListTransactions       DESCRIBE on TRANSACTIONAL_ID for transactional.id
+
+REGISTRY
+
+    GetGlobalConfig         DESCRIBE_CONFIGS on REGISTRY for schema registry
+    UpdateGlobalConfig      ALTER_CONFIGS on REGISTRY for schema registry
+
+    GetGlobalMode           DESCRIBE_CONFIGS on REGISTRY for schema registry
+    UpdateGlobalMode        ALTER_CONFIGS on REGISTRY for schema registry
+
+    GetReferencedBy         DESCRIBE on REGISTRY for schema registry
+    ListSchemasForId        DESCRIBE on REGISTRY for schema registry
+
+    ListSchemaTypes         (no ACLs required)
+    HealthCheck             (no ACLs required)
+
+SUBJECT
+
+    ListSubjects            DESCRIBE on SUBJECT for subject
+
+    CheckSchema             READ on SUBJECT for subject
+    RegisterSchema          WRITE on SUBJECT for subject
+
+    GetSchemaByVersion      READ on SUBJECT for subject
+    GetSchemaRaw            READ on SUBJECT for subject
+
+    ListSubjectVersions     DESCRIBE on SUBJECT for subject
+
+    DeleteSchemaVersion     DELETE on SUBJECT for subject
+    DeleteSubject           DELETE on SUBJECT for subject
+
+    GetSubjectConfig        DESCRIBE_CONFIGS on SUBJECT for subject
+    UpdateSubjectConfig     ALTER_CONFIGS on SUBJECT for subject
+    DeleteSubjectConfig     ALTER_CONFIGS on SUBJECT for subject
+
+    GetSubjectMode          DESCRIBE_CONFIGS on SUBJECT for subject
+    UpdateSubjectMode       ALTER_CONFIGS on SUBJECT for subject
+    DeleteSubjectMode       ALTER_CONFIGS on SUBJECT for subject
+
+    CheckCompatibility      READ on SUBJECT for subject
+
+    GetSchemaById           READ on SUBJECT for subject
 `

--- a/src/go/rpk/pkg/cli/security/acl/common.go
+++ b/src/go/rpk/pkg/cli/security/acl/common.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/redpanda-data/common-go/rpsr"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -36,6 +37,9 @@ const (
 	denyRoleFlag       = "deny-role"
 	denyHostFlag       = "deny-host"
 	operationFlag      = "operation"
+	registryFlag       = "registry-global"
+	subjectFlag        = "registry-subject"
+	subsystemFlag      = "subsystem"
 
 	kafkaCluster = "kafka-cluster"
 
@@ -61,23 +65,23 @@ type (
 	// Corresponding to the above, acl and aclWithMessage are the rows
 	// for PrintStructFields.
 	acl struct {
-		Principal           string                      `json:"principal"`
-		Host                string                      `json:"host"`
-		ResourceType        kmsg.ACLResourceType        `json:"resource_type"`
-		ResourceName        string                      `json:"resource_name"`
-		ResourcePatternType kmsg.ACLResourcePatternType `json:"resource_pattern_type"`
-		Operation           kmsg.ACLOperation           `json:"operation"`
-		Permission          kmsg.ACLPermissionType      `json:"permission"`
+		Principal           string `json:"principal"`
+		Host                string `json:"host"`
+		ResourceType        string `json:"resource_type"`
+		ResourceName        string `json:"resource_name"`
+		ResourcePatternType string `json:"resource_pattern_type"`
+		Operation           string `json:"operation"`
+		Permission          string `json:"permission"`
 	}
 	aclWithMessage struct {
-		Principal           string                      `json:"principal"`
-		Host                string                      `json:"host"`
-		ResourceType        kmsg.ACLResourceType        `json:"resource_type"`
-		ResourceName        string                      `json:"resource_name"`
-		ResourcePatternType kmsg.ACLResourcePatternType `json:"resource_pattern_type"`
-		Operation           kmsg.ACLOperation           `json:"operation"`
-		Permission          kmsg.ACLPermissionType      `json:"permission"`
-		Message             string                      `json:"message"`
+		Principal           string `json:"principal"`
+		Host                string `json:"host"`
+		ResourceType        string `json:"resource_type"`
+		ResourceName        string `json:"resource_name"`
+		ResourcePatternType string `json:"resource_pattern_type"`
+		Operation           string `json:"operation"`
+		Permission          string `json:"permission"`
+		Message             string `json:"message"`
 	}
 )
 
@@ -122,17 +126,29 @@ type acls struct {
 	denyRoles       []string
 	denyHosts       []string
 
+	// schema registry flags
+	subjects []string
+	registry bool
+
 	// create & delete & list flags, to be parsed
 	resourcePatternType string
 	operations          []string
 
-	parsed parsed
+	kParsed  kafkaParsed
+	srParsed schemaRegistryParsed
 }
 
-// parsed contains the results of flags that need parsing.
-type parsed struct {
+// kafkaParsed contains the results of flags that need parsing for Kafka ACLs.
+type kafkaParsed struct {
 	operations []kmsg.ACLOperation
 	pattern    kmsg.ACLResourcePatternType
+}
+
+// schemaRegistryParsed contains the result of flags that need parsing for
+// SR ACLs.
+type schemaRegistryParsed struct {
+	operations []rpsr.Operation
+	pattern    rpsr.PatternType
 }
 
 func (a *acls) addDeprecatedFlags(cmd *cobra.Command) {
@@ -257,30 +273,64 @@ func (a *acls) backcompat(list bool) error {
 	return nil
 }
 
-func (a *acls) parseCommon() error {
+func (a *acls) parseKafkaCommons() error {
 	for _, op := range a.operations {
 		parsed, err := kmsg.ParseACLOperation(op)
 		if err != nil {
-			return fmt.Errorf("invalid operation %q", op)
+			return fmt.Errorf("invalid kafka operation %q", op)
 		}
-		a.parsed.operations = append(a.parsed.operations, parsed)
+		a.kParsed.operations = append(a.kParsed.operations, parsed)
 	}
 	if a.resourcePatternType == "" {
 		a.resourcePatternType = "literal"
 	}
 	pattern, err := kmsg.ParseACLResourcePatternType(a.resourcePatternType)
 	if err != nil {
-		return fmt.Errorf("invalid resource pattern type %q", a.resourcePatternType)
+		return fmt.Errorf("invalid kafka resource pattern type %q", a.resourcePatternType)
 	}
-	a.parsed.pattern = pattern
+	a.kParsed.pattern = pattern
 	return nil
 }
 
-func (a *acls) createCreations() (*kadm.ACLBuilder, error) {
+func (a *acls) parseSRCommons() error {
+	for _, op := range a.operations {
+		parsed, err := rpsr.ParseOperation(op)
+		if err != nil {
+			return fmt.Errorf("invalid schema registry operation %q", op)
+		}
+		a.srParsed.operations = append(a.srParsed.operations, parsed)
+	}
+	if a.resourcePatternType == "" {
+		a.resourcePatternType = "literal"
+	}
+	pattern, err := rpsr.ParsePatternType(a.resourcePatternType)
+	if err != nil {
+		return fmt.Errorf("invalid schema registry resource pattern type %q", a.resourcePatternType)
+	}
+	a.srParsed.pattern = pattern
+	return nil
+}
+
+func (a *acls) createCreations() (*kadm.ACLBuilder, []rpsr.ACL, error) {
+	kC, err := a.createKafkaACLCreation()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create kafka ACLs: %v", err)
+	}
+	if a.hasSR() {
+		srC, err := a.createSRACLCreation()
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to create schema registry ACLs: %v", err)
+		}
+		return kC, srC, nil
+	}
+	return kC, nil, nil
+}
+
+func (a *acls) createKafkaACLCreation() (*kadm.ACLBuilder, error) {
 	if err := a.backcompat(false); err != nil {
 		return nil, err
 	}
-	if err := a.parseCommon(); err != nil {
+	if err := a.parseKafkaCommons(); err != nil {
 		return nil, err
 	}
 
@@ -293,8 +343,8 @@ func (a *acls) createCreations() (*kadm.ACLBuilder, error) {
 	// Using empty lists / non-Maybe functions when building create ACLs is
 	// fine, since creation does not opt in to "any" when things are empty.
 	b := kadm.NewACLs().
-		ResourcePatternType(a.parsed.pattern).
-		MaybeOperations(a.parsed.operations...). // avoid defaulting to "any" if none are provided
+		ResourcePatternType(a.kParsed.pattern).
+		MaybeOperations(a.kParsed.operations...). // avoid defaulting to "any" if none are provided
 		Topics(a.topics...).
 		Groups(a.groups...).
 		MaybeClusters(a.cluster). // avoid opting in to all clusters by default
@@ -309,13 +359,68 @@ func (a *acls) createCreations() (*kadm.ACLBuilder, error) {
 	return b, b.ValidateCreate()
 }
 
-func (a *acls) createDeletionsAndDescribes(
-	list bool,
-) (*kadm.ACLBuilder, error) {
+func (a *acls) createSRACLCreation() ([]rpsr.ACL, error) {
+	if err := a.parseSRCommons(); err != nil {
+		return nil, err
+	}
+
+	PrefixRole(a.allowRoles)
+	PrefixRole(a.denyRoles)
+
+	a.allowPrincipals = append(a.allowPrincipals, a.allowRoles...)
+	a.denyPrincipals = append(a.denyPrincipals, a.denyRoles...)
+
+	b := rpsr.NewACLBuilder().
+		Pattern(a.srParsed.pattern).
+		Operations(a.srParsed.operations...).
+		Subjects(a.subjects...).
+		MaybeRegistry(a.registry).
+		AllowPrincipals(a.allowPrincipals...).
+		DenyPrincipals(a.denyPrincipals...)
+
+	// Kafka ACL creation currently defaults to any ('*') if we have a
+	// principal; we match the behavior.
+	if b.HasAllowedPrincipals() {
+		b.AllowHostsOrAll(a.allowHosts...)
+	} else {
+		b.AllowHosts(a.allowHosts...)
+	}
+	if b.HasDeniedPrincipals() {
+		b.DenyHostsOrAll(a.denyHosts...)
+	} else {
+		b.DenyHosts(a.denyHosts...)
+	}
+
+	b.PrefixUserExcept(rolePrefix)
+
+	return b.ValidateAndBuildCreate()
+}
+
+func (a *acls) createDeletionsAndDescribes(list, isKafka, isSR bool) (kBuilder *kadm.ACLBuilder, srACLs []rpsr.ACL, err error) {
+	// If is none, then is all (i.e: no flags specified, or just common flags).
+	if !isKafka && !isSR {
+		isKafka, isSR = true, true
+	}
+	if isKafka {
+		kBuilder, err = a.createKafkaDeletionsAndDescribes(list)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to create kafka ACLs: %v", err)
+		}
+	}
+	if isSR {
+		srACLs, err = a.createSRDeletionsAndDescribes()
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to create schema registry ACLs: %v", err)
+		}
+	}
+	return kBuilder, srACLs, nil
+}
+
+func (a *acls) createKafkaDeletionsAndDescribes(list bool) (*kadm.ACLBuilder, error) {
 	if err := a.backcompat(list); err != nil {
 		return nil, err
 	}
-	if err := a.parseCommon(); err != nil {
+	if err := a.parseKafkaCommons(); err != nil {
 		return nil, err
 	}
 
@@ -330,8 +435,8 @@ func (a *acls) createDeletionsAndDescribes(
 	// is empty, but we can use the Maybe functions to avoid optin into all
 	// by default.
 	b := kadm.NewACLs().
-		ResourcePatternType(a.parsed.pattern).
-		Operations(a.parsed.operations...).
+		ResourcePatternType(a.kParsed.pattern).
+		Operations(a.kParsed.operations...).
 		MaybeTopics(a.topics...).
 		MaybeGroups(a.groups...).
 		MaybeClusters(a.cluster).
@@ -360,4 +465,118 @@ func (a *acls) createDeletionsAndDescribes(
 	b.PrefixUserExcept(rolePrefix) // add "User:" prefix to everything if needed
 
 	return b, b.ValidateFilter()
+}
+
+func (a *acls) createSRDeletionsAndDescribes() ([]rpsr.ACL, error) {
+	if err := a.parseSRCommons(); err != nil {
+		return nil, err
+	}
+
+	PrefixRole(a.allowRoles)
+	PrefixRole(a.denyRoles)
+
+	a.allowPrincipals = append(a.allowPrincipals, a.allowRoles...)
+	a.denyPrincipals = append(a.denyPrincipals, a.denyRoles...)
+
+	b := rpsr.NewACLBuilder().
+		PatternOrAny(a.srParsed.pattern).
+		OperationsOrAny(a.srParsed.operations...).
+		Subjects(a.subjects...).
+		MaybeRegistry(a.registry).
+		AllowPrincipals(a.allowPrincipals...).
+		DenyPrincipals(a.denyPrincipals...).
+		AllowHosts(a.allowHosts...).
+		DenyHosts(a.denyHosts...)
+
+	// User & Hosts: when unspecified, we default to everything.
+	if !b.HasPrincipals() {
+		b.AllowPrincipalsOrAny()
+		b.DenyPrincipalsOrAny()
+	}
+	if !b.HasHosts() {
+		b.AllowHostsOrAny()
+		b.DenyHostsOrAny()
+	}
+	// Resources: if no resources are specified, we use all resources.
+	if !b.HasResources() {
+		b.AnyResources()
+	}
+
+	b.PrefixUserExcept(rolePrefix)
+
+	return b.BuildFilter(), nil
+}
+
+func (a *acls) hasSR() bool {
+	if a.registry || len(a.subjects) > 0 {
+		return true
+	}
+	return false
+}
+
+// kafkaOrSRFilters returns whether Kafka or Schema Registry flags were set.
+// If checkSubsystem is true and --subsystem is set, it ensures only compatible
+// flags are used for the selected subsystem(s).
+func kafkaOrSRFilters(cmd *cobra.Command, checkSubsystem bool) (isKafka, isSR bool, err error) {
+	kFlags := []string{topicFlag, groupFlag, clusterFlag, txnIDFlag}
+	srFlags := []string{registryFlag, subjectFlag}
+
+	subsystemChanged := cmd.Flags().Changed(subsystemFlag)
+	var subsystems []string
+	if subsystemChanged {
+		subsystems, err = cmd.Flags().GetStringSlice(subsystemFlag)
+		if err != nil {
+			return false, false, err
+		}
+	}
+
+	// If we're checking the subsystem and it changed:
+	if checkSubsystem && subsystemChanged {
+		onlyKafka := false
+		onlyRegistry := false
+
+		for _, sub := range subsystems {
+			switch strings.ToLower(sub) {
+			case "kafka":
+				onlyKafka = true
+			case "registry":
+				onlyRegistry = true
+			default:
+				return false, false, fmt.Errorf("unsupported subsystem %q: only 'kafka' and 'registry' are supported", sub)
+			}
+		}
+
+		if onlyKafka && !onlyRegistry {
+			for _, flag := range srFlags {
+				if cmd.Flags().Changed(flag) {
+					return false, false, fmt.Errorf("specified kafka subsystem only, but the Schema Registry flag %q was specified", flag)
+				}
+			}
+			return true, false, nil
+		}
+
+		if onlyRegistry && !onlyKafka {
+			for _, flag := range kFlags {
+				if cmd.Flags().Changed(flag) {
+					return false, false, fmt.Errorf("specified Schema Registry subsystem only, but the Kafka flag %q was specified", flag)
+				}
+			}
+			return false, true, nil
+		}
+		// If both kafka and registry are included, fall through to flag-based detection.
+	}
+
+	for _, flag := range kFlags {
+		if cmd.Flags().Changed(flag) {
+			isKafka = true
+			break
+		}
+	}
+	for _, flag := range srFlags {
+		if cmd.Flags().Changed(flag) {
+			isSR = true
+			break
+		}
+	}
+	return isKafka, isSR, nil
 }

--- a/src/go/rpk/pkg/cli/security/acl/common_test.go
+++ b/src/go/rpk/pkg/cli/security/acl/common_test.go
@@ -12,6 +12,8 @@ package acl
 import (
 	"testing"
 
+	"github.com/redpanda-data/common-go/rpsr"
+
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -278,7 +280,7 @@ func TestParseCommon(t *testing.T) {
 			name: "nothing is fine",
 			exp: acls{
 				resourcePatternType: "literal",
-				parsed: parsed{
+				kParsed: kafkaParsed{
 					pattern: kadm.ACLPatternLiteral,
 				},
 			},
@@ -295,7 +297,7 @@ func TestParseCommon(t *testing.T) {
 				operations:          []string{"read", "write"},
 				cluster:             true,
 				resourcePatternType: "match",
-				parsed: parsed{
+				kParsed: kafkaParsed{
 					operations: []kmsg.ACLOperation{
 						kmsg.ACLOperationRead,
 						kmsg.ACLOperationWrite,
@@ -323,13 +325,74 @@ func TestParseCommon(t *testing.T) {
 		//
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.in.parseCommon()
+			err := test.in.parseKafkaCommons()
 			gotErr := err != nil
 			require.Equal(t, test.expErr, gotErr, "error mismatch, got: %v, exp? %v", err, test.expErr)
 			if test.expErr {
 				return
 			}
 			require.Equal(t, test.exp, test.in, "backcompat result mismatch!")
+		})
+	}
+}
+
+func TestParseSRCommons(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		in     acls
+		exp    acls
+		expErr bool
+	}{
+		{
+			name: "Default to literal",
+			exp: acls{
+				resourcePatternType: "literal",
+				srParsed: schemaRegistryParsed{
+					pattern: rpsr.PatternTypeLiteral,
+				},
+			},
+		},
+		{
+			name: "valid operations and pattern",
+			in: acls{
+				operations:          []string{"read", "write"},
+				resourcePatternType: "prefixed",
+			},
+			exp: acls{
+				operations:          []string{"read", "write"},
+				resourcePatternType: "prefixed",
+				srParsed: schemaRegistryParsed{
+					operations: []rpsr.Operation{
+						rpsr.OperationRead,
+						rpsr.OperationWrite,
+					},
+					pattern: rpsr.PatternTypePrefix,
+				},
+			},
+		},
+		{
+			name: "invalid operation fails",
+			in: acls{
+				operations: []string{"invalid"},
+			},
+			expErr: true,
+		},
+		{
+			name: "invalid pattern fails",
+			in: acls{
+				resourcePatternType: "unknown",
+			},
+			expErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.in.parseSRCommons()
+			gotErr := err != nil
+			require.Equal(t, test.expErr, gotErr, "error mismatch, got: %v, exp? %v", err, test.expErr)
+			if test.expErr {
+				return
+			}
+			require.Equal(t, test.exp, test.in, "parseSRCommons result mismatch!")
 		})
 	}
 }

--- a/src/go/rpk/pkg/cli/security/acl/create.go
+++ b/src/go/rpk/pkg/cli/security/acl/create.go
@@ -10,12 +10,12 @@
 package acl
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/types"
@@ -36,19 +36,25 @@ As mentioned in the 'rpk security acl' help text, if no host is specified, an
 allowed principal is allowed access from all hosts. The wildcard principal '*'
 allows all principals. At least one principal, one host, one resource, and one
 operation is required to create a single ACL.
-
-Allow all permissions to user bar on topic "foo" and group "g":
-    --allow-principal bar --operation all --topic foo --group g
-Allow all permissions to role bar on topic "foo" and group "g":
-    --allow-role bar --operation all --topic foo --group g
-Allow read permissions to all users on topics biz and baz:
-    --allow-principal '*' --operation read --topic biz,baz
-Allow write permissions to user buzz to transactional ID "txn":
-    --allow-principal User:buzz --operation write --transactional-id txn
 `,
+		Example: `
+Allow all permissions to user bar on topic "foo" and group "g":
+  rpk security acl create --allow-principal bar --operation all --topic foo --group g
 
-		Args: cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
+Allow all permissions to role bar on topic "foo" and group "g":
+  rpk security acl create --allow-role bar --operation all --topic foo --group g
+
+Allow read permissions to all users on topics biz and baz:
+  rpk security acl create --allow-principal '*' --operation read --topic biz,baz
+
+Allow write permissions to user buzz to transactional ID "txn":
+  rpk security acl create  --allow-principal User:buzz --operation write --transactional-id txn
+
+Allow read permissions to user panda on topic "bar" and schema registry subject "bar-value":
+  rpk security acl create --allow-principal panda --operation read --topic bar --registry-subject bar-value
+`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
@@ -56,10 +62,53 @@ Allow write permissions to user buzz to transactional ID "txn":
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer adm.Close()
 
-			b, err := a.createCreations()
+			srClient, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			kCreations, srCreations, err := a.createCreations()
 			out.MaybeDieErr(err)
-			results, err := adm.CreateACLs(context.Background(), b)
-			out.MaybeDie(err, "unable to create ACLs: %v", err)
+
+			var results []aclWithMessage
+			if kCreations != nil {
+				kResults, err := adm.CreateACLs(cmd.Context(), kCreations)
+				out.MaybeDie(err, "unable to create ACLs: %v", err)
+				for _, c := range kResults {
+					errMsg := kafka.ErrMessage(c.Err)
+					if c.ErrMessage != "" {
+						errMsg = fmt.Sprintf("%v: %v", errMsg, c.ErrMessage)
+					}
+					results = append(results, aclWithMessage{
+						c.Principal,
+						c.Host,
+						c.Type.String(),
+						c.Name,
+						c.Pattern.String(),
+						c.Operation.String(),
+						c.Permission.String(),
+						errMsg,
+					})
+				}
+			}
+			if len(srCreations) > 0 {
+				err = srClient.CreateACLs(cmd.Context(), srCreations)
+				errMsg := ""
+				if err != nil {
+					errMsg = err.Error()
+				}
+				for _, c := range srCreations {
+					results = append(results, aclWithMessage{
+						c.Principal,
+						c.Host,
+						string(c.ResourceType),
+						c.Resource,
+						string(c.PatternType),
+						string(c.Operation),
+						string(c.Permission),
+						errMsg,
+					})
+				}
+			}
+
 			if len(results) == 0 {
 				fmt.Println("Specified flags created no ACLs.")
 				return
@@ -68,21 +117,8 @@ Allow write permissions to user buzz to transactional ID "txn":
 
 			tw := out.NewTable(headersWithError...)
 			defer tw.Flush()
-			for _, c := range results {
-				errMsg := kafka.ErrMessage(c.Err)
-				if c.ErrMessage != "" {
-					errMsg = fmt.Sprintf("%v: %v", errMsg, c.ErrMessage)
-				}
-				tw.PrintStructFields(aclWithMessage{
-					c.Principal,
-					c.Host,
-					c.Type,
-					c.Name,
-					c.Pattern,
-					c.Operation,
-					c.Permission,
-					errMsg,
-				})
+			for _, r := range results {
+				tw.PrintStructFields(r)
 			}
 		},
 	}
@@ -98,9 +134,10 @@ func (a *acls) addCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to grant ACLs for (repeatable)")
 	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to grant ACLs to the cluster")
 	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to grant ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.registry, registryFlag, false, "Whether to grant ACLs for the schema registry")
+	cmd.Flags().StringSliceVar(&a.subjects, subjectFlag, nil, "Schema Registry subjects to grant ACLs for (repeatable)")
 
 	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "literal", "Pattern to use when matching resource names (literal or prefixed)")
-
 	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to grant (repeatable)")
 
 	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Principals for which these permissions will be granted (repeatable)")

--- a/src/go/rpk/pkg/cli/security/acl/delete.go
+++ b/src/go/rpk/pkg/cli/security/acl/delete.go
@@ -13,9 +13,13 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
+	"github.com/redpanda-data/common-go/rpsr"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -56,7 +60,7 @@ resource names:
   * "literal" returns exact name matches
 `,
 		Args: cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter // always text for now
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
@@ -65,12 +69,19 @@ resource names:
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer adm.Close()
 
-			b, err := a.createDeletionsAndDescribes(false)
+			srClient, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			isKafka, isSR, err := kafkaOrSRFilters(cmd, false)
+			out.MaybeDie(err, "invalid request: %v", err)
+
+			kBuilder, srACLs, err := a.createDeletionsAndDescribes(false, isKafka, isSR)
 			out.MaybeDieErr(err)
 
 			var printDeletionsHeader bool
+			var filteredSRACLs []rpsr.ACL
 			if !noConfirm || dry {
-				describeReqResp(adm, printAllFilters, true, b, f)
+				filteredSRACLs = describeReqResp(cmd.Context(), adm, srClient, printAllFilters, true, kBuilder, srACLs, f)
 				fmt.Println()
 
 				confirmed, err := out.Confirm("Confirm deletion of the above matching ACLs?")
@@ -90,8 +101,7 @@ resource names:
 				printAllFilters = false
 				printDeletionsHeader = true
 			}
-
-			deleteReqResp(adm, printAllFilters, printDeletionsHeader, b)
+			deleteReqResp(cmd.Context(), adm, srClient, printAllFilters, printDeletionsHeader, kBuilder, srACLs, filteredSRACLs)
 		},
 	}
 	p.InstallKafkaFlags(cmd)
@@ -109,9 +119,10 @@ func (a *acls) addDeleteFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to remove ACLs for (repeatable)")
 	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to remove ACLs to the cluster")
 	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to remove ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.registry, registryFlag, false, "Whether to remove ACLs for the schema registry")
+	cmd.Flags().StringSliceVar(&a.subjects, subjectFlag, nil, "Schema Registry subjects to remove ACLs for (repeatable)")
 
 	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "Pattern to use when matching resource names (any, match, literal, or prefixed)")
-
 	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to remove (repeatable)")
 
 	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Allowed principal ACLs to remove (repeatable)")
@@ -123,71 +134,136 @@ func (a *acls) addDeleteFlags(cmd *cobra.Command) {
 }
 
 func deleteReqResp(
+	ctx context.Context,
 	adm *kadm.Client,
+	srCl *rpsr.Client,
 	printAllFilters bool,
 	printDeletionsHeader bool,
 	b *kadm.ACLBuilder,
+	srACLsFilter []rpsr.ACL,
+	filteredSRACLs []rpsr.ACL,
 ) {
-	results, err := adm.DeleteACLs(context.Background(), b)
-	out.MaybeDie(err, "unable to delete ACLs: %v", err)
-	types.Sort(results)
-
+	var (
+		kResults  []kadm.DeleteACLsResult
+		srResults []rpsr.ACL
+		err       error
+		srErr     error
+	)
+	if b != nil {
+		kResults, err = adm.DeleteACLs(ctx, b)
+		out.MaybeDie(err, "unable to delete Kafka ACLs: %v", err)
+	}
+	// Kafka ACLs deletion is done, and the result already contains the error
+	// message for each row. For SR we store a single error message and display
+	// it at the end.
+	if srACLsFilter != nil {
+		if filteredSRACLs == nil {
+			filteredSRACLs, err = srCl.ListACLsBatch(ctx, srACLsFilter)
+			if err != nil {
+				zap.L().Sugar().Warnf("failed to list schema registry ACLs: %v", err)
+				srErr = fmt.Errorf("unable to list sr ACLs: %v", err)
+			}
+		}
+		err = srCl.DeleteACLs(ctx, filteredSRACLs)
+		if err != nil {
+			srErr = fmt.Errorf("unable to delete Schema Registry ACLs: %v", err)
+		}
+		srResults = filteredSRACLs
+	}
 	// If any filters failed, or if all filters are requested, we print the
 	// filter section.
 	var printFailedFilters bool
-	for _, f := range results {
+	for _, f := range kResults {
 		if f.Err != nil {
 			printFailedFilters = true
 			break
 		}
 	}
+
 	if printAllFilters || printFailedFilters {
 		out.Section("filters")
-		printDeleteFilters(printAllFilters, results)
+		printDeleteFilters(printAllFilters, kResults, srACLsFilter)
 		fmt.Println()
 		printDeletionsHeader = true
 	}
 	if printDeletionsHeader {
 		out.Section("deletions")
 	}
-	printDeleteResults(results)
+	printDeleteResults(kResults, srResults, srErr)
 }
 
-func printDeleteFilters(all bool, results kadm.DeleteACLsResults) {
-	tw := out.NewTable(headersWithError...)
-	defer tw.Flush()
-	for _, f := range results {
+func printDeleteFilters(all bool, kResults kadm.DeleteACLsResults, srACLs []rpsr.ACL) {
+	var results []aclWithMessage
+	for _, f := range kResults {
 		if f.Err == nil && !all {
 			continue
 		}
-		tw.PrintStructFields(aclWithMessage{
+		results = append(results, aclWithMessage{
 			unptr(f.Principal),
 			unptr(f.Host),
-			f.Type,
+			f.Type.String(),
 			unptr(f.Name),
-			f.Pattern,
-			f.Operation,
-			f.Permission,
+			f.Pattern.String(),
+			f.Operation.String(),
+			f.Permission.String(),
 			kafka.ErrMessage(f.Err),
 		})
 	}
-}
-
-func printDeleteResults(results kadm.DeleteACLsResults) {
+	for _, f := range srACLs {
+		results = append(results, aclWithMessage{
+			Principal:           f.Principal,
+			Host:                f.Host,
+			ResourceType:        string(f.ResourceType),
+			ResourceName:        f.Resource,
+			ResourcePatternType: string(f.PatternType),
+			Operation:           string(f.Operation),
+			Permission:          string(f.Permission),
+		})
+	}
+	types.Sort(results)
 	tw := out.NewTable(headersWithError...)
 	defer tw.Flush()
 	for _, f := range results {
+		tw.PrintStructFields(f)
+	}
+}
+
+func printDeleteResults(kResults kadm.DeleteACLsResults, srACLs []rpsr.ACL, srErr error) {
+	var results []aclWithMessage
+	for _, f := range kResults {
 		for _, d := range f.Deleted {
-			tw.PrintStructFields(aclWithMessage{
+			results = append(results, aclWithMessage{
 				d.Principal,
 				d.Host,
-				d.Type,
+				d.Type.String(),
 				d.Name,
-				d.Pattern,
-				d.Operation,
-				d.Permission,
+				d.Pattern.String(),
+				d.Operation.String(),
+				d.Permission.String(),
 				kafka.ErrMessage(d.Err),
 			})
 		}
+	}
+	for _, f := range srACLs {
+		msg := ""
+		if srErr != nil {
+			msg = srErr.Error()
+		}
+		results = append(results, aclWithMessage{
+			Principal:           f.Principal,
+			Host:                f.Host,
+			ResourceType:        string(f.ResourceType),
+			ResourceName:        f.Resource,
+			ResourcePatternType: string(f.PatternType),
+			Operation:           string(f.Operation),
+			Permission:          string(f.Permission),
+			Message:             msg,
+		})
+	}
+	types.Sort(results)
+	tw := out.NewTable(headersWithError...)
+	defer tw.Flush()
+	for _, f := range results {
+		tw.PrintStructFields(f)
 	}
 }

--- a/src/go/rpk/pkg/cli/security/acl/list.go
+++ b/src/go/rpk/pkg/cli/security/acl/list.go
@@ -13,9 +13,13 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
+	"github.com/redpanda-data/common-go/rpsr"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -23,8 +27,11 @@ import (
 )
 
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	var a acls
-	var printAllFilters bool
+	var (
+		a               acls
+		printAllFilters bool
+		subsystem       []string
+	)
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls", "describe"},
@@ -47,9 +54,29 @@ resource names:
   * "match" returns wildcard matches, prefix patterns that match your input, and literal matches
   * "prefix" returns prefix patterns that match your input (prefix "fo" matches "foo")
   * "literal" returns exact name matches
+
+The list command lists ACLs for both Kafka and Schema Registry. To limit the 
+results to a specific subsystem, use the --subsystem flag with either "kafka" or 
+"registry".
 `,
-		Args: cobra.ExactArgs(0),
-		Run: func(_ *cobra.Command, _ []string) {
+		Example: `
+List all ACLs:
+  rpk security acl list
+
+List all Schema Registry ACLs:
+  rpk security acl list --subsytem registry
+
+List all ACLs for topic "foo":
+  rpk security acl list --topic foo
+
+List all ACLs for user "bar" on topic "foo":
+  rpk security acl list --allow-principal bar --topic foo
+
+List all ACLs for role "admin" on schema registry subject "foo-value":
+  rpk security acl list --allow-role admin --registry-subject foo-value
+`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
 			if h, ok := f.Help(&aclListOutput{}); ok {
 				out.Exit(h)
@@ -61,14 +88,21 @@ resource names:
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 			defer adm.Close()
 
-			b, err := a.createDeletionsAndDescribes(true)
+			srClient, err := schemaregistry.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+
+			isKafka, isSR, err := kafkaOrSRFilters(cmd, true)
+			out.MaybeDie(err, "invalid request: %v", err)
+
+			kBuilder, srACLs, err := a.createDeletionsAndDescribes(true, isKafka, isSR)
 			out.MaybeDieErr(err)
-			describeReqResp(adm, printAllFilters, false, b, f)
+			describeReqResp(cmd.Context(), adm, srClient, printAllFilters, false, kBuilder, srACLs, f)
 		},
 	}
 	p.InstallFormatFlag(cmd)
 	p.InstallKafkaFlags(cmd)
 	a.addListFlags(cmd)
+	cmd.Flags().StringSliceVar(&subsystem, subsystemFlag, []string{"kafka", "registry"}, "The subsystem to match ACLs for (kafka, registry, or both)")
 	cmd.Flags().BoolVarP(&printAllFilters, "print-filters", "f", false, "Print the filters that were requested (failed filters are always printed)")
 	return cmd
 }
@@ -88,9 +122,10 @@ func (a *acls) addListFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&a.groups, groupFlag, nil, "Group to match ACLs for (repeatable)")
 	cmd.Flags().BoolVar(&a.cluster, clusterFlag, false, "Whether to match ACLs to the cluster")
 	cmd.Flags().StringSliceVar(&a.txnIDs, txnIDFlag, nil, "Transactional IDs to match ACLs for (repeatable)")
+	cmd.Flags().BoolVar(&a.registry, registryFlag, false, "Whether to grant ACLs for the schema registry")
+	cmd.Flags().StringSliceVar(&a.subjects, subjectFlag, nil, "Schema Registry subjects to grant ACLs for (repeatable)")
 
 	cmd.Flags().StringVar(&a.resourcePatternType, patternFlag, "any", "Pattern to use when matching resource names (any, match, literal, or prefixed)")
-
 	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to match (repeatable)")
 
 	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Allowed principal ACLs to match (repeatable)")
@@ -102,36 +137,56 @@ func (a *acls) addListFlags(cmd *cobra.Command) {
 }
 
 func describeReqResp(
+	ctx context.Context,
 	adm *kadm.Client,
+	srClient *rpsr.Client,
 	printAllFilters bool,
 	printMatchesHeader bool,
 	b *kadm.ACLBuilder,
+	srACLs []rpsr.ACL,
 	f config.OutFormatter,
-) {
-	results, err := adm.DescribeACLs(context.Background(), b)
-	out.MaybeDie(err, "unable to list ACLs: %v", err)
-	types.Sort(results)
+) []rpsr.ACL {
+	var (
+		kResults  []kadm.DescribeACLsResult
+		srResults []rpsr.ACL
+		err       error
+		srErr     error
+	)
+	if b != nil {
+		kResults, err = adm.DescribeACLs(ctx, b)
+		out.MaybeDie(err, "unable to list kafka ACLs: %v", err)
+	}
+
+	if srACLs != nil {
+		srResults, err = srClient.ListACLsBatch(ctx, srACLs)
+		if err != nil {
+			// For backwards compatibility, we print the error instead of
+			// exiting.
+			srErr = fmt.Errorf("unable to list sr ACLs: %v", err)
+			zap.L().Sugar().Warnf("failed to list schema registry ACLs: %v", err)
+		}
+	}
 
 	// If any filters failed, or if all filters are
 	// requested, we print the filter section.
 	var printFailedFilters bool
-	for _, f := range results {
+	for _, f := range kResults {
 		if f.Err != nil {
 			printFailedFilters = true
 			break
 		}
 	}
-	output := aclListOutput{}
-	for _, f := range results {
+	var output aclListOutput
+	for _, f := range kResults {
 		if printAllFilters || printFailedFilters {
 			output.Filters = append(output.Filters, aclWithMessage{
 				unptr(f.Principal),
 				unptr(f.Host),
-				f.Type,
+				f.Type.String(),
 				unptr(f.Name),
-				f.Pattern,
-				f.Operation,
-				f.Permission,
+				f.Pattern.String(),
+				f.Operation.String(),
+				f.Permission.String(),
 				kafka.ErrMessage(f.Err),
 			})
 		}
@@ -139,18 +194,50 @@ func describeReqResp(
 			output.Matches = append(output.Matches, acl{
 				d.Principal,
 				d.Host,
-				d.Type,
+				d.Type.String(),
 				d.Name,
-				d.Pattern,
-				d.Operation,
-				d.Permission,
+				d.Pattern.String(),
+				d.Operation.String(),
+				d.Permission.String(),
 			})
 		}
 	}
+	if printAllFilters || printFailedFilters {
+		for _, f := range srACLs {
+			msg := ""
+			if srErr != nil {
+				msg = srErr.Error()
+			}
+			output.Filters = append(output.Filters, aclWithMessage{
+				Principal:           f.Principal,
+				Host:                f.Host,
+				ResourceType:        string(f.ResourceType),
+				ResourceName:        f.Resource,
+				ResourcePatternType: string(f.PatternType),
+				Operation:           string(f.Operation),
+				Permission:          string(f.Permission),
+				Message:             msg,
+			})
+		}
+	}
+	for _, f := range srResults {
+		output.Matches = append(output.Matches, acl{
+			Principal:           f.Principal,
+			Host:                f.Host,
+			ResourceType:        string(f.ResourceType),
+			ResourceName:        f.Resource,
+			ResourcePatternType: string(f.PatternType),
+			Operation:           string(f.Operation),
+			Permission:          string(f.Permission),
+		})
+	}
+
+	types.Sort(output)
+
 	if isText, _, t, err := f.Format(&output); !isText {
 		out.MaybeDie(err, "unable to print in the requested format %q: %v", f.Kind, err)
 		fmt.Printf("%s\n", t)
-		return
+		return srResults
 	}
 	if len(output.Filters) > 0 {
 		out.Section("filters")
@@ -162,6 +249,7 @@ func describeReqResp(
 		out.Section("matches")
 	}
 	printDescribedACLs(output)
+	return srResults
 }
 
 type aclListOutput struct {

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -24,7 +24,7 @@ from rptest.util import wait_until_result
 from rptest.services import tls
 from rptest.clients.types import TopicSpec
 from ducktape.errors import TimeoutError
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 DEFAULT_TIMEOUT = 30
 
@@ -207,6 +207,26 @@ class RpkColumnHeader:
 class RpkTable:
     columns: list[RpkColumnHeader]
     rows: list[list[str]]
+
+
+@dataclass
+class RPKACLInput:
+    # Can't use mutables in defaults of dataclass
+    # https://docs.python.org/3/library/dataclasses.html#dataclasses.field
+    allow_principal: list[str] = field(default_factory=list)
+    deny_principal: list[str] = field(default_factory=list)
+    allow_role: list[str] = field(default_factory=list)
+    deny_role: list[str] = field(default_factory=list)
+    allow_host: list[str] = field(default_factory=list)
+    deny_host: list[str] = field(default_factory=list)
+    topic: list[str] = field(default_factory=list)
+    group: list[str] = field(default_factory=list)
+    operation: list[str] = field(default_factory=list)
+    txn_id: list[str] = field(default_factory=list)
+    cluster: bool = False
+    resource_pattern_type: str = ""
+    registry_subject: list[str] = field(default_factory=list)
+    registry_global: bool = False
 
 
 def parse_rpk_table(out):
@@ -1364,7 +1384,8 @@ class RpkTool:
 
     def acl_list(self,
                  flags: list[str] = [],
-                 node: Optional[ClusterNode] = None):
+                 node: Optional[ClusterNode] = None,
+                 format: str = "text"):
         """
         Run `rpk acl list` and return the results.
 
@@ -1377,11 +1398,17 @@ class RpkTool:
         """
         cmd = [
             self._rpk_binary(),
+            "security",
             "acl",
             "list",
+            "--format",
+            format,
         ] + flags + self._kafka_conn_settings(node)
 
         output = self._execute(cmd)
+
+        if format == "json":
+            return json.loads(output)
 
         if "CLUSTER_AUTHORIZATION_FAILED" in output:
             raise ClusterAuthorizationError("acl list")
@@ -1397,6 +1424,7 @@ class RpkTool:
         """
         cmd = [
             self._rpk_binary(),
+            "security",
             "acl",
             "create",
             "--allow-principal",
@@ -1425,6 +1453,80 @@ class RpkTool:
                 f"acl_create_allow_cluster failed with {table.rows[0][-1]}")
 
         return output
+
+    def acl_create(self, acl: RPKACLInput):
+
+        cmd = [
+            self._rpk_binary(),
+            "security",
+            "acl",
+            "create",
+        ] + self._schema_registry_conn_settings() + self._kafka_conn_settings(
+        )
+
+        def append_flag(flag: str, values: list[str]):
+            if values:
+                cmd.extend([flag, ",".join(values)])
+
+        def append_bool_flag(flag: str, value: bool):
+            if value:
+                cmd.append(flag)
+
+        append_flag("--allow-principal", acl.allow_principal)
+        append_flag("--deny-principal", acl.deny_principal)
+        append_flag("--allow-role", acl.allow_role)
+        append_flag("--deny-role", acl.deny_role)
+        append_flag("--allow-host", acl.allow_host)
+        append_flag("--deny-host", acl.deny_host)
+        append_flag("--topic", acl.topic)
+        append_flag("--group", acl.group)
+        append_flag("--operation", acl.operation)
+        append_flag("--transactional-id", acl.txn_id)
+        append_bool_flag("--cluster", acl.cluster)
+        append_flag("--registry-subject", acl.registry_subject)
+        append_bool_flag("--registry-global", acl.registry_global)
+
+        if acl.resource_pattern_type:
+            cmd += ["--resource-pattern-type", acl.resource_pattern_type]
+
+        return self._execute(cmd)
+
+    def acl_delete(self, acl: RPKACLInput):
+        cmd = [
+            self._rpk_binary(),
+            "security",
+            "acl",
+            "delete",
+            "--no-confirm",
+        ] + self._schema_registry_conn_settings() + self._kafka_conn_settings(
+        )
+
+        def append_flag(flag: str, values: list[str]):
+            if values:
+                cmd.extend([flag, ",".join(values)])
+
+        def append_bool_flag(flag: str, value: bool):
+            if value:
+                cmd.append(flag)
+
+        append_flag("--allow-principal", acl.allow_principal)
+        append_flag("--deny-principal", acl.deny_principal)
+        append_flag("--allow-role", acl.allow_role)
+        append_flag("--deny-role", acl.deny_role)
+        append_flag("--allow-host", acl.allow_host)
+        append_flag("--deny-host", acl.deny_host)
+        append_flag("--topic", acl.topic)
+        append_flag("--group", acl.group)
+        append_flag("--operation", acl.operation)
+        append_flag("--transactional-id", acl.txn_id)
+        append_bool_flag("--cluster", acl.cluster)
+        append_flag("--registry-subject", acl.registry_subject)
+        append_bool_flag("--registry-global", acl.registry_global)
+
+        if acl.resource_pattern_type:
+            cmd += ["--resource-pattern-type", acl.resource_pattern_type]
+
+        return self._execute(cmd)
 
     def cluster_metadata_id(self):
         """

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -11,8 +11,8 @@ from rptest.services.failure_injector import make_failure_injector, FailureSpec
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.admin_api_auth_test import create_user_and_wait
-from rptest.clients.rpk import RpkTool, RpkException
-from rptest.services.redpanda import SecurityConfig, SaslCredentials
+from rptest.clients.rpk import RpkTool, RpkException, RPKACLInput
+from rptest.services.redpanda import SecurityConfig, SchemaRegistryConfig
 from rptest.util import expect_exception
 from ducktape.utils.util import wait_until
 
@@ -22,7 +22,11 @@ class RpkACLTest(RedpandaTest):
     password = "panda"
     mechanism = "SCRAM-SHA-256"
 
-    def __init__(self, test_ctx, *args, **kwargs):
+    def __init__(self,
+                 test_ctx,
+                 schema_registry_config=SchemaRegistryConfig(),
+                 *args,
+                 **kwargs):
         self._ctx = test_ctx
         security = SecurityConfig()
         security.enable_sasl = True
@@ -31,6 +35,7 @@ class RpkACLTest(RedpandaTest):
               self).__init__(test_ctx,
                              security=security,
                              extra_rp_conf={'election_timeout_ms': 10000},
+                             schema_registry_config=schema_registry_config,
                              *args,
                              **kwargs)
         self._rpk = RpkTool(redpanda=self.redpanda,
@@ -38,6 +43,8 @@ class RpkACLTest(RedpandaTest):
                             password=self.password,
                             sasl_mechanism=self.mechanism)
         self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        self.schema_registry_config = SchemaRegistryConfig()
+        self.schema_registry_config.require_client_auth = True
 
     def _superclient(self):
         return RpkTool(self.redpanda,
@@ -291,3 +298,61 @@ class RpkACLTest(RedpandaTest):
         with expect_exception(RpkException,
                               lambda e: 'AUTHORIZATION_FAILED' in str(e)):
             self._rpk.produce(TOPIC_NAME, 'foo', 'bar')
+
+    @cluster(num_nodes=1)
+    def test_schema_registry_acl(self):
+        """
+        Simple test that only verifies if rpk is able to parse and create
+        Schema Registry ACLs along Redpanda ACLs
+        """
+
+        TOPIC_NAME = 'some-topic'
+        ROLE_NAME = 'admin'
+        superclient = self._superclient()
+
+        # Create ACL with only SR = 2 ACLs.
+        sr_only_acl = RPKACLInput(allow_principal=["panda"],
+                                  registry_subject=["aaa-value"],
+                                  operation=["read", "write"],
+                                  resource_pattern_type="literal")
+        superclient.acl_create(sr_only_acl)
+
+        acl_list_all = superclient.acl_list(format="json")
+        assert len(acl_list_all['matches']
+                   ) == 2, f"Expected to have 2 ACLs created: {acl_list_all}"
+
+        # Delete ALL, empty input means all.
+        superclient.acl_delete(RPKACLInput())
+        acl_list_all = superclient.acl_list(format="json")
+        assert acl_list_all['matches'] is None
+
+        # ACL with SR + Kafka = 4 in total.
+        sr_kafka_acl = RPKACLInput(allow_principal=["panda"],
+                                   topic=["foo"],
+                                   registry_subject=["foo-value"],
+                                   operation=["read", "write"],
+                                   resource_pattern_type="literal")
+        superclient.acl_create(sr_kafka_acl)
+
+        acl_list_all = superclient.acl_list(format="json")
+        assert len(acl_list_all['matches']
+                   ) == 4, f"Expected to have 4 ACLs created: {acl_list_all}"
+
+        # List with filter (read)
+        acl_list_filter = superclient.acl_list(format="json",
+                                               flags=["--operation", "read"])
+        assert len(acl_list_filter['matches']
+                   ) == 2, f"Expected to have 2 ACLs created: {acl_list_all}"
+
+        # Filter by subsystem
+        acl_list_filter = superclient.acl_list(format="json",
+                                               flags=["--subsystem", "kafka"])
+        assert len(acl_list_filter['matches']
+                   ) == 2, f"Expected to have 2 ACLs created: {acl_list_all}"
+
+        # Delete with filter should delete all that
+        # we have, both in SR and Kafka
+        superclient.acl_delete(sr_kafka_acl)
+
+        acl_list_all = superclient.acl_list(format="json")
+        assert acl_list_all['matches'] is None


### PR DESCRIPTION
This PR adds support for managing the new Schema Registry (SR) ACLs through rpk, using the existing rpk security acl command set (create, list, delete).

- This includes 2 new flags: `--registry-subject` and `registry-global`, which rpk will use to determine whether SR ACLs are being created.
- The same commands used for managing Kafka ACLs are now extended to support SR ACLs.
- The implementation reuses the existing command structure and maintains the same output formats.
- No breaking changes have been introduced; users can interact with SR ACLs in a consistent way with existing Kafka ACL workflows.


### Examples

**Create**
```
$ rpk security acl create --allow-principal panda --topic foo --registry-subject foo-key,foo-value --operation all
PRINCIPAL   HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:panda  *     SUBJECT        foo-key        LITERAL                ALL        ALLOW       
User:panda  *     SUBJECT        foo-value      LITERAL                ALL        ALLOW       
User:panda  *     TOPIC          foo            LITERAL                ALL        ALLOW   
```

**List**
```
$ rpk security acl list --registry-subject foo-key
PRINCIPAL   HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:panda  *     SUBJECT        foo-key        LITERAL                ALL        ALLOW

$ rpk security acl list --subsystem kafka 
PRINCIPAL    HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:panda   *     TOPIC          foo            LITERAL                ALL        ALLOW   
```

**Delete**
```
$ rpk security acl delete --allow-principal panda
MATCHES
=======
PRINCIPAL   HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:panda  *     SUBJECT        foo-key        LITERAL                ALL        ALLOW
User:panda  *     SUBJECT        foo-value      LITERAL                ALL        ALLOW
User:panda  *     TOPIC          foo            LITERAL                ALL        ALLOW

? Confirm deletion of the above matching ACLs? Yes

DELETIONS
=========
PRINCIPAL   HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:panda  *     SUBJECT        foo-key        LITERAL                ALL        ALLOW       
User:panda  *     SUBJECT        foo-value      LITERAL                ALL        ALLOW       
User:panda  *     TOPIC          foo            LITERAL                ALL        ALLOW      
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Features

* rpk security acl: added support to create, list, and delete Schema Registry ACLs through rpk