### PR TITLE
kafka/server: Enable fetch_test

### DIFF
--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -739,7 +739,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_gtest(
+redpanda_cc_btest(
     name = "fetch_test",
     timeout = "short",
     srcs = [
@@ -751,7 +751,6 @@ redpanda_cc_gtest(
         "//src/v/kafka/server",
         "//src/v/model",
         "//src/v/redpanda/tests:fixture",
-        "//src/v/test_utils:gtest",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@fmt",


### PR DESCRIPTION
The test was incorrectly using gtest instead of btest, which meant that no tests were registered or run.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
