### PR TITLE
[v25.2.x] kafka/server: Enable fetch_test

### DIFF
--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -739,7 +739,7 @@ redpanda_cc_gtest(
     ],
 )
 
-redpanda_cc_gtest(
+redpanda_cc_btest(
     name = "fetch_test",
     timeout = "short",
     srcs = [
@@ -751,7 +751,6 @@ redpanda_cc_gtest(
         "//src/v/kafka/server",
         "//src/v/model",
         "//src/v/redpanda/tests:fixture",
-        "//src/v/test_utils:gtest",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@fmt",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26911
