### PR TITLE
dt: add missing schema registry flags to acl list

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1413,7 +1413,8 @@ class RpkTool:
             "list",
             "--format",
             format,
-        ] + flags + self._kafka_conn_settings(node)
+        ] + flags + self._schema_registry_conn_settings(
+        ) + self._kafka_conn_settings(node)
 
         output = self._execute(cmd)
 


### PR DESCRIPTION
The command used to be only used for Kafka, for
docker we don't need this as rpk will infer the
registry listener. But for CDT we need to
explicitly add the flags as we can't rely on
localhost.

Fixes CORE-12918

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes


* none
