### PR TITLE
`docker`: bump `MinIO` version

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - -f
       - http://localhost:9000/minio/health/live
       timeout: 20s
-    image: minio/minio:RELEASE.2024-10-29T16-01-48Z
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     networks:
       redpanda-test:
         ipv4_address: 192.168.215.125


### PR DESCRIPTION
Opening for CI

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
