### PR TITLE
CORE-9277 schedule leader balancer after node becomes online

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -177,6 +177,26 @@ void leader_balancer::on_maintenance_change(
     }
 }
 
+void leader_balancer::handle_node_health_report(
+  const node_health_report& report,
+  std::optional<node_health_report_ptr> previous_report) {
+    if (!can_schedule_sooner()) {
+        return;
+    }
+
+    // Do not schedule a tick if the report was already present for current
+    // node.
+    if (previous_report) {
+        return;
+    }
+
+    vlog(
+      clusterlog.trace,
+      "node {} health report appeared, scheduling balance",
+      report.id);
+    schedule_sooner(node_status_changed_delay);
+}
+
 void leader_balancer::handle_topic_deltas(
   const chunked_vector<topic_table_topic_delta>& deltas) {
     if (!can_schedule_sooner()) {
@@ -285,6 +305,9 @@ ss::future<> leader_balancer::start() {
       std::bind_front(
         std::mem_fn(&leader_balancer::handle_topic_deltas), this));
 
+    _health_monitor_handle = _health_monitor.register_node_callback(
+      std::bind_front(
+        std::mem_fn(&leader_balancer::handle_node_health_report), this));
     /*
      * register_leadership_notification above may run callbacks synchronously
      * during registration, so make sure the timer is unarmed before arming.
@@ -311,6 +334,7 @@ ss::future<> leader_balancer::stop() {
     _members.unregister_maintenance_state_change_notification(
       _maintenance_state_notify_handle);
     _topics.unregister_topic_delta_notification(_topic_deltas_handle);
+    _health_monitor.unregister_node_callback(_health_monitor_handle);
     _timer.cancel();
     return _gate.close();
 }

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -173,7 +173,7 @@ void leader_balancer::on_maintenance_change(
     // if a node transitions out of maintenance wake up the balancer early to
     // transfer leadership back to it.
     if (ms == model::maintenance_state::inactive) {
-        schedule_sooner(leader_activation_delay);
+        schedule_sooner(node_status_changed_delay);
     }
 }
 

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -143,6 +143,9 @@ private:
 
     void handle_topic_deltas(const chunked_vector<topic_table_topic_delta>&);
 
+    void handle_node_health_report(
+      const node_health_report&, std::optional<node_health_report_ptr>);
+
     void check_register_leadership_change_notification();
     void check_unregister_leadership_change_notification();
 
@@ -232,7 +235,7 @@ private:
       _leadership_change_notify_handle;
     cluster::notification_id_type _maintenance_state_notify_handle;
     cluster::notification_id_type _topic_deltas_handle;
-
+    cluster::notification_id_type _health_monitor_handle;
     ss::gate _gate;
     ss::timer<clock_type> _timer;
     clock_type::time_point _last_iteration_at;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -74,6 +74,11 @@ class leader_balancer {
     static constexpr std::chrono::milliseconds
       transfer_leadership_recovery_timeout
       = 25ms;
+    /*
+     * after node maintenance change or its health report appears, wait for a
+     * while to make sure node is ready to accept leaders.
+     */
+    static constexpr clock_type::duration node_status_changed_delay = 10s;
 
 public:
     leader_balancer(


### PR DESCRIPTION
Previously the leadership balancer wasn't triggered after the node was
identified as online. This might not necessarily delay leadership
tranfers. Registered a notification into cluster health monitor backend
to react when a health report for the node appears.

Signed-off-by: Michał Maślanka <michal@redpanda.com>
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none