### PR TITLE
ct/l1: expose domains in metastore interface

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -78,6 +78,15 @@ public:
         kafka::offset next_offset;
     };
 
+    // A domain is a set of topic partitions that may colocate data into the
+    // same objects together. A domain_id uniquely identifies a domain, making
+    // it useful as a map key when grouping together data.
+    using domain_id = named_type<int64_t, struct domain_id_tag>;
+
+    // Returns the domain_id for the given partition.
+    virtual ss::future<std::expected<domain_id, errc>>
+    get_domain_id(const model::topic_id_partition&) const = 0;
+
     // Returns offsets (e.g. start, next) for the given partition.
     virtual ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) = 0;
@@ -86,7 +95,7 @@ public:
     // because they break an invariant of a partition's offset ranges, all
     // objects are rejected.
     virtual ss::future<std::expected<void, errc>>
-    add_objects(const chunked_vector<object_metadata>&) = 0;
+    add_objects(domain_id, const chunked_vector<object_metadata>&) = 0;
 
     // Adds the given objects to the metastore, expecting that the new extents
     // replace an extent or set of extents covering the same range.
@@ -97,7 +106,7 @@ public:
     // correctness, these simplify accounting and makes it easier to validate
     // that we haven't lost data.
     virtual ss::future<std::expected<void, errc>>
-    replace_objects(const chunked_vector<object_metadata>&) = 0;
+    replace_objects(domain_id, const chunked_vector<object_metadata>&) = 0;
 
     // Finds the first object of a given partition with data greater than or
     // equal to the given offset. If no such offset exists, returns

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -47,8 +47,8 @@ simple_metastore::get_offsets(const model::topic_id_partition& tpr) {
     };
 }
 
-ss::future<std::expected<void, metastore::errc>>
-simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
+ss::future<std::expected<void, metastore::errc>> simple_metastore::add_objects(
+  domain_id, const chunked_vector<object_metadata>& objects) {
     chunked_vector<new_object> new_objects;
     for (const auto& o : objects) {
         new_objects.emplace_back(make_new_object(o));
@@ -65,7 +65,7 @@ simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
 
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::replace_objects(
-  const chunked_vector<object_metadata>& objects) {
+  domain_id, const chunked_vector<object_metadata>& objects) {
     chunked_vector<new_object> new_objects;
     for (const auto& o : objects) {
         new_objects.emplace_back(make_new_object(o));

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -21,14 +21,21 @@ namespace experimental::cloud_topics::l1 {
 // Not replicated or persisted, used for tests only.
 class simple_metastore : public metastore {
 public:
+    static constexpr auto simple_domain_id = metastore::domain_id{0};
+    ss::future<std::expected<metastore::domain_id, errc>>
+    get_domain_id(const model::topic_id_partition&) const override {
+        // In the name of simplicity, make all data belong to the same domain.
+        co_return simple_domain_id;
+    }
+
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;
 
     ss::future<std::expected<void, errc>>
-    add_objects(const chunked_vector<object_metadata>&) override;
+    add_objects(domain_id, const chunked_vector<object_metadata>&) override;
 
     ss::future<std::expected<void, errc>>
-    replace_objects(const chunked_vector<object_metadata>&) override;
+    replace_objects(domain_id, const chunked_vector<object_metadata>&) override;
 
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -22,6 +22,7 @@ const object_id oid1 = l1::create_object_id();
 const object_id oid2 = l1::create_object_id();
 const object_id oid3 = l1::create_object_id();
 const object_id oid4 = l1::create_object_id();
+const metastore::domain_id dummy_dom_id = simple_metastore::simple_domain_id;
 
 const std::string_view tid_a = "deadbeef-aaaa-0000-0000-000000000000/0";
 const std::string_view tid_b = "deadbeef-bbbb-0000-0000-000000000000/0";
@@ -122,7 +123,8 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .add(tid_b, 0_o, 10_o, 2000_t, 100, 199)
                    .build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
 
     // We didn't add tid_c, so we should still get an error.
@@ -155,7 +157,9 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
     {
         auto ometa
           = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-        auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+        auto add_res = m.add_objects(
+                          dummy_dom_id, om_list_t::single(std::move(ometa)))
+                         .get();
         ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
 
         auto offsets_res
@@ -169,7 +173,9 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
         // Add another object just past where we expect it.
         auto ometa
           = om_builder(oid2, 100).add(tid_a, 12_o, 20_o, 2000_t, 0, 99).build();
-        auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+        auto add_res = m.add_objects(
+                          dummy_dom_id, om_list_t::single(std::move(ometa)))
+                         .get();
         ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
         ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
 
@@ -184,7 +190,8 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
     // Now add the object right at the end, where it should be.
     auto ometa
       = om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
 
     auto offsets_res
@@ -200,6 +207,7 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         auto ometa
           = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(
+                          dummy_dom_id,
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)))
                          .get();
@@ -211,6 +219,7 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         auto ometa
           = om_builder(oid2, 100).add(tid_a, 10_o, 20_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(
+                          dummy_dom_id,
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)))
                          .get();
@@ -221,7 +230,9 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         // Add another object that fully overlaps with what exists.
         auto ometa
           = om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-        auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+        auto add_res = m.add_objects(
+                          dummy_dom_id, om_list_t::single(std::move(ometa)))
+                         .get();
         ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
         ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
     }
@@ -232,7 +243,8 @@ TEST(SimpleMetastoreTest, TestAddPastBeginning) {
     // Add the first object so it doesn't start at 0.
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 1_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
     ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
 }
@@ -246,7 +258,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
       om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto tpr = model::topic_id_partition::from(tid_a);
@@ -274,7 +286,8 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto get_res = m.get_first_ge(
@@ -289,7 +302,8 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetOutOfRange) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto get_res = m.get_first_ge(
@@ -308,7 +322,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
       om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2999_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 3999_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto tpr = model::topic_id_partition::from(tid_a);
@@ -336,7 +350,8 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBelowStart) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto get_res
@@ -349,7 +364,8 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampOutOfRange) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(dummy_dom_id, om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto get_res
@@ -363,13 +379,13 @@ TEST(StateUpdateTest, TestReplaceBasic) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     om_list_t new_os;
     new_os.emplace_back(
       om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
     // Sanity check that replacement leaves us with expected offsets.
@@ -391,13 +407,13 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     om_list_t new_os;
     new_os.emplace_back(
       om_builder(oid3, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
     // Replaced offsets should be served from oid3.
@@ -443,7 +459,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     // For one partition, replace the entire range. For another, replace part
@@ -453,7 +469,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                           .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
                           .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                           .build());
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
     // Replaced offsets should be served from oid3.
@@ -493,12 +509,12 @@ TEST(StateUpdateTest, TestReplaceEmptyRequest) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Add a replacement object that has no objects.
     om_list_t new_os;
-    auto replace_res = m.replace_objects(new_os).get();
+    auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
     ASSERT_FALSE(replace_res.has_value());
     EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
 }
@@ -508,7 +524,7 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
     {
         // Add a replacement object that has no objects.
         om_list_t new_os;
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -517,7 +533,7 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
         om_list_t new_os;
         new_os.emplace_back(
           om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -528,7 +544,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     for (const auto& [base_o, last_o] :
@@ -538,7 +554,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
         new_os.emplace_back(om_builder(oid2, 100)
                               .add(tid_a, base_o, last_o, 2000_t, 0, 99)
                               .build());
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -549,7 +565,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     {
@@ -560,7 +576,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_a, 11_o, 12_o, 2000_t, 0, 99)
                               .build());
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -571,7 +587,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                               .build());
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -588,14 +604,14 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     {
         om_list_t new_os;
         new_os.emplace_back(
           om_builder(oid3, 100).add(tid_a, 0_o, 19_o, 2000_t, 0, 99).build());
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -606,7 +622,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_b, 0_o, 19_o, 2000_t, 0, 99)
                               .build());
-        auto replace_res = m.replace_objects(new_os).get();
+        auto replace_res = m.replace_objects(dummy_dom_id, new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
     }
@@ -617,7 +633,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsMissingPartition) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_b, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Look for a different partition.
@@ -635,7 +651,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsAllDirty) {
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Without having anything compacted, the whole log is dirty.
@@ -653,7 +669,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Simple compaction to clean offsets [3, 5].
@@ -748,7 +764,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res = m.add_objects(dummy_dom_id, os).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Simple compaction to clean offsets [3, 5].


### PR DESCRIPTION
In order to ensure that data is not shared across domain boundaries, writers that use the metastore (e.g. reconciler, compaction, leveler) will need to be domain-aware.

This adds a "domain_id" as a part of the metastore public interface, with a dummy numeric value being used in the simple_metastore. I expect there to be a more complex grouping of topics to domains in the future. I also expect that L1 topic partitions will each manage data for a single domain, and that domain_id will be used to route requests to the appropriate L1 topic partition.

For now though, it's just exposed so that code authors can do someting like (roughly):

```
map<domain_id, object_builder> objects;
for (const auto& tp : topic_partitions) {
    auto domain_id = metastore.get_domain_id(tp);
    objects[domain_id].add(...data from tp...);
}
for (auto& [id, ob] : objects) {
    metastore.add_objects(id, ob.build());
}
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
