### PR TITLE
[CORE-10282] `rptest`: bump timeout for flakey test with `ABS`

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -276,9 +276,13 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
             # the target segments limit is one higher than expected because
             # retention policy won't violate the target max size. that is: it
             # won't reclaim the last segment if it puts it over the edge.
+            timeout_sec = 15
+            # TODO: Remove temporary value to get around general slowness with Azurite.
+            if cloud_storage_type == CloudStorageType.ABS:
+                timeout_sec = 120
             wait_until(lambda: self.segments_removed(
                 self.default_retention_segments + 1),
-                       timeout_sec=15,
+                       timeout_sec=timeout_sec,
                        backoff_sec=1,
                        err_msg=f"Segments were not removed")
         else:
@@ -319,8 +323,12 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
         # the target segments limit is one higher than expected because
         # retention policy won't violate the target max size. that is: it
         # won't reclaim the last segment if it puts it over the edge.
+        timeout_sec = 15
+        # TODO: Remove temporary value to get around general slowness with Azurite.
+        if cloud_storage_type == CloudStorageType.ABS:
+            timeout_sec = 120
         wait_until(lambda: self.segments_removed(self.retention_segments + 1),
-                   timeout_sec=15,
+                   timeout_sec=timeout_sec,
                    backoff_sec=1,
                    err_msg=f"Segments were not removed")
 


### PR DESCRIPTION
Azurite has known general performance problems in CI, with uploads being _much_ slower than seen in S3/MinIO tests.

These two tests, and specifically these `wait_until()` calls consistently flake in CI due to these performance issues. Bump their timeout (only for ABS) to hopefully temporarily cool CI redness while other solutions are investigated for fixing our infrastructure for ABS tests.

Addresses: [CORE-10282](https://redpandadata.atlassian.net/browse/CORE-10282)

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-10282]: https://redpandadata.atlassian.net/browse/CORE-10282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ