### PR TITLE
`kafka`: `maybe_yield()` in `group_manager::list_groups`

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1698,7 +1698,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
     co_return response;
 }
 
-std::pair<error_code, chunked_vector<listed_group>>
+ss::future<std::pair<error_code, chunked_vector<listed_group>>>
 group_manager::list_groups(const list_groups_filter_data& filter_data) const {
     auto loading = std::any_of(
       _partitions.cbegin(),
@@ -1721,12 +1721,13 @@ group_manager::list_groups(const list_groups_filter_data& filter_data) const {
                g->protocol_type().value_or(protocol_type()),
                group_state_to_kafka_name(g->state())});
         }
+        co_await ss::maybe_yield();
     }
 
     auto error = loading ? error_code::coordinator_load_in_progress
                          : error_code::none;
 
-    return std::make_pair(error, std::move(groups));
+    co_return std::make_pair(error, std::move(groups));
 }
 
 described_group

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -175,7 +175,7 @@ public:
 
     // returns the set of registered groups, and an error if one occurred while
     // retrieving the group list (e.g. coordinator_load_in_progress).
-    std::pair<error_code, chunked_vector<listed_group>>
+    ss::future<std::pair<error_code, chunked_vector<listed_group>>>
     list_groups(const list_groups_filter_data& filter_data = {}) const;
 
     described_group describe_group(const model::ntp&, const kafka::group_id&);

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -40,11 +40,14 @@ struct group_manager_fixture
         co_await app.group_initializer.local().assure_topic_exists();
         co_await wait_for_leader(offsets_ntp);
         // Wait until the partitions are registered.
-        RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [this] {
-            auto& gm = app._group_manager;
-            auto [ec, _] = gm.local().list_groups();
-            return ec == kafka::error_code::none
-                   && gm.local().attached_partitions_count() == 1;
+        auto& gm = app._group_manager;
+        RPTEST_REQUIRE_EVENTUALLY_CORO(10s, [&gm] {
+            return gm.local().list_groups().then([&gm](auto res) {
+                auto& ec = res.first;
+                return ss::make_ready_future<bool>(
+                  ec == kafka::error_code::none
+                  && gm.local().attached_partitions_count() == 1);
+            });
         });
         co_await wait_for_version_fence();
     }


### PR DESCRIPTION
There were some reactor stalls occuring in this function on a cluster with a large number of consumer groups (see: https://gist.github.com/ballard26/749c8432bf29f2eb0df0393c51e935ef)

Co-routinize the function and call `ss::maybe_yield()` within the `for` loop over the `_groups` to help prevent reactor stalls here.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
