### PR TITLE
Fix logging in case if compacted reupload has to reupload last segment with a single batch

### DIFF
--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -275,7 +275,7 @@ void segment_collector::collect_segments() {
 
     if (
       is_reupload_mode(_mode)
-      && _begin_inclusive >= _manifest.get_last_offset()) {
+      && _begin_inclusive > _manifest.get_last_offset()) {
         vlog(
           archival_log.warn,
           "Start offset {} is ahead of manifest last offset {} for ntp {}, not "


### PR DESCRIPTION
This commit fixes off by one error that affects only logging. This is how it manifests:
- We have the following segments in the manifest: [0..10][11] The first segment contains 11 elements. The second one contains only one elelemnt.
- The last_offset is 11. The last_compacted_offset is 10 because the first segment was reuploaded and the last one wasn't.
- The segment collector is created with _begin_inclusive set to 11 and mode set to compacted reupload.
- Eventually, we're getting to this check and logging a warning because _begin_inclusive is equal to last_offset.

The fix is to trigger the warning only if the _begin_inclusive is strictly greater than last_offset.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none