### PR TITLE
raft/voter_priority_tracker: fix first leader nepo

### DIFF
--- a/src/v/raft/voter_priority_tracker.h
+++ b/src/v/raft/voter_priority_tracker.h
@@ -71,7 +71,7 @@ public:
 private:
     vnode _self;
     std::optional<voter_priority> _replica_priority_override;
-    voter_priority _target_priority;
+    voter_priority _target_priority = voter_priority::max();
 };
 
 } // namespace raft

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -177,7 +177,8 @@ class RaftAvailabilityTest(RedpandaTest):
         # Find which node is the leader
         admin = Admin(self.redpanda)
         initial_leader_id, replicas = self._wait_for_leader()
-        assert initial_leader_id == replicas[0]
+        assert initial_leader_id == replicas[
+            0], f'expected leader id: {replicas[0]}, but found leader {initial_leader_id}'
 
         self._expect_available()
 


### PR DESCRIPTION
On creation of a group, the first node_id in the replica set is supposed to preferentially be selected as leader. This PR fixes a bug where on creation, the initial 'target_priority' was set to zero instead of MAX, which allowed for all nodes to vote for themselves immediately, instead of waiting a few rounds for the target priority to fall.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes
### Bug Fixes
* repair initial leadership appointment machinery

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
