### PR TITLE
tests/data-migrate: do not test with groups until bugs fixed

### DIFF
--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -514,7 +514,8 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                 for i, t in enumerate(topics[:3])
             ]
             in_migration = InboundDataMigration(topics=inbound_topics,
-                                                consumer_groups=["g-1", "g-2"])
+                                                consumer_groups=[])
+            #TODO: use consumer_groups=["g-1", "g-2"] when group migration bugs are fixed
             self.logger.info(f'{try_wo_license=}')
             if try_wo_license:
                 self.toggle_license(on=True)
@@ -916,9 +917,11 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
             '/transfer_leadership\] reason - seastar::broken_named_semaphore',
             '/transfer_leadership\] reason - seastar::gate_closed_exception',
         ])
-    @matrix(transfer_leadership=[True, False],
-            include_groups=[True, False],
-            params=generate_tmptpdi_params())
+    @matrix(
+        transfer_leadership=[True, False],
+        #TODO: use include_groups=[True, False] when group migration bugs are fixed
+        include_groups=[False],
+        params=generate_tmptpdi_params())
     def test_migrated_topic_data_integrity(self, include_groups: bool,
                                            transfer_leadership: bool,
                                            params: TmtpdiParams):


### PR DESCRIPTION
Consumer groups migration uncovered some problems in data migration worker. Disable problematic tests to reduce noise.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
