### PR TITLE
cloud_storage_clients/s3_client: tmp log skip

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -144,6 +144,15 @@ DEFAULT_LOG_ALLOW_LIST = [
     # the catalog that have "Assert" in them. These are typically benign and
     # just indicate a race in committing to Iceberg.
     re.compile(r"UpdateRequirement.*Assert"),
+
+    # Temporary: https://redpandadata.atlassian.net/browse/CORE-9897
+    # there is an ongoing investigation into s3_client receiving 400 Bad Request. For now, stop the CI bleed
+    re.compile(
+        r"S3 PUT request failed with error for key .*: code: _unknown_error_code_, message: http status: Bad Request, error body: 400 Bad Request, request_id: , resource:"
+    ),
+    re.compile(
+        r"Accessing .*, unexpected REST API error \"http status: Bad Request, error body: 400 Bad Request\" detected, code: _unknown_error_code_, request_id: , resource:"
+    )
 ]
 
 # Log errors that are expected in tests that restart nodes mid-test


### PR DESCRIPTION
Investigation is ongoing into '400 Bad Request' responses received by
s3_client when performing PUT operations. The 'error' log lines
generated by this issue are causing consistent bleed in CI investigation
time.

This PR adds these particular 400s to the default allowlist for bad logs
in non-cloud redpanda tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
