### PR TITLE
Allow retries in ntp_archiver::upload_segment and upload_index

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1631,8 +1631,7 @@ ss::future<> ntp_archiver::upload_index(
   ss::sstring path, cloud_storage::offset_index index) {
     retry_chain_node rtc{
       _conf->segment_upload_timeout(),
-      100ms,
-      retry_strategy::disallow,
+      _conf->upload_loop_initial_backoff(),
       &_rtcnode};
     retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
     auto fut = co_await ss::coroutine::as_future(_remote.upload_index(

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1617,7 +1617,6 @@ ntp_archiver::maybe_upload_aborted_tx(
   cloud_storage::remote_segment_path path,
   std::optional<fragmented_vector<model::tx_range>> tx,
   retry_chain_node& parent_rtc) {
-    // We're not doing any retries here so initial backoff could be any
     retry_chain_node fib(&parent_rtc);
     if (tx.has_value() && !tx.value().empty()) {
         cloud_storage::tx_range_manifest manifest(path, std::move(tx).value());
@@ -1648,11 +1647,9 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
   segment_collector_stream strm,
   const cloud_storage::segment_meta& meta,
   std::optional<fragmented_vector<model::tx_range>> tx_ranges) {
-    // We're not doing any retries here so initial backoff could be any
     retry_chain_node rtc(
       _conf->segment_upload_timeout(),
-      100ms,
-      retry_strategy::disallow,
+      _conf->upload_loop_initial_backoff(),
       &_rtcnode);
     retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
     auto h = _gate.hold();


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

A previous PR[1] refactored upload_segment and in so doing added
retry_strategy::disallow to the retry_chain_node governing the upload.

As a result, we saw an uptick in
- 'cloud_storage_failed_uploads'
- 'cloud_storage_bytes_sent'
- 'io_queue_total_read_bytes'

Along with an increased incidence of 'backoff quota exceeded' logs from
cloud_io.

Specifically cloud_io::remote::upload_stream increments
'cloud_storage_failed_uploads' in a number of failure cases, but along with
the increased frequency of the backoff quota log line, it's likely bordering
on a certainty that the uptick in failures is a result of rtc node retries
being exhausted as a result of transient errors that would previously be
masked by retry logic inside cloud_io.

For now, we should return to the default retry strategy (exponential backoff)
and assess the viability of offloading retries to the archival loop at a
later time.

[1] https://github.com/redpanda-data/redpanda/pull/25951

Does the same for upload_index.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
