### PR TITLE
docs: update descriptions for ephemeral creds

### DIFF
--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -149,19 +149,39 @@ configuration::configuration()
   , sasl_mechanism(
       *this,
       "sasl_mechanism",
-      "The SASL mechanism to use when connecting.",
+      "The SASL mechanism to use when the HTTP Proxy client connects to the "
+      "Kafka API. These credentials are used when the HTTP Proxy API "
+      "listener has `authentication_method: none` but the cluster requires "
+      "authenticated access to the Kafka API. Starting in Redpanda 25.2, "
+      "ephemeral credentials for HTTP Proxy are removed. If your HTTP Proxy "
+      "listeners use `authentication_method: none`, you must configure these "
+      "SASL properties for HTTP Proxy to authenticate with the Kafka API. "
+      "For more information, see "
+      "https://docs.redpanda.com/current/manage/security/authentication/",
       {},
       "")
   , scram_username(
       *this,
       "scram_username",
-      "Username to use for SCRAM authentication mechanisms.",
+      "Username to use for SCRAM authentication mechanisms when the HTTP "
+      "Proxy client connects to the Kafka API. This property is required "
+      "when the HTTP Proxy API listener has `authentication_method: none` "
+      "but the cluster requires authenticated access to the Kafka API. "
+      "Starting in Redpanda 25.2, ephemeral credentials for HTTP Proxy are "
+      "removed. You must configure this property if your HTTP Proxy "
+      "listeners use `authentication_method: none`.",
       {},
       "")
   , scram_password(
       *this,
       "scram_password",
-      "Password to use for SCRAM authentication mechanisms.",
+      "Password to use for SCRAM authentication mechanisms when the HTTP "
+      "Proxy client connects to the Kafka API. This property is required "
+      "when the HTTP Proxy API listener has `authentication_method: none` "
+      "but the cluster requires authenticated access to the Kafka API. "
+      "Starting in Redpanda 25.2, ephemeral credentials for HTTP Proxy are "
+      "removed. You must configure this property if your HTTP Proxy "
+      "listeners use `authentication_method: none`.",
       {.secret = config::is_secret::yes},
       "")
   , client_identifier(


### PR DESCRIPTION
Resolves https://redpandadata.atlassian.net/browse/DOC-1500

Related https://github.com/redpanda-data/docs/pull/1210

Improve description for broker credentials used in http proxy

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none