### PR TITLE
[CORE-9280] rptest: Fix tiered-storage pause test

### DIFF
--- a/tests/rptest/tests/tiered_storage_pause_test.py
+++ b/tests/rptest/tests/tiered_storage_pause_test.py
@@ -151,12 +151,18 @@ class TestTieredStoragePause(PreallocNodesTest):
         zero. Otherwise the expectation is that start offset is greater than zero"""
         rpk = RpkTool(self.redpanda)
         partitions = rpk.describe_topic(self._topic)
-        for p in partitions:
+
+        def _check():
+            partitions = rpk.describe_topic(self._topic)
             if expected:
-                res = p.start_offset == 0
+                return all([p.start_offset == 0 for p in partitions])
             else:
-                res = p.start_offset > 0
-            assert res, f"local retention have unexpected value, expected to start from zero = {expected}, start offset = {p.start_offset}"
+                return all([p.start_offset > 0 for p in partitions])
+
+        wait_until(_check,
+                   timeout_sec=40,
+                   backoff_sec=5,
+                   err_msg="local retention have unexpected value")
 
     def wait_until_start_offset_advances(self):
         """


### PR DESCRIPTION
Fix flaky ducktape test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none