### PR TITLE
dt/tests: deflake test_recovery_after_snapshot_is_delivered

### DIFF
--- a/tests/rptest/tests/idempotency_test.py
+++ b/tests/rptest/tests/idempotency_test.py
@@ -97,6 +97,13 @@ class IdempotencySnapshotDelivery(PreallocNodesTest):
 
         producer.start(clean=False)
 
+        # Wait until the producer connection has been established by ensuring
+        # that at least one message has been acked.
+        # Otherwise producer initialization may hit a dead broker (from test induced pkills)
+        # and franz-go only retries once (hardcoded) before giving up.
+
+        wait_until(lambda: producer.produce_status.acked >= 1, 30, 1)
+
         pkill_config = ActionConfig(cluster_start_lead_time_sec=10,
                                     min_time_between_actions_sec=10,
                                     max_time_between_actions_sec=20)


### PR DESCRIPTION
franz-go seems to only retry once before giving up when initializing a producer and it is possible with this test that the init may hit a dead node due to test induced failures.

https://github.com/twmb/franz-go/commit/a995b1b06dffddb3a48b7d42fd66f0c7f32403c6

Fixes: https://redpandadata.atlassian.net/browse/CORE-12839

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
