### PR TITLE
cloud_metadata: fix upload_in_term test

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -134,6 +134,7 @@ public:
                 req, model::timeout_clock::now() + 5s);
             if (
               result.errc == cluster::errc::not_leader_controller
+              || result.errc == cluster::errc::no_leader_controller
               || result.errc == raft::errc::not_leader) {
                 vlog(
                   logger.debug,
@@ -351,7 +352,8 @@ TEST_F(cluster_metadata_uploader_fixture, test_upload_in_term) {
     auto result = patch_config(cluster::config_update_request{
                                  .upsert = {{"cluster_id", "foo"}}})
                     .get();
-    ASSERT_TRUE(!result.errc);
+    ASSERT_TRUE(!result.errc)
+      << fmt::format("errc {} version {}", result.errc, result.version);
     RPTEST_REQUIRE_EVENTUALLY(
       5s, [this] { return controller_stm.maybe_write_snapshot(); });
     const auto new_snap_offset = get_local_snap_offset();


### PR DESCRIPTION
The test checked that it was able to patch config, and part of patch config includes a retry loop if the controller isn't a leader. the retry loop checked if it were a leader, but it didn't take into account the possibility of the error indicating that there is current _no_ leader which is a distinct case. PR adds that to the possible reasons for continuing the retry.

passes with retry=300x

```
bazel test //src/v/cluster/cloud_metadata/tests:uploader_test --config=sanitizer --runs_per_test=300 --test_summary=detailed
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
