### PR TITLE
dt/si: Dial timeouts way down in fast uploads mode

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -642,6 +642,9 @@ class SISettings:
         self.before_call_headers = before_call_headers
         self.addressing_style = addressing_style
 
+        self.cloud_storage_segment_upload_timeout_ms = None
+        self.cloud_storage_manifest_upload_timeout_ms = None
+
         # Allow disabling end of test scrubbing.
         # It takes a long time with lots of segments i.e. as created in scale
         # tests. Should figure out how to re-enable it, or consider using
@@ -651,6 +654,9 @@ class SISettings:
         if fast_uploads:
             self.cloud_storage_segment_max_upload_interval_sec = 10
             self.cloud_storage_manifest_max_upload_interval_sec = 1
+            # with fast uploads enabled, it's better to fail a problematic
+            # segment upload or download quickly so we can try again
+            self.cloud_storage_segment_upload_timeout_ms = 15000
 
         self._expected_damage_types = set()
 
@@ -883,6 +889,14 @@ class SISettings:
         if self.cloud_storage_max_throughput_per_shard:
             conf[
                 'cloud_storage_max_throughput_per_shard'] = self.cloud_storage_max_throughput_per_shard
+
+        if self.cloud_storage_segment_upload_timeout_ms is not None:
+            conf[
+                'cloud_storage_segment_upload_timeout_ms'] = self.cloud_storage_segment_upload_timeout_ms
+
+        if self.cloud_storage_manifest_upload_timeout_ms is not None:
+            conf[
+                'cloud_storage_manifest_upload_timeout_ms'] = self.cloud_storage_manifest_upload_timeout_ms
 
         # Enable scrubbing in testing unless it was explicitly disabled.
         if 'cloud_storage_enable_scrubbing' not in conf:

--- a/tests/rptest/tests/archive_retention_test.py
+++ b/tests/rptest/tests/archive_retention_test.py
@@ -22,7 +22,7 @@ from rptest.services.redpanda import CloudStorageType, SISettings, MetricsEndpoi
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (produce_until_segments, produce_total_bytes,
                          wait_for_local_storage_truncate, segments_count,
-                         expect_exception)
+                         expect_exception, wait_until_with_progress_check)
 from rptest.utils.si_utils import BucketView, NTP, quiesce_uploads
 
 
@@ -104,15 +104,18 @@ class CloudArchiveRetentionTest(RedpandaTest):
         def produce_until_spillover():
             initial_uploaded = self.num_manifests_uploaded()
 
-            def new_manifest_spilled():
+            def new_manifest_spilled(get_num_spilled):
                 self.produce(topic, 300)
-                num_spilled = self.num_manifests_uploaded()
+                num_spilled = get_num_spilled()
                 return num_spilled > initial_uploaded + 10
 
-            wait_until(new_manifest_spilled,
-                       timeout_sec=120,
-                       backoff_sec=10,
-                       err_msg="Manifests were not created")
+            wait_until_with_progress_check(
+                self.num_manifests_uploaded,
+                condition=new_manifest_spilled,
+                timeout_sec=360,
+                progress_sec=60,
+                backoff_sec=10,
+                err_msg="Manifests were not created")
 
         wait_for_topic()
         produce_until_spillover()

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -12,6 +12,7 @@ import pprint
 import threading
 from contextlib import contextmanager
 from typing import Callable, Optional, Any, ContextManager
+from logging import Logger
 
 from ducktape.utils.util import wait_until
 from requests.exceptions import HTTPError
@@ -20,6 +21,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.storage import Segment
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.errors import TimeoutError
 
 
 class Scale:
@@ -123,6 +125,61 @@ def wait_until_result(condition: Callable[[], Any], *args: Any,
 
     wait_until(wrapped_condition, *args, **kwargs)
     return res
+
+
+def wait_until_with_progress_check(check: Callable[[], Any],
+                                   condition: Callable[[Callable[[], Any]],
+                                                       Any],
+                                   timeout_sec: int,
+                                   progress_sec: int,
+                                   backoff_sec: int,
+                                   err_msg: str | None = None,
+                                   logger: Logger | None = None):
+    """
+    a wrapper around ducktape's wait_until that provides the ability to track
+    a crude approximation of progress
+
+    usage requires two timeouts:
+      - timeout_sec: the overall timeout, after which the function will throw a
+        TimeoutError no matter what
+      - progress_sec: an incremental timeout, after each expiry we check that the
+        value returned by a 'check' function has changed with respect to a cached
+        result. if not, immediately throw TimeoutError
+
+    params:
+      - check: the value we expect to change after each 'progress_sec'
+      - condition: the condition we are waiting for. should be written in terms
+        of the check function, e.g.
+        check:
+           def get_val():
+               return admin.stuff()['val']
+        condition:
+           def condition(check: Callable):
+               return check() > 10
+           # used like
+           condition(get_val)
+      - timeout_sec (see above)
+      - progress_sec (see above)
+      - err_msg: Passed down to wait_until
+      - logger: log progress after each progress_sec iteration
+    """
+    val = check()
+    while timeout_sec > 0:
+        try:
+            wait_until(lambda: condition(check),
+                       timeout_sec=progress_sec,
+                       backoff_sec=backoff_sec,
+                       err_msg=err_msg)
+        except TimeoutError as e:
+            next_v = check()
+            if next_v == val:
+                raise TimeoutError(f"Stopped making progress: {str(e)}")
+            if logger is not None:
+                logger.debug(f"Progress: prev: {val} curr: {next_v}...")
+            val = next_v
+            timeout_sec = timeout_sec - progress_sec
+        else:
+            break
 
 
 def segments_count(redpanda, topic, partition_idx):


### PR DESCRIPTION
In at least one ducktape test, we can get into a situation where a leadership transfer followed by a faulty volley of segment uploads can eat away most of our time budget for the test. To account for that, simply dial down the upload timeouts, operating under the assumption that fast uploads should result in smaller segments.

Also introduces `rptest.util.wait_until_with_progress_check`, which allows us to set a longer top-level timeout that short circuits if some specified value stops changing.

Ran the problematic test config against this change a whole bunch of times (3 x 350 x 2) w/ no failures:
- [ducktape-debug](https://buildkite.com/redpanda/redpanda/builds/69260#01981c35-2727-482f-89c2-a93c4477c6a8)
- [ducktape-release](https://buildkite.com/redpanda/redpanda/builds/69260#01981c35-272f-4cdc-9173-83467295bb70)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
