### PR TITLE
json: update validator interface

### DIFF
--- a/src/v/cloud_storage/recovery_request.cc
+++ b/src/v/cloud_storage/recovery_request.cc
@@ -111,7 +111,7 @@ void recovery_request::parse_request_body(const ss::sstring& body) {
           "{}", rapidjson::GetParseError_En(document.GetParseError()))};
     }
 
-    auto validator = json::validator(std::string{request_schema});
+    auto validator = json::validator(request_schema);
     if (!document.Accept(validator.schema_validator)) {
         json::StringBuffer sbuf;
         json::Writer<json::StringBuffer> w{sbuf};

--- a/src/v/json/validator.h
+++ b/src/v/json/validator.h
@@ -14,19 +14,19 @@
 #include "json/stringbuffer.h"
 #include "json/writer.h"
 
-#include <string>
+#include <string_view>
 
 namespace json {
 
 struct validator {
-    explicit validator(const std::string& schema_text)
+    explicit validator(const std::string_view schema_text)
       : schema(make_schema_document(schema_text))
       , schema_validator(schema) {}
 
     static json::SchemaDocument
-    make_schema_document(const std::string& schema) {
+    make_schema_document(const std::string_view schema) {
         json::Document doc;
-        if (doc.Parse(schema).HasParseError()) {
+        if (doc.Parse(schema.data(), schema.size()).HasParseError()) {
             throw std::runtime_error(
               fmt::format("Invalid schema document: {}", schema));
         }

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -983,7 +983,7 @@ ss::future<ss::json::json_return_type> admin_server::get_node_uuid_handler() {
 }
 
 static json::validator make_broker_id_override_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {

--- a/src/v/redpanda/admin/migrations.cc
+++ b/src/v/redpanda/admin/migrations.cc
@@ -161,7 +161,7 @@ void write_migration_as_json(
 }
 
 json::validator make_migration_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -362,7 +362,7 @@ admin_server::unclean_abort_partition_reconfig_handler(
 namespace {
 
 json::validator make_set_replicas_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "array",
     "items": {
@@ -612,7 +612,7 @@ admin_server::set_partition_replicas_handler(
 
 namespace {
 json::validator make_set_replica_core_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {
@@ -1183,7 +1183,7 @@ admin_server::get_majority_lost_partitions(
 
 namespace {
 json::validator make_node_id_array_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
     {
       "type": "array",
       "items": {
@@ -1207,7 +1207,7 @@ parse_node_ids_from_json(const json::Document::ValueType& val) {
 }
 
 json::validator make_force_recover_partitions_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
   "type": "object",
   "properties": {
@@ -1288,7 +1288,7 @@ json::validator make_force_recover_partitions_validator() {
 }
 
 json::validator make_ntp_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
   "type": "object",
   "properties": {
@@ -1322,7 +1322,7 @@ model::ntp parse_ntp_from_json(const json::Document::ValueType& value) {
 }
 
 json::validator make_replicas_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
   "type": "array",
   "items": {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1532,7 +1532,7 @@ void admin_server::register_config_routes() {
 
 namespace {
 json::validator make_cluster_config_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {
@@ -2163,7 +2163,7 @@ void admin_server::register_status_routes() {
 
 namespace {
 json::validator make_feature_put_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {
@@ -2970,7 +2970,7 @@ void admin_server::register_hbadger_routes() {
 
 namespace {
 json::validator make_self_test_start_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {
@@ -3186,7 +3186,7 @@ admin_server::get_disk_stat_handler(std::unique_ptr<ss::http::request> req) {
 
 namespace {
 json::validator make_disk_stat_overrides_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {
@@ -3369,7 +3369,7 @@ admin_server::get_metrics_uuid(std::unique_ptr<ss::http::request>) {
 }
 
 static json::validator make_post_cluster_partitions_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {

--- a/src/v/redpanda/admin/topics.cc
+++ b/src/v/redpanda/admin/topics.cc
@@ -33,7 +33,7 @@ using admin::apply_validator;
 namespace {
 
 json::validator make_mount_configuration_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -88,7 +88,7 @@ json::validator make_mount_configuration_validator() {
 }
 
 json::validator make_unmount_array_validator() {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -136,7 +136,7 @@ admin_server::list_transforms(std::unique_ptr<ss::http::request>) {
 
 namespace {
 void validate_transform_deploy_document(const json::Document& doc) {
-    const std::string schema = R"(
+    const std::string_view schema = R"(
 {
     "type": "object",
     "properties": {

--- a/src/v/security/license.cc
+++ b/src/v/security/license.cc
@@ -99,7 +99,7 @@ license_components parse_license(std::string_view license) {
         license.substr(itr + strlen(signature_delimiter)))};
 }
 
-const char* const license_data_validator_schema_v0 = R"(
+constexpr std::string_view license_data_validator_schema_v0 = R"(
 {
     "type": "object",
     "properties": {
@@ -126,7 +126,7 @@ const char* const license_data_validator_schema_v0 = R"(
 }
 )";
 
-const char* const license_data_validator_schema_v1 = R"(
+constexpr std::string_view license_data_validator_schema_v1 = R"(
 {
     "type": "object",
     "properties": {
@@ -162,7 +162,7 @@ const char* const license_data_validator_schema_v1 = R"(
 struct license_data_parser {
     using data_parser = void (*)(license& lc, const json::Document& doc);
 
-    const char* schema;
+    std::string_view schema;
     data_parser parser;
 };
 

--- a/src/v/storage/file_sanitizer_types.h
+++ b/src/v/storage/file_sanitizer_types.h
@@ -21,7 +21,7 @@
 
 namespace storage {
 
-const std::string failure_injector_schema = R"(
+constexpr std::string_view failure_injector_schema = R"(
 {
     "type": "object",
     "properties": {


### PR DESCRIPTION
rapidjson works on its own internal string representation.
A string view is more appropriate than a string here.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
