### PR TITLE
rptest: add recovery test case after full truncation

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -336,6 +336,94 @@ class NoDataCase(BaseCase):
         return False
 
 
+class TruncatedPartitionCase(BaseCase):
+    """
+    Similar to NoDataCase but this time the start offsets and
+    high watermarks are not zero.
+    """
+
+    topics = (TopicSpec(name='panda-topic',
+                        partition_count=1,
+                        replication_factor=3), )
+
+    message_count = 1000
+
+    leader_epoch: int | None = None
+
+    def generate_baseline(self):
+        for topic in self.topics:
+            # Transfer leadership to increment leader epoch so that we can
+            # test its recovery.
+            for _ in range(3):
+                admin = Admin(self._redpanda)
+
+                rpk_partition = next(self._rpk.describe_topic(topic.name))
+                target_node_id = next(
+                    filter(lambda r: r != rpk_partition.leader,
+                           rpk_partition.replicas))
+                leader = admin.get_partitions(topic, 0)['leader_id']
+                admin.partition_transfer_leadership("kafka", topic, 0,
+                                                    target_node_id)
+
+                def leader_changed():
+                    p = list(self._rpk.describe_topic(topic.name))[0]
+                    self.leader_epoch = p.leader_epoch
+                    return p.leader and p.leader != leader
+
+                wait_until(
+                    leader_changed,
+                    timeout_sec=30,
+                    backoff_sec=1,
+                    err_msg=
+                    f"Leader for topic {topic.name} didn't change after transfer leadership"
+                )
+
+            self.logger.info(
+                f"Leader epoch after transfer leadership: {self.leader_epoch}")
+
+            assert self.leader_epoch and self.leader_epoch >= 3, \
+                f"Leader epoch should be at least 3 after transfer leadership but is {self.leader_epoch}"
+
+            producer = self._rpk_producer_maker(topic=topic.name,
+                                                msg_count=self.message_count,
+                                                msg_size=1024)
+            producer.start()
+            producer.wait()
+            producer.free()
+
+        quiesce_uploads(self._redpanda, [topic.name for topic in self.topics],
+                        timeout_sec=60)
+
+        for topic in self.topics:
+            response = self._rpk.trim_prefix(topic.name, self.message_count)
+            assert len(response) == topic.partition_count
+
+        def segments_removed():
+            b = BucketView(self._redpanda)
+            m = b.get_partition_manifest(NTP('kafka', self.topics[0].name, 0))
+            self.logger.debug(f"Manifest after trim: {m}")
+            return not m["segments"]
+
+        wait_until(segments_removed,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg='Segments were not removed')
+
+        p = list(self._rpk.describe_topic(self.topics[0].name))[0]
+
+        assert p.high_watermark == self.message_count, \
+            f"High watermark should be {self.message_count} after trim_prefix but is {p.high_watermark}"
+
+    def validate_cluster(self, baseline, restored):
+        p = list(self._rpk.describe_topic(self.topics[0].name))[0]
+
+        assert p.high_watermark == self.message_count, \
+            f"High watermark should be {self.message_count} after partition recovery but is {p.high_watermark}"
+
+        assert p.leader_epoch == self.leader_epoch, \
+            f"Leader epoch should be {self.leader_epoch} after partition recovery but is {p.leader_epoch}"
+
+
 class EmptySegmentsCase(BaseCase):
     """Restore topic that has segments in S3, but segments have only non-data
     batches (raft configuration, raft configuration).
@@ -1661,6 +1749,27 @@ class TopicRecoveryTest(RedpandaTest):
                                      self.kafka_tools, self.rpk,
                                      self.s3_bucket, self.logger,
                                      self.rpk_producer_maker)
+        self.do_run(test_case)
+
+    @cluster(num_nodes=4,
+             log_allow_list=MISSING_DATA_ERRORS + TRANSIENT_ERRORS)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_truncated_partition(self, cloud_storage_type):
+        """
+        Test an edge case where the partition manifest is present
+        but the partition is empty.
+        """
+
+        self.redpanda.set_cluster_config({
+            "cloud_storage_housekeeping_interval_ms":
+            5000,
+        })
+
+        test_case = TruncatedPartitionCase(self.redpanda,
+                                           self.cloud_storage_client,
+                                           self.kafka_tools, self.rpk,
+                                           self.s3_bucket, self.logger,
+                                           self.rpk_producer_maker)
         self.do_run(test_case)
 
     @cluster(num_nodes=4,


### PR DESCRIPTION
Similar behavior with time based retention.

---

This will fail the CI run because that's not the actual behavior implemented.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
