### PR TITLE
[v25.2.x] thirdparty: update seastar to 0aed36eee620e

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -216,7 +216,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "REzNykznEh60llakuEM7hqmCATk1NXMEyLmDs4sdq5o=",
+        "bzlTransitiveDigest": "iyNO4ZbKbGaef4pf9ZlHorArakMobBDVn0pXB783lcY=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -387,9 +387,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "4f64324c068aff7fec3cb9bba9b49bd876b0a07889de325a38385463716af18a",
-              "strip_prefix": "seastar-8a5ef9d49b50d2056637db761938fbf23a35013b",
-              "url": "https://github.com/redpanda-data/seastar/archive/8a5ef9d49b50d2056637db761938fbf23a35013b.tar.gz"
+              "sha256": "1ec7a91eef59a3d5d0761517807c0b1762f83174c2a6a8efe3dc0b3840901dc1",
+              "strip_prefix": "seastar-0aed36eee620e95c0c8289801824ca52091a0e66",
+              "url": "https://github.com/redpanda-data/seastar/archive/0aed36eee620e95c0c8289801824ca52091a0e66.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -162,9 +162,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "4f64324c068aff7fec3cb9bba9b49bd876b0a07889de325a38385463716af18a",
-        strip_prefix = "seastar-8a5ef9d49b50d2056637db761938fbf23a35013b",
-        url = "https://github.com/redpanda-data/seastar/archive/8a5ef9d49b50d2056637db761938fbf23a35013b.tar.gz",
+        sha256 = "1ec7a91eef59a3d5d0761517807c0b1762f83174c2a6a8efe3dc0b3840901dc1",
+        strip_prefix = "seastar-0aed36eee620e95c0c8289801824ca52091a0e66",
+        url = "https://github.com/redpanda-data/seastar/archive/0aed36eee620e95c0c8289801824ca52091a0e66.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26904
