### PR TITLE
[CORE-12883] k/s/handlers: fix memory estimation for metadata api

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -612,6 +612,20 @@ ss::future<response_ptr> describe_cluster_handler::handle(
     co_return co_await ctx.respond(std::move(reply));
 }
 
+namespace {
+// Safety margin to account for overallocations by the chunked_vector.
+// This is meant to represent either the table-doubling before filling
+// the first fragment or the allocation for an extra fragment.
+template<typename T>
+size_t chunked_vector_overalloc(size_t n_elems) {
+    if (std::cmp_less(n_elems, chunked_vector<T>::elements_per_fragment())) {
+        return sizeof(T) * n_elems;
+    } else {
+        return chunked_vector<T>::max_frag_bytes();
+    }
+}
+} // namespace
+
 size_t
 metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
     // We cannot make a precise estimate of the size of a metadata response by
@@ -674,6 +688,8 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
 
         size_estimate += pcount
                          * (bytes_per_partition + bytes_per_replica * rcount);
+
+        size_estimate += chunked_vector_overalloc<partition>(pcount);
     }
 
     // Finally, we double the estimate, because the highwater mark for memory
@@ -686,9 +702,7 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
 
     // We still add on the default_estimate to handle the size of the request
     // itself and miscellaneous other procesing (this is a small adjustment,
-    // generally ~8000 bytes). Finally, we add max_frag_bytes to account for the
-    // worse-cast overshoot during vector re-allocation.
-    return default_memory_estimate(request_size) + size_estimate
-           + chunked_vector<metadata_response_partition>::max_frag_bytes();
+    // generally ~8000 bytes).
+    return default_memory_estimate(request_size) + size_estimate;
 }
 } // namespace kafka

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -692,6 +692,10 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
         size_estimate += chunked_vector_overalloc<partition>(pcount);
     }
 
+    const auto n_topics = md_cache.all_topics_metadata().size();
+    size_estimate += chunked_vector_overalloc<kafka::metadata_response_topic>(
+      n_topics);
+
     // Finally, we double the estimate, because the highwater mark for memory
     // use comes when the in-memory structures (metadata_response_data and
     // subobjects) exist on the heap and they are encoded into the reponse,


### PR DESCRIPTION
Fixes: [CORE-12883](https://redpandadata.atlassian.net/browse/CORE-12883)

The final addition to the memory estimate fails to address that this value is a per-topic addition, instead of an one off. Also, now that the container is a chunked_vector instead of fragmented, always expecting the full fragment size is very pessimistic.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none


[CORE-12883]: https://redpandadata.atlassian.net/browse/CORE-12883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ