### PR TITLE
`storage`: reduce `segment` count in lease for timequeries

### DIFF
--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -48,13 +48,11 @@ lock_manager::range_lock(const timequery_config& cfg) {
       cfg.min_offset, cfg.max_offset);
 
     segment_set::underlying_t tmp;
-    // Copy segments that have timestamps >= cfg.time and overlap with the
-    // offset range [min_offset, max_offset].
-    std::copy_if(
-      _set.begin(),
-      _set.end(),
-      std::back_inserter(tmp),
-      [&query_interval, &cfg](ss::lw_shared_ptr<segment>& s) {
+    // Copy the first segment that has timestamps >= cfg.time and overlaps with
+    // the offset range [min_offset, max_offset].
+    // We only need one segment/batch to satisfy a timequery.
+    auto it = std::find_if(
+      _set.begin(), _set.end(), [&query_interval, &cfg](const auto& s) {
           if (s->empty()) {
               return false;
           }
@@ -77,6 +75,11 @@ lock_manager::range_lock(const timequery_config& cfg) {
 
           return segment_interval.overlaps(query_interval);
       });
+
+    if (it != _set.end()) {
+        tmp.push_back(*it);
+    }
+
     return range(std::move(tmp));
 }
 


### PR DESCRIPTION
Quick follow-up to https://github.com/redpanda-data/redpanda/pull/26830, only last commit is new.

We only need a single `segment`/`record_batch` to satisfy a timequery.

Instead of using `std::copy_if()` and taking a lease on many `segment`s in the `log`, use `std::find_if()` with the same predicate to instead only populate the `lock_manager::lease` with the necessary `segment`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Reduce the number of locks held on `segment`s in the `log` during a timequery.
