### PR TITLE
thirdparty: update seastar to 0aed36eee620e

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -216,7 +216,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "REzNykznEh60llakuEM7hqmCATk1NXMEyLmDs4sdq5o=",
+        "bzlTransitiveDigest": "iyNO4ZbKbGaef4pf9ZlHorArakMobBDVn0pXB783lcY=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -387,9 +387,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "4f64324c068aff7fec3cb9bba9b49bd876b0a07889de325a38385463716af18a",
-              "strip_prefix": "seastar-8a5ef9d49b50d2056637db761938fbf23a35013b",
-              "url": "https://github.com/redpanda-data/seastar/archive/8a5ef9d49b50d2056637db761938fbf23a35013b.tar.gz"
+              "sha256": "1ec7a91eef59a3d5d0761517807c0b1762f83174c2a6a8efe3dc0b3840901dc1",
+              "strip_prefix": "seastar-0aed36eee620e95c0c8289801824ca52091a0e66",
+              "url": "https://github.com/redpanda-data/seastar/archive/0aed36eee620e95c0c8289801824ca52091a0e66.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -162,9 +162,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "4f64324c068aff7fec3cb9bba9b49bd876b0a07889de325a38385463716af18a",
-        strip_prefix = "seastar-8a5ef9d49b50d2056637db761938fbf23a35013b",
-        url = "https://github.com/redpanda-data/seastar/archive/8a5ef9d49b50d2056637db761938fbf23a35013b.tar.gz",
+        sha256 = "1ec7a91eef59a3d5d0761517807c0b1762f83174c2a6a8efe3dc0b3840901dc1",
+        strip_prefix = "seastar-0aed36eee620e95c0c8289801824ca52091a0e66",
+        url = "https://github.com/redpanda-data/seastar/archive/0aed36eee620e95c0c8289801824ca52091a0e66.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Update seastar ref to tip of v25.2.x branch.

This primarily brings in Alpine build fixes and addr2line optimizations.

Fixes CORE-12786.

This should go into 25.2 as well as this is the 25.2.x branch of seastar (and we want the addr2line opts there as well).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


