### PR TITLE
CORE-12899 dt: always await user creation in tests

### DIFF
--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -19,6 +19,7 @@ from typing import Any, Optional, Callable, NamedTuple, Protocol, cast
 from json.decoder import JSONDecodeError
 from uuid import UUID
 from ducktape.cluster.cluster import ClusterNode
+from ducktape.utils.util import wait_until
 import requests
 from requests import Response
 from requests.adapters import HTTPAdapter
@@ -1264,7 +1265,8 @@ class Admin:
     def create_user(self,
                     username,
                     password="12345678",
-                    algorithm="SCRAM-SHA-256"):
+                    algorithm="SCRAM-SHA-256",
+                    await_exists=False):
         self.redpanda.logger.debug(
             f"Creating user {username}:{password}:{algorithm}")
 
@@ -1277,6 +1279,24 @@ class Admin:
                           password=password,
                           algorithm=algorithm,
                       ))
+
+        if await_exists:
+            self.await_user_exists(username)
+
+    def await_user_exists(self,
+                          username: str,
+                          timeout_sec: int = 15,
+                          backoff_sec: int = 1):
+        def user_exists():
+            for node in self.redpanda.started_nodes():
+                users = self.list_users(node=node)
+                if username not in users:
+                    return False
+            return True
+
+        wait_until(user_exists,
+                   timeout_sec=timeout_sec,
+                   backoff_sec=backoff_sec)
 
     def delete_user(self, username):
         self.redpanda.logger.info(f"Deleting user {username}")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3006,7 +3006,7 @@ class RedpandaService(RedpandaServiceBase):
             self._start_duration_seconds = time.time() - self._start_time
 
         if not self._skip_create_superuser:
-            self._admin.create_user(*self._superuser)
+            self._admin.create_user(*self._superuser, await_exists=True)
 
         self.wait_for_membership(first_start=first_start)
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2147,12 +2147,10 @@ class ClusterConfigNoKafkaTest(RedpandaTest):
 
         user = "alice"
         password = "sekrit"
-        admin.create_user(user, password, algorithm="SCRAM-SHA-256")
-
-        # It takes a moment for the user creation to propagate, we
-        # need it to have reached whichever node we next user to set
-        # configuration
-        time.sleep(5)
+        admin.create_user(user,
+                          password,
+                          algorithm="SCRAM-SHA-256",
+                          await_exists=True)
 
         alice_admin = Admin(self.redpanda, auth=(user, password))
         self.redpanda.set_cluster_config(

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -1993,30 +1993,10 @@ class PandaProxyMTLSBase(PandaProxyEndpoints):
         admin = Admin(self.redpanda)
 
         # Create the users
-        admin.create_user(self.admin_user.username, self.admin_user.password,
-                          self.admin_user.algorithm)
-
-        # Hack: create a user, so that we can watch for this user in order to
-        # confirm that all preceding controller log writes landed: this is
-        # an indirect way to check that ACLs (and users) have propagated
-        # to all nodes before we proceed.
-        checkpoint_user = "_test_checkpoint"
-        admin.create_user(checkpoint_user, "_password",
-                          self.admin_user.algorithm)
-
-        # wait for users to propagate to nodes
-        def auth_metadata_propagated():
-            for node in self.redpanda.nodes:
-                users = admin.list_users(node=node)
-                if checkpoint_user not in users:
-                    return False
-                elif self.security.sasl_enabled(
-                ) or self.security.kafka_enable_authorization:
-                    assert self.admin_user.username in users
-                    assert self.admin_user.username in users
-            return True
-
-        wait_until(auth_metadata_propagated, timeout_sec=10, backoff_sec=1)
+        admin.create_user(self.admin_user.username,
+                          self.admin_user.password,
+                          self.admin_user.algorithm,
+                          await_exists=True)
 
         # Create topic with rpk instead of KafkaCLITool because rpk is configured to use TLS certs
         self.super_client(basic_auth_enabled).create_topic(self.topic)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4161,16 +4161,8 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         admin = Admin(self.redpanda)
         admin.create_user(username=self.user.username,
                           password=self.user.password,
-                          algorithm=self.user.mechanism)
-
-        def user_exists():
-            for node in self.redpanda.nodes:
-                users = admin.list_users(node=node)
-                if self.user.username not in users:
-                    return False
-            return True
-
-        wait_until(user_exists, timeout_sec=10, backoff_sec=1)
+                          algorithm=self.user.mechanism,
+                          await_exists=True)
 
     @cluster(num_nodes=3)
     def test_schemas_types(self):
@@ -4962,30 +4954,10 @@ class SchemaRegistryMTLSBase(SchemaRegistryEndpoints):
         admin = Admin(self.redpanda)
 
         # Create the users
-        admin.create_user(self.admin_user.username, self.admin_user.password,
-                          self.admin_user.algorithm)
-
-        # Hack: create a user, so that we can watch for this user in order to
-        # confirm that all preceding controller log writes landed: this is
-        # an indirect way to check that ACLs (and users) have propagated
-        # to all nodes before we proceed.
-        checkpoint_user = "_test_checkpoint"
-        admin.create_user(checkpoint_user, "_password",
-                          self.admin_user.algorithm)
-
-        # wait for users to propagate to nodes
-        def auth_metadata_propagated():
-            for node in self.redpanda.nodes:
-                users = admin.list_users(node=node)
-                if checkpoint_user not in users:
-                    return False
-                elif self.security.sasl_enabled(
-                ) or self.security.kafka_enable_authorization:
-                    assert self.admin_user.username in users
-                    assert self.admin_user.username in users
-            return True
-
-        wait_until(auth_metadata_propagated, timeout_sec=10, backoff_sec=1)
+        admin.create_user(self.admin_user.username,
+                          self.admin_user.password,
+                          self.admin_user.algorithm,
+                          await_exists=True)
 
         # Create topic with rpk instead of KafkaCLITool because rpk is configured to use TLS certs
         self.super_client(basic_auth_enabled).create_topic(self.topic)
@@ -6796,7 +6768,8 @@ class SchemaRegistryAclAuthzTest(SchemaRegistryEndpoints):
         admin = Admin(self.redpanda)
         admin.create_user(username=self.user.username,
                           password=self.user.password,
-                          algorithm=self.user.mechanism)
+                          algorithm=self.user.mechanism,
+                          await_exists=True)
 
     def _create_acl(self,
                     resource,


### PR DESCRIPTION
* [dt/admin: helper to await user exists](https://github.com/redpanda-data/redpanda/commit/ca81e94e83f974df924dcc4d125c490fa397dee7) 
Tests often need to create users and then move on expecting that the
user is ready to be used on all nodes. To help ensure that tests can
rely on the created user being all-observable, introduce a helper.

* [dt: always await user creation in tests](https://github.com/redpanda-data/redpanda/commit/c6d03e54c4631dc67864371ba06cb4cd1126b961) 
In all the cases where we currently create a user in a ducktape test, it
makes sense to also wait until the user is all-observable, since all of
the tests expect that the user exists going forward.

Fixes https://redpandadata.atlassian.net/browse/CORE-12899

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
