### PR TITLE
[v25.2.x] treewide: remove small/large fragment_vector

### DIFF
--- a/src/v/container/fragmented_vector.h
+++ b/src/v/container/fragmented_vector.h
@@ -583,19 +583,6 @@ private:
 };
 
 /**
- * An alias for a fragmented_vector using a larger fragment size, close
- * to the limit of the maximum contiguous allocation size.
- */
-template<typename T>
-using large_fragment_vector = fragmented_vector<T, 32 * 1024>;
-
-/**
- * An alias for a fragmented_vector using a smaller fragment size.
- */
-template<typename T>
-using small_fragment_vector = fragmented_vector<T, 1024>;
-
-/**
  * A vector that does not allocate large contiguous chunks. Instead the
  * allocations are broken up across many different individual vectors, but the
  * exposed view is of a single container.

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -75,7 +75,7 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
       .aborted_transactions{},
       .records{}};
 
-    small_fragment_vector<fetch_response::partition_response> responses;
+    chunked_vector<fetch_response::partition_response> responses;
     responses.push_back(std::move(pr));
     auto response = fetch_response::partition{.topic = tp.topic};
     response.partitions = std::move(responses);

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -20,8 +20,7 @@
 
 namespace kafka::client {
 
-void topic_cache::apply(
-  small_fragment_vector<metadata_response::topic>&& topics) {
+void topic_cache::apply(chunked_vector<metadata_response::topic>&& topics) {
     topics_t cache;
     cache.reserve(topics.size());
     for (const auto& t : topics) {

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -46,7 +46,7 @@ public:
     ~topic_cache() noexcept = default;
 
     /// \brief Apply the given metadata response.
-    void apply(small_fragment_vector<metadata_response::topic>&& topics);
+    void apply(chunked_vector<metadata_response::topic>&& topics);
 
     /// \brief Obtain the leader for the given topic-partition
     model::node_id leader(model::topic_partition tp) const;

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -214,7 +214,7 @@ struct fetch_response final {
     public:
         using partition_iterator = chunked_vector<partition>::iterator;
         using partition_response_iterator
-          = small_fragment_vector<partition_response>::iterator;
+          = chunked_vector<partition_response>::iterator;
 
         struct value_type {
             partition_iterator partition;

--- a/src/v/kafka/protocol/offset_fetch.h
+++ b/src/v/kafka/protocol/offset_fetch.h
@@ -62,8 +62,7 @@ struct offset_fetch_response final {
         data.error_code = error_code::none;
         if (topics) {
             for (auto& topic : *topics) {
-                small_fragment_vector<offset_fetch_response_partition>
-                  partitions;
+                chunked_vector<offset_fetch_response_partition> partitions;
                 for (auto id : topic.partition_indexes) {
                     offset_fetch_response_partition p = {
                       .partition_index = id,

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -528,10 +528,10 @@ extra_headers = {
 # These types, when they appear as the member type of an array, will override
 # the container type from std::vector
 override_member_container = {
-    'metadata_response_partition': 'large_fragment_vector',
-    'metadata_response_topic': 'small_fragment_vector',
-    'partition_data': 'small_fragment_vector',
-    'offset_fetch_response_partition': 'small_fragment_vector',
+    'metadata_response_partition': 'chunked_vector',
+    'metadata_response_topic': 'chunked_vector',
+    'partition_data': 'chunked_vector',
+    'offset_fetch_response_partition': 'chunked_vector',
     'int32_t': 'std::vector',
     'model::node_id': 'std::vector',
     'model::partition_id': 'std::vector',

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2497,7 +2497,7 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
     if (!r.data.topics) {
         absl::flat_hash_map<
           model::topic,
-          small_fragment_vector<offset_fetch_response_partition>>
+          chunked_vector<offset_fetch_response_partition>>
           tmp;
         for (const auto& e : _offsets) {
             offset_fetch_response_partition p = {

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -264,12 +264,11 @@ static metadata_response::topic make_topic_response(
     return res;
 }
 
-static ss::future<small_fragment_vector<metadata_response::topic>>
-get_topic_metadata(
+static ss::future<chunked_vector<metadata_response::topic>> get_topic_metadata(
   request_context& ctx,
   metadata_request& request,
   const is_node_isolated_or_decommissioned is_node_isolated) {
-    small_fragment_vector<metadata_response::topic> res;
+    chunked_vector<metadata_response::topic> res;
 
     // request can be served from whatever happens to be in the cache
     if (request.list_all_topics) {
@@ -293,8 +292,8 @@ get_topic_metadata(
               ctx, request, md.get_metadata(), is_node_isolated));
         }
 
-        return ss::make_ready_future<
-          small_fragment_vector<metadata_response::topic>>(std::move(res));
+        return ss::make_ready_future<chunked_vector<metadata_response::topic>>(
+          std::move(res));
     }
 
     std::vector<model::topic> topics_to_be_created;
@@ -367,8 +366,8 @@ get_topic_metadata(
                 .name = std::move(t)};
           });
 
-        return ss::make_ready_future<
-          small_fragment_vector<metadata_response::topic>>(std::move(res));
+        return ss::make_ready_future<chunked_vector<metadata_response::topic>>(
+          std::move(res));
     }
 
     std::for_each(
@@ -690,7 +689,6 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
     // generally ~8000 bytes). Finally, we add max_frag_bytes to account for the
     // worse-cast overshoot during vector re-allocation.
     return default_memory_estimate(request_size) + size_estimate
-           + large_fragment_vector<
-             metadata_response_partition>::max_frag_bytes();
+           + chunked_vector<metadata_response_partition>::max_frag_bytes();
 }
 } // namespace kafka


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26941 