### PR TITLE
tiered_storage_model_test: try to fix timeout

### DIFF
--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -259,6 +259,8 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                         return
             except:
                 self.logger.error("Failed to grep logs", exc_info=True)
+            finally:
+                self.logger.info("tail -f on {node.name} stopping")
 
         for n in self.redpanda.nodes:
             node = n
@@ -266,8 +268,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
             self.thread_pool.submit(lambda: tail_minus_f(node))
 
     def tearDown(self):
-        self.stop_flag = True
-        self.thread_pool.shutdown()
+        self.shutdown_bg_tasks("tearDown")
 
     def apply_config_overrides(self):
         """Apply configuration overrides to the redpanda cluster."""
@@ -542,10 +543,12 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.current_stage = stage
         self.run_stage_inputs(stage, test_case)
 
-    def shutdown_bg_tasks(self):
-        self.logger.info(f"Shutting down background tasks")
+    def shutdown_bg_tasks(self, why: str):
+        self.logger.info(f"Shutting down background tasks ({why})")
         self.stop_flag = True
+        self.logger.info(f"Before threadpool shutdown ({why})")
         self.thread_pool.shutdown()
+        self.logger.info(f"After threadpool shutdown ({why})")
 
     # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
     @skip_fips_mode
@@ -568,32 +571,35 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
             test_case_name = json.loads(test_case)["name"]
             test_case = get_test_case_from_name(test_case_name)
             assert test_case is not None, f"no test case found with name {test_case_name}"
-        # Configuration phase
-        self.start_inputs(test_case)
-        self.start_validators(test_case)
-        self.run_bg_validators(test_case)
 
-        # Setup stage
-        self.prepare_stage(TestRunStage.Startup, test_case)
-        self.run_stage_validators(TestRunStage.Startup, test_case)
+        try:
+            # Configuration phase
+            self.start_inputs(test_case)
+            self.start_validators(test_case)
+            self.run_bg_validators(test_case)
 
-        # Producing the data
-        self.prepare_stage(TestRunStage.Produce, test_case)
-        self.produce_until_validated(test_case)
+            # Setup stage
+            self.prepare_stage(TestRunStage.Startup, test_case)
+            self.run_stage_validators(TestRunStage.Startup, test_case)
 
-        # Intermediate step
-        self.prepare_stage(TestRunStage.Intermediate, test_case)
-        self.run_stage_validators(TestRunStage.Intermediate, test_case)
+            # Producing the data
+            self.prepare_stage(TestRunStage.Produce, test_case)
+            self.produce_until_validated(test_case)
 
-        # Consuming the data
-        self.prepare_stage(TestRunStage.Consume, test_case)
-        self.consume_until_validated(test_case)
+            # Intermediate step
+            self.prepare_stage(TestRunStage.Intermediate, test_case)
+            self.run_stage_validators(TestRunStage.Intermediate, test_case)
 
-        # Shutting down
-        self.prepare_stage(TestRunStage.Shutdown, test_case)
-        self.run_stage_validators(TestRunStage.Shutdown, test_case)
+            # Consuming the data
+            self.prepare_stage(TestRunStage.Consume, test_case)
+            self.consume_until_validated(test_case)
 
-        self.shutdown_bg_tasks()
+            # Shutting down
+            self.prepare_stage(TestRunStage.Shutdown, test_case)
+            self.run_stage_validators(TestRunStage.Shutdown, test_case)
+
+        finally:
+            self.shutdown_bg_tasks("test ending")
 
         # Check that all validators are done and raise error if
         # some of them failed.


### PR DESCRIPTION
Test seems to timeout when shutting down background tasks.

One theory is that it's the log `tail -f` task that is hanging: Redpanda has been stopped so will not produce any more logs, so the ssh_capture will never return with a new line and so we never check the stop flag.

Solve this by stopping the background tasks before we shutdown the Redpanda cluster.

CORE-12908

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
