### PR TITLE
tests/docker: update addr2line SHA

### DIFF
--- a/tests/docker/ducktape-deps/addr2line
+++ b/tests/docker/ducktape-deps/addr2line
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -e
+
+# Pulls down the addr2line python code for use in DT tests. This doesn't necessarily
+# need to point into our fork, in the case we need upstream improvements we haven't
+# downstreamed yet.
+
+SEASTAR_REPO=redpanda-data/seastar
+SEASTAR_HASH=0aed36eee620e95c0c8289801824ca52091a0e66
+
 mkdir -p /opt/scripts
-curl https://raw.githubusercontent.com/scylladb/seastar/0af88fa21226394ecbfe109b428774f96b73dcb2/scripts/addr2line.py -o /opt/scripts/addr2line.py
-curl https://raw.githubusercontent.com/scylladb/seastar/0af88fa21226394ecbfe109b428774f96b73dcb2/scripts/seastar-addr2line -o /opt/scripts/seastar-addr2line
+for filename in addr2line.py seastar-addr2line; do
+  curl https://raw.githubusercontent.com/$SEASTAR_REPO/$SEASTAR_HASH/scripts/$filename -o /opt/scripts/$filename
+done
+
 chmod +x /opt/scripts/seastar-addr2line


### PR DESCRIPTION
Update the version of the seastar-addr2line tool we use to point to the tip of our v25.2.x branch, as we've downstreamed the needed fixes, and have backtrace decoding optimizations in there that we want to use.

While we are at it, DRY the script and add a small doc.

CORE-12786

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

