### PR TITLE
`storage`: pass `abort_source` to `maybe_create_contiguous_segment_set()`

### DIFF
--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -168,8 +168,8 @@ is_last_segment(segment* s, std::optional<ss::sstring> last_clean_segment) {
                 == std::string(last_clean_segment.value());
 }
 
-ss::future<std::optional<segment_set>>
-maybe_create_contiguous_segment_set(segment_set::underlying_t segs) {
+ss::future<std::optional<segment_set>> maybe_create_contiguous_segment_set(
+  segment_set::underlying_t segs, ss::abort_source& as) {
     if (segs.size() < 2) {
         co_return segment_set(std::move(segs));
     }
@@ -198,6 +198,7 @@ maybe_create_contiguous_segment_set(segment_set::underlying_t segs) {
                         .get_dirty_offset();
     segment_set::underlying_t ignored_segs;
     for (auto it = std::next(segs.begin()); it != segs.end();) {
+        as.check();
         auto& s = *it;
         auto& prev = *std::prev(it);
         if (
@@ -420,7 +421,7 @@ static ss::future<segment_set> unsafe_do_recover(
         // Pass `good` by value on purpose, we need to preserve segments for
         // sad return path below in case we are unable to produce a
         // contiguous segment set here.
-        auto seg_set_opt = maybe_create_contiguous_segment_set(good).get();
+        auto seg_set_opt = maybe_create_contiguous_segment_set(good, as).get();
         if (seg_set_opt.has_value()) {
             return std::move(seg_set_opt).value();
         }

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -269,9 +269,10 @@ static ss::future<segment_set> unsafe_do_recover(
     return ss::async([segments = std::move(segments),
                       last_clean_segment = std::move(last_clean_segment),
                       &as]() mutable {
-        if (segments.empty() || as.abort_requested()) {
+        if (segments.empty()) {
             return std::move(segments);
         }
+        as.check();
         segment_set::underlying_t good = std::move(segments).release();
         absl::btree_set<segment*> to_recover_set;
         for (auto it = good.begin(); it != good.end(); ++it) {
@@ -382,9 +383,7 @@ static ss::future<segment_set> unsafe_do_recover(
 
         for (auto& s : to_recover) {
             // check for abort
-            if (unlikely(as.abort_requested())) {
-                return segment_set(std::move(good));
-            }
+            as.check();
 
             if (is_last_segment(s.get(), last_clean_segment)) {
                 vlog(

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -121,7 +121,7 @@ ss::future<segment_set> recover_segments(
 // on disk by an adjacent merge compaction (i.e were scheduled for removal, but
 // were not removed due to e.g. a broker crash) will not be included in the
 // `log` post reboot.
-ss::future<std::optional<segment_set>>
-maybe_create_contiguous_segment_set(segment_set::underlying_t segs);
+ss::future<std::optional<segment_set>> maybe_create_contiguous_segment_set(
+  segment_set::underlying_t segs, ss::abort_source& as);
 
 } // namespace storage

--- a/src/v/storage/tests/segment_set_test.cc
+++ b/src/v/storage/tests/segment_set_test.cc
@@ -102,8 +102,9 @@ public:
         for (const auto& spec : test.segments) {
             segs.push_back(co_await make_segment(idx, spec));
         }
+        ss::abort_source never_abort;
         auto set_opt = co_await maybe_create_contiguous_segment_set(
-          std::move(segs));
+          std::move(segs), never_abort);
         if (!set_opt.has_value()) {
             RPTEST_REQUIRE_CORO(!test.expected_result.has_value());
         } else {


### PR DESCRIPTION
To better respect potential shutdowns during `segment` recovery at start-up.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
