### PR TITLE
archival: treat purge key_not_found error as success

### DIFF
--- a/src/v/cluster/archival/purger.cc
+++ b/src/v/cluster/archival/purger.cc
@@ -271,8 +271,13 @@ ss::future<purger::purge_result> purger::purge_manifest(
       bucket, {format, manifest_key}, manifest, manifest_purge_rtc);
 
     if (manifest_get_result == download_result::notfound) {
-        vlog(ctxlog.debug, "Partition manifest get {} not found", manifest_key);
-        result.status = purge_status::permanent_failure;
+        vlog(
+          ctxlog.debug,
+          "Partition manifest get {} not found, assuming success",
+          manifest_key);
+        // It's possible multiple purgers raced and a different node succeeded
+        // in purging the manifest, so treat this as a success.
+        result.status = purge_status::success;
         co_return result;
     } else if (manifest_get_result != download_result::success) {
         vlog(


### PR DESCRIPTION
It's possible for multiple nodes to attempt to purge a given manifest. This can result in an error warning like:

```
INFO  2025-07-16 06:18:02,802 [shard 1:au  ] archival - [fiber1~1~1|0|19999ms] - purger.cc:267 - Purging manifest at "396eb6a1-e64d-4d73-ac93-b9530617272b/meta/kafka/fuzzy-operator-9185-qrolkq/0_56/manifest.bin" and its contents for partition {kafka/fuzzy-operator-9185-qrolkq/0}
DEBUG 2025-07-16 06:18:02,802 [shard 1:au  ] cloud_io - [fiber1~1~1~0|1|19999ms] - remote.cc:503 - Downloading manifest from "396eb6a1-e64d-4d73-ac93-b9530617272b/meta/kafka/fuzzy-operator-9185-qrolkq/0_56/manifest.bin"
WARN  2025-07-16 06:18:02,802 [shard 1:au  ] s3 - s3_client.cc:784 - S3 GET request failed for key "396eb6a1-e64d-4d73-ac93-b9530617272b/meta/kafka/fuzzy-operator-9185-qrolkq/0_56/manifest.bin": Not Found [Accept-Ranges: bytes];[Content-Length: 539];[Content-Type: application/xml];[Server: MinIO];[Strict-Transport-Security: max-age=31536000; includeSubDomains];[Vary: Origin];[Vary: Accept-Encoding];[X-Amz-Id-2: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8];[X-Amz-Request-Id: 1852A6DF41347267];[X-Content-Type-Options: nosniff];[X-Ratelimit-Limit: 55414];[X-Ratelimit-Remaining: 55413];[X-Xss-Protection: 1; mode=block];[Date: Wed, 16 Jul 2025 06:18:02 GMT];
WARN  2025-07-16 06:18:02,802 [shard 1:au  ] cloud_io - [fiber1~1~1~0|1|19998ms] - remote.cc:571 - Downloading manifest from panda-bucket-25080860-620c-11f0-9796-0242c0a8d733, {key_not_found}, manifest at "396eb6a1-e64d-4d73-ac93-b9530617272b/meta/kafka/fuzzy-operator-9185-qrolkq/0_56/manifest.bin" not available
ERROR 2025-07-16 06:18:02,802 [shard 1:au  ] archival - [fiber1~1|0|19998ms] - purger.cc:171 - Permanent failures encountered while purging partition {kafka/fuzzy-operator-9185-qrolkq/0}. Giving up ...
```

This is in fact a benign race, since ultimately, the manifest has been purged. This commit changes this case to be treated as a purge success for the "missing" manifest.

Fixes https://redpandadata.atlassian.net/browse/CORE-6890

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
