### PR TITLE
[CORE-12832] pp/sr: System allocator fallback for protobuf schemas

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -26,6 +26,7 @@
 #include "utils/base64.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/memory.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -456,6 +457,7 @@ ss::future<pb::FileDescriptorProto> build_file_with_refs(
         }
     }
 
+    ss::memory::scoped_system_alloc_fallback fb;
     parser p;
     auto new_fdp = p.parse(schema);
     normalize_imports(new_fdp, norm);
@@ -515,7 +517,7 @@ struct protobuf_schema_definition::impl {
      * messages
      */
     ss::sstring debug_string() const {
-        // TODO BP: Prevent this linearization
+        ss::memory::scoped_system_alloc_fallback fb;
         auto s = fd->DebugString();
 
         // reordering not required if no package or no dependencies

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -54,6 +54,19 @@ redpanda_test_cc_library(
     ],
 )
 
+redpanda_test_cc_library(
+    name = "protobuf_utils",
+    srcs = [
+        "protobuf_utils.cc",
+    ],
+    hdrs = [
+        "protobuf_utils.h",
+    ],
+    deps = [
+        "//src/v/pandaproxy/schema_registry:core",
+    ],
+)
+
 redpanda_cc_btest(
     name = "sanitize_avro",
     timeout = "short",
@@ -230,6 +243,7 @@ redpanda_cc_btest(
         "//src/v/pandaproxy/schema_registry:core",
         "//src/v/pandaproxy/schema_registry/test:compatibility_common",
         "//src/v/pandaproxy/schema_registry/test:compatibility_protobuf",
+        "//src/v/pandaproxy/schema_registry/test:protobuf_utils",
         "//src/v/test_utils:seastar_boost",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@boost//:test",
@@ -360,6 +374,7 @@ redpanda_cc_gtest(
         "//src/v/pandaproxy/schema_registry:core",
         "//src/v/pandaproxy/schema_registry/test:compatibility_common",
         "//src/v/pandaproxy/schema_registry/test:compatibility_protobuf",
+        "//src/v/pandaproxy/schema_registry/test:protobuf_utils",
         "//src/v/test_utils:gtest",
         "//src/v/test_utils:runfiles",
         "//src/v/utils:file_io",
@@ -382,6 +397,7 @@ redpanda_cc_bench(
         "//src/v/http",
         "//src/v/json",
         "//src/v/pandaproxy/schema_registry:core",
+        "//src/v/pandaproxy/schema_registry/test:protobuf_utils",
         "//src/v/pandaproxy/test:fixture",
         "@abseil-cpp//absl/strings",
         "@seastar//:benchmark",

--- a/src/v/pandaproxy/schema_registry/test/BUILD
+++ b/src/v/pandaproxy/schema_registry/test/BUILD
@@ -385,6 +385,28 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "protobuf_large_alloc_test",
+    timeout = "short",
+    srcs = [
+        "protobuf_large_alloc.cc",
+    ],
+    cpu = 1,
+    data = [
+        ":test_protos",
+    ],
+    memory = "256MiB",
+    deps = [
+        "//src/v/base",
+        "//src/v/pandaproxy/schema_registry:core",
+        "//src/v/pandaproxy/schema_registry/test:protobuf_utils",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_bench(
     name = "api_rpbench",
     timeout = "moderate",

--- a/src/v/pandaproxy/schema_registry/test/api_bench.cc
+++ b/src/v/pandaproxy/schema_registry/test/api_bench.cc
@@ -12,8 +12,8 @@
 #include "absl/strings/escaping.h"
 #include "base/vassert.h"
 #include "http/client.h"
-#include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/test/client_utils.h"
+#include "pandaproxy/schema_registry/test/protobuf_utils.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 
@@ -38,16 +38,6 @@ struct endpoint {
     signature fn;
     ss::sstring name;
 };
-
-ss::sstring make_proto_schema(const pps::subject& sub, int n_fields) {
-    ss::sstring body = ss::format(
-      "syntax = \"proto3\";\nmessage MyType{} {{\n", sub);
-    for (int32_t i = 1; i <= n_fields; ++i) {
-        body += ss::format("\tint32 i{} = {};\n", i, i);
-    }
-    body += "}\n";
-    return body;
-}
 
 ss::sstring make_payload(
   const ss::sstring& schema,
@@ -77,7 +67,7 @@ void setup_client(::http::client& client, perf_settings ps) {
     for (int i_sub = 0; i_sub < ps.n_subjects; ++i_sub) {
         pps::subject sub = make_subject(i_sub);
         for (int i_ver = 1; i_ver <= ps.n_versions; ++i_ver) {
-            auto schema = make_proto_schema(sub, i_ver);
+            auto schema = pps::test_utils::make_proto_schema(sub, i_ver);
             auto payload = make_payload(schema);
             auto res = post_schema(client, sub, payload);
             vassert(
@@ -93,7 +83,7 @@ void perf_body(
   ::http::client& client, const endpoint& ep, const perf_settings& ps) {
     const auto subject = make_subject(ps.i_subject);
     const auto version = ps.version_logic(ps.n_versions);
-    const auto schema = make_proto_schema(subject, version);
+    const auto schema = pps::test_utils::make_proto_schema(subject, version);
     const auto payload = make_payload(schema);
 
     perf_tests::start_measuring_time();

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -16,6 +16,7 @@
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/test/compatibility_common.h"
+#include "pandaproxy/schema_registry/test/protobuf_utils.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/testing/thread_test_case.hh>
@@ -28,48 +29,15 @@
 
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
+namespace ppstu = pp::schema_registry::test_utils;
 
 namespace {
-
-struct simple_sharded_store {
-    explicit simple_sharded_store()
-      : store{} {
-        store.start(pps::is_mutable::yes, ss::default_smp_service_group())
-          .get();
-    }
-    ~simple_sharded_store() { store.stop().get(); }
-    simple_sharded_store(const simple_sharded_store&) = delete;
-    simple_sharded_store(simple_sharded_store&&) = delete;
-    simple_sharded_store& operator=(const simple_sharded_store&) = delete;
-    simple_sharded_store& operator=(simple_sharded_store&&) = delete;
-
-    pps::schema_id
-    insert(const pps::subject_schema& schema, pps::schema_version version) {
-        const auto id = next_id++;
-        store
-          .upsert(
-            pps::seq_marker{
-              std::nullopt,
-              std::nullopt,
-              version,
-              pps::seq_marker_key_type::schema},
-            schema.share(),
-            id,
-            version,
-            pps::is_deleted::no)
-          .get();
-        return id;
-    }
-
-    pps::schema_id next_id{1};
-    pps::sharded_store store;
-};
 
 bool check_compatible(
   pps::compatibility_level lvl,
   std::string_view reader,
   std::string_view writer) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
     store.store.set_compatibility(lvl).get();
     store.insert(
       pandaproxy::schema_registry::subject_schema{
@@ -101,7 +69,7 @@ pps::compatibility_result check_compatible_verbose(
 } // namespace
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto schema1 = pps::subject_schema{pps::subject{"simple"}, simple.share()};
     store.insert(schema1.share(), pps::schema_version{1});
@@ -112,7 +80,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_nested) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto schema1 = pps::subject_schema{pps::subject{"nested"}, nested.share()};
     store.insert(schema1.share(), pps::schema_version{1});
@@ -125,7 +93,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_nested) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     // imported depends on simple, which han't been inserted
     auto schema1 = pps::subject_schema{
@@ -142,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto schema1 = pps::subject_schema{pps::subject{"simple"}, simple.share()};
     auto schema2 = pps::subject_schema{
@@ -162,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto schema1 = pps::subject_schema{
       pps::subject{"simple.proto"}, simple.share()};
@@ -187,7 +155,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto schema1 = pps::subject_schema{
       pps::subject{"simple.proto"}, simple.share()};
@@ -212,7 +180,7 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_recursive_reference) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_binary_protobuf) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     BOOST_REQUIRE_NO_THROW(
       store.store
@@ -225,7 +193,7 @@ SEASTAR_THREAD_TEST_CASE(test_binary_protobuf) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto broken_base64_raw_proto = base64_raw_proto.substr(1);
 
@@ -250,7 +218,7 @@ SEASTAR_THREAD_TEST_CASE(test_invalid_binary_protobuf) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_well_known) {
-    simple_sharded_store store;
+    ppstu::simple_sharded_store store;
 
     auto schema = pps::subject_schema{
       pps::subject{"test_auto_well_known"},
@@ -501,27 +469,6 @@ SEASTAR_THREAD_TEST_CASE(
       pps::compatibility_level::full_transitive, recursive, recursive));
 }
 
-auto sanitize(
-  std::string_view raw_proto, pps::normalize norm = pps::normalize::no) {
-    simple_sharded_store s;
-    iobuf buf = pps::make_canonical_protobuf_schema(
-                  s.store,
-                  pps::subject_schema{
-                    pps::subject{"foo"},
-                    pps::schema_definition{
-                      raw_proto, pps::schema_type::protobuf}},
-                  norm)
-                  .get()
-                  .def()
-                  .raw()();
-    iobuf_parser parser{std::move(buf)};
-    return parser.read_string(parser.bytes_left());
-}
-
-auto normalize(std::string_view raw_proto) {
-    return sanitize(raw_proto, pps::normalize::yes);
-}
-
 constexpr auto foobar_proto = R"(syntax = "proto3";
 package foo;
 
@@ -534,7 +481,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_strip_comments_and_newlines) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(
+      ppstu::sanitize(R"(
 
 /* comment */
 
@@ -562,7 +509,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_ordering_no_newlines) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(syntax = "proto3";
+      ppstu::sanitize(R"(syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 package foo;
 message Bar {
@@ -574,7 +521,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_ordering_more_newlines) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(
+      ppstu::sanitize(R"(
 
 syntax = "proto3";
 
@@ -869,8 +816,8 @@ extend .google.protobuf.ServiceOptions {
 }
 
 )";
-    BOOST_CHECK_EQUAL(sanitize(schema), sanitized);
-    BOOST_CHECK_EQUAL(normalize(schema), normalized);
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_nested_custom_options) {
@@ -987,8 +934,8 @@ extend .google.protobuf.MessageOptions {
 }
 
 )";
-    BOOST_CHECK_EQUAL(sanitize(schema), sanitized);
-    BOOST_CHECK_EQUAL(normalize(schema), normalized);
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_message_custom_options) {
@@ -1059,8 +1006,8 @@ extend .google.protobuf.EnumValueOptions {
 
 )";
 
-    BOOST_REQUIRE_EQUAL(sanitize(schema), sanitized);
-    BOOST_CHECK_EQUAL(normalize(schema), normalized);
+    BOOST_REQUIRE_EQUAL(ppstu::sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize_extension_ranges) {
@@ -1195,13 +1142,13 @@ extend .google.protobuf.ExtensionRangeOptions {
 
 )";
 
-    BOOST_CHECK_EQUAL(sanitize(schema), sanitized);
-    BOOST_CHECK_EQUAL(normalize(schema), normalized);
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), sanitized);
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_syntax) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(
+      ppstu::sanitize(R"(
 package foo;
 
 import "google/protobuf/timestamp.proto";
@@ -1223,7 +1170,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_package) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(syntax = "proto3";
+      ppstu::sanitize(R"(syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 
@@ -1243,7 +1190,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_syntax_package) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(
+      ppstu::sanitize(R"(
 
 import "google/protobuf/timestamp.proto";
 
@@ -1263,7 +1210,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_no_imports) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(syntax = "proto3";
+      ppstu::sanitize(R"(syntax = "proto3";
 package foo;
 
 message Bar {
@@ -1283,7 +1230,7 @@ message Bar {
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_sanitize_multiple_imports) {
     BOOST_REQUIRE_EQUAL(
-      sanitize(R"(syntax = "proto3";
+      ppstu::sanitize(R"(syntax = "proto3";
 
 package foo;
 
@@ -1321,7 +1268,7 @@ import weak "google/protobuf/any.proto";
 import "google/protobuf/api.proto";
 )";
 
-    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/timestamp.proto";
@@ -1331,7 +1278,7 @@ import public "google/protobuf/duration.proto";
 
 
 )"));
-    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/api.proto";
@@ -1359,7 +1306,7 @@ message HasGoogleMap {
 }
 )";
 
-    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/struct.proto";
@@ -1377,7 +1324,7 @@ message HasGoogleMap {
   map<string, .google.protobuf.Value> map_string_value = 1;
 }
 )"));
-    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/any.proto";
@@ -1423,7 +1370,7 @@ message HasMap {
 }
 )";
 
-    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), (R"(syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 message Value {
@@ -1436,7 +1383,7 @@ message HasMap {
 }
 
 )"));
-    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), (R"(syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 message Value {
@@ -1471,7 +1418,7 @@ message SearchResponse {
   }
 })";
 
-    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto2";
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), (R"(syntax = "proto2";
 
 message SearchResponse {
   repeated group Result = 1 {
@@ -1492,7 +1439,7 @@ message SearchResponse {
 }
 
 )"));
-    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto2";
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), (R"(syntax = "proto2";
 
 message SearchResponse {
   repeated group Result = 1 {
@@ -1544,7 +1491,7 @@ message WithOneOf {
 }
 
 )";
-    BOOST_CHECK_EQUAL(sanitize(schema), expected_sanitized);
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), expected_sanitized);
     auto expected_normalized = R"(syntax = "proto3";
 
 package foo;
@@ -1560,7 +1507,7 @@ message WithOneOf {
 }
 
 )";
-    BOOST_CHECK_EQUAL(normalize(schema), expected_normalized);
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), expected_normalized);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_normalize) {
@@ -1664,7 +1611,7 @@ service FooService {
   rpc Foo(Bar) returns (Baz);
 })";
 
-    BOOST_CHECK_EQUAL(sanitize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::sanitize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/timestamp.proto";
@@ -1741,7 +1688,7 @@ service FooService {
   rpc Foo(.foo.Bar) returns (.foo.Baz);
 }
 )"));
-    BOOST_CHECK_EQUAL(normalize(schema), (R"(syntax = "proto3";
+    BOOST_CHECK_EQUAL(ppstu::normalize(schema), (R"(syntax = "proto3";
 package foo;
 
 import "google/protobuf/any.proto";

--- a/src/v/pandaproxy/schema_registry/test/protobuf_large_alloc.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_large_alloc.cc
@@ -1,0 +1,117 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "base/units.h"
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/test/protobuf_utils.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/memory.hh>
+#include <seastar/util/defer.hh>
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include <new>
+
+namespace pps = pandaproxy::schema_registry;
+
+struct memory_chunk {
+    std::vector<std::byte> buffer;
+
+    explicit memory_chunk(size_t n_bytes)
+      : buffer{n_bytes} {}
+    memory_chunk(const memory_chunk&) = default;
+    memory_chunk(memory_chunk&&) = default;
+    memory_chunk& operator=(const memory_chunk&) = default;
+    memory_chunk& operator=(memory_chunk&&) = default;
+    ~memory_chunk() = default;
+};
+
+namespace {
+// Fill up the available memory and then release every second
+// object to end up with a very fragment memory
+std::vector<std::optional<memory_chunk>> fragment_memory() {
+    // Chunk size set to the same size as the maximum allocation of the chunked
+    // vector
+    constexpr auto chunk_size = 128_KiB;
+
+    std::vector<std::optional<memory_chunk>> chunks;
+    chunks.reserve(ss::memory::stats().total_memory() / chunk_size);
+
+    while (ss::memory::stats().free_memory() > chunk_size) {
+        try {
+            chunks.emplace_back(memory_chunk{chunk_size});
+        } catch (std::bad_alloc&) {
+            // we might run out of memory sooner, due to existing
+            // framentation in memory. That's ok. Just exit the loop
+            break;
+        }
+    }
+
+    const auto n_chunks = chunks.size();
+    for (size_t i = 0; i < n_chunks; i += 2) {
+        chunks[i].reset();
+    }
+    return chunks;
+}
+
+} // namespace
+
+TEST(ProtoLargeAlloc, test_protobuf_memory_stuff) {
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+    GTEST_SKIP() << "Default seastar allocator detected. Skipping large alloc "
+                    "protobuf test";
+#endif
+    ss::memory::set_abort_on_allocation_failure(false);
+    auto allocation_failure_guard = ss::defer(
+      []() { ss::memory::set_abort_on_allocation_failure(true); });
+
+    pps::test_utils::simple_sharded_store s;
+
+    // Size of these schemas is set to around half-megabyte. The exact value is
+    // not important, as long as it is significantly larger than the
+    // fragmentation interval introduced in fragment_memory
+    const pps::subject sub{"test_subject_01"};
+    const auto large_schema = pps::test_utils::make_proto_schema(sub, 25'000);
+    EXPECT_EQ(large_schema.size(), 552841);
+
+    // Compiles the large_schema and returns the number of fallback
+    // allocations needed for this operation
+    const auto make_proto = [&s, &sub, &large_schema]() {
+        const ss::memory::statistics start_stats = ss::memory::stats();
+        auto canocal_schema
+          = pps::make_canonical_protobuf_schema(
+              s.store,
+              pps::subject_schema{
+                sub,
+                pps::schema_definition{
+                  large_schema, pps::schema_type::protobuf, {}}})
+              .get();
+        const ss::memory::statistics post_stats = ss::memory::stats();
+
+        return post_stats.fallback_allocations()
+               - start_stats.fallback_allocations();
+    };
+
+    // When there is enough free contiguous memory, verify that the schema
+    // doesn't need any fallback system allocations.
+    EXPECT_EQ(make_proto(), 0);
+
+    const std::vector<std::optional<memory_chunk>> chunks = fragment_memory();
+
+    // Since there isn't enough contiguous free memory, any request in proto
+    // that cannot be handled using the seastar allocator will fallback to the
+    // system allocator. We don't check the exact number of fallback
+    // allocations, as this is an implementation detail of how things are being
+    // handled in the libproto. Here we only verify that there have been some
+    // fallback allocations.
+    EXPECT_GT(make_proto(), 0);
+}

--- a/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_rendering.cc
@@ -12,6 +12,7 @@
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/test/compatibility_common.h"
+#include "pandaproxy/schema_registry/test/protobuf_utils.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "test_utils/runfiles.h"
 #include "utils/file_io.h"
@@ -23,42 +24,9 @@
 
 namespace pp = pandaproxy;
 namespace pps = pp::schema_registry;
+namespace ppstu = pp::schema_registry::test_utils;
 
 namespace {
-
-struct simple_sharded_store {
-    explicit simple_sharded_store()
-      : store{} {
-        store.start(pps::is_mutable::yes, ss::default_smp_service_group())
-          .get();
-    }
-    ~simple_sharded_store() { store.stop().get(); }
-    simple_sharded_store(const simple_sharded_store&) = delete;
-    simple_sharded_store(simple_sharded_store&&) = delete;
-    simple_sharded_store& operator=(const simple_sharded_store&) = delete;
-    simple_sharded_store& operator=(simple_sharded_store&&) = delete;
-
-    pps::schema_id
-    insert(const pps::subject_schema& schema, pps::schema_version version) {
-        const auto id = next_id++;
-        store
-          .upsert(
-            pps::seq_marker{
-              std::nullopt,
-              std::nullopt,
-              version,
-              pps::seq_marker_key_type::schema},
-            schema.share(),
-            id,
-            version,
-            pps::is_deleted::no)
-          .get();
-        return id;
-    }
-
-    pps::schema_id next_id{1};
-    pps::sharded_store store;
-};
 
 std::filesystem::path test_dir() {
     return test_utils::get_runfile_path(
@@ -87,30 +55,6 @@ ss::sstring read_schema(const std::string_view test_case, const SchemaType pt) {
 
 } // namespace
 
-std::string sanitize(
-  std::string_view raw_proto,
-  pps::normalize norm = pps::normalize::no,
-  pps::output_format format = pps::output_format::none) {
-    simple_sharded_store s;
-    iobuf buf = pps::make_canonical_protobuf_schema(
-                  s.store,
-                  pps::subject_schema{
-                    pps::subject{"foo"},
-                    pps::schema_definition{
-                      raw_proto, pps::schema_type::protobuf, {}}},
-                  norm,
-                  format)
-                  .get()
-                  .def()
-                  .raw()();
-    iobuf_parser parser{std::move(buf)};
-    return parser.read_string(parser.bytes_left());
-}
-
-auto normalize(std::string_view raw_proto) {
-    return sanitize(raw_proto, pps::normalize::yes);
-}
-
 class ProtoRendering : public testing::TestWithParam<std::string> {};
 
 TEST_P(ProtoRendering, test_protobuf_rendering) {
@@ -119,22 +63,22 @@ TEST_P(ProtoRendering, test_protobuf_rendering) {
 
     const auto sanitized_expected = read_schema(
       test_case, SchemaType::sanitized);
-    const auto sanitized_processed = sanitize(input);
+    const auto sanitized_processed = ppstu::sanitize(input);
     EXPECT_EQ(sanitized_expected, sanitized_processed);
 
     const auto normalized_expected = read_schema(
       test_case, SchemaType::normalized);
-    const auto normalized_processed = normalize(input);
+    const auto normalized_processed = ppstu::normalize(input);
     EXPECT_EQ(normalized_expected, normalized_processed);
 
     // These are to verify that the processed schemas are valid schemas.
     // We don't want to run these if the above fail because
     // they produce lot's of visual noise.
     if (sanitized_expected == sanitized_processed) {
-        EXPECT_EQ(sanitized_processed, sanitize(sanitized_processed));
+        EXPECT_EQ(sanitized_processed, ppstu::sanitize(sanitized_processed));
     }
     if (normalized_expected == normalized_processed) {
-        EXPECT_EQ(normalized_processed, normalize(normalized_processed));
+        EXPECT_EQ(normalized_processed, ppstu::normalize(normalized_processed));
     }
 }
 
@@ -144,9 +88,9 @@ TEST_P(ProtoRendering, test_protobuf_serialized_mode) {
 
     // Validate that a round trip to serialized and
     // back results in the starting schema
-    auto schema_b64 = sanitize(
+    auto schema_b64 = ppstu::sanitize(
       input, pps::normalize::no, pps::output_format::serialized);
-    const auto schema_text = sanitize(schema_b64, pps::normalize::no);
+    const auto schema_text = ppstu::sanitize(schema_b64, pps::normalize::no);
     EXPECT_EQ(input, schema_text);
 }
 

--- a/src/v/pandaproxy/schema_registry/test/protobuf_utils.cc
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_utils.cc
@@ -1,0 +1,51 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/test/protobuf_utils.h"
+
+#include "pandaproxy/schema_registry/protobuf.h"
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+namespace pandaproxy::schema_registry::test_utils {
+
+ss::sstring make_proto_schema(const pps::subject& sub, int n_fields) {
+    ss::sstring body = ss::format(
+      "syntax = \"proto3\";\nmessage MyType{} {{\n", sub);
+    for (int32_t i = 1; i <= n_fields; ++i) {
+        body += ss::format("\tint32 i{} = {};\n", i, i);
+    }
+    body += "}\n";
+    return body;
+}
+
+std::string sanitize(
+  std::string_view raw_proto, pps::normalize norm, pps::output_format format) {
+    pps::test_utils::simple_sharded_store s;
+    iobuf buf = pps::make_canonical_protobuf_schema(
+                  s.store,
+                  pps::subject_schema{
+                    pps::subject{"foo"},
+                    pps::schema_definition{
+                      raw_proto, pps::schema_type::protobuf, {}}},
+                  norm,
+                  format)
+                  .get()
+                  .def()
+                  .raw()();
+    iobuf_parser parser{std::move(buf)};
+    return parser.read_string(parser.bytes_left());
+}
+
+std::string normalize(std::string_view raw_proto) {
+    return sanitize(raw_proto, pps::normalize::yes);
+}
+
+} // namespace pandaproxy::schema_registry::test_utils

--- a/src/v/pandaproxy/schema_registry/test/protobuf_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/protobuf_utils.h
@@ -1,0 +1,62 @@
+// Copyright 2021 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/types.h"
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+namespace pandaproxy::schema_registry::test_utils {
+struct simple_sharded_store {
+    explicit simple_sharded_store()
+      : store{} {
+        store.start(pps::is_mutable::yes, ss::default_smp_service_group())
+          .get();
+    }
+    ~simple_sharded_store() { store.stop().get(); }
+    simple_sharded_store(const simple_sharded_store&) = delete;
+    simple_sharded_store(simple_sharded_store&&) = delete;
+    simple_sharded_store& operator=(const simple_sharded_store&) = delete;
+    simple_sharded_store& operator=(simple_sharded_store&&) = delete;
+
+    pps::schema_id
+    insert(const pps::subject_schema& schema, pps::schema_version version) {
+        const auto id = next_id++;
+        store
+          .upsert(
+            pps::seq_marker{
+              .seq = std::nullopt,
+              .node = std::nullopt,
+              .version = version,
+              .key_type = pps::seq_marker_key_type::schema},
+            schema.share(),
+            id,
+            version,
+            pps::is_deleted::no)
+          .get();
+        return id;
+    }
+
+    pps::schema_id next_id{1};
+    pps::sharded_store store;
+};
+
+ss::sstring make_proto_schema(const pps::subject& sub, int n_fields);
+
+std::string sanitize(
+  std::string_view raw_proto,
+  pps::normalize norm = pps::normalize::no,
+  pps::output_format format = pps::output_format::none);
+
+std::string normalize(std::string_view raw_proto);
+
+} // namespace pandaproxy::schema_registry::test_utils


### PR DESCRIPTION
Implements: [CORE-12832](https://redpandadata.atlassian.net/browse/CORE-12832)

Since we don't have any control over the allocation strategy used by libproto internally, this can cause issued due to big allocations happening there.

The system allocator fallback guards have been placed where we know that big serializations are happening in libproto. Any similar call to libproto that might be introduced later on should be protected by the same guard.

Note: This PR depends on https://github.com/redpanda-data/seastar/pull/209

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12832]: https://redpandadata.atlassian.net/browse/CORE-12832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ