### PR TITLE
`storage`: pass `seg->size_before()` as `segment_size` hint to `segment_appender`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1597,10 +1597,11 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     auto staging_to_clean = scoped_file_tracker{
       cfg.files_to_cleanup, {tmpname, cmp_idx_tmpname}};
 
+    const auto size_before = seg->size_bytes();
     auto appender = co_await internal::make_segment_appender(
       tmpname,
       segment_appender::write_behind_memory / internal::chunks().chunk_size(),
-      std::nullopt,
+      size_before,
       resources(),
       cfg.sanitizer_config);
 
@@ -1657,7 +1658,6 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     if (seg->is_closed()) {
         throw segment_closed_exception();
     }
-    const auto size_before = seg->size_bytes();
     const auto size_after = appender->file_byte_offset();
 
     // Clear our indexes before swapping the data files (note, the new

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -395,10 +395,11 @@ ss::future<storage::index_state> do_copy_segment_data(
     // prepare a new segment with only the compacted_offsets
     auto tmpname = seg->reader().path().to_staging();
 
+    auto size_before = seg->size_bytes();
     auto appender = co_await make_segment_appender(
       tmpname,
       segment_appender::write_behind_memory / internal::chunks().chunk_size(),
-      std::nullopt,
+      size_before,
       resources,
       cfg.sanitizer_config);
 


### PR DESCRIPTION
During compaction, it is guaranteed that the size of the `segment` on disk after a de-duplication operation is less than the size of the `segment` before the operation. There is a handy tool within the `segment_appender` by which you can pass a `segment_size` as a hint to not overly `fallocate()` more space than is necessary on disk (as doing so is wasteful and leads to greater fragmentation, since we will `ftruncate()` the file to its rightful size after writing to it).

In the pathological case where we have many small `segment`s on disk being continually re-compacted, the default `segment_fallocation_step` of `32_MiB` may be _much_ more space than is necessary (we have seen instances where `segment`s are on the order of hundreds of `KiB`, and certainly less than tens of `MiB`).

We were not making use of this hint to the `segment_appender` in the compaction routines. This lead to us previously adjusting the `segment_fallocation_step` default config for a user experiencing the pathological case of _many_ small `segment`s from `32_MiB` down to `2_MiB`, which yielded great results for their p99 latency (which was incredibly high due to time spent searching for memory in the XFS filesystem during an `fallocate()` call, due to the aforementioned fragmentation which we have great reason to believe is entirely due to the high `segment` count/low `segment` file size).

Optimize this code path for the pathological case by providing the pre-compacted `segment` size as a hint, since we know that there is no possibility for the `segment` size to be higher post compaction.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Reduces the fragmentation caused by `ftruncate()` calls on `segment`s being rewritten as a part of compaction by providing a better estimate for the size required from initial `fallocate()` calls in the `storage` subsystem
