### PR TITLE
bazel: upgrade to clang-20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,7 @@ common --@toolchains_llvm//toolchain/config:compiler-rt=False
 build --linkopt --unwindlib=libgcc
 build --linkopt -stdlib=libc++
 
-common:clang-18 --extra_toolchains=@previous_llvm_toolchain//:all
-common:clang-20 --extra_toolchains=@next_llvm_toolchain//:all
+common:clang-19 --extra_toolchains=@previous_llvm_toolchain//:all
 
 # Use Bash instead of system python for finding the hermetic interpreter
 # within Bazel due to the `python3` binary not being present on CI
@@ -30,12 +29,12 @@ build:system-clang --action_env=BAZEL_COMPILER=clang
 build:system-clang --cxxopt=-std=c++23 --host_cxxopt=-std=c++23
 build:system-clang --linkopt -fuse-ld=lld
 # use a compiler name that doesn't symlink to ccache
-build:system-clang-18 --config=system-clang
-build:system-clang-18 --action_env=CC=clang-18 --host_action_env=CC=clang-18
-build:system-clang-18 --action_env=CXX=clang++-18 --host_action_env=CXX=clang++-18
 build:system-clang-19 --config=system-clang
 build:system-clang-19 --action_env=CC=clang-19 --host_action_env=CC=clang-19
 build:system-clang-19 --action_env=CXX=clang++-19 --host_action_env=CXX=clang++-19
+build:system-clang-20 --config=system-clang
+build:system-clang-20 --action_env=CC=clang-20 --host_action_env=CC=clang-20
+build:system-clang-20 --action_env=CXX=clang++-20 --host_action_env=CXX=clang++-20
 
 # Use new proto toolchain resolution
 build --incompatible_enable_proto_toolchain_resolution

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange'
-WarningsAsErrors: 'cppcoreguidelines-avoid-capturing-lambda-coroutines,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move'
+WarningsAsErrors: 'cppcoreguidelines-avoid-capturing-lambda-coroutines,bugprone-use-after-move,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-dangling-handle,bugprone-sizeof-container,bugprone-stringview-nullptr,bugprone-unused-return-value,bugprone-suspicious-string-compare,misc-unused-using-decls,misc-unused-alias-decls,modernize-redundant-void-arg,performance-implicit-conversion-in-loop,performance-trivially-destructible,performance-no-automatic-move,bugprone-unused-local-non-trivial-variable'
 HeaderFilterRegex: '^(?!external/.*).*'
 FormatStyle:    file
 CheckOptions:
@@ -32,5 +32,7 @@ CheckOptions:
     value:           KiB;MiB;GiB;TiB
   - key:             performance-unnecessary-value-param.AllowedTypes
     value:           seastar::shared_ptr;seastar::lw_shared_ptr;
+  - key:             bugprone-unused-local-non-trivial-variable.IncludeTypes
+    value:           ::seastar::future
 ...
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -165,15 +165,15 @@ COMPILERS = {
     "next": {
         "tars": {
             "aarch64": {
-                "build_date": "2025-06-18",
-                "sha": "895bc671e9d75e80fb09b1cf842b3191239d4aeb1bf79bb8108490571481c177",
+                "build_date": "2025-07-22",
+                "sha": "ce0a8d7f4df980dd3aa0deacd390804f887d31065cd79b71827bba6cd4d2e2e8",
             },
             "x86_64": {
-                "build_date": "2025-06-18",
-                "sha": "6eee67bc40ffe6a8470df0f8bea5ab0e99ad5785d1cc84d2c5d14c1a9021b3da",
+                "build_date": "2025-07-22",
+                "sha": "c424df0195e1641b6226dbb380a849d2013975150af40932392361d9893005ac",
             },
         },
-        "version": "20.1.7",
+        "version": "20.1.8",
     },
 }
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -139,19 +139,6 @@ COMPILERS = {
     "previous": {
         "tars": {
             "aarch64": {
-                "build_date": "2025-03-10",
-                "sha": "9f52789c5aee794d6f013249b6e003b50f72e4c3874fd656723a72bf9322eff9",
-            },
-            "x86_64": {
-                "build_date": "2025-03-10",
-                "sha": "51e547308112bc6671f391d03420c315b7c099238d797631e00374f1bd80712e",
-            },
-        },
-        "version": "18.1.8",
-    },
-    "current": {
-        "tars": {
-            "aarch64": {
                 "build_date": "2025-03-15",
                 "sha": "cdba86609d71cfc379bfce9fb5ce97389cc08320fb713c6abab8d698a53e3fa2",
             },
@@ -162,7 +149,7 @@ COMPILERS = {
         },
         "version": "19.1.7",
     },
-    "next": {
+    "current": {
         "tars": {
             "aarch64": {
                 "build_date": "2025-07-22",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4499,7 +4499,7 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "Y2heRh/+vyv+TNlxvHaJMv4Qvk/skBlTnhqOk6s4VjY=",
-        "usagesDigest": "IA3VY3eCQ0agjYBS73Jyh+E890b93T9etIojaGQbxEs=",
+        "usagesDigest": "0bOTaIUIKodHv9H8QPWdqnhUg96nSEl12Z4hRtIlrfY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4688,20 +4688,20 @@
               "exec_os": "",
               "libclang_rt": {},
               "llvm_mirror": "",
-              "llvm_version": "20.1.7",
+              "llvm_version": "20.1.8",
               "llvm_versions": {},
               "netrc": "",
               "sha256": {
-                "linux-aarch64": "895bc671e9d75e80fb09b1cf842b3191239d4aeb1bf79bb8108490571481c177",
-                "linux-x86_64": "6eee67bc40ffe6a8470df0f8bea5ab0e99ad5785d1cc84d2c5d14c1a9021b3da"
+                "linux-aarch64": "ce0a8d7f4df980dd3aa0deacd390804f887d31065cd79b71827bba6cd4d2e2e8",
+                "linux-x86_64": "c424df0195e1641b6226dbb380a849d2013975150af40932392361d9893005ac"
               },
               "strip_prefix": {},
               "urls": {
                 "linux-aarch64": [
-                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.7/llvm-20.1.7-debian-11-aarch64-2025-06-18.tar.zst"
+                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.8/llvm-20.1.8-debian-11-aarch64-2025-07-22.tar.zst"
                 ],
                 "linux-x86_64": [
-                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.7/llvm-20.1.7-debian-11-x86_64-2025-06-18.tar.zst"
+                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-20.1.8/llvm-20.1.8-debian-11-x86_64-2025-07-22.tar.zst"
                 ]
               }
             }
@@ -4751,7 +4751,7 @@
               "link_flags": {},
               "link_libs": {},
               "llvm_versions": {
-                "": "20.1.7"
+                "": "20.1.8"
               },
               "opt_compile_flags": {},
               "opt_link_flags": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4499,99 +4499,12 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "Y2heRh/+vyv+TNlxvHaJMv4Qvk/skBlTnhqOk6s4VjY=",
-        "usagesDigest": "0bOTaIUIKodHv9H8QPWdqnhUg96nSEl12Z4hRtIlrfY=",
+        "usagesDigest": "rwpkkTnNHzR5ruvmlEIhcIOwvqU55SHssS+CA2XsDnU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "previous_llvm_toolchain_llvm": {
-            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
-            "attributes": {
-              "alternative_llvm_sources": [],
-              "auth_patterns": {},
-              "distribution": "auto",
-              "exec_arch": "",
-              "exec_os": "",
-              "libclang_rt": {},
-              "llvm_mirror": "",
-              "llvm_version": "18.1.8",
-              "llvm_versions": {},
-              "netrc": "",
-              "sha256": {
-                "linux-aarch64": "9f52789c5aee794d6f013249b6e003b50f72e4c3874fd656723a72bf9322eff9",
-                "linux-x86_64": "51e547308112bc6671f391d03420c315b7c099238d797631e00374f1bd80712e"
-              },
-              "strip_prefix": {},
-              "urls": {
-                "linux-aarch64": [
-                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-18.1.8/llvm-18.1.8-debian-11-aarch64-2025-03-10.tar.zst"
-                ],
-                "linux-x86_64": [
-                  "https://github.com/redpanda-data/llvm-project/releases/download/llvmorg-18.1.8/llvm-18.1.8-debian-11-x86_64-2025-03-10.tar.zst"
-                ]
-              }
-            }
-          },
-          "previous_llvm_toolchain": {
-            "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
-            "attributes": {
-              "absolute_paths": false,
-              "archive_flags": {},
-              "compile_flags": {
-                "linux-aarch64": [
-                  "--target=aarch64-unknown-linux-gnu",
-                  "-march=armv8-a+crc+crypto",
-                  "-U_FORTIFY_SOURCE",
-                  "-fstack-protector",
-                  "-fno-omit-frame-pointer",
-                  "-fcolor-diagnostics",
-                  "-Wall",
-                  "-Wthread-safety",
-                  "-Wself-assign"
-                ],
-                "linux-x86_64": [
-                  "--target=x86_64-unknown-linux-gnu",
-                  "-march=westmere",
-                  "-U_FORTIFY_SOURCE",
-                  "-fstack-protector",
-                  "-fno-omit-frame-pointer",
-                  "-fcolor-diagnostics",
-                  "-Wall",
-                  "-Wthread-safety",
-                  "-Wself-assign"
-                ]
-              },
-              "conly_flags": {},
-              "coverage_compile_flags": {},
-              "coverage_link_flags": {},
-              "cxx_builtin_include_directories": {},
-              "cxx_flags": {},
-              "cxx_standard": {
-                "": "c++23"
-              },
-              "dbg_compile_flags": {},
-              "exec_arch": "",
-              "exec_os": "",
-              "extra_exec_compatible_with": {},
-              "extra_target_compatible_with": {},
-              "link_flags": {},
-              "link_libs": {},
-              "llvm_versions": {
-                "": "18.1.8"
-              },
-              "opt_compile_flags": {},
-              "opt_link_flags": {},
-              "stdlib": {},
-              "target_settings": {},
-              "unfiltered_compile_flags": {},
-              "toolchain_roots": {},
-              "sysroot": {
-                "linux-x86_64": "'@@+non_module_dependencies+x86_64_sysroot//:sysroot'",
-                "linux-aarch64": "'@@+non_module_dependencies+aarch64_sysroot//:sysroot'"
-              }
-            }
-          },
-          "current_llvm_toolchain_llvm": {
             "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
             "attributes": {
               "alternative_llvm_sources": [],
@@ -4619,7 +4532,7 @@
               }
             }
           },
-          "current_llvm_toolchain": {
+          "previous_llvm_toolchain": {
             "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
             "attributes": {
               "absolute_paths": false,
@@ -4678,7 +4591,7 @@
               }
             }
           },
-          "next_llvm_toolchain_llvm": {
+          "current_llvm_toolchain_llvm": {
             "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%llvm",
             "attributes": {
               "alternative_llvm_sources": [],
@@ -4706,7 +4619,7 @@
               }
             }
           },
-          "next_llvm_toolchain": {
+          "current_llvm_toolchain": {
             "repoRuleId": "@@toolchains_llvm+//toolchain:rules.bzl%toolchain",
             "attributes": {
               "absolute_paths": false,

--- a/bazel/toolchain/Dockerfile.llvm
+++ b/bazel/toolchain/Dockerfile.llvm
@@ -11,7 +11,7 @@ RUN apt update && apt install -y \
     lsb-release
 
 # Install latest versions using backports
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list && \
+RUN echo "deb http://archive.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list && \
     apt-get update && \
     apt-get install -y -t bullseye-backports \
       cmake \

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -1164,7 +1164,6 @@ TEST_P(
   all_types_throttle_remote_fixture,
   test_download_segment_throttle) { // NOLINT
     set_expectations_and_listen({});
-    auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = remote_segment_path{prefixed_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123})};
@@ -1251,7 +1250,6 @@ TEST_P(
   all_types_no_throttle_remote_fixture,
   test_download_segment_no_throttle) { // NOLINT
     set_expectations_and_listen({});
-    auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = remote_segment_path{prefixed_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123})};

--- a/src/v/cluster/cloud_metadata/offsets_recovery_manager.h
+++ b/src/v/cluster/cloud_metadata/offsets_recovery_manager.h
@@ -25,16 +25,8 @@ class offsets_recovery_manager : public offsets_recovery_requestor {
 public:
     offsets_recovery_manager(
       ss::sharded<offsets_recovery_router>& recovery,
-      ss::sharded<kafka::coordinator_ntp_mapper>& mapper,
-      ss::sharded<cluster::members_table>& members,
-      ss::sharded<cluster::controller_api>& controller_api,
-      ss::sharded<topics_frontend>& topics_frontend,
       kafka::group_initializer& group_initializer)
       : _recovery_router(recovery)
-      , _mapper(mapper)
-      , _members(members)
-      , _controller_api(controller_api)
-      , _topics_frontend(topics_frontend)
       , _group_initializer(group_initializer) {}
 
     ss::future<error_outcome> recover(
@@ -46,10 +38,6 @@ public:
 
 private:
     ss::sharded<offsets_recovery_router>& _recovery_router;
-    ss::sharded<kafka::coordinator_ntp_mapper>& _mapper;
-    ss::sharded<cluster::members_table>& _members;
-    ss::sharded<cluster::controller_api>& _controller_api;
-    ss::sharded<topics_frontend>& _topics_frontend;
     kafka::group_initializer& _group_initializer;
 };
 

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -368,9 +368,8 @@ TEST_F(cluster_metadata_uploader_fixture, test_upload_loop_deletes_orphans) {
     auto& uploader = app.controller->metadata_uploader().value().get();
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
 
-    auto upload_in_term
-      = uploader.upload_until_term_change().handle_exception_type(
-        [](const seastar::abort_requested_exception& e) { std::ignore = e; });
+    ssx::background = uploader.upload_until_term_change().handle_exception_type(
+      [](const seastar::abort_requested_exception& e) { std::ignore = e; });
     // Wait for some valid metadata to show up.
     cluster::cloud_metadata::cluster_metadata_manifest manifest;
     RPTEST_REQUIRE_EVENTUALLY(5s, [this, &manifest] {

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -104,7 +104,7 @@ private:
     table* _table;
     ss::abort_source* _as;
     cluster::controller_stm* _controller;
-    features::feature_table* _features;
+    [[maybe_unused]] features::feature_table* _features;
 
     mutex _mu{"panda-link::frontend::mu"};
 };

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -605,7 +605,7 @@ ss::future<> controller::start(
 
     co_await cluster_creation_hook(discovery);
     {
-        auto u = _stm.local().lock_apply();
+        auto u = co_await _stm.local().lock_apply();
         // start shard_balancer before controller_backend so that it bootstraps
         // shard_placement_table and controller_backend can start with already
         // initialized table.

--- a/src/v/cluster/shard_placement_table.cc
+++ b/src/v/cluster/shard_placement_table.cc
@@ -242,13 +242,14 @@ ss::future<> shard_placement_table::enable_persistence() {
 
     vlog(clusterlog.info, "enabling table persistence...");
 
-    auto write_locks = container().map([](shard_placement_table& local) {
-        return local._persistence_lock.hold_write_lock().then(
-          [](ss::rwlock::holder holder) {
-              return ss::make_foreign(
-                std::make_unique<ss::rwlock::holder>(std::move(holder)));
-          });
-    });
+    auto write_locks = co_await container().map(
+      [](shard_placement_table& local) {
+          return local._persistence_lock.hold_write_lock().then(
+            [](ss::rwlock::holder holder) {
+                return ss::make_foreign(
+                  std::make_unique<ss::rwlock::holder>(std::move(holder)));
+            });
+      });
 
     co_await container().invoke_on_all([](shard_placement_table& local) {
         return local.persist_shard_local_state();

--- a/src/v/datalake/coordinator/catalog_factory.cc
+++ b/src/v/datalake/coordinator/catalog_factory.cc
@@ -244,7 +244,6 @@ rest_catalog_factory::create_catalog(ss::abort_source& as) {
     co_return std::make_unique<iceberg::rest_catalog>(
       std::move(client),
       config_->iceberg_rest_catalog_request_timeout_ms.bind(),
-      credential_manager_,
       config_->iceberg_rest_catalog_base_location());
 }
 

--- a/src/v/datalake/coordinator/coordinator_manager.cc
+++ b/src/v/datalake/coordinator/coordinator_manager.cc
@@ -18,7 +18,6 @@
 #include "datalake/coordinator/iceberg_file_committer.h"
 #include "datalake/coordinator/iceberg_snapshot_remover.h"
 #include "datalake/coordinator/state_machine.h"
-#include "datalake/credential_manager.h"
 #include "datalake/logger.h"
 #include "datalake/record_schema_resolver.h"
 #include "iceberg/manifest_io.h"
@@ -39,8 +38,7 @@ coordinator_manager::coordinator_manager(
   pandaproxy::schema_registry::api* sr_api,
   std::unique_ptr<catalog_factory> catalog_factory,
   ss::sharded<cloud_io::remote>& io,
-  cloud_storage_clients::bucket_name bucket,
-  datalake::credential_manager& credential_mgr)
+  cloud_storage_clients::bucket_name bucket)
   : self_(self)
   , storage_(storage.local())
   , gm_(gm.local())
@@ -50,8 +48,8 @@ coordinator_manager::coordinator_manager(
   , schema_registry_(schema::registry::make_default(sr_api))
   , manifest_io_(io.local(), bucket)
   , catalog_factory_(std::move(catalog_factory))
-  , type_resolver_(std::make_unique<record_schema_resolver>(*schema_registry_))
-  , credential_mgr_(credential_mgr) {}
+  , type_resolver_(
+      std::make_unique<record_schema_resolver>(*schema_registry_)) {}
 
 coordinator_manager::~coordinator_manager() = default;
 

--- a/src/v/datalake/coordinator/coordinator_manager.h
+++ b/src/v/datalake/coordinator/coordinator_manager.h
@@ -52,8 +52,7 @@ public:
       pandaproxy::schema_registry::api*,
       std::unique_ptr<catalog_factory>,
       ss::sharded<cloud_io::remote>&,
-      cloud_storage_clients::bucket_name,
-      datalake::credential_manager&);
+      cloud_storage_clients::bucket_name);
     ~coordinator_manager();
 
     ss::future<> start();
@@ -96,9 +95,6 @@ private:
       leadership_notifications_;
 
     absl::btree_map<model::ntp, ss::lw_shared_ptr<coordinator>> coordinators_;
-
-    // Credential manager for handling authentication
-    datalake::credential_manager& credential_mgr_;
 };
 
 } // namespace datalake::coordinator

--- a/src/v/iceberg/rest_catalog.cc
+++ b/src/v/iceberg/rest_catalog.cc
@@ -77,13 +77,11 @@ table_update::update copy(const table_update::update& update) {
 rest_catalog::rest_catalog(
   std::unique_ptr<rest_client::catalog_client> client,
   config::binding<std::chrono::milliseconds> request_timeout,
-  datalake::credential_manager& credential_mgr,
   std::optional<ss::sstring> base_location)
   : client_(std::move(client))
   , request_timeout_(std::move(request_timeout))
   , base_location_(std::move(base_location))
-  , lock_("iceberg/rest-catalog")
-  , credential_manager_(credential_mgr) {}
+  , lock_("iceberg/rest-catalog") {}
 
 void rest_catalog::set_table_location_if_needed(
   create_table_request& request, const table_identifier& t_id) const {

--- a/src/v/iceberg/rest_catalog.h
+++ b/src/v/iceberg/rest_catalog.h
@@ -32,7 +32,6 @@ public:
     explicit rest_catalog(
       std::unique_ptr<rest_client::catalog_client>,
       config::binding<std::chrono::milliseconds> request_timeout,
-      datalake::credential_manager& credential_mgr,
       std::optional<ss::sstring> base_location = std::nullopt);
 
     rest_catalog(const rest_catalog&) = delete;
@@ -69,6 +68,5 @@ private:
     // REST request at a time
     mutex lock_;
     ss::abort_source as_;
-    datalake::credential_manager& credential_manager_;
 };
 }; // namespace iceberg

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -55,8 +55,7 @@ struct RestCatalogTest
   , s3_imposter_fixture {
     RestCatalogTest()
       : sr(cloud_io::scoped_remote::create(10, conf))
-      , io(remote(), bucket_name)
-      , mock_credential_manager() {
+      , io(remote(), bucket_name) {
         set_expectations_and_listen({});
     }
 
@@ -331,9 +330,7 @@ TEST_F(RestCatalogTest, CheckLoadTableHappyPath) {
     }});
 
     iceberg::rest_catalog catalog(
-      std::move(client),
-      config::mock_binding<std::chrono::milliseconds>(10s),
-      mock_credential_manager);
+      std::move(client), config::mock_binding<std::chrono::milliseconds>(10s));
 
     auto metadata = catalog
                       .load_table(iceberg::table_identifier{
@@ -374,9 +371,7 @@ TEST_F(RestCatalogTest, CheckCreateTableHappyPath) {
     }});
 
     iceberg::rest_catalog catalog(
-      std::move(client),
-      config::mock_binding<std::chrono::milliseconds>(10s),
-      mock_credential_manager);
+      std::move(client), config::mock_binding<std::chrono::milliseconds>(10s));
 
     auto metadata = catalog
                       .create_table(
@@ -476,9 +471,7 @@ TEST_F(RestCatalogTest, CommitTxnHappyPath) {
     }});
 
     iceberg::rest_catalog catalog(
-      std::move(client),
-      config::mock_binding<std::chrono::milliseconds>(10s),
-      mock_credential_manager);
+      std::move(client), config::mock_binding<std::chrono::milliseconds>(10s));
     auto table_md = create_empty_table_metadata(bucket_name);
     iceberg::transaction txn(std::move(table_md));
 
@@ -513,9 +506,7 @@ TEST_F(RestCatalogTest, CommitEmptyTransaction) {
     auto client = make_catalog_client({[](client_mock&) {}});
 
     iceberg::rest_catalog catalog(
-      std::move(client),
-      config::mock_binding<std::chrono::milliseconds>(10s),
-      mock_credential_manager);
+      std::move(client), config::mock_binding<std::chrono::milliseconds>(10s));
     auto table_md = create_empty_table_metadata(bucket_name);
 
     iceberg::transaction txn(std::move(table_md));
@@ -570,9 +561,7 @@ TEST_F(RestCatalogTest, TestConcurrentAccesses) {
     }});
 
     iceberg::rest_catalog catalog(
-      std::move(client),
-      config::mock_binding<std::chrono::milliseconds>(10s),
-      mock_credential_manager);
+      std::move(client), config::mock_binding<std::chrono::milliseconds>(10s));
     auto t_id = iceberg::table_identifier{
       .ns = {"foo", "bar", "baz"}, .table = "panda_table"};
     ss::parallel_for_each(boost::irange(20), [&](int) {

--- a/src/v/kafka/client/test/describe_topics.cc
+++ b/src/v/kafka/client/test/describe_topics.cc
@@ -72,7 +72,7 @@ FIXTURE_TEST(test_describe_with_configuration_keys, describe_topic_fixture) {
       .replication_factor = 1,
       .configs = {custom_config},
     };
-    const auto created_topic = client.create_topic(std::move(req));
+    const auto created_topic = client.create_topic(std::move(req)).get();
 
     {
         info("Checking if describing the topic returns the custom config");

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -121,8 +121,7 @@ proxy::proxy(
       json::serialization_format::application_json,
       plog,
       preqs)
-  , _ensure_started{[this]() { return do_start(); }}
-  , _controller(controller) {
+  , _ensure_started{[this]() { return do_start(); }} {
     _inflight_config_binding.watch([this]() {
         const size_t capacity = _inflight_config_binding();
         _inflight_sem.set_capacity(capacity);

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -61,7 +61,6 @@ private:
     server::context_t _ctx;
     server _server;
     one_shot _ensure_started;
-    cluster::controller* _controller;
     bool _is_started{false};
 };
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -557,7 +557,7 @@ TEST_F_CORO(raft_fixture, test_prioritizing_longest_log) {
         co_await n->init_and_start(all_vnodes());
     }
 
-    auto leader_id = wait_for_leader(10s);
+    co_await wait_for_leader(10s);
 
     co_await wait_for_visible_offset(visible_offset, 10s);
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1381,8 +1381,7 @@ void application::wire_up_runtime_services(
             std::ref(cloud_io),
             std::ref(_datalake_credential_mgr)),
           std::ref(cloud_io),
-          std::ref(*bucket),
-          std::ref(_datalake_credential_mgr))
+          std::ref(*bucket))
           .get();
         construct_service(
           _datalake_coordinator_fe,
@@ -2161,12 +2160,7 @@ void application::wire_up_redpanda_services(
 
     offsets_recovery_manager
       = ss::make_shared<cluster::cloud_metadata::offsets_recovery_manager>(
-        std::ref(offsets_recovery_router),
-        std::ref(coordinator_ntp_mapper),
-        controller->get_members_table(),
-        controller->get_api(),
-        std::ref(controller->get_topics_frontend()),
-        group_initializer.local());
+        std::ref(offsets_recovery_router), group_initializer.local());
 
     syschecks::systemd_message("Creating kafka group router").get();
     construct_service(

--- a/src/v/resource_mgmt/tests/cpu_profiler_test.cc
+++ b/src/v/resource_mgmt/tests/cpu_profiler_test.cc
@@ -230,6 +230,7 @@ SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override_abort) {
     auto end = ss::steady_clock_type::now();
 
     BOOST_REQUIRE(end - start < 1min);
+    res_fut.get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_cpu_profiler_enable_override_filter_old_samples) {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -61,10 +61,10 @@ sh_binary(
     name = "clang_format",
     srcs = ["format_cc.sh"],
     args = [
-        "$(rootpath @current_llvm_toolchain//:clang-format)",
+        "$(rootpath @previous_llvm_toolchain//:clang-format)",
     ],
     data = [
-        "@current_llvm_toolchain//:clang-format",
+        "@previous_llvm_toolchain//:clang-format",
     ],
     # Only build this target on demand, so we don't download
     # this toolchain if we're using a different one for the build.


### PR DESCRIPTION
- **bazel/toolchain: use archive mirror for backport debs**
- **bazel: upgrade clang-20**
- **clang-tidy: enable unused variable warnings**
- **bazel: default compiler to clang-20**
- **treewide: format with clang-20**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
