### PR TITLE
tests: compare with v25.2.x branch for pass criteria

### DIFF
--- a/tests/ducktape-common-retry.yml
+++ b/tests/ducktape-common-retry.yml
@@ -8,14 +8,14 @@ zero-drift: &zero-drift
   zero-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v25.2.x
         time_window: 2w
         allowed_drift: 0 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)
   fifty-drift:
     mode:
       dynamic_reliability:
-        compare_with_branch: dev
+        compare_with_branch: v25.2.x
         time_window: 2w
         allowed_drift: 50 # upstream_reliability - current_ci_reliability <= allowed_drift
         fallback_reliability: 90.0 # when reliability cannot be fetched from branch (e.g. new test)


### PR DESCRIPTION
Now that `v25.2.x` is cut and test results are available, the pt auto-retry config should compare with `v25.2.x` branch

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
