### PR TITLE
`http`: loop while `!_serializer.is_header_done()`

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -515,11 +515,13 @@ ss::future<> client::request_stream::send_some(iobuf&& seq) {
     boost::beast::error_code error_code = {};
     iobuf outbuf;
     parser_visitor visitor{outbuf, _serializer};
-    _serializer.next(error_code, visitor);
-    if (error_code) {
-        vlog(_ctxlog.error, "serialization error {}", error_code);
-        boost::system::system_error except(error_code);
-        return ss::make_exception_future<>(except);
+    while (!_serializer.is_header_done()) {
+        _serializer.next(error_code, visitor);
+        if (error_code) {
+            vlog(_ctxlog.error, "serialization error {}", error_code);
+            boost::system::system_error except(error_code);
+            return ss::make_exception_future<>(except);
+        }
     }
     auto scattered = iobuf_as_scattered(std::move(outbuf));
     return ss::with_gate(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -144,15 +144,6 @@ DEFAULT_LOG_ALLOW_LIST = [
     # the catalog that have "Assert" in them. These are typically benign and
     # just indicate a race in committing to Iceberg.
     re.compile(r"UpdateRequirement.*Assert"),
-
-    # Temporary: https://redpandadata.atlassian.net/browse/CORE-9897
-    # there is an ongoing investigation into s3_client receiving 400 Bad Request. For now, stop the CI bleed
-    re.compile(
-        r"S3 PUT request failed with error for key .*: code: _unknown_error_code_, message: http status: Bad Request, error body: 400 Bad Request, request_id: , resource:"
-    ),
-    re.compile(
-        r"Accessing .*, unexpected REST API error \"http status: Bad Request, error body: 400 Bad Request\" detected, code: _unknown_error_code_, request_id: , resource:"
-    )
 ]
 
 # Log errors that are expected in tests that restart nodes mid-test


### PR DESCRIPTION
Opening for CI.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
