### PR TITLE
`storage`: deflake `compaction_e2e_test`

### DIFF
--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -1182,10 +1182,6 @@ TEST_P(
                     tombstone_retention_ms)
                     .get();
 
-    // Compaction will only have occurred if tombstones were eligible for
-    // deletion.
-    ASSERT_EQ(did_compact, wait_for_retention_ms);
-
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());
         consumer.start().get();
@@ -1339,10 +1335,6 @@ TEST_P(
                     log->segments().back()->offsets().get_base_offset(),
                     tombstone_retention_ms)
                     .get();
-
-    // Compaction will only have occurred if tombstones were eligible for
-    // deletion.
-    ASSERT_EQ(did_compact, wait_for_retention_ms);
 
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());


### PR DESCRIPTION
These two conditions are 1. flakey (due to timing) and 2. not helpful for proving that tombstones were removed from the `log`, as this fact will be proven afterwards using a Kafka consumer.

Remove them to deflake the test (test coverage remains identical thanks to other expectations/checks in the test).

Test is [99.87%](https://buildkite.com/organizations/redpanda/analytics/suites/redpanda-unit/tests/f2df3859-5e61-8ff1-8a26-ae9ef0b7f463?period=28days&tags=scm.branch%3Adev) reliable in `dev`, but let's make it 100%.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
