### PR TITLE
cloud_storage: reproduce offset rollback on read replica after truncate

### DIFF
--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -306,4 +306,38 @@ FIXTURE_TEST(
       = rr_lister.start_offset_for_partition(topic_name, model::partition_id(0))
           .get();
     BOOST_REQUIRE_EQUAL(rr_lwm, rr_hwm);
+
+    // Clean up segments.
+    archiver.apply_retention().get();
+    archiver.garbage_collect().get();
+    BOOST_REQUIRE_EQUAL(0, archiver.manifest().size());
+
+    BOOST_REQUIRE_EQUAL(
+      cloud_storage::upload_result::success,
+      archiver.upload_manifest("test").get());
+    archiver.flush_manifest_clean_offset().get();
+
+    // Once synced on the read replica, it should fail to be read.
+    BOOST_REQUIRE(rr_archiver.sync_for_tests().get());
+    BOOST_REQUIRE_EQUAL(
+      cloud_storage::download_result::success,
+      rr_archiver.sync_manifest().get());
+
+    auto rr_lwm2 = rr_lister
+                     .high_watermark_for_partition(
+                       topic_name, model::partition_id(0))
+                     .get();
+
+    BOOST_TEST_CONTEXT("Checking that LWM didn't change after cleanup") {
+        BOOST_CHECK_EQUAL(rr_lwm2, rr_lwm);
+    }
+
+    auto rr_hwm2 = rr_lister
+                     .high_watermark_for_partition(
+                       topic_name, model::partition_id(0))
+                     .get();
+
+    BOOST_TEST_CONTEXT("Checking that HWM didn't change after cleanup") {
+        BOOST_CHECK_EQUAL(rr_hwm2, rr_hwm);
+    }
 }


### PR DESCRIPTION
Show a bug.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
