### PR TITLE
[UX-254] rpk container: bump console version to 3.0

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -36,7 +36,7 @@ import (
 var (
 	tag               = "latest"
 	redpandaImageBase = "redpandadata/redpanda:" + tag
-	consoleImageBase  = "redpandadata/console:v2.8.5"
+	consoleImageBase  = "redpandadata/console:v3.1.2"
 )
 
 const (
@@ -621,29 +621,29 @@ func parseConsoleConfigFile(kafkaAddr, srAddr, adminAddr []string) (string, erro
 		Urls    []string `yaml:"urls"`
 	}
 	type Kafka struct {
-		Brokers        []string `yaml:"brokers"`
-		SchemaRegistry Listener `yaml:"schemaRegistry"`
+		Brokers []string `yaml:"brokers"`
 	}
 	type Redpanda struct {
 		AdminAPI Listener `yaml:"adminApi"`
 	}
 	type ConsoleCfg struct {
-		Kafka    Kafka    `yaml:"kafka"`
-		Redpanda Redpanda `yaml:"redpanda"`
+		Kafka          Kafka    `yaml:"kafka"`
+		Redpanda       Redpanda `yaml:"redpanda"`
+		SchemaRegistry Listener `yaml:"schemaRegistry"`
 	}
 	cfg := ConsoleCfg{
 		Kafka: Kafka{
 			Brokers: kafkaAddr,
-			SchemaRegistry: Listener{
-				Enabled: true,
-				Urls:    srAddr,
-			},
 		},
 		Redpanda: Redpanda{
 			AdminAPI: Listener{
 				Enabled: true,
 				Urls:    adminAddr,
 			},
+		},
+		SchemaRegistry: Listener{
+			Enabled: true,
+			Urls:    srAddr,
 		},
 	}
 	b, err := yaml.Marshal(cfg)

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -578,18 +578,13 @@ func checkConsole(node node) func() error {
 			httpapi.Host("http://"+node.addr),
 			httpapi.Retries(1),
 		)
-		var res map[string]bool
-		err := cl.Get(context.Background(), "/admin/startup", nil, &res)
+		// We use the /admin/startup  to check if the console is healthy, if we
+		// receive a 200 then we are good. httpapi errs on != 2xx.
+		err := cl.Get(context.Background(), "/admin/startup", nil, nil)
 		if err != nil {
-			return fmt.Errorf("error checking console status: %v", err)
+			return fmt.Errorf("console is not healthy; error while checking console status: %v", err)
 		}
-		if res["isHttpOk"] {
-			if res["isKafkaOk"] {
-				return nil
-			}
-			return errors.New("console is not healthy, Kafka API is not reachable from console")
-		}
-		return errors.New("console is not healthy")
+		return nil
 	}
 }
 


### PR DESCRIPTION
This includes a change in the configuration file
and now the probe does not return `isKafkaOk` due
to user impersonation.

Next step is to inject the console version on
build.

Fixes UX-254
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes


### Improvements

* rpk container now uses Redpanda Console version 3.1.2
