### PR TITLE
c/a/test: Check that term doesn't change across sync call

### DIFF
--- a/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/cluster/archival/tests/archival_metadata_stm_gtest.cc
@@ -321,6 +321,9 @@ TEST_F_CORO(
     // Allow replication to progress.
     may_resume_append->set_value();
 
+    auto term_before_sync = co_await with_leader(
+      10s, [](raft::raft_node_instance& node) { return node.raft()->term(); });
+
     // This sync will succeed and will wait for replication to progress.
     auto synced = co_await with_leader(
       10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
@@ -342,7 +345,7 @@ TEST_F_CORO(
       });
 
     ASSERT_EQ_CORO(committed_offset, model::offset{2});
-    ASSERT_EQ_CORO(term, model::term_id{1});
+    ASSERT_EQ_CORO(term, term_before_sync);
 
     co_await wait_for_apply();
 }
@@ -466,6 +469,9 @@ TEST_F_CORO(
     // Allow replication to progress.
     may_resume_append->set_value();
 
+    auto term_before_sync = co_await with_leader(
+      10s, [](raft::raft_node_instance& node) { return node.raft()->term(); });
+
     // This sync will succeed and will wait for replication to progress.
     auto synced = co_await with_leader(
       10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
@@ -490,7 +496,7 @@ TEST_F_CORO(
       });
 
     ASSERT_EQ_CORO(committed_offset, model::offset{2});
-    ASSERT_EQ_CORO(term, model::term_id{1});
+    ASSERT_EQ_CORO(term, term_before_sync);
 
     co_await wait_for_apply();
 }


### PR DESCRIPTION
These tests are intended to check that sync operations w/in a single raft term behave in a certain way. Previously the test would assert that the rafter term after a successful sync operation matches a specific, hard-coded value.

This seems to be a fine assumption in the vast majority of cases, but the test has failed at least once in CI. It appears that this assertion could fail in either of two cases:
1. sync unexpectedly succeeded across a raft term boundary, in which case the test should fail.
2. leader election took place _prior_ to kicking off the sync operation, in which case we should be asserting on the term ID after that election and the test should pass.

This commit changes the assert to instead compare the term after sync to the term before sync. This should eliminate the possibility of asserting on (2).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
