### PR TITLE
[CORE-12861] rpc: use a fragmented container for correlation tracking

### DIFF
--- a/src/v/rpc/BUILD
+++ b/src/v/rpc/BUILD
@@ -48,6 +48,7 @@ redpanda_cc_library(
         "//src/v/bytes:scattered_message",
         "//src/v/compression",
         "//src/v/config",
+        "//src/v/container:chunked_hash_map",
         "//src/v/hashing:crc32c",
         "//src/v/hashing:xx",
         "//src/v/metrics",

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -15,6 +15,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "base/outcome.h"
 #include "base/seastarx.h"
+#include "container/chunked_hash_map.h"
 #include "metrics/metrics.h"
 #include "model/metadata.h"
 #include "net/transport.h"
@@ -262,9 +263,10 @@ private:
      *
      * NOTE: _correlation_idx is unrelated to the sequence type used to define
      * on-wire ordering below.
+     *
+     * TODO(CORE-12902)
      */
-    absl::flat_hash_map<uint32_t, std::unique_ptr<response_entry>>
-      _correlations;
+    chunked_hash_map<uint32_t, std::unique_ptr<response_entry>> _correlations;
     uint32_t _correlation_idx{0};
 
     /**


### PR DESCRIPTION
We observed this container growing large in CORE-12861 because of unreplied RPC messages.

Fixes: CORE-12861

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
