### PR TITLE
[CORE-9134] `rptest`: deflake `cloud_storage_chunk_read_path_test`

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -17,7 +17,7 @@ from rptest.services.redpanda import RedpandaService
 from rptest.services.redpanda import SISettings
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import Scale
-from rptest.util import wait_for_removal_of_n_segments
+from rptest.util import produce_until_segments, wait_for_removal_of_n_segments
 from rptest.utils.si_utils import nodes_report_cloud_segments
 
 
@@ -115,15 +115,23 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
                                        msg_count=msg_count,
                                        custom_node=self.preallocated_nodes)
         producer.start()
-        wait_until(
-            lambda: nodes_report_cloud_segments(self.redpanda, n_segments),
-            timeout_sec=180,
-            backoff_sec=3)
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=n_segments,
+        )
+        snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
+            "kafka", self.topic, 0)
+
         producer.stop()
         producer.wait()
 
-        snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
-            "kafka", self.topic, 0)
+        wait_until(lambda: nodes_report_cloud_segments(
+            self.redpanda, n_segments, topic_name=self.topic),
+                   timeout_sec=180,
+                   backoff_sec=3)
+
         for t in self.topics:
             self.client().alter_topic_config(
                 t.name, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,


### PR DESCRIPTION
1. Wait for `n` local `segment`s to be produced, then take the initial snapshot instead of waiting for `n` `segment`s to be present in the cloud (the latter could result in some of the initially produced and uploaded `segment`s having already been removed by the time the snapshot is taken)
2. The `wait_until()` function forgot to pass the topic name, meaning that all topics were being considered when counting the number of `segment` in cloud storage. This can lead to a timeout later, when we are instead waiting for `n` `segment`s to be removed from local storage.

JIRA: https://redpandadata.atlassian.net/browse/CORE-9134, also https://redpandadata.atlassian.net/browse/CORE-8734

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
