### PR TITLE
[CORE-10323] iceberg: serialize Struct fields as JSON string columns

### DIFF
--- a/src/v/iceberg/conversion/BUILD
+++ b/src/v/iceberg/conversion/BUILD
@@ -130,6 +130,7 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf",
         "//src/v/container:chunked_vector",
         "//src/v/iceberg:values",
+        "//src/v/serde/json:writer",
         "//src/v/serde/protobuf",
         "//src/v/ssx:future_util",
         "@abseil-cpp//absl/time",

--- a/src/v/iceberg/conversion/schema_protobuf.cc
+++ b/src/v/iceberg/conversion/schema_protobuf.cc
@@ -161,6 +161,18 @@ field_outcome from_protobuf(
           msg_t->well_known_type() == pb::Descriptor::WELLKNOWNTYPE_TIMESTAMP) {
             return success(fd, iceberg::timestamp_type{});
         }
+        // special case for handling google.protobuf.Struct, Value, and
+        // ListValue - all serialize as JSON strings
+        if (msg_t->well_known_type() == pb::Descriptor::WELLKNOWNTYPE_STRUCT) {
+            return success(fd, iceberg::string_type{});
+        }
+        if (msg_t->well_known_type() == pb::Descriptor::WELLKNOWNTYPE_VALUE) {
+            return success(fd, iceberg::string_type{});
+        }
+        if (
+          msg_t->well_known_type() == pb::Descriptor::WELLKNOWNTYPE_LISTVALUE) {
+            return success(fd, iceberg::string_type{});
+        }
         auto st_result = struct_from_protobuf(*msg_t, stack);
         if (st_result.has_error()) {
             return st_result.error();

--- a/src/v/iceberg/conversion/schema_protobuf.cc
+++ b/src/v/iceberg/conversion/schema_protobuf.cc
@@ -32,8 +32,6 @@ namespace pb = google::protobuf;
 using field_outcome = conversion_outcome<iceberg::nested_field_ptr>;
 using struct_outcome = conversion_outcome<iceberg::struct_type>;
 
-static constexpr int max_recursion_depth = 100;
-
 field_outcome from_protobuf(
   const pb::FieldDescriptor& fd, bool is_repeated, proto_descriptors_stack&);
 
@@ -62,7 +60,7 @@ struct_outcome struct_from_protobuf(
         return conversion_exception(
           fmt::format(
             "Protocol buffer field {} not supported - max nested depth of {} "
-            "reached",
+            "exceeded",
             msg.DebugString(),
             max_recursion_depth));
     }

--- a/src/v/iceberg/conversion/tests/BUILD
+++ b/src/v/iceberg/conversion/tests/BUILD
@@ -8,6 +8,7 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/iceberg:values",
         "@googletest//:gtest",
+        "@rapidjson",
     ],
 )
 
@@ -19,7 +20,10 @@ proto_library(
 proto_library(
     name = "complex_proto",
     srcs = ["testdata/complex.proto"],
-    deps = ["@protobuf//:timestamp_proto"],
+    deps = [
+        "@protobuf//:struct_proto",
+        "@protobuf//:timestamp_proto",
+    ],
 )
 
 proto_library(
@@ -130,6 +134,7 @@ redpanda_cc_gtest(
         ":proto_definitions_wrapper",
         ":test_messages_cc_proto",
         "//src/v/iceberg:datatypes",
+        "//src/v/iceberg/conversion:protobuf_utils",
         "//src/v/iceberg/conversion:schema_protobuf",
         "//src/v/iceberg/conversion:values_protobuf",
         "//src/v/serde/protobuf",
@@ -140,6 +145,7 @@ redpanda_cc_gtest(
         "@protobuf",
         "@protobuf//src/google/protobuf/compiler:importer",
         "@protobuf//src/google/protobuf/io:tokenizer",
+        "@rapidjson",
         "@seastar",
     ],
 )

--- a/src/v/iceberg/conversion/tests/gmock_iceberg_matchers.h
+++ b/src/v/iceberg/conversion/tests/gmock_iceberg_matchers.h
@@ -13,6 +13,8 @@
 #include "iceberg/values.h"
 
 #include <gmock/gmock.h>
+#include <rapidjson/document.h>
+#include <rapidjson/error/en.h>
 
 namespace iceberg::testing {
 
@@ -55,6 +57,46 @@ auto IcebergMap(MatcherT matcher) {
 template<typename KeyMatcherT, typename ValueMatcherT>
 auto IcebergKeyValue(KeyMatcherT k_matcher, ValueMatcherT v_matcher) {
     return FieldsAre(k_matcher, v_matcher);
+}
+
+// Compares a JSON string to JSON in an iceberg::string_value.
+MATCHER_P(IsJSON, expected_json_str, "") {
+    // Parse expected.
+    rapidjson::Document expected_doc;
+    expected_doc.Parse(expected_json_str);
+    if (expected_doc.HasParseError()) {
+        *result_listener << "Expected JSON parse error at offset "
+                         << expected_doc.GetErrorOffset() << ": "
+                         << rapidjson::GetParseError_En(
+                              expected_doc.GetParseError());
+        return false;
+    }
+
+    // Parse actual.
+    std::string actual_str;
+    for (const auto& frag : arg.val) {
+        actual_str.append(frag.get(), frag.size());
+    }
+
+    rapidjson::Document actual_doc;
+    actual_doc.Parse(actual_str.c_str());
+    if (actual_doc.HasParseError()) {
+        *result_listener << "Actual JSON parse error at offset "
+                         << actual_doc.GetErrorOffset() << ": "
+                         << rapidjson::GetParseError_En(
+                              actual_doc.GetParseError())
+                         << "\nActual string: " << actual_str;
+        return false;
+    }
+
+    // Compare.
+    if (expected_doc != actual_doc) {
+        *result_listener << "JSON documents differ.\nExpected: "
+                         << expected_json_str << "\nActual: " << actual_str;
+        return false;
+    }
+
+    return true;
 }
 
 }; // namespace iceberg::testing

--- a/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
@@ -9,6 +9,7 @@
  */
 
 #include "gtest/gtest.h"
+#include "iceberg/conversion/protobuf_utils.h"
 #include "iceberg/conversion/schema_protobuf.h"
 #include "iceberg/conversion/tests/gmock_iceberg_matchers.h"
 #include "iceberg/conversion/tests/proto_definitions.h"
@@ -27,6 +28,7 @@
 #include <google/protobuf/io/tokenizer.h>
 #include <google/protobuf/message.h>
 #include <gtest/gtest.h>
+#include <rapidjson/document.h>
 
 #include <memory>
 #include <optional>
@@ -188,6 +190,33 @@ TEST_CORO(SchemaProtobuf, TestMessageWithTimestamp) {
     auto field = std::move(result.value());
     EXPECT_THAT(
       field.fields, ElementsAre(IsField(1, "timestamp", timestamp_type{})));
+}
+
+TEST_CORO(SchemaProtobuf, TestMessageWithStruct) {
+    auto d = StructWithStruct::GetDescriptor();
+    auto result = iceberg::type_to_iceberg(*d);
+    ASSERT_FALSE_CORO(result.has_error());
+    auto field = std::move(result.value());
+    EXPECT_THAT(
+      field.fields, ElementsAre(IsField(1, "struct_field", string_type{})));
+}
+
+TEST_CORO(SchemaProtobuf, TestMessageWithValue) {
+    auto d = StructWithValue::GetDescriptor();
+    auto result = iceberg::type_to_iceberg(*d);
+    ASSERT_FALSE_CORO(result.has_error());
+    auto field = std::move(result.value());
+    EXPECT_THAT(
+      field.fields, ElementsAre(IsField(1, "value_field", string_type{})));
+}
+
+TEST_CORO(SchemaProtobuf, TestMessageWithListValue) {
+    auto d = StructWithListValue::GetDescriptor();
+    auto result = iceberg::type_to_iceberg(*d);
+    ASSERT_FALSE_CORO(result.has_error());
+    auto field = std::move(result.value());
+    EXPECT_THAT(
+      field.fields, ElementsAre(IsField(1, "list_value_field", string_type{})));
 }
 
 TEST_CORO(SchemaProtobuf, TestProtoTestMessages) {
@@ -545,6 +574,151 @@ TEST(values_protobuf, TestTimestamp) {
       ElementsAre(OptionalIcebergPrimitive<timestamp_value>(1743540027001635)));
 }
 
+TEST(values_protobuf, TestStruct) {
+    StructWithStruct s;
+
+    // Look at the EXPECT_THAT below to see the structure.
+    auto* struct_field = s.mutable_struct_field();
+    (*struct_field->mutable_fields())["string"].set_string_value("test_string");
+    (*struct_field->mutable_fields())["number"].set_number_value(12.04);
+    (*struct_field->mutable_fields())["bool"].set_bool_value(true);
+    (*struct_field->mutable_fields())["null"].set_null_value(
+      google::protobuf::NullValue::NULL_VALUE);
+
+    auto* nested
+      = (*struct_field->mutable_fields())["nested"].mutable_struct_value();
+    (*nested->mutable_fields())["name"].set_string_value("nested");
+
+    auto* array = (*nested->mutable_fields())["items"].mutable_list_value();
+    array->add_values()->set_string_value("array_string");
+    array->add_values()->set_number_value(42.5);
+
+    auto* array_struct = array->add_values()->mutable_struct_value();
+    (*array_struct->mutable_fields())["name"].set_string_value("taco");
+    (*array_struct->mutable_fields())["value"].set_number_value(99.9);
+
+    auto* nested_list = array->add_values()->mutable_list_value();
+    nested_list->add_values()->set_string_value("nested1");
+    nested_list->add_values()->set_string_value("nested2");
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    ASSERT_EQ(struct_v->fields.size(), 1);
+    ASSERT_TRUE(struct_v->fields[0].has_value());
+
+    const auto& struct_json = std::get<iceberg::string_value>(
+      std::get<iceberg::primitive_value>(struct_v->fields[0].value()));
+
+    EXPECT_THAT(struct_json, IsJSON(R"({
+        "string": "test_string",
+        "number": 12.04,
+        "bool": true,
+        "null": null,
+        "nested": {
+          "name": "nested",
+          "items": [
+            "array_string",
+            42.5,
+            {"name": "taco", "value": 99.9},
+            ["nested1", "nested2"]
+          ]
+        }
+      })"));
+}
+
+TEST(values_protobuf, TestStructWithEmptyStructAndArray) {
+    StructWithStruct s;
+
+    // Look at the EXPECT_THAT below to see the structure.
+    auto* struct_field = s.mutable_struct_field();
+    (*struct_field->mutable_fields())["empty_struct"].mutable_struct_value();
+    (*struct_field->mutable_fields())["empty_array"].mutable_list_value();
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    ASSERT_EQ(struct_v->fields.size(), 1);
+    ASSERT_TRUE(struct_v->fields[0].has_value());
+
+    const auto& struct_json = std::get<iceberg::string_value>(
+      std::get<iceberg::primitive_value>(struct_v->fields[0].value()));
+
+    EXPECT_THAT(struct_json, IsJSON(R"({
+        "empty_struct": {},
+        "empty_array": []
+      })"));
+}
+
+TEST(values_protobuf, TestEmptyStruct) {
+    // Leave struct_field empty.
+    StructWithStruct s;
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    ASSERT_EQ(struct_v->fields.size(), 1);
+    EXPECT_FALSE(struct_v->fields[0].has_value());
+}
+
+// NB: We test serializing all Value variants in TestStruct.
+//     This tests that Value is convertible, not that all variants of
+//     Value are serializable to JSON.
+TEST(values_protobuf, TestValue) {
+    StructWithValue s;
+    s.mutable_value_field()->set_string_value("test");
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    ASSERT_EQ(struct_v->fields.size(), 1);
+    ASSERT_TRUE(struct_v->fields[0].has_value());
+
+    const auto& value_json = std::get<iceberg::string_value>(
+      std::get<iceberg::primitive_value>(struct_v->fields[0].value()));
+
+    EXPECT_THAT(value_json, IsJSON(R"("test")"));
+}
+
+// See also TestStruct for ListValue values with all value Variants.
+TEST(values_protobuf, TestListValue) {
+    StructWithListValue s;
+    auto* list = s.mutable_list_value_field();
+    list->add_values()->set_string_value("first");
+    list->add_values()->set_number_value(2);
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    ASSERT_EQ(struct_v->fields.size(), 1);
+    ASSERT_TRUE(struct_v->fields[0].has_value());
+
+    const auto& list_json = std::get<iceberg::string_value>(
+      std::get<iceberg::primitive_value>(struct_v->fields[0].value()));
+
+    EXPECT_THAT(list_json, IsJSON(R"(["first", 2])"));
+}
+
 TEST_CORO(values_protobuf, TestNotSupportedMessageType) {
     RecursiveMessage recursive;
     recursive.set_field(10);
@@ -670,4 +844,49 @@ TEST_CORO(values_protobuf, TestProtoNumbers) {
         OptionalIcebergPrimitive<string_value>("4234234"),
         OptionalIcebergPrimitive<int_value>(-234234),
         OptionalIcebergPrimitive<long_value>(-234234342)));
+}
+
+TEST(values_protobuf, TestValueWithNaN) {
+    StructWithStruct s;
+    auto* struct_field = s.mutable_struct_field();
+    (*struct_field->mutable_fields())["nan_value"].set_number_value(
+      std::numeric_limits<double>::quiet_NaN());
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(
+      result.error().what(),
+      HasSubstr("NaN and Infinity are not supported in JSON"));
+}
+
+TEST(values_protobuf, TestValueWithInfinity) {
+    StructWithStruct s;
+    auto* struct_field = s.mutable_struct_field();
+    (*struct_field->mutable_fields())["inf_value"].set_number_value(
+      std::numeric_limits<double>::infinity());
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(
+      result.error().what(),
+      HasSubstr("NaN and Infinity are not supported in JSON"));
+}
+
+TEST(values_protobuf, TestStructDepthLimit) {
+    StructWithStruct s;
+
+    // Create a deeply nested structure exceeding max_recursion_depth
+    auto* current = s.mutable_struct_field();
+    for (int i = 0; i < max_recursion_depth + 1; ++i) {
+        current = (*current->mutable_fields())[fmt::format("nested_{}", i)]
+                    .mutable_struct_value();
+    }
+
+    auto result = serialize_and_convert(s).get();
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(
+      result.error().what(),
+      HasSubstr(
+        fmt::format(
+          "Maximum recursion depth {} exceeded", max_recursion_depth)));
 }

--- a/src/v/iceberg/conversion/tests/testdata/complex.proto
+++ b/src/v/iceberg/conversion/tests/testdata/complex.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/struct.proto";
 
 enum State {
     ACTIVE = 0;
@@ -59,4 +60,16 @@ message StructWithOneOf {
 
 message StructWithTimestamp {
     google.protobuf.Timestamp timestamp = 1;
+}
+
+message StructWithStruct {
+    google.protobuf.Struct struct_field = 1;
+}
+
+message StructWithValue {
+    google.protobuf.Value value_field = 1;
+}
+
+message StructWithListValue {
+    google.protobuf.ListValue list_value_field = 1;
 }

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -39,6 +39,15 @@ type_conversion_error(const pb::FieldDescriptor& fd) {
         fd.type_name()));
 }
 
+std::optional<value_conversion_exception> check_recursion_depth(int depth) {
+    if (depth > max_recursion_depth) {
+        return value_conversion_exception(
+          fmt::format(
+            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    }
+    return std::nullopt;
+}
+
 template<typename BaseT, typename IcebergT, typename DefaultF>
 std::optional<IcebergT> convert(
   std::optional<parsed::message::field> f,
@@ -243,10 +252,8 @@ serialize_protobuf_value_to_json(
 ss::future<result<std::monostate, value_conversion_exception>>
 serialize_protobuf_list_to_json(
   serde::json::writer& writer, const parsed::message& list, int depth) {
-    if (depth >= max_recursion_depth) {
-        co_return value_conversion_exception(
-          fmt::format(
-            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    if (auto err = check_recursion_depth(depth); err.has_value()) {
+        co_return *err;
     }
 
     writer.begin_array();
@@ -271,10 +278,8 @@ serialize_protobuf_list_to_json(
 ss::future<result<std::monostate, value_conversion_exception>>
 serialize_protobuf_map_to_json(
   serde::json::writer& writer, const parsed::message& map, int depth) {
-    if (depth >= max_recursion_depth) {
-        co_return value_conversion_exception(
-          fmt::format(
-            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    if (auto err = check_recursion_depth(depth); err.has_value()) {
+        co_return *err;
     }
 
     writer.begin_object();
@@ -300,10 +305,8 @@ serialize_protobuf_map_to_json(
 ss::future<result<std::monostate, value_conversion_exception>>
 serialize_protobuf_value_to_json(
   serde::json::writer& writer, const parsed::message& value_msg, int depth) {
-    if (depth >= max_recursion_depth) {
-        co_return value_conversion_exception(
-          fmt::format(
-            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    if (auto err = check_recursion_depth(depth); err.has_value()) {
+        co_return *err;
     }
 
     for (const auto& [field_num, field_value] : value_msg.fields) {
@@ -531,10 +534,10 @@ ss::future<optional_value_outcome> message_to_value(
             "Recursive message types are not supported. Descriptor: {}",
             descriptor.DebugString()));
     }
-    if (stack.size() >= max_recursion_depth) {
+    if (stack.size() > max_recursion_depth) {
         co_return value_conversion_exception(
           fmt::format(
-            "Reached maximum recursion depth. Descriptor: {}",
+            "Exceeded maximum recursion depth. Descriptor: {}",
             descriptor.DebugString()));
     }
 

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -15,6 +15,7 @@
 #include "iceberg/conversion/conversion_outcome.h"
 #include "iceberg/conversion/protobuf_utils.h"
 #include "iceberg/values.h"
+#include "serde/json/writer.h"
 #include "ssx/future-util.h"
 
 #include <seastar/util/defer.hh>
@@ -22,6 +23,8 @@
 #include <seastar/util/variant_utils.hh>
 
 #include <fmt/core.h>
+
+#include <cmath>
 
 namespace iceberg {
 namespace pb = google::protobuf;
@@ -232,6 +235,164 @@ convert_timestamp(std::unique_ptr<parsed::message> message) {
     co_return value_outcome{iceberg::timestamp_value{absl::ToUnixMicros(ts)}};
 }
 
+// Forward declaration for recursive calls
+ss::future<result<std::monostate, value_conversion_exception>>
+serialize_protobuf_value_to_json(
+  serde::json::writer& writer, const parsed::message& value_msg, int depth);
+
+ss::future<result<std::monostate, value_conversion_exception>>
+serialize_protobuf_list_to_json(
+  serde::json::writer& writer, const parsed::message& list, int depth) {
+    if (depth >= max_recursion_depth) {
+        co_return value_conversion_exception(
+          fmt::format(
+            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    }
+
+    writer.begin_array();
+    if (auto it = list.fields.find(1); it != list.fields.end()) {
+        const auto& repeated_data = std::get<parsed::repeated>(it->second);
+        const auto& messages
+          = std::get<chunked_vector<std::unique_ptr<parsed::message>>>(
+            repeated_data.elements);
+
+        for (const auto& msg_ptr : messages) {
+            auto result = co_await serialize_protobuf_value_to_json(
+              writer, *msg_ptr, depth + 1);
+            if (result.has_error()) {
+                co_return result.error();
+            }
+        }
+    }
+    writer.end_array();
+    co_return std::monostate{};
+}
+
+ss::future<result<std::monostate, value_conversion_exception>>
+serialize_protobuf_map_to_json(
+  serde::json::writer& writer, const parsed::message& map, int depth) {
+    if (depth >= max_recursion_depth) {
+        co_return value_conversion_exception(
+          fmt::format(
+            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    }
+
+    writer.begin_object();
+    if (auto it = map.fields.find(1); it != map.fields.end()) {
+        const auto& map_data = std::get<parsed::map>(it->second);
+        for (const auto& [key, value] : map_data.entries) {
+            // google.protobuf.Struct maps always have string keys
+            writer.key(std::get<iobuf>(key));
+            // Convert value
+            const auto& value_msg_ptr
+              = std::get<std::unique_ptr<parsed::message>>(value);
+            auto result = co_await serialize_protobuf_value_to_json(
+              writer, *value_msg_ptr, depth + 1);
+            if (result.has_error()) {
+                co_return result.error();
+            }
+        }
+    }
+    writer.end_object();
+    co_return std::monostate{};
+}
+
+ss::future<result<std::monostate, value_conversion_exception>>
+serialize_protobuf_value_to_json(
+  serde::json::writer& writer, const parsed::message& value_msg, int depth) {
+    if (depth >= max_recursion_depth) {
+        co_return value_conversion_exception(
+          fmt::format(
+            "Maximum recursion depth {} exceeded", max_recursion_depth));
+    }
+
+    for (const auto& [field_num, field_value] : value_msg.fields) {
+        switch (field_num) {
+        case 1: // null
+            writer.null();
+            co_return std::monostate{};
+        case 2: { // number
+            auto d = std::get<double>(field_value);
+            if (std::isnan(d) || std::isinf(d)) {
+                co_return value_conversion_exception(
+                  "NaN and Infinity are not supported in JSON");
+            }
+            writer.number(d);
+            co_return std::monostate{};
+        }
+        case 3: // string
+            writer.string(std::get<iobuf>(field_value));
+            co_return std::monostate{};
+        case 4: // bool
+            writer.boolean(std::get<bool>(field_value));
+            co_return std::monostate{};
+        case 5: { // struct
+            const auto& map = std::get<std::unique_ptr<parsed::message>>(
+              field_value);
+            co_return co_await serialize_protobuf_map_to_json(
+              writer, *map, depth + 1);
+        }
+        case 6: { // list
+            const auto& list = std::get<std::unique_ptr<parsed::message>>(
+              field_value);
+            co_return co_await serialize_protobuf_list_to_json(
+              writer, *list, depth + 1);
+        }
+        }
+    }
+    // If no field is set, default to null (per libprotobuf behavior)
+    writer.null();
+    co_return std::monostate{};
+}
+
+ss::future<optional_value_outcome> convert_struct_to_json(
+  std::unique_ptr<parsed::message> message,
+  const proto_descriptors_stack& stack) {
+    if (message == nullptr) {
+        co_return std::nullopt;
+    }
+
+    serde::json::writer writer;
+    auto result = co_await serialize_protobuf_map_to_json(
+      writer, *message, stack.size());
+    if (result.has_error()) {
+        co_return result.error();
+    }
+    co_return value_outcome{iceberg::string_value{std::move(writer).finish()}};
+}
+
+ss::future<optional_value_outcome> convert_value_to_json(
+  std::unique_ptr<parsed::message> message,
+  const proto_descriptors_stack& stack) {
+    if (message == nullptr) {
+        co_return std::nullopt;
+    }
+
+    serde::json::writer writer;
+    auto result = co_await serialize_protobuf_value_to_json(
+      writer, *message, stack.size());
+    if (result.has_error()) {
+        co_return result.error();
+    }
+    co_return value_outcome{iceberg::string_value{std::move(writer).finish()}};
+}
+
+ss::future<optional_value_outcome> convert_list_value_to_json(
+  std::unique_ptr<parsed::message> message,
+  const proto_descriptors_stack& stack) {
+    if (message == nullptr) {
+        co_return std::nullopt;
+    }
+
+    serde::json::writer writer;
+    auto result = co_await serialize_protobuf_list_to_json(
+      writer, *message, stack.size());
+    if (result.has_error()) {
+        co_return result.error();
+    }
+    co_return value_outcome{iceberg::string_value{std::move(writer).finish()}};
+}
+
 ss::future<optional_value_outcome> message_field_to_value(
   std::optional<parsed::message::field> field,
   const pb::FieldDescriptor& field_descriptor,
@@ -322,6 +483,24 @@ ss::future<optional_value_outcome> single_field_to_value(
           field_descriptor.message_type()->well_known_type()
           == pb::Descriptor::WELLKNOWNTYPE_TIMESTAMP) {
             co_return co_await convert_timestamp(std::move(msg_field));
+        }
+        if (
+          field_descriptor.message_type()->well_known_type()
+          == pb::Descriptor::WELLKNOWNTYPE_STRUCT) {
+            co_return co_await convert_struct_to_json(
+              std::move(msg_field), stack);
+        }
+        if (
+          field_descriptor.message_type()->well_known_type()
+          == pb::Descriptor::WELLKNOWNTYPE_VALUE) {
+            co_return co_await convert_value_to_json(
+              std::move(msg_field), stack);
+        }
+        if (
+          field_descriptor.message_type()->well_known_type()
+          == pb::Descriptor::WELLKNOWNTYPE_LISTVALUE) {
+            co_return co_await convert_list_value_to_json(
+              std::move(msg_field), stack);
         }
         co_return co_await message_to_value(
           std::move(msg_field), *field_descriptor.message_type(), stack);

--- a/tests/rptest/tests/datalake/protobuf_json_test.py
+++ b/tests/rptest/tests/datalake/protobuf_json_test.py
@@ -1,0 +1,180 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+import os
+import tempfile
+from typing import Any, cast
+
+from ducktape.mark import matrix
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class ProtobufJsonTest(RedpandaTest):
+    """
+    Test translation of google.protobuf.Struct, Value, and ListValue to
+    JSON strings in Iceberg.
+    """
+
+    TOPIC_NAME = "proto_json"
+
+    def __init__(self, test_context):
+        super(ProtobufJsonTest, self).__init__(
+            test_context=test_context,
+            num_brokers=3,
+            si_settings=SISettings(
+                test_context,
+                cloud_storage_enable_remote_read=False,
+                cloud_storage_enable_remote_write=False,
+            ),
+            extra_rp_conf={
+                "iceberg_enabled": True,
+                "iceberg_catalog_commit_interval_ms": 1000,
+            },
+            schema_registry_config=SchemaRegistryConfig(),
+        )
+
+    def setUp(self):
+        # Redpanda will be started by DatalakeServices
+        pass
+
+    @cluster(num_nodes=5)
+    @matrix(
+        cloud_storage_type=supported_storage_types(),
+        query_engine=[QueryEngineType.SPARK],
+    )
+    def test_protobuf_struct_value_listvalue_to_json(
+        self, cloud_storage_type, query_engine
+    ):
+        """
+        Test that google.protobuf.Struct, Value, and ListValue fields are correctly
+        translated to JSON strings in Iceberg tables.
+        """
+        with DatalakeServices(
+            self.test_context,
+            redpanda=self.redpanda,
+            include_query_engines=[query_engine],
+        ) as dl:
+            dl.create_iceberg_enabled_topic(
+                self.TOPIC_NAME,
+                partitions=1,
+                replicas=3,
+                iceberg_mode="value_schema_id_prefix",
+            )
+
+            proto_schema = """
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+message TestMessage {
+  google.protobuf.Struct struct_field = 1;
+  google.protobuf.Value value_field = 2;
+  google.protobuf.ListValue list_field = 3;
+}
+"""
+
+            # Create schema in the schema registry.
+            rpk = RpkTool(self.redpanda)
+            with tempfile.NamedTemporaryFile(
+                suffix=".proto", mode="w", delete=False
+            ) as tf:
+                tf.write(proto_schema)
+                tf.flush()
+                schema_file = tf.name
+            try:
+                subject = f"{self.TOPIC_NAME}-value"
+                result = cast(dict[str, Any], rpk.create_schema(subject, schema_file))
+                schema_id: int = int(result["id"])
+                self.logger.info(f"Created schema with ID: {schema_id}")
+            finally:
+                os.unlink(schema_file)
+
+            # The values are expected to round-trip through Redpanda and Iceberg.
+            test_cases = [
+                {
+                    "name": "simple_struct",
+                    "struct_field": {"name": "Alice", "age": 30, "active": True},
+                    "value_field": "simple string",
+                    "list_field": [1, 2, 3],
+                },
+                {
+                    "name": "nested_struct",
+                    "struct_field": {
+                        "user": {"name": "Bob", "details": {"age": 25, "city": "NYC"}}
+                    },
+                    "value_field": 42,
+                    "list_field": ["a", "b", "c"],
+                },
+                {
+                    "name": "null_values",
+                    "struct_field": {},
+                    "value_field": None,
+                    "list_field": [],
+                },
+            ]
+
+            for tc in test_cases:
+                message = {
+                    "struct_field": tc["struct_field"],
+                    "value_field": tc["value_field"],
+                    "list_field": tc["list_field"],
+                }
+                msg_json = json.dumps(message)
+                rpk.produce(
+                    self.TOPIC_NAME,
+                    key="",
+                    msg=msg_json,
+                    schema_id=schema_id,
+                    proto_msg="TestMessage",
+                )
+                self.logger.info(f"Produced message for test case: {tc['name']}")
+
+            dl.wait_for_translation(self.TOPIC_NAME, msg_count=len(test_cases))
+
+            results = dl.spark().run_query_fetch_all(
+                f"SELECT struct_field, value_field, list_field FROM redpanda.{self.TOPIC_NAME} ORDER BY redpanda.offset"
+            )
+
+            assert len(results) == len(test_cases), (
+                f"Expected {len(test_cases)} rows, got {len(results)}"
+            )
+
+            for _, (tc, row) in enumerate(zip(test_cases, results)):
+                struct_json, value_json, list_json = row
+
+                self.logger.info(f"Verifying test case: {tc['name']}")
+                self.logger.info(f"  struct_field: {struct_json}")
+                self.logger.info(f"  value_field: {value_json}")
+                self.logger.info(f"  list_field: {list_json}")
+
+                actual_struct = json.loads(struct_json) if struct_json else None
+                actual_value = json.loads(value_json) if value_json else None
+                actual_list = json.loads(list_json) if list_json else None
+
+                assert actual_struct == tc["struct_field"], (
+                    f"Test case '{tc['name']}': struct_field mismatch. "
+                    f"Expected: {tc['struct_field']}, Got: {actual_struct}"
+                )
+                assert actual_value == tc["value_field"], (
+                    f"Test case '{tc['name']}': value_field mismatch. "
+                    f"Expected: {tc['value_field']}, Got: {actual_value}"
+                )
+                assert actual_list == tc["list_field"], (
+                    f"Test case '{tc['name']}': list_field mismatch. "
+                    f"Expected: {tc['list_field']}, Got: {actual_list}"
+                )
+
+            self.logger.info("All test cases passed!")

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -135,6 +135,7 @@
         "rptest/tests/datalake/mount_unmount_test.py",
         "rptest/tests/datalake/nessie_catalog_smoke_test.py",
         "rptest/tests/datalake/partition_movement_test.py",
+        "rptest/tests/datalake/protobuf_json_test.py",
         "rptest/tests/datalake/recovery_mode_test.py",
         "rptest/tests/datalake/rest_catalog_connection_test.py",
         "rptest/tests/datalake/simple_connect_test.py",


### PR DESCRIPTION
This adds support for the protobuf Struct recursive type. Instead of creating nested fields, it makes a string column and serializes the Struct as a JSON string. This is a simple way to handle Struct fields and has been requested by a number of users. Many query engines can deserialize and query the JSON string, so it's pretty useful.

A follow-up will include a Ducktape test of this, end-to-end.

Fixes CORE-10323

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Features

* Redpanda now supports protobuf Struct field in Iceberg tables. A Struct field will be translated into a string column, and its value with be the JSON serialization of the Struct value.

