### PR TITLE
dt: Improve all_uploaded condition in test_node_wise_recovery

### DIFF
--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -566,7 +566,9 @@ class NodeWiseRecoveryTest(RedpandaTest):
         self.producer.clean()
         self.producer.free()
 
-    def wait_for_final_manifest_uploads(self, topic):
+    def wait_for_final_manifest_uploads(self,
+                                        topic,
+                                        fraction_uploaded: float = 0.8):
         def all_uploaded():
             for p in self.rpk.describe_topic(topic):
                 status = self.admin.get_partition_cloud_storage_status(
@@ -575,6 +577,16 @@ class NodeWiseRecoveryTest(RedpandaTest):
                     node=self.redpanda.get_node_by_id(p.leader))
                 if ("ms_since_last_manifest_upload"
                         not in status) or status["metadata_update_pending"]:
+                    self.logger.debug(
+                        f"Pending manifest update: {status['ms_since_last_manifest_upload']=} {status['metadata_update_pending']=}"
+                    )
+                    return False
+                if int(
+                        status["cloud_log_last_offset"]
+                ) < fraction_uploaded * int(status["local_log_last_offset"]):
+                    self.logger.debug(
+                        f"{topic}/{p.id}: {status['cloud_log_last_offset']=} vs {status['local_log_last_offset']=}"
+                    )
                     return False
             return True
 
@@ -623,10 +635,12 @@ class NodeWiseRecoveryTest(RedpandaTest):
         to_kill_node_ids = [
             int(self.redpanda.node_id(n)) for n in to_kill_nodes
         ]
+        expected_fraction_uploaded = 0.8
         for t in topics:
             self.produce_until_log_eviction(t.name)
         for t in topics:
-            self.wait_for_final_manifest_uploads(t.name)
+            self.wait_for_final_manifest_uploads(
+                t.name, fraction_uploaded=expected_fraction_uploaded)
 
         partitions_lost_majority = admin.get_majority_lost_partitions_from_nodes(
             dead_brokers=to_kill_node_ids)
@@ -754,7 +768,8 @@ class NodeWiseRecoveryTest(RedpandaTest):
                     f"partition {t}/{partition_id} replicas initial high watermark: {initial_hw} final high watermark: {final_hw}"
                 )
                 if t.redpanda_remote_write or t.replication_factor == 3:
-                    assert 0.8 * initial_hw <= final_hw <= initial_hw
+                    assert expected_fraction_uploaded * initial_hw <= final_hw <= initial_hw, \
+                        f"partition {t.name}/{partition_id}: {initial_hw=} vs {final_hw=}"
 
     @cluster(num_nodes=6)
     def test_recovery_local_data_missing(self):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

And improve logging.

A previous commit[1] added a check to that partition manifests were in-sync
w/ uploaded segments. Effectively post-recovery offset checks were racy with
respect to pre-recovery manifest uploads. This check was implemented against
manifest upload accounting from cloud_storage/status.

This commit strengthens those checks to also wait for cloud_log_last_offset (the
last offset in the manifest) to approach local_log_last_offset. The
The reasoning being that we may as well wait to sync with the local log since
the post-recovery check is based on pre-recovery local log HWM anyway.

[1] https://github.com/redpanda-data/redpanda/commit/5b39a4f28b7dc5e37ac5419516b990125b3e4bde

ran 50x in [cdt](https://buildkite.com/redpanda/redpanda/builds/69483#019834d5-d5e6-4b8c-8c98-64bbe4a35abc), no such failures

fixes https://redpandadata.atlassian.net/browse/CORE-7977

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
