### PR TITLE
`storage`: don't compress if `big_enough_for_index` in `make_random_batch`

### DIFF
--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -30,10 +30,14 @@ model::record_batch make_random_batch(
         batch_size = 1024;
     }
 
+    // Don't allow compression if we are purposefully trying to make this batch
+    // large enough to be indexed in the `segment_index`.
+    bool allow_compression = !big_enough_for_index;
+
     auto b = model::test::make_random_batch(
       model::offset(o),
       num_records,
-      true,
+      allow_compression,
       model::record_batch_type::raft_data,
       std::vector<size_t>(num_records, batch_size),
       ts);


### PR DESCRIPTION
Compression can reduce the size of the batch, making it ineligible for indexing. Some timequery tests rely on the fact that a batch _will_ be indexed if `big_enough_for_index` is left as `true`, leading to flake-y tests with compression enabled.

Fixes [CORE-12889].

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12889]: https://redpandadata.atlassian.net/browse/CORE-12889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ