### PR TITLE
[v24.3.x] csc/client_pool: Log client lease expiration at WARN

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -450,13 +450,13 @@ auto client_pool::acquire_with_timeout(
            ctx = std::move(ctx)]() mutable {
               if (ctx.has_value()) {
                   vlog(
-                    pool_log.debug,
+                    pool_log.warn,
                     "{} - Lease expired after {}ms. Shutting down client...",
                     ctx.value(),
                     to / 1ms);
               } else {
                   vlog(
-                    pool_log.debug,
+                    pool_log.warn,
                     "Lease expired after {}ms. Shutting down client...",
                     to / 1ms);
               }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26966
