### PR TITLE
[CORE-10026] kafka: Support fetch v12

### DIFF
--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -35,7 +35,7 @@ requires std::predicate<Pred>
 void wait_for(model::timeout_clock::duration timeout, Pred&& p) {
     with_timeout(
       model::timeout_clock::now() + timeout,
-      do_until(
+      ss::do_until(
         [p = std::forward<Pred>(p)] { return p(); },
         [] { return ss::sleep(std::chrono::milliseconds(400)); }))
       .get();

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2562,6 +2562,7 @@ struct leader_term {
 
     std::optional<model::node_id> leader;
     model::term_id term;
+    friend auto operator<=>(const leader_term&, const leader_term&) = default;
     friend std::ostream& operator<<(std::ostream&, const leader_term&);
 };
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -58,6 +58,49 @@
 #include <ranges>
 #include <string_view>
 
+namespace {
+
+template<std::ranges::input_range R>
+auto enumerate(R&& range) {
+    return std::views::zip(std::views::iota(size_t{0}), std::forward<R>(range));
+}
+
+std::optional<kafka::error_code> needs_updated_leader(kafka::error_code err) {
+    switch (err) {
+    case kafka::error_code::unknown_topic_or_partition:
+    case kafka::error_code::not_leader_for_partition:
+    case kafka::error_code::fenced_leader_epoch:
+        return err;
+    default:
+        return std::nullopt;
+    }
+}
+
+std::optional<kafka::leader_id_and_epoch> get_leader_id_and_epoch(
+  const cluster::metadata_cache& md_cache, const model::ktp& ktp) {
+    auto lt = md_cache.get_leader_term(ktp.as_tn_view(), ktp.get_partition());
+    if (lt && lt->leader) {
+        return kafka::leader_id_and_epoch{
+          *lt->leader, kafka::leader_epoch_from_term(lt->term)};
+    }
+    return std::nullopt;
+}
+
+kafka::read_result make_errored_read_result(
+  const cluster::metadata_cache& md_cache,
+  const model::ktp& ktp,
+  kafka::error_code err) {
+    return needs_updated_leader(err)
+      .and_then([&](auto err) {
+          return get_leader_id_and_epoch(md_cache, ktp)
+            .transform([&](auto leader) {
+                return kafka::read_result(err, std::move(leader));
+            });
+      })
+      .value_or(kafka::read_result(err));
+}
+} // namespace
+
 namespace kafka {
 static constexpr std::chrono::milliseconds default_fetch_timeout = 5s;
 /**
@@ -296,6 +339,7 @@ static void adjust_memory_units(
  */
 static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
+  const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   ntp_fetch_config ntp_config,
   bool foreign_read,
@@ -323,10 +367,12 @@ static ss::future<read_result> do_read_from_ntp(
      */
     auto kafka_partition = make_partition_proxy(ntp_config.ktp(), cluster_pm);
     if (unlikely(!kafka_partition)) {
-        co_return read_result(error_code::unknown_topic_or_partition);
+        co_return make_errored_read_result(
+          md_cache, ntp_config.ktp(), error_code::unknown_topic_or_partition);
     }
     if (!ntp_config.cfg.read_from_follower && !kafka_partition->is_leader()) {
-        co_return read_result(error_code::not_leader_for_partition);
+        co_return make_errored_read_result(
+          md_cache, ntp_config.ktp(), error_code::not_leader_for_partition);
     }
 
     /**
@@ -335,7 +381,8 @@ static ss::future<read_result> do_read_from_ntp(
     auto leader_epoch_err = details::check_leader_epoch(
       ntp_config.cfg.current_leader_epoch, *kafka_partition);
     if (leader_epoch_err != error_code::none) {
-        co_return read_result(leader_epoch_err);
+        co_return make_errored_read_result(
+          md_cache, ntp_config.ktp(), leader_epoch_err);
     }
     auto offset_ec = co_await kafka_partition->validate_fetch_offset(
       ntp_config.cfg.start_offset,
@@ -408,6 +455,7 @@ namespace testing {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager& cluster_pm,
+  const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   const model::ktp& ktp,
   fetch_config config,
@@ -418,6 +466,7 @@ ss::future<read_result> read_from_ntp(
   ssx::semaphore& memory_fetch_sem) {
     return do_read_from_ntp(
       cluster_pm,
+      md_cache,
       replica_selector,
       {ktp, std::move(config)},
       foreign_read,
@@ -468,6 +517,9 @@ static void fill_fetch_responses(
         fetch_response::partition_response resp;
         resp.partition_index = res.partition;
         resp.error_code = res.error;
+        if (res.current_leader) {
+            resp.current_leader = *res.current_leader;
+        }
 
         // These are set to -1 in the general error case.
         // Set to actual values in the success case or when the error is
@@ -557,6 +609,7 @@ static void fill_fetch_responses(
 
 static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
   cluster::partition_manager& cluster_pm,
+  const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   chunked_vector<ntp_fetch_config> ntp_fetch_configs,
   read_distribution_probe& read_probe,
@@ -592,6 +645,7 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
     auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
       [&cluster_pm,
+       &md_cache,
        &replica_selector,
        deadline,
        foreign_read,
@@ -601,6 +655,7 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
           auto p_id = ntp_cfg.ktp().get_partition();
           return do_read_from_ntp(
                    cluster_pm,
+                   md_cache,
                    replica_selector,
                    ntp_cfg,
                    foreign_read,
@@ -674,6 +729,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
             // This is meant to help avoiding unintended cross shard access
             return fetch_ntps_in_parallel(
               mgr,
+              octx.rctx.metadata_cache(),
               octx.rctx.server().local().get_replica_selector(),
               std::move(configs),
               octx.rctx.server().local().read_probe(),
@@ -807,20 +863,24 @@ private:
         // are produced to without acks=all. The `last_visible_index` more
         // closely corresponds to the Kafka high watermark as well.
         std::vector<model::offset> last_visible_indexes(requests.size());
-        std::vector<std::tuple<size_t, model::partition_id>> errored_partitions;
+        std::vector<std::tuple<
+          size_t,
+          model::partition_id,
+          std::optional<kafka::leader_id_and_epoch>>>
+          errored_partitions;
         size_t total_size{0};
         bool has_error{false};
 
         for (size_t i = 0; i < requests.size(); i++) {
             const auto& req = requests[i];
             auto part = _ctx.mgr.get(req.ktp());
-            if (!part) {
-                errored_partitions.emplace_back(i, req.ktp().get_partition());
-                continue;
-            }
-            auto consensus = part->raft();
+            auto consensus = part ? part->raft() : nullptr;
             if (!consensus) {
-                errored_partitions.emplace_back(i, req.ktp().get_partition());
+                errored_partitions.emplace_back(
+                  i,
+                  req.ktp().get_partition(),
+                  get_leader_id_and_epoch(
+                    _ctx.srv.metadata_cache(), req.ktp()));
                 continue;
             }
             last_visible_indexes[i] = consensus->last_visible_index();
@@ -831,6 +891,7 @@ private:
         // `fetch_ntps_in_parallel`.
         std::vector<read_result> results = co_await fetch_ntps_in_parallel(
           _ctx.mgr,
+          _ctx.srv.metadata_cache(),
           _ctx.srv.get_replica_selector(),
           std::move(requests),
           _ctx.srv.read_probe(),
@@ -843,8 +904,9 @@ private:
         // If we weren't able to read the last_visible_index for a partition
         // before calling `fetch_ntps_in_parallel` then we need to
         // return with an error for that partition.
-        for (auto [i, partition] : errored_partitions) {
+        for (auto [i, partition, leader_info] : errored_partitions) {
             results[i] = read_result(error_code::not_leader_for_partition);
+            results[i].current_leader = std::move(leader_info);
             results[i].partition = partition;
         }
 

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -33,7 +33,7 @@ fetch_scheduling_group_provider(const connection_context&);
 using fetch_handler = single_stage_handler<
   fetch_api,
   4,
-  11,
+  12,
   default_estimate_adaptor,
   fetch_scheduling_group_provider>;
 
@@ -263,6 +263,13 @@ struct read_result {
       , last_stable_offset(-1)
       , error(e) {}
 
+    explicit read_result(error_code e, leader_id_and_epoch leader)
+      : start_offset(-1)
+      , high_watermark(-1)
+      , last_stable_offset(-1)
+      , current_leader(std::move(leader))
+      , error(e) {}
+
     // special case for offset_out_of_range_error
     read_result(
       error_code e,
@@ -337,6 +344,7 @@ struct read_result {
     model::offset last_stable_offset;
     std::optional<std::chrono::milliseconds> delta_from_tip_ms;
     std::optional<model::node_id> preferred_replica;
+    std::optional<leader_id_and_epoch> current_leader;
     error_code error;
     model::partition_id partition;
     std::vector<cluster::tx::tx_range> aborted_transactions;
@@ -420,6 +428,7 @@ namespace testing {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
+  const cluster::metadata_cache&,
   const replica_selector&,
   const model::ktp&,
   fetch_config,

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -747,9 +747,11 @@ redpanda_cc_btest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/cluster/tests:cluster_test_fixture",
         "//src/v/kafka/protocol",
         "//src/v/kafka/server",
         "//src/v/model",
+        "//src/v/raft",
         "//src/v/redpanda/tests:fixture",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/tests/cluster_test_fixture.h"
 #include "kafka/protocol/batch_consumer.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/fetch.h"
@@ -174,6 +175,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
                 [&octx, ktp, config](cluster::partition_manager& pm) {
                     return kafka::testing::read_from_ntp(
                       pm,
+                      octx.rctx.metadata_cache(),
                       octx.rctx.server().local().get_replica_selector(),
                       ktp,
                       config,
@@ -481,6 +483,134 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
         == kafka::error_code::fenced_leader_epoch,
       fmt::format(
         "error: {}", resp.data.responses[0].partitions[0].error_code));
+}
+
+FIXTURE_TEST(fetch_current_leader_v12, cluster_test_fixture) {
+    // create a topic partition with some data
+    model::topic topic("foo");
+    model::partition_id pid(0);
+
+    create_node_application(model::node_id{0});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
+    wait_for_all_members(3s).get();
+
+    model::ktp ktp(topic, pid);
+    auto ntp = ktp.to_ntp();
+    create_topic(ktp.as_tn_view(), 1, 3).get();
+
+    wait_for(10s, [&] {
+        auto [app_ptr, _] = get_leader(ntp);
+        return app_ptr != nullptr;
+    });
+
+    auto [app_ptr, partition] = get_leader(ntp);
+
+    auto publish_some = [ntp](redpanda_thread_fixture* app_ptr) {
+        app_ptr->app.partition_manager
+          .invoke_on(
+            *app_ptr->app.shard_table.local().shard_for(ntp),
+            [ntp](cluster::partition_manager& mgr) {
+                auto partition = mgr.get(ntp);
+
+                auto batches
+                  = model::test::make_random_batches(model::offset(0), 5).get();
+
+                BOOST_TEST_INFO("Replicating batches to leader");
+
+                partition->raft()
+                  ->replicate(
+                    chunked_vector<model::record_batch>(std::move(batches)),
+                    raft::replicate_options(
+                      raft::consistency_level::quorum_ack))
+                  .discard_result()
+                  .get();
+            })
+          .get();
+    };
+
+    publish_some(app_ptr);
+
+    BOOST_TEST_INFO("Shuffling leadership");
+    shuffle_leadership(ntp).get();
+
+    BOOST_TEST_INFO("Waiting for new leader");
+    wait_for(10s, [&] {
+        auto [fixture, _] = get_leader(ntp);
+        return fixture != nullptr;
+    });
+
+    BOOST_TEST_INFO("Getting new leader");
+    auto [new_app_ptr, new_partition] = get_leader(ntp);
+
+    publish_some(new_app_ptr);
+
+    // An alternative is to issue a linearizable_barrier, like list_offsets.
+    BOOST_TEST_INFO("Waiting for metadata cache to update");
+    wait_for(10s, [&] {
+        cluster::leader_term expected{
+          new_app_ptr->app.controller->self(), new_partition->raft()->term()};
+        auto term = app_ptr->app.metadata_cache.local().get_leader_term(
+          ktp.as_tn_view(), ktp.get_partition());
+        return term == expected;
+    });
+
+    auto send_request =
+      [&](redpanda_thread_fixture* app_ptr, model::term_id term) {
+          kafka::fetch_request req;
+          req.data.max_bytes = std::numeric_limits<int32_t>::max();
+          req.data.min_bytes = 1;
+          req.data.max_wait_ms = std::chrono::milliseconds(1000);
+          req.data.topics.emplace_back(kafka::fetch_topic{
+            .topic = topic,
+            .partitions = {{
+              .partition = pid,
+              .current_leader_epoch = kafka::leader_epoch_from_term(term),
+              .fetch_offset = model::offset(6),
+            }}});
+
+          auto client = instance(app_ptr->app.controller->self())
+                          ->make_kafka_client()
+                          .get();
+
+          client.connect().get();
+
+          auto response
+            = client.dispatch(std::move(req), kafka::api_version(12)).get();
+          client.stop().then([&client] { client.shutdown(); }).get();
+          return response;
+      };
+
+    auto expected = kafka::leader_id_and_epoch{
+      new_partition->raft()->get_leader_id().value_or(model::node_id{-1}),
+      kafka::leader_epoch_from_term(new_partition->raft()->term())};
+
+    {
+        BOOST_TEST_INFO("Dispatching old epoch to old leader");
+        auto resp = send_request(app_ptr, model::term_id{1});
+        const auto& part = resp.data.responses[0].partitions[0];
+        BOOST_REQUIRE_EQUAL(
+          part.error_code, kafka::error_code::not_leader_for_partition);
+        BOOST_REQUIRE_EQUAL(expected, part.current_leader);
+    }
+    {
+        BOOST_TEST_INFO("Dispatching old epoch to new leader");
+        auto resp = send_request(new_app_ptr, model::term_id{1});
+        const auto& part = resp.data.responses[0].partitions[0];
+        BOOST_REQUIRE_EQUAL(
+          part.error_code, kafka::error_code::fenced_leader_epoch);
+        BOOST_REQUIRE_EQUAL(expected, part.current_leader);
+    }
+    {
+        BOOST_TEST_INFO("Dispatching new epoch to new leader");
+        auto resp = send_request(new_app_ptr, model::term_id{2});
+        const auto& part = resp.data.responses[0].partitions[0];
+        BOOST_REQUIRE_EQUAL(part.error_code, kafka::error_code::none);
+        // When there is not an error, leader_id_and_epoch should not be set
+        BOOST_REQUIRE_EQUAL(model::node_id{-1}, part.current_leader.leader_id);
+        BOOST_REQUIRE_EQUAL(
+          kafka::leader_epoch{-1}, part.current_leader.leader_epoch);
+    }
 }
 
 FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {


### PR DESCRIPTION
Support Fetch v12

I wonder if the fetch should issue a `linearizable_barrier` before returning the epoch, as is done for `list_offsets`?

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
