### PR TITLE
[v25.1.x] raft/voter_priority_tracker: fix first leader nepo

### DIFF
--- a/src/v/raft/voter_priority_tracker.h
+++ b/src/v/raft/voter_priority_tracker.h
@@ -71,7 +71,7 @@ public:
 private:
     vnode _self;
     std::optional<voter_priority> _replica_priority_override;
-    voter_priority _target_priority;
+    voter_priority _target_priority = voter_priority::max();
 };
 
 } // namespace raft

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -177,7 +177,8 @@ class RaftAvailabilityTest(RedpandaTest):
         # Find which node is the leader
         admin = Admin(self.redpanda)
         initial_leader_id, replicas = self._wait_for_leader()
-        assert initial_leader_id == replicas[0]
+        assert initial_leader_id == replicas[
+            0], f'expected leader id: {replicas[0]}, but found leader {initial_leader_id}'
 
         self._expect_available()
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26814
