### PR TITLE
kafka: Implement Topic IDs for Metadata, Fetch, CreateTopics

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -110,6 +110,8 @@ std::string_view to_string_view(feature f) {
         return "node_restart_risk_assessment";
     case feature::topic_ids:
         return "topic_ids";
+    case feature::topic_ids_api:
+        return "topic_ids_api";
     case feature::kafka_data_rpc:
         return "kafka_data_rpc";
     case feature::topic_locations_in_outbound_migrations:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -43,6 +43,7 @@ enum class feature : std::uint64_t {
     iceberg_schema_merging = 1ULL << 0U,
     topic_locations_in_outbound_migrations = 1ULL << 2U,
     schema_registry_authz = 1ULL << 3U,
+    topic_ids_api = 1ULL << 4U,
     consumer_groups_migrations = 1ULL << 7U,
     cloud_retention = 1ULL << 11U,
     node_isolation = 1ULL << 19U,
@@ -481,6 +482,12 @@ inline constexpr std::array feature_schema{
     release_version::v25_3_1,
     "iceberg_schema_merging",
     feature::iceberg_schema_merging,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v25_3_1,
+    "topic_ids_api",
+    feature::topic_ids_api,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -15,6 +15,7 @@
 #include "kafka/client/direct_consumer/data_queue.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
 #include "kafka/client/errors.h"
+#include "kafka/protocol/types.h"
 #include "ssx/async_algorithm.h"
 #include "ssx/future-util.h"
 
@@ -815,10 +816,11 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
 }
 
 ss::future<api_version> fetcher::get_fetch_request_version() const {
+    constexpr auto max_client_version = kafka::api_version{12};
     auto version = co_await _parent->_cluster->supported_api_versions(
       _id, kafka::fetch_api::key);
     if (version) {
-        co_return std::min(version->max, kafka::fetch_api::max_valid);
+        co_return std::min(version->max, max_client_version);
     }
     // if the version is not supported, we fallback to the minimum version
     // which is 1, this is the first version of the Fetch API that use the new

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -152,6 +152,7 @@ private:
  * - support incremental fetches
  * - support leader epochs
  * - support server side throttling and quotas
+ * - support topic identifiers
  */
 class fetcher {
 public:

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -9,13 +9,13 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
-#include "absl/container/flat_hash_map.h"
 #include "container/chunked_hash_map.h"
 #include "container/intrusive_list_helpers.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
+#include "kafka/protocol/types.h"
 #include "model/fundamental.h"
-#include "model/ktp.h"
+#include "model/kitp.h"
 #include "model/timeout_clock.h"
 
 #include <boost/iterator/iterator_adaptor.hpp>
@@ -25,7 +25,7 @@
 namespace kafka {
 
 struct fetch_session_partition {
-    model::ktp_with_hash topic_partition;
+    model::kitp_with_hash topic_partition;
     int32_t max_bytes;
     model::offset start_offset;
     model::offset fetch_offset;
@@ -34,8 +34,10 @@ struct fetch_session_partition {
     kafka::leader_epoch current_leader_epoch = invalid_leader_epoch;
 
     fetch_session_partition(
-      const model::topic& tp, const fetch_request::partition& p)
-      : topic_partition(tp, p.partition)
+      const model::topic_id id,
+      const model::topic& tp,
+      const fetch_request::partition& p)
+      : topic_partition(id, tp, p.partition)
       , max_bytes(p.partition_max_bytes)
       , fetch_offset(p.fetch_offset)
       , high_watermark(model::offset(-1))
@@ -61,51 +63,8 @@ private:
         intrusive_list_hook _hook;
     };
 
-    struct topic_partition_hash {
-        using is_transparent = void;
-
-        size_t operator()(model::topic_partition_view v) const {
-            return absl::Hash<model::topic_partition_view>{}(v);
-        }
-
-        size_t operator()(const model::topic_partition& v) const {
-            return absl::Hash<model::topic_partition>{}(v);
-        }
-    };
-
-    struct topic_partition_eq {
-        using is_transparent = void;
-
-        bool operator()(
-          const model::topic_partition& lhs,
-          const model::topic_partition& rhs) const {
-            return lhs.topic == rhs.topic && lhs.partition == rhs.partition;
-        }
-
-        bool operator()(
-          const model::topic_partition_view& lhs,
-          const model::topic_partition_view& rhs) const {
-            return lhs.topic == rhs.topic && lhs.partition == rhs.partition;
-        }
-
-        bool operator()(
-          const model::topic_partition& lhs,
-          const model::topic_partition_view& rhs) const {
-            return model::topic_view(lhs.topic) == rhs.topic
-                   && lhs.partition == rhs.partition;
-        }
-        bool operator()(
-          const model::topic_partition_view& lhs,
-          const model::topic_partition& rhs) const {
-            return operator()(rhs, lhs);
-        }
-    };
-
-    using underlying_t = chunked_hash_map<
-      model::topic_partition_view,
-      std::unique_ptr<entry>,
-      topic_partition_hash,
-      topic_partition_eq>;
+    using underlying_t
+      = chunked_hash_map<model::kitp_view, std::unique_ptr<entry>>;
 
     using io_list_t = intrusive_list<entry, &entry::_hook>;
 
@@ -130,7 +89,7 @@ public:
     void emplace(kafka::fetch_session_partition v) {
         auto e = std::make_unique<entry>(std::move(v));
         auto [it, success] = partitions.emplace(
-          e->partition.topic_partition.as_tp_view(), std::move(e));
+          e->partition.topic_partition.as_kitp_view(), std::move(e));
         vassert(
           success,
           "Can not insert {} to partitions map as it is already present.",
@@ -138,17 +97,13 @@ public:
         insertion_order.push_back(*it->second);
     }
 
-    bool contains(model::topic_partition_view v) {
-        return partitions.contains(v);
-    }
+    bool contains(model::kitp_view v) { return partitions.contains(v); }
 
-    void erase(model::topic_partition_view v) { partitions.erase(v); }
+    void erase(model::kitp_view v) { partitions.erase(v); }
 
-    iterator find(model::topic_partition_view v) { return partitions.find(v); }
+    iterator find(model::kitp_view v) { return partitions.find(v); }
 
-    const_iterator find(model::topic_partition_view v) const {
-        return partitions.find(v);
-    }
+    const_iterator find(model::kitp_view v) const { return partitions.find(v); }
 
     bool empty() const { return partitions.empty(); }
 

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -6,6 +6,7 @@
 #include "kafka/server/logger.h"
 #include "metrics/prometheus_sanitize.h"
 #include "model/fundamental.h"
+#include "model/kitp.h"
 #include "model/timeout_clock.h"
 
 #include <seastar/core/metrics.hh>
@@ -18,9 +19,9 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
     for (auto it = req.cbegin(); it != req.cend(); ++it) {
         auto& topic = *it->topic;
         auto& partition = *it->partition;
-        model::topic_partition tp(topic.topic, partition.partition);
+        model::kitp_view kitp(topic.topic_id, topic.topic, partition.partition);
 
-        if (auto s_it = session.partitions().find(tp);
+        if (auto s_it = session.partitions().find(kitp);
             s_it != session.partitions().end()) {
             s_it->second->partition.max_bytes = partition.partition_max_bytes;
             s_it->second->partition.fetch_offset = partition.fetch_offset;
@@ -28,7 +29,7 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
               = partition.current_leader_epoch;
         } else {
             session.partitions().emplace(
-              fetch_session_partition(topic.topic, partition));
+              fetch_session_partition(topic.topic_id, topic.topic, partition));
         }
     }
 
@@ -36,7 +37,7 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
         for (auto& fp : ft.partitions) {
             model::topic_partition tp(ft.topic, model::partition_id(fp));
             session.partitions().erase(
-              model::topic_partition_view(ft.topic, model::partition_id(fp)));
+              model::kitp_view(ft.topic_id, ft.topic, model::partition_id(fp)));
         }
     }
 }

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -140,7 +140,7 @@ api_versions_response api_versions_handler::handle_raw(request_context& ctx) {
     {
         // If feature::topic_ids is not active, limit reported API versions
         const auto& features = ctx.feature_table().local();
-        if (unlikely(!features.is_active(features::feature::topic_ids))) {
+        if (unlikely(!features.is_active(features::feature::topic_ids_api))) {
             topic_id_api_version_limiter(r);
         }
     }

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -17,11 +17,13 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/logger.h"
 #include "kafka/protocol/timeout.h"
+#include "kafka/protocol/types.h"
 #include "kafka/server/handlers/configs/config_response_utils.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/handlers/topics/validators.h"
 #include "kafka/server/quota_manager.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "security/acl.h"
 #include "utils/to_string.h"
@@ -431,6 +433,23 @@ ss::future<response_ptr> create_topics_handler::handle(
     append_topic_properties(ctx, response);
     if (ctx.header().version >= api_version(5)) {
         append_topic_configs(ctx, response);
+    }
+
+    if (ctx.header().version >= api_version(7)) {
+        for (auto& topic : response.data.topics) {
+            if (topic.errored()) {
+                continue;
+            }
+
+            topic.topic_id = ctx.metadata_cache()
+                               .get_topic_metadata_ref(
+                                 model::topic_namespace_view{
+                                   model::kafka_namespace, topic.name})
+                               .transform([](const auto& md) {
+                                   return md.get().get_configuration().tp_id;
+                               })
+                               ->value_or(model::topic_id{});
+        }
     }
 
     log_topic_status(c_res);

--- a/src/v/kafka/server/handlers/create_topics.h
+++ b/src/v/kafka/server/handlers/create_topics.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using create_topics_handler = single_stage_handler<create_topics_api, 0, 6>;
+using create_topics_handler = single_stage_handler<create_topics_api, 0, 7>;
 
 }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -30,6 +30,8 @@
 #include "kafka/server/kafka_probe.h"
 #include "kafka/server/read_distribution_probe.h"
 #include "model/fundamental.h"
+#include "model/kitp.h"
+#include "model/ktp.h"
 #include "model/limits.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -1334,7 +1336,8 @@ void for_each_fetch_partition(const op_context& octx, const Func& f) {
         for (auto& topic : octx.request.data.topics) {
             f(topic.topic,
               topic.partitions | std::views::transform([&](const auto& p) {
-                  return fetch_session_partition{topic.topic, p};
+                  return fetch_session_partition{
+                    topic.topic_id, topic.topic, p};
               }));
         }
     } else {
@@ -1346,12 +1349,19 @@ void for_each_fetch_partition(const op_context& octx, const Func& f) {
         while (it != end) {
             // from the current position, find the range of partitions which
             // have the same topic, and pass that to the callback
-            const model::topic& current_topic = it->topic_partition.get_topic();
+            const auto& current = it->topic_partition;
             auto same_topic_end = std::find_if(
               it, end, [&](const kafka::fetch_session_partition& part) {
-                  return part.topic_partition.get_topic() != current_topic;
+                  const auto no_id = model::topic_id{};
+                  const auto& next = part.topic_partition;
+                  if (
+                    current.get_topic_id() == no_id
+                    || next.get_topic_id() == no_id) {
+                      return current.get_topic() != next.get_topic();
+                  }
+                  return next.get_topic_id() != current.get_topic_id();
               });
-            f(current_topic, std::ranges::subrange(it, same_topic_end));
+            f(current.get_topic(), std::ranges::subrange(it, same_topic_end));
             it = same_topic_end;
         }
     }
@@ -1390,6 +1400,12 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       ++resp_it;
                   }
               };
+
+              // An empty topic name means that lookup by id failed during
+              // creation of the op_context.
+              if (unlikely(topic().empty())) {
+                  return fail_all_partitions(error_code::unknown_topic_id);
+              }
 
               /**
                * If not authorized do not include into a plan.
@@ -1438,8 +1454,9 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       }
                   }
 
-                  auto& tp = fp.topic_partition;
-                  auto partition_id = tp.get_partition();
+                  const auto& kitp = fp.topic_partition;
+                  const auto partition_id = kitp.get_partition();
+                  model::ktp_with_hash ktp{kitp.get_topic(), partition_id};
 
                   if (unlikely(
                         metadata_cache.is_disabled(tn_view, partition_id))) {
@@ -1449,7 +1466,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       continue;
                   }
 
-                  auto shard = octx.rctx.shards().shard_for(tp);
+                  auto shard = octx.rctx.shards().shard_for(ktp);
                   if (unlikely(!shard)) {
                       // there is given partition in topic metadata, return
                       // unknown_topic_or_partition error
@@ -1461,7 +1478,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                        * return not_leader_for_partition error to force metadata
                        * update.
                        */
-                      auto ec = metadata_cache.contains(tp.to_ntp())
+                      auto ec = metadata_cache.contains(kitp)
                                   ? error_code::not_leader_for_partition
                                   : error_code::unknown_topic_or_partition;
                       resp_it->set(
@@ -1470,7 +1487,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       continue;
                   }
 
-                  auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(tp);
+                  auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(ktp);
                   auto max_bytes = std::min(
                     bytes_left_in_plan, size_t(fp.max_bytes));
                   /**
@@ -1481,7 +1498,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                   }
 
                   plan.fetches_per_shard[*shard].push_back(
-                    tp,
+                    std::move(ktp),
                     fetch_config{
                       .start_offset = fp.fetch_offset,
                       .max_offset = model::model_limits<model::offset>::max(),
@@ -1640,6 +1657,26 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
         deadline = model::timeout_clock::now() + delay.value();
     }
 
+    if (rctx.header().version() >= api_version{13}) {
+        /*
+         * Populate topic names
+         *
+         * Topic names that are not authorized must not be returned, but the
+         * response does not serialize them, so this does not need to be undone.
+         */
+        const auto set_topic = [this](auto& t) {
+            auto tp_ns = rctx.metadata_cache().get_name_by_id(t.topic_id);
+            if (tp_ns.has_value()) {
+                t.topic = std::move(tp_ns->tp);
+            } else {
+                // An empty topic name will be translated to unknown_topic_id
+                // during plan creation
+            }
+        };
+        std::ranges::for_each(request.data.topics, set_topic);
+        std::ranges::for_each(request.data.forgotten_topics_data, set_topic);
+    }
+
     /*
      * TODO: max size is multifaceted. it needs to be absolute, but also
      * integrate with other resource contraints that are dynamic within the
@@ -1655,7 +1692,8 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
 // insert and reserve space for a new topic in the response
 void op_context::start_response_topic(const fetch_request::topic& topic) {
     response.data.responses.emplace_back(
-      fetchable_topic_response{.topic = topic.topic});
+      fetchable_topic_response{
+        .topic = topic.topic, .topic_id = topic.topic_id});
 }
 
 void op_context::start_response_partition(const fetch_request::partition& p) {
@@ -1680,16 +1718,18 @@ void op_context::create_response_placeholders() {
               start_response_partition(*v.partition);
           });
     } else {
-        model::topic last_topic;
+        std::optional<model::kitp_with_hash> last_topic;
         std::for_each(
           session_ctx.session()->partitions().cbegin_insertion_order(),
           session_ctx.session()->partitions().cend_insertion_order(),
           [this, &last_topic](const fetch_session_partition& fp) {
-              auto& topic = fp.topic_partition.get_topic();
-              if (last_topic != topic) {
+              auto& kitp = fp.topic_partition;
+              if (last_topic != kitp) {
                   response.data.responses.emplace_back(
-                    fetchable_topic_response{.topic = topic});
-                  last_topic = topic;
+                    fetchable_topic_response{
+                      .topic = kitp.get_topic(),
+                      .topic_id = kitp.get_topic_id()});
+                  last_topic = kitp;
               }
               fetch_response::partition_response p{
                 .partition_index = fp.topic_partition.get_partition(),
@@ -1784,7 +1824,9 @@ ss::future<response_ptr> op_context::send_response() && {
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {
             final_response.data.responses.emplace_back(
-              fetchable_topic_response{.topic = it->partition->topic});
+              fetchable_topic_response{
+                .topic = it->partition->topic,
+                .topic_id = it->partition->topic_id});
         }
 
         fetch_response::partition_response r{
@@ -1857,8 +1899,10 @@ void op_context::response_placeholder::set(
     // if we are not sessionless update session cache
     if (!_ctx->session_ctx.is_sessionless()) {
         auto& session_partitions = _ctx->session_ctx.session()->partitions();
-        auto key = model::topic_partition_view(
-          _it->partition->topic, _it->partition_response->partition_index);
+        auto key = model::kitp_view(
+          _it->partition->topic_id,
+          _it->partition->topic,
+          _it->partition_response->partition_index);
 
         if (auto it = session_partitions.find(key);
             it != session_partitions.end()) {

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -54,6 +54,34 @@
 #include <exception>
 #include <ranges>
 
+namespace {
+
+std::optional<kafka::leader_id_and_epoch> get_leader_id_and_epoch(
+  const cluster::metadata_cache& md_cache, const model::ktp& ktp) {
+    auto lt = md_cache.get_leader_term(ktp.as_tn_view(), ktp.get_partition());
+    if (lt && lt->leader) {
+        return kafka::leader_id_and_epoch{
+          .leader_id = *lt->leader,
+          .leader_epoch = kafka::leader_epoch_from_term(lt->term)};
+    }
+    return std::nullopt;
+}
+
+kafka::read_result make_errored_read_result(
+  const cluster::metadata_cache& md_cache,
+  const model::ktp& ktp,
+  kafka::error_code err) {
+    if (auto l = get_leader_id_and_epoch(md_cache, ktp); l.has_value()) {
+        // remap unknown to not_leader as it's in the metadata_cache
+        if (err == kafka::error_code::unknown_topic_or_partition) {
+            err = kafka::error_code::not_leader_for_partition;
+        }
+        return {err, std::move(*l)};
+    }
+    return kafka::read_result(err);
+}
+} // namespace
+
 namespace kafka {
 static constexpr std::chrono::milliseconds default_fetch_timeout = 5s;
 /**
@@ -291,6 +319,7 @@ static void adjust_memory_units(
  */
 static ss::future<read_result> do_read_from_ntp(
   cluster::partition_manager& cluster_pm,
+  const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   ntp_fetch_config ntp_config,
   bool foreign_read,
@@ -318,10 +347,12 @@ static ss::future<read_result> do_read_from_ntp(
      */
     auto kafka_partition = make_partition_proxy(ntp_config.ktp(), cluster_pm);
     if (unlikely(!kafka_partition)) {
-        co_return read_result(error_code::unknown_topic_or_partition);
+        co_return make_errored_read_result(
+          md_cache, ntp_config.ktp(), error_code::unknown_topic_or_partition);
     }
     if (!ntp_config.cfg.read_from_follower && !kafka_partition->is_leader()) {
-        co_return read_result(error_code::not_leader_for_partition);
+        co_return make_errored_read_result(
+          md_cache, ntp_config.ktp(), error_code::not_leader_for_partition);
     }
 
     /**
@@ -330,7 +361,8 @@ static ss::future<read_result> do_read_from_ntp(
     auto leader_epoch_err = details::check_leader_epoch(
       ntp_config.cfg.current_leader_epoch, *kafka_partition);
     if (leader_epoch_err != error_code::none) {
-        co_return read_result(leader_epoch_err);
+        co_return make_errored_read_result(
+          md_cache, ntp_config.ktp(), leader_epoch_err);
     }
     auto offset_ec = co_await kafka_partition->validate_fetch_offset(
       ntp_config.cfg.start_offset,
@@ -403,6 +435,7 @@ namespace testing {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager& cluster_pm,
+  const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   const model::ktp& ktp,
   fetch_config config,
@@ -413,6 +446,7 @@ ss::future<read_result> read_from_ntp(
   ssx::semaphore& memory_fetch_sem) {
     return do_read_from_ntp(
       cluster_pm,
+      md_cache,
       replica_selector,
       {{ktp.get_topic(), ktp.get_partition()}, std::move(config)},
       foreign_read,
@@ -463,6 +497,9 @@ static void fill_fetch_responses(
         fetch_response::partition_response resp;
         resp.partition_index = res.partition;
         resp.error_code = res.error;
+        if (res.current_leader) {
+            resp.current_leader = *res.current_leader;
+        }
 
         // These are set to -1 in the general error case.
         // Set to actual values in the success case or when the error is
@@ -552,6 +589,7 @@ static void fill_fetch_responses(
 
 static ss::future<chunked_vector<read_result>> fetch_ntps(
   cluster::partition_manager& cluster_pm,
+  const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   chunked_vector<ntp_fetch_config> ntp_fetch_configs,
   read_distribution_probe& read_probe,
@@ -580,6 +618,7 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
 
         auto&& res = co_await do_read_from_ntp(
           cluster_pm,
+          md_cache,
           replica_selector,
           ntp_cfg,
           foreign_read,
@@ -656,6 +695,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
             // This is meant to help avoiding unintended cross shard access
             return fetch_ntps(
               mgr,
+              octx.rctx.metadata_cache(),
               octx.rctx.server().local().get_replica_selector(),
               std::move(configs),
               octx.rctx.server().local().read_probe(),
@@ -789,20 +829,23 @@ private:
         // are produced to without acks=all. The `last_visible_index` more
         // closely corresponds to the Kafka high watermark as well.
         std::vector<model::offset> last_visible_indexes(requests.size());
-        std::vector<std::tuple<size_t, model::partition_id>> errored_partitions;
+        std::vector<std::pair<size_t, read_result>> errored_partitions;
         size_t total_size{0};
         bool has_error{false};
 
         for (size_t i = 0; i < requests.size(); i++) {
             const auto& req = requests[i];
             auto part = _ctx.mgr.get(req.ktp());
-            if (!part) {
-                errored_partitions.emplace_back(i, req.ktp().get_partition());
-                continue;
-            }
-            auto consensus = part->raft();
+            auto consensus = part ? part->raft() : nullptr;
             if (!consensus) {
-                errored_partitions.emplace_back(i, req.ktp().get_partition());
+                errored_partitions.emplace_back(
+                  i,
+                  make_errored_read_result(
+                    _ctx.srv.metadata_cache(),
+                    req.ktp(),
+                    kafka::error_code::not_leader_for_partition));
+                errored_partitions.back().second.partition
+                  = req.ktp().get_partition();
                 continue;
             }
             last_visible_indexes[i] = consensus->last_visible_index();
@@ -813,6 +856,7 @@ private:
         // `fetch_ntps`.
         auto results = co_await fetch_ntps(
           _ctx.mgr,
+          _ctx.srv.metadata_cache(),
           _ctx.srv.get_replica_selector(),
           std::move(requests),
           _ctx.srv.read_probe(),
@@ -825,9 +869,8 @@ private:
         // If we weren't able to read the last_visible_index for a partition
         // before calling `fetch_ntps_in_parallel` then we need to
         // return with an error for that partition.
-        for (auto [i, partition] : errored_partitions) {
-            results[i] = read_result(error_code::not_leader_for_partition);
-            results[i].partition = partition;
+        for (auto& [i, result] : errored_partitions) {
+            results[i] = std::move(result);
         }
 
         for (const auto& r : results) {

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -33,7 +33,7 @@ fetch_scheduling_group_provider(const connection_context&);
 using fetch_handler = single_stage_handler<
   fetch_api,
   4,
-  11,
+  12,
   default_estimate_adaptor,
   fetch_scheduling_group_provider>;
 
@@ -260,6 +260,13 @@ struct read_result {
       , last_stable_offset(-1)
       , error(e) {}
 
+    read_result(error_code e, leader_id_and_epoch leader)
+      : start_offset(-1)
+      , high_watermark(-1)
+      , last_stable_offset(-1)
+      , current_leader(std::move(leader))
+      , error(e) {}
+
     // special case for offset_out_of_range_error
     read_result(
       error_code e,
@@ -334,6 +341,7 @@ struct read_result {
     model::offset last_stable_offset;
     std::optional<std::chrono::milliseconds> delta_from_tip_ms;
     std::optional<model::node_id> preferred_replica;
+    std::optional<leader_id_and_epoch> current_leader;
     error_code error;
     model::partition_id partition;
     std::vector<cluster::tx::tx_range> aborted_transactions;
@@ -420,6 +428,7 @@ namespace testing {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
+  const cluster::metadata_cache&,
   const replica_selector&,
   const model::ktp&,
   fetch_config,

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -33,7 +33,7 @@ fetch_scheduling_group_provider(const connection_context&);
 using fetch_handler = single_stage_handler<
   fetch_api,
   4,
-  12,
+  13,
   default_estimate_adaptor,
   fetch_scheduling_group_provider>;
 

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -38,6 +38,7 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <fmt/ostream.h>
 
+#include <algorithm>
 #include <iterator>
 #include <type_traits>
 
@@ -121,12 +122,15 @@ metadata_response::topic make_topic_response_from_topic_metadata(
   const is_node_isolated_or_decommissioned is_node_isolated,
   bool recovery_mode_enabled) {
     static constexpr model::node_id no_leader(-1);
-    metadata_response::topic tp;
-    tp.error_code = error_code::none;
-    model::topic_namespace_view tp_ns = tp_md.get_configuration().tp_ns;
-    tp.name = tp_md.get_configuration().tp_ns.tp;
+    const auto& topic_cfg = tp_md.get_configuration();
+    const auto& tp_ns = topic_cfg.tp_ns;
 
-    tp.is_internal = is_internal(tp_ns);
+    metadata_response::topic tp{
+      .error_code = error_code::none,
+      .name = tp_ns.tp,
+      .topic_id = topic_cfg.tp_id.value_or(model::topic_id{}),
+      .is_internal = is_internal(tp_ns),
+    };
 
     const bool is_user_topic = model::is_user_topic(tp_ns);
     const auto* disabled_set = md_cache.get_topic_disabled_set(tp_ns);
@@ -246,6 +250,11 @@ make_error_topic_response(model::topic tp, error_code ec) {
     return metadata_response::topic{.error_code = ec, .name = std::move(tp)};
 }
 
+metadata_response::topic
+make_error_topic_response(model::topic_id id, error_code ec) {
+    return metadata_response::topic{.error_code = ec, .topic_id = id};
+}
+
 static metadata_response::topic make_topic_response(
   request_context& ctx,
   metadata_request& rq,
@@ -302,23 +311,47 @@ static ss::future<chunked_vector<metadata_response::topic>> get_topic_metadata(
     std::vector<model::topic> topics_to_be_created;
     std::vector<ss::future<metadata_response::topic>> new_topics;
 
+    bool use_topic_ids = std::ranges::any_of(
+      *request.data.topics,
+      [](const auto& topic) { return topic.topic_id != model::topic_id{}; });
+
     for (auto& topic : *request.data.topics) {
         const auto move_topic_name = [&topic]() {
             return std::move(topic.name).value_or(model::topic{});
         };
 
-        /**
-         * Authorize source topic in case if we deal with materialized one
-         */
-        if (!ctx.authorized(
-              security::acl_operation::describe,
-              topic.name.value_or(model::topic{}))) {
-            // not authorized, return authorization error
-            res.push_back(make_error_topic_response(
-              move_topic_name(), error_code::topic_authorization_failed));
-            continue;
+        const bool use_topic_name = !use_topic_ids && topic.name.has_value();
+        const bool use_topic_id = use_topic_ids
+                                  && topic.topic_id != model::topic_id{};
+
+        const bool should_describe = use_topic_name || use_topic_id;
+
+        if (use_topic_id) {
+            // Check if topic is not found by ID
+            auto name = ctx.metadata_cache().get_name_by_id(topic.topic_id);
+            if (!name.has_value()) {
+                res.push_back(make_error_topic_response(
+                  topic.topic_id, kafka::error_code::unknown_topic_id));
+                continue;
+            }
+            topic.name = std::move(name)->tp;
         }
-        if (topic.name.has_value()) {
+
+        if (should_describe) {
+            /**
+             * Authorize source topic in case if we deal with materialized one
+             */
+            if (!ctx.authorized(
+                  security::acl_operation::describe, topic.name.value())) {
+                // not authorized, return authorization error, without giving
+                // away the topic name or id if it wasn't provided.
+                const auto ec = error_code::topic_authorization_failed;
+                res.push_back(
+                  use_topic_id
+                    ? make_error_topic_response(topic.topic_id, ec)
+                    : make_error_topic_response(move_topic_name(), ec));
+                continue;
+            }
             if (auto md = ctx.metadata_cache().get_topic_metadata(
                   model::topic_namespace_view(
                     model::kafka_namespace, *topic.name));
@@ -334,13 +367,19 @@ static ss::future<chunked_vector<metadata_response::topic>> get_topic_metadata(
         if (
           !config::shard_local_cfg().auto_create_topics_enabled
           || !request.data.allow_auto_topic_creation) {
-            bool valid = topic.name.has_value()
-                         && validate_kafka_topic_name(*topic.name)
-                              == model::errc::success;
-            res.push_back(make_error_topic_response(
-              move_topic_name(),
-              valid ? error_code::unknown_topic_or_partition
-                    : error_code::invalid_topic_exception));
+            if (!use_topic_ids) {
+                bool valid = topic.name.has_value()
+                             && validate_kafka_topic_name(*topic.name)
+                                  == model::errc::success;
+                res.push_back(make_error_topic_response(
+                  move_topic_name(),
+                  valid ? error_code::unknown_topic_or_partition
+                        : error_code::invalid_topic_exception));
+            }
+            continue;
+        } else if (use_topic_ids) {
+            // Kafka doesn't allow autocreating topics if any of the requested
+            // topics had an id.
             continue;
         }
         /**

--- a/src/v/kafka/server/handlers/metadata.h
+++ b/src/v/kafka/server/handlers/metadata.h
@@ -25,6 +25,6 @@ namespace kafka {
 memory_estimate_fn metadata_memory_estimator;
 
 using metadata_handler
-  = single_stage_handler<metadata_api, 0, 8, metadata_memory_estimator>;
+  = single_stage_handler<metadata_api, 0, 12, metadata_memory_estimator>;
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -754,9 +754,11 @@ redpanda_cc_btest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/cluster/tests:cluster_test_fixture",
         "//src/v/kafka/protocol",
         "//src/v/kafka/server",
         "//src/v/model",
+        "//src/v/raft",
         "//src/v/redpanda/tests:fixture",
         "//src/v/storage/tests:disk_log_builder",
         "//src/v/test_utils:seastar_boost",

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -677,7 +677,7 @@ FIXTURE_TEST(create_topic_assigns_topic_id, create_topic_fixture) {
     auto resp = client
                   .dispatch(
                     make_req({topic}, /*validate_only = */ false),
-                    kafka::api_version(5))
+                    kafka::api_version(7))
                   .get();
     BOOST_REQUIRE_EQUAL(
       resp.data.topics[0].error_code, kafka::error_code::none);
@@ -687,5 +687,7 @@ FIXTURE_TEST(create_topic_assigns_topic_id, create_topic_fixture) {
     auto md = app.controller->get_topics_state().local().get_topic_metadata(
       tpn);
     BOOST_REQUIRE(md.has_value());
-    BOOST_REQUIRE(md->get_configuration().tp_id.has_value());
+    auto tp_id = md->get_configuration().tp_id;
+    BOOST_REQUIRE(tp_id.has_value());
+    BOOST_REQUIRE_EQUAL(resp.data.topics[0].topic_id, *tp_id);
 }

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -26,6 +26,17 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/testing/perf_tests.hh>
 
+namespace {
+
+constexpr auto version_with_rack{kafka::api_version{11}};
+constexpr auto version_max_supported{kafka::fetch_handler::max_supported};
+
+static_assert(
+  version_max_supported == version_with_rack,
+  "Consider adding a test for next supported version");
+
+} // namespace
+
 struct fetch_bench_config {
     int num_fetches;
 
@@ -64,7 +75,10 @@ struct fetch_topic {
     std::vector<fetch_part> partitions;
 };
 
-using fetch_request_config = std::vector<fetch_topic>;
+struct fetch_request_config {
+    std::vector<fetch_topic> topics;
+    kafka::api_version api_version;
+};
 
 template<fetch_bench_config cfg>
 struct fetch_bench_fixture : redpanda_thread_fixture {
@@ -84,7 +98,7 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
             size_t total_batches = 0;
 
             chunked_vector<kafka::fetch_topic> fetch_topics;
-            for (auto& topic_fetch : req_config) {
+            for (auto& topic_fetch : req_config.topics) {
                 kafka::fetch_topic ft;
                 ft.topic = topic_fetch.name;
 
@@ -125,7 +139,7 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
 
             kafka::request_header header{
               .key = kafka::fetch_handler::api::key,
-              .version = kafka::fetch_handler::max_supported};
+              .version = req_config.api_version};
 
             return make_request_context(
               std::move(request), header, conn_context);
@@ -291,33 +305,39 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
 using large_fetch_t = fetch_bench_fixture<large_fetch_config>;
 using small_fetch_t = fetch_bench_fixture<small_fetch_config>;
 
-fetch_request_config single_partition_req_config(model::topic t) {
-    return fetch_request_config{fetch_topic{
-      .name = std::move(t),
-      .partitions = {fetch_part{model::partition_id(0), model::offset(0), 1}}}};
+fetch_request_config single_partition_req_config(
+  model::topic t, kafka::api_version v = version_max_supported) {
+    return fetch_request_config{
+      .topics = {fetch_topic{
+        .name = std::move(t),
+        .partitions = {fetch_part{
+          model::partition_id(0), model::offset(0), 1}}}},
+      .api_version = v};
 }
 
-fetch_request_config multi_partition_req_config(model::topic t) {
-    return fetch_request_config{fetch_topic{
-      .name = std::move(t),
-      .partitions = {
-        fetch_part{model::partition_id(0), model::offset(0), 1},
-        fetch_part{model::partition_id(1), model::offset(0), 1}}}};
+fetch_request_config multi_partition_req_config(
+  model::topic t, kafka::api_version v = version_max_supported) {
+    return fetch_request_config{
+      .topics = {fetch_topic{
+        .name = std::move(t),
+        .partitions
+        = {fetch_part{model::partition_id(0), model::offset(0), 1}, fetch_part{model::partition_id(1), model::offset(0), 1}}}},
+      .api_version = v};
 }
 
-PERF_TEST_CN(large_fetch_t, single_partition_fetch) {
+PERF_TEST_CN(large_fetch_t, single_partition_fetch_version_max) {
     static model::topic t = co_await initialize_single_partition_topic();
 
     co_return co_await fetch_from(single_partition_req_config(t));
 }
 
-PERF_TEST_CN(small_fetch_t, single_partition_fetch) {
+PERF_TEST_CN(small_fetch_t, single_partition_fetch_version_max) {
     static model::topic t = co_await initialize_single_partition_topic();
 
     co_return co_await fetch_from(single_partition_req_config(t));
 }
 
-PERF_TEST_CN(large_fetch_t, multi_partition_fetch) {
+PERF_TEST_CN(large_fetch_t, multi_partition_fetch_version_max) {
     static model::topic t = co_await initialize_multi_partition_topic();
 
     // One partition will be from the same shard, while the other will be
@@ -326,7 +346,7 @@ PERF_TEST_CN(large_fetch_t, multi_partition_fetch) {
     co_return co_await fetch_from(multi_partition_req_config(t));
 }
 
-PERF_TEST_CN(small_fetch_t, multi_partition_fetch) {
+PERF_TEST_CN(small_fetch_t, multi_partition_fetch_version_max) {
     static model::topic t = co_await initialize_multi_partition_topic();
 
     // One partition will be from the same shard, while the other will be

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -30,10 +30,11 @@ namespace {
 
 constexpr auto version_with_rack{kafka::api_version{11}};
 constexpr auto version_with_epoch_validation{kafka::api_version{12}};
+constexpr auto version_with_topic_ids{kafka::api_version{13}};
 constexpr auto version_max_supported{kafka::fetch_handler::max_supported};
 
 static_assert(
-  version_max_supported == version_with_epoch_validation,
+  version_max_supported == version_with_topic_ids,
   "Consider adding a test for next supported version");
 
 } // namespace
@@ -98,10 +99,24 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
         auto make_rctx = [&] {
             size_t total_batches = 0;
 
+            const auto& md_cache = app.metadata_cache.local();
+
             chunked_vector<kafka::fetch_topic> fetch_topics;
             for (auto& topic_fetch : req_config.topics) {
                 kafka::fetch_topic ft;
-                ft.topic = topic_fetch.name;
+                if (req_config.api_version >= version_with_topic_ids) {
+                    auto tp_id = md_cache
+                                   .get_topic_metadata_ref(
+                                     model::topic_namespace_view(
+                                       model::kafka_namespace,
+                                       topic_fetch.name))
+                                   ->get()
+                                   .get_configuration()
+                                   .tp_id.value();
+                    ft.topic_id = tp_id;
+                } else {
+                    ft.topic = topic_fetch.name;
+                }
 
                 // add the partitions to the fetch request
                 for (const auto& part : topic_fetch.partitions) {
@@ -172,7 +187,10 @@ struct fetch_bench_fixture : redpanda_thread_fixture {
                                       * (cfg.batch_size + cfg.batch_overhead);
         for (int i = 0; i < cfg.num_fetches + 1; i++) {
             auto& octx = *octxs[i];
-            vassert(!octx.response_error, "fetch wasn't successful");
+            vassert(
+              !octx.response_error,
+              "fetch wasn't successful {}",
+              octx.response_error);
             vassert(
               octx.response_size == expected_response_size,
               "not the expected response size. expected {} actual {}",
@@ -339,6 +357,14 @@ PERF_TEST_CN(large_fetch_t, single_partition_fetch_version_with_rack) {
       single_partition_req_config(t, version_with_rack));
 }
 
+PERF_TEST_CN(
+  large_fetch_t, single_partition_fetch_version_with_epoch_validation) {
+    static model::topic t = co_await initialize_single_partition_topic();
+
+    co_return co_await fetch_from(
+      single_partition_req_config(t, version_with_epoch_validation));
+}
+
 PERF_TEST_CN(small_fetch_t, single_partition_fetch_version_max) {
     static model::topic t = co_await initialize_single_partition_topic();
 
@@ -350,6 +376,14 @@ PERF_TEST_CN(small_fetch_t, single_partition_fetch_version_with_rack) {
 
     co_return co_await fetch_from(
       single_partition_req_config(t, version_with_rack));
+}
+
+PERF_TEST_CN(
+  small_fetch_t, single_partition_fetch_version_with_epoch_validation) {
+    static model::topic t = co_await initialize_single_partition_topic();
+
+    co_return co_await fetch_from(
+      single_partition_req_config(t, version_with_epoch_validation));
 }
 
 PERF_TEST_CN(large_fetch_t, multi_partition_fetch_version_max) {
@@ -368,6 +402,14 @@ PERF_TEST_CN(large_fetch_t, multi_partition_fetch_version_with_rack) {
       multi_partition_req_config(t, version_with_rack));
 }
 
+PERF_TEST_CN(
+  large_fetch_t, multi_partition_fetch_version_with_epoch_validation) {
+    static model::topic t = co_await initialize_multi_partition_topic();
+
+    co_return co_await fetch_from(
+      multi_partition_req_config(t, version_with_epoch_validation));
+}
+
 PERF_TEST_CN(small_fetch_t, multi_partition_fetch_version_max) {
     static model::topic t = co_await initialize_multi_partition_topic();
 
@@ -382,4 +424,12 @@ PERF_TEST_CN(small_fetch_t, multi_partition_fetch_version_with_rack) {
 
     co_return co_await fetch_from(
       multi_partition_req_config(t, version_with_rack));
+}
+
+PERF_TEST_CN(
+  small_fetch_t, multi_partition_fetch_version_with_epoch_validation) {
+    static model::topic t = co_await initialize_multi_partition_topic();
+
+    co_return co_await fetch_from(
+      multi_partition_req_config(t, version_with_epoch_validation));
 }

--- a/src/v/kafka/server/tests/fetch_bench.cc
+++ b/src/v/kafka/server/tests/fetch_bench.cc
@@ -29,10 +29,11 @@
 namespace {
 
 constexpr auto version_with_rack{kafka::api_version{11}};
+constexpr auto version_with_epoch_validation{kafka::api_version{12}};
 constexpr auto version_max_supported{kafka::fetch_handler::max_supported};
 
 static_assert(
-  version_max_supported == version_with_rack,
+  version_max_supported == version_with_epoch_validation,
   "Consider adding a test for next supported version");
 
 } // namespace
@@ -331,10 +332,24 @@ PERF_TEST_CN(large_fetch_t, single_partition_fetch_version_max) {
     co_return co_await fetch_from(single_partition_req_config(t));
 }
 
+PERF_TEST_CN(large_fetch_t, single_partition_fetch_version_with_rack) {
+    static model::topic t = co_await initialize_single_partition_topic();
+
+    co_return co_await fetch_from(
+      single_partition_req_config(t, version_with_rack));
+}
+
 PERF_TEST_CN(small_fetch_t, single_partition_fetch_version_max) {
     static model::topic t = co_await initialize_single_partition_topic();
 
     co_return co_await fetch_from(single_partition_req_config(t));
+}
+
+PERF_TEST_CN(small_fetch_t, single_partition_fetch_version_with_rack) {
+    static model::topic t = co_await initialize_single_partition_topic();
+
+    co_return co_await fetch_from(
+      single_partition_req_config(t, version_with_rack));
 }
 
 PERF_TEST_CN(large_fetch_t, multi_partition_fetch_version_max) {
@@ -346,6 +361,13 @@ PERF_TEST_CN(large_fetch_t, multi_partition_fetch_version_max) {
     co_return co_await fetch_from(multi_partition_req_config(t));
 }
 
+PERF_TEST_CN(large_fetch_t, multi_partition_fetch_version_with_rack) {
+    static model::topic t = co_await initialize_multi_partition_topic();
+
+    co_return co_await fetch_from(
+      multi_partition_req_config(t, version_with_rack));
+}
+
 PERF_TEST_CN(small_fetch_t, multi_partition_fetch_version_max) {
     static model::topic t = co_await initialize_multi_partition_topic();
 
@@ -353,4 +375,11 @@ PERF_TEST_CN(small_fetch_t, multi_partition_fetch_version_max) {
     // from a foreign shard. This will hopefully allow us to detect if more
     // or less cross shard calls are being made for a fetch.
     co_return co_await fetch_from(multi_partition_req_config(t));
+}
+
+PERF_TEST_CN(small_fetch_t, multi_partition_fetch_version_with_rack) {
+    static model::topic t = co_await initialize_multi_partition_topic();
+
+    co_return co_await fetch_from(
+      multi_partition_req_config(t, version_with_rack));
 }

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -18,6 +18,7 @@
 #include "kafka/server/handlers/fetch.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "redpanda/tests/fixture.h"
 #include "security/acl.h"
 
@@ -50,9 +51,13 @@ struct fixture {
     }
 };
 
+constexpr kafka::api_version topic_names{11};
+constexpr kafka::api_version topic_ids{13};
+
 static constexpr size_t topic_name_length = 30;
 
 struct test_args {
+    kafka::api_version fetch_version{topic_names};
     size_t topic_count;
     size_t partitions_per_topic;
     bool use_authz;
@@ -97,7 +102,7 @@ struct fetch_plan : redpanda_thread_fixture {
         }
 
         _args = args;
-        auto [tcount, pcount, use_authz] = args;
+        auto [api_version, tcount, pcount, use_authz] = args;
 
         co_await wait_for_controller_leadership();
 
@@ -116,7 +121,7 @@ struct fetch_plan : redpanda_thread_fixture {
               pcount);
         });
 
-        auto fetch_req = make_fetch_req();
+        auto fetch_req = make_fetch_req(api_version);
 
         // we need to share a connection among any requests here since the
         // session cache is associated with a connection
@@ -134,7 +139,8 @@ struct fetch_plan : redpanda_thread_fixture {
         // in the session cache
         kafka::fetch_session_id sess_id;
         {
-            auto rctx = make_request_context(make_fetch_req(), header, conn);
+            auto rctx = make_request_context(
+              make_fetch_req(api_version), header, conn);
             // set up a fetch session
             auto ctx = rctx.fetch_sessions().maybe_get_session(fetch_req);
             vassert(
@@ -208,7 +214,7 @@ struct fetch_plan : redpanda_thread_fixture {
         co_return *_state;
     }
 
-    kafka::fetch_request make_fetch_req() {
+    kafka::fetch_request make_fetch_req(kafka::api_version api_version) {
         // create a request
         kafka::fetch_request_data frq_data;
         frq_data.replica_id = kafka::client::consumer_replica_id;
@@ -222,7 +228,16 @@ struct fetch_plan : redpanda_thread_fixture {
         for (auto& topic : _state->topics) {
             // make the fetch topic
             kafka::fetch_topic ft;
-            ft.topic = topic;
+            if (api_version >= kafka::api_version{13}) {
+                ft.topic_id = app.metadata_cache.local()
+                                .get_topic_metadata_ref(
+                                  {model::kafka_namespace, topic})
+                                ->get()
+                                .get_configuration()
+                                .tp_id.value();
+            } else {
+                ft.topic = topic;
+            }
 
             // add the partitions to the fetch request
             for (size_t pid = 0; pid < _args.partitions_per_topic; pid++) {
@@ -241,7 +256,11 @@ struct fetch_plan : redpanda_thread_fixture {
         return kafka::fetch_request{std::move(frq_data)};
     };
 
-    ss::future<size_t> run_bench(size_t tcount, size_t pcount, bool authz) {
+    ss::future<size_t> run_bench(
+      kafka::api_version api_version,
+      size_t tcount,
+      size_t pcount,
+      bool authz) {
 #ifdef NDEBUG
         const size_t iters = 1000000 / (tcount * pcount);
 #else
@@ -249,7 +268,11 @@ struct fetch_plan : redpanda_thread_fixture {
         const size_t iters = 1;
 #endif
 
-        auto& state = co_await init_bench({tcount, pcount, authz});
+        auto& state = co_await init_bench(
+          {.fetch_version = api_version,
+           .topic_count = tcount,
+           .partitions_per_topic = pcount,
+           .use_authz = authz});
 
         perf_tests::start_measuring_time();
         for (size_t i = 0; i < iters; i++) {
@@ -268,9 +291,40 @@ struct fetch_plan : redpanda_thread_fixture {
     }
 };
 
-PERF_TEST_F(fetch_plan, t1p1_no_auth) { return run_bench(1, 1, false); }
-PERF_TEST_F(fetch_plan, t1p1_yes_auth) { return run_bench(1, 1, true); }
-PERF_TEST_F(fetch_plan, t1p100_no_auth) { return run_bench(1, 100, false); }
-PERF_TEST_F(fetch_plan, t1p100_yes_auth) { return run_bench(1, 100, true); }
-PERF_TEST_F(fetch_plan, t100p1_no_auth) { return run_bench(100, 1, false); }
-PERF_TEST_F(fetch_plan, t100p1_yes_auth) { return run_bench(100, 1, true); }
+PERF_TEST_F(fetch_plan, t1p1_no_auth) {
+    return run_bench(topic_names, 1, 1, false);
+}
+PERF_TEST_F(fetch_plan, t1p1_yes_auth) {
+    return run_bench(topic_names, 1, 1, true);
+}
+PERF_TEST_F(fetch_plan, t1p100_no_auth) {
+    return run_bench(topic_names, 1, 100, false);
+}
+PERF_TEST_F(fetch_plan, t1p100_yes_auth) {
+    return run_bench(topic_names, 1, 100, true);
+}
+PERF_TEST_F(fetch_plan, t100p1_no_auth) {
+    return run_bench(topic_names, 100, 1, false);
+}
+PERF_TEST_F(fetch_plan, t100p1_yes_auth) {
+    return run_bench(topic_names, 100, 1, true);
+}
+
+PERF_TEST_F(fetch_plan, t1p1_no_auth_ids) {
+    return run_bench(topic_ids, 1, 1, false);
+}
+PERF_TEST_F(fetch_plan, t1p1_yes_auth_ids) {
+    return run_bench(topic_ids, 1, 1, true);
+}
+PERF_TEST_F(fetch_plan, t1p100_no_auth_ids) {
+    return run_bench(topic_ids, 1, 100, false);
+}
+PERF_TEST_F(fetch_plan, t1p100_yes_auth_ids) {
+    return run_bench(topic_ids, 1, 100, true);
+}
+PERF_TEST_F(fetch_plan, t100p1_no_auth_ids) {
+    return run_bench(topic_ids, 100, 1, false);
+}
+PERF_TEST_F(fetch_plan, t100p1_yes_auth_ids) {
+    return run_bench(topic_ids, 100, 1, true);
+}

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -70,7 +70,7 @@ FIXTURE_TEST(test_next_epoch, fixture) {
 FIXTURE_TEST(test_fetch_session_basic_operations, fixture) {
     kafka::fetch_session session(kafka::fetch_session_id(123));
     struct tpo {
-        model::ktp ktp;
+        model::kitp ktp;
         model::offset offset;
     };
     std::vector<tpo> expected;
@@ -84,12 +84,14 @@ FIXTURE_TEST(test_fetch_session_basic_operations, fixture) {
 
         expected.push_back(
           tpo{
-            model::ktp{
+            model::kitp{
+              model::topic_id(),
               model::topic(req.topic),
               model::partition_id(req.partitions[0].partition)},
             model::offset(req.partitions[0].fetch_offset)});
         session.partitions().emplace(
-          kafka::fetch_session_partition(req.topic, req.partitions[0]));
+          kafka::fetch_session_partition(
+            model::topic_id{}, req.topic, req.partitions[0]));
     }
 
     BOOST_TEST_MESSAGE("test insertion order iteration");
@@ -99,29 +101,31 @@ FIXTURE_TEST(test_fetch_session_basic_operations, fixture) {
       session.partitions().cend_insertion_order());
 
     for (auto fp : rng) {
-        BOOST_REQUIRE_EQUAL(fp.topic_partition, expected[i].ktp);
+        BOOST_REQUIRE_EQUAL(
+          static_cast<const model::kitp&>(fp.topic_partition), expected[i].ktp);
         BOOST_REQUIRE_EQUAL(fp.fetch_offset, expected[i].offset);
         ++i;
     }
 
     BOOST_TEST_MESSAGE("test lookup");
     for (auto& t : expected) {
-        const auto& key = t.ktp.as_tp_view();
+        const auto& key = t.ktp.as_kitp_view();
         BOOST_REQUIRE(session.partitions().contains(key));
         BOOST_REQUIRE(
           session.partitions().find(key) != session.partitions().end());
     }
 
-    auto not_existing = model::topic_partition(
-      model::topic("123456"), model::partition_id(9999));
+    auto not_existing = model::kitp(
+      model::topic_id(), model::topic("123456"), model::partition_id(9999));
 
-    BOOST_REQUIRE(!session.partitions().contains(not_existing));
+    BOOST_REQUIRE(!session.partitions().contains(not_existing.as_kitp_view()));
     BOOST_REQUIRE(
-      session.partitions().find(not_existing) == session.partitions().end());
+      session.partitions().find(not_existing.as_kitp_view())
+      == session.partitions().end());
 
     BOOST_TEST_MESSAGE("test erase");
 
-    const auto& key = expected[0].ktp.as_tp_view();
+    const auto& key = expected[0].ktp.as_kitp_view();
     auto mem_usage_before = session.mem_usage();
     session.partitions().erase(key);
     BOOST_REQUIRE(!session.partitions().contains(key));

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/tests/cluster_test_fixture.h"
 #include "kafka/protocol/batch_consumer.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/fetch.h"
@@ -177,6 +178,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
                 [&octx, ktp, config](cluster::partition_manager& pm) {
                     return kafka::testing::read_from_ntp(
                       pm,
+                      octx.rctx.metadata_cache(),
                       octx.rctx.server().local().get_replica_selector(),
                       ktp,
                       config,
@@ -491,6 +493,137 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
         == kafka::error_code::fenced_leader_epoch,
       fmt::format(
         "error: {}", resp.data.responses[0].partitions[0].error_code));
+}
+
+FIXTURE_TEST(fetch_current_leader_v12, cluster_test_fixture) {
+    // create a topic partition with some data
+    model::topic topic("foo");
+    model::partition_id pid(0);
+
+    create_node_application(model::node_id{0});
+    create_node_application(model::node_id{1});
+    create_node_application(model::node_id{2});
+    wait_for_all_members(3s).get();
+
+    model::ktp ktp(topic, pid);
+    auto ntp = ktp.to_ntp();
+    create_topic(ktp.as_tn_view(), 1, 3).get();
+
+    wait_for(10s, [&] {
+        auto [app_ptr, _] = get_leader(ntp);
+        return app_ptr != nullptr;
+    });
+
+    auto [app_ptr, partition] = get_leader(ntp);
+
+    auto publish_some = [ntp](redpanda_thread_fixture* app_ptr) {
+        app_ptr->app.partition_manager
+          .invoke_on(
+            *app_ptr->app.shard_table.local().shard_for(ntp),
+            [ntp](cluster::partition_manager& mgr) {
+                auto partition = mgr.get(ntp);
+
+                auto batches
+                  = model::test::make_random_batches(model::offset(0), 5).get();
+
+                BOOST_TEST_INFO("Replicating batches to leader");
+
+                partition->raft()
+                  ->replicate(
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
+                    raft::replicate_options(
+                      raft::consistency_level::quorum_ack))
+                  .discard_result()
+                  .get();
+            })
+          .get();
+    };
+
+    publish_some(app_ptr);
+
+    BOOST_TEST_INFO("Shuffling leadership");
+    shuffle_leadership(ntp).get();
+
+    BOOST_TEST_INFO("Waiting for new leader");
+    wait_for(10s, [&] {
+        auto [fixture, _] = get_leader(ntp);
+        return fixture != nullptr;
+    });
+
+    BOOST_TEST_INFO("Getting new leader");
+    auto [new_app_ptr, new_partition] = get_leader(ntp);
+
+    publish_some(new_app_ptr);
+
+    // An alternative is to issue a linearizable_barrier, like list_offsets.
+    BOOST_TEST_INFO("Waiting for metadata cache to update");
+    wait_for(10s, [&] {
+        cluster::leader_term expected{
+          new_app_ptr->app.controller->self(), new_partition->raft()->term()};
+        auto term = app_ptr->app.metadata_cache.local().get_leader_term(
+          ktp.as_tn_view(), ktp.get_partition());
+        return term == expected;
+    });
+
+    auto send_request =
+      [&](redpanda_thread_fixture* app_ptr, model::term_id term) {
+          kafka::fetch_request req;
+          req.data.max_bytes = std::numeric_limits<int32_t>::max();
+          req.data.min_bytes = 1;
+          req.data.max_wait_ms = std::chrono::milliseconds(1000);
+          req.data.topics.emplace_back(
+            kafka::fetch_topic{
+              .topic = topic,
+              .partitions = {{
+                .partition = pid,
+                .current_leader_epoch = kafka::leader_epoch_from_term(term),
+                .fetch_offset = model::offset(6),
+              }}});
+
+          auto client = instance(app_ptr->app.controller->self())
+                          ->make_kafka_client()
+                          .get();
+
+          client.connect().get();
+
+          auto response
+            = client.dispatch(std::move(req), kafka::api_version(12)).get();
+          client.stop().then([&client] { client.shutdown(); }).get();
+          return response;
+      };
+
+    auto expected = kafka::leader_id_and_epoch{
+      new_partition->raft()->get_leader_id().value_or(model::node_id{-1}),
+      kafka::leader_epoch_from_term(new_partition->raft()->term())};
+
+    {
+        BOOST_TEST_INFO("Dispatching old epoch to old leader");
+        auto resp = send_request(app_ptr, model::term_id{1});
+        const auto& part = resp.data.responses[0].partitions[0];
+        BOOST_REQUIRE_EQUAL(
+          part.error_code, kafka::error_code::not_leader_for_partition);
+        BOOST_REQUIRE_EQUAL(expected, part.current_leader);
+    }
+    {
+        BOOST_TEST_INFO("Dispatching old epoch to new leader");
+        auto resp = send_request(new_app_ptr, model::term_id{1});
+        const auto& part = resp.data.responses[0].partitions[0];
+        BOOST_REQUIRE_EQUAL(
+          part.error_code, kafka::error_code::fenced_leader_epoch);
+        BOOST_REQUIRE_EQUAL(expected, part.current_leader);
+    }
+    {
+        BOOST_TEST_INFO("Dispatching new epoch to new leader");
+        auto resp = send_request(new_app_ptr, model::term_id{2});
+        const auto& part = resp.data.responses[0].partitions[0];
+        BOOST_REQUIRE_EQUAL(part.error_code, kafka::error_code::none);
+        // When there is not an error, leader_id_and_epoch should not be set
+        BOOST_REQUIRE_EQUAL(model::node_id{-1}, part.current_leader.leader_id);
+        BOOST_REQUIRE_EQUAL(
+          kafka::leader_epoch{-1}, part.current_leader.leader_epoch);
+    }
 }
 
 FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -250,7 +250,14 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
           });
     }).get();
 
-    for (auto version : boost::irange<uint16_t>(
+    const auto& topic_id = app.metadata_cache.local()
+                             .get_topic_metadata_ref(
+                               model::topic_namespace_view(ntp))
+                             ->get()
+                             .get_configuration()
+                             .tp_id;
+
+    for (auto version : boost::irange<kafka::api_version>(
            kafka::fetch_handler::min_supported,
            kafka::fetch_handler::max_supported + int16_t(1))) {
         info("Checking fetch api v{}", version);
@@ -263,21 +270,28 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
         req.data.session_epoch = kafka::final_fetch_session_epoch;
         req.data.topics.emplace_back(
           kafka::fetch_topic{
-            .topic = topic,
             .partitions = {{
               .partition = pid,
               .fetch_offset = offset,
             }},
           });
+        if (version >= kafka::api_version{13}) {
+            req.data.topics.back().topic_id = *topic_id;
+        } else {
+            req.data.topics.back().topic = topic;
+        }
 
         auto client = make_kafka_client().get();
         client.connect().get();
-        auto resp
-          = client.dispatch(std::move(req), kafka::api_version(version)).get();
+        auto resp = client.dispatch(std::move(req), version).get();
         client.stop().then([&client] { client.shutdown(); }).get();
 
         BOOST_REQUIRE(resp.data.responses.size() == 1);
-        BOOST_REQUIRE(resp.data.responses[0].topic == topic());
+        if (version >= kafka::api_version{13}) {
+            BOOST_REQUIRE_EQUAL(resp.data.responses[0].topic_id, *topic_id);
+        } else {
+            BOOST_REQUIRE(resp.data.responses[0].topic == topic());
+        }
         BOOST_REQUIRE(resp.data.responses[0].partitions.size() == 1);
         BOOST_REQUIRE(
           resp.data.responses[0].partitions[0].error_code
@@ -379,6 +393,38 @@ FIXTURE_TEST(fetch_non_existent, redpanda_thread_fixture) {
     BOOST_REQUIRE_EQUAL(
       resp.data.responses.at(0).partitions.at(0).error_code,
       kafka::error_code::unknown_topic_or_partition);
+}
+
+FIXTURE_TEST(fetch_non_existent_v13, redpanda_thread_fixture) {
+    auto topic_id = model::topic_id{uuid_t::create()};
+    auto log_config = make_default_config();
+    wait_for_controller_leadership().get();
+    kafka::fetch_request non_existent_ntp;
+    non_existent_ntp.data.max_wait_ms = std::chrono::milliseconds(100);
+    non_existent_ntp.data.topics.emplace_back(
+      kafka::fetch_topic{
+        .topic_id = topic_id,
+        .partitions = {{
+          .partition = model::partition_id{0},
+          .current_leader_epoch = kafka::leader_epoch(0),
+          .fetch_offset = model::offset(0),
+        }}});
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto defer = ss::defer([&client] {
+        client.stop().then([&client] { client.shutdown(); }).get();
+    });
+    auto resp = client
+                  .dispatch(std::move(non_existent_ntp), kafka::api_version(13))
+                  .get();
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE(resp.data.responses.at(0).errored());
+    BOOST_REQUIRE_EQUAL(resp.data.responses.at(0).partitions.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses.at(0).topic_id, topic_id);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses.at(0).partitions.at(0).error_code,
+      kafka::error_code::unknown_topic_id);
 }
 
 FIXTURE_TEST(fetch_empty, redpanda_thread_fixture) {
@@ -557,7 +603,7 @@ FIXTURE_TEST(fetch_current_leader_v12, cluster_test_fixture) {
 
     publish_some(new_app_ptr);
 
-    // An alternative is to issue a linearizable_barrier, like list_offsets.
+    // This is in lieu of a linearizable_barrier.
     BOOST_TEST_INFO("Waiting for metadata cache to update");
     wait_for(10s, [&] {
         cluster::leader_term expected{

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -18,6 +18,7 @@
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/metadata.h"
+#include "model/fundamental.h"
 #include "model/timeout_clock.h"
 #include "redpanda/tests/fixture.h"
 #include "security/acl.h"
@@ -143,46 +144,63 @@ FIXTURE_TEST(metadata_v9_no_topics, metadata_fixture) {
       kafka::details::to_bit_field(default_cluster_auths));
 }
 
-FIXTURE_TEST(metadata_v9_topics, metadata_fixture) {
-    ss::sstring test_topic_name = "metadata_v9_topics";
+FIXTURE_TEST(metadata_v8_plus_topics, metadata_fixture) {
+    using kafka::api_version;
+    constexpr auto min_version = api_version{8};
+    constexpr auto max_version = kafka::metadata_handler::max_supported;
+    constexpr auto expect_topic_id_min = api_version{10};
+
+    ss::sstring test_topic_name = "metadata_topics";
 
     create_topic(test_topic_name, 1, 1);
 
-    kafka::metadata_request req{.data{
-      .topics = {},
-      .allow_auto_topic_creation = false,
-      .include_cluster_authorized_operations = false,
-      .include_topic_authorized_operations = false}};
+    constexpr auto make_req = [] {
+        return kafka::metadata_request{.data{
+          .topics = {},
+          .allow_auto_topic_creation = false,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+    };
+
+    constexpr auto make_topic_auth_req = [] {
+        return kafka::metadata_request{.data{
+          .topics = {},
+          .allow_auto_topic_creation = false,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = true}};
+    };
+
     auto client = make_kafka_client().get();
     auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
-    auto resp = client.dispatch(std::move(req), kafka::api_version(8)).get();
-    BOOST_REQUIRE(!resp.data.errored());
-    BOOST_CHECK_EQUAL(
-      resp.data.cluster_authorized_operations, not_provided_authz_return);
-    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
-    BOOST_CHECK_EQUAL(resp.data.topics[0].name, model::topic{test_topic_name});
-    BOOST_CHECK_EQUAL(
-      resp.data.topics[0].topic_authorized_operations,
-      not_provided_authz_return);
+    for (api_version ver{min_version}; ver <= max_version; ++ver) {
+        auto resp = client.dispatch(make_req(), ver).get();
+        BOOST_REQUIRE(!resp.data.errored());
+        BOOST_CHECK_EQUAL(
+          resp.data.cluster_authorized_operations, not_provided_authz_return);
+        BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+        BOOST_CHECK_EQUAL(
+          resp.data.topics[0].name, model::topic{test_topic_name});
+        if (ver < expect_topic_id_min) {
+            BOOST_CHECK_EQUAL(resp.data.topics[0].topic_id, model::topic_id{});
+        } else {
+            BOOST_CHECK_NE(resp.data.topics[0].topic_id, model::topic_id{});
+        }
+        BOOST_CHECK_EQUAL(
+          resp.data.topics[0].topic_authorized_operations,
+          not_provided_authz_return);
 
-    kafka::metadata_request req_topic_authz{
-      .data{
-        .topics = {},
-        .allow_auto_topic_creation = false,
-        .include_cluster_authorized_operations = false,
-        .include_topic_authorized_operations = true},
-    };
-    resp = client.dispatch(std::move(req_topic_authz), kafka::api_version(8))
-             .get();
-    BOOST_REQUIRE(!resp.data.errored());
-    BOOST_CHECK_EQUAL(
-      resp.data.cluster_authorized_operations, not_provided_authz_return);
-    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
-    BOOST_CHECK_EQUAL(resp.data.topics[0].name, model::topic{test_topic_name});
-    BOOST_CHECK_EQUAL(
-      resp.data.topics[0].topic_authorized_operations,
-      kafka::details::to_bit_field(default_topics_auths));
+        resp = client.dispatch(make_topic_auth_req(), ver).get();
+        BOOST_REQUIRE(!resp.data.errored());
+        BOOST_CHECK_EQUAL(
+          resp.data.cluster_authorized_operations, not_provided_authz_return);
+        BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+        BOOST_CHECK_EQUAL(
+          resp.data.topics[0].name, model::topic{test_topic_name});
+        BOOST_CHECK_EQUAL(
+          resp.data.topics[0].topic_authorized_operations,
+          kafka::details::to_bit_field(default_topics_auths));
+    }
 }
 
 FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
@@ -284,49 +302,62 @@ FIXTURE_TEST(metadata_v9_authz_acl, metadata_fixture) {
 
 FIXTURE_TEST(metadata_empty_topic_name, metadata_fixture) {
     using kafka::api_version;
-    if (kafka::metadata_handler::max_supported < api_version{12}) {
-        return;
-    }
+    constexpr auto min_version = api_version{8};
+    constexpr auto max_version = kafka::metadata_handler::max_supported;
 
     auto client = make_kafka_client().get();
     auto deferred_close = ss::defer([&client] { client.stop().get(); });
     client.connect().get();
 
-    constexpr auto make_request = []() {
+    constexpr auto make_request = [](std::optional<model::topic> topic) {
         return kafka::metadata_request{.data{
-          .topics = {{{.name{}}}},
+          .topics = {{{.name{topic}}}},
           .allow_auto_topic_creation = false,
           .include_cluster_authorized_operations = false,
           .include_topic_authorized_operations = false}};
     };
     const kafka::metadata_response_data default_response;
-    for (api_version ver{8}; ver < api_version{12}; ++ver) {
-        auto resp = client.dispatch(make_request(), ver).get();
-        BOOST_REQUIRE(resp.data.errored());
-        BOOST_REQUIRE(!resp.data.topics.empty());
-        if (ver <= api_version{9}) {
+    for (api_version ver{min_version}; ver <= api_version{max_version}; ++ver) {
+        using opt_topic = std::optional<model::topic>;
+        for (const auto& topic : {opt_topic{}, opt_topic{""}}) {
+            auto resp = client.dispatch(make_request(topic), ver).get();
+            BOOST_REQUIRE(resp.data.errored());
+            BOOST_REQUIRE(!resp.data.topics.empty());
+
+            const auto expected_error
+              = (ver == api_version{10} || ver == api_version{11})
+                    && !topic.has_value()
+                  ? kafka::error_code::invalid_request
+                  : kafka::error_code::invalid_topic_exception;
+
+            std::cout << "api_version: " << ver << ", topic: "
+                      << (topic.value_or(model::topic("<nullopt>")))
+                      << ", expected: " << expected_error << std::endl;
+
             BOOST_REQUIRE_EQUAL(
-              resp.data.topics.front().error_code,
-              kafka::error_code::invalid_topic_exception);
-        } else {
-            BOOST_REQUIRE_EQUAL(
-              resp.data.topics.front().error_code,
-              kafka::error_code::invalid_request);
-            BOOST_REQUIRE(resp.data.brokers.empty());
-            BOOST_REQUIRE_EQUAL(
-              resp.data.cluster_id, default_response.cluster_id);
-            BOOST_REQUIRE_EQUAL(
-              resp.data.controller_id, default_response.controller_id);
+              resp.data.topics.front().error_code, expected_error);
+
+            if (expected_error == kafka::error_code::invalid_request) {
+                BOOST_REQUIRE(resp.data.brokers.empty());
+                BOOST_REQUIRE_EQUAL(
+                  resp.data.cluster_id, default_response.cluster_id);
+                BOOST_REQUIRE_EQUAL(
+                  resp.data.controller_id, default_response.controller_id);
+            } else {
+                BOOST_REQUIRE(!resp.data.brokers.empty());
+                BOOST_REQUIRE_NE(
+                  resp.data.cluster_id, default_response.cluster_id);
+                BOOST_REQUIRE_NE(
+                  resp.data.controller_id, default_response.controller_id);
+            }
         }
     }
 }
 
 FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
     using kafka::api_version;
-    if (kafka::metadata_handler::max_supported < api_version{12}) {
-        return;
-    }
-    ss::sstring test_topic_name = "metadata_non_empty_topic_id";
+    constexpr auto max_supported = kafka::metadata_handler::max_supported;
+    const model::topic test_topic_name{"metadata_non_empty_topic_id"};
 
     create_topic(test_topic_name, 1, 1);
 
@@ -355,6 +386,24 @@ FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
         BOOST_REQUIRE_EQUAL(resp.data.cluster_id, default_response.cluster_id);
         BOOST_REQUIRE_EQUAL(
           resp.data.controller_id, default_response.controller_id);
+    }
+
+    for (api_version ver{12}; ver <= max_supported; ++ver) {
+        auto test_topic_id = get_topic_id(test_topic_name);
+        BOOST_REQUIRE(test_topic_id.has_value());
+        BOOST_REQUIRE_NE(test_topic_id.value(), model::topic_id{});
+
+        auto resp = client
+                      .dispatch(
+                        kafka::metadata_request{
+                          .data{.topics{{{.topic_id{*test_topic_id}}}}}},
+                        ver)
+                      .get();
+
+        BOOST_REQUIRE(!resp.data.errored());
+        BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.data.topics.front().topic_id, *test_topic_id);
+        BOOST_REQUIRE_EQUAL(resp.data.topics.front().name, test_topic_name);
     }
 }
 
@@ -390,6 +439,54 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
     }
 }
 
+FIXTURE_TEST(metadata_v12_mixed, metadata_fixture) {
+    // Test specifying a topic name and a topic id in the same request
+    // If any topic id is present, only topic ids are used.
+    using namespace kafka;
+    const model::topic test_topic_name_0{"metadata_v12_mixed_0"};
+    const model::topic test_topic_name_1{"metadata_v12_mixed_1"};
+
+    auto undo = set_auto_create_topics(false);
+
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+    client.connect().get();
+
+    client
+      .dispatch(
+        kafka::create_topics_request{.data{
+          .topics{
+            {.name{test_topic_name_0},
+             .num_partitions = 1,
+             .replication_factor = 1},
+            {.name{test_topic_name_1},
+             .num_partitions = 1,
+             .replication_factor = 1}},
+          .timeout_ms = 10s,
+          .validate_only = false}},
+        kafka::api_version{2})
+      .get();
+
+    auto topic_1_id = get_topic_id(model::topic(test_topic_name_1));
+    BOOST_REQUIRE(topic_1_id.has_value());
+
+    // Request topic 0 by name and topic 1 by id (expect only topic 1)
+    auto resp
+      = client
+          .dispatch(
+            kafka::metadata_request{
+              .data{.topics{
+                {{.name{test_topic_name_0}}, {.topic_id{*topic_1_id}}}}},
+            },
+            api_version{12})
+          .get();
+
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+    BOOST_REQUIRE(!resp.data.errored());
+    BOOST_REQUIRE(resp.data.topics[0].name == test_topic_name_1);
+    BOOST_REQUIRE(resp.data.topics[0].error_code == kafka::error_code::none);
+}
+
 FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
     using kafka::api_version;
     constexpr auto max_supported = kafka::metadata_handler::max_supported;
@@ -416,7 +513,7 @@ FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
     BOOST_REQUIRE(!create_resp.data.errored());
 
     const kafka::metadata_response_data default_response;
-    for (api_version ver{8}; ver < max_supported; ++ver) {
+    for (api_version ver{8}; ver <= max_supported; ++ver) {
         auto req = kafka::metadata_request{.data{
           .topics
           = {{{.name{ssx::sformat("{}_{}_{}", test_topic_create, "by_name", ver)}}, {.name{test_topic_query}}}},
@@ -430,5 +527,67 @@ FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
         BOOST_REQUIRE_EQUAL(topics.size(), 2);
         BOOST_REQUIRE_EQUAL(topics[0].error_code, kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(topics[1].error_code, kafka::error_code::none);
+    }
+
+    auto query_topic_id = get_topic_id(model::topic(test_topic_query));
+    BOOST_REQUIRE(query_topic_id.has_value());
+
+    for (api_version ver{12}; ver <= max_supported; ++ver) {
+        auto new_topic = ssx::sformat(
+          "{}_{}_{}", test_topic_create, "by_id", ver);
+        auto req = kafka::metadata_request{.data{
+          .topics = {{{.name{new_topic}}, {.topic_id{*query_topic_id}}}},
+          .allow_auto_topic_creation = true,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+        auto resp = client.dispatch(std::move(req), ver).get();
+
+        BOOST_REQUIRE(!resp.data.errored());
+        const auto& topics = resp.data.topics;
+        BOOST_REQUIRE_EQUAL(topics.size(), 1);
+        BOOST_REQUIRE_EQUAL(topics[0].error_code, kafka::error_code::none);
+    }
+}
+
+FIXTURE_TEST(metadata_v12_unauthorized, metadata_fixture) {
+    using kafka::api_version;
+    constexpr auto min_version = api_version{12};
+    constexpr auto max_version = kafka::metadata_handler::max_supported;
+
+    auto topic = model::topic("metadata_v12_unauthorized");
+    create_topic(topic, 1, 1);
+    auto topic_id = get_topic_id(topic);
+
+    const auto make_request = [&topic_id]() {
+        return kafka::metadata_request{.data{
+          .topics = {{{.topic_id{*topic_id}}}},
+          .allow_auto_topic_creation = false,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+    };
+
+    const ss::sstring user = "username_256";
+    const ss::sstring pass = "password_256";
+
+    create_user(user, pass);
+
+    enable_sasl();
+    auto disable_sasl_defer = ss::defer([this] { disable_sasl(); });
+
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+
+    client.connect().get();
+    authn_kafka_client(client, user, pass);
+
+    for (api_version ver{min_version}; ver <= api_version{max_version}; ++ver) {
+        auto resp = client.dispatch(make_request(), ver).get();
+        BOOST_REQUIRE(resp.data.errored());
+        BOOST_REQUIRE(!resp.data.topics.empty());
+        BOOST_REQUIRE_EQUAL(
+          resp.data.topics[0].error_code,
+          kafka::error_code::topic_authorization_failed);
+        BOOST_REQUIRE_EQUAL(resp.data.topics[0].topic_id, topic_id);
+        BOOST_REQUIRE(!resp.data.topics[0].name.has_value());
     }
 }

--- a/src/v/model/kitp.h
+++ b/src/v/model/kitp.h
@@ -103,7 +103,7 @@ public:
      * The kitp must not be in a moved-from state and this is checked via assert
      * in non-release builds.
      */
-    const topic& get_topic() const { return ktp().get_topic(); }
+    const topic& get_topic() const { return as_ktp().get_topic(); }
 
     /**
      * @brief Returns the kitp's partition id.
@@ -111,7 +111,7 @@ public:
      * The kitp must not be in a moved-from state and this is checked via assert
      * in non-release builds.
      */
-    partition_id get_partition() const { return ktp().get_partition(); }
+    partition_id get_partition() const { return as_ktp().get_partition(); }
 
     topic_namespace_view as_tn_view() const {
         return {kafka_namespace, get_topic()};

--- a/tests/docker/ducktape-deps/base-tools
+++ b/tests/docker/ducktape-deps/base-tools
@@ -22,6 +22,7 @@ apt-get install -y \
   git \
   libsasl2-dev \
   libsasl2-modules-gssapi-mit \
+  libcurl4-openssl-dev \
   libssl-dev \
   libzstd-dev \
   pkg-config \

--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 mkdir /opt/librdkafka
-curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.6.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.11.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
-./configure
+./configure --enable-gssapi --enable-curl
 make -j$(nproc)
 make install
 cd /opt/librdkafka/tests

--- a/tests/go/kgo-verifier/go.mod
+++ b/tests/go/kgo-verifier/go.mod
@@ -1,15 +1,15 @@
 module github.com/redpanda-data/redpanda/tests/go/kgo-verifier
 
-go 1.23.8
+go 1.24.0
 
-toolchain go1.23.11
+toolchain go1.24.7
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
-	github.com/twmb/franz-go v1.19.5
+	github.com/twmb/franz-go v1.19.6-0.20250902220237-b02944b2098b
 	github.com/twmb/franz-go/pkg/kadm v1.16.1
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 	github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-20211217123319-86af7226d9f0

--- a/tests/go/kgo-verifier/go.sum
+++ b/tests/go/kgo-verifier/go.sum
@@ -290,8 +290,8 @@ github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twmb/franz-go v1.2.3-0.20211104052441-7952375c09c0/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
 github.com/twmb/franz-go v1.2.4/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
-github.com/twmb/franz-go v1.19.5 h1:W7+o8D0RsQsedqib71OVlLeZ0zI6CbFra7yTYhZTs5Y=
-github.com/twmb/franz-go v1.19.5/go.mod h1:4kFJ5tmbbl7asgwAGVuyG1ZMx0NNpYk7EqflvWfPCpM=
+github.com/twmb/franz-go v1.19.6-0.20250902220237-b02944b2098b h1:+w6sQKLCeuOWzCdPKXYsqqMzPeRSWVqCmF9kE7WC1M0=
+github.com/twmb/franz-go v1.19.6-0.20250902220237-b02944b2098b/go.mod h1:grHaglMHfYOvG3MUqBx7rlpkkkp9sRixMvIttQTvsaI=
 github.com/twmb/franz-go/pkg/kadm v0.0.0-20211116225244-e97ad6b8ef3e/go.mod h1:fuA2THFeFx/ms1w1R432uxWJqq7o3Q+olvJR4NFpWcM=
 github.com/twmb/franz-go/pkg/kadm v1.16.1 h1:IEkrhTljgLHJ0/hT/InhXGjPdmWfFvxp7o/MR7vJ8cw=
 github.com/twmb/franz-go/pkg/kadm v1.16.1/go.mod h1:Ue/ye1cc9ipsQFg7udFbbGiFNzQMqiH73fGC2y0rwyc=

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -466,7 +466,7 @@ class RawKCL(KCL):
             return []
 
     def raw_create_topics(self, version, topics, validate_only=False):
-        assert version >= 0 and version <= 6, (
+        assert version >= 0 and version <= 7, (
             "version out of supported redpanda range for this API"
         )
         create_topics_request = {

--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -90,9 +90,9 @@ class ClusterQuotaPartitionMutationTest(RedpandaTest):
         # Use KCL so that the details about the response can be examined, namely
         # this test must observe that the newly introduce 'throttle_quota_exceeded'
         # response code is used and that 'ThrottleMillis' was approprately set
-        response = self.kcl.raw_create_topics(6, exceed_quota_req)
+        response = self.kcl.raw_create_topics(7, exceed_quota_req)
         response = json.loads(response)
-        assert response["Version"] == 6
+        assert response["Version"] == 7
         baz_response = [t for t in response["Topics"] if t["Topic"] == "baz"]
         foo_response = [t for t in response["Topics"] if t["Topic"] == "foo"]
         bar_response = [t for t in response["Topics"] if t["Topic"] == "bar"]

--- a/tests/rptest/tests/compatibility/sarama_produce_test.py
+++ b/tests/rptest/tests/compatibility/sarama_produce_test.py
@@ -43,7 +43,7 @@ class SaramaProduceTest(RedpandaTest):
         )
 
     @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_produce(self, version):
         verifier_bin = "/opt/redpanda-tests/go/sarama/produce_test/produce_test"
 

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -43,7 +43,7 @@ class SaramaTest(RedpandaTest):
         self._timeout = 30 if self.scale.local else 1200
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_interceptors(self, version):
         sarama_example = SaramaExamples.SaramaInterceptors(
             self.redpanda, version, self.topic
@@ -56,7 +56,7 @@ class SaramaTest(RedpandaTest):
         wait_until(example.condition_met, timeout_sec=self._timeout, backoff_sec=1)
 
     @cluster(num_nodes=4)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_http_server(self, version):
         sarama_example = SaramaExamples.SaramaHttpServer(self.redpanda, version)
         example = ExampleRunner(self._ctx, sarama_example, timeout_sec=self._timeout)
@@ -91,7 +91,7 @@ class SaramaTest(RedpandaTest):
         )
 
     @cluster(num_nodes=5)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_consumergroup(self, version):
         count = 10 if self.scale.local else 5000
 
@@ -144,7 +144,7 @@ class SaramaScramTest(RedpandaTest):
         super(SaramaScramTest, self).__init__(test_context, security=security)
 
     @cluster(num_nodes=3)
-    @matrix(version=["2.1.0"])
+    @matrix(version=["2.1.0", "2.6.0"])
     def test_sarama_sasl_scram(self, version):
         # Get the SASL SCRAM command and a ducktape node
         cmd = SaramaExamples.sarama_sasl_scram(self.redpanda, version, self.topic)

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -10,7 +10,7 @@
 import threading
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
-from ducktape.mark import parametrize
+from ducktape.mark import ignore, parametrize
 
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.python_librdkafka import PythonLibrdkafka
@@ -608,6 +608,7 @@ class OIDCReauthTest(RedpandaOIDCTestBase):
             **kwargs,
         )
 
+    @ignore  # https://github.com/redpanda-data/redpanda/pull/26968 - broken by newer librdkafka
     @cluster(num_nodes=4)
     def test_oidc_reauth(self):
         kc_node = self.keycloak.nodes[0]

--- a/tests/rptest/transactions/tx_authorization_test.py
+++ b/tests/rptest/transactions/tx_authorization_test.py
@@ -10,6 +10,7 @@
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 
+from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 
 from rptest.transactions.util import (
@@ -128,6 +129,7 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
 
         producer = self.sasl_txn_producer(user, cfg=producer_cfg)
 
+    @ignore  # https://github.com/redpanda-data/redpanda/pull/26968 - broken by newer librdkafka
     @cluster(num_nodes=3)
     def simple_authz_test(self):
         consume_user = self.USER_1


### PR DESCRIPTION
It's a bit tricky to untangle Topic ID support, so this combines previous PRs:

Closes #26235
Closes #26926

Fixes CORE-9879
Fixes CORE-10028
Fixes CORE-9880
Fixes CORE-9881

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Features

* Support KIP-516
