### PR TITLE
Adding more functions and checks for Iceberg on cloud

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/iceberg_catalogs_test.py
+++ b/tests/rptest/redpanda_cloud_tests/iceberg_catalogs_test.py
@@ -12,6 +12,8 @@ import logging
 import json
 import time
 import requests
+import base64
+import random
 
 from ducktape.mark import matrix
 from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
@@ -27,11 +29,6 @@ from rptest.services.redpanda import RedpandaServiceCloud
 from rptest.services.databricks_workspace import DatabricksWorkspace
 from rptest.context.databricks import DatabricksContext, OauthCredentials
 from rptest.services.catalog_service import CatalogType
-#from rptest.tests.datalake.datalake_services import DatalakeServices
-#from rptest.tests.datalake.query_engine_base import QueryEngineType
-#from rptest.tests.datalake.utils import supported_storage_types
-#from rptest.tests.redpanda_test import RedpandaTest
-#from rptest.utils.mode_checks import cleanup_on_early_exit
 
 
 def supported_catalog_types():
@@ -71,53 +68,150 @@ class IcebergCloudCatalogsTest(RedpandaCloudTest):
         self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=1)
+    def test_cluster_updates(self):
+        """
+        Test repeated Redpanda cluster property updates with a secret reference.
+
+        This test performs the following steps:
+        1. Creates a new Redpanda secret with a randomly generated name and base64-encoded value.
+        2. Constructs a properties payload enabling Iceberg integration, using the created secret.
+        3. Repeats a cluster update operation `num_iterations` times to validate:
+        - That each update succeeds without errors.
+        - That the update completes within a reasonable amount of time.
+        - That polling for the operation status correctly identifies completion.
+        
+        This test helps to catch regressions in update logic, API response handling, and operation polling.
+
+        Raises:
+            Exception: If any update operation fails or polling detects a failure state.
+        """
+        cloud_cluster = self.redpanda._cloud_cluster
+        secret_id = f"UNITY_CLIENT_SECRET_{random.randint(10000, 99999)}"
+        secret_data = "fake_secret"
+        # Encode secret as base64
+        encoded_secret_data = base64.b64encode(
+            secret_data.encode("utf-8")).decode("utf-8")
+        # Create encoded Redpanda secret with random ID
+        create_resp = cloud_cluster.create_secret(secret_id,
+                                                  encoded_secret_data)
+        self.logger.debug(f"Create secret response: {create_resp}")
+
+        properties = {
+            "iceberg_enabled":
+            True,
+            "iceberg_rest_catalog_endpoint":
+            "https://fake.cloud.databricks.com/api/2.1/unity-catalog/iceberg-rest",
+            "iceberg_rest_catalog_authentication_mode":
+            "oauth2",
+            "iceberg_rest_catalog_client_id":
+            "iceberg_rest_catalog_client_id",
+            "iceberg_rest_catalog_client_secret":
+            f"${{secrets.{secret_id}}}",
+            "iceberg_rest_catalog_warehouse":
+            "fake_catalog_name",
+            "iceberg_catalog_type":
+            "rest",
+            "iceberg_disable_snapshot_tagging":
+            "true",
+            "iceberg_rest_catalog_oauth2_scope":
+            "all-apis",
+            "iceberg_rest_catalog_oauth2_server_uri":
+            "https://dbc-0f5177e3-6aa4.cloud.databricks.com/oidc/v1/token"
+        }
+
+        self.logger.debug(f"Properties to be sent: {properties}")
+
+        num_iterations = 10
+        for i in range(num_iterations):
+            self.logger.info(
+                f"Starting cluster update iteration {i + 1}/{num_iterations}")
+            try:
+                response = cloud_cluster.update_cluster_property_public(
+                    self._clusterId, properties)
+                if not response:
+                    self.logger.error("Failed to update cluster properties.")
+                    return
+                self.logger.debug(f"Update successful: {response}")
+
+                operation = response.get("operation", {})
+                operation_id = operation.get("id")
+                if not operation_id:
+                    self.logger.error(
+                        "No operation ID returned from update_cluster_property_public."
+                    )
+                    return
+                self.logger.debug(f"Operation id: {operation_id}")
+
+                success = cloud_cluster.wait_for_operation_complete(
+                    self._clusterId, operation_id)
+                if not success:
+                    self.logger.error(
+                        f"Operation {operation_id} did not complete successfully."
+                    )
+
+            except Exception as e:
+                self.logger.error(
+                    f"An error occurred while updating cluster properties: {e}"
+                )
+                raise
+
+    @cluster(num_nodes=1)
     def test_databricks_basic(self):
         dbx_ctx = DatabricksContext.from_context(self._ctx)
 
         cloud_cluster = self.redpanda._cloud_cluster
-        client: RpCloudApiClient = cloud_cluster.public_api
+        #client: RpCloudApiClient = cloud_cluster.public_api
 
         databricks_client = DatabricksWorkspace(context=self._ctx)
         bucket = f"redpanda-cloud-storage-{self._clusterId}"
         catalog_info = databricks_client.create_catalog(bucket=bucket)
-        properties = {"iceberg_enabled": True}
-        enable_resp = cloud_cluster.update_cluster_property_public(
-            self._clusterId, properties)
-        self.logger.debug(f"Enable iceberg response: {enable_resp}")
 
         # Parameters for creating Redpanda secret
-        secret_id = "UNITY_CLIENT_SECRET"
+        secret_id = f"UNITY_CLIENT_SECRET_{random.randint(10000, 99999)}"
 
-        #secret_data = dbx_ctx.client_secret
         # Access credentials (client_secret, client_id) from dbx_ctx.credentials
         if isinstance(dbx_ctx.credentials, OauthCredentials):
             secret_data = dbx_ctx.credentials.client_secret
             databricks_client_id = dbx_ctx.credentials.client_id
+            self.logger.debug(f"Using oauth2 for: {databricks_client_id}")
         else:
+            self.logger.debug("Using bearer token")
             secret_data = dbx_ctx.credentials.token
             databricks_client_id = None
-
-        create_resp = cloud_cluster.create_secret(secret_id, secret_data)
+        self.logger.debug(f"Databricks client ID: {databricks_client_id}")
+        # Encode secret as base64
+        encoded_secret_data = base64.b64encode(
+            secret_data.encode("utf-8")).decode("utf-8")
+        # Create Redpanda secret
+        create_resp = cloud_cluster.create_secret(secret_id,
+                                                  encoded_secret_data)
         self.logger.debug(f"Create secret response: {create_resp}")
 
         iceberg_rest_catalog_endpoint = dbx_ctx.iceberg_rest_url
-        iceberg_rest_catalog_warehouse = dbx_ctx.sql_warehouse_path
 
         # Construct the payload for the request
         properties = {
+            "iceberg_enabled":
+            True,
             "iceberg_rest_catalog_endpoint":
             iceberg_rest_catalog_endpoint,
             "iceberg_rest_catalog_authentication_mode":
             "oauth2"
             if isinstance(dbx_ctx.credentials, OauthCredentials) else "bearer",
             "iceberg_rest_catalog_client_id":
-            databricks_client_id,
+            str(databricks_client_id),
             "iceberg_rest_catalog_client_secret":
-            "${secrets.UNITY_CLIENT_SECRET}",
+            f"${{secrets.{secret_id}}}",
             "iceberg_rest_catalog_warehouse":
             catalog_info.name,
             "iceberg_catalog_type":
-            "rest"
+            "rest",
+            "iceberg_disable_snapshot_tagging":
+            "true",
+            "iceberg_rest_catalog_oauth2_scope":
+            "all-apis",
+            "iceberg_rest_catalog_oauth2_server_uri":
+            "https://dbc-0f5177e3-6aa4.cloud.databricks.com/oidc/v1/token"
         }
 
         # Log the constructed payload for debugging
@@ -125,12 +219,11 @@ class IcebergCloudCatalogsTest(RedpandaCloudTest):
 
         try:
             # Send the HTTP PATCH request
-            response = client.update_cluster_property_public(
-                cluster_id=cloud_cluster.current.cluster_id,
-                properties=properties)
+            response = cloud_cluster.update_cluster_property_public(
+                self._clusterId, properties)
 
             if response:
-                self.logger.debug(f"Update successful: {response.json()}")
+                self.logger.debug(f"Update successful: {response}")
             else:
                 self.logger.error("Failed to update cluster properties.")
 
@@ -138,6 +231,25 @@ class IcebergCloudCatalogsTest(RedpandaCloudTest):
             self.logger.error(
                 f"An error occurred while updating cluster properties: {e}")
 
+        # Extract operation ID
+        operation = response.get("operation", {})
+        operation_id = operation.get("id")
+        if not operation_id:
+            self.logger.error(
+                "No operation ID returned from update_cluster_property_public."
+            )
+            return
+        self.logger.debug(f"Operation id: {operation_id}")
+
+        # Poll for operation completion
+        success = cloud_cluster.wait_for_operation_complete(
+            self._clusterId, operation_id)
+
+        if not success:
+            self.logger.error(
+                f"Operation {operation_id} did not complete successfully.")
+
+        # Create topic(s) and produce data
         self.rpk = RpkTool(self.redpanda)
         test_topic = 'test_topic'
         self.rpk.create_topic(test_topic)
@@ -145,12 +257,12 @@ class IcebergCloudCatalogsTest(RedpandaCloudTest):
                                     TopicSpec.PROPERTY_ICEBERG_MODE,
                                     'key_value')
 
-        MESSAGE_COUNT = 100
+        MESSAGE_COUNT = 10
         for i in range(MESSAGE_COUNT):
             self.rpk.produce(test_topic, f"foo {i} ", f"bar {i}")
 
-        self.logger.debug("Waiting 1 minute...")
-        time.sleep(60)
+        self.logger.debug("Waiting 10 minute...")
+        time.sleep(600)
         # TODO Marat add verification, more tests and options (separate PR)
 
         databricks_client.stop()

--- a/tests/rptest/services/databricks_workspace.py
+++ b/tests/rptest/services/databricks_workspace.py
@@ -115,6 +115,14 @@ class DatabricksWorkspace(Service):
             assert principal_row, "Failed to get current user"
             principal = principal_row[0]
 
+            # TODO: Identify Minimal Privileges (Least access principle)
+            self.logger.debug(
+                f"GRANT ALL PRIVILEGES ON CATALOG `{catalog_info.name}` TO `{principal}`"
+            )
+            sql = f"GRANT ALL PRIVILEGES ON CATALOG `{catalog_info.name}` TO `{principal}`"
+            cursor.execute(sql)
+            self.logger.debug("Granted PRIVILEGES successfully")
+
             self.logger.debug(f"Creating grants for: {principal=}")
 
             cursor.execute(
@@ -126,8 +134,11 @@ class DatabricksWorkspace(Service):
         return DatabricksCatalogInfo(name=catalog_info.name)
 
     def _verify_credentials(self):
-        self.logger.debug(
-            f"Authenticated as: {self._client.current_user.me()}")
+        try:
+            user_info = self._client.current_user.me()
+            self.logger.debug(f"Authenticated as: {user_info}")
+        except Exception as e:
+            self.logger.error(f"Error fetching user info: {str(e)}")
 
     def _cleanup_catalogs(self):
         for catalog_name in self._catalog_names:

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -4,6 +4,7 @@ from functools import cache
 import json
 import os
 import requests
+import time
 import uuid
 import yaml
 import ipaddress
@@ -1624,3 +1625,50 @@ class CloudCluster():
     def _get_dataplane_api_url(self):
         cluster = self.rpcloud.get_cluster(self.current.cluster_id)
         return cluster['dataplane_api']['url']
+
+    def wait_for_operation_complete(
+            self,
+            cluster_id: str,
+            operation_id: str,
+            timeout_sec: int = 1200,  # 20 minutes
+            target_state: str = 'STATE_COMPLETED') -> bool:
+        """
+        Polls the /v1/operations/{operation_id} endpoint until it reaches the target_state.
+        Logs and alerts if the operation does not complete in the given timeout.
+
+        Returns True if completed successfully, False otherwise.
+        """
+        start_time = datetime.utcnow().isoformat()
+        start_ts = time.time()
+        poll_interval = 30
+
+        self._logger.debug(f"Starting poll for operation {operation_id} "
+                           f"on cluster {cluster_id} at {start_ts}")
+
+        while time.time() - start_ts < timeout_sec:
+            try:
+                resp = self.public_api._http_get(
+                    endpoint=f"/v1/operations/{operation_id}")
+            except Exception as e:
+                self._logger.warning(f"Failed to fetch operation status: {e}")
+                time.sleep(poll_interval)
+                continue
+
+            op = resp.get("operation", {})
+            state = op.get("state")
+            self._logger.debug(f"Operation {operation_id} state: {state}")
+
+            if state == target_state:
+                duration_sec = int(time.time() - start_ts)
+                self._logger.info(
+                    f"Operation {operation_id} for cluster {cluster_id} completed successfully in {duration_sec} seconds."
+                )
+                return True
+
+            time.sleep(poll_interval)
+
+        self._logger.error(
+            f"Operation {operation_id} for cluster {cluster_id} "
+            f"did not reach {target_state} within {timeout_sec // 60} minutes."
+        )
+        return False


### PR DESCRIPTION
Adding more functions and checks for Iceberg on cloud

Added functions to update properties, Redpanda secrets, create with random ID so it could be run multiple times, operation ID polling to make sure cluster properties get updated before we proceed. Also, added cluster update tests to make sure it gets updated consistently and within a reasonable time.

This code was already used on local branch for sometime now and tested.

P.S.
@simon0191 As we discussed, I run cluster updates in a loop multiple times trying to reproduce an issue that we saw where cluster took a long time (1h+ to update properties). Was not able to reproduce it yet and average time it took is about (less than) ~10 minutes (~540 s)

Below are the most important changes grouped by theme:

### Iceberg Catalog Integration and Cluster Updates
* Added a new test, `test_cluster_updates`, to validate repeated Redpanda cluster property updates with Iceberg integration. This includes creating secrets, constructing payloads, and polling operation statuses to ensure updates succeed and complete efficiently.
* Enhanced the `test_databricks_basic` method to include base64 encoding for secrets, expanded payload properties for Iceberg integration, and improved logging for debugging purposes.

### Privilege Management and Error Handling
* Introduced privilege grants in `create_catalog` for Databricks catalogs, ensuring the least access principle is followed. Added debug logging for privilege assignment.
* Improved error handling in `_verify_credentials` by catching exceptions during user authentication and logging errors.

### Operational Polling and Logging Enhancements
* Added a `wait_for_operation_complete` method in `RedpandaCloud` to poll operation statuses until completion, with configurable timeout and detailed logging.
* Enhanced logging in `warn_and_return` to provide detailed information about missing critical topics, expected topics, and actual topics found.

## Backports Required

- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
