### PR TITLE
CORE-12937 schema_registry: core import mode support

### DIFF
--- a/src/go/rpk/pkg/cli/registry/mode/set.go
+++ b/src/go/rpk/pkg/cli/registry/mode/set.go
@@ -23,7 +23,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-var supportedModes = []string{"READONLY", "READWRITE"}
+var supportedModes = []string{"READONLY", "READWRITE", "IMPORT"}
 
 func setCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var modeFlag string
@@ -40,6 +40,7 @@ mode at the same time as per-subject mode.
 Acceptable mode values: 
   - READONLY
   - READWRITE
+  - IMPORT
 `,
 		Example: `
 Set the global schema registry mode to READONLY

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -79,7 +79,7 @@ struct error_category final : std::error_category {
                    "BACKWARD, FORWARD, FULL, BACKWARD_TRANSITIVE, "
                    "FORWARD_TRANSITIVE, and FULL_TRANSITIVE";
         case error_code::mode_invalid:
-            return "Invalid mode. Valid values are READWRITE, READONLY";
+            return "Invalid mode. Valid values are READWRITE, READONLY, IMPORT";
         case error_code::version_exhausted:
             return "Versions exhausted, maximum 2147483647 reached";
         case error_code::format_not_supported:

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -207,6 +207,12 @@ inline error_info format_not_supported(const output_format f) {
       fmt::format("Format value '{}' is not supported", f)};
 }
 
+inline error_info overwrite_schema_with_id_not_permitted(schema_id id) {
+    return error_info{
+      error_code::subject_version_operation_not_permitted,
+      fmt::format("Overwrite new schema with id {} is not permitted.", id())};
+}
+
 inline bool failed_subject_schema_lookup(std::error_code ec) {
     return ec == error_code::subject_not_found
            || ec == error_code::subject_version_not_found;

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -558,12 +558,16 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     auto ids = co_await rq.service().schema_store().get_schema_version(
       schema.share());
 
+    const auto mode = co_await rq.service().schema_store().get_mode(
+      sub, default_to_global::yes);
+    const auto should_reinsert = mode == mode::import && ids.id != schema.id;
+
     schema_id schema_id{ids.id.value_or(invalid_schema_id)};
-    if (!ids.version.has_value()) {
-        schema.id = ids.id.value_or(invalid_schema_id);
-        schema.version = schema.version == invalid_schema_version
-                           ? ids.version.value_or(invalid_schema_version)
-                           : schema.version;
+    if (!ids.version.has_value() || should_reinsert) {
+        schema.id = (schema.id == invalid_schema_id)
+                      ? ids.id.value_or(invalid_schema_id)
+                      : schema.id;
+
         schema_id = co_await rq.service().writer().write_subject_version(
           std::move(schema));
     }

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -259,6 +259,8 @@ ss::future<server::reply_t> put_mode(server::request_t rq, server::reply_t rp) {
                  .value_or(force::no);
     auto res = co_await rjson_parse(*rq.req, mode_handler<>{});
 
+    // Ensure we are up to date (eg. see all existing subjects for import mode)
+    co_await rq.service().writer().read_sync();
     co_await rq.service().writer().write_mode(std::nullopt, res.mode, frc);
 
     auto resp = ppj::rjson_serialize_iobuf(res);

--- a/src/v/pandaproxy/schema_registry/requests/mode.h
+++ b/src/v/pandaproxy/schema_registry/requests/mode.h
@@ -55,7 +55,7 @@ public:
         auto sv = std::string_view{str, len};
         if (_state == state::mode) {
             auto s = from_string_view<mode>(sv);
-            if (s.has_value() && s.value() != mode::import) {
+            if (s.has_value()) {
                 result.mode = *s;
                 _state = state::object;
             } else {

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -224,7 +224,13 @@ void seq_writer::advance_offset_inner(model::offset offset) {
 
 ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
   stored_schema schema, model::offset write_at) {
-    co_await check_mutable(schema.schema.sub());
+    const auto& sub = schema.schema.sub();
+    co_await check_mutable(sub);
+
+    const auto mode = co_await _store.get_mode(sub, default_to_global::yes);
+    if (schema.id < 0 && mode != mode::read_write) {
+        throw as_exception(mode_not_readwrite(sub));
+    }
 
     // Check if store already contains this data: if
     // so, we do no I/O and return the schema ID.

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -391,6 +391,35 @@ ss::future<std::optional<bool>> seq_writer::do_write_mode(
         }
     }
 
+    if (m == mode::import && !f) {
+        auto make_exception = []() {
+            return as_exception(error_info{
+              error_code::subject_version_operation_not_permitted,
+              "Schema Registry can only move to import mode if empty"});
+        };
+        if (!sub && co_await _store.has_subjects(include_deleted::yes)) {
+            throw make_exception();
+        }
+        if (sub) {
+            try {
+                auto versions = co_await _store.get_versions(
+                  *sub, include_deleted::yes);
+                if (!versions.empty()) {
+                    throw make_exception();
+                }
+            } catch (const exception& e) {
+                if (e.code() != error_code::subject_not_found) {
+                    throw;
+                }
+                // Subject not found is OK - treat as empty
+            }
+        }
+
+        // TODO: relax the above restrictions to
+        // 1. Allow soft-deleted schemas to exist, but
+        // 2. Hard delete them before moving to import mode
+    }
+
     batch_builder rb(write_at, sub);
     rb(
       mode_key{.seq{write_at}, .node{_node_id}, .sub{sub}},

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -180,7 +180,7 @@ sharded_store::get_schema_version(stored_schema schema) {
         } else if (co_await has_schema(schema.id)) {
             // The supplied id already exists, but the schema is different
             co_return ss::coroutine::return_exception(exception(
-              error_code::subject_version_schema_id_already_exists,
+              error_code::subject_version_operation_not_permitted,
               fmt::format(
                 "Overwrite new schema with id {} is not permitted.",
                 schema.id())));

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -169,12 +169,27 @@ sharded_store::get_schema_version(stored_schema schema) {
       map, std::optional<schema_id>{}, reduce);
 
     // Determine if a provided schema id is appropriate
-    if (schema.id != invalid_schema_id) {
+    const auto& sub = schema.schema.sub();
+    const auto mode = co_await get_mode(sub, default_to_global::yes);
+    if (mode == mode::import) {
+        if (
+          schema.id != invalid_schema_id && s_id != schema.id
+          && co_await has_schema(schema.id)) {
+            // The supplied id already exists, but the schema is different
+            co_return ss::coroutine::return_exception(
+              as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
+        }
+        vlog(
+          srlog.debug,
+          "get_schema_version: existing ID {} in import mode",
+          s_id);
+    } else if (schema.id != invalid_schema_id) {
         if (s_id.has_value() && s_id != schema.id) {
             co_return ss::coroutine::return_exception(exception(
               error_code::subject_version_schema_id_already_exists,
               fmt::format(
-                "Schema already registered with id {} instead of input id {}",
+                "Schema already registered with id {} instead of input id "
+                "{}",
                 s_id.value()(),
                 schema.id())));
         } else if (co_await has_schema(schema.id)) {
@@ -185,15 +200,16 @@ sharded_store::get_schema_version(stored_schema schema) {
             // Use the supplied id
             s_id = schema.id;
             vlog(
-              srlog.debug, "project_ids: using supplied ID {}", s_id.value());
+              srlog.debug,
+              "get_schema_version: using supplied ID {}",
+              s_id.value());
         }
     } else if (s_id) {
-        vlog(srlog.debug, "project_ids: existing ID {}", s_id.value());
+        vlog(srlog.debug, "get_schema_version: existing ID {}", s_id.value());
     }
 
     // Determine if the subject already has a version that references this
     // schema, deleted versions are seen.
-    const auto& sub = schema.schema.sub();
     const auto versions = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
@@ -218,7 +234,7 @@ sharded_store::get_schema_version(stored_schema schema) {
     }
 
     // Check compatibility of the schema
-    if (!v_id.has_value() && !versions.empty()) {
+    if (!v_id.has_value() && !versions.empty() && mode != mode::import) {
         auto compat = co_await is_compatible(
           versions.back().version, schema.schema.share(), verbose::yes);
         if (!compat.is_compat) {

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -179,11 +179,8 @@ sharded_store::get_schema_version(stored_schema schema) {
                 schema.id())));
         } else if (co_await has_schema(schema.id)) {
             // The supplied id already exists, but the schema is different
-            co_return ss::coroutine::return_exception(exception(
-              error_code::subject_version_operation_not_permitted,
-              fmt::format(
-                "Overwrite new schema with id {} is not permitted.",
-                schema.id())));
+            co_return ss::coroutine::return_exception(
+              as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
         } else {
             // Use the supplied id
             s_id = schema.id;

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -199,7 +199,7 @@ FIXTURE_TEST(
         auto eb = get_error_body(res.body);
         BOOST_REQUIRE(
           eb.ec
-          == pp::reply_error_code::subject_version_schema_id_already_exists);
+          == pp::reply_error_code::subject_version_operation_not_permitted);
         BOOST_REQUIRE_EQUAL(
           eb.message, R"(Overwrite new schema with id 4 is not permitted.)");
     }

--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -651,7 +651,12 @@ message Test3 {
         # It goes back to the global mode (READONLY)
         assert findModeBySubject(out, subject_2) == read_only_mode
 
-        # We do not support import yet
-        with expect_exception(RpkException,
-                              lambda e: 'invalid mode "IMPORT"' in str(e)):
-            self._rpk.set_mode("IMPORT", [subject_1, subject_2], format="text")
+        # We support import as well
+        self._rpk.set_mode("IMPORT", [subject_1, subject_2], format="text")
+
+        # Invalid modes should throw
+        with expect_exception(
+                RpkException,
+                lambda e: 'invalid mode "SOME_INVALID"' in str(e)):
+            self._rpk.set_mode("SOME_INVALID", [subject_1, subject_2],
+                               format="text")

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4129,6 +4129,144 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         result_raw = self.sr_client.get_schemas_ids_id_versions(id=1)
         assert result_raw.status_code == 200
 
+    @cluster(num_nodes=3)
+    def test_enabling_import_mode(self):
+        """
+        Test the conditions on enabling import mode
+        """
+        sub1 = "test-subject-1"
+        sub2 = "test-subject-2"
+
+        schema1 = json.dumps({"schema": schema1_def})
+        schema2 = json.dumps({"schema": schema2_def})
+
+        # Test criteria for enabling global-level import mode (schema registry is empty)
+        self.logger.info("Testing global import mode enablement conditions")
+
+        self.logger.debug("Creating schema for global import mode testing")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=schema1)
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug(
+            "Try to enable global import mode with existing schema - should fail"
+        )
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 422)
+        self.assert_equal(result_raw.json()["error_code"], 42205)
+
+        self.logger.debug(
+            "Try to enable global import mode with existing schema with force=true - should succeed"
+        )
+        result_raw = self.sr_client.set_mode(data=json.dumps(
+            {"mode": "IMPORT"}),
+                                             force=True)
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["mode"], "IMPORT")
+
+        self.logger.debug("Reset to READWRITE mode")
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "READWRITE"}))
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug("Soft delete schema version")
+        result_raw = self.sr_client.delete_subject_version(subject=sub1,
+                                                           version=1)
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug(
+            "Try to enable global import mode after soft delete - should still fail"
+        )
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 422)
+        self.assert_equal(result_raw.json()["error_code"], 42205)
+
+        self.logger.debug("Hard delete schema version")
+        result_raw = self.sr_client.delete_subject_version(subject=sub1,
+                                                           version=1,
+                                                           permanent=True)
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug(
+            "Enable global import mode after hard delete - should succeed")
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["mode"], "IMPORT")
+
+        self.logger.debug("Reset global mode for further testing")
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "READWRITE"}))
+        self.assert_equal(result_raw.status_code, 200)
+
+        # Test subject-level criteria for enabling subject-level import mode (subject is empty)
+        self.logger.info(
+            "Testing subject-level import mode enablement conditions")
+
+        self.logger.debug(
+            "Creating schema for subject-level import mode testing")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub2, data=schema2)
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug(
+            "Try to enable subject import mode with existing schema - should fail"
+        )
+        result_raw = self.sr_client.set_mode_subject(subject=sub2,
+                                                     data=json.dumps(
+                                                         {"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 422)
+        self.assert_equal(result_raw.json()["error_code"], 42205)
+
+        self.logger.debug(
+            "Try to enable subject import mode with existing schema with force=true - should succeed"
+        )
+        result_raw = self.sr_client.set_mode_subject(subject=sub2,
+                                                     data=json.dumps(
+                                                         {"mode": "IMPORT"}),
+                                                     force=True)
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["mode"], "IMPORT")
+
+        self.logger.debug("Reset to READWRITE mode")
+        result_raw = self.sr_client.set_mode_subject(
+            subject=sub2, data=json.dumps({"mode": "READWRITE"}))
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug("Soft delete schema for subject")
+        result_raw = self.sr_client.delete_subject_version(subject=sub2,
+                                                           version=1)
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug(
+            "Try to enable subject import mode after soft delete - should still fail"
+        )
+        result_raw = self.sr_client.set_mode_subject(subject=sub2,
+                                                     data=json.dumps(
+                                                         {"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 422)
+        self.assert_equal(result_raw.json()["error_code"], 42205)
+
+        self.logger.debug("Hard delete schema for subject")
+        result_raw = self.sr_client.delete_subject_version(subject=sub2,
+                                                           version=1,
+                                                           permanent=True)
+        self.assert_equal(result_raw.status_code, 200)
+
+        self.logger.debug(
+            "Enable subject import mode after hard delete - should succeed")
+        result_raw = self.sr_client.set_mode_subject(subject=sub2,
+                                                     data=json.dumps(
+                                                         {"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["mode"], "IMPORT")
+
+        self.logger.debug("Cleaning up - reset modes")
+        result_raw = self.sr_client.delete_mode_subject(subject=sub2)
+        self.assert_equal(result_raw.status_code, 200)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4267,6 +4267,117 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         result_raw = self.sr_client.delete_mode_subject(subject=sub2)
         self.assert_equal(result_raw.status_code, 200)
 
+    @cluster(num_nodes=3)
+    @matrix(subject_scope=[False, True])
+    def test_import_mode_behaviour(self, subject_scope):
+        """Test expected import mode behaviour"""
+        sub1 = "test-subject-1"
+        expected_ver_to_id = {}
+
+        if subject_scope:
+            self.logger.debug(f"Enable IMPORT mode for subject {sub1}")
+            result_raw = self.sr_client.set_mode_subject(
+                subject=sub1, data=json.dumps({"mode": "IMPORT"}))
+            self.assert_equal(result_raw.status_code, 200)
+            self.assert_equal(result_raw.json()["mode"], "IMPORT")
+        else:
+            self.logger.debug(f"Enable IMPORT mode globally")
+            result_raw = self.sr_client.set_mode(
+                data=json.dumps({"mode": "IMPORT"}))
+            self.assert_equal(result_raw.status_code, 200)
+            self.assert_equal(result_raw.json()["mode"], "IMPORT")
+
+        self.logger.debug("Post schema without id - should fail")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=json.dumps({"schema": schema1_def}))
+        self.assert_equal(result_raw.status_code, 422)
+        self.assert_equal(result_raw.json()["error_code"], 42205)
+
+        self.logger.debug("Post schema with arbitrary id - should succeed")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=json.dumps({
+                "schema": schema1_def,
+                "id": 4
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 4)
+        expected_ver_to_id[1] = 4
+
+        self.logger.debug(
+            "Re-post existing schema without id - should succeed")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=json.dumps({"schema": schema1_def}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 4)
+
+        self.logger.debug(
+            "Post the same schema again with a different id - should succeed")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=json.dumps({
+                "schema": schema1_def,
+                "id": 2
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 2)
+        expected_ver_to_id[2] = 2
+
+        self.logger.debug(
+            "Post a compatible schema with arbitrary version - should succeed")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1,
+            data=json.dumps({
+                "schema": schema2_def,
+                "id": 6,
+                "version": 7
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 6)
+        expected_ver_to_id[7] = 6
+
+        self.logger.debug("Post an incompatible schema - should succeed")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=json.dumps({
+                "schema": schema3_def,
+                "id": 7
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 7)
+        expected_ver_to_id[8] = 7
+
+        self.logger.debug(
+            "Try to overwrite an existing schema id - should fail")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1, data=json.dumps({
+                "schema": schema2_def,
+                "id": 7
+            }))
+        self.assert_equal(result_raw.status_code, 422)
+        self.assert_equal(result_raw.json()["error_code"], 42205)
+
+        self.logger.debug(
+            "Try to overwrite an existing schema version (with different schema id) - should succeed"
+        )
+        # Note: version=1 here corresponds to the earlier schema id 4 using the schema definition schema1_def
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            subject=sub1,
+            data=json.dumps({
+                "schema": schema2_def,
+                "id": 8,
+                "version": 1
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 8)
+        self.assert_equal(expected_ver_to_id[1], 4)
+        expected_ver_to_id[1] = 8
+
+        self.logger.debug(
+            f"Finally, sanity check the expected set of schemas - expecting: {expected_ver_to_id=}"
+        )
+        rpk = self._get_rpk_tools()
+        resp = rpk.list_schemas([sub1])
+        got_ver_to_id = {int(elem["version"]): elem["id"] for elem in resp}
+        self.assert_equal(expected_ver_to_id, got_ver_to_id)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -3964,22 +3964,21 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
             subject=subject, data=json.dumps({"schema": schema1_def}))
         assert result_raw.status_code == requests.codes.ok
 
-        self.logger.debug("Set global mode to IMPORT")
+        self.logger.debug("Set global mode to UNSUPPORTED")
         result_raw = self.sr_client.set_mode(
-            data=json.dumps({"mode": "IMPORT"}))
+            data=json.dumps({"mode": "UNSUPPORTED"}))
         assert result_raw.status_code == 422
         assert result_raw.json()["error_code"] == 42204
         assert result_raw.json(
-        )["message"] == "Invalid mode. Valid values are READWRITE, READONLY"
+        )["message"] == "Invalid mode. Valid values are READWRITE, READONLY, IMPORT"
 
-        self.logger.debug("Set subject mode to IMPORT")
-        result_raw = self.sr_client.set_mode_subject(subject="test-sub",
-                                                     data=json.dumps(
-                                                         {"mode": "IMPORT"}))
+        self.logger.debug("Set subject mode to UNSUPPORTED")
+        result_raw = self.sr_client.set_mode_subject(
+            subject="test-sub", data=json.dumps({"mode": "UNSUPPORTED"}))
         assert result_raw.status_code == 422
         assert result_raw.json()["error_code"] == 42204
         assert result_raw.json(
-        )["message"] == "Invalid mode. Valid values are READWRITE, READONLY"
+        )["message"] == "Invalid mode. Valid values are READWRITE, READONLY, IMPORT"
 
     @cluster(num_nodes=3)
     def test_mode_readonly(self):


### PR DESCRIPTION
Support enabling import mode in the Schema Registry.

In import mode, users can register schemas with the following differences from read write mode:
* users can specify the id and version of the schema
* re-inserting a schema definition with a different schema id is allowed
* no compatibility checks are performed

Fixes https://redpandadata.atlassian.net/browse/CORE-12937

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
