### PR TITLE
Remove almost all fragmented_vector use

### DIFF
--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -241,8 +241,7 @@ void access_time_tracker::remove(std::string_view key) noexcept {
 }
 
 ss::future<> access_time_tracker::sync(
-  const fragmented_vector<file_list_item>& existent,
-  add_entries_t add_entries) {
+  const chunked_vector<file_list_item>& existent, add_entries_t add_entries) {
     absl::btree_set<ss::sstring> paths;
     for (const auto& i : existent) {
         paths.insert(i.path);
@@ -296,8 +295,8 @@ access_time_tracker::get(const std::string& key) const {
 
 bool access_time_tracker::is_dirty() const { return _dirty; }
 
-fragmented_vector<file_list_item> access_time_tracker::lru_entries() const {
-    fragmented_vector<file_list_item> items;
+chunked_vector<file_list_item> access_time_tracker::lru_entries() const {
+    chunked_vector<file_list_item> items;
     items.reserve(_table.size());
     for (const auto& [path, metadata] : _table) {
         items.emplace_back(metadata.time_point(), path, metadata.size);

--- a/src/v/cloud_storage/access_time_tracker.h
+++ b/src/v/cloud_storage/access_time_tracker.h
@@ -64,12 +64,12 @@ public:
     using add_entries_t = ss::bool_class<struct trim_additive_tag>;
     /// Remove every key which isn't present in list of input files
     ss::future<> sync(
-      const fragmented_vector<file_list_item>&,
+      const chunked_vector<file_list_item>&,
       add_entries_t add_entries = add_entries_t::no);
 
     size_t size() const { return _table.size(); }
 
-    fragmented_vector<file_list_item> lru_entries() const;
+    chunked_vector<file_list_item> lru_entries() const;
 
 private:
     /// Returns true if the key's metadata should be tracked.

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -720,7 +720,7 @@ cache::remove_segment_full(const file_list_item& file_stat) {
 }
 
 ss::future<cache::trim_result> cache::trim_fast(
-  const fragmented_vector<file_list_item>& candidates,
+  const chunked_vector<file_list_item>& candidates,
   uint64_t size_to_delete,
   size_t objects_to_delete) {
     probe.fast_trim();
@@ -728,7 +728,7 @@ ss::future<cache::trim_result> cache::trim_fast(
 }
 
 ss::future<cache::trim_result> cache::do_trim(
-  const fragmented_vector<file_list_item>& candidates,
+  const chunked_vector<file_list_item>& candidates,
   uint64_t size_to_delete,
   size_t objects_to_delete) {
     trim_result result;
@@ -776,7 +776,7 @@ ss::future<cache::trim_result> cache::do_trim(
     ssize_t max_carryover_bytes
       = config::shard_local_cfg()
           .cloud_storage_cache_trim_carryover_bytes.value();
-    fragmented_vector<file_list_item> tmp;
+    chunked_vector<file_list_item> tmp;
     auto estimated_size = std::min(
       static_cast<size_t>(max_carryover_bytes),
       candidates.size() - candidate_i);
@@ -1635,7 +1635,7 @@ cache::trim_carryover(uint64_t delete_bytes, uint64_t delete_objects) {
     if (it == _last_trim_carryover->end()) {
         _last_trim_carryover = std::nullopt;
     } else {
-        fragmented_vector<file_list_item> tmp;
+        chunked_vector<file_list_item> tmp;
         size_t estimate = _last_trim_carryover->end() - it;
         tmp.reserve(estimate);
         std::copy(it, _last_trim_carryover->end(), std::back_inserter(tmp));

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -205,12 +205,12 @@ private:
     /// Ordinary trim: prioritze trimming data chunks, only delete indices etc
     /// if all their chunks are dropped.
     ss::future<trim_result> trim_fast(
-      const fragmented_vector<file_list_item>& candidates,
+      const chunked_vector<file_list_item>& candidates,
       uint64_t delete_bytes,
       size_t delete_objects);
 
     ss::future<trim_result> do_trim(
-      const fragmented_vector<file_list_item>& candidates,
+      const chunked_vector<file_list_item>& candidates,
       uint64_t delete_bytes,
       size_t delete_objects);
 
@@ -359,7 +359,7 @@ private:
     friend struct ::cloud_storage_fixture;
 
     // List of probable deletion candidates from the last trim.
-    std::optional<fragmented_vector<file_list_item>> _last_trim_carryover;
+    std::optional<chunked_vector<file_list_item>> _last_trim_carryover;
 
     ss::timer<ss::lowres_clock> _tracker_sync_timer;
     ssx::semaphore _tracker_sync_timer_sem{

--- a/src/v/cloud_storage/inventory/inv_consumer.cc
+++ b/src/v/cloud_storage/inventory/inv_consumer.cc
@@ -43,7 +43,7 @@ struct flush_entry {
     model::ntp ntp;
     // The vector of hashes which will be written to disk in the file_name on
     // next flush.
-    fragmented_vector<uint64_t> hashes;
+    chunked_vector<uint64_t> hashes;
     // The file to which hashes will be written. The file name is incremented on
     // each flush, so each file name contains some hashes, and we may end up
     // with multiple files per NTP. The hash loader will read all the files and
@@ -92,7 +92,7 @@ std::vector<ss::sstring> inventory_consumer::parse_row(ss::sstring row) {
 }
 
 ss::future<>
-inventory_consumer::process_paths(fragmented_vector<ss::sstring> paths) {
+inventory_consumer::process_paths(chunked_vector<ss::sstring> paths) {
     for (const auto& path : paths) {
         // The row is expected to be in the form:
         // "bucket","path"
@@ -150,7 +150,7 @@ inventory_consumer::flush(inventory_consumer::write_all_t write_all_entries) {
 
     // Set up a vector to sort entries. The ntp and next filename are not moved
     // out of the map, only the hashes are moved out.
-    fragmented_vector<flush_entry> entries;
+    chunked_vector<flush_entry> entries;
     ranges::transform(
       _ntp_flush_states, std::back_inserter(entries), [](auto& e) {
           return flush_entry{

--- a/src/v/cloud_storage/inventory/inv_consumer.h
+++ b/src/v/cloud_storage/inventory/inv_consumer.h
@@ -64,7 +64,7 @@ public:
     ~inventory_consumer() = default;
 
 private:
-    ss::future<> process_paths(fragmented_vector<ss::sstring> paths);
+    ss::future<> process_paths(chunked_vector<ss::sstring> paths);
 
     // Checks if the path belongs to one of the NTPs whose leadership belongs to
     // this node. If so, the path is hashed and added to current NTP flush
@@ -89,7 +89,7 @@ private:
 
     struct flush_state {
         uint64_t next_file_name{0};
-        fragmented_vector<uint64_t> hashes{};
+        chunked_vector<uint64_t> hashes{};
     };
     // Mapping of hash vectors per NTP, populated as paths from inventory are
     // processed.

--- a/src/v/cloud_storage/inventory/ntp_hashes.cc
+++ b/src/v/cloud_storage/inventory/ntp_hashes.cc
@@ -102,7 +102,7 @@ ss::future<> ntp_path_hashes::load_hashes(ss::input_stream<char>& stream) {
         chunk.append(co_await stream.read_exactly(chunk_size));
 
         auto chunk_parser = iobuf_parser{std::move(chunk)};
-        auto hashes = serde::read<fragmented_vector<uint64_t>>(chunk_parser);
+        auto hashes = serde::read<chunked_vector<uint64_t>>(chunk_parser);
         vlog(_ctxlog.trace, "read {} path hashes from disk", hashes.size());
 
         for (auto hash : hashes) {

--- a/src/v/cloud_storage/inventory/report_parser.cc
+++ b/src/v/cloud_storage/inventory/report_parser.cc
@@ -84,7 +84,7 @@ ss::future<> report_parser::stop() {
 report_parser::rows_t report_parser::split_to_rows() {
     using ibi = iobuf::byte_iterator;
     rows_t rows;
-    fragmented_vector<char> row;
+    chunked_vector<char> row;
     for (auto begin = ibi{_buffer.cbegin(), _buffer.cend()},
               end = ibi{_buffer.cend(), _buffer.cend()};
          begin != end;

--- a/src/v/cloud_storage/inventory/report_parser.h
+++ b/src/v/cloud_storage/inventory/report_parser.h
@@ -25,7 +25,7 @@ namespace cloud_storage::inventory {
 using is_gzip_compressed = ss::bool_class<struct gzip_compressed_tag>;
 
 template<typename C>
-concept RowsConsumer = requires(C c, fragmented_vector<ss::sstring> rows) {
+concept RowsConsumer = requires(C c, chunked_vector<ss::sstring> rows) {
     { c(rows) } -> std::same_as<ss::future<>>;
 };
 
@@ -43,7 +43,7 @@ public:
 class report_parser {
 public:
     using row_t = iobuf;
-    using rows_t = fragmented_vector<ss::sstring>;
+    using rows_t = chunked_vector<ss::sstring>;
 
     report_parser(const report_parser&) = delete;
     report_parser& operator=(const report_parser&) = delete;

--- a/src/v/cloud_storage/inventory/utils.cc
+++ b/src/v/cloud_storage/inventory/utils.cc
@@ -24,7 +24,7 @@
 namespace {
 
 ss::future<> write_hashes_to_file(
-  ss::output_stream<char>& stream, fragmented_vector<uint64_t> hashes) {
+  ss::output_stream<char>& stream, chunked_vector<uint64_t> hashes) {
     iobuf serialized;
     serde::write(serialized, std::move(hashes));
 
@@ -39,7 +39,7 @@ ss::future<> write_hashes_to_file(
 }
 
 ss::future<>
-write_hashes_to_file(ss::file& f, fragmented_vector<uint64_t> hashes) {
+write_hashes_to_file(ss::file& f, chunked_vector<uint64_t> hashes) {
     std::exception_ptr ep;
     auto stream = co_await ss::make_file_output_stream(f);
     auto res = co_await ss::coroutine::as_future(
@@ -57,7 +57,7 @@ namespace cloud_storage::inventory {
 ss::future<> flush_ntp_hashes(
   std::filesystem::path root,
   model::ntp ntp,
-  fragmented_vector<uint64_t> hashes,
+  chunked_vector<uint64_t> hashes,
   uint64_t file_name) {
     auto ntp_hash_path = root / std::string_view{ntp.path()};
     const auto ntp_hash_dir = ntp_hash_path.string();

--- a/src/v/cloud_storage/inventory/utils.h
+++ b/src/v/cloud_storage/inventory/utils.h
@@ -26,7 +26,7 @@ namespace cloud_storage::inventory {
 ss::future<> flush_ntp_hashes(
   std::filesystem::path root,
   model::ntp ntp,
-  fragmented_vector<uint64_t> hashes,
+  chunked_vector<uint64_t> hashes,
   uint64_t file_name);
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -726,13 +726,13 @@ bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
     return false;
 }
 
-fragmented_vector<partition_manifest::lw_segment_meta>
+chunked_vector<partition_manifest::lw_segment_meta>
 partition_manifest::lw_replaced_segments() const {
     return _replaced.copy();
 }
 
-fragmented_vector<segment_meta> partition_manifest::replaced_segments() const {
-    fragmented_vector<segment_meta> res;
+chunked_vector<segment_meta> partition_manifest::replaced_segments() const {
+    chunked_vector<segment_meta> res;
     for (const auto& s : _replaced) {
         res.push_back(lw_segment_meta::convert(s));
     }
@@ -1035,9 +1035,9 @@ partition_manifest partition_manifest::clone() const {
         segment_name name;
         segment_meta meta;
     };
-    fragmented_vector<segment_name_meta> segments;
-    fragmented_vector<segment_name_meta> replaced;
-    fragmented_vector<segment_name_meta> spillover;
+    chunked_vector<segment_name_meta> segments;
+    chunked_vector<segment_name_meta> replaced;
+    chunked_vector<segment_name_meta> spillover;
     for (const auto& m : _segments) {
         segments.push_back(
           {.name = generate_local_segment_name(m.base_offset, m.segment_term),

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -112,7 +112,7 @@ public:
     using value = segment_meta;
     using segment_map = segment_meta_cstore;
     using spillover_manifest_map = segment_meta_cstore;
-    using replaced_segments_list = fragmented_vector<lw_segment_meta>;
+    using replaced_segments_list = chunked_vector<lw_segment_meta>;
     using const_iterator = segment_map::const_iterator;
 
     /// Generate segment name to use in the cloud
@@ -137,14 +137,14 @@ public:
       model::offset lo,
       model::offset lco,
       model::offset insync,
-      const fragmented_vector<segment_t>& segments,
-      const fragmented_vector<segment_t>& replaced,
+      const chunked_vector<segment_t>& segments,
+      const chunked_vector<segment_t>& replaced,
       kafka::offset start_kafka_offset,
       model::offset archive_start_offset,
       model::offset_delta archive_start_offset_delta,
       model::offset archive_clean_offset,
       uint64_t archive_size_bytes,
-      const fragmented_vector<segment_t>& spillover,
+      const chunked_vector<segment_t>& spillover,
       model::timestamp last_partition_scrub,
       std::optional<model::offset> last_scrubbed_offset,
       anomalies detected_anomalies,
@@ -471,11 +471,11 @@ public:
     const_iterator segment_containing(kafka::offset o) const;
 
     // Return collection of segments that were replaced in lightweight format.
-    fragmented_vector<partition_manifest::lw_segment_meta>
+    chunked_vector<partition_manifest::lw_segment_meta>
     lw_replaced_segments() const;
 
     /// Return collection of segments that were replaced by newer segments.
-    fragmented_vector<segment_meta> replaced_segments() const;
+    chunked_vector<segment_meta> replaced_segments() const;
 
     /// Return the number of replaced segments currently awaiting deletion.
     size_t replaced_segments_count() const;

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -92,7 +92,7 @@ struct walk_accumulator {
     const access_time_tracker& tracker;
     std::deque<ss::sstring> dirlist;
     std::optional<recursive_directory_walker::filter_type> filter;
-    fragmented_vector<file_list_item> files;
+    chunked_vector<file_list_item> files;
     uint64_t current_cache_size{0};
     size_t filtered_out_files{0};
     size_t tmp_files_size{0};
@@ -104,7 +104,7 @@ ss::future<> walker_process_directory(
   const ss::sstring& start_dir,
   ss::sstring target,
   cloud_storage::walk_accumulator& state,
-  fragmented_vector<ss::sstring>& empty_dirs) {
+  chunked_vector<ss::sstring>& empty_dirs) {
     try {
         ss::file target_dir = co_await open_directory(target);
 
@@ -151,7 +151,7 @@ ss::future<walk_result> recursive_directory_walker::walk(
     // Object to accumulate data as we walk directories
     walk_accumulator state(start_dir, tracker, std::move(collect_filter));
 
-    fragmented_vector<ss::sstring> empty_dirs;
+    chunked_vector<ss::sstring> empty_dirs;
 
     // Listing directories involves blocking I/O which in Seastar is serviced by
     // a dedicated thread pool and workqueue. When listing directories with

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -33,8 +33,8 @@ struct file_list_item {
 struct walk_result {
     uint64_t cache_size{0};
     size_t filtered_out_files{0};
-    fragmented_vector<file_list_item> regular_files;
-    fragmented_vector<ss::sstring> empty_dirs;
+    chunked_vector<file_list_item> regular_files;
+    chunked_vector<ss::sstring> empty_dirs;
     size_t tmp_files_size{0};
 };
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -736,7 +736,7 @@ void remote_segment::set_waiter_errors(const std::exception_ptr& err) {
         _wait_list.pop_front();
     }
 
-    fragmented_vector<chunk_request> chunk_waiters;
+    chunked_vector<chunk_request> chunk_waiters;
     chunk_waiters.swap(_chunk_waiters);
     for (auto& w : chunk_waiters) {
         w.promise.set_exception(err);
@@ -895,13 +895,13 @@ ss::future<> remote_segment::run_hydrate_bg() {
     _hydration_loop_running = false;
 }
 
-ss::future<fragmented_vector<remote_segment::chunk_request>>
+ss::future<chunked_vector<remote_segment::chunk_request>>
 remote_segment::service_chunk_requests() {
     auto g = _gate.hold();
-    fragmented_vector<ss::future<ss::file>> chunk_op_results;
+    chunked_vector<ss::future<ss::file>> chunk_op_results;
     chunk_op_results.reserve(_chunk_waiters.size());
 
-    fragmented_vector<chunk_request> requests;
+    chunked_vector<chunk_request> requests;
     requests.swap(_chunk_waiters);
 
     std::ranges::transform(
@@ -915,7 +915,7 @@ remote_segment::service_chunk_requests() {
     auto results = co_await ss::when_all(
       chunk_op_results.begin(), chunk_op_results.end());
 
-    fragmented_vector<chunk_request> failed;
+    chunked_vector<chunk_request> failed;
     for (size_t i = 0; i < results.size(); ++i) {
         auto request = std::move(requests[i]);
         auto current_result = std::move(results[i]);

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -297,7 +297,7 @@ private:
     ss::file _data_file;
     std::optional<offset_index> _index;
 
-    using tx_range_vec = fragmented_vector<model::tx_range>;
+    using tx_range_vec = chunked_vector<model::tx_range>;
     std::optional<tx_range_vec> _tx_range;
 
     // For backing off on apparent thrash/saturation of the local cache
@@ -335,14 +335,14 @@ private:
     /// failed to materialize (possibly due to cache eviction), and returns the
     /// collected set of such failed requests. These should then be requeued by
     /// the caller.
-    ss::future<fragmented_vector<chunk_request>> service_chunk_requests();
+    ss::future<chunked_vector<chunk_request>> service_chunk_requests();
 
     /// Waiters pending chunk downloads. Only the first hydration request for a
     /// given chunk ends up here. All following requests for that chunk are
     /// stored by the chunk API in its own wait list. This way only a single
     /// file handle is created for a given chunk, and the chunk API distributes
     /// shared ptrs to that handle to consumers.
-    fragmented_vector<chunk_request> _chunk_waiters;
+    chunked_vector<chunk_request> _chunk_waiters;
 
     friend class remote_segment_test_helper;
 };

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -193,7 +193,7 @@ void segment_chunks::resolve_prefetch_futures() {
     auto available_it = std::ranges::partition(
       _prefetches, [](const auto& f) { return !f.available(); });
 
-    fragmented_vector<ss::future<segment_chunk::handle_t>> resolved;
+    chunked_vector<ss::future<segment_chunk::handle_t>> resolved;
     resolved.reserve(available_it.size());
 
     std::ranges::move(available_it, std::back_inserter(resolved));

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -138,7 +138,7 @@ private:
 
     uint64_t _max_hydrated_chunks;
     ss::condition_variable _bg_cvar;
-    fragmented_vector<ss::future<segment_chunk::handle_t>> _prefetches;
+    chunked_vector<ss::future<segment_chunk::handle_t>> _prefetches;
 };
 
 class chunk_eviction_strategy {

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -394,7 +394,7 @@ public:
           0);
     }
 
-    fragmented_vector<uint64_t> path_hashes(
+    chunked_vector<uint64_t> path_hashes(
       const absl::flat_hash_set<cloud_storage::segment_meta>& skip_metas) {
         std::vector<ss::sstring> paths;
         std::ranges::copy(
@@ -530,8 +530,8 @@ private:
         return paths;
     }
 
-    fragmented_vector<uint64_t> path_hashes(std::vector<ss::sstring> paths) {
-        fragmented_vector<uint64_t> hashes;
+    chunked_vector<uint64_t> path_hashes(std::vector<ss::sstring> paths) {
+        chunked_vector<uint64_t> hashes;
         for (auto& path : paths) {
             hashes.push_back(xxhash_64(path.data(), path.size()));
         }

--- a/src/v/cloud_storage/tests/tx_range_manifest_bench.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_bench.cc
@@ -25,7 +25,7 @@ struct sax_deserializer {};
 
 ss::future<> test_body(size_t n) {
     // Test data.
-    fragmented_vector<model::tx_range> tx_ranges{};
+    chunked_vector<model::tx_range> tx_ranges{};
     for (size_t i = 0; i < n; ++i) {
         tx_ranges.push_back(model::tx_range{
           model::producer_identity(i, i + 1),

--- a/src/v/cloud_storage/tests/tx_range_manifest_test.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_test.cc
@@ -34,9 +34,8 @@ static remote_manifest_path
 using tx_range_t = model::tx_range;
 
 template<typename T = int>
-static fragmented_vector<T>
-make_fragmented_vector(std::initializer_list<T> in) {
-    fragmented_vector<T> ret;
+static chunked_vector<T> make_fragmented_vector(std::initializer_list<T> in) {
+    chunked_vector<T> ret;
     std::copy(
       std::make_move_iterator(in.begin()),
       std::make_move_iterator(in.end()),
@@ -81,7 +80,7 @@ SEASTAR_THREAD_TEST_CASE(empty_serialization_roundtrip_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(serialization_roundtrip_test) {
-    fragmented_vector<tx_range_t> tx_ranges = make_fragmented_vector(ranges);
+    chunked_vector<tx_range_t> tx_ranges = make_fragmented_vector(ranges);
     tx_range_manifest m(segment_path, std::move(tx_ranges));
     auto [is, size] = m.serialize().get();
     iobuf buf;

--- a/src/v/cloud_storage/tx_range_manifest.cc
+++ b/src/v/cloud_storage/tx_range_manifest.cc
@@ -224,7 +224,7 @@ struct tx_range_manifest_json_handler {
     // User data.
     int version{-1};
     int compat_version{-1};
-    fragmented_vector<model::tx_range> ranges;
+    chunked_vector<model::tx_range> ranges;
 };
 
 remote_manifest_path generate_remote_tx_path(const remote_segment_path& path) {
@@ -232,7 +232,7 @@ remote_manifest_path generate_remote_tx_path(const remote_segment_path& path) {
 }
 
 tx_range_manifest::tx_range_manifest(
-  remote_segment_path spath, fragmented_vector<model::tx_range> range)
+  remote_segment_path spath, chunked_vector<model::tx_range> range)
   : _path(std::move(spath))
   , _ranges(std::move(range)) {}
 

--- a/src/v/cloud_storage/tx_range_manifest.h
+++ b/src/v/cloud_storage/tx_range_manifest.h
@@ -24,7 +24,7 @@ class tx_range_manifest final : public base_manifest {
 public:
     /// Create manifest for specific ntp
     explicit tx_range_manifest(
-      remote_segment_path spath, fragmented_vector<model::tx_range> range);
+      remote_segment_path spath, chunked_vector<model::tx_range> range);
 
     /// Create empty manifest that supposed to be updated later
     explicit tx_range_manifest(remote_segment_path spath);
@@ -54,7 +54,7 @@ public:
         return manifest_type::tx_range;
     };
 
-    fragmented_vector<model::tx_range>&& get_tx_range() && {
+    chunked_vector<model::tx_range>&& get_tx_range() && {
         return std::move(_ranges);
     }
 
@@ -63,6 +63,6 @@ public:
 
 private:
     remote_segment_path _path;
-    fragmented_vector<model::tx_range> _ranges;
+    chunked_vector<model::tx_range> _ranges;
 };
 } // namespace cloud_storage

--- a/src/v/cloud_topics/level_zero/reader/fetch_request_handler.cc
+++ b/src/v/cloud_topics/level_zero/reader/fetch_request_handler.cc
@@ -103,7 +103,7 @@ ss::future<> fetch_handler::process_single_request(l0::read_request<>* req) {
         req->set_value(errc::unexpected_failure);
     });
     std::optional<model::record_batch_reader> prepared;
-    std::optional<fragmented_vector<model::tx_range>> aborted_tx;
+    std::optional<chunked_vector<model::tx_range>> aborted_tx;
     try {
         auto meta = std::move(req->query.meta);
 

--- a/src/v/cloud_topics/level_zero/reconciler/tests/range_batch_consumer_test.cc
+++ b/src/v/cloud_topics/level_zero/reconciler/tests/range_batch_consumer_test.cc
@@ -28,8 +28,7 @@ model::record_batch_reader make_reader(
         }
         batches.push_back(std::move(b).build());
     }
-    return model::make_fragmented_memory_record_batch_reader(
-      std::move(batches));
+    return model::make_chunked_memory_record_batch_reader(std::move(batches));
 }
 
 TEST(RangeBatchConsumer, EmptyReader) {

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -228,9 +228,9 @@ struct archival_metadata_stm::snapshot
   : public serde::
       envelope<snapshot, serde::version<6>, serde::compat_version<0>> {
     /// List of segments
-    fragmented_vector<segment> segments;
+    chunked_vector<segment> segments;
     /// List of replaced segments
-    fragmented_vector<segment> replaced;
+    chunked_vector<segment> replaced;
     /// Start offset (might be different from the base offset of the first
     /// segment). Default value means that the snapshot was old and didn't
     /// have start_offset. In this case we need to set it to compute it from
@@ -260,7 +260,7 @@ struct archival_metadata_stm::snapshot
     // when DeleteRecords was used to override)
     kafka::offset start_kafka_offset;
     // List of spillover manifests
-    fragmented_vector<segment> spillover_manifests;
+    chunked_vector<segment> spillover_manifests;
     // Timestamp of last completed scrub
     model::timestamp last_partition_scrub;
     // Offest at which the previous scrubbing stopped
@@ -515,10 +515,10 @@ command_batch_builder archival_metadata_stm::batch_start(
     return {*this, deadline, as};
 }
 
-fragmented_vector<archival_metadata_stm::segment>
+chunked_vector<archival_metadata_stm::segment>
 archival_metadata_stm::segments_from_manifest(
   const cloud_storage::partition_manifest& manifest) {
-    fragmented_vector<segment> segments;
+    chunked_vector<segment> segments;
     for (auto meta : manifest) {
         if (meta.ntp_revision == model::initial_revision_id{}) {
             meta.ntp_revision = manifest.get_revision_id();
@@ -539,11 +539,11 @@ archival_metadata_stm::segments_from_manifest(
     return segments;
 }
 
-fragmented_vector<archival_metadata_stm::segment>
+chunked_vector<archival_metadata_stm::segment>
 archival_metadata_stm::replaced_segments_from_manifest(
   const cloud_storage::partition_manifest& manifest) {
     auto replaced = manifest.replaced_segments();
-    fragmented_vector<segment> segments;
+    chunked_vector<segment> segments;
     for (auto meta : replaced) {
         if (meta.ntp_revision == model::initial_revision_id{}) {
             meta.ntp_revision = manifest.get_revision_id();
@@ -554,11 +554,11 @@ archival_metadata_stm::replaced_segments_from_manifest(
     return segments;
 }
 
-fragmented_vector<archival_metadata_stm::segment>
+chunked_vector<archival_metadata_stm::segment>
 archival_metadata_stm::spillover_from_manifest(
   const cloud_storage::partition_manifest& manifest) {
     const auto& sp_list = manifest.get_spillover_map();
-    fragmented_vector<segment> res;
+    chunked_vector<segment> res;
     for (auto meta : sp_list) {
         res.push_back(segment_from_meta(meta));
     }
@@ -1586,7 +1586,7 @@ void archival_metadata_stm::apply_reset_scrubbing_metadata() {
     _manifest->reset_scrubbing_metadata();
 }
 
-fragmented_vector<cloud_storage::partition_manifest::lw_segment_meta>
+chunked_vector<cloud_storage::partition_manifest::lw_segment_meta>
 archival_metadata_stm::get_segments_to_cleanup() const {
     // Include replaced segments to the backlog
     using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;
@@ -1596,7 +1596,7 @@ archival_metadata_stm::get_segments_to_cleanup() const {
     // segments. This is a protection from the data loss. This should not
     // happen, but protects us from data loss in cases where bugs elsewhere.
     const auto backlog_size = source_backlog.size();
-    fragmented_vector<lw_segment_meta> backlog;
+    chunked_vector<lw_segment_meta> backlog;
     std::copy_if(
       source_backlog.begin(),
       source_backlog.end(),

--- a/src/v/cluster/archival/archival_metadata_stm.h
+++ b/src/v/cluster/archival/archival_metadata_stm.h
@@ -256,7 +256,7 @@ public:
 
     // Return list of all segments that has to be
     // removed from S3.
-    fragmented_vector<cloud_storage::partition_manifest::lw_segment_meta>
+    chunked_vector<cloud_storage::partition_manifest::lw_segment_meta>
     get_segments_to_cleanup() const;
 
     /// Create batch builder that can be used to combine and replicate multiple
@@ -345,13 +345,13 @@ private:
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
 
-    static fragmented_vector<segment>
+    static chunked_vector<segment>
     segments_from_manifest(const cloud_storage::partition_manifest& manifest);
 
-    static fragmented_vector<segment> replaced_segments_from_manifest(
+    static chunked_vector<segment> replaced_segments_from_manifest(
       const cloud_storage::partition_manifest& manifest);
 
-    static fragmented_vector<segment>
+    static chunked_vector<segment>
     spillover_from_manifest(const cloud_storage::partition_manifest& manifest);
 
     void apply_add_segment(const segment& segment);

--- a/src/v/cluster/archival/archiver_manager.cc
+++ b/src/v/cluster/archival/archiver_manager.cc
@@ -495,7 +495,7 @@ public:
     using transition_table = boost::mpl::vector<
     //  Source state      | Event                  | Dest state        | Action
     row<st_passive,         ev_leadership_acquired,  st_starting_async,  tr_passive_to_starting >, /* Start archiver when the leadership is acquired */
-    row<st_starting_async,  ev_archiver_started,     st_active,          tr_starting_to_active  >, /* Transition to active when the archiver is started */ 
+    row<st_starting_async,  ev_archiver_started,     st_active,          tr_starting_to_active  >, /* Transition to active when the archiver is started */
     row<st_starting_async,  ev_archiver_failure,     st_passive,         tr_starting_to_passive >, /* Return to the initial state due to failure */
     row<st_starting_async,  ev_leadership_lost,      none,               defer                  >, /* Leadership notification during archiver startup */
     row<st_starting_async,  ev_shutdown,             none,               defer                  >, /* Shutdown notification during archiver startup */
@@ -926,8 +926,8 @@ public:
         }
     }
 
-    fragmented_vector<model::ntp> managed_partitions() const {
-        fragmented_vector<model::ntp> results;
+    chunked_vector<model::ntp> managed_partitions() const {
+        chunked_vector<model::ntp> results;
         for (const auto& kv : _managed) {
             results.push_back(kv.first);
         }
@@ -935,8 +935,8 @@ public:
     }
 
     /// Snapshot of managed partitions which are leaders
-    fragmented_vector<model::ntp> leader_partitions() const {
-        fragmented_vector<model::ntp> results;
+    chunked_vector<model::ntp> leader_partitions() const {
+        chunked_vector<model::ntp> results;
         for (const auto& kv : _managed) {
             if (kv.second->is_active()) {
                 results.push_back(kv.first);
@@ -980,12 +980,12 @@ ss::future<> archiver_manager::start() { co_await _impl->start(); }
 
 ss::future<> archiver_manager::stop() { co_await _impl->stop(); }
 
-fragmented_vector<model::ntp> archiver_manager::managed_partitions() const {
+chunked_vector<model::ntp> archiver_manager::managed_partitions() const {
     return _impl->managed_partitions();
 }
 
 /// Snapshot of managed partitions which are leaders
-fragmented_vector<model::ntp> archiver_manager::leader_partitions() const {
+chunked_vector<model::ntp> archiver_manager::leader_partitions() const {
     return _impl->leader_partitions();
 }
 

--- a/src/v/cluster/archival/archiver_manager.h
+++ b/src/v/cluster/archival/archiver_manager.h
@@ -43,10 +43,10 @@ public:
     ss::future<> stop();
 
     /// Snapshot of managed partitions
-    fragmented_vector<model::ntp> managed_partitions() const;
+    chunked_vector<model::ntp> managed_partitions() const;
 
     /// Snapshot of managed partitions which are leaders
-    fragmented_vector<model::ntp> leader_partitions() const;
+    chunked_vector<model::ntp> leader_partitions() const;
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1533,20 +1533,20 @@ std::optional<ss::sstring> ntp_archiver::upload_should_abort() const {
     }
 }
 
-ss::future<fragmented_vector<model::tx_range>>
+ss::future<chunked_vector<model::tx_range>>
 ntp_archiver::get_aborted_transactions(
   model::offset start_offset, model::offset end_offset) {
     auto guard = _gate.hold();
     co_return co_await _parent.aborted_transactions(start_offset, end_offset);
 }
 
-ss::future<std::pair<std::optional<fragmented_vector<model::tx_range>>, size_t>>
+ss::future<std::pair<std::optional<chunked_vector<model::tx_range>>, size_t>>
 ntp_archiver::get_aborted_transactions(
   const segment_collector_stream& meta,
   const cloud_storage::segment_name& sname) {
     ss::log_level level{};
     std::exception_ptr ep{};
-    std::optional<fragmented_vector<model::tx_range>> tx_ranges{};
+    std::optional<chunked_vector<model::tx_range>> tx_ranges{};
     size_t tx_size{0};
     if (!meta.is_compacted) {
         try {
@@ -1619,7 +1619,7 @@ ntp_archiver::make_segment_index(
 ss::future<std::optional<cloud_storage::upload_result>>
 ntp_archiver::maybe_upload_aborted_tx(
   cloud_storage::remote_segment_path path,
-  std::optional<fragmented_vector<model::tx_range>> tx,
+  std::optional<chunked_vector<model::tx_range>> tx,
   retry_chain_node& parent_rtc) {
     retry_chain_node fib(&parent_rtc);
     if (tx.has_value() && !tx.value().empty()) {
@@ -1649,7 +1649,7 @@ ss::future<> ntp_archiver::upload_index(
 ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
   segment_collector_stream strm,
   const cloud_storage::segment_meta& meta,
-  std::optional<fragmented_vector<model::tx_range>> tx_ranges) {
+  std::optional<chunked_vector<model::tx_range>> tx_ranges) {
     retry_chain_node rtc(
       _conf->segment_upload_timeout(),
       _conf->upload_loop_initial_backoff(),

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -567,8 +567,7 @@ private:
     ss::future<ntp_archiver_upload_result> upload_segment(
       segment_collector_stream strm,
       const cloud_storage::segment_meta& meta,
-      std::optional<fragmented_vector<model::tx_range>> tx_ranges
-      = std::nullopt);
+      std::optional<chunked_vector<model::tx_range>> tx_ranges = std::nullopt);
 
     /// Upload tx-manifest
     /// Return error-code if the manifest was uploaded or upload was attempted
@@ -577,17 +576,17 @@ private:
     ss::future<std::optional<cloud_storage::upload_result>>
     maybe_upload_aborted_tx(
       cloud_storage::remote_segment_path path,
-      std::optional<fragmented_vector<model::tx_range>> tx,
+      std::optional<chunked_vector<model::tx_range>> tx,
       retry_chain_node& parent_rtc);
 
     /// Get aborted transactions for upload
     ///
     /// \return list of aborted transactions
-    ss::future<fragmented_vector<model::tx_range>> get_aborted_transactions(
+    ss::future<chunked_vector<model::tx_range>> get_aborted_transactions(
       model::offset start_offset, model::offset end_offset);
 
     ss::future<
-      std::pair<std::optional<fragmented_vector<model::tx_range>>, size_t>>
+      std::pair<std::optional<chunked_vector<model::tx_range>>, size_t>>
     get_aborted_transactions(
       const segment_collector_stream& meta, const cloud_storage::segment_name&);
 

--- a/src/v/cluster/archival/tests/archival_service_fixture.h
+++ b/src/v/cluster/archival/tests/archival_service_fixture.h
@@ -130,11 +130,11 @@ public:
       : cluster_test_fixture()
       , http_imposter_fixture(fixture_port_number) {}
 
-    fragmented_vector<model::ntp> create_topic(
+    chunked_vector<model::ntp> create_topic(
       model::topic id,
       int num_partitions,
       std::vector<model::node_id> replicas) {
-        fragmented_vector<model::ntp> ntp_list;
+        chunked_vector<model::ntp> ntp_list;
         cluster::topic_configuration cfg(
           model::kafka_namespace, id, num_partitions, (int16_t)replicas.size());
 
@@ -340,7 +340,7 @@ public:
     /// on every node.
     /// Returns number of managed replicas.
     void wait_all_partitions_managed(
-      const fragmented_vector<model::ntp>& all_ntp,
+      const chunked_vector<model::ntp>& all_ntp,
       model::node_id node_id,
       ss::lowres_clock::duration timeout = 30s) {
         std::set<model::ntp> expected(all_ntp.begin(), all_ntp.end());
@@ -360,7 +360,7 @@ public:
     /// on every node.
     /// Returns number of managed replicas.
     void wait_all_partitions_managed(
-      const fragmented_vector<model::ntp>& all_ntp,
+      const chunked_vector<model::ntp>& all_ntp,
       ss::lowres_clock::duration timeout = 30s) {
         std::set<model::ntp> expected(all_ntp.begin(), all_ntp.end());
         auto deadline = ss::lowres_clock::now() + timeout;
@@ -379,7 +379,7 @@ public:
     /// on every node.
     /// Returns number of managed replicas.
     void wait_all_partition_leaders(
-      const fragmented_vector<model::ntp>& expected,
+      const chunked_vector<model::ntp>& expected,
       model::node_id target,
       ss::lowres_clock::duration timeout = 30s) {
         std::set<model::ntp> s_expected(expected.begin(), expected.end());
@@ -399,7 +399,7 @@ public:
     /// on every node.
     /// Returns number of managed replicas.
     void wait_all_partition_leaders(
-      const fragmented_vector<model::ntp>& expected,
+      const chunked_vector<model::ntp>& expected,
       ss::lowres_clock::duration timeout = 30s) {
         std::set<model::ntp> s_expected(expected.begin(), expected.end());
         auto deadline = ss::lowres_clock::now() + timeout;

--- a/src/v/cluster/cloud_metadata/offsets_lookup.cc
+++ b/src/v/cluster/cloud_metadata/offsets_lookup.cc
@@ -46,8 +46,7 @@ offsets_lookup::lookup(offsets_lookup_request req) {
         co_return reply;
     }
     reply.node_id = _node_id;
-    absl::btree_map<ss::shard_id, fragmented_vector<model::ntp>>
-      lookups_per_shard;
+    absl::btree_map<ss::shard_id, chunked_vector<model::ntp>> lookups_per_shard;
 
     // Group the lookup requests by shard.
     for (auto& ntp : req.ntps) {

--- a/src/v/cluster/cloud_metadata/offsets_lookup_batcher.cc
+++ b/src/v/cluster/cloud_metadata/offsets_lookup_batcher.cc
@@ -88,7 +88,7 @@ ss::future<> offsets_lookup_batcher::run_lookups(
 
         // Copy the NTPs to send. As we process duplicates, we may end up
         // removing from our lookup set.
-        fragmented_vector<model::ntp> ntps(
+        chunked_vector<model::ntp> ntps(
           ntps_to_lookup.begin(), ntps_to_lookup.end());
 
         // Batch up all our lookup requests per node.

--- a/src/v/cluster/cloud_metadata/offsets_lookup_rpc_types.h
+++ b/src/v/cluster/cloud_metadata/offsets_lookup_rpc_types.h
@@ -29,7 +29,7 @@ struct offsets_lookup_request
     model::node_id node_id;
 
     // List of NTPs being looked up.
-    fragmented_vector<model::ntp> ntps;
+    chunked_vector<model::ntp> ntps;
 
     auto serde_fields() { return std::tie(node_id, ntps); }
 
@@ -66,7 +66,7 @@ struct offsets_lookup_reply
     model::node_id node_id;
 
     // Kakfa end offsets per NTP.
-    fragmented_vector<ntp_offset> ntp_and_offset;
+    chunked_vector<ntp_offset> ntp_and_offset;
 
     auto serde_fields() { return std::tie(node_id, ntp_and_offset); }
 

--- a/src/v/cluster/cloud_metadata/offsets_snapshot.h
+++ b/src/v/cluster/cloud_metadata/offsets_snapshot.h
@@ -47,13 +47,13 @@ struct group_offsets
           serde::version<0>,
           serde::compat_version<0>> {
         using rpc_adl_exempt = std::true_type;
-        topic_partitions(model::topic t, fragmented_vector<partition_offset> ps)
+        topic_partitions(model::topic t, chunked_vector<partition_offset> ps)
           : topic(std::move(t))
           , partitions(std::move(ps)) {}
         topic_partitions() = default;
 
         model::topic topic;
-        fragmented_vector<partition_offset> partitions;
+        chunked_vector<partition_offset> partitions;
 
         auto serde_fields() { return std::tie(topic, partitions); }
         friend bool operator==(const topic_partitions&, const topic_partitions&)
@@ -64,7 +64,7 @@ struct group_offsets
     ss::sstring group_id;
 
     // Data partitions and their committed offsets.
-    fragmented_vector<topic_partitions> offsets;
+    chunked_vector<topic_partitions> offsets;
 
     auto serde_fields() { return std::tie(group_id, offsets); }
 
@@ -83,7 +83,7 @@ struct group_offsets_snapshot
     model::partition_id offsets_topic_pid;
 
     // Consumer groups and their offsets.
-    fragmented_vector<group_offsets> groups;
+    chunked_vector<group_offsets> groups;
 
     auto serde_fields() { return std::tie(offsets_topic_pid, groups); }
 

--- a/src/v/cluster/cluster_recovery_reconciler.h
+++ b/src/v/cluster/cluster_recovery_reconciler.h
@@ -38,10 +38,10 @@ public:
     struct controller_actions {
         std::optional<security::license> license;
         config_update_request config;
-        fragmented_vector<cluster::user_credential> users;
-        fragmented_vector<security::acl_binding> acls;
-        fragmented_vector<topic_configuration> remote_topics;
-        fragmented_vector<topic_configuration> local_topics;
+        chunked_vector<cluster::user_credential> users;
+        chunked_vector<security::acl_binding> acls;
+        chunked_vector<topic_configuration> remote_topics;
+        chunked_vector<topic_configuration> local_topics;
         // TODO: restore wasm plugins/transforms
 
         bool empty() const {

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -110,7 +110,7 @@ struct config_t
       envelope<config_t, serde::version<0>, serde::compat_version<0>> {
     config_version version;
     absl::btree_map<ss::sstring, ss::sstring> values;
-    fragmented_vector<config_status> nodes_status;
+    chunked_vector<config_status> nodes_status;
 
     friend bool operator==(const config_t&, const config_t&) = default;
 
@@ -224,8 +224,8 @@ struct named_role_t
 struct security_t
   : public serde::
       envelope<security_t, serde::version<1>, serde::compat_version<0>> {
-    fragmented_vector<user_and_credential> user_credentials;
-    fragmented_vector<security::acl_binding> acls;
+    chunked_vector<user_and_credential> user_credentials;
+    chunked_vector<security::acl_binding> acls;
     chunked_vector<named_role_t> roles;
 
     friend bool operator==(const security_t&, const security_t&) = default;

--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -79,7 +79,7 @@ namespace {
 ss::future<get_leadership_reply>
 make_get_leadership_reply(const partition_leaders_table& leaders) {
     try {
-        fragmented_vector<ntp_leader> ret;
+        chunked_vector<ntp_leader> ret;
         co_await leaders.for_each_leader([&ret](
                                            model::topic_namespace_view tp_ns,
                                            model::partition_id pid,

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -187,13 +187,13 @@ struct get_leadership_reply
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     using is_success = ss::bool_class<struct glr_tag>;
-    fragmented_vector<ntp_leader> leaders;
+    chunked_vector<ntp_leader> leaders;
     is_success success = is_success::yes;
 
     get_leadership_reply() noexcept = default;
 
     explicit get_leadership_reply(
-      fragmented_vector<ntp_leader> leaders, is_success success)
+      chunked_vector<ntp_leader> leaders, is_success success)
       : leaders(std::move(leaders))
       , success(success) {}
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1564,11 +1564,11 @@ ss::shared_ptr<cluster::tm_stm> partition::tm_stm() {
     return _raft->stm_manager()->get<cluster::tm_stm>();
 }
 
-ss::future<fragmented_vector<tx::tx_range>>
+ss::future<chunked_vector<tx::tx_range>>
 partition::aborted_transactions(model::offset from, model::offset to) {
     if (!_rm_stm) {
-        return ss::make_ready_future<fragmented_vector<tx::tx_range>>(
-          fragmented_vector<tx::tx_range>());
+        return ss::make_ready_future<chunked_vector<tx::tx_range>>(
+          chunked_vector<tx::tx_range>());
     }
     return _rm_stm->aborted_transactions(from, to);
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -229,7 +229,7 @@ public:
     const storage::ntp_config& get_ntp_config() const;
     ss::shared_ptr<cluster::tm_stm> tm_stm();
 
-    ss::future<fragmented_vector<model::tx_range>>
+    ss::future<chunked_vector<model::tx_range>>
     aborted_transactions(model::offset from, model::offset to);
 
     ss::future<std::vector<model::tx_range>>

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1141,7 +1141,7 @@ partition_balancer_planner::request_context::for_each_replica_random_order(
         model::node_id node;
     };
 
-    fragmented_vector<item> replicas;
+    chunked_vector<item> replicas;
     for (const auto& t : _parent._state.topics().topics_map()) {
         for (const auto& [_, a] : t.second.get_assignments()) {
             auto reassignment_it = _reassignments.find(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1309,8 +1309,8 @@ model::offset rm_stm::last_stable_offset() {
 }
 
 static void filter_intersecting(
-  fragmented_vector<tx_range>& target,
-  const fragmented_vector<tx_range>& source,
+  chunked_vector<tx_range>& target,
+  const chunked_vector<tx_range>& source,
   model::offset from,
   model::offset to) {
     for (auto& range : source) {
@@ -1324,7 +1324,7 @@ static void filter_intersecting(
     }
 }
 
-ss::future<fragmented_vector<tx_range>>
+ss::future<chunked_vector<tx_range>>
 rm_stm::aborted_transactions(model::offset from, model::offset to) {
     return _state_lock.hold_read_lock().then(
       [from, to, this](ss::basic_rwlock<>::holder unit) mutable {
@@ -1337,13 +1337,13 @@ model::producer_id rm_stm::highest_producer_id() const {
     return _highest_producer_id;
 }
 
-ss::future<fragmented_vector<tx_range>>
+ss::future<chunked_vector<tx_range>>
 rm_stm::do_aborted_transactions(model::offset from, model::offset to) {
-    fragmented_vector<tx_range> result;
+    chunked_vector<tx_range> result;
     if (!_is_tx_enabled) {
         co_return result;
     }
-    fragmented_vector<abort_index> intersecting_idxes;
+    chunked_vector<abort_index> intersecting_idxes;
     for (const auto& idx : _aborted_tx_state.abort_indexes) {
         if (idx.last < from) {
             continue;
@@ -1937,8 +1937,8 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
     // all the operations during snapshot creation are made against the two
     // local variables, after all garbage collection is done the internal stm
     // state is updated.
-    fragmented_vector<abort_index> final_abort_indexes;
-    fragmented_vector<abort_index> expired_abort_indexes;
+    chunked_vector<abort_index> final_abort_indexes;
+    chunked_vector<abort_index> expired_abort_indexes;
 
     // first, check if there are any indicies and aborted ranges to drop.
     // whatever is there to retain is moved to the `final_` local variables.
@@ -1953,7 +1953,7 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
         }
     }
 
-    fragmented_vector<tx::tx_range> preserved_aborted_ranges;
+    chunked_vector<tx::tx_range> preserved_aborted_ranges;
     // remove obsolete aborted ranges, this doesn't influence correctness as
     // logs start offset already advanced past those ranges.
     std::copy_if(
@@ -1983,7 +1983,7 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
 
         model::offset first = model::offset::max();
         model::offset last = model::offset::min();
-        fragmented_vector<tx::tx_range> aborted_ranges;
+        chunked_vector<tx::tx_range> aborted_ranges;
 
         for (const auto& entry : _aborted_tx_state.aborted) {
             first = std::min(first, entry.first);
@@ -2031,7 +2031,7 @@ ss::future<raft::stm_snapshot> rm_stm::do_take_local_snapshot(
       });
 
     _aborted_tx_state.abort_indexes = std::move(final_abort_indexes);
-    fragmented_vector<tx::tx_range> cleaned_aborted_ranges;
+    chunked_vector<tx::tx_range> cleaned_aborted_ranges;
     cleaned_aborted_ranges.reserve(_aborted_tx_state.aborted.size());
     // preserve those aborted ranges which were not included in the snapshot
     std::copy_if(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -154,7 +154,7 @@ public:
      * transactions this will return next offset to be applied to the the stm.
      */
     model::offset last_stable_offset();
-    ss::future<fragmented_vector<tx::tx_range>>
+    ss::future<chunked_vector<tx::tx_range>>
       aborted_transactions(model::offset, model::offset);
 
     /**
@@ -186,7 +186,7 @@ public:
         return storage::stm_type::user_topic_transactional;
     }
 
-    ss::future<fragmented_vector<model::tx_range>>
+    ss::future<chunked_vector<model::tx_range>>
     aborted_tx_ranges(model::offset from, model::offset to) override {
         return aborted_transactions(from, to);
     }
@@ -239,7 +239,7 @@ protected:
 private:
     void setup_metrics();
     ss::future<> do_remove_persistent_state();
-    ss::future<fragmented_vector<tx::tx_range>>
+    ss::future<chunked_vector<tx::tx_range>>
       do_aborted_transactions(model::offset, model::offset);
 
     // Tells whether the producer is already known or is created
@@ -355,8 +355,8 @@ private:
 
     // Populated from state machine up calls.
     struct aborted_tx_state {
-        fragmented_vector<tx::tx_range> aborted;
-        fragmented_vector<tx::abort_index> abort_indexes;
+        chunked_vector<tx::tx_range> aborted;
+        chunked_vector<tx::abort_index> abort_indexes;
         tx::abort_snapshot last_abort_snapshot{.last = model::offset(-1)};
     };
 

--- a/src/v/cluster/rm_stm_types.cc
+++ b/src/v/cluster/rm_stm_types.cc
@@ -401,11 +401,10 @@ namespace reflection {
 using namespace cluster::tx;
 
 template<class T>
-using fvec = fragmented_vector<T>;
+using fvec = chunked_vector<T>;
 
 ss::future<> async_adl<tx_snapshot_v4>::to(iobuf& out, tx_snapshot_v4 snap) {
-    co_await detail::async_adl_list<
-      fragmented_vector<model::producer_identity>>{}
+    co_await detail::async_adl_list<chunked_vector<model::producer_identity>>{}
       .to(out, std::move(snap.fenced));
     co_await detail::async_adl_list<fvec<tx_range>>{}.to(
       out, std::move(snap.ongoing));
@@ -458,8 +457,7 @@ ss::future<> async_adl<tx_snapshot_v5>::to(iobuf& out, tx_snapshot_v5 snap) {
     reflection::serialize(out, snap.offset);
     co_await detail::async_adl_list<fvec<producer_state_snapshot_deprecated>>{}
       .to(out, std::move(snap.producers));
-    co_await detail::async_adl_list<
-      fragmented_vector<model::producer_identity>>{}
+    co_await detail::async_adl_list<chunked_vector<model::producer_identity>>{}
       .to(out, std::move(snap.fenced));
     co_await detail::async_adl_list<fvec<tx_range>>{}.to(
       out, std::move(snap.ongoing));

--- a/src/v/cluster/rm_stm_types.h
+++ b/src/v/cluster/rm_stm_types.h
@@ -133,7 +133,7 @@ struct prepare_marker {
 struct abort_snapshot {
     model::offset first;
     model::offset last;
-    fragmented_vector<tx_range> aborted;
+    chunked_vector<tx_range> aborted;
 
     bool match(abort_index idx) {
         return idx.first == first && idx.last == last;
@@ -288,15 +288,15 @@ struct deprecated_seq_entry {
 struct tx_snapshot_v4 {
     static constexpr uint8_t version = 4;
 
-    fragmented_vector<model::producer_identity> fenced;
-    fragmented_vector<tx_range> ongoing;
-    fragmented_vector<prepare_marker> prepared;
-    fragmented_vector<tx_range> aborted;
-    fragmented_vector<abort_index> abort_indexes;
+    chunked_vector<model::producer_identity> fenced;
+    chunked_vector<tx_range> ongoing;
+    chunked_vector<prepare_marker> prepared;
+    chunked_vector<tx_range> aborted;
+    chunked_vector<abort_index> abort_indexes;
     model::offset offset;
-    fragmented_vector<deprecated_seq_entry> seqs;
-    fragmented_vector<tx_data_snapshot> tx_data;
-    fragmented_vector<expiration_snapshot> expiration;
+    chunked_vector<deprecated_seq_entry> seqs;
+    chunked_vector<tx_data_snapshot> tx_data;
+    chunked_vector<expiration_snapshot> expiration;
 
     bool operator==(const tx_snapshot_v4&) const = default;
 };
@@ -314,17 +314,17 @@ struct tx_snapshot_v5 {
     // members for transactional state. Once transactional state
     // is ported into producer_state, these data members can
     // be removed.
-    fragmented_vector<producer_state_snapshot_deprecated> producers;
+    chunked_vector<producer_state_snapshot_deprecated> producers;
 
     // transactional state
-    fragmented_vector<model::producer_identity> fenced;
-    fragmented_vector<tx_range> ongoing;
-    fragmented_vector<prepare_marker> prepared;
-    fragmented_vector<tx_range> aborted;
-    fragmented_vector<abort_index> abort_indexes;
+    chunked_vector<model::producer_identity> fenced;
+    chunked_vector<tx_range> ongoing;
+    chunked_vector<prepare_marker> prepared;
+    chunked_vector<tx_range> aborted;
+    chunked_vector<abort_index> abort_indexes;
 
-    fragmented_vector<tx_data_snapshot> tx_data;
-    fragmented_vector<expiration_snapshot> expiration;
+    chunked_vector<tx_data_snapshot> tx_data;
+    chunked_vector<expiration_snapshot> expiration;
     model::producer_id highest_producer_id{};
 
     bool operator==(const tx_snapshot_v5&) const = default;
@@ -338,9 +338,9 @@ struct tx_snapshot_v6
     tx_snapshot_v6() = default;
     explicit tx_snapshot_v6(tx_snapshot_v5, raft::group_id);
 
-    fragmented_vector<producer_state_snapshot> producers;
-    fragmented_vector<tx_range> aborted;
-    fragmented_vector<abort_index> abort_indexes;
+    chunked_vector<producer_state_snapshot> producers;
+    chunked_vector<tx_range> aborted;
+    chunked_vector<abort_index> abort_indexes;
     model::producer_id highest_producer_id;
 
     tx_snapshot_v5 downgrade_to_v5() &&;

--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -94,7 +94,7 @@ private:
     };
     chunked_hash_map<raft::group_id, model::broker_shard> _current_leaders;
 
-    using replicas_t = fragmented_vector<replica>;
+    using replicas_t = chunked_vector<replica>;
     replicas_t _replicas;
     size_t _replicas_begin{0};
 };

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -762,8 +762,7 @@ cluster::tx::tx_snapshot_v4 make_tx_snapshot_v4() {
 cluster::tx::tx_snapshot_v5 make_tx_snapshot_v5() {
     auto producers = tests::random_frag_vector(
       tests::random_producer_state, 50, ctx_logger);
-    fragmented_vector<cluster::tx::producer_state_snapshot_deprecated>
-      snapshots;
+    chunked_vector<cluster::tx::producer_state_snapshot_deprecated> snapshots;
     for (const auto& producer : producers) {
         auto snapshot = producer->snapshot(kafka::offset{0});
         cluster::tx::producer_state_snapshot_deprecated old_snapshot;

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -805,7 +805,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
 
     roundtrip_test(cluster::get_leadership_request());
 
-    fragmented_vector<cluster::ntp_leader> leaders;
+    chunked_vector<cluster::ntp_leader> leaders;
     leaders.emplace_back(
       model::random_ntp(),
       tests::random_named_int<model::term_id>(),

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -592,8 +592,8 @@ void tm_stm::upsert_transaction(tx_metadata tx) {
     _transactions_lru.push_back(tx_it->second);
 }
 
-fragmented_vector<tx_metadata> tm_stm::get_transactions_list() const {
-    fragmented_vector<tx_metadata> ret;
+chunked_vector<tx_metadata> tm_stm::get_transactions_list() const {
+    chunked_vector<tx_metadata> ret;
     ret.reserve(_transactions.size());
     for (const auto& [_, wrapper] : _transactions) {
         ret.push_back(wrapper.tx);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -214,14 +214,14 @@ public:
         static constexpr uint8_t version = 0;
 
         model::offset offset;
-        fragmented_vector<tx_metadata> transactions;
+        chunked_vector<tx_metadata> transactions;
     };
 
     struct tm_snapshot {
         static constexpr uint8_t version = 1;
 
         model::offset offset;
-        fragmented_vector<tx_metadata> transactions;
+        chunked_vector<tx_metadata> transactions;
         // hash_ranges is unused and the relevant code can be
         // removed at some point.
         locally_hosted_txs hash_ranges;
@@ -317,7 +317,7 @@ public:
     absl::btree_set<kafka::transactional_id> get_expired_txs();
 
     using get_txs_result
-      = checked<fragmented_vector<tx_metadata>, tm_stm::op_status>;
+      = checked<chunked_vector<tx_metadata>, tm_stm::op_status>;
     ss::future<get_txs_result> get_all_transactions();
 
     ss::future<checked<tx_metadata, tm_stm::op_status>>
@@ -392,7 +392,7 @@ private:
 
     void upsert_transaction(tx_metadata);
 
-    fragmented_vector<tx_metadata> get_transactions_list() const;
+    chunked_vector<tx_metadata> get_transactions_list() const;
 
 private:
     std::chrono::milliseconds _sync_timeout;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -872,7 +872,7 @@ std::error_code topic_table::validate_force_reconfigurable_partition(
 }
 
 std::error_code topic_table::validate_force_reconfigurable_partitions(
-  const fragmented_vector<ntp_with_majority_loss>& partitions) const {
+  const chunked_vector<ntp_with_majority_loss>& partitions) const {
     std::error_code result = errc::success;
     for (const auto& entry : partitions) {
         auto error = validate_force_reconfigurable_partition(entry);
@@ -1309,7 +1309,7 @@ class topic_table::snapshot_applier {
     updates_t& _updates_in_progress;
     disabled_partitions_t& _disabled_partitions;
     chunked_vector<topic_delta>& _pending_topic_deltas;
-    fragmented_vector<ntp_delta>& _pending_ntp_deltas;
+    chunked_vector<ntp_delta>& _pending_ntp_deltas;
     topic_table_probe& _probe;
     model::revision_id& _topics_map_revision;
     model::revision_id _snap_revision;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -450,7 +450,7 @@ public:
     using ntp_delta = topic_table_ntp_delta;
 
     using ntp_delta_range_t
-      = boost::iterator_range<fragmented_vector<ntp_delta>::const_iterator>;
+      = boost::iterator_range<chunked_vector<ntp_delta>::const_iterator>;
     using ntp_delta_cb_t = ss::noncopyable_function<void(ntp_delta_range_t)>;
     using lw_ntp_cb_t = ss::noncopyable_function<void()>;
 
@@ -816,7 +816,7 @@ public:
     }
 
     std::error_code validate_force_reconfigurable_partitions(
-      const fragmented_vector<ntp_with_majority_loss>&) const;
+      const chunked_vector<ntp_with_majority_loss>&) const;
 
     auto partitions_to_force_recover_it_begin() const {
         return stable_iterator<
@@ -855,7 +855,7 @@ private:
     struct waiter {
         explicit waiter(uint64_t id)
           : id(id) {}
-        ss::promise<fragmented_vector<ntp_delta>> promise;
+        ss::promise<chunked_vector<ntp_delta>> promise;
         ss::abort_source::subscription sub;
         uint64_t id;
     };
@@ -910,7 +910,7 @@ private:
     std::vector<std::pair<cluster::notification_id_type, topic_delta_cb_t>>
       _topic_notifications;
 
-    fragmented_vector<ntp_delta> _pending_ntp_deltas;
+    chunked_vector<ntp_delta> _pending_ntp_deltas;
     cluster::notification_id_type _ntp_notification_id{0};
     cluster::notification_id_type _lw_ntp_notification_id{0};
     std::vector<std::pair<cluster::notification_id_type, ntp_delta_cb_t>>

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1349,11 +1349,11 @@ ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
       _stm, _as, std::move(cmd), tout, term);
 }
 
-ss::future<result<fragmented_vector<ntp_with_majority_loss>>>
+ss::future<result<chunked_vector<ntp_with_majority_loss>>>
 topics_frontend::partitions_with_lost_majority(
   std::vector<model::node_id> dead_nodes) {
     try {
-        fragmented_vector<ntp_with_majority_loss> result;
+        chunked_vector<ntp_with_majority_loss> result;
         const auto& topics = _topics.local();
         for (auto it = topics.topics_iterator_begin();
              it != topics.topics_iterator_end();
@@ -1399,7 +1399,7 @@ topics_frontend::partitions_with_lost_majority(
 ss::future<std::error_code>
 topics_frontend::force_recover_partitions_from_nodes(
   std::vector<model::node_id> nodes,
-  fragmented_vector<ntp_with_majority_loss>
+  chunked_vector<ntp_with_majority_loss>
     user_approved_force_recovery_partitions,
   model::timeout_clock::time_point timeout) {
     auto result = co_await stm_linearizable_barrier(timeout);

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -119,12 +119,12 @@ public:
      * Given a list of defunct nodes, generates a list of ntps that lost
      * majority due to unavailability of the nodes.
      */
-    ss::future<result<fragmented_vector<ntp_with_majority_loss>>>
+    ss::future<result<chunked_vector<ntp_with_majority_loss>>>
     partitions_with_lost_majority(std::vector<model::node_id> dead_nodes);
 
     ss::future<std::error_code> force_recover_partitions_from_nodes(
       std::vector<model::node_id> nodes,
-      fragmented_vector<ntp_with_majority_loss>
+      chunked_vector<ntp_with_majority_loss>
         user_approved_force_recovery_partitions,
       model::timeout_clock::time_point timeout);
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -56,7 +56,7 @@ public:
     ss::future<end_tx_reply>
       end_txn(end_tx_request, model::timeout_clock::duration);
 
-    using return_all_txs_res = result<fragmented_vector<tx_metadata>, tx::errc>;
+    using return_all_txs_res = result<chunked_vector<tx_metadata>, tx::errc>;
     ss::future<return_all_txs_res>
     get_all_transactions_for_one_tx_partition(model::ntp tx_manager_ntp);
     ss::future<return_all_txs_res> get_all_transactions();

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2152,7 +2152,7 @@ struct bulk_force_reconfiguration_cmd_data
       = default;
 
     std::vector<model::node_id> from_nodes;
-    fragmented_vector<ntp_with_majority_loss>
+    chunked_vector<ntp_with_majority_loss>
       user_approved_force_recovery_partitions;
 
     auto serde_fields() {

--- a/src/v/compat/metadata_dissemination_generator.h
+++ b/src/v/compat/metadata_dissemination_generator.h
@@ -47,7 +47,7 @@ EMPTY_COMPAT_GENERATOR(cluster::get_leadership_request);
 template<>
 struct instance_generator<cluster::get_leadership_reply> {
     static cluster::get_leadership_reply random() {
-        fragmented_vector<cluster::ntp_leader> leaders;
+        chunked_vector<cluster::ntp_leader> leaders;
         leaders.emplace_back(
           model::random_ntp(),
           tests::random_named_int<model::term_id>(),

--- a/src/v/container/tests/fragmented_vector_async_test.cc
+++ b/src/v/container/tests/fragmented_vector_async_test.cc
@@ -13,7 +13,7 @@
 #include <seastar/testing/thread_test_case.hh>
 
 SEASTAR_THREAD_TEST_CASE(fragmented_vector_fill_async_test) {
-    fragmented_vector<int> v;
+    chunked_vector<int> v;
     fragmented_vector_fill_async(v, 0).get();
     BOOST_REQUIRE(v.size() == 0);
 
@@ -35,7 +35,7 @@ SEASTAR_THREAD_TEST_CASE(fragmented_vector_fill_async_test) {
 }
 
 SEASTAR_THREAD_TEST_CASE(fragmented_vector_clear_async_test) {
-    fragmented_vector<int> v;
+    chunked_vector<int> v;
     fragmented_vector_clear_async(v).get();
     BOOST_REQUIRE(v.size() == 0);
 

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -36,8 +36,8 @@ namespace {
 std::string generate_nested_proto_internal(size_t total_depth) {
     constexpr auto proto_template = R"(
     message Foo{} {{
-        {} 
-        string a{} = {}; 
+        {}
+        string a{} = {};
         {}
     }})";
 
@@ -308,7 +308,7 @@ public:
     }
 
     ss::future<size_t> run_bench() {
-        auto reader = model::make_fragmented_memory_record_batch_reader(
+        auto reader = model::make_chunked_memory_record_batch_reader(
           share_batches(_batch_data));
         auto consumer = counting_consumer{.mux = create_mux(), .as = _as};
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -289,7 +289,7 @@ ss::future<> group_manager::handle_offset_expiration() {
      * build a light-weight snapshot of the groups to process. the snapshot
      * allows us to avoid concurrent modifications to _groups container.
      */
-    fragmented_vector<std::pair<group_ptr, size_t>> groups;
+    chunked_vector<std::pair<group_ptr, size_t>> groups;
     for (auto& group : _groups) {
         groups.emplace_back(group.second, 0);
     }
@@ -796,7 +796,7 @@ ss::future<group_offsets_snapshot_result> group_manager::snapshot_groups(
     }
     // Make a copy of the groups that we're about to snapshot, to avoid racing
     // with removals during iteration.
-    fragmented_vector<std::pair<group_id, group_ptr>> groups;
+    chunked_vector<std::pair<group_id, group_ptr>> groups;
     std::copy_if(
       _groups.begin(),
       _groups.end(),
@@ -815,7 +815,7 @@ ss::future<group_offsets_snapshot_result> group_manager::snapshot_groups(
         go.group_id = group_id();
         absl::btree_map<
           model::topic,
-          fragmented_vector<group_offsets::partition_offset>>
+          chunked_vector<group_offsets::partition_offset>>
           offsets;
         for (const auto& [tp, o] : group->offsets()) {
             offsets[tp.topic].emplace_back(

--- a/src/v/kafka/server/group_tx_tracker_stm.h
+++ b/src/v/kafka/server/group_tx_tracker_stm.h
@@ -83,7 +83,7 @@ public:
         return storage::stm_type::consumer_offsets_transactional;
     }
 
-    ss::future<fragmented_vector<model::tx_range>>
+    ss::future<chunked_vector<model::tx_range>>
     aborted_tx_ranges(model::offset, model::offset) override {
         // Instead of tracking aborted transactions, group partitions rely on a
         // different approach. When a group transaction is committed, the data
@@ -91,7 +91,7 @@ public:
         // conversion happens atomically along with writing a commit marker.
         // This eliminates the need to track completed transactional batches and
         // they are unconditionally omitted in the compaction pass.
-        return ss::make_ready_future<fragmented_vector<model::tx_range>>();
+        return ss::make_ready_future<chunked_vector<model::tx_range>>();
     }
 
     ss::future<> do_apply(const model::record_batch&) override;

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -27,7 +27,7 @@ static constexpr std::string_view buckets_key{"buckets"};
 struct persisted_state {
     std::chrono::seconds configured_period;
     size_t configured_windows;
-    fragmented_vector<usage_window> current_state;
+    chunked_vector<usage_window> current_state;
 };
 
 static ss::future<>
@@ -78,7 +78,7 @@ restore_from_disk(storage::kvstore& kvstore) {
       .configured_period = serde::from_iobuf<std::chrono::seconds>(
         std::move(*period)),
       .configured_windows = serde::from_iobuf<size_t>(std::move(*windows)),
-      .current_state = serde::from_iobuf<fragmented_vector<usage_window>>(
+      .current_state = serde::from_iobuf<chunked_vector<usage_window>>(
         std::move(*data))};
 }
 
@@ -377,7 +377,7 @@ void usage_aggregator<clock_type>::close_window() {
 
 template<typename clock_type>
 void usage_aggregator<clock_type>::reset_state(
-  fragmented_vector<usage_window> buckets) {
+  chunked_vector<usage_window> buckets) {
     /// called after restart to determine which bucket is the 'current' bucket
     _current_window = 0;
     if (!buckets.empty()) {

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -141,7 +141,7 @@ protected:
     virtual void window_closed() {}
 
 private:
-    void reset_state(fragmented_vector<usage_window> buckets);
+    void reset_state(chunked_vector<usage_window> buckets);
     void close_window();
     void rearm_window_timer();
     bool is_bucket_stale(size_t idx, uint64_t close_ts) const;
@@ -160,7 +160,7 @@ private:
     ss::gate _bg_write_gate;
     ss::gate _gate;
     size_t _current_window{0};
-    fragmented_vector<usage_window> _buckets;
+    chunked_vector<usage_window> _buckets;
     storage::kvstore& _kvstore;
 };
 } // namespace kafka

--- a/src/v/kafka/utils/txn_reader.cc
+++ b/src/v/kafka/utils/txn_reader.cc
@@ -173,8 +173,7 @@ std::unique_ptr<model::record_batch_reader::impl> make_txn_filtered_reader(
         }
         filtered.push_back(std::move(batch));
     }
-    return model::make_fragmented_memory_record_batch_reader(
-             std::move(filtered))
+    return model::make_chunked_memory_record_batch_reader(std::move(filtered))
       .release();
 }
 

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -173,7 +173,7 @@ record_batch_reader make_generating_record_batch_reader(
 }
 
 namespace {
-record_batch_reader make_fragmented_memory_record_batch_reader(
+record_batch_reader make_chunked_memory_record_batch_reader(
   std::vector<record_batch_reader::storage_t> data) {
     class reader final : public record_batch_reader::impl {
     public:
@@ -206,10 +206,10 @@ record_batch_reader make_fragmented_memory_record_batch_reader(
 
 template<typename Container>
 std::vector<record_batch_reader::storage_t>
-make_fragmented_memory_storage_batches(Container batches) {
+make_chunked_memory_storage_batches(Container batches) {
     std::vector<record_batch_reader::storage_t> data;
     size_t elements_per_fragment
-      = fragmented_vector<model::record_batch>::elements_per_fragment();
+      = chunked_vector<model::record_batch>::elements_per_fragment();
     data.reserve(batches.size() / elements_per_fragment);
     record_batch_reader::data_t data_chunk;
     size_t i = 0;
@@ -246,45 +246,31 @@ ss::future<Container> consume_reader_to_fragmented_memory(
 }
 } // namespace
 
-record_batch_reader make_fragmented_memory_record_batch_reader(
-  fragmented_vector<model::record_batch> batches) {
-    return make_fragmented_memory_record_batch_reader(
-      make_fragmented_memory_storage_batches<
-        fragmented_vector<model::record_batch>>(std::move(batches)));
-}
-
-record_batch_reader make_fragmented_memory_record_batch_reader(
+record_batch_reader make_chunked_memory_record_batch_reader(
   chunked_vector<model::record_batch> batches) {
-    return make_fragmented_memory_record_batch_reader(
-      make_fragmented_memory_storage_batches<
-        chunked_vector<model::record_batch>>(std::move(batches)));
+    return make_chunked_memory_record_batch_reader(
+      make_chunked_memory_storage_batches<chunked_vector<model::record_batch>>(
+        std::move(batches)));
 }
 
-record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
-  fragmented_vector<model::record_batch> batches) {
-    return make_fragmented_memory_record_batch_reader(
-      make_fragmented_memory_storage_batches<
-        fragmented_vector<model::record_batch>>(std::move(batches)));
-}
-
-record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+record_batch_reader make_foreign_chunked_memory_record_batch_reader(
   chunked_vector<model::record_batch> batches) {
-    return make_fragmented_memory_record_batch_reader(
-      make_fragmented_memory_storage_batches<
-        chunked_vector<model::record_batch>>(std::move(batches)));
+    return make_chunked_memory_record_batch_reader(
+      make_chunked_memory_storage_batches<chunked_vector<model::record_batch>>(
+        std::move(batches)));
 }
 
-record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+record_batch_reader make_chunked_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch> batches) {
-    return make_fragmented_memory_record_batch_reader(
-      make_fragmented_memory_storage_batches<
+    return make_chunked_memory_record_batch_reader(
+      make_chunked_memory_storage_batches<
         ss::chunked_fifo<model::record_batch>>(std::move(batches)));
 }
 
-record_batch_reader make_fragmented_memory_record_batch_reader(
+record_batch_reader make_chunked_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch> batches) {
-    return make_fragmented_memory_record_batch_reader(
-      make_fragmented_memory_storage_batches<
+    return make_chunked_memory_record_batch_reader(
+      make_chunked_memory_storage_batches<
         ss::chunked_fifo<model::record_batch>>(std::move(batches)));
 }
 
@@ -305,11 +291,11 @@ ss::future<record_batch_reader::data_t> consume_reader_to_memory(
     return std::move(reader).consume(memory_batch_consumer{}, timeout);
 }
 
-ss::future<fragmented_vector<model::record_batch>>
+ss::future<chunked_vector<model::record_batch>>
 consume_reader_to_fragmented_memory(
   record_batch_reader reader, timeout_clock::time_point timeout) {
     return consume_reader_to_fragmented_memory<
-      fragmented_vector<model::record_batch>>(std::move(reader), timeout);
+      chunked_vector<model::record_batch>>(std::move(reader), timeout);
 }
 
 ss::future<chunked_vector<model::record_batch>>

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -338,11 +338,11 @@ record_batch_reader make_record_batch_reader(Args&&... args) {
 record_batch_reader
   make_memory_record_batch_reader(record_batch_reader::storage_t);
 
-record_batch_reader make_fragmented_memory_record_batch_reader(
-  fragmented_vector<model::record_batch>);
+record_batch_reader
+  make_chunked_memory_record_batch_reader(chunked_vector<model::record_batch>);
 
-record_batch_reader make_fragmented_memory_record_batch_reader(
-  chunked_vector<model::record_batch>);
+record_batch_reader
+  make_chunked_memory_record_batch_reader(chunked_vector<model::record_batch>);
 
 inline record_batch_reader
 make_memory_record_batch_reader(model::record_batch b) {
@@ -384,16 +384,16 @@ record_batch_reader make_foreign_memory_record_batch_reader(record_batch);
 record_batch_reader
   make_foreign_memory_record_batch_reader(record_batch_reader::data_t);
 
-record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
-  fragmented_vector<model::record_batch>);
-
-record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+record_batch_reader make_foreign_chunked_memory_record_batch_reader(
   chunked_vector<model::record_batch>);
 
-record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+record_batch_reader make_foreign_chunked_memory_record_batch_reader(
+  chunked_vector<model::record_batch>);
+
+record_batch_reader make_chunked_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch>);
 
-record_batch_reader make_fragmented_memory_record_batch_reader(
+record_batch_reader make_chunked_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch>);
 
 record_batch_reader make_generating_record_batch_reader(
@@ -402,7 +402,7 @@ record_batch_reader make_generating_record_batch_reader(
 ss::future<record_batch_reader::data_t> consume_reader_to_memory(
   record_batch_reader, timeout_clock::time_point timeout);
 
-ss::future<fragmented_vector<model::record_batch>>
+ss::future<chunked_vector<model::record_batch>>
 consume_reader_to_fragmented_memory(
   record_batch_reader, timeout_clock::time_point timeout);
 

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -864,7 +864,7 @@ get_security_acls(server::request_t rq, server::reply_t rp) {
         security::resource_pattern_filter::resource_subsystem::schema_registry},
       security::acl_entry_filter{principal, host, operation, permission}};
 
-    auto sr_acls = std::ranges::to<fragmented_vector<acl>>(
+    auto sr_acls = std::ranges::to<chunked_vector<acl>>(
       acl_store.acls(filter)
       | std::views::transform(
         [](const security::acl_binding& binding) { return acl(binding); }));
@@ -955,7 +955,7 @@ delete_security_acls(server::request_t rq, server::reply_t rp) {
     auto deleted = co_await security_frontend.delete_acls(
       std::move(filters), 5s);
 
-    auto res = fragmented_vector<acl>{};
+    auto res = chunked_vector<acl>{};
     std::ranges::for_each(deleted, [&res](cluster::delete_acls_result r) {
         if (r.error != cluster::errc::success) {
             throw exception(

--- a/src/v/pandaproxy/schema_registry/requests/acls.h
+++ b/src/v/pandaproxy/schema_registry/requests/acls.h
@@ -92,7 +92,7 @@ class acl_handler : public json::base_handler<Encoding> {
 public:
     using require_fields = ss::bool_class<struct require_fields_tag>;
     using Ch = typename json::base_handler<Encoding>::Ch;
-    using rjson_parse_result = fragmented_vector<acl>;
+    using rjson_parse_result = chunked_vector<acl>;
 
     explicit acl_handler(require_fields require_fields)
       : json::base_handler<Encoding>{json::serialization_format::none}

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2973,8 +2973,7 @@ ss::future<storage::append_result> consensus::disk_append(
 
     return details::for_each_ref_extract_configuration(
              _log->offsets().dirty_offset,
-             model::make_fragmented_memory_record_batch_reader(
-               std::move(batches)),
+             model::make_chunked_memory_record_batch_reader(std::move(batches)),
              consumer(_log->make_appender(cfg)),
              cfg.timeout)
       .then([this, should_update_last_quorum_idx](

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -49,8 +49,8 @@ ss::future<raft::configuration_bootstrap_state> read_bootstrap_state(
 
 chunked_circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   model::offset, chunked_circular_buffer<model::record_batch>&&);
-fragmented_vector<model::record_batch> make_ghost_batches_in_gaps(
-  model::offset, fragmented_vector<model::record_batch>&&);
+chunked_vector<model::record_batch> make_ghost_batches_in_gaps(
+  model::offset, chunked_vector<model::record_batch>&&);
 
 /// writes snapshot with given data to disk
 ss::future<>

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -384,9 +384,9 @@ model::offset persisted_stm_base<BaseT, T>::max_removable_local_log_offset() {
 }
 
 template<typename BaseT, supported_stm_snapshot T>
-ss::future<fragmented_vector<model::tx_range>>
+ss::future<chunked_vector<model::tx_range>>
 persisted_stm_base<BaseT, T>::aborted_tx_ranges(model::offset, model::offset) {
-    return ss::make_ready_future<fragmented_vector<model::tx_range>>();
+    return ss::make_ready_future<chunked_vector<model::tx_range>>();
 }
 
 template<typename BaseT, supported_stm_snapshot T>

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -214,7 +214,7 @@ public:
     std::optional<kafka::offset> lowest_pinned_data_offset() const override {
         return std::nullopt;
     }
-    ss::future<fragmented_vector<model::tx_range>>
+    ss::future<chunked_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) override;
 
     ss::future<> apply(

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -361,7 +361,7 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
         }
 
         // heal the partition 5s later
-        (void)ss::sleep(5s).then([isolated_nodes] {
+        (void)ss::sleep(20s).then([isolated_nodes] {
             vlog(test_log.info, "healing the network partition");
             isolated_nodes->clear();
         });

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -744,7 +744,7 @@ void admin_server::register_partition_routes() {
             [](auto& partition_manager, bool materialized, auto get_leader) {
                 return partition_manager.map_reduce0(
                   [materialized, get_leader](auto& pm) {
-                      fragmented_vector<summary> partitions;
+                      chunked_vector<summary> partitions;
                       for (const auto& it : pm.partitions()) {
                           summary p;
                           p.ns = it.first.ns;
@@ -757,10 +757,10 @@ void admin_server::register_partition_routes() {
                       }
                       return partitions;
                   },
-                  fragmented_vector<summary>{},
+                  chunked_vector<summary>{},
                   [](
-                    fragmented_vector<summary> acc,
-                    fragmented_vector<summary> update) {
+                    chunked_vector<summary> acc,
+                    chunked_vector<summary> update) {
                       std::move(
                         std::make_move_iterator(update.begin()),
                         std::make_move_iterator(update.end()),
@@ -1047,7 +1047,7 @@ admin_server::get_topic_partitions_handler(
           fmt::format("Could not find topic: {}/{}", tp_ns.ns, tp_ns.tp));
     }
     using partition_t = ss::httpd::partition_json::partition;
-    fragmented_vector<partition_t> partitions;
+    chunked_vector<partition_t> partitions;
     const auto& assignments = tp_md->get().get_assignments();
     partitions.reserve(assignments.size());
 
@@ -1385,8 +1385,7 @@ admin_server::force_recover_partitions_from_nodes(
     // parse the json body into a controller command.
     std::vector<model::node_id> dead_nodes = parse_node_ids_from_json(
       doc["dead_nodes"]);
-    fragmented_vector<cluster::ntp_with_majority_loss>
-      partitions_to_force_recover;
+    chunked_vector<cluster::ntp_with_majority_loss> partitions_to_force_recover;
     for (auto& r : doc["partitions_to_force_recover"].GetArray()) {
         auto ntp = parse_ntp_from_json(r["ntp"]);
         auto replicas = parse_replicas_from_json(r["replicas"]);

--- a/src/v/redpanda/admin/transaction.cc
+++ b/src/v/redpanda/admin/transaction.cc
@@ -88,7 +88,7 @@ admin_server::get_all_transactions_handler(
     }
 
     using tx_info = ss::httpd::transaction_json::transaction_summary;
-    fragmented_vector<tx_info> ans;
+    chunked_vector<tx_info> ans;
     ans.reserve(res.value().size());
 
     for (auto& tx : res.value()) {

--- a/src/v/reflection/test/collections_interop.cc
+++ b/src/v/reflection/test/collections_interop.cc
@@ -18,7 +18,7 @@ SEASTAR_THREAD_TEST_CASE(collections_interop) {
     auto vector = tests::random_vector(
       []() { return random_generators::gen_alphanum_string(32); }, 1024);
     ss::chunked_fifo<ss::sstring> fifo;
-    fragmented_vector<ss::sstring> f_vector;
+    chunked_vector<ss::sstring> f_vector;
     std::copy(vector.begin(), vector.end(), std::back_inserter(fifo));
     std::copy(vector.begin(), vector.end(), std::back_inserter(f_vector));
 

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -284,12 +284,12 @@ ss::future<eviction_policy::schedule> eviction_policy::create_new_schedule() {
     co_return sched;
 }
 
-ss::future<fragmented_vector<eviction_policy::partition>>
+ss::future<chunked_vector<eviction_policy::partition>>
 eviction_policy::collect_reclaimable_offsets() {
     /*
      * build a lightweight copy to avoid invalidations during iteration
      */
-    fragmented_vector<ss::lw_shared_ptr<cluster::partition>> partitions;
+    chunked_vector<ss::lw_shared_ptr<cluster::partition>> partitions;
     for (const auto& p : _pm->local().partitions()) {
         if (!p.second->remote_partition()) {
             continue;
@@ -309,7 +309,7 @@ eviction_policy::collect_reclaimable_offsets() {
      * in smallish batches partitions are queried for their reclaimable
      * segments. all of this information is bundled up and returned.
      */
-    fragmented_vector<partition> res;
+    chunked_vector<partition> res;
     co_await ss::max_concurrent_for_each(
       partitions.begin(), partitions.end(), 20, [&res, cfg](const auto& p) {
           auto log = p->log();

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -92,7 +92,7 @@ public:
      */
     struct shard_partitions {
         ss::shard_id shard;
-        fragmented_vector<partition> partitions;
+        chunked_vector<partition> partitions;
     };
 
     /*
@@ -207,7 +207,7 @@ private:
     size_t evict_balanced_from_level(
       schedule&, size_t, std::string_view, const level_selector&);
 
-    ss::future<fragmented_vector<partition>> collect_reclaimable_offsets();
+    ss::future<chunked_vector<partition>> collect_reclaimable_offsets();
     ss::future<size_t> install_schedule(shard_partitions);
 };
 

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -262,8 +262,8 @@ acl_store::acls(const acl_binding_filter& filter) const {
     return result;
 }
 
-ss::future<fragmented_vector<acl_binding>> acl_store::all_bindings() const {
-    fragmented_vector<acl_binding> result;
+ss::future<chunked_vector<acl_binding>> acl_store::all_bindings() const {
+    chunked_vector<acl_binding> result;
     for (const auto& acl : _acls) {
         for (const auto& entry : acl.second) {
             result.push_back(acl_binding{acl.first, entry});
@@ -274,7 +274,7 @@ ss::future<fragmented_vector<acl_binding>> acl_store::all_bindings() const {
 }
 
 ss::future<>
-acl_store::reset_bindings(const fragmented_vector<acl_binding>& bindings) {
+acl_store::reset_bindings(const chunked_vector<acl_binding>& bindings) {
     // NOTE: not coroutinized because otherwise clang-14 crashes.
     _acls.clear();
     return ss::do_for_each(

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -57,8 +57,8 @@ public:
 
     // NOTE: the following functions assume that acl_store doesn't change across
     // yield points.
-    ss::future<fragmented_vector<acl_binding>> all_bindings() const;
-    ss::future<> reset_bindings(const fragmented_vector<acl_binding>& bindings);
+    ss::future<chunked_vector<acl_binding>> all_bindings() const;
+    ss::future<> reset_bindings(const chunked_vector<acl_binding>& bindings);
 
 private:
     /*

--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -125,12 +125,12 @@ authorizer::acls(const acl_binding_filter& filter) const {
     return store().acls(filter);
 }
 
-ss::future<fragmented_vector<acl_binding>> authorizer::all_bindings() const {
+ss::future<chunked_vector<acl_binding>> authorizer::all_bindings() const {
     return store().all_bindings();
 }
 
 ss::future<>
-authorizer::reset_bindings(const fragmented_vector<acl_binding>& bindings) {
+authorizer::reset_bindings(const chunked_vector<acl_binding>& bindings) {
     return store().reset_bindings(bindings);
 }
 

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -233,8 +233,8 @@ public:
       const acl_principal& principal,
       const acl_host& host) const;
 
-    ss::future<fragmented_vector<acl_binding>> all_bindings() const;
-    ss::future<> reset_bindings(const fragmented_vector<acl_binding>& bindings);
+    ss::future<chunked_vector<acl_binding>> all_bindings() const;
+    ss::future<> reset_bindings(const chunked_vector<acl_binding>& bindings);
 
     acl_store& store() &;
     const acl_store& store() const&;

--- a/src/v/security/role_store.h
+++ b/src/v/security/role_store.h
@@ -80,7 +80,7 @@ class role_store {
     using role_accessor = std::pair<
       role_name_view, /* role_name */
       ss::noncopyable_function<const members_store_type&(void)>>;
-    using range_query_container_type = fragmented_vector<role_name_view>;
+    using range_query_container_type = chunked_vector<role_name_view>;
 
 public:
     using roles_range

--- a/src/v/serde/json/tests/dom.h
+++ b/src/v/serde/json/tests/dom.h
@@ -27,7 +27,7 @@ struct null_t {
 class value;
 
 using json_object = chunked_hash_map<iobuf, value>;
-using json_array = fragmented_vector<value>;
+using json_array = chunked_vector<value>;
 
 constexpr null_t null_value{};
 

--- a/src/v/serde/json/tests/dom_rapidjson.cc
+++ b/src/v/serde/json/tests/dom_rapidjson.cc
@@ -28,16 +28,16 @@ ss::future<value> parse_document_rapidjson(iobuf buf) {
 
     struct stack_element {
         container_type type;
-        fragmented_vector<value> values;
+        chunked_vector<value> values;
     };
 
-    fragmented_vector<stack_element> stack{};
+    chunked_vector<stack_element> stack{};
     stack.push_back({container_type::document, {}});
 
     struct dom_handler {
-        fragmented_vector<stack_element>* stack;
+        chunked_vector<stack_element>* stack;
 
-        explicit dom_handler(fragmented_vector<stack_element>* stack)
+        explicit dom_handler(chunked_vector<stack_element>* stack)
           : stack(stack) {};
 
         using Ch = rapidjson::UTF8<>::Ch;

--- a/src/v/serde/json/tests/dom_serde.cc
+++ b/src/v/serde/json/tests/dom_serde.cc
@@ -25,10 +25,10 @@ ss::future<value> parse_document_serde(iobuf buf) {
 
     struct stack_element {
         container_type type;
-        fragmented_vector<value> values;
+        chunked_vector<value> values;
     };
 
-    fragmented_vector<stack_element> stack{};
+    chunked_vector<stack_element> stack{};
     stack.push_back({container_type::document, {}});
 
     while (co_await parser.next()) {

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -804,8 +804,8 @@ SEASTAR_THREAD_TEST_CASE(fragmented_vector_test) {
 
     for (auto i : sizes) {
         // build input
-        fragmented_vector<int> v_in;
-        fragmented_vector<int> v_in_copy;
+        chunked_vector<int> v_in;
+        chunked_vector<int> v_in_copy;
         for (int j = 0; j < i; ++j) {
             v_in.push_back(j);
             v_in_copy.push_back(j);
@@ -817,7 +817,7 @@ SEASTAR_THREAD_TEST_CASE(fragmented_vector_test) {
         iobuf b;
         serde::write(b, std::move(v_in));
         iobuf_parser parser{std::move(b)};
-        const auto v_out = serde::read<fragmented_vector<int>>(parser);
+        const auto v_out = serde::read<chunked_vector<int>>(parser);
 
         BOOST_REQUIRE_EQUAL(v_out.size(), v_in_copy.size());
         BOOST_REQUIRE_EQUAL_COLLECTIONS(
@@ -1109,7 +1109,7 @@ SEASTAR_THREAD_TEST_CASE(collections_interop) {
     auto vector = tests::random_vector(
       []() { return random_generators::gen_alphanum_string(32); }, 1024);
     ss::chunked_fifo<ss::sstring> fifo;
-    fragmented_vector<ss::sstring> f_vector;
+    chunked_vector<ss::sstring> f_vector;
     std::copy(vector.begin(), vector.end(), std::back_inserter(fifo));
     std::copy(vector.begin(), vector.end(), std::back_inserter(f_vector));
 

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -268,7 +268,7 @@ public:
     explicit tx_reducer(
       model::ntp ntp,
       ss::lw_shared_ptr<storage::stm_manager> stm_mgr,
-      fragmented_vector<model::tx_range>&& txs,
+      chunked_vector<model::tx_range>&& txs,
       compacted_index_writer* w) noexcept
       : _ntp(std::move(ntp))
       , _delegate(index_rebuilder_reducer(w))
@@ -313,7 +313,7 @@ private:
     // A min heap of aborted transactions based on begin offset.
     using underlying_t = std::priority_queue<
       model::tx_range,
-      fragmented_vector<model::tx_range>,
+      chunked_vector<model::tx_range>,
       model::tx_range_cmp>;
     underlying_t _aborted_txs;
     // Current list of aborted transactions maintained up to the

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1784,7 +1784,7 @@ ss::future<> disk_log_impl::maybe_adjust_retention_timestamps() {
     auto retention_cfg = time_based_retention_cfg::make(
       _feature_table.local()); // this will retrieve cluster cfgs
 
-    fragmented_vector<segment_set::type> segs_all_bogus;
+    chunked_vector<segment_set::type> segs_all_bogus;
     for (const auto& s : _segs) {
         auto max_ts = s->index().retention_timestamp(retention_cfg);
 
@@ -3855,10 +3855,10 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
      * retention is not enabled data may be available in cloud storage and
      * still be subject to reclaim in low disk space situations.
      */
-    fragmented_vector<segment_set::type> retention_segments;
-    fragmented_vector<segment_set::type> available_segments;
-    fragmented_vector<segment_set::type> remaining_segments;
-    fragmented_vector<segment_set::type> local_retention_segments;
+    chunked_vector<segment_set::type> retention_segments;
+    chunked_vector<segment_set::type> available_segments;
+    chunked_vector<segment_set::type> remaining_segments;
+    chunked_vector<segment_set::type> local_retention_segments;
     for (auto& seg : _segs) {
         if (
           retention_offset.has_value()
@@ -4073,7 +4073,7 @@ disk_log_impl::disk_usage_target_time_retention(gc_config cfg) {
       });
 
     // collect segments for reducing
-    fragmented_vector<segment_set::type> segments;
+    chunked_vector<segment_set::type> segments;
     for (; it != std::cend(_segs); ++it) {
         segments.push_back(*it);
     }
@@ -4210,7 +4210,7 @@ ss::future<usage_report> disk_log_impl::disk_usage(gc_config cfg) {
     co_return usage_report(use, reclaim, target);
 }
 
-fragmented_vector<ss::lw_shared_ptr<segment>>
+chunked_vector<ss::lw_shared_ptr<segment>>
 disk_log_impl::cloud_gc_eligible_segments() {
     vassert(
       is_cloud_retention_active(),
@@ -4233,7 +4233,7 @@ disk_log_impl::cloud_gc_eligible_segments() {
     const auto max_removable = stm_manager()->max_removable_local_log_offset();
 
     // collect eligible segments
-    fragmented_vector<segment_set::type> segments;
+    chunked_vector<segment_set::type> segments;
     for (auto remaining = _segs.size() - keep_segs; auto& seg : _segs) {
         if (seg->offsets().get_committed_offset() <= max_removable) {
             segments.push_back(seg);
@@ -4331,7 +4331,7 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
     /*
      * lightweight segment set copy for safe iteration
      */
-    fragmented_vector<segment_set::type> segments;
+    chunked_vector<segment_set::type> segments;
     for (const auto& seg : _segs) {
         segments.push_back(seg);
     }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -185,7 +185,7 @@ public:
      * across all partitions.
      */
     auto& gate() { return _compaction_housekeeping_gate; }
-    fragmented_vector<ss::lw_shared_ptr<segment>> cloud_gc_eligible_segments();
+    chunked_vector<ss::lw_shared_ptr<segment>> cloud_gc_eligible_segments();
     void set_cloud_gc_offset(model::offset) override;
 
     ss::future<reclaimable_offsets>

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -1049,7 +1049,7 @@ ss::future<usage_report> log_manager::disk_usage() {
      */
     auto cfg = default_gc_config();
 
-    fragmented_vector<ss::shared_ptr<log>> logs;
+    chunked_vector<ss::shared_ptr<log>> logs;
     for (auto& it : _logs) {
         logs.push_back(it.second->handle);
     }

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -185,11 +185,7 @@ private:
         }
     };
 
-    // There is one segment_appender per partition replica so we don't want to
-    // allocate too many elements by default and hence limit.
-    // Limit to 16 elements which is about 640 bytes per chunk.
-    using flush_ops_container
-      = fragmented_vector<flush_op, sizeof(flush_op) * 16>;
+    using flush_ops_container = chunked_vector<flush_op>;
     flush_ops_container _flush_ops;
     size_t _flushed_offset{0};
     size_t _stable_offset{0};

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -15,7 +15,7 @@
 #include "storage/segment_set.h"
 
 namespace storage {
-using segment_list_t = fragmented_vector<segment_set::type>;
+using segment_list_t = chunked_vector<segment_set::type>;
 class stm_manager;
 
 // Adds the keys from the given compacted index reader to the map. Returns

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -664,7 +664,7 @@ ss::future<compaction_result> do_self_compact_segment(
 ss::future<> build_compaction_index(
   model::record_batch_reader rdr,
   ss::lw_shared_ptr<storage::stm_manager> stm_manager,
-  fragmented_vector<model::tx_range> aborted_txs,
+  chunked_vector<model::tx_range> aborted_txs,
   segment_full_path p,
   compaction_config cfg,
   storage_resources& resources) {

--- a/src/v/storage/tests/compaction_fuzz_test.cc
+++ b/src/v/storage/tests/compaction_fuzz_test.cc
@@ -58,9 +58,9 @@ static model::record_batch make_random_batch(
     return std::move(builder).build();
 }
 
-static fragmented_vector<model::record_batch>
+static chunked_vector<model::record_batch>
 generate_random_record_batches(int num, int cardinality) {
-    fragmented_vector<model::record_batch> result;
+    chunked_vector<model::record_batch> result;
     std::vector<std::optional<ss::sstring>> keys;
     std::vector<std::optional<ss::sstring>> values;
     std::vector<model::record_batch_type> types{
@@ -126,7 +126,7 @@ struct ot_state_consumer {
 /// segment arrangement. The arrangement is defined
 /// by the set of segment base offset values.
 ss::future<ot_state> arrange_and_compact(
-  const fragmented_vector<model::record_batch>& batches,
+  const chunked_vector<model::record_batch>& batches,
   std::deque<model::offset> arrangement,
   bool simulate_internal_topic_compaction = false) {
     std::sort(arrangement.begin(), arrangement.end());
@@ -185,7 +185,7 @@ ss::future<ot_state> arrange_and_compact(
 /// This function generates random alignment based on the set of batches
 /// that will be written into the log.
 std::deque<model::offset> generate_random_arrangement(
-  const fragmented_vector<model::record_batch>& batches, size_t num_segments) {
+  const chunked_vector<model::record_batch>& batches, size_t num_segments) {
     EXPECT_LE(num_segments, batches.size());
     std::deque<model::offset> arr;
     // User reservoir sample to produce num_segments

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5007,7 +5007,7 @@ public:
       , _size(segment_size) {}
 
     size_t max_step_size() const {
-        fragmented_vector<size_t> diffs;
+        chunked_vector<size_t> diffs;
         chunked_vector<uint64_t> pos
           = _index._state.index.copy_position_index();
         diffs.reserve(pos.size() + 1);

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -121,7 +121,7 @@ public:
 
     // Only valid for state machines maintaining transactional state.
     // Returns aborted transactions in range [from, to] offsets.
-    virtual ss::future<fragmented_vector<model::tx_range>>
+    virtual ss::future<chunked_vector<model::tx_range>>
       aborted_tx_ranges(model::offset, model::offset) = 0;
 
     virtual model::control_record_type
@@ -187,9 +187,9 @@ public:
     model::offset max_removable_local_log_offset();
     std::optional<kafka::offset> lowest_pinned_data_offset() const;
 
-    ss::future<fragmented_vector<model::tx_range>>
+    ss::future<chunked_vector<model::tx_range>>
     aborted_tx_ranges(model::offset to, model::offset from) {
-        fragmented_vector<model::tx_range> r;
+        chunked_vector<model::tx_range> r;
         if (_tx_stm) {
             r = co_await _tx_stm->aborted_tx_ranges(to, from);
         }

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -85,8 +85,8 @@ template<
   typename... Args,
   typename T = std::invoke_result_t<Fn, Args...>>
 inline auto random_frag_vector(Fn&& gen, size_t size = 20, Args&&... args)
-  -> fragmented_vector<T> {
-    fragmented_vector<T> v;
+  -> chunked_vector<T> {
+    chunked_vector<T> v;
     while (size-- > 0) {
         v.push_back(gen(std::forward<Args>(args)...));
     }


### PR DESCRIPTION
Remove almost all remaining frag vector. Defers cleanup of frag_vector class itself.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

