### PR TITLE
pp/reply: handle sleep_aborted exception

### DIFF
--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -137,14 +137,19 @@ inline auto unprocessable_entity(ss::sstring msg) {
       std::move(msg));
 }
 
+inline auto shutdown_exception_reply(const std::exception& e) {
+    auto eb = errored_body(reply_error_code::kafka_retriable_error, e.what());
+    eb.set_reply_unavailable();
+    return eb;
+}
+
 inline auto exception_reply(ss::logger& log, std::exception_ptr e) {
     try {
         std::rethrow_exception(e);
     } catch (const ss::gate_closed_exception& e) {
-        auto eb = errored_body(
-          reply_error_code::kafka_retriable_error, e.what());
-        eb.set_reply_unavailable();
-        return eb;
+        return shutdown_exception_reply(e);
+    } catch (const ss::abort_requested_exception& e) {
+        return shutdown_exception_reply(e);
     } catch (const json::exception_base& e) {
         return errored_body(e.error, e.what());
     } catch (const parse::exception_base& e) {


### PR DESCRIPTION
Added handling the `seastar::sleep_aborted` exception in the same way as `gate_close_exception` is being handled. The sleep aborted exception is indicating the application is shutting down. The same way as the gate closed exception does.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none