### PR TITLE
Do not audit ephemeral users

### DIFF
--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -49,12 +49,9 @@
 namespace kafka {
 
 /// Checks to see if the event is auditable.
-/// Current check will exclude any produce messages by the audit principal
-inline bool
-skip_auditing(api_key key, const security::acl_principal& principal) {
-    return security::audit::kafka_api_to_event_type(key)
-             == security::audit::event_type::produce
-           && principal == security::audit_principal;
+/// Skips auditing ephemeral users
+inline bool skip_auditing(const security::acl_principal& principal) {
+    return principal.type() == security::principal_type::ephemeral_user;
 }
 
 inline constexpr auto request_header_size = sizeof(int16_t) + sizeof(int16_t)
@@ -374,7 +371,7 @@ public:
         auto key = _header.key;
 
         // Not auditing produce authz attempts from audit principal
-        if (skip_auditing(key, result.principal)) [[unlikely]] {
+        if (skip_auditing(result.principal)) [[unlikely]] {
             return resp;
         }
 
@@ -434,7 +431,7 @@ private:
       const T& name,
       api_key key,
       std::optional<std::string_view> client_id) {
-        if (skip_auditing(key, auth_result.principal)) [[unlikely]] {
+        if (skip_auditing(auth_result.principal)) [[unlikely]] {
             return;
         }
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -52,8 +52,6 @@
 namespace pandaproxy::schema_registry {
 
 using server = ctx_server<service>;
-const security::acl_principal principal{
-  security::principal_type::ephemeral_user, "__schema_registry"};
 
 class wrap {
 public:
@@ -378,7 +376,7 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
           model::schema_registry_internal_tp.topic,
           security::pattern_type::literal},
         security::acl_entry{
-          principal,
+          security::schema_registry_principal,
           security::acl_host::wildcard_host(),
           security::acl_operation::all,
           security::acl_permission::allow}}};
@@ -392,24 +390,31 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
         vlog(
           srlog.warn,
           "Failed to create ACLs for {}, err {} - {}",
-          principal,
+          security::schema_registry_principal,
           *it,
           cluster::make_error_code(*it).message());
     } else {
-        vlog(srlog.debug, "Successfully created ACLs for {}", principal);
+        vlog(
+          srlog.debug,
+          "Successfully created ACLs for {}",
+          security::schema_registry_principal);
     }
 }
 
 ss::future<> service::configure() {
     auto sasl_config = co_await kafka::client::create_client_credentials(
-      *_controller, config::shard_local_cfg(), _client_config, principal);
+      *_controller,
+      config::shard_local_cfg(),
+      _client_config,
+      security::schema_registry_principal);
     co_await _client.invoke_on_all(
       [sasl_config = std::move(sasl_config)](kafka::client::client& c) {
           c.set_credentials(sasl_config);
       });
 
     const auto& store = _controller->get_ephemeral_credential_store().local();
-    bool has_ephemeral_credentials = store.has(store.find(principal));
+    bool has_ephemeral_credentials = store.has(
+      store.find(security::schema_registry_principal));
     co_await container().invoke_on_all(
       _ctx.smp_sg, [has_ephemeral_credentials](service& s) {
           s._has_ephemeral_credentials = has_ephemeral_credentials;
@@ -465,7 +470,7 @@ ss::future<> service::inform(model::node_id id) {
 
 ss::future<> service::do_inform(model::node_id id) {
     auto& fe = _controller->get_ephemeral_credential_frontend().local();
-    auto ec = co_await fe.inform(id, principal);
+    auto ec = co_await fe.inform(id, security::schema_registry_principal);
     vlog(srlog.info, "Informed: broker: {}, ec: {}", id, ec);
 }
 

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -844,6 +844,9 @@ private:
 inline const acl_principal audit_principal{
   principal_type::ephemeral_user, "__auditing"};
 
+inline const acl_principal schema_registry_principal{
+  principal_type::ephemeral_user, "__schema_registry"};
+
 namespace testing {
 
 struct acl_binding_filter_v0 : public acl_binding_filter {

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -1112,8 +1112,12 @@ audit_log_manager::should_enqueue_audit_event(
 std::optional<audit_log_manager::audit_event_passthrough>
 audit_log_manager::should_enqueue_audit_event(
   event_type type, const security::audit::user& user) const {
+    auto principal_type = user.type_id == audit::user::type::system
+                            ? security::principal_type::ephemeral_user
+                            : security::principal_type::user;
+
     return should_enqueue_audit_event(
-      type, security::acl_principal{security::principal_type::user, user.name});
+      type, security::acl_principal{principal_type, user.name});
 }
 
 std::optional<audit_log_manager::audit_event_passthrough>

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -1081,12 +1081,21 @@ audit_log_manager::should_enqueue_audit_event(
     return should_enqueue_audit_event();
 }
 
+namespace {
+bool is_ignored_ephemeral_user(const security::acl_principal& principal) {
+    return principal == security::audit_principal
+           || principal == security::schema_registry_principal;
+}
+} // namespace
+
 std::optional<audit_log_manager::audit_event_passthrough>
 audit_log_manager::should_enqueue_audit_event(
   event_type type,
   const security::acl_principal& principal,
   ignore_enabled_events ignore_events) const {
-    if (_audit_excluded_principals.contains(principal)) {
+    if (
+      _audit_excluded_principals.contains(principal)
+      || is_ignored_ephemeral_user(principal)) {
         return std::make_optional(audit_event_passthrough::yes);
     }
 

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -37,7 +37,17 @@ scram_authenticator<T>::handle_client_first(bytes_view auth_bytes) {
       acl_principal{principal_type::user, authid});
     _credential = std::make_unique<scram_credential>(std::move(*credential));
     _audit_user.name = _principal.name();
-    _audit_user.type_id = audit::user::type::user;
+    const auto principal_type_to_audit_type = [](principal_type type) {
+        switch (type) {
+        case principal_type::user:
+            return audit::user::type::user;
+        case principal_type::ephemeral_user:
+            return audit::user::type::system;
+        case principal_type::role:
+            return audit::user::type::other;
+        }
+    };
+    _audit_user.type_id = principal_type_to_audit_type(_principal.type());
 
     if (
       !_client_first->authzid().empty() && _client_first->authzid() != authid) {

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -1614,6 +1614,32 @@ class AuditLogTestKafkaAuthnApi(AuditLogTestBase):
 
     @skip_fips_mode
     @cluster(num_nodes=5)
+    def test_no_ephemeral_user(self):
+        """
+        Verifies that ephemeral users do not generate audit messages
+        """
+        self.setup_cluster()
+
+        user_rpk = self.get_rpk()
+
+        _ = user_rpk.list_topics()
+
+        try:
+            # Read all records that have the audit log user for two seconds - should not get any records
+            records = self.read_all_from_audit_log(
+                partial(self.authn_filter_function,
+                        self.kafka_rpc_service_name, "__auditing", 99,
+                        "SASL-SCRAM"),
+                lambda records: len(records) >= 1,
+                timeout_sec=5)
+
+            assert False, f"Should not have seen any records, got {len(records)} records"
+        except TimeoutError:
+            # This is good, we should not see any records
+            pass
+
+    @skip_fips_mode
+    @cluster(num_nodes=5)
     def test_authn_failure_messages(self):
         """Validates that failed authentication messages are audited
         """
@@ -1655,16 +1681,6 @@ class AuditLogTestKafkaAuthnApi(AuditLogTestBase):
         _ = self.get_rpk_credentials(username=self.username,
                                      password=self.password,
                                      mechanism=self.algorithm).list_topics()
-
-        authn_records = self.read_all_from_audit_log(
-            partial(self.authn_filter_function, self.kafka_rpc_service_name,
-                    "__auditing", 99, "SASL-SCRAM"),
-            lambda records: self.aggregate_count(records) >= 1)
-
-        assert len(
-            authn_records
-        ) >= 1, f"Expected at least one authn record for audit user, but got none"
-
         try:
             recs = self.read_all_from_audit_log(
                 partial(self.authz_api_filter_function,


### PR DESCRIPTION
Redpanda will no longer generate audit events for ephemeral users.  Ephemeral users are only used by internal Redpanda services (SR and auditing).

Fixes: CORE-12910
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [X] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* No longer generating audit events for internal Redpanda services
