### PR TITLE
[CORE-12307] `rptest`: deflake `compaction_recovery_test`

### DIFF
--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -99,9 +99,13 @@ class CompactionRecoveryTest(RedpandaTest):
             kafka_tools.produce(self.topic, 1024, 1024)
             storage = self.redpanda.storage()
             partitions[:] = storage.partitions("kafka", self.topic)
-            return partitions and all(
+            partitions_finished = list(
                 map(lambda p: len(p.segments) > count and p.recovered(),
                     partitions))
+            self.logger.debug(
+                f"Partition segments: {list(zip(partitions, partitions_finished))}"
+            )
+            return all(partitions_finished)
 
         wait_until(lambda: check_partitions(),
                    timeout_sec=90,

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -52,7 +52,10 @@ class CompactionRecoveryTest(RedpandaTest):
                         cleanup_policy=TopicSpec.CLEANUP_COMPACT), )
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(compacted_log_segment_size=1048576, )
+        extra_rp_conf = dict(
+            compacted_log_segment_size=1048576,
+            max_compacted_log_segment_size=1,
+        )
 
         super(CompactionRecoveryTest,
               self).__init__(test_context=test_context,
@@ -77,7 +80,6 @@ class CompactionRecoveryTest(RedpandaTest):
 
         extra_rp_conf = dict(compacted_log_segment_size=1048576,
                              log_compaction_interval_ms=1000,
-                             max_compacted_log_segment_size=1,
                              compaction_ctrl_min_shares=1000,
                              compaction_ctrl_max_shares=1000)
 


### PR DESCRIPTION
Per the class comment, we want to disable adjacent segment compaction to prevent indices from constantly being rebuilt/concatenated in this test.

However, this value was only being set after a restart, which means the initial `wait_until()` dependent on the production of `segment`s could flake if `segment`s were constantly being adjacently merged together (reducing the `segment` count below what is being awaited).

Set this value from the start of the test to disable adjacent segment merging for its entirety.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
