### PR TITLE
kc/test: added missing cluster stop to test

### DIFF
--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -427,6 +427,7 @@ redpanda_cc_gtest(
         "//src/v/kafka/client:cluster",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/kafka/client/test/cluster_test_with_mock.cc
+++ b/src/v/kafka/client/test/cluster_test_with_mock.cc
@@ -13,6 +13,8 @@
 #include "test_utils/async.h"
 #include "test_utils/test.h"
 
+#include <seastar/util/defer.hh>
+
 using namespace kafka::client;
 using namespace std::chrono_literals;
 
@@ -37,7 +39,7 @@ TEST_F(cluster_mock_fixture, TestBrokerDiscovery) {
     cluster_mock.add_broker(
       model::node_id(1), net::unresolved_address{"localhost", 9092});
     cluster.start().get();
-
+    auto deferred_stop = ss::defer([&cluster] { cluster.stop().get(); });
     RPTEST_REQUIRE_EVENTUALLY(
       5s, [&cluster]() { return cluster.get_brokers().size() == 1; });
 
@@ -62,6 +64,7 @@ TEST_F(cluster_mock_fixture, TestBrokerDiscovery) {
 TEST_F(cluster_mock_fixture, TestMetadataCallback) {
     cluster_mock.register_default_handlers();
     auto cluster = create_client_cluster();
+    auto deferred_stop = ss::defer([&cluster] { cluster.stop().get(); });
     int callback_invocations = 0;
 
     cluster_mock.add_broker(
@@ -76,8 +79,8 @@ TEST_F(cluster_mock_fixture, TestMetadataCallback) {
 TEST_F(cluster_mock_fixture, TestApiVersionDiscovery) {
     cluster_mock.register_default_handlers();
     auto cluster = create_client_cluster();
-    model::node_id broker_0(0);
 
+    model::node_id broker_0(0);
     cluster_mock.add_broker(
       broker_0, net::unresolved_address{"localhost", 9092});
     cluster_mock.set_supported_versions(
@@ -86,6 +89,7 @@ TEST_F(cluster_mock_fixture, TestApiVersionDiscovery) {
       api_version_range{
         .min = kafka::api_version(0), .max = kafka::api_version(8)});
     cluster.start().get();
+    auto deferred_stop = ss::defer([&cluster] { cluster.stop().get(); });
 
     /**
      * In this single node cluster the supported API versions for the


### PR DESCRIPTION
The test wasn't stopping cluster correctly it was flaky as usually cluster didn't yet started metadata update when the test finished but when it did the test would fail with assertion.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none