### PR TITLE
`storage`: fix `storage_e2e_test` includes & dependencies

### DIFF
--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -627,6 +627,7 @@ redpanda_cc_gtest(
         "//src/v/random:generators",
         "//src/v/reflection:adl",
         "//src/v/resource_mgmt:memory_groups",
+        "//src/v/ssx:future_util",
         "//src/v/storage",
         "//src/v/storage:batch_cache",
         "//src/v/storage:record_batch_builder",

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -25,6 +25,7 @@
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "resource_mgmt/memory_groups.h"
+#include "ssx/future-util.h"
 #include "storage/batch_cache.h"
 #include "storage/disk_log_impl.h"
 #include "storage/log_housekeeping_meta.h"


### PR DESCRIPTION
Fix for possible merge race between https://github.com/redpanda-data/redpanda/pull/26677 and something else?

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
