### PR TITLE
[v25.2.x] [CORE-6875] `cloud_storage`: fall back to main manifest search in `async_manifest_view::get_term_last_offset()`

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -741,9 +741,18 @@ async_manifest_view::get_term_last_offset(model::term_id term) noexcept {
             }
         }
     } else if (stmm.get_archive_start_offset() != model::offset{}) {
+        // The desired term might be bounded within the spillover manifests
         const auto spill_index = get_spillover_upper_bound_by_term(term);
         if (!spill_index.has_value()) {
-            co_return std::nullopt;
+            // The first segment in the main manifest must be the one we are
+            // searching for, since stmm.begin()->segment_term > term and we
+            // didn't find a higher term in the spillover manifest. This implies
+            // the term boundary is between spillover region and main manifest.
+            // For example:
+            // Main manifest: [2, 3], Spillover map: [[0], [1]], desired term =
+            // 1, there is no higher bound in the spillover map and
+            // stmm.begin()->segment_term > term.
+            co_return stmm.begin()->base_kafka_offset() - kafka::offset(1);
         }
 
         vlog(

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -1245,3 +1245,43 @@ FIXTURE_TEST(
           .get();
     }
 }
+
+FIXTURE_TEST(
+  test_async_manifest_view_get_term_last_offset_with_spillover_edge_case,
+  async_manifest_view_fixture) {
+    using t = model::term_id;
+    using o = model::offset;
+    int num_segments = 4;
+    std::vector<segment_meta> segs;
+    segs.reserve(num_segments);
+    int ts_step = 10;
+    int o_step = 10;
+    for (int i = 0; i < num_segments; ++i) {
+        segs.push_back(segment_meta{
+          .size_bytes = 4097,
+          .base_offset = o{i * o_step},
+          .committed_offset = o{(i + 1) * o_step - 1},
+          .base_timestamp = model::timestamp{i * ts_step},
+          .max_timestamp = model::timestamp{i * ts_step + 1},
+          .segment_term = t{i}});
+    }
+    auto target_term = model::term_id{1};
+    // Populate 2 spillover manifests in map. The desired term,
+    // model::term_id{1}, is going to be the last entry in the spillover
+    // manifests, i.e there will be no higher term entry in
+    // `get_segment_term_column`, and the main manifest contains no segments
+    // with a lower term than the desired term:
+    // Main manifest: [2, 3]
+    // Spillover map: [[0], [1]]
+    // We should expect that when we fail to find a result in the spillover map
+    // via `get_spillover_upper_bound_by_term()`, we still fall back to
+    // searching the main manifest for the term's last offset.
+    add_segments_to_stm_manifest(segs);
+    trigger_spillover(1);
+    trigger_spillover(1);
+
+    auto offset = view.get_term_last_offset(target_term).get();
+    BOOST_REQUIRE(offset.has_value());
+    BOOST_REQUIRE(offset.value().has_value());
+    BOOST_REQUIRE_EQUAL(offset.value().value(), kafka::offset{19});
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26860
