### PR TITLE
base: introduce VFMT_* macros

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -17,6 +17,7 @@ redpanda_cc_library(
         "unreachable.h",
         "vassert.h",
         "vassert-register.h",
+        "vfmt.h",
         "vlog.h",
     ],
     include_prefix = "base",

--- a/src/v/base/vfmt.h
+++ b/src/v/base/vfmt.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+/**
+ * Helper macros to declare and implement fmt::formatter for a type.
+ *
+ * This will aid in the libfmt migration from v9 into v10.
+ *
+ * Note that we use VFMT because libfmt's own macros start with FMT_ and we
+ * don't want them to clash.
+ */
+
+#pragma once
+
+// Declare a fmt::formatter for #type (hiding the verbose boilerplate)
+//
+// This macro should only be used in root scope (so outside any namespaces).
+//
+// Note this only is for declaring the formatter, so if you want to provide
+// implementation entirely in the header as well you'll need to use VFMT_INLINE.
+// Otherwise use VFMT_IMPL in the implementation file.
+//
+// Example usage:
+//
+//   namespace foo {
+//   struct my_type {
+//     int a;
+//     std::string b;
+//   };
+//   } // namespace foo
+//
+//   VFMT_DECL(foo::my_type);
+//
+#define VFMT_DECL(type)                                                        \
+    template<>                                                                 \
+    struct fmt::formatter<type> : fmt::formatter<std::string_view> {           \
+        auto format(const type&, fmt::format_context& ctx) const               \
+          -> decltype(ctx.out());                                              \
+    };                                                                         \
+    std::ostream& operator<<(std::ostream& os, const type&)
+
+// Implement a fmt::formatter for #type (hiding the verbose boilerplate)
+//
+// This macro should only be used in root scope (so outside any namespaces).
+//
+// Note this only is for implementing the formatter, so you'll need to also use
+// VFMT_DECL in the header as well.
+//
+// The type's argument is always named `v` in the function implementation.
+//
+// Example usage:
+//
+//   VFMT_DECL(foo::my_type) {
+//     return fmt::format_to(ctx.out(), "{{a: {}, b: {}}}", v.a, v.b)
+//   }
+//
+#define VFMT_IMPL(type)                                                        \
+    std::ostream& operator<<(std::ostream& os, const type& v) {                \
+        fmt::print(os, "{}", v);                                               \
+        return os;                                                             \
+    }                                                                          \
+    auto fmt::formatter<type>::format(const type& v, fmt::format_context& ctx) \
+      const -> decltype(ctx.out())
+
+// Declare and implement a fmt::formatter for #type (hiding the verbose
+// boilerplate)
+//
+// This macro should only be used in root scope (so outside any namespaces).
+//
+// Note this is for inline usage of creating a formatter, if you want to break
+// it up between a header and implementation file, see VFMT_DECL and VFMT_IMPL
+//
+// Example usage:
+//
+//   namespace foo {
+//   struct my_type {
+//     int a;
+//     std::string b;
+//   };
+//   } // namespace foo
+//   VFMT_INLINE(foo::my_type) {
+//     return fmt::format_to(ctx.out(), "{{a: {}, b: {}}}", v.a, v.b);
+//   }
+//
+#define VFMT_INLINE(type)                                                      \
+    template<>                                                                 \
+    struct fmt::formatter<type> : fmt::formatter<std::string_view> {           \
+        auto format(const type&, fmt::format_context& ctx) const               \
+          -> decltype(ctx.out());                                              \
+    };                                                                         \
+    inline std::ostream& operator<<(std::ostream& os, const type& v) {         \
+        fmt::print(os, "{}", v);                                               \
+        return os;                                                             \
+    }                                                                          \
+    inline auto fmt::formatter<type>::format(                                  \
+      const type& v, fmt::format_context& ctx) const -> decltype(ctx.out())

--- a/src/v/cloud_storage/remote_label.h
+++ b/src/v/cloud_storage/remote_label.h
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "base/vfmt.h"
 #include "model/fundamental.h"
 #include "serde/rw/envelope.h"
 #include "serde/rw/uuid.h"
@@ -28,12 +29,10 @@ struct remote_label
     // The cluster UUID of a given cluster. This is critical in avoiding
     // collisions when multiple clusters use the same bucket.
     model::cluster_uuid cluster_uuid{};
-
-    friend std::ostream&
-    operator<<(std::ostream& os, const remote_label& label) {
-        fmt::print(os, "{{cluster_uuid: {}}}", label.cluster_uuid);
-        return os;
-    }
 };
 
 } // namespace cloud_storage
+
+VFMT_INLINE(cloud_storage::remote_label) {
+    return fmt::format_to(ctx.out(), "{{cluster_uuid: {}}}", v.cluster_uuid);
+}

--- a/src/v/crash_tracker/types.cc
+++ b/src/v/crash_tracker/types.cc
@@ -11,6 +11,7 @@
 
 #include "crash_tracker/types.h"
 
+#include "base/vfmt.h"
 #include "version/version.h"
 
 namespace crash_tracker {
@@ -34,23 +35,6 @@ std::ostream& operator<<(std::ostream& os, crash_type ct) {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const crash_description& cd) {
-    fmt::print(
-      os,
-      "Redpanda version: {}. Arch: {}. {}",
-      cd.app_version,
-      cd.arch,
-      cd.crash_message.c_str());
-
-    const auto opt_stacktrace = cd.stacktrace.c_str();
-    const auto has_stacktrace = strlen(opt_stacktrace) > 0;
-    if (has_stacktrace) {
-        fmt::print(os, " Backtrace: {}.", opt_stacktrace);
-    }
-
-    return os;
-}
-
 bool is_crash_loop_limit_reached(std::exception_ptr eptr) {
     try {
         std::rethrow_exception(eptr);
@@ -62,3 +46,20 @@ bool is_crash_loop_limit_reached(std::exception_ptr eptr) {
 }
 
 } // namespace crash_tracker
+
+VFMT_IMPL(crash_tracker::crash_description) {
+    auto it = fmt::format_to(
+      ctx.out(),
+      "Redpanda version: {}. Arch: {}. {}",
+      v.app_version,
+      v.arch,
+      v.crash_message.c_str());
+
+    const auto opt_stacktrace = v.stacktrace.c_str();
+    const auto has_stacktrace = strlen(opt_stacktrace) > 0;
+    if (has_stacktrace) {
+        it = fmt::format_to(it, " Backtrace: {}.", opt_stacktrace);
+    }
+
+    return it;
+}

--- a/src/v/crash_tracker/types.h
+++ b/src/v/crash_tracker/types.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "base/vfmt.h"
 #include "model/timestamp.h"
 #include "serde/envelope.h"
 #include "serde/rw/enum.h"
@@ -136,8 +137,6 @@ struct crash_description
         return std::tie(
           type, crash_time, crash_message, stacktrace, app_version, arch);
     }
-
-    friend std::ostream& operator<<(std::ostream&, const crash_description&);
 };
 
 struct crash_tracker_metadata
@@ -163,3 +162,5 @@ public:
 bool is_crash_loop_limit_reached(std::exception_ptr);
 
 } // namespace crash_tracker
+
+VFMT_DECL(crash_tracker::crash_description);

--- a/src/v/serde/parquet/schema.cc
+++ b/src/v/serde/parquet/schema.cc
@@ -77,21 +77,19 @@ void index_schema(schema_element& root) {
 
 } // namespace serde::parquet
 
-auto fmt::formatter<serde::parquet::schema_element>::format(
-  const serde::parquet::schema_element& e, fmt::format_context& ctx) const
-  -> decltype(ctx.out()) {
+VFMT_IMPL(serde::parquet::schema_element) {
     return fmt::format_to(
       ctx.out(),
       "{{ position: {}, type: {}, repetition_type: {}, max_def_level: {}, "
       "max_rep_level: {}, path: {}, logical_type: {}, field_id: {}, "
       "children: [{}]}}",
-      e.position,
-      e.type.index(),
-      static_cast<uint8_t>(e.repetition_type),
-      e.max_definition_level(),
-      e.max_repetition_level(),
-      fmt::join(e.path, "/"),
-      e.logical_type.index(),
-      e.field_id.value_or(-1),
-      fmt::join(e.children, ", "));
+      v.position,
+      v.type.index(),
+      static_cast<uint8_t>(v.repetition_type),
+      v.max_definition_level(),
+      v.max_repetition_level(),
+      fmt::join(v.path, "/"),
+      v.logical_type.index(),
+      v.field_id.value_or(-1),
+      fmt::join(v.children, ", "));
 }

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "base/vfmt.h"
 #include "container/fragmented_vector.h"
 #include "utils/named_type.h"
 
@@ -348,9 +349,4 @@ void index_schema(schema_element& root);
 
 } // namespace serde::parquet
 
-template<>
-struct fmt::formatter<serde::parquet::schema_element>
-  : fmt::formatter<std::string_view> {
-    auto format(const serde::parquet::schema_element&, fmt::format_context& ctx)
-      const -> decltype(ctx.out());
-};
+VFMT_DECL(serde::parquet::schema_element);

--- a/src/v/serde/parquet/value.cc
+++ b/src/v/serde/parquet/value.cc
@@ -47,12 +47,10 @@ value copy(const value& val) {
 
 } // namespace serde::parquet
 
-auto fmt::formatter<serde::parquet::value>::format(
-  const serde::parquet::value& val, fmt::format_context& ctx) const
-  -> decltype(ctx.out()) {
+VFMT_IMPL(serde::parquet::value) {
     using namespace serde::parquet;
     return ss::visit(
-      val,
+      v,
       [&ctx](const null_value&) { return fmt::format_to(ctx.out(), "NULL"); },
       [&ctx](const boolean_value& v) {
           return fmt::format_to(ctx.out(), "{}", v.val);
@@ -93,14 +91,10 @@ auto fmt::formatter<serde::parquet::value>::format(
       });
 }
 
-auto fmt::formatter<serde::parquet::group_member>::format(
-  const serde::parquet::group_member& f, fmt::format_context& ctx) const
-  -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{}", f.field);
+VFMT_IMPL(serde::parquet::group_member) {
+    return fmt::format_to(ctx.out(), "{}", v.field);
 }
 
-auto fmt::formatter<serde::parquet::repeated_element>::format(
-  const serde::parquet::repeated_element& e, fmt::format_context& ctx) const
-  -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{}", e.element);
+VFMT_IMPL(serde::parquet::repeated_element) {
+    return fmt::format_to(ctx.out(), "{}", v.element);
 }

--- a/src/v/serde/parquet/value.h
+++ b/src/v/serde/parquet/value.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/vfmt.h"
 #include "bytes/iobuf.h"
 #include "container/fragmented_vector.h"
 
@@ -106,26 +107,6 @@ value copy(const value&);
 
 } // namespace serde::parquet
 
-template<>
-struct fmt::formatter<serde::parquet::value>
-  : fmt::formatter<std::string_view> {
-    // This does not truncate the output, so it could print a very large value
-    auto format(const serde::parquet::value&, fmt::format_context& ctx) const
-      -> decltype(ctx.out());
-};
-
-template<>
-struct fmt::formatter<serde::parquet::group_member>
-  : fmt::formatter<std::string_view> {
-    auto
-    format(const serde::parquet::group_member&, fmt::format_context& ctx) const
-      -> decltype(ctx.out());
-};
-
-template<>
-struct fmt::formatter<serde::parquet::repeated_element>
-  : fmt::formatter<std::string_view> {
-    auto format(
-      const serde::parquet::repeated_element&, fmt::format_context& ctx) const
-      -> decltype(ctx.out());
-};
+VFMT_DECL(serde::parquet::value);
+VFMT_DECL(serde::parquet::group_member);
+VFMT_DECL(serde::parquet::repeated_element);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -9,6 +9,7 @@
 
 #include "storage/types.h"
 
+#include "base/vfmt.h"
 #include "base/vlog.h"
 #include "storage/compacted_index.h"
 #include "storage/logger.h"
@@ -43,18 +44,6 @@ std::optional<kafka::offset> stm_manager::lowest_pinned_data_offset() const {
         }
     }
     return result;
-}
-
-std::ostream& operator<<(std::ostream& o, const disk& d) {
-    fmt::print(
-      o,
-      "{{path: {}, free: {}, total: {}, alert: {}, fsid: {}}}",
-      d.path,
-      human::bytes(d.free),
-      human::bytes(d.total),
-      d.alert,
-      d.fsid);
-    return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const log_reader_config& cfg) {
@@ -269,3 +258,14 @@ operator<<(std::ostream& o, compacted_index::recovery_state state) {
 }
 
 } // namespace storage
+
+VFMT_IMPL(storage::disk) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{path: {}, free: {}, total: {}, alert: {}, fsid: {}}}",
+      v.path,
+      human::bytes(v.free),
+      human::bytes(v.total),
+      v.alert,
+      v.fsid);
+}

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/vfmt.h"
 #include "container/fragmented_vector.h"
 #include "model/fundamental.h"
 #include "model/record.h"
@@ -70,7 +71,6 @@ struct disk
     // to represent a disk not only for marshalling data to disk/network.
     unsigned long int fsid;
 
-    friend std::ostream& operator<<(std::ostream&, const disk&);
     friend bool operator==(const disk&, const disk&) = default;
 };
 
@@ -756,3 +756,5 @@ struct reclaimable_offsets {
 };
 
 } // namespace storage
+
+VFMT_DECL(storage::disk);

--- a/tools/libfmt_migration.md
+++ b/tools/libfmt_migration.md
@@ -1,0 +1,36 @@
+We need to upgrade from libfmt version 9 to libfmt version 10.
+
+The major blocker for this upgrade is the breaking change of
+removing support for using an argument that has `operator<<`
+as an argument to `fmt::print` (or other related formatters).
+
+Our codebase heavily uses `operator<<`, and we've been trying
+to use `fmt::formatter` in new code. However, most of our 
+`operator<<` implementations are using `fmt::print(os, "...", ...)`
+as the implementation, so in theory it should be easy to migrate
+to `fmt::formatter` everywhere and upgrade libfmt.
+
+In commit `4aa779bfa34fcc32499abfc7d6e2f922f3b25eef` we added
+macros to assist in the migration (and also make custom 
+`fmt::formatter` less verbose). Please look at that commit and
+use the macros there to convert any `operator<<` you see in the
+codebase to using these macros instead.
+
+The codebase uses bazel and you can build all the relevant C++
+code using `bazel build //src/v/...`. Please ensure the codebase
+builds before and after every commit. Adhere to the rules in
+CONTRIBUTING.md when creating commit messages. Before committing
+run `bazel run //tools:clang_format` to ensure the code is well
+formatted.
+
+Migrate up to 10 or so `operator<<` to using these new macros,
+then stop (I know you're not good at counting, and it just matters
+that we break up these changes for the humans reviewing).
+
+These `VFMT_*` macros also implement `operator<<`, so be sure to
+remove old implementations of `operator<<`. If the `operator<<`
+is purely defined in the header inline just use `VFMT_INLINE`.
+Otherwise use `VFMT_DECL(type)` in the header and `VFMT_IMPL(type) { ... }`
+in the corresponding implementation file, never use VFMT_IMPL on
+a type from another subsystem. If there is an existing pattern
+like this with `operator<<` please flag it.


### PR DESCRIPTION
At some point we need to migrate to libfmt v10+, introduce some
macros to encourage folks to not use std::ostream.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
