### PR TITLE
[v25.1.x] `storage`: pass `seg->size_before()` as `segment_size` hint to `segment_appender` (MANUAL BACKPORT)

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1511,10 +1511,11 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     auto staging_to_clean = scoped_file_tracker{
       cfg.files_to_cleanup, {tmpname, cmp_idx_tmpname}};
 
+    const auto size_before = seg->size_bytes();
     auto appender = co_await internal::make_segment_appender(
       tmpname,
       segment_appender::write_behind_memory / internal::chunks().chunk_size(),
-      std::nullopt,
+      size_before,
       cfg.iopc,
       resources(),
       cfg.sanitizer_config);
@@ -1572,7 +1573,6 @@ ss::future<> disk_log_impl::rewrite_segment_with_offset_map(
     if (seg->is_closed()) {
         throw segment_closed_exception();
     }
-    const auto size_before = seg->size_bytes();
     const auto size_after = appender->file_byte_offset();
 
     // Clear our indexes before swapping the data files (note, the new

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -390,10 +390,11 @@ ss::future<storage::index_state> do_copy_segment_data(
     // prepare a new segment with only the compacted_offsets
     auto tmpname = seg->reader().path().to_staging();
 
+    auto size_before = seg->size_bytes();
     auto appender = co_await make_segment_appender(
       tmpname,
       segment_appender::write_behind_memory / internal::chunks().chunk_size(),
-      std::nullopt,
+      size_before,
       cfg.iopc,
       resources,
       cfg.sanitizer_config);


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/27022. `cherry-pick` conflict due to removed `ss::io_priority_class` in future versions of `redpanda`.

Fixes https://github.com/redpanda-data/redpanda/issues/27037.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Reduces the fragmentation caused by `ftruncate()` calls on `segment`s being rewritten as a part of compaction by providing a better estimate for the size required from initial `fallocate()` calls in the `storage` subsystem
