### PR TITLE
Revert "c/a/archiver: Start offset_index upload in the background"

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1491,8 +1491,7 @@ ss::future<> ntp_archiver::upload_index(
   ss::sstring path, cloud_storage::offset_index index) {
     retry_chain_node rtc{
       _conf->segment_upload_timeout(),
-      100ms,
-      retry_strategy::disallow,
+      _conf->upload_loop_initial_backoff(),
       &_rtcnode};
     retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
     auto fut = co_await ss::coroutine::as_future(_remote.upload_index(

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1477,7 +1477,6 @@ ntp_archiver::maybe_upload_aborted_tx(
   cloud_storage::remote_segment_path path,
   std::optional<fragmented_vector<model::tx_range>> tx,
   retry_chain_node& parent_rtc) {
-    // We're not doing any retries here so initial backoff could be any
     retry_chain_node fib(&parent_rtc);
     if (tx.has_value() && !tx.value().empty()) {
         cloud_storage::tx_range_manifest manifest(path, std::move(tx).value());
@@ -1508,11 +1507,9 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
   segment_collector_stream strm,
   const cloud_storage::segment_meta& meta,
   std::optional<fragmented_vector<model::tx_range>> tx_ranges) {
-    // We're not doing any retries here so initial backoff could be any
     retry_chain_node rtc(
       _conf->segment_upload_timeout(),
-      100ms,
-      retry_strategy::disallow,
+      _conf->upload_loop_initial_backoff(),
       &_rtcnode);
     retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
     auto h = _gate.hold();

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1487,21 +1487,6 @@ ntp_archiver::maybe_upload_aborted_tx(
     co_return std::nullopt;
 }
 
-ss::future<> ntp_archiver::upload_index(
-  ss::sstring path, cloud_storage::offset_index index) {
-    retry_chain_node rtc{
-      _conf->segment_upload_timeout(),
-      _conf->upload_loop_initial_backoff(),
-      &_rtcnode};
-    retry_chain_logger ctxlog(archival_log, rtc, _ntp.path());
-    auto fut = co_await ss::coroutine::as_future(_remote.upload_index(
-      _conf->bucket_name, cloud_storage_clients::object_key{path}, index, rtc));
-
-    if (fut.failed()) {
-        vlog(ctxlog.warn, "Index upload failed: {}", fut.get_exception());
-    }
-}
-
 ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
   segment_collector_stream strm,
   const cloud_storage::segment_meta& meta,
@@ -1657,11 +1642,16 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
     // segment, so it is okay to ignore the index upload failure, we still
     // want to advance the offsets because the segment did get uploaded.
 
-    ssx::spawn_with_gate(
-      _gate,
-      [this, path = std::move(index_path), index = std::move(index)]() mutable {
-          return upload_index(std::move(path), std::move(index));
-      });
+    // Note: this operation can be started in the background.
+    // In order to do this the context should be associated with the
+    // background operation. We can't background it as is because the
+    // 'upload_index' call is taking 'rtc' as a reference. So there should be
+    // some wrapper for this call.
+    std::ignore = co_await _remote.upload_index(
+      _conf->bucket_name,
+      cloud_storage_clients::object_key{index_path},
+      index,
+      rtc);
 
     co_return ntp_archiver_upload_result(index_stats);
 

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -558,8 +558,6 @@ private:
       archival_stm_fence fence,
       std::vector<wait_uploads_complete_result> finished_uploads);
 
-    ss::future<> upload_index(ss::sstring path, cloud_storage::offset_index);
-
     ss::future<ntp_archiver_upload_result> upload_segment(
       segment_collector_stream strm,
       const cloud_storage::segment_meta& meta,

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -320,7 +320,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     // Upload two non compacted segments, no segment is compacted yet.
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -342,7 +342,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     verify_segment_request("0-1-v1.log", part->archival_meta_stm()->manifest());
 
@@ -363,7 +363,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
 
-    requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     verify_segment_request(
       "1000-4-v1.log", part->archival_meta_stm()->manifest());
@@ -395,7 +395,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
     upload_and_verify(archiver.value(), expected);
 
     // Two segments, two indices, one manifest
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -416,7 +416,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
@@ -456,7 +456,7 @@ FIXTURE_TEST(
 
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     std::stringstream st;
     stm_manifest.serialize_json(st);
@@ -494,7 +494,7 @@ FIXTURE_TEST(test_upload_compacted_segments_fill_gap, reupload_fixture) {
     archival::ntp_archiver::batch_result expected{{0, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected);
 
-    requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     verify_segment_request("0-1-v1.log", stm_manifest);
 
@@ -522,7 +522,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
 
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -561,7 +561,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
 
     expected = archival::ntp_archiver::batch_result{{1, 0, 0}, {1, 0, 0}};
     upload_and_verify(archiver.value(), expected, model::offset::max());
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     verify_segment_request("0-1-v1.log", part->archival_meta_stm()->manifest());
     verify_segment_request(
@@ -592,7 +592,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     archival::ntp_archiver::batch_result expected{{2, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
 
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -645,7 +645,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     upload_and_verify(archiver.value(), expected, model::offset::max());
 
     log_requests();
-    requests_size_eventually(4);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 4);
 
     verify_segment_request(
       "30-5-v1.log", part->archival_meta_stm()->manifest());
@@ -673,7 +673,7 @@ FIXTURE_TEST(test_upload_when_compaction_disabled, reupload_fixture) {
 
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -692,7 +692,7 @@ FIXTURE_TEST(test_upload_when_compaction_disabled, reupload_fixture) {
     reset_http_call_state();
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(0);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 0);
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(), model::offset{});
@@ -716,7 +716,7 @@ FIXTURE_TEST(test_upload_when_reupload_disabled, reupload_fixture) {
 
     auto expected = archival::ntp_archiver::batch_result{{2, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -742,7 +742,7 @@ FIXTURE_TEST(test_upload_when_reupload_disabled, reupload_fixture) {
       .get("cloud_storage_enable_compacted_topic_reupload")
       .set_value(false);
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(0);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 0);
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(), model::offset{});
@@ -775,7 +775,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     archival::ntp_archiver::batch_result expected{{4, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected);
 
-    requests_size_eventually(9);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 9);
 
     auto manifest = load_manifest(
       get_targets().find(manifest_url)->second.content);
@@ -816,7 +816,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
 
     expected = archival::ntp_archiver::batch_result{{4, 0, 0}, {0, 0, 0}};
     upload_and_verify(archiver.value(), expected, model::offset::max());
-    requests_size_eventually(9);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 9);
 
     verify_segment_request(
       "40-1-v1.log", part->archival_meta_stm()->manifest());
@@ -837,7 +837,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {1, 0, 0}};
 
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
@@ -865,7 +865,7 @@ FIXTURE_TEST(test_upload_compacted_segments_cross_term, reupload_fixture) {
     upload_and_verify(archiver.value(), expected);
 
     // Two segments, two indices, one manifest
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     auto manifest = verify_manifest_request(*part);
     verify_segment_request("0-1-v1.log", manifest);
@@ -889,7 +889,7 @@ FIXTURE_TEST(test_upload_compacted_segments_cross_term, reupload_fixture) {
 
     expected = archival::ntp_archiver::batch_result{{0, 0, 0}, {2, 0, 0}};
     upload_and_verify(archiver.value(), expected);
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -168,7 +168,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     for (auto [url, req] : get_targets()) {
         vlog(test_log.info, "{} {}", req.method, req.url);
     }
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     cloud_storage::partition_manifest manifest;
     {
@@ -295,7 +295,7 @@ FIXTURE_TEST(test_upload_after_failure, archiver_fixture) {
 
     BOOST_REQUIRE_EQUAL(compacted_result.num_succeeded, 0);
     BOOST_REQUIRE_EQUAL(compacted_result.num_failed, 0);
-    requests_size_eventually(4);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 4);
 
     cloud_storage::partition_manifest manifest;
     {
@@ -388,7 +388,7 @@ FIXTURE_TEST(
     auto&& [non_compacted_result, compacted_result] = res;
     BOOST_REQUIRE_EQUAL(non_compacted_result.num_succeeded, 0);
     BOOST_REQUIRE_EQUAL(non_compacted_result.num_failed, 1);
-    requests_size_eventually(1);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 1);
 }
 
 // NOLINTNEXTLINE
@@ -900,8 +900,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     for (auto req : get_requests()) {
         vlog(test_log.info, "{} {}", req.method, req.url);
     }
-
-    requests_size_eventually(5);
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
 
     cloud_storage::partition_manifest manifest;
     {
@@ -1125,8 +1124,7 @@ static void test_partial_upload_impl(
     BOOST_REQUIRE_EQUAL(compacted_result.num_failed, 0);
 
     test.log_requests();
-    // index uploads happen in the background, so give a little slack here
-    test.requests_size_eventually(3);
+    BOOST_REQUIRE_EQUAL(test.get_requests().size(), 3);
 
     {
         auto [begin, end] = test.get_targets().equal_range(manifest_url);
@@ -1166,7 +1164,7 @@ static void test_partial_upload_impl(
     BOOST_REQUIRE_EQUAL(compacted_result.num_failed, 0);
 
     test.log_requests();
-    test.requests_size_eventually(6);
+    BOOST_REQUIRE_EQUAL(test.get_requests().size(), 6);
     {
         auto [begin, end] = test.get_targets().equal_range(manifest_url);
         size_t len = std::distance(begin, end);

--- a/src/v/cluster/archival/tests/service_fixture.h
+++ b/src/v/cluster/archival/tests/service_fixture.h
@@ -197,12 +197,6 @@ public:
         archiver._flush_cond.broadcast();
     }
 
-    void requests_size_eventually(
-      size_t expected, ss::lowres_clock::duration to = 3s) {
-        RPTEST_REQUIRE_EVENTUALLY(
-          to, [&] { return get_requests().size() == expected; });
-    }
-
     ss::sharded<cloud_storage_clients::client_pool> pool;
     ss::sharded<cloud_io::remote> io;
     ss::sharded<cloud_storage::remote> remote;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

It seems possible that we could accumulate a bunch of background upload fibers depending on the rate of segment uploads. It's still nice to have, but it seems risky to include in the release w/o any monitoring or backpressure.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
