### PR TITLE
bazel: support flaky attribute on tests

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -85,7 +85,8 @@ def _redpanda_cc_test(
         env = {},
         target_compatible_with = [],
         data = [],
-        local_defines = []):
+        local_defines = [],
+        flaky = False):
     """
     Helper to define a Redpanda C++ test.
 
@@ -105,6 +106,7 @@ def _redpanda_cc_test(
       target_compatible_with: constraints
       data: data file dependencies
       local_defines: list of defines
+      flaky: whether the test is flaky (value passed to bazel attribute of the same name)
     """
     common_args = [
         "--blocked-reactor-notify-ms 2000000",
@@ -148,6 +150,7 @@ def _redpanda_cc_test(
         target_compatible_with = target_compatible_with,
         data = data + test_data,
         local_defines = local_defines,
+        flaky = flaky,
     )
 
 def _redpanda_cc_fuzz_test(
@@ -225,7 +228,8 @@ def redpanda_cc_gtest(
         memory = None,
         target_compatible_with = [],
         data = [],
-        tags = []):
+        tags = [],
+        flaky = False):
     _redpanda_cc_unit_test(
         dash_dash_protocol = False,
         name = name,
@@ -241,6 +245,7 @@ def redpanda_cc_gtest(
         data = data,
         local_defines = ["IS_GTEST"],
         tags = tags,
+        flaky = flaky,
     )
 
 def redpanda_cc_btest(
@@ -255,7 +260,8 @@ def redpanda_cc_btest(
         memory = None,
         target_compatible_with = [],
         data = [],
-        tags = []):
+        tags = [],
+        flaky = False):
     _redpanda_cc_unit_test(
         dash_dash_protocol = True,
         name = name,
@@ -271,6 +277,7 @@ def redpanda_cc_btest(
         data = data,
         local_defines = ["IS_BTEST"],
         tags = tags,
+        flaky = flaky,
     )
 
 def redpanda_cc_fuzz_test(


### PR DESCRIPTION
Bazel has a flaky attribute which changes some behavior when set on a test (e.g., the test may be automatically retried), but we do not support it in our btest and gtest macros.

Add support for it and pipe it through to bazel.

Fixes CORE-12895.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

Test-only change, we want this to be able to mark flaky tests in v25.2 too (earlier release don't use bazel).

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
