### PR TITLE
archival: Fix high reupload rate

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2258,6 +2258,17 @@ ntp_archiver::wait_uploads_complete(
 
         result.meta.push_back(*upload.meta);
     }
+    if (result.num_succeeded > result.meta.size()) {
+        vlog(
+          _rtclog.info,
+          "Some segments were discarded due to metadata consistency violation: "
+          "{} uploaded vs {} accepted",
+          result.num_succeeded,
+          result.meta.size());
+        auto num_discarded = result.num_succeeded - result.meta.size();
+        result.num_succeeded -= num_discarded;
+        result.num_failed += num_discarded;
+    }
     co_return result;
 }
 


### PR DESCRIPTION
The backoff algorithm is triggered if the number of uploaded segments is zero. This enables backoff in case there is nothing to upload or if there are upload errors.

However, if segment uploads are discarded due to consistency violations, the successful upload counter is not updated. If all uploads are discarded, the backoff algorithm is not triggered, and the upload loop behaves as if a segment was uploaded successfully. As a result, in the presence of persistent consistency violations, ntp_archiver causes high I/O utilization by repeatedly retrying the same uploads.

This commit fixes the issue by adjusting the successful upload counter after performing metadata consistency checks.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none