### PR TITLE
bazel: Alias debug to sanitizer build config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,6 +86,13 @@ build:sanitizer --@seastar//:system_allocator=True
 build:sanitizer --@krb5//:sanitizers=address,undefined,vptr,function,alignment
 
 # =================================
+# Debug
+# =================================
+# alias to match our legacy cmake debug BUILD_TYPE so we don't have to do any
+# mapping in taskfiles
+build:debug --config=sanitizer
+
+# =================================
 # ODR Finder
 # =================================
 build:odr-finder --cxxopt -stdlib=libc++


### PR DESCRIPTION
This introduces the `debug` config as a pure alias for `sanitizer`.

This will allow us to simplify the tasksfiles by not having to do the mapping there.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


