### PR TITLE
[v25.1.x] [CORE-12883] k/s/handlers: fix memory estimation for metadata api

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -621,6 +621,10 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
         size_estimate += chunked_vector_overalloc<partition>(pcount);
     }
 
+    const auto n_topics = md_cache.all_topics_metadata().size();
+    size_estimate += chunked_vector_overalloc<kafka::metadata_response_topic>(
+      n_topics);
+
     // Finally, we double the estimate, because the highwater mark for memory
     // use comes when the in-memory structures (metadata_response_data and
     // subobjects) exist on the heap and they are encoded into the reponse,

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -541,6 +541,20 @@ ss::future<response_ptr> metadata_handler::handle(
     co_return co_await ctx.respond(std::move(reply));
 }
 
+namespace {
+// Safety margin to account for overallocations by the chunked_vector.
+// This is meant to represent either the table-doubling before filling
+// the first fragment or the allocation for an extra fragment.
+template<typename T>
+size_t chunked_vector_overalloc(size_t n_elems) {
+    if (std::cmp_less(n_elems, chunked_vector<T>::elements_per_fragment())) {
+        return sizeof(T) * n_elems;
+    } else {
+        return chunked_vector<T>::max_frag_bytes();
+    }
+}
+} // namespace
+
 size_t
 metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
     // We cannot make a precise estimate of the size of a metadata response by
@@ -603,6 +617,8 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
 
         size_estimate += pcount
                          * (bytes_per_partition + bytes_per_replica * rcount);
+
+        size_estimate += chunked_vector_overalloc<partition>(pcount);
     }
 
     // Finally, we double the estimate, because the highwater mark for memory
@@ -615,9 +631,7 @@ metadata_memory_estimator(size_t request_size, connection_context& conn_ctx) {
 
     // We still add on the default_estimate to handle the size of the request
     // itself and miscellaneous other procesing (this is a small adjustment,
-    // generally ~8000 bytes). Finally, we add max_frag_bytes to account for the
-    // worse-cast overshoot during vector re-allocation.
-    return default_memory_estimate(request_size) + size_estimate
-           + chunked_vector<metadata_response_partition>::max_frag_bytes();
+    // generally ~8000 bytes).
+    return default_memory_estimate(request_size) + size_estimate;
 }
 } // namespace kafka


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27015
