### PR TITLE
cluster_link/replication: introduce partition_replicator & link_replication_mgr

### DIFF
--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -1,0 +1,16 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+redpanda_cc_library(
+    name = "deps",
+    hdrs = [
+        "deps.h",
+    ],
+    include_prefix = "cluster_link/replication",
+    visibility = ["__subpackages__"],
+    deps = [
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/raft",
+    ],
+)

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -14,3 +14,28 @@ redpanda_cc_library(
         "//src/v/raft",
     ],
 )
+
+redpanda_cc_library(
+    name = "partition_replicator",
+    srcs = [
+        "partition_replicator.cc",
+    ],
+    hdrs = [
+        "partition_replicator.h",
+    ],
+    include_prefix = "cluster_link/replication",
+    visibility = ["__subpackages__"],
+    deps = [
+        ":deps",
+        "//src/v/cluster_link:logger",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/ssx:future_util",
+        "//src/v/ssx:semaphore",
+        "//src/v/utils:backoff_policy",
+        "//src/v/utils:named_type",
+        "//src/v/utils:notification_list",
+        "//src/v/utils:prefix_logger",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/replication/BUILD
+++ b/src/v/cluster_link/replication/BUILD
@@ -39,3 +39,26 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "link_replication_mgr",
+    srcs = [
+        "link_replication_mgr.cc",
+    ],
+    hdrs = [
+        "link_replication_mgr.h",
+    ],
+    include_prefix = "cluster_link/replication",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":deps",
+        ":partition_replicator",
+        "//src/v/base",
+        "//src/v/cluster_link:logger",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "//src/v/ssx:work_queue",
+        "//src/v/utils:to_string",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/replication/deps.h
+++ b/src/v/cluster_link/replication/deps.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "container/chunked_vector.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "raft/replicate.h"
+#include "ssx/semaphore.h"
+
+namespace cluster_link::replication {
+
+/**
+ * Interface to which the data from source is replicated to.
+ */
+class data_sink {
+public:
+    virtual ~data_sink() = default;
+
+    virtual ss::future<> start() = 0;
+    virtual ss::future<> stop() noexcept = 0;
+
+    virtual kafka::offset last_replicated_offset() const = 0;
+
+    virtual raft::replicate_stages replicate(
+      chunked_vector<model::record_batch> batches,
+      model::timeout_clock::duration timeout,
+      ss::abort_source& as)
+      = 0;
+
+    // Notifies the sink of any terminal failure that can
+    // result in replicator not being able to start/progress.
+    virtual void notify_replicator_failure(model::term_id) = 0;
+};
+
+class data_sink_factory {
+public:
+    virtual ~data_sink_factory() = default;
+    virtual std::unique_ptr<data_sink> make_sink(const model::ntp&) = 0;
+};
+
+/**
+ * Interface to fetch the data from.
+ */
+class data_source {
+public:
+    virtual ~data_source() = default;
+
+    virtual ss::future<> start() = 0;
+    virtual ss::future<> stop() noexcept = 0;
+
+    /**
+     * Reset the data source to its initial state.
+     * fetching from the given offset.
+     */
+    virtual ss::future<> reset(kafka::offset) = 0;
+
+    struct data {
+        chunked_vector<model::record_batch> batches;
+        ssx::semaphore_units units;
+    };
+
+    /**
+     * Fetches some data, if any.
+     */
+    virtual ss::future<data> fetch_next(ss::abort_source&) = 0;
+};
+
+class data_source_factory {
+public:
+    virtual ~data_source_factory() = default;
+    virtual std::unique_ptr<data_source> make_source(const model::ntp&) = 0;
+};
+
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/link_replication_mgr.cc
+++ b/src/v/cluster_link/replication/link_replication_mgr.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster_link/replication/link_replication_mgr.h"
+
+#include "base/units.h"
+#include "cluster_link/logger.h"
+#include "utils/to_string.h"
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::replication {
+
+link_replication_manager::link_replication_manager(
+  ss::scheduling_group sg,
+  std::unique_ptr<data_source_factory> source_factory,
+  std::unique_ptr<data_sink_factory> sink_factory)
+  : _sg(sg)
+  , _source_factory(std::move(source_factory))
+  , _sink_factory(std::move(sink_factory))
+  , _queue(_sg, [](const std::exception_ptr& ex) {
+      vlog(cllog.error, "unexpected error in processing notifications: {}", ex);
+  }) {}
+
+ss::future<> link_replication_manager::start() { return ss::now(); }
+
+ss::future<> link_replication_manager::stop() {
+    vlog(cllog.trace, "Stopping link replication manager");
+    // to avoid further submissions to the queue.
+    auto f = _gate.close();
+    co_await _queue.shutdown();
+    co_await std::move(f);
+    // stop any pending replicators
+    for (auto& [_, replicator] : _replicators) {
+        co_await replicator->stop();
+    }
+    _replicators.clear();
+    vlog(cllog.trace, "Link replication manager stopped");
+}
+
+ss::future<> link_replication_manager::do_start_replicator(
+  model::ntp ntp, model::term_id term) {
+    auto holder = _gate.hold();
+    vlog(cllog.debug, "Starting replicator for {}", ntp);
+    auto it = _replicators.find(ntp);
+    vassert(
+      it == _replicators.end(),
+      "Replicator for {} already exists, an instance should be stopped before "
+      "starting a new one",
+      ntp);
+    auto source = _source_factory->make_source(ntp);
+    auto sink = _sink_factory->make_sink(ntp);
+    auto replicator = std::make_unique<partition_replicator>(
+      ntp, term, std::move(source), std::move(sink));
+    auto [r_it, _] = _replicators.emplace(ntp, std::move(replicator));
+    co_await r_it->second->start();
+}
+
+void link_replication_manager::start_replicator(
+  model::ntp ntp, model::term_id term) {
+    if (_gate.is_closed()) {
+        return;
+    }
+    _queue.submit([this, term, ntp = std::move(ntp)]() mutable {
+        return do_start_replicator(ntp, term).handle_exception(
+          [this, term, ntp = std::move(ntp)](
+            const std::exception_ptr& e) mutable {
+              vlog(
+                cllog.error,
+                "Failed to start replicator for {} at term {}: {},",
+                ntp,
+                term,
+                e);
+              auto it = _replicators.find(ntp);
+              if (it != _replicators.end() && !_gate.is_closed()) {
+                  it->second->notify_sink_on_failure(term);
+              }
+          });
+    });
+}
+
+ss::future<> link_replication_manager::do_stop_replicator(
+  model::ntp ntp, std::optional<model::term_id> term) {
+    auto holder = _gate.hold();
+    vlog(cllog.debug, "Stopping replicator for {}", ntp);
+    auto it = _replicators.find(ntp);
+    if (it == _replicators.end() || (term && (*term < it->second->term()))) {
+        vlog(
+          cllog.warn,
+          "No replicator found for {} at term {}, skipping stop",
+          ntp,
+          term);
+        co_return;
+    }
+    auto replicator = std::move(it->second);
+    _replicators.erase(it);
+    co_await replicator->stop();
+}
+
+void link_replication_manager::stop_replicator(
+  model::ntp ntp, std::optional<model::term_id> term) {
+    if (_gate.is_closed()) {
+        return;
+    }
+    _queue.submit([this, ntp = std::move(ntp), term]() mutable {
+        return do_stop_replicator(ntp, term).handle_exception(
+          [ntp = std::move(ntp), term](const std::exception_ptr& e) mutable {
+              vlog(
+                cllog.error,
+                "Failed to stop replicator for {} at term {}: {},",
+                ntp,
+                term,
+                e);
+          });
+    });
+}
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/link_replication_mgr.h
+++ b/src/v/cluster_link/replication/link_replication_mgr.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster_link/replication/partition_replicator.h"
+#include "container/chunked_hash_map.h"
+#include "ssx/work_queue.h"
+
+namespace cluster_link::replication {
+
+/**
+ * Link replication manager is responsible for managing the lifecycle of
+ * partition replicators for a given cluster link. One instance per cluster link
+ * and shard.
+ */
+class link_replication_manager {
+public:
+    explicit link_replication_manager(
+      ss::scheduling_group,
+      std::unique_ptr<data_source_factory> source_factory,
+      std::unique_ptr<data_sink_factory> sink_factory);
+
+    ss::future<> start();
+
+    ss::future<> stop();
+
+    void start_replicator(model::ntp, model::term_id);
+    // term is optional because a replica being unmanaged out of the shard
+    // can no longer has a term that we can access.
+    void stop_replicator(model::ntp, std::optional<model::term_id>);
+
+private:
+    ss::future<> do_start_replicator(model::ntp, model::term_id);
+    ss::future<> do_stop_replicator(model::ntp, std::optional<model::term_id>);
+    ss::scheduling_group _sg;
+    std::unique_ptr<data_source_factory> _source_factory;
+    std::unique_ptr<data_sink_factory> _sink_factory;
+    ssx::work_queue _queue;
+    chunked_hash_map<model::ntp, std::unique_ptr<partition_replicator>>
+      _replicators;
+    ss::gate _gate;
+};
+
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster_link/replication/partition_replicator.h"
+
+#include "cluster_link/logger.h"
+#include "ssx/future-util.h"
+
+namespace cluster_link::replication {
+
+static constexpr std::chrono::seconds base_backoff{1};
+static constexpr std::chrono::seconds max_backoff{10};
+
+partition_replicator::partition_replicator(
+  const model::ntp& ntp,
+  model::term_id term,
+  std::unique_ptr<data_source> source,
+  std::unique_ptr<data_sink> sink)
+  : _term(term)
+  , _log(cllog, fmt::format("[{}-term-{}] replicator", ntp, term))
+  , _source(std::move(source))
+  , _sink(std::move(sink))
+  , _backoff_policy(make_exponential_backoff_policy<ss::lowres_clock>(
+      base_backoff, max_backoff)) {}
+
+ss::future<> partition_replicator::start() {
+    vlog(_log.trace, "Starting replicator");
+    co_await _source->start();
+    co_await _sink->start();
+    ssx::repeat_until_gate_closed(_gate, [this] {
+        return fetch_and_replicate().handle_exception(
+          [this](const std::exception_ptr& e) {
+              auto log_level = ssx::is_shutdown_exception(e)
+                                 ? ss::log_level::trace
+                                 : ss::log_level::warn;
+              _log.log(log_level, "Error in partition replicator: {}", e);
+          });
+    });
+}
+
+ss::future<> partition_replicator::stop() {
+    vlog(_log.trace, "Stopping replicator");
+    _as.request_abort();
+    auto f = _gate.close();
+    co_await _source->stop();
+    co_await _sink->stop();
+    co_await std::move(f);
+    vlog(_log.trace, "Stopped replicator");
+}
+
+void partition_replicator::notify_sink_on_failure(model::term_id term) const {
+    _sink->notify_replicator_failure(term);
+}
+
+ss::future<bool> partition_replicator::handle_replication_result(
+  ss::future<result<raft::replicate_result>> f,
+  model::offset begin,
+  model::offset end) noexcept {
+    try {
+        auto result = co_await std::move(f);
+        if (result.has_error()) {
+            vlog(
+              _log.warn,
+              "Replication of batches in range [{} - {}] failed with error: {}",
+              begin,
+              end,
+              result.error());
+            co_return false;
+        }
+        vlog(
+          _log.trace,
+          "Replicated batches in range [{} - {}] with at offset: {}",
+          begin,
+          end,
+          result.value().last_offset);
+        // A successful end to end replication indicates everything worked from
+        // source to sink
+        // We only intend to backoff on consecutive failures.
+        _backoff_policy.reset();
+        co_return true;
+    } catch (...) {
+        vlog(
+          _log.error,
+          "Exception during replication: {}",
+          std::current_exception());
+    }
+    co_return false;
+}
+
+ss::future<> partition_replicator::replicate_and_wait(
+  replicate_ctx ctx, ss::gate& gate, ss::abort_source& as) {
+    auto stages = _sink->replicate(
+      std::move(ctx.batches), model::max_duration, as);
+    co_await std::move(stages.request_enqueued);
+    ssx::spawn_with_gate(
+      gate,
+      [this,
+       f = std::move(stages.replicate_finished),
+       begin = ctx.begin,
+       end = ctx.end,
+       inflight = std::move(ctx.inflight_units),
+       data = std::move(ctx.data_units),
+       &as]() mutable {
+          return handle_replication_result(std::move(f), begin, end)
+            .then([&as](bool success) {
+                if (!success) {
+                    as.request_abort();
+                }
+            })
+            .finally(
+              [inflight = std::move(inflight), data = std::move(data)]() {});
+      });
+}
+
+ss::future<> partition_replicator::fetch_and_replicate() {
+    _gate.check();
+    // abort source for this iteration of fetch_and_replicate
+    ss::abort_source as;
+    auto subscription = _as.subscribe([&as] noexcept { as.request_abort(); });
+    co_await _source->reset(
+      kafka::next_offset(_sink->last_replicated_offset()));
+    ss::gate gate;
+    try {
+        while (!_gate.is_closed() && !as.abort_requested()) {
+            auto inflight_units = co_await ss::get_units(_max_requests, 1, as);
+            auto data = co_await _source->fetch_next(as);
+            if (data.batches.empty()) {
+                continue;
+            }
+            co_await replicate_and_wait(
+              {.begin = data.batches.front().base_offset(),
+               .end = data.batches.back().last_offset(),
+               .batches = std::move(data.batches),
+               .inflight_units = std::move(inflight_units),
+               .data_units = std::move(data.units)},
+              gate,
+              as);
+        }
+    } catch (const ss::sleep_aborted&) {
+        // ignore, sleep from fetch was aborted.
+    } catch (...) {
+        vlog(
+          _log.error,
+          "Error in fetch_and_replicate: {}",
+          std::current_exception());
+        as.request_abort();
+    }
+    co_await gate.close();
+    if (!_gate.is_closed() && !_as.abort_requested()) {
+        auto sleep_for = _backoff_policy.current_backoff_duration();
+        vlog(
+          _log.trace,
+          "Backing off for {}ms",
+          sleep_for / std::chrono::milliseconds{1});
+        co_await ss::sleep_abortable(sleep_for, _as);
+        _backoff_policy.next_backoff();
+    }
+}
+
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cluster_link/replication/deps.h"
+#include "ssx/semaphore.h"
+#include "utils/prefix_logger.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
+
+#include <utils/backoff_policy.h>
+
+namespace cluster_link::replication {
+
+/**
+ * A partition replicator is responsible for replicating data from a remote
+ * partition to the corresponding local partition. Each partition replicator
+ * instance manages replication for a single local partition leader on the
+ * current shard.
+ *
+ * Architecture:
+ *
+ *   +------------+                    +-------------+
+ *   |data_source |                    | data_sink   |
+ *   +------------+                    +-------------+
+ *        |                                   ^
+ *        | fetch_batches()                   | replicate()
+ *        v                                   |
+ *   +-----------------------------------------+
+ *   |        partition_replicator             |
+ *   |    fetch_and_replicate() loop           |
+ *   +-----------------------------------------+
+ *
+ * Operation:
+ * 1. The fetch_and_replicate() method executes a continuous loop that fetches
+ *    data from the data_source and replicates it to the data_sink
+ * 2. A semaphore (_max_requests) controls the maximum number of concurrent
+ *    replicate requests to enable request pipelining
+ * 3. The wait_for_replication_result() method manages replication completion
+ *    and error handling
+ * 4. Requests are enqueued synchronously while replication results are
+ *    processed asynchronously
+ * 5. Any replication failure causes the fetch loop to abort and triggers
+ *    a reset of the data_source
+ */
+
+class partition_replicator {
+public:
+    explicit partition_replicator(
+      const model::ntp& ntp,
+      model::term_id,
+      std::unique_ptr<data_source> source,
+      std::unique_ptr<data_sink> sink);
+    ss::future<> start();
+    ss::future<> stop();
+
+    model::term_id term() const { return _term; }
+
+    void notify_sink_on_failure(model::term_id) const;
+
+private:
+    struct replicate_ctx {
+        model::offset begin;
+        model::offset end;
+        chunked_vector<model::record_batch> batches;
+        ssx::semaphore_units inflight_units;
+        ssx::semaphore_units data_units;
+    };
+    ss::future<> fetch_and_replicate();
+    ss::future<>
+    replicate_and_wait(replicate_ctx, ss::gate&, ss::abort_source&);
+    // Returns true if replication was successful, false if it failed
+    ss::future<bool> handle_replication_result(
+      ss::future<result<raft::replicate_result>>,
+      model::offset begin,
+      model::offset end) noexcept;
+    model::term_id _term;
+    prefix_logger _log;
+    ss::gate _gate;
+    ss::abort_source _as;
+    std::unique_ptr<data_source> _source;
+    std::unique_ptr<data_sink> _sink;
+    // to pipeline multiple replicate requests in parallel
+    static constexpr ssize_t max_in_flight_requests = 5;
+    ssx::semaphore _max_requests{
+      max_in_flight_requests, "partition_replicator"};
+    backoff_policy _backoff_policy;
+};
+
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/tests/BUILD
+++ b/src/v/cluster_link/replication/tests/BUILD
@@ -18,3 +18,20 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "link_replication_mgr_test",
+    timeout = "short",
+    srcs = [
+        "link_replication_mgr_tests.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster_link/replication:link_replication_mgr",
+        "//src/v/model/tests:random",
+        "//src/v/random:generators",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/replication/tests/BUILD
+++ b/src/v/cluster_link/replication/tests/BUILD
@@ -1,0 +1,20 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "partition_replicator_test",
+    timeout = "short",
+    srcs = [
+        "partition_replicator_tests.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster_link/replication:partition_replicator",
+        "//src/v/model/tests:random",
+        "//src/v/random:generators",
+        "//src/v/ssx:future_util",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random",
+        "//src/v/utils:mutex",
+        "@seastar",
+    ],
+)

--- a/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
+++ b/src/v/cluster_link/replication/tests/link_replication_mgr_tests.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cluster_link/replication/link_replication_mgr.h"
+#include "model/tests/random_batch.h"
+#include "random/generators.h"
+#include "test_utils/randoms.h"
+#include "test_utils/test.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+std::chrono::milliseconds sleep_for() {
+    return std::chrono::milliseconds{random_generators::get_int(5, 15)};
+}
+} // namespace
+
+namespace cluster_link::replication {
+
+class test_data_source : public data_source {
+public:
+    ss::future<> reset(kafka::offset) override { return ss::now(); }
+    ss::future<> start() override {
+        if (tests::random_bool()) {
+            return ss::make_exception_future<>(
+              std::runtime_error("Simulated start failure"));
+        }
+        return ss::make_ready_future<>();
+    }
+    ss::future<> stop() noexcept override { return _gate.close(); }
+    ss::future<data_source::data> fetch_next(ss::abort_source& as) override {
+        auto holder = _gate.hold();
+        co_await ss::sleep_abortable(sleep_for(), as);
+        auto batch = model::test::make_random_batch(
+          model::offset{0}, 5, true, model::record_batch_type::raft_data);
+        chunked_vector<model::record_batch> batches;
+        batches.push_back(std::move(batch));
+        co_return data_source::data{std::move(batches), ssx::semaphore_units{}};
+    }
+
+private:
+    ss::gate _gate;
+};
+
+class test_data_sink : public data_sink {
+public:
+    ss::future<> start() override { return ss::make_ready_future<>(); }
+    ss::future<> stop() noexcept override { return _gate.close(); }
+
+    kafka::offset last_replicated_offset() const final {
+        return kafka::offset{0};
+    }
+
+    raft::replicate_stages replicate(
+      chunked_vector<model::record_batch>,
+      model::timeout_clock::duration,
+      ss::abort_source&) override {
+        auto holder = _gate.hold();
+        if (tests::random_bool()) {
+            if (tests::random_bool()) {
+                return {
+                  ss::now(),
+                  ssx::now<result<raft::replicate_result>>(
+                    raft::errc::not_leader)};
+            }
+            throw std::runtime_error("Simulated replication failure");
+        }
+        auto result_f = ss::sleep(sleep_for()).then([] {
+            return ssx::now(
+              result<raft::replicate_result>(raft::replicate_result{}));
+        });
+        return {ss::sleep(sleep_for()), std::move(result_f)};
+    };
+
+    void notify_replicator_failure(model::term_id) final {}
+
+private:
+    ss::gate _gate;
+};
+
+class test_data_source_factory : public data_source_factory {
+    std::unique_ptr<data_source> make_source(const model::ntp&) override {
+        return std::make_unique<test_data_source>();
+    }
+};
+
+class test_data_sink_factory : public data_sink_factory {
+    std::unique_ptr<data_sink> make_sink(const model::ntp&) override {
+        return std::make_unique<test_data_sink>();
+    }
+};
+
+class LinkReplicationMgrFixture : public seastar_test {
+    ss::future<> SetUpAsync() override {
+        _mgr = std::make_unique<link_replication_manager>(
+          ss::default_scheduling_group(),
+          std::make_unique<test_data_source_factory>(),
+          std::make_unique<test_data_sink_factory>());
+        co_await _mgr->start();
+    }
+
+    ss::future<> TearDownAsync() override {
+        if (_mgr) {
+            co_await _mgr->stop();
+        }
+    }
+
+protected:
+    std::unique_ptr<link_replication_manager> _mgr;
+};
+
+TEST_F_CORO(LinkReplicationMgrFixture, TestFuzzStartStop) {
+    struct ntp_term {
+        model::ntp ntp;
+        model::term_id term;
+    };
+    std::vector<ntp_term> added;
+    int64_t term = 0;
+    int32_t partition_id = 0;
+    auto add_one = [this, &added, &term, &partition_id]() {
+        auto ntp = model::ntp(
+          "kafka", "test", model::partition_id(partition_id++));
+        auto term_id = model::term_id(term++);
+        _mgr->start_replicator(ntp, term_id);
+        added.push_back({std::move(ntp), term_id});
+        return ss::sleep(sleep_for());
+    };
+
+    auto remove_one = [this, &added]() {
+        if (added.empty()) {
+            return ss::sleep(sleep_for());
+        }
+        auto idx = random_generators::get_int<size_t>(added.size() - 1);
+        auto to_remove = added[idx];
+        added.erase(added.begin() + idx);
+        _mgr->stop_replicator(std::move(to_remove.ntp), to_remove.term);
+        return ss::sleep(sleep_for());
+    };
+
+    auto end_time = ss::lowres_clock::now() + 10s;
+    auto add_f = ss::do_until(
+      [&] { return end_time < ss::lowres_clock::now(); },
+      [&]() { return add_one(); });
+    auto remove_f = ss::do_until(
+      [&] { return end_time < ss::lowres_clock::now(); },
+      [&]() { return remove_one(); });
+
+    co_await ss::when_all_succeed(std::move(add_f), std::move(remove_f));
+}
+
+} // namespace cluster_link::replication

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "base/units.h"
+#include "cluster_link/replication/partition_replicator.h"
+#include "model/tests/random_batch.h"
+#include "ssx/future-util.h"
+#include "test_utils/async.h"
+#include "test_utils/randoms.h"
+#include "test_utils/test.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/sleep.hh>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::replication {
+
+class test_data_source : public data_source {
+public:
+    ss::future<> start() final { return ss::now(); }
+    ss::future<> stop() noexcept final {
+        _max_memory.broken();
+        return _gate.close();
+    }
+    ss::future<> reset(kafka::offset start_offset) final {
+        _start_offset = start_offset;
+        _next_to_consume = start_offset;
+        _num_resets++;
+        _data = {};
+        return ss::now();
+    }
+
+    int num_resets() const { return _num_resets; }
+    int num_fetches() const { return _num_fetches; }
+
+    ss::future<data_source::data> fetch_next(ss::abort_source& as) final {
+        _num_fetches++;
+        auto holder = _gate.hold();
+        while (_data.batches.empty()) {
+            co_await ss::sleep_abortable(10ms, as);
+        }
+        co_return std::exchange(_data, {});
+    }
+
+    ss::future<> push_data() {
+        // until atleast 1 unit is available
+        co_await _max_memory.wait();
+        _max_memory.signal();
+        auto offset = kafka::offset_cast(_next_to_consume);
+        auto batch = model::test::make_random_batch(
+          offset, 10, true, model::record_batch_type::raft_data);
+        auto size = static_cast<size_t>(batch.size_bytes());
+        auto units = co_await ss::get_units(
+          _max_memory, std::min(size, _max_memory.current()));
+        _next_to_consume = kafka::next_offset(
+          model::offset_cast(batch.last_offset()));
+        _data.batches.push_back(std::move(batch));
+        if (_data.units.count()) {
+            _data.units.adopt(std::move(units));
+        } else {
+            _data.units = std::move(units);
+        }
+    }
+
+    size_t available_memory() const { return _max_memory.current(); }
+
+private:
+    std::optional<kafka::offset> _start_offset{};
+    kafka::offset _next_to_consume;
+    int _num_fetches = 0;
+    int _num_resets = 0;
+    data _data;
+    ss::gate _gate;
+    ssx::semaphore _max_memory{5_MiB, "test_data_source"};
+};
+
+class test_data_sink : public data_sink {
+public:
+    ss::future<> start() final { return ss::now(); }
+    ss::future<> stop() noexcept final { return ss::now(); }
+    kafka::offset last_replicated_offset() const final {
+        return _last_replicated_offset;
+    }
+
+    ss::future<result<raft::replicate_result>>
+    replicate_success(kafka::offset offset) {
+        co_await ss::sleep(1ms);
+        raft::replicate_result result;
+        result.last_offset = kafka::offset_cast(offset);
+        result.last_term = model::term_id(0);
+        _last_replicated_offset = offset;
+        co_return result;
+    }
+
+    raft::replicate_stages replicate(
+      chunked_vector<model::record_batch> batches,
+      model::timeout_clock::duration,
+      ss::abort_source&) final {
+        if (_fail_replication) {
+            if (tests::random_bool()) {
+                throw std::runtime_error("Simulated replication failure");
+            }
+            result<raft::replicate_result> err{raft::errc::not_leader};
+            return raft::replicate_stages{ss::now(), ssx::now(err)};
+        }
+        return raft::replicate_stages{
+          _replication_mu.get_units().discard_result(),
+          replicate_success(model::offset_cast(batches.back().last_offset()))};
+    }
+
+    void notify_replicator_failure(model::term_id) final {}
+
+    ss::future<mutex::units> block_replication() {
+        co_return co_await _replication_mu.get_units();
+    }
+
+    void set_fail_replication(bool value) { _fail_replication = value; }
+
+private:
+    model::ntp _ntp{"kafka", "test", model::partition_id(0)};
+    mutex _replication_mu{"test_replication"};
+    bool _fail_replication = false;
+    kafka::offset _last_replicated_offset;
+};
+
+class PartitionReplicatorFixture : public seastar_test {
+public:
+    ss::future<> SetUpAsync() override {
+        auto source = std::make_unique<test_data_source>();
+        auto sink = std::make_unique<test_data_sink>();
+        _source = source.get();
+        _sink = sink.get();
+        _replicator = std::make_unique<partition_replicator>(
+          _ntp, model::term_id(0), std::move(source), std::move(sink));
+        return _replicator->start();
+    }
+
+    ss::future<> TearDownAsync() override {
+        if (_replicator) {
+            co_await _replicator->stop();
+        }
+    }
+
+    ss::future<> push_data() { co_await _source->push_data(); }
+
+protected:
+    test_data_source* _source;
+    test_data_sink* _sink;
+    std::unique_ptr<partition_replicator> _replicator;
+    model::ntp _ntp{"kafka", "test", 0};
+};
+
+TEST_F_CORO(PartitionReplicatorFixture, TestHappyPath) {
+    // push some data into the source and wait for it be replicated
+    for (int i = 0; i < 10; ++i) {
+        co_await push_data();
+    }
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->last_replicated_offset() == kafka::offset(99); });
+}
+
+TEST_F_CORO(PartitionReplicatorFixture, TestResetOnFailure) {
+    for (int i = 0; i < 10; ++i) {
+        co_await push_data();
+    }
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      5s, [&] { return _sink->last_replicated_offset() == kafka::offset(99); });
+
+    // initial reset
+    ASSERT_EQ_CORO(_source->num_resets(), 1);
+
+    // now fail the replication
+    _sink->set_fail_replication(true);
+    co_await push_data();
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [&] {
+        return _sink->last_replicated_offset() == kafka::offset(99)
+               && _source->num_resets() == 2;
+    });
+
+    _sink->set_fail_replication(false);
+    co_await push_data();
+    // ensure replication is unblocked
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [&] {
+        return _sink->last_replicated_offset() == kafka::offset(109)
+               && _source->num_resets() == 2;
+    });
+}
+
+TEST_F_CORO(PartitionReplicatorFixture, TestMemoryExhaustion) {
+    auto units = co_await _sink->block_replication();
+    while (_source->available_memory() > 0) {
+        co_await push_data();
+    }
+    // fetches should be blocked at this point
+    auto num_fetches = _source->num_fetches();
+    ASSERT_THROW_CORO(
+      co_await tests::cooperative_spin_wait_with_timeout(
+        3s, [&] { return _source->num_fetches() > num_fetches; }),
+      ss::timed_out_error);
+
+    // unblock replication and wait for memory to be freed up.
+    units.return_all();
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      3s, [&] { return _source->available_memory() == 5_MiB; });
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      3s, [&] { return _source->num_fetches() > num_fetches; });
+}
+
+} // namespace cluster_link::replication

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -74,7 +74,8 @@ raft::replicate_stages write_at_offset_stm::replicate(
   model::record_batch batch,
   kafka::offset expected_base_offset,
   std::optional<kafka::offset> prev_log_offset,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration timeout,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
     ss::promise<> enqueued_promise;
     auto f = enqueued_promise.get_future();
     return raft::replicate_stages{
@@ -84,6 +85,7 @@ raft::replicate_stages write_at_offset_stm::replicate(
         expected_base_offset,
         prev_log_offset,
         timeout,
+        std::move(as),
         std::move(enqueued_promise))};
 }
 
@@ -92,6 +94,7 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
   kafka::offset expected_base_offset,
   std::optional<kafka::offset> prev_log_offset,
   model::timeout_clock::duration timeout,
+  std::optional<std::reference_wrapper<ss::abort_source>> as,
   ss::promise<> enqueued_promise) {
     // offset translated batches are not supported by write at offset state
     // machine
@@ -175,7 +178,8 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
      * Thanks to that assumption we can simply reset all inflight state instead
      * of reverting to the previous last offset.
      */
-    auto stages = try_replicate_in_stages(std::move(batches));
+    auto stages = try_replicate_in_stages(
+      std::move(batches), timeout, std::move(as));
 
     auto enq = std::move(stages.request_enqueued).finally([u = std::move(u)] {
     });
@@ -236,12 +240,17 @@ kafka::offset write_at_offset_stm::expected_last_offset() const {
 }
 
 raft::replicate_stages write_at_offset_stm::try_replicate_in_stages(
-  chunked_vector<model::record_batch> batches) {
+  chunked_vector<model::record_batch> batches,
+  model::timeout_clock::duration timeout,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
     try {
         return _raft->replicate_in_stages(
           _insync_term,
           std::move(batches),
-          raft::replicate_options(raft::consistency_level::quorum_ack));
+          raft::replicate_options(
+            raft::consistency_level::quorum_ack,
+            std::chrono::duration_cast<std::chrono::milliseconds>(timeout),
+            std::move(as)));
     } catch (...) {
         vlog(
           _log.warn,

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -99,7 +99,9 @@ public:
       model::record_batch,
       kafka::offset expected_base_offset,
       std::optional<kafka::offset> prev_log_offset,
-      model::timeout_clock::duration timeout);
+      model::timeout_clock::duration timeout,
+      std::optional<std::reference_wrapper<ss::abort_source>> as
+      = std::nullopt);
 
     ss::future<iobuf> take_raft_snapshot(model::offset) final;
     ss::future<> apply_raft_snapshot(const iobuf&) final;
@@ -135,10 +137,13 @@ private:
       kafka::offset expected_base_offset,
       std::optional<kafka::offset> prev_log_offset,
       model::timeout_clock::duration timeout,
+      std::optional<std::reference_wrapper<ss::abort_source>> as,
       ss::promise<> enqueued_promise);
 
-    raft::replicate_stages
-      try_replicate_in_stages(chunked_vector<model::record_batch>);
+    raft::replicate_stages try_replicate_in_stages(
+      chunked_vector<model::record_batch>,
+      model::timeout_clock::duration timeout,
+      std::optional<std::reference_wrapper<ss::abort_source>> as);
 
     kafka::offset expected_last_offset() const;
 


### PR DESCRIPTION
`partition_replicator` drives the work loop that fetches data from remote cluster and then replicating to a partition leader on local shard. `link_replication_manager` on a shard manages all the `partition_replicator` instances for that link.

future work wires up `link_replication_manager` with `cluster_link::manager` that manages link lifecycles.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
