### PR TITLE
kc/cluster: skip listing topics when initializing cluster metadata

### DIFF
--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -136,9 +136,11 @@ ss::future<> cluster::initialize_metadata_with_seed() {
             co_await broker->stop();
             continue;
         }
-
         auto reply_f = co_await ss::coroutine::as_future(broker->dispatch(
-          metadata_request{.list_all_topics = false}, request_version_f.get()));
+          // use empty topic list not to request all topics, we are only
+          // interested in brokers list
+          metadata_request{.data = metadata_request_data{.topics = {}}},
+          request_version_f.get()));
         /**
          * stop the broker after the request is done to ensure that
          * the broker is not left in a connected state. This is important
@@ -188,7 +190,7 @@ ss::future<> cluster::dispatch_metadata_request() {
           broker, _as);
         // TODO: support topic subscription
         auto reply = co_await broker->dispatch(
-          metadata_request{.list_all_topics = false}, request_version);
+          metadata_request{}, request_version);
         vassert(
           std::holds_alternative<kafka::metadata_response>(reply),
           "Metadata response is required to be returned as a result of "


### PR DESCRIPTION
Skip setting flag that is being ignored in `metadata_request` and do not list all the topics when querying for initial metadata from seed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
