### PR TITLE
[v25.1.x] iceberg/config: validate REST endpoint configuration (MANUAL BACKPORT)

### DIFF
--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -345,6 +345,20 @@ validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
 }
 
 std::optional<ss::sstring>
+validate_iceberg_rest_catalog_config(const config::configuration& config) {
+    auto catalog_type = config.iceberg_catalog_type();
+    if (catalog_type == datalake_catalog_type::rest) {
+        const auto& endpoint = config.iceberg_rest_catalog_endpoint;
+        if (!endpoint().has_value()) {
+            return fmt::format(
+              "Must set {} when iceberg_catalog_type is set to 'rest'",
+              endpoint.name());
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<ss::sstring>
 validate_consumer_group_metrics(const std::vector<ss::sstring>& metrics) {
     constexpr auto supported = std::to_array<std::string_view>(
       {"group", "partition", "consumer_lag"});

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -64,6 +64,9 @@ std::optional<ss::sstring>
 validate_iceberg_rest_catalog_auth_mode(const configuration& config);
 
 std::optional<ss::sstring>
+validate_iceberg_rest_catalog_config(const configuration& config);
+
+std::optional<ss::sstring>
 validate_consumer_group_metrics(const std::vector<ss::sstring>& metrics);
 
 }; // namespace config

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1762,6 +1762,14 @@ void config_multi_property_validation(
           updated_config.cloud_storage_enable_remote_write.name());
     }
 
+    // Validate iceberg REST catalog configuration
+    auto catalog_err = config::validate_iceberg_rest_catalog_config(
+      updated_config);
+    if (catalog_err.has_value()) {
+        errors[ss::sstring{updated_config.iceberg_catalog_type.name()}]
+          = catalog_err.value();
+    }
+
     // Validate iceberg authentication mode properties
     auto opt_err = config::validate_iceberg_rest_catalog_auth_mode(
       updated_config);

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1801,6 +1801,43 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             self.redpanda.set_cluster_config(valid_props, expect_restart=True)
 
 
+class ClusterConfigIcebergTest(RedpandaTest):
+    """Class to test configuration with Iceberg enabled as a prerequisite.
+       This also requires cloud storage configuration."""
+    def __init__(self, test_context):
+        super().__init__(test_context, si_settings=SISettings(test_context))
+
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def test_iceberg_rest_catalog_endpoint_validation(self):
+        """
+        Tests that the Iceberg REST catalog endpoint validation works correctly.
+        """
+        # Enabling iceberg alone should work.
+        self.redpanda.set_cluster_config({'iceberg_enabled': True},
+                                         expect_restart=True)
+
+        # Setting catalog type to rest without endpoint should be rejected.
+        with expect_exception(requests.exceptions.HTTPError,
+                              lambda e: e.response.status_code == 400):
+            self.redpanda.set_cluster_config(
+                {
+                    'iceberg_enabled': True,
+                    'iceberg_catalog_type': 'rest'
+                },
+                expect_restart=True)
+
+        # Setting catalog type to rest with endpoint should work.
+        self.redpanda.set_cluster_config(
+            {
+                'iceberg_enabled': True,
+                'iceberg_catalog_type': 'rest',
+                'iceberg_rest_catalog_endpoint': 'http://localhost:8181'
+            },
+            expect_restart=True)
+
+
 """
 PropertyAliasData:
     primary_name: str  # this is the primary name in the current version of redpanda


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26831

Backport done manually due to a trivial conflict in admin/server.cc with some validation logic removed in later versions.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


### Improvements

* Redpanda will now validate that an Iceberg REST endpoint is set when cluster configuration is altered to enable the Iceberg REST catalog.
