### PR TITLE
task_manager_integration_test: mark as flaky

### DIFF
--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -72,6 +72,7 @@ redpanda_cc_gtest(
     srcs = [
         "task_manager_integration_test.cc",
     ],
+    flaky = True,
     deps = [
         ":test_deps",
         "//src/v/cluster_link:impl",


### PR DESCRIPTION
Mark as flaky in bazel to allow it to be retried 3x.

CORE-12894

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
