### PR TITLE
[v25.1.x] `storage`: use linear search in `lock_manager::range_lock(const timequery_config& cfg)` (MANUAL BACKPORT)

### DIFF
--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -51,11 +51,22 @@ lock_manager::range_lock(const timequery_config& cfg) {
     // Copy segments that have timestamps >= cfg.time and overlap with the
     // offset range [min_offset, max_offset].
     std::copy_if(
-      _set.lower_bound(cfg.time),
+      _set.begin(),
       _set.end(),
       std::back_inserter(tmp),
-      [&query_interval](ss::lw_shared_ptr<segment>& s) {
+      [&query_interval, &cfg](ss::lw_shared_ptr<segment>& s) {
           if (s->empty()) {
+              return false;
+          }
+
+          // We exclude the segments that only contain configuration batches
+          // from our search, as their timestamps may be wildly different from
+          // the user provided timestamps.
+          if (s->index().non_data_timestamps()) {
+              return false;
+          }
+
+          if (s->index().max_timestamp() < cfg.time) {
               return false;
           }
 

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -126,28 +126,6 @@ segment_set::lower_bound(model::offset offset) const {
     return segments_lower_bound(
       std::cbegin(_handles), std::cend(_handles), offset);
 }
-// Lower bound for timestamp based indexing
-//
-// From KIP-33:
-//
-// When searching by timestamp, broker will start from the earliest log segment
-// and check the last time index entry. If the timestamp of the last time index
-// entry is greater than the target timestamp, the broker will do binary search
-// on that time index to find the closest index entry and scan the log from
-// there. Otherwise it will move on to the next log segment.
-segment_set::iterator segment_set::lower_bound(model::timestamp needle) {
-    // Note that we exclude the segments that only contain configuration batches
-    // from our search, as their timestamps may be wildly different from the
-    // user provided timestamps.
-    return filtered_lower_bound(
-      _handles.begin(),
-      _handles.end(),
-      needle,
-      segment_ordering{},
-      [](const auto& segment) {
-          return segment->index().non_data_timestamps() == false;
-      });
-}
 
 segment_set::iterator segment_set::upper_bound(model::term_id term) {
     return std::upper_bound(

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -74,8 +74,6 @@ public:
 
     iterator lower_bound(model::offset o);
     const_iterator lower_bound(model::offset o) const;
-    iterator lower_bound(model::timestamp o);
-    const_iterator lower_bound(model::timestamp o) const;
     iterator upper_bound(model::term_id o);
     const_iterator upper_bound(model::term_id o) const;
 

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -306,7 +306,7 @@ FIXTURE_TEST(timequery_one_element_index, log_builder_fixture) {
     b | stop();
 }
 
-FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
+FIXTURE_TEST(timequery_non_monotonic_segment, log_builder_fixture) {
     using namespace storage; // NOLINT
 
     b | start();
@@ -376,6 +376,241 @@ FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
 
     BOOST_TEST(res);
     BOOST_TEST(res->offset == model::offset(0));
+
+    b | stop();
+}
+
+FIXTURE_TEST(timequery_non_monotonic_log, log_builder_fixture) {
+    using namespace storage; // NOLINT
+
+    b | start();
+
+    // seg0:
+    // timestamps = [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009]
+    // offsets =    [0,    1,    2,    3,    4,    5,    6,    7,    8,    9   ]
+    // seg1:
+    // timestamps = [0]
+    // offsets =    [10]
+    std::vector<std::pair<model::offset, model::timestamp>> batch_spec0 = {
+      {model::offset(0), model::timestamp(1000)},
+      {model::offset(1), model::timestamp(1001)},
+      {model::offset(2), model::timestamp(1002)},
+      {model::offset(3), model::timestamp(1003)},
+      {model::offset(4), model::timestamp(1004)},
+      {model::offset(5), model::timestamp(1005)},
+      {model::offset(6), model::timestamp(1006)},
+      {model::offset(7), model::timestamp(1007)},
+      {model::offset(8), model::timestamp(1008)},
+      {model::offset(9), model::timestamp(1009)},
+    };
+    b | add_segment(0);
+    for (const auto& [offset, ts] : batch_spec0) {
+        auto batch = make_random_batch(offset, ts);
+        b | add_batch(std::move(batch));
+    }
+
+    std::vector<std::pair<model::offset, model::timestamp>> batch_spec1 = {
+      {model::offset(10), model::timestamp(0)},
+    };
+    b | add_segment(10);
+    for (const auto& [offset, ts] : batch_spec1) {
+        auto batch = make_random_batch(offset, ts);
+        b | add_batch(std::move(batch));
+    }
+
+    const auto& segs = b.get_log_segments();
+    BOOST_REQUIRE_EQUAL(segs.size(), 2);
+    for (const auto& seg : segs) {
+        BOOST_REQUIRE(seg->index().batch_timestamps_are_monotonic());
+    }
+
+    auto log = b.get_log();
+    for (const auto& [offset, ts] : batch_spec0) {
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(ts),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(res);
+        BOOST_REQUIRE_EQUAL(res->time, ts);
+        BOOST_REQUIRE_EQUAL(res->offset, offset);
+    }
+
+    // From KIP-33:
+    // "When searching by timestamp, broker will start from the earliest log
+    // segment and check the last time index entry. If the timestamp of the last
+    // time index entry is greater than the target timestamp, the broker will do
+    // binary search on that time index to find the closest index entry and scan
+    // the log from there. Otherwise it will move on to the next log segment."
+    // https://cwiki.apache.org/confluence/display/KAFKA/KIP-33+-+Add+a+time+based+log+index
+    // Per those rules, a timequery for a timestamp {0} will return a result
+    // from the first segment, not the second.
+    for (const auto& [offset, ts] : batch_spec1) {
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(ts),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(res);
+        BOOST_REQUIRE_EQUAL(res->time, model::timestamp{1000});
+        BOOST_REQUIRE_EQUAL(res->offset, model::offset{0});
+    }
+
+    // Query for a bogus, really small timestamp.
+    // We should return the first element in the log
+    storage::timequery_config config(
+      log->offsets().start_offset,
+      model::timestamp(-5000),
+      log->offsets().dirty_offset,
+      ss::default_priority_class(),
+      std::nullopt);
+
+    auto res = log->timequery(config).get();
+
+    BOOST_REQUIRE(res);
+    BOOST_REQUIRE_EQUAL(res->offset, model::offset(0));
+
+    b | stop();
+}
+
+FIXTURE_TEST(timequery_non_monotonic_log_many_segments, log_builder_fixture) {
+    using namespace storage; // NOLINT
+    b | start();
+
+    auto make_segment = [&](auto batch_spec) {
+        b | add_segment(batch_spec[0].first);
+        for (const auto& [offset, ts] : batch_spec) {
+            auto batch = make_random_batch(offset, ts);
+            b | add_batch(std::move(batch));
+        }
+    };
+
+    // seg0:
+    // timestamps = [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009]
+    // offsets =    [0,    1,    2,    3,    4,    5,    6,    7,    8,    9   ]
+    // seg1:
+    // timestamps = [0]
+    // offsets =    [10]
+    // seg2:
+    // timestamps = [1200]
+    // offsets =    [11]
+    // seg3:
+    // timestamps = [1500]
+    // offsets =    [12]
+    {
+        std::vector<std::pair<model::offset, model::timestamp>> batch_spec0 = {
+          {model::offset(0), model::timestamp(1000)},
+          {model::offset(1), model::timestamp(1001)},
+          {model::offset(2), model::timestamp(1002)},
+          {model::offset(3), model::timestamp(1003)},
+          {model::offset(4), model::timestamp(1004)},
+          {model::offset(5), model::timestamp(1005)},
+          {model::offset(6), model::timestamp(1006)},
+          {model::offset(7), model::timestamp(1007)},
+          {model::offset(8), model::timestamp(1008)},
+          {model::offset(9), model::timestamp(1009)},
+        };
+        make_segment(batch_spec0);
+        std::vector<std::pair<model::offset, model::timestamp>> batch_spec1 = {
+          {model::offset(10), model::timestamp(0)},
+        };
+        make_segment(batch_spec1);
+
+        std::vector<std::pair<model::offset, model::timestamp>> batch_spec2 = {
+          {model::offset(11), model::timestamp(1200)},
+        };
+        make_segment(batch_spec2);
+
+        std::vector<std::pair<model::offset, model::timestamp>> batch_spec3 = {
+          {model::offset(12), model::timestamp(1500)},
+        };
+        make_segment(batch_spec3);
+    }
+
+    const auto& segs = b.get_log_segments();
+    BOOST_REQUIRE_EQUAL(segs.size(), 4);
+    for (const auto& seg : segs) {
+        BOOST_REQUIRE(seg->index().batch_timestamps_are_monotonic());
+    }
+
+    auto log = b.get_log();
+
+    // Some hardcoded expected cases given the above batch specs.
+    {
+        // Query should land in seg0.
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(500),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(res);
+        BOOST_REQUIRE_EQUAL(res->time, model::timestamp{1000});
+        BOOST_REQUIRE_EQUAL(res->offset, model::offset{0});
+    }
+
+    {
+        // Query should land in seg2.
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(1010),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(res);
+        BOOST_REQUIRE_EQUAL(res->time, model::timestamp{1200});
+        BOOST_REQUIRE_EQUAL(res->offset, model::offset{11});
+    }
+    {
+        // Query should land in seg3.
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(1201),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(res);
+        BOOST_REQUIRE_EQUAL(res->time, model::timestamp{1500});
+        BOOST_REQUIRE_EQUAL(res->offset, model::offset{12});
+    }
+    {
+        // Query should land in seg3.
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(1499),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(res);
+        BOOST_REQUIRE_EQUAL(res->time, model::timestamp{1500});
+        BOOST_REQUIRE_EQUAL(res->offset, model::offset{12});
+    }
+    {
+        // Query should land outside log.
+        storage::timequery_config config(
+          log->offsets().start_offset,
+          model::timestamp(1501),
+          log->offsets().dirty_offset,
+          ss::default_priority_class(),
+          std::nullopt);
+
+        auto res = log->timequery(config).get();
+        BOOST_REQUIRE(!res);
+    }
 
     b | stop();
 }


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26830. `cherry-pick` conflict due to altered `timequery_test.cc` from previous version of `redpanda` (`Boost.Test` instead of `gtest` in this version)

Fixes https://github.com/redpanda-data/redpanda/issues/26838.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in timequeries performed over local `storage` which could lead to inconsistent or undefined results.
