### PR TITLE
[v25.2.x] c/p_probe: Reconfigure metrics when scrubbing enabled/disabled

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -28,9 +28,13 @@ static constexpr int64_t follower_iceberg_lag_metric = 0;
 
 replicated_partition_probe::replicated_partition_probe(
   const partition& p) noexcept
-  : _partition(p) {
+  : _partition(p)
+  , _enable_scrubbing_bind(
+      config::shard_local_cfg().cloud_storage_enable_scrubbing.bind()) {
     config::shard_local_cfg().enable_schema_id_validation.bind().watch(
       [this]() { reconfigure_metrics(); });
+
+    _enable_scrubbing_bind.watch([this]() { reconfigure_metrics(); });
 }
 
 void replicated_partition_probe::reconfigure_metrics() {
@@ -373,8 +377,8 @@ void replicated_partition_probe::setup_public_scrubber_metric(
     namespace sm = ss::metrics;
 
     // No point in setting up the scrubber metrics if there's no
-    // archival metadata STM to pull values from.
-    if (!_partition.archival_meta_stm()) {
+    // archival metadata STM to pull values from or if scrubbing is not enabled
+    if (!_partition.archival_meta_stm() || !_enable_scrubbing_bind()) {
         return;
     }
 

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "config/configuration.h"
 #include "metrics/metrics.h"
 #include "model/fundamental.h"
 
@@ -136,6 +137,7 @@ private:
     uint64_t _schema_id_validation_records_failed{0};
     int64_t _iceberg_translation_offset_lag{metric_default_initialized_state};
     int64_t _iceberg_commit_offset_lag{metric_default_initialized_state};
+    config::binding<bool> _enable_scrubbing_bind;
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
 };

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -657,3 +657,42 @@ class CloudStorageScrubberTest(RedpandaTest):
 
     def match_missing_segment(self, log_entry: str) -> bool:
         return any(expr.search(log_entry) for expr in self.expected_error_logs)
+
+    def _metrics_present(self, pattern: str,
+                         endpoint: MetricsEndpoint) -> bool:
+        return self.redpanda.metrics_sample(
+            pattern, metrics_endpoint=endpoint) is not None
+
+    @cluster(
+        num_nodes=3,
+        log_allow_list=SCRUBBER_LOG_ALLOW_LIST +
+        [AllowLogsOnPredicate(method="match_missing_segment")],
+    )
+    def test_no_metrics_if_scrubber_disabled(self):
+        self.logger.debug(
+            "We shouldn't publish anomaly metrics when scrubbing is turned off"
+        )
+
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_scrubbing": False})
+
+        assert not self._metrics_present('anomalies', MetricsEndpoint.PUBLIC_METRICS), \
+            "Unexpectedly found 'anomalies' on public metrics with scrubbing off"
+
+        assert not self._metrics_present('anomalies', MetricsEndpoint.METRICS), \
+            "Unexpectedly found 'anomalies' on internal metrics"
+
+        self.logger.debug(
+            "Now turn scrubbing back on and verify that public metrics appear")
+
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_enable_scrubbing": True})
+
+        wait_until(lambda: self._metrics_present(
+            'anomalies', MetricsEndpoint.PUBLIC_METRICS),
+                   timeout_sec=60,
+                   backoff_sec=5,
+                   err_msg="'anomalies' never appeared on public metrics")
+
+        assert not self._metrics_present('anomalies', MetricsEndpoint.METRICS), \
+            "Unexpectedly found 'anomalies' on internal metrics"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26836
