### PR TITLE
[25.2.x] bazel: Update seastar

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -216,7 +216,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "iyNO4ZbKbGaef4pf9ZlHorArakMobBDVn0pXB783lcY=",
+        "bzlTransitiveDigest": "4zkTOUvicSzuzs8icxl1naFaJrP4KwsDwHWBQNhCbjg=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -387,9 +387,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "1ec7a91eef59a3d5d0761517807c0b1762f83174c2a6a8efe3dc0b3840901dc1",
-              "strip_prefix": "seastar-0aed36eee620e95c0c8289801824ca52091a0e66",
-              "url": "https://github.com/redpanda-data/seastar/archive/0aed36eee620e95c0c8289801824ca52091a0e66.tar.gz"
+              "sha256": "4665a3f117c47e830e819e7b1184ace9f701d20487817f0c46e124b7b62750ba",
+              "strip_prefix": "seastar-737485d4e702a447c310e804cc9bfc57cb7c60cf",
+              "url": "https://github.com/redpanda-data/seastar/archive/737485d4e702a447c310e804cc9bfc57cb7c60cf.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -162,9 +162,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "1ec7a91eef59a3d5d0761517807c0b1762f83174c2a6a8efe3dc0b3840901dc1",
-        strip_prefix = "seastar-0aed36eee620e95c0c8289801824ca52091a0e66",
-        url = "https://github.com/redpanda-data/seastar/archive/0aed36eee620e95c0c8289801824ca52091a0e66.tar.gz",
+        sha256 = "4665a3f117c47e830e819e7b1184ace9f701d20487817f0c46e124b7b62750ba",
+        strip_prefix = "seastar-737485d4e702a447c310e804cc9bfc57cb7c60cf",
+        url = "https://github.com/redpanda-data/seastar/archive/737485d4e702a447c310e804cc9bfc57cb7c60cf.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Update seastar pointer to latest.

Makes SEASTAR_ASSERT abort with SIGABRT and not SIGILL.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none


