### PR TITLE
dt/util: Introduce wait_until_with_progress_check

### DIFF
--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -12,6 +12,7 @@ import pprint
 import threading
 from contextlib import contextmanager
 from typing import Callable, Optional, Any, ContextManager
+from logging import Logger
 
 from ducktape.utils.util import wait_until
 from requests.exceptions import HTTPError
@@ -20,6 +21,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.storage import Segment
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.errors import TimeoutError
 
 
 class Scale:
@@ -123,6 +125,61 @@ def wait_until_result(condition: Callable[[], Any], *args: Any,
 
     wait_until(wrapped_condition, *args, **kwargs)
     return res
+
+
+def wait_until_with_progress_check(check: Callable[[], Any],
+                                   condition: Callable[[Callable[[], Any]],
+                                                       Any],
+                                   timeout_sec: int,
+                                   progress_sec: int,
+                                   backoff_sec: int,
+                                   err_msg: str | None = None,
+                                   logger: Logger | None = None):
+    """
+    a wrapper around ducktape's wait_until that provides the ability to track
+    a crude approximation of progress
+
+    usage requires two timeouts:
+      - timeout_sec: the overall timeout, after which the function will throw a
+        TimeoutError no matter what
+      - progress_sec: an incremental timeout, after each expiry we check that the
+        value returned by a 'check' function has changed with respect to a cached
+        result. if not, immediately throw TimeoutError
+
+    params:
+      - check: the value we expect to change after each 'progress_sec'
+      - condition: the condition we are waiting for. should be written in terms
+        of the check function, e.g.
+        check:
+           def get_val():
+               return admin.stuff()['val']
+        condition:
+           def condition(check: Callable):
+               return check() > 10
+           # used like
+           condition(get_val)
+      - timeout_sec (see above)
+      - progress_sec (see above)
+      - err_msg: Passed down to wait_until
+      - logger: log progress after each progress_sec iteration
+    """
+    val = check()
+    while timeout_sec > 0:
+        try:
+            wait_until(lambda: condition(check),
+                       timeout_sec=progress_sec,
+                       backoff_sec=backoff_sec,
+                       err_msg=err_msg)
+        except TimeoutError as e:
+            next_v = check()
+            if next_v == val:
+                raise TimeoutError(f"Stopped making progress: {str(e)}")
+            if logger is not None:
+                logger.debug(f"Progress: prev: {val} curr: {next_v}...")
+            val = next_v
+            timeout_sec = timeout_sec - progress_sec
+        else:
+            break
 
 
 def segments_count(redpanda, topic, partition_idx):


### PR DESCRIPTION
a wrapper around ducktape's wait_until that provides the ability to track a crude approximation of progress

usage requires two timeouts:
  - timeout_sec: the overall timeout, after which the function will throw a TimeoutError no matter what
  - progress_sec: an incremental timeout, after each expiry we check that the value returned by a 'check' function has changed with respect to a cached result. if not, immediately throw TimeoutError

params:
  - check: the value we expect to change after each 'progress_sec'
  - condition: the condition we are waiting for. should be written in terms of the check function, e.g. check: def get_val(): return admin.stuff()['val'] condition: def condition(check: Callable): return check() > 10 # used like condition(get_val)
  - timeout_sec (see above)
  - progress_sec (see above)
  - err_msg: Passed down to wait_until
  - logger: log progress after each progress_sec iteration

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
* 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
