### PR TITLE
rpk: miscelaneous improvements for 25.2

### DIFF
--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     - noctx
     - nolintlint
     - revive
-    - tenv
+    - usetesting
     - unconvert
     - wastedassign
     - whitespace
@@ -59,7 +59,7 @@ linters-settings:
   revive:
     ignore-generated-header: true
     severity: warning
-    confidence: 0.8
+    confidence: 0.6
     rules:
       - name: atomic
       - name: blank-imports
@@ -76,7 +76,11 @@ linters-settings:
       - name: error-naming
       - name: error-return
       - name: error-strings
-      - name: errorf
+        arguments:
+          - out.Die
+          - out.MaybeDie
+          - out.DieString
+          - out.MaybeDieString
       - name: get-return
       - name: identical-branches
       - name: if-return

--- a/src/go/rpk/Makefile
+++ b/src/go/rpk/Makefile
@@ -64,7 +64,7 @@ run_gofumpt:
 	$(GOFUMPT_OS_CMD)
 
 install_golangci_lint:
-	@which $(GOLANGCILINTCMD) || (if [ $$? -eq 1 ]; then  echo "golangci-lint not found, installing..."; curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.62.0; fi)
+	@which $(GOLANGCILINTCMD) || (if [ $$? -eq 1 ]; then  echo "golangci-lint not found, installing..."; curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.64.8; fi)
 
 run_linter:
 	$(GOLANGCILINTCMD) run

--- a/src/go/rpk/pkg/cli/cloud/mcp/mcp.go
+++ b/src/go/rpk/pkg/cli/cloud/mcp/mcp.go
@@ -26,7 +26,8 @@ import (
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "mcp",
+		Use:   "mcp",
+		Short: "Manage Redpanda Cloud MCP server",
 	}
 
 	cmd.AddCommand(

--- a/src/go/rpk/pkg/cli/cloud/mcp/mcp.go
+++ b/src/go/rpk/pkg/cli/cloud/mcp/mcp.go
@@ -157,7 +157,7 @@ func newStdioCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 					m.Lock()
 					tokenOK = false
 					m.Unlock()
-					return fmt.Errorf("Redpanda Cloud token is expired. Instruct the user to run `rpk%s cloud login` to obtain a fresh one. Afterwards, they can ask to retry", extra)
+					return fmt.Errorf("the Redpanda Cloud token is expired. Instruct the user to run `rpk%s cloud login` to obtain a fresh one. Afterwards, they can ask to retry", extra)
 				}
 				m.RLock()
 				ok := tokenOK

--- a/src/go/rpk/pkg/cli/cluster/config/reset.go
+++ b/src/go/rpk/pkg/cli/cluster/config/reset.go
@@ -55,12 +55,12 @@ WARNING: this should only be used when redpanda is not running.
 
 			// Read YAML
 			f, err := afero.ReadFile(fs, configCacheFile)
-			out.MaybeDie(err, "Couldn't read %q", configCacheFile)
+			out.MaybeDie(err, "unable to read %q", configCacheFile)
 
 			// Decode YAML
 			var content clusterConfig
 			err = yaml.Unmarshal(f, &content)
-			out.MaybeDie(err, "Couldn't parse %q: %v", configCacheFile, err)
+			out.MaybeDie(err, "unable to parse %q: %v", configCacheFile, err)
 
 			// Snip out the value we are resetting
 			for _, pn := range propertyNames {
@@ -73,7 +73,7 @@ WARNING: this should only be used when redpanda is not running.
 
 			// Write back output
 			err = afero.WriteFile(fs, configCacheFile, outBytes, 0o755)
-			out.MaybeDie(err, "Couldn't write %q: %v", configCacheFile, err)
+			out.MaybeDie(err, "unable to write %q: %v", configCacheFile, err)
 
 			fmt.Println("The property has been successfully removed from the cluster configuration cache. Next time Redpanda starts, the setting will be treated as if it were set to its default value.")
 		},

--- a/src/go/rpk/pkg/cli/group/offset_delete.go
+++ b/src/go/rpk/pkg/cli/group/offset_delete.go
@@ -66,7 +66,7 @@ topic_b 0
 			} else if fromFile != "" {
 				topicsSet, err = parseTopicPartitionsFile(fs, fromFile)
 			} else {
-				err = fmt.Errorf("Must pass at least one command line argument --topic or --from-file")
+				err = fmt.Errorf("must pass at least one command line argument --topic or --from-file")
 			}
 			out.MaybeDieErr(err)
 

--- a/src/go/rpk/pkg/cli/profile/BUILD
+++ b/src/go/rpk/pkg/cli/profile/BUILD
@@ -24,6 +24,7 @@ go_library(
     deps = [
         "//src/go/rpk/pkg/adminapi",
         "//src/go/rpk/pkg/cli/container/common",
+        "//src/go/rpk/pkg/cobraext",
         "//src/go/rpk/pkg/config",
         "//src/go/rpk/pkg/oauth",
         "//src/go/rpk/pkg/oauth/providers/auth0",

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -20,6 +20,7 @@ import (
 	controlplanev1 "buf.build/gen/go/redpandadata/cloud/protocolbuffers/go/redpanda/api/controlplane/v1"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	container "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
@@ -31,16 +32,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	fromCloudFlag     = "from-cloud"
+	fromContainerFlag = "from-rpk-container"
+)
+
 func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		set               []string
-		fromRedpanda      string
-		fromProfile       string
-		fromCloud         string
-		fromContainer     bool
-		description       string
-		fromCloudFlag     = "from-cloud"
-		fromContainerFlag = "from-rpk-container"
+		set           []string
+		fromRedpanda  string
+		fromProfile   string
+		fromCloud     string
+		fromContainer bool
+		description   string
 	)
 
 	cmd := &cobra.Command{
@@ -86,8 +90,18 @@ printed in the output of 'rpk profile list'.
 
 rpk always switches to the newly created profile.
 `,
-		Args: cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		DisableFlagParsing: true, // Manually parse for the custom --from-cloud flag.
+		Run: func(cmd *cobra.Command, rawArgs []string) {
+			args, err := parseCreateFlags(cmd, rawArgs)
+			out.MaybeDieErr(err)
+			if cmd.Flags().Changed("help") {
+				cmd.Help()
+				return
+			}
+			if len(args) > 1 {
+				out.Die("too many arguments, expected at most one profile name, got %d", len(args))
+			}
+
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
@@ -132,13 +146,65 @@ Or:
 	cmd.Flags().BoolVar(&fromContainer, fromContainerFlag, false, "Create and switch to a new profile generated from a running cluster created with rpk container")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Optional description of the profile")
 
-	cmd.Flags().Lookup("from-cloud").NoOptDefVal = "prompt"
+	cmd.Flags().Lookup(fromCloudFlag).NoOptDefVal = "prompt"
 
 	cmd.RegisterFlagCompletionFunc("set", validSetArgs)
 
 	cmd.MarkFlagsMutuallyExclusive("from-redpanda", "from-cloud", "from-profile")
 
 	return cmd
+}
+
+// parseCreateFlags parses the flags for the create command. Fixing the
+// `--from-cloud` flag if it is set, and returns the remaining arguments for
+// the command execution.
+func parseCreateFlags(cmd *cobra.Command, args []string) ([]string, error) {
+	args = fixFromCloudArgs(args)
+	f := cmd.Flags()
+	err := f.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+	argsLeft, _ := cobraext.StripFlagset(args, f)
+	return argsLeft, nil
+}
+
+// fixFromCloudArgs is a hack to 'fix' the `--from-cloud` when is set.
+// We want to ensure that:
+//  1. If the user provided a value, use it (--from-cloud value)
+//     or (--from-cloud=value).
+//  2. If the user set `--from-cloud` without a value, we want to leave it
+//     as is, so that flag parsing uses the NoOptDefVal.
+//
+// We have to do this manually as cobra does not support NoOptDefVale with
+// positional arguments, see: https://github.com/spf13/cobra/issues/866
+func fixFromCloudArgs(args []string) []string {
+	// In flag parsing, we check for the last instance of `--from-cloud` in
+	// the argument list.
+	idx := -1
+	for i, arg := range args {
+		// We only care about the `--from-cloud` flag. `--from-cloud=value` is
+		// already parsed correctly.
+		if arg == "--"+fromCloudFlag {
+			idx = i
+		}
+	}
+	if idx >= 0 {
+		// If it's at the end, there is no value to add. Return the args as is.
+		if idx == len(args)-1 {
+			return args
+		}
+		// A cluster ID does not start with a dash, so if the next argument
+		// is not a flag, we "fix" the args.
+		if !strings.HasPrefix(args[idx+1], "-") {
+			newFlag := fmt.Sprintf("--%s=%s", fromCloudFlag, args[idx+1])
+			// We remove the value from the args and add it together.
+			rest := args[idx+2:]
+			args = append(args[:idx], newFlag)
+			args = append(args, rest...)
+		}
+	}
+	return args
 }
 
 // CreateFlow runs the profile creation flow and prints what was done.
@@ -156,7 +222,7 @@ func CreateFlow(
 	name string,
 	description string,
 ) error {
-	if p := yAct.Profile(name); p != nil {
+	if p := yAct.Profile(name); name != "" && p != nil {
 		return &ProfileExistsError{name}
 	}
 

--- a/src/go/rpk/pkg/cli/profile/create_test.go
+++ b/src/go/rpk/pkg/cli/profile/create_test.go
@@ -87,3 +87,89 @@ func TestCombineClusterNames(t *testing.T) {
 		})
 	}
 }
+
+func TestFixFromCloudArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		exp  []string
+	}{
+		{
+			name: "no from-cloud flag",
+			args: []string{"create", "profile-name", "--from-rpk-container"},
+			exp:  []string{"create", "profile-name", "--from-rpk-container"},
+		},
+		{
+			name: "from-cloud with equals syntax",
+			args: []string{"--from-cloud=cluster-123", "profile-name"},
+			exp:  []string{"--from-cloud=cluster-123", "profile-name"},
+		},
+		{
+			name: "from-cloud with value as separate arg",
+			args: []string{"create", "--from-cloud", "cluster-123", "profile-name"},
+			exp:  []string{"create", "--from-cloud=cluster-123", "profile-name"},
+		},
+		{
+			name: "from-cloud not at index 0",
+			args: []string{"--from-cloud", "cluster-123"},
+			exp:  []string{"--from-cloud=cluster-123"},
+		},
+		{
+			name: "from-cloud at end without value",
+			args: []string{"extra-arg", "profile-name", "--from-cloud"},
+			exp:  []string{"extra-arg", "profile-name", "--from-cloud"},
+		},
+		{
+			name: "from-cloud as only arg",
+			args: []string{"--from-cloud"},
+			exp:  []string{"--from-cloud"},
+		},
+		{
+			name: "from-cloud with value as separate arg - 2nd arg",
+			args: []string{"create", "profile-name", "--from-cloud", "cluster-123"},
+			exp:  []string{"create", "profile-name", "--from-cloud=cluster-123"},
+		},
+		{
+			name: "from-cloud with cluster ID followed by another flag",
+			args: []string{"create", "--from-cloud", "cluster-123", "--verbose", "profile-name"},
+			exp:  []string{"create", "--from-cloud=cluster-123", "--verbose", "profile-name"},
+		},
+		{
+			name: "from-cloud followed by another flag (no cluster ID)",
+			args: []string{"create", "--from-cloud", "--verbose", "profile-name"},
+			exp:  []string{"create", "--from-cloud", "--verbose", "profile-name"},
+		},
+		{
+			name: "multiple from-cloud flags - last one wins",
+			args: []string{"create", "--from-cloud", "cluster-111", "--from-cloud", "cluster-222", "profile-name"},
+			exp:  []string{"create", "--from-cloud", "cluster-111", "--from-cloud=cluster-222", "profile-name"},
+		},
+		{
+			name: "from-cloud as first arg with value",
+			args: []string{"--from-cloud", "cluster-123", "create", "profile-name"},
+			exp:  []string{"--from-cloud=cluster-123", "create", "profile-name"},
+		},
+		{
+			name: "from-cloud with hyphenated cluster ID",
+			args: []string{"create", "--from-cloud", "cluster-abc-123", "profile-name"},
+			exp:  []string{"create", "--from-cloud=cluster-abc-123", "profile-name"},
+		},
+		{
+			name: "empty args slice",
+			args: []string{},
+			exp:  []string{},
+		},
+		{
+			name: "from-cloud with value containing spaces (edge case, not possible in practice rn)",
+			args: []string{"create", "--from-cloud", "cluster with spaces", "profile-name"},
+			exp:  []string{"create", "--from-cloud=cluster with spaces", "profile-name"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fixFromCloudArgs(tt.args)
+			require.Equal(t, tt.exp, result)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/redpanda/start.go
@@ -593,7 +593,7 @@ func resolveWellKnownIo(
 	fmt.Println("Detecting the current cloud provider and VM")
 	provider, err := cloud.AvailableProviders()
 	if err != nil {
-		return nil, errors.New("Could not detect the current cloud provider")
+		return nil, errors.New("could not detect the current cloud provider")
 	}
 	ioProps, err = iotune.DataForProvider(y.Redpanda.Directory, provider)
 	if err != nil {
@@ -745,14 +745,14 @@ func parseSeeds(seeds []string) ([]config.SeedServer, error) {
 		addr, err := parseAddress(s, defaultPort)
 		if err != nil {
 			return seedServers, fmt.Errorf(
-				"Couldn't parse seed '%s': %v",
+				"unable to parse seed '%s': %v",
 				s,
 				err,
 			)
 		}
 		if addr == nil {
 			return seedServers, fmt.Errorf(
-				"Couldn't parse seed '%s': empty address",
+				"unable to parse seed '%s': empty address",
 				s,
 			)
 		}

--- a/src/go/rpk/pkg/cli/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/redpanda/start_test.go
@@ -121,12 +121,12 @@ func TestParseSeeds(t *testing.T) {
 		{
 			name:           "it should fail for empty addresses",
 			arg:            []string{""},
-			expectedErrMsg: "Couldn't parse seed '': empty address",
+			expectedErrMsg: "unable to parse seed '': empty address",
 		},
 		{
 			name:           "it should fail if the host is empty",
 			arg:            []string{" :1234"},
-			expectedErrMsg: "Couldn't parse seed ' :1234': invalid host \" :1234\" does not match \"host\", nor \"host:port\", nor \"scheme://host:port\"",
+			expectedErrMsg: "unable to parse seed ' :1234': invalid host \" :1234\" does not match \"host\", nor \"host:port\", nor \"scheme://host:port\"",
 		},
 	}
 
@@ -760,13 +760,13 @@ func TestStartCommand(t *testing.T) {
 		args: []string{
 			"-s", "goodhost.com:54897,:33145",
 		},
-		expectedErrMsg: "Couldn't parse seed ':33145': invalid host \":33145\" does not match \"host\", nor \"host:port\", nor \"scheme://host:port\"",
+		expectedErrMsg: "unable to parse seed ':33145': invalid host \":33145\" does not match \"host\", nor \"host:port\", nor \"scheme://host:port\"",
 	}, {
 		name: "it should fail if the port isnt an int",
 		args: []string{
 			"-s", "host:port",
 		},
-		expectedErrMsg: "Couldn't parse seed 'host:port': invalid host \"host:port\" does not match \"host\", nor \"host:port\", nor \"scheme://host:port\"",
+		expectedErrMsg: "unable to parse seed 'host:port': invalid host \"host:port\" does not match \"host\", nor \"host:port\", nor \"scheme://host:port\"",
 	}, {
 		name: "it should parse the --rpc-addr and persist it",
 		args: []string{

--- a/src/go/rpk/pkg/cli/security/acl/list.go
+++ b/src/go/rpk/pkg/cli/security/acl/list.go
@@ -176,7 +176,11 @@ func describeReqResp(
 			break
 		}
 	}
-	var output aclListOutput
+	// Intentionally starting 'Matches' with an empty slice to avoid printing
+	// null when marshalling to JSON.
+	output := aclListOutput{
+		Matches: []acl{},
+	}
 	for _, f := range kResults {
 		if printAllFilters || printFailedFilters {
 			output.Filters = append(output.Filters, aclWithMessage{

--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -338,5 +338,5 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 		}
 		return nil
 	}
-	return fmt.Errorf("Unknown language %q", p.Lang)
+	return fmt.Errorf("unknown language %q", p.Lang)
 }

--- a/src/go/rpk/pkg/cloud/providers.go
+++ b/src/go/rpk/pkg/cloud/providers.go
@@ -69,7 +69,7 @@ func availableProviderFrom(
 		wg.Done()
 	}
 	if v == nil {
-		return nil, errors.New("The cloud provider couldn't be detected")
+		return nil, errors.New("the cloud provider could not be detected")
 	}
 	return v, nil
 }

--- a/src/go/rpk/pkg/cloud/providers_test.go
+++ b/src/go/rpk/pkg/cloud/providers_test.go
@@ -66,5 +66,5 @@ func TestUnvailableProvider(t *testing.T) {
 	provider[name3] = &mockProvider{false, name3, ""}
 
 	_, err := availableProviderFrom(provider)
-	require.EqualError(t, err, "The cloud provider couldn't be detected")
+	require.EqualError(t, err, "the cloud provider could not be detected")
 }

--- a/src/go/rpk/pkg/redpanda/launcher.go
+++ b/src/go/rpk/pkg/redpanda/launcher.go
@@ -46,7 +46,7 @@ func (*launcher) Start(installDir string, args *RedpandaArgs) error {
 	}
 
 	if args.ConfigFilePath == "" {
-		return errors.New("Redpanda config file is required")
+		return errors.New("the Redpanda configuration file is required")
 	}
 	redpandaArgs := collectRedpandaArgs(args)
 

--- a/src/go/rpk/pkg/redpanda/paths.go
+++ b/src/go/rpk/pkg/redpanda/paths.go
@@ -38,7 +38,7 @@ func FindInstallDir(fs afero.Fs) (string, error) {
 		installDirPath := filepath.Join(installDirCandidate, path)
 		zap.L().Sugar().Debugf("Checking if path '%s' exists", installDirPath)
 		if exists, _ := afero.Exists(fs, installDirPath); !exists {
-			return "", fmt.Errorf("Directory '%s' does not contain '%s'",
+			return "", fmt.Errorf("directory '%s' does not contain '%s'",
 				installDirCandidate, path)
 		}
 	}

--- a/src/go/rpk/pkg/system/filesystem/fs_darwin.go
+++ b/src/go/rpk/pkg/system/filesystem/fs_darwin.go
@@ -12,5 +12,5 @@ package filesystem
 import "errors"
 
 func GetFilesystemType(string) (FsType, error) {
-	return Unknown, errors.New("Filesystem detection not available for MacOS")
+	return Unknown, errors.New("filesystem detection not available for MacOS")
 }

--- a/src/go/rpk/pkg/system/grub.go
+++ b/src/go/rpk/pkg/system/grub.go
@@ -64,7 +64,7 @@ func (g *grub) CheckVersion() error {
 	zap.L().Sugar().Debug("Checking if GRUB is present")
 	_, err := g.commands.Which("grub2-mkconfig", g.timeout)
 	if err != nil {
-		return fmt.Errorf("Only GRUB 2 is currently supported")
+		return fmt.Errorf("only GRUB 2 is currently supported")
 	}
 	return nil
 }
@@ -145,7 +145,7 @@ func (g *grub) MakeConfig() error {
 			return err
 		}
 	}
-	return fmt.Errorf("Unable to find grub.cfg")
+	return fmt.Errorf("unable to find grub.cfg")
 }
 
 func matchAndSplitCmdOptions(optLine string) []string {

--- a/src/go/rpk/pkg/system/memory_darwin.go
+++ b/src/go/rpk/pkg/system/memory_darwin.go
@@ -16,5 +16,5 @@ import (
 )
 
 func getMemInfo(_ afero.Fs) (*MemInfo, error) {
-	return nil, errors.New("Memory info collection not available in MacOS")
+	return nil, errors.New("memory info collection not available in MacOS")
 }

--- a/src/go/rpk/pkg/system/runtime_options.go
+++ b/src/go/rpk/pkg/system/runtime_options.go
@@ -29,7 +29,7 @@ func ReadRuntineOptions(fs afero.Fs, path string) (*RuntimeOptions, error) {
 		return nil, err
 	}
 	if len(lines) != 1 {
-		return nil, fmt.Errorf("Unable to parse options file '%s'", path)
+		return nil, fmt.Errorf("unable to parse options file '%s'", path)
 	}
 	activeOptionPattern := regexp.MustCompile(`^\[(.*)\]$`)
 	options := strings.Fields(lines[0])

--- a/src/go/rpk/pkg/tuners/cpu/tuner.go
+++ b/src/go/rpk/pkg/tuners/cpu/tuner.go
@@ -135,7 +135,7 @@ func (tuner *tuner) getMaxCState() (uint, error) {
 		return uint(cState), nil
 	}
 	// Only stop tune execution (i.e return error) if max_cstate file length is unsupported.
-	return 0, fmt.Errorf("Unsupported length of 'max_cstate' file")
+	return 0, fmt.Errorf("unsupported length of 'max_cstate' file")
 }
 
 func (tuner *tuner) disableCStates() error {
@@ -156,7 +156,7 @@ func (tuner *tuner) checkIfPStateIsEnabled() (bool, error) {
 	}
 
 	if len(lines) == 0 {
-		return false, fmt.Errorf("Unable to read P-State status")
+		return false, fmt.Errorf("unable to read P-State status")
 	}
 	return lines[0] == "intel_pstate", nil
 }

--- a/src/go/rpk/pkg/tuners/disk/block_device.go
+++ b/src/go/rpk/pkg/tuners/disk/block_device.go
@@ -77,7 +77,7 @@ func parseUeventFile(lines []string) (map[string]string, error) {
 	for _, line := range lines {
 		parts := strings.Split(line, "=")
 		if len(parts) != 2 {
-			return nil, errors.New("Malformed uevent file content")
+			return nil, errors.New("malformed uevent file content")
 		}
 		deviceAttrs[parts[0]] = parts[1]
 	}

--- a/src/go/rpk/pkg/tuners/disk/block_devices.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices.go
@@ -77,7 +77,7 @@ func (b *blockDevices) GetDirectoriesDevices(
 	dirDevices := make(map[string][]string)
 	for _, directory := range directories {
 		if exists, _ := afero.Exists(b.fs, directory); !exists {
-			return nil, fmt.Errorf("Directory '%s' does not exists", directory)
+			return nil, fmt.Errorf("directory '%s' does not exists", directory)
 		}
 		devices, err := b.GetDirectoryDevices(directory)
 		if err != nil {

--- a/src/go/rpk/pkg/tuners/disk_scheduler_tuner.go
+++ b/src/go/rpk/pkg/tuners/disk_scheduler_tuner.go
@@ -84,7 +84,7 @@ func getPreferredScheduler(
 			return sched, nil
 		}
 	}
-	return "", fmt.Errorf("None and Noop schedulers are not supported for %s",
+	return "", fmt.Errorf("none and noop schedulers are not supported for %s",
 		device)
 }
 

--- a/src/go/rpk/pkg/tuners/iotune/data.go
+++ b/src/go/rpk/pkg/tuners/iotune/data.go
@@ -51,7 +51,7 @@ func DataForProvider(
 ) (*IoProperties, error) {
 	vmType, err := v.VMType()
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't get the current VM type for provider '%s'", v.Name())
+		return nil, fmt.Errorf("couldn't get the current VM type for provider '%s'", v.Name())
 	}
 	fmt.Printf("Detected provider '%s' and VM type '%s'\n", v.Name(), vmType)
 	return DataFor(mountpoint, v.Name(), vmType, "default")

--- a/src/go/rpk/pkg/tuners/iotune/io_tune.go
+++ b/src/go/rpk/pkg/tuners/iotune/io_tune.go
@@ -65,7 +65,7 @@ func (ioTune *ioTune) Run(args IoTuneArgs) ([]string, error) {
 
 func ioTuneCommandLineArgs(args IoTuneArgs) ([]string, error) {
 	if len(args.Dirs) == 0 {
-		return nil, errors.New("At least one directory is required for iotune")
+		return nil, errors.New("at least one directory is required for iotune")
 	}
 	var cmdArgs []string
 	cmdArgs = append(cmdArgs, "--evaluation-directory")

--- a/src/go/rpk/pkg/tuners/irq/balance_service.go
+++ b/src/go/rpk/pkg/tuners/irq/balance_service.go
@@ -182,7 +182,7 @@ func (balanceService *balanceService) GetBannedIRQs() ([]int, error) {
 	if len(bannedIRQsMatches) > 0 {
 		for _, groupMatch := range bannedIRQsMatches {
 			if len(groupMatch) != 2 {
-				return nil, fmt.Errorf("Malformed option --banirq option")
+				return nil, fmt.Errorf("malformed option --banirq option")
 			}
 			IRQ, err := strconv.Atoi(groupMatch[1])
 			if err != nil {
@@ -210,7 +210,7 @@ func (balanceService *balanceService) getBalanceServiceInfo() (
 			systemd = true
 		} else if exists, _ := afero.Exists(fs, "/etc/conf.d/irqbalance"); !exists {
 			zap.L().Sugar().Error("Unknown system configuration - not restarting irqbalance!")
-			return nil, errors.New("Unsupported irqbalance service configuration")
+			return nil, errors.New("unsupported irqbalance service configuration")
 		} else {
 			configFile = "/etc/conf.d/irqbalance"
 			optionsKey = "IRQBALANCE_OPTS"

--- a/src/go/rpk/pkg/tuners/irq/cpu_masks.go
+++ b/src/go/rpk/pkg/tuners/irq/cpu_masks.go
@@ -84,7 +84,7 @@ func (masks *cpuMasks) CPUMaskForComputations(
 		// all available cores
 		computationsMask = cpuMask
 	} else {
-		err = fmt.Errorf("Unsupported mode: '%s'", mode)
+		err = fmt.Errorf("unsupported mode: '%s'", mode)
 	}
 
 	if masks.hwloc.CheckIfMaskIsEmpty(computationsMask) {

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -64,7 +64,7 @@ func getDefaultMode(
 		}
 		return defaultMode, nil
 	}
-	return "", fmt.Errorf("Virtual device %s is not supported", nic.Name())
+	return "", fmt.Errorf("virtual device %s is not supported", nic.Name())
 }
 
 func GetRpsCPUMask(

--- a/src/go/rpk/pkg/tuners/thp.go
+++ b/src/go/rpk/pkg/tuners/thp.go
@@ -50,7 +50,7 @@ func getTHPDir(fs afero.Fs) (string, error) {
 		}
 	}
 	return "", fmt.Errorf(
-		"None of %s was found",
+		"none of %s was found",
 		strings.Join(locations(), ", "),
 	)
 }

--- a/src/go/rpk/pkg/tuners/thp_test.go
+++ b/src/go/rpk/pkg/tuners/thp_test.go
@@ -43,7 +43,7 @@ func TestTHPTunerSupported(t *testing.T) {
 		{
 			name:           "should return false if no dir exists",
 			expected:       false,
-			expectedReason: "None of /sys/kernel/mm/transparent_hugepage, /sys/kernel/mm/redhat_transparent_hugepage was found",
+			expectedReason: "none of /sys/kernel/mm/transparent_hugepage, /sys/kernel/mm/redhat_transparent_hugepage was found",
 		},
 	}
 

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -324,7 +324,7 @@ class RpkACLTest(RedpandaTest):
         # Delete ALL, empty input means all.
         superclient.acl_delete(RPKACLInput())
         acl_list_all = superclient.acl_list(format="json")
-        assert acl_list_all['matches'] is None
+        assert len(acl_list_all['matches']) == 0
 
         # ACL with SR + Kafka = 4 in total.
         sr_kafka_acl = RPKACLInput(allow_principal=["panda"],
@@ -355,4 +355,4 @@ class RpkACLTest(RedpandaTest):
         superclient.acl_delete(sr_kafka_acl)
 
         acl_list_all = superclient.acl_list(format="json")
-        assert acl_list_all['matches'] is None
+        assert len(acl_list_all['matches']) == 0


### PR DESCRIPTION
This PR includes several changes across rpk, each commit has their own description easier for the reviewer:

**rpk profile create: Fix --from-cloud flag**

- Fixes the `--from-cloud cloud-ID` syntax due to a restriction in Cobra's NoOptDefault value.
- Handles rare edge case where an empty profile name in rpk.yaml prevented new profile creation.
- Fixes UX-309 

	
**rpk security acl list: Avoid null on empty matches**

- Now returns an empty list instead of null when no ACLs are found.
- Fixes UX-320.

**Linter compliance improvements**

- Updates error strings in the out package to follow [Go error style guidelines](https://go.dev/wiki/CodeReviewComments#error-strings).
- Bumps golangci-lint version used in the Makefile for internal testing.

	
Also adds missing help text to the rpk mcp command.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* rpk security acl list --format json: no longer prints `null` for empty lists.
* rpk profile create --from-cloud now accepts the `--from-cloud <cluster-id>` syntax
