### PR TITLE
ducktape: fix bad test case with acks=1

### DIFF
--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -271,7 +271,8 @@ class EndToEndTest(Test):
                        producer_timeout_sec=30,
                        consumer_timeout_sec=30,
                        enable_idempotence=False,
-                       enable_compaction=False):
+                       enable_compaction=False,
+                       acks=-1):
         try:
             self.await_num_produced(min_records, producer_timeout_sec)
 
@@ -281,7 +282,8 @@ class EndToEndTest(Test):
             self.run_consumer_validation(
                 consumer_timeout_sec=consumer_timeout_sec,
                 enable_idempotence=enable_idempotence,
-                enable_compaction=enable_compaction)
+                enable_compaction=enable_compaction,
+                acks=acks)
         except BaseException:
             self._collect_all_logs()
             raise
@@ -289,7 +291,8 @@ class EndToEndTest(Test):
     def run_consumer_validation(self,
                                 consumer_timeout_sec=30,
                                 enable_idempotence=False,
-                                enable_compaction=False) -> None:
+                                enable_compaction=False,
+                                acks=-1) -> None:
         try:
             # Take copy of this dict in case a rogue VerifiableProducer
             # thread modifies it.
@@ -304,7 +307,7 @@ class EndToEndTest(Test):
 
             self.consumer.stop()
 
-            self.validate(enable_idempotence, enable_compaction)
+            self.validate(enable_idempotence, enable_compaction, acks)
         except BaseException:
             self._collect_all_logs()
             raise
@@ -367,15 +370,18 @@ class EndToEndTest(Test):
 
         return success, msg
 
-    def validate(self, enable_idempotence, enable_compaction):
+    def validate(self, enable_idempotence, enable_compaction, acks=-1):
+        assert acks in [-1, 1], "acks must be -1 or 1"
+
         self.logger.info("Number of acked records: %d" %
                          len(self.producer.acked))
         self.logger.info("Number of consumed records: %d" %
                          len(self.records_consumed))
-
         success = True
         msg = ""
+
         if enable_compaction:
+            assert acks != 1, "use acks=-1 if validating compaction"
             success, msg = self.validate_compacted()
         else:
             # Correctness of the set difference operation depends on using equivalent
@@ -383,9 +389,14 @@ class EndToEndTest(Test):
             missing = set(self.producer.acked) - set(self.records_consumed)
 
             if len(missing) > 0:
-                success = False
-                msg = annotate_missing_msgs(missing, self.producer.acked,
-                                            self.records_consumed, msg)
+                if acks == -1:
+                    success = False
+                    msg = annotate_missing_msgs(missing, self.producer.acked,
+                                                self.records_consumed, msg)
+                else:
+                    # Losing leader-acked messages is bad but acceptable.
+                    msg += f"Detected {len(missing)} messages that were acked but not consumed. " \
+                           f"This is acceptable with acks=1.\n"
 
             # Are there duplicates?
             if len(set(self.records_consumed)) != len(self.records_consumed):

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -142,6 +142,7 @@ class SimpleEndToEndTest(EndToEndTest):
         fi_thread.start()
         self.run_validation(min_records=100000,
                             producer_timeout_sec=300,
-                            consumer_timeout_sec=300)
+                            consumer_timeout_sec=300,
+                            acks=acks)
         stop_fi_ev.set()
         fi_thread.join()


### PR DESCRIPTION
`test_relaxed_acks` had one parameterization running with `acks=1`, but it expected that the consumer would see exactly the set of offsets that were acked to the producers, even with injected node failures. This is not always the case:
1. If the leader acks a message but doesn't have time to replicate it before failing, and a new leader is elected while the original leader is down, the original leader will truncate the acked message from its log and no consumer will see it.
2. If the leader acks a message but doesn't have time to replicate or flush it to disk before failing, and the leader is reelected when it restarts, it may lose the message and no consumer will see it.
 
Situation 2 was recently seen in CI.

This change adjust validation to allow for messages to go missing when `acks=1`.

Fixes CORE-12793

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

