### PR TITLE
ts: Use scheduling group to do disk I/O

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1451,9 +1451,19 @@ remote_segment_batch_reader::remote_segment_batch_reader(
 
 ss::future<result<chunked_circular_buffer<model::record_batch>>>
 remote_segment_batch_reader::read_some(
-  model::timeout_clock::time_point,
+  model::timeout_clock::time_point timeout,
   storage::offset_translator_state& ot_state) {
     ss::gate::holder h(_gate);
+    return _seg
+      ->with_scheduling_group(
+        [this, timeout, &ot_state] { return do_read_some(timeout, ot_state); })
+      .finally([h = std::move(h)] {});
+}
+
+ss::future<result<chunked_circular_buffer<model::record_batch>>>
+remote_segment_batch_reader::do_read_some(
+  model::timeout_clock::time_point,
+  storage::offset_translator_state& ot_state) {
     if (_ringbuf.empty()) {
         if (!_parser) {
             // remote_segment_batch_reader shouldn't be used concurrently

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -179,6 +179,12 @@ public:
 
     size_t concurrency() { return _api.concurrency(); }
 
+    template<class Fn>
+    auto with_scheduling_group(Fn&& fn) {
+        return ss::with_scheduling_group(
+          _api.resources().get_scheduling_group(), std::forward<Fn>(fn));
+    }
+
 private:
     /// get a file offset for the corresponding kafka offset
     /// if the index is available
@@ -427,6 +433,10 @@ public:
 private:
     friend class single_record_consumer;
     ss::future<std::unique_ptr<storage::continuous_batch_parser>> init_parser();
+
+    ss::future<result<chunked_circular_buffer<model::record_batch>>>
+    do_read_some(
+      model::timeout_clock::time_point, storage::offset_translator_state&);
 
     size_t produce(model::record_batch batch);
 


### PR DESCRIPTION
Currently, the ts_read_sg consumer group is only used for segment hydration. This allows the reader that consumes from the cloud storage cache to saturate the disk t-put. This commit fixes that by shifting stream creation operation to also run under the scheduling group.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none