### PR TITLE
pbgen: sort messages to try and prevent incomplete data types

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -377,11 +377,14 @@ func (g *headerGenerator) generateFile(w *codewriter) {
 		g.generateEnumSerde(enum, w)
 		w.Println()
 	}
-	// Now emit all messages.
-	for _, msg := range msgs {
+	// Now emit all messages, but do it in a best effort order to avoid
+	// circular dependencies. If you are still seeing circular dependencies,
+	// this sort is stable, so you can reorder messages to get the order you want.
+	for _, msg := range sortMessages(msgs) {
 		g.generateMessage(msg, w)
 		w.Println()
 	}
+	// Last emit services
 	for i := range g.file.Services().Len() {
 		service := g.file.Services().Get(i)
 		g.generateService(service, w)
@@ -1848,6 +1851,26 @@ func collectDescriptors(parent protoreflect.Descriptor) (msgs []protoreflect.Mes
 		}
 	}
 	return
+}
+
+func sortMessages(msgs []protoreflect.MessageDescriptor) []protoreflect.MessageDescriptor {
+	return sortCyclicalGraph(msgs, func(m protoreflect.MessageDescriptor) []protoreflect.MessageDescriptor {
+		var children []protoreflect.MessageDescriptor
+		for i := range m.Fields().Len() {
+			f := m.Fields().Get(i)
+			if f.IsMap() {
+				if child := f.MapKey().Message(); child != nil {
+					children = append(children, child)
+				}
+				if child := f.MapValue().Message(); child != nil {
+					children = append(children, child)
+				}
+			} else if child := f.Message(); child != nil {
+				children = append(children, child)
+			}
+		}
+		return children
+	})
 }
 
 // ----------------------------------------------------------

--- a/bazel/pbgen/utils.go
+++ b/bazel/pbgen/utils.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -37,4 +39,167 @@ func pascalToSnakeCase(s string) string {
 		builder.WriteRune(unicode.ToLower(r))
 	}
 	return builder.String()
+}
+
+// Sort a directed graph, possibly with cycles.
+//
+// This is done by using Tarjan's algorithm to find strongly connected components (SCCs),
+// then we topologically sort each SCC.
+//
+// The returned order is where leaf nodes (nodes with no children) come first, then nodes
+// that depend on them, and so on.
+func sortCyclicalGraph[T comparable](nodes []T, getChildren func(node T) []T) []T {
+	sccs := stronglyConnectedComponents(nodes, getChildren)
+	nodeToSccID := make(map[T]int)
+	for i, scc := range sccs {
+		for _, node := range scc {
+			nodeToSccID[node] = i
+		}
+	}
+	// Build the graph of components.
+	sccGraph := make(map[int][]int)
+	sccNodeList := make([]int, len(sccs))
+	for i := range sccs {
+		sccNodeList[i] = i
+		// For each node in the original graph...
+		for _, node := range sccs[i] {
+			// Look at its children...
+			for _, child := range getChildren(node) {
+				// If a child is in a *different* component, add an edge
+				// between the components in our new graph.
+				if nodeToSccID[node] != nodeToSccID[child] {
+					sccGraph[nodeToSccID[node]] = append(sccGraph[nodeToSccID[node]], nodeToSccID[child])
+				}
+			}
+		}
+	}
+	getSccChildren := func(sccID int) []int {
+		return sccGraph[sccID]
+	}
+	sortedSccIndices, err := topologicalSort(sccNodeList, getSccChildren)
+	if err != nil {
+		panic(fmt.Errorf("stronglyConnectedComponents returned a cyclic graph, which is unexpected: %v", err))
+	}
+	var finalOrder []T
+	for _, sccIndex := range sortedSccIndices {
+		// The nodes within a cycle can be in any order, here we just append them.
+		finalOrder = append(finalOrder, sccs[sccIndex]...)
+	}
+	slices.Reverse(finalOrder)
+	return finalOrder
+}
+
+func stronglyConnectedComponents[T comparable](nodes []T, getChildren func(node T) []T) [][]T {
+	state := &sccState[T]{
+		nodes:       nodes,
+		getChildren: getChildren,
+		ids:         make(map[T]int),
+		low:         make(map[T]int),
+		onStack:     make(map[T]bool),
+		stack:       make([]T, 0),
+		generator:   0,
+		sccs:        make([][]T, 0),
+	}
+	// The algorithm requires visiting each node. If a node hasn't been assigned an ID,
+	// it means it hasn't been visited yet, so we start a DFS from it.
+	for _, node := range state.nodes {
+		if _, visited := state.ids[node]; !visited {
+			state.dfs(node)
+		}
+	}
+	return state.sccs
+}
+
+// sccState holds the state required for Tarjan's algorithm.
+// It's used internally by the StronglyConnectedComponents function.
+type sccState[T comparable] struct {
+	nodes       []T
+	getChildren func(node T) []T
+	ids         map[T]int
+	low         map[T]int
+	onStack     map[T]bool
+	stack       []T
+	generator   int
+	sccs        [][]T
+}
+
+// dfs is the core of Tarjan's algorithm. It performs a depth-first search
+// to find the strongly connected components.
+func (s *sccState[T]) dfs(at T) {
+	// Push the current node onto the stack and mark it as on the stack.
+	s.stack = append(s.stack, at)
+	s.onStack[at] = true
+
+	// Assign the node an ID and a low-link value from the generator.
+	s.generator++
+	s.ids[at] = s.generator
+	s.low[at] = s.generator
+
+	// Visit all neighbors of the current node.
+	for _, to := range s.getChildren(at) {
+		if _, visited := s.ids[to]; !visited {
+			s.dfs(to)
+		}
+		// If the neighbor is on the stack, it's part of the current SCC.
+		// We might need to update our low-link value.
+		if s.onStack[to] {
+			s.low[at] = min(s.low[at], s.low[to])
+		}
+	}
+	// After visiting all neighbors, check if the current node is the root of an SCC.
+	// The root is a node where its ID equals its low-link value.
+	if s.ids[at] == s.low[at] {
+		var scc []T
+		// If it's a root, pop nodes from the stack until we pop the root itself.
+		// All nodes popped here form one strongly connected component.
+		for len(s.stack) > 0 {
+			node := s.stack[len(s.stack)-1]
+			s.stack = s.stack[:len(s.stack)-1]
+			s.onStack[node] = false
+
+			scc = append(scc, node)
+
+			if node == at {
+				break
+			}
+		}
+		// Add the found SCC to our list of all SCCs.
+		s.sccs = append(s.sccs, scc)
+	}
+}
+
+// topologicalSort based on DFS
+func topologicalSort[T comparable](nodes []T, getChildren func(node T) []T) ([]T, error) {
+	var sortedOrder []T
+	visited := make(map[T]bool)
+	recursionStack := make(map[T]bool)
+	var dfs func(node T) error
+	dfs = func(node T) error {
+		visited[node] = true
+		recursionStack[node] = true
+		for _, child := range getChildren(node) {
+			if recursionStack[child] {
+				return fmt.Errorf("graph contains a cycle")
+			}
+			if !visited[child] {
+				if err := dfs(child); err != nil {
+					return err
+				}
+			}
+		}
+		recursionStack[node] = false
+		sortedOrder = append(sortedOrder, node)
+		return nil
+	}
+	for _, node := range nodes {
+		if !visited[node] {
+			if err := dfs(node); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for i, j := 0, len(sortedOrder)-1; i < j; i, j = i+1, j-1 {
+		sortedOrder[i], sortedOrder[j] = sortedOrder[j], sortedOrder[i]
+	}
+	return sortedOrder, nil
 }

--- a/bazel/pbgen/utils_test.go
+++ b/bazel/pbgen/utils_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"maps"
+	"slices"
+	"testing"
+)
 
 func TestToLower(t *testing.T) {
 	testCases := map[string]string{
@@ -29,6 +33,73 @@ func TestToLower(t *testing.T) {
 		result := pascalToSnakeCase(input)
 		if result != expected {
 			t.Errorf("converting %q to snake case, got: %q want: %q", input, result, expected)
+		}
+	}
+}
+
+func TestComponentSort(t *testing.T) {
+	testCases := []struct {
+		sorted []string
+		graph  map[string][]string
+	}{
+		{
+			graph: map[string][]string{
+				"A": {"B"},
+				"B": {"C"},
+				"C": {"A"},
+				"D": {"A"},
+			},
+			sorted: []string{"A", "B", "C", "D"},
+		},
+		{
+			graph: map[string][]string{
+				"A": {"B"},
+				"B": {"C", "E", "F"},
+				"C": {"D", "G"},
+				"D": {"C", "H"},
+				"E": {"A", "F"},
+				"F": {"G"},
+				"G": {"F"},
+				"H": {"D", "G"},
+			},
+			sorted: []string{"G", "F", "C", "D", "H", "A", "B", "E"},
+		},
+		{
+			graph: map[string][]string{
+				"A": {"B"},
+				"B": {"A"},
+				"C": {"D"},
+				"D": {"E"},
+				"E": {"C"},
+			},
+			sorted: []string{"A", "B", "C", "D", "E"},
+		},
+		{
+			graph: map[string][]string{
+				"A": {"B"},
+				"B": {"C"},
+				"C": {"D"},
+				"D": {"E"},
+				"E": {},
+			},
+			sorted: []string{"E", "D", "C", "B", "A"},
+		},
+		{
+			graph:  map[string][]string{},
+			sorted: []string{},
+		},
+		{
+			graph:  map[string][]string{"A": {}},
+			sorted: []string{"A"},
+		},
+	}
+
+	for _, tc := range testCases {
+		nodes := slices.Collect(maps.Keys(tc.graph))
+		slices.Sort(nodes) // Key iteration order is not guaranteed, so we sort the keys first.
+		sorted := sortCyclicalGraph(nodes, func(id string) []string { return tc.graph[id] })
+		if !slices.Equal(sorted, tc.sorted) {
+			t.Errorf("expected sorted order %v, got %v", tc.sorted, sorted)
 		}
 	}
 }

--- a/src/v/serde/protobuf/tests/codegen_test.proto
+++ b/src/v/serde/protobuf/tests/codegen_test.proto
@@ -30,3 +30,14 @@ enum Proto3Test {
     PROTO3_TEST_STARTED = 1;
     PROTO3_TEST_FINISHED = 2;
 }
+
+message A {
+    C c = 1;
+}
+
+message B {
+    C c = 1;
+    A a = 2;
+}
+
+message C {}

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -17,6 +17,271 @@
 
 namespace example {
 
+a::a() noexcept = default;
+a::a(a&&) noexcept = default;
+a& a::operator=(a&&) noexcept = default;
+a::~a() noexcept = default;
+bool a::operator==(const a&) const = default;
+c& a::get_c() { return c_; }
+const c& a::get_c() const { return c_; }
+void a::set_c(c&& v) { c_ = std::move(v); }
+seastar::future<> a::from_proto(serde::pb::wire_format_parser* parser, a* self) {
+  while (parser->bytes_left() > 0) {
+    auto tag = parser->read_tag();
+    switch (tag.field_number) {
+    case 1: { // c
+      auto msg_parser = parser->read_message<"example.A.c">(tag);
+      c sub_msg;
+      co_await c::from_proto(&msg_parser, &sub_msg);
+      self->set_c(std::move(sub_msg));
+      break;
+    }
+    default:
+      parser->skip_unknown(tag);
+      break;
+    }
+  }
+  co_return;
+}
+seastar::future<a> a::from_proto(iobuf buf) {
+  a self;
+  serde::pb::wire_format_parser parser{std::move(buf)};
+  co_await from_proto(&parser, &self);
+  parser.check_empty();
+  co_return self;
+}
+seastar::future<iobuf> a::to_proto() const {
+  iobuf buf;
+  {
+    // c
+    serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
+    iobuf msg_buf = co_await get_c().to_proto();
+    serde::pb::write_length(static_cast<int32_t>(msg_buf.size_bytes()), &buf);
+    buf.append(std::move(msg_buf));
+  }
+  co_return buf;
+}
+seastar::future<iobuf> a::to_json() const {
+  serde::json::writer w;
+  w.begin_object();
+  w.key("c");
+  w.append_raw_json(co_await get_c().to_json());
+  w.end_object();
+  co_return std::move(w).finish();
+}
+seastar::future<> a::from_json(serde::pb::json::peekable_parser* parser, a* self) {
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, int32_t>>({
+    {"c", 1},
+  });
+  auto entries = serde::pb::json::object_key_generator(parser);
+  while (auto key = co_await entries()) {
+    auto fields = std::ranges::equal_range(key_to_field_number, *key, std::less<>(), [](const auto& pair) { return pair.first; });
+    if (fields.empty()) {
+      co_await parser->skip_value();
+      continue;
+    }
+    switch (fields.front().second) {
+    case 1: { // c
+      if (co_await parser->peek() == serde::json::token::value_null) {
+        co_await parser->next();
+      } else {
+        c v{};
+        co_await c::from_json(parser, &v);
+        self->set_c(std::move(v));
+      }
+      break;
+    }
+    default:
+      vassert(false, "codegen error unexpected field number: {}", fields.front().second);
+    }
+  }
+  co_return;
+}
+seastar::future<a> a::from_json(iobuf data) {
+  a self;
+  serde::pb::json::peekable_parser parser(std::move(data));
+  co_await from_json(&parser, &self);
+  co_await serde::pb::json::check_next_eof(&parser);
+  co_return self;
+}
+
+b::b() noexcept = default;
+b::b(b&&) noexcept = default;
+b& b::operator=(b&&) noexcept = default;
+b::~b() noexcept = default;
+bool b::operator==(const b&) const = default;
+c& b::get_c() { return c_; }
+const c& b::get_c() const { return c_; }
+void b::set_c(c&& v) { c_ = std::move(v); }
+a& b::get_a() { return a_; }
+const a& b::get_a() const { return a_; }
+void b::set_a(a&& v) { a_ = std::move(v); }
+seastar::future<> b::from_proto(serde::pb::wire_format_parser* parser, b* self) {
+  while (parser->bytes_left() > 0) {
+    auto tag = parser->read_tag();
+    switch (tag.field_number) {
+    case 1: { // c
+      auto msg_parser = parser->read_message<"example.B.c">(tag);
+      c sub_msg;
+      co_await c::from_proto(&msg_parser, &sub_msg);
+      self->set_c(std::move(sub_msg));
+      break;
+    }
+    case 2: { // a
+      auto msg_parser = parser->read_message<"example.B.a">(tag);
+      a sub_msg;
+      co_await a::from_proto(&msg_parser, &sub_msg);
+      self->set_a(std::move(sub_msg));
+      break;
+    }
+    default:
+      parser->skip_unknown(tag);
+      break;
+    }
+  }
+  co_return;
+}
+seastar::future<b> b::from_proto(iobuf buf) {
+  b self;
+  serde::pb::wire_format_parser parser{std::move(buf)};
+  co_await from_proto(&parser, &self);
+  parser.check_empty();
+  co_return self;
+}
+seastar::future<iobuf> b::to_proto() const {
+  iobuf buf;
+  {
+    // c
+    serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
+    iobuf msg_buf = co_await get_c().to_proto();
+    serde::pb::write_length(static_cast<int32_t>(msg_buf.size_bytes()), &buf);
+    buf.append(std::move(msg_buf));
+  }
+  {
+    // a
+    serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 2}, &buf);
+    iobuf msg_buf = co_await get_a().to_proto();
+    serde::pb::write_length(static_cast<int32_t>(msg_buf.size_bytes()), &buf);
+    buf.append(std::move(msg_buf));
+  }
+  co_return buf;
+}
+seastar::future<iobuf> b::to_json() const {
+  serde::json::writer w;
+  w.begin_object();
+  w.key("c");
+  w.append_raw_json(co_await get_c().to_json());
+  w.key("a");
+  w.append_raw_json(co_await get_a().to_json());
+  w.end_object();
+  co_return std::move(w).finish();
+}
+seastar::future<> b::from_json(serde::pb::json::peekable_parser* parser, b* self) {
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, int32_t>>({
+    {"a", 2},
+    {"c", 1},
+  });
+  auto entries = serde::pb::json::object_key_generator(parser);
+  while (auto key = co_await entries()) {
+    auto fields = std::ranges::equal_range(key_to_field_number, *key, std::less<>(), [](const auto& pair) { return pair.first; });
+    if (fields.empty()) {
+      co_await parser->skip_value();
+      continue;
+    }
+    switch (fields.front().second) {
+    case 1: { // c
+      if (co_await parser->peek() == serde::json::token::value_null) {
+        co_await parser->next();
+      } else {
+        c v{};
+        co_await c::from_json(parser, &v);
+        self->set_c(std::move(v));
+      }
+      break;
+    }
+    case 2: { // a
+      if (co_await parser->peek() == serde::json::token::value_null) {
+        co_await parser->next();
+      } else {
+        a v{};
+        co_await a::from_json(parser, &v);
+        self->set_a(std::move(v));
+      }
+      break;
+    }
+    default:
+      vassert(false, "codegen error unexpected field number: {}", fields.front().second);
+    }
+  }
+  co_return;
+}
+seastar::future<b> b::from_json(iobuf data) {
+  b self;
+  serde::pb::json::peekable_parser parser(std::move(data));
+  co_await from_json(&parser, &self);
+  co_await serde::pb::json::check_next_eof(&parser);
+  co_return self;
+}
+
+c::c() noexcept = default;
+c::c(c&&) noexcept = default;
+c& c::operator=(c&&) noexcept = default;
+c::~c() noexcept = default;
+bool c::operator==(const c&) const = default;
+seastar::future<> c::from_proto(serde::pb::wire_format_parser* parser, c* self) {
+  std::ignore = self;
+  while (parser->bytes_left() > 0) {
+    auto tag = parser->read_tag();
+    switch (tag.field_number) {
+    default:
+      parser->skip_unknown(tag);
+      break;
+    }
+  }
+  co_return;
+}
+seastar::future<c> c::from_proto(iobuf buf) {
+  c self;
+  serde::pb::wire_format_parser parser{std::move(buf)};
+  co_await from_proto(&parser, &self);
+  parser.check_empty();
+  co_return self;
+}
+seastar::future<iobuf> c::to_proto() const {
+  iobuf buf;
+  co_return buf;
+}
+seastar::future<iobuf> c::to_json() const {
+  serde::json::writer w;
+  w.begin_object();
+  w.end_object();
+  co_return std::move(w).finish();
+}
+seastar::future<> c::from_json(serde::pb::json::peekable_parser* parser, c* self) {
+  std::ignore = self;
+  constexpr static std::array<std::pair<std::string_view, int32_t>, 0> key_to_field_number = {};
+  auto entries = serde::pb::json::object_key_generator(parser);
+  while (auto key = co_await entries()) {
+    auto fields = std::ranges::equal_range(key_to_field_number, *key, std::less<>(), [](const auto& pair) { return pair.first; });
+    if (fields.empty()) {
+      co_await parser->skip_value();
+      continue;
+    }
+    switch (fields.front().second) {
+    default:
+      vassert(false, "codegen error unexpected field number: {}", fields.front().second);
+    }
+  }
+  co_return;
+}
+seastar::future<c> c::from_json(iobuf data) {
+  c self;
+  serde::pb::json::peekable_parser parser(std::move(data));
+  co_await from_json(&parser, &self);
+  co_await serde::pb::json::check_next_eof(&parser);
+  co_return self;
+}
+
 void enum_from_proto(iobuf_parser* p, corpus* e) {
   auto v = serde::pb::read_varint<int32_t, serde::pb::zigzag::no>(p);
   constexpr static auto values = std::to_array<int32_t>({

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -18,6 +18,9 @@ class peekable_parser;
 
 namespace example {
 
+class a;
+class b;
+class c;
 
 // Test that enums that have prefixes in their values as recommended by protobuf
 // are stripped and turned into enum classes.
@@ -61,5 +64,104 @@ void enum_from_proto(iobuf_parser*, proto3_test*);
 // Returns the name of the enum value
 std::string_view enum_to_string(const proto3_test&);
 void enum_from_json(serde::pb::json::peekable_parser*, proto3_test*);
+
+class c {
+public:
+  c() noexcept;
+  c(const c&) = delete;
+  c& operator=(const c&) = delete;
+  c(c&&) noexcept;
+  c& operator=(c&&) noexcept;
+  ~c() noexcept;
+  
+  bool operator==(const c&) const;  
+  // Serializes example.C into a protocol buffer, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_proto() const;
+  // Serializes example.C into proto3 JSON, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_json() const;
+  // Deserializes example.C from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<c> from_proto(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, c*);
+  // Deserializes example.C from json, in a way that will not cause stalls for large messages.
+  static seastar::future<c> from_json(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, c*);
+  
+
+private:
+};
+
+class a {
+public:
+  a() noexcept;
+  a(const a&) = delete;
+  a& operator=(const a&) = delete;
+  a(a&&) noexcept;
+  a& operator=(a&&) noexcept;
+  ~a() noexcept;
+  
+  bool operator==(const a&) const;  
+  // Serializes example.A into a protocol buffer, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_proto() const;
+  // Serializes example.A into proto3 JSON, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_json() const;
+  // Deserializes example.A from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<a> from_proto(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, a*);
+  // Deserializes example.A from json, in a way that will not cause stalls for large messages.
+  static seastar::future<a> from_json(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, a*);
+  
+  c& get_c();
+  const c& get_c() const;
+  void set_c(c&& v);
+
+private:
+  c c_;
+};
+
+class b {
+public:
+  b() noexcept;
+  b(const b&) = delete;
+  b& operator=(const b&) = delete;
+  b(b&&) noexcept;
+  b& operator=(b&&) noexcept;
+  ~b() noexcept;
+  
+  bool operator==(const b&) const;  
+  // Serializes example.B into a protocol buffer, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_proto() const;
+  // Serializes example.B into proto3 JSON, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_json() const;
+  // Deserializes example.B from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<b> from_proto(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, b*);
+  // Deserializes example.B from json, in a way that will not cause stalls for large messages.
+  static seastar::future<b> from_json(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, b*);
+  
+  c& get_c();
+  const c& get_c() const;
+  void set_c(c&& v);
+  a& get_a();
+  const a& get_a() const;
+  void set_a(a&& v);
+
+private:
+  c c_;
+  a a_;
+};
 
 } // example

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
@@ -50,40 +50,36 @@ void enum_from_proto(iobuf_parser*, foreign_enum_edition2023*);
 std::string_view enum_to_string(const foreign_enum_edition2023&);
 void enum_from_json(serde::pb::json::peekable_parser*, foreign_enum_edition2023*);
 
-class test_all_types_edition2023_nested_message {
+class foreign_message_edition2023 {
 public:
-  test_all_types_edition2023_nested_message() noexcept;
-  test_all_types_edition2023_nested_message(const test_all_types_edition2023_nested_message&) = delete;
-  test_all_types_edition2023_nested_message& operator=(const test_all_types_edition2023_nested_message&) = delete;
-  test_all_types_edition2023_nested_message(test_all_types_edition2023_nested_message&&) noexcept;
-  test_all_types_edition2023_nested_message& operator=(test_all_types_edition2023_nested_message&&) noexcept;
-  ~test_all_types_edition2023_nested_message() noexcept;
+  foreign_message_edition2023() noexcept;
+  foreign_message_edition2023(const foreign_message_edition2023&) = delete;
+  foreign_message_edition2023& operator=(const foreign_message_edition2023&) = delete;
+  foreign_message_edition2023(foreign_message_edition2023&&) noexcept;
+  foreign_message_edition2023& operator=(foreign_message_edition2023&&) noexcept;
+  ~foreign_message_edition2023() noexcept;
   
-  bool operator==(const test_all_types_edition2023_nested_message&) const;  
-  // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into a protocol buffer, in a way that will not cause stalls for large messages.
+  bool operator==(const foreign_message_edition2023&) const;  
+  // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
-  // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into proto3 JSON, in a way that will not cause stalls for large messages.
+  // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into proto3 JSON, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_json() const;
-  // Deserializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage from a protocol buffer, in a way that will not cause stalls for large messages.
-  static seastar::future<test_all_types_edition2023_nested_message> from_proto(iobuf);
+  // Deserializes protobuf_test_messages.editions.ForeignMessageEdition2023 from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<foreign_message_edition2023> from_proto(iobuf);
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
-  static seastar::future<> from_proto(serde::pb::wire_format_parser*, test_all_types_edition2023_nested_message*);
-  // Deserializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage from json, in a way that will not cause stalls for large messages.
-  static seastar::future<test_all_types_edition2023_nested_message> from_json(iobuf);
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, foreign_message_edition2023*);
+  // Deserializes protobuf_test_messages.editions.ForeignMessageEdition2023 from json, in a way that will not cause stalls for large messages.
+  static seastar::future<foreign_message_edition2023> from_json(iobuf);
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
-  static seastar::future<> from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023_nested_message*);
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, foreign_message_edition2023*);
   
-  int32_t get_a() const;
-  void set_a(int32_t v);
-  std::unique_ptr<test_all_types_edition2023>& get_corecursive();
-  const std::unique_ptr<test_all_types_edition2023>& get_corecursive() const;
-  void set_corecursive(std::unique_ptr<test_all_types_edition2023>&& v);
+  int32_t get_c() const;
+  void set_c(int32_t v);
 
 private:
-  int32_t a_{};
-  std::unique_ptr<test_all_types_edition2023> corecursive_;
+  int32_t c_{};
 };
 
 // groups
@@ -120,6 +116,42 @@ public:
 private:
   int32_t group_int32_{};
   uint32_t group_uint32_{};
+};
+
+class test_all_types_edition2023_nested_message {
+public:
+  test_all_types_edition2023_nested_message() noexcept;
+  test_all_types_edition2023_nested_message(const test_all_types_edition2023_nested_message&) = delete;
+  test_all_types_edition2023_nested_message& operator=(const test_all_types_edition2023_nested_message&) = delete;
+  test_all_types_edition2023_nested_message(test_all_types_edition2023_nested_message&&) noexcept;
+  test_all_types_edition2023_nested_message& operator=(test_all_types_edition2023_nested_message&&) noexcept;
+  ~test_all_types_edition2023_nested_message() noexcept;
+  
+  bool operator==(const test_all_types_edition2023_nested_message&) const;  
+  // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into a protocol buffer, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_proto() const;
+  // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into proto3 JSON, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_json() const;
+  // Deserializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<test_all_types_edition2023_nested_message> from_proto(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, test_all_types_edition2023_nested_message*);
+  // Deserializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage from json, in a way that will not cause stalls for large messages.
+  static seastar::future<test_all_types_edition2023_nested_message> from_json(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023_nested_message*);
+  
+  int32_t get_a() const;
+  void set_a(int32_t v);
+  std::unique_ptr<test_all_types_edition2023>& get_corecursive();
+  const std::unique_ptr<test_all_types_edition2023>& get_corecursive() const;
+  void set_corecursive(std::unique_ptr<test_all_types_edition2023>&& v);
+
+private:
+  int32_t a_{};
+  std::unique_ptr<test_all_types_edition2023> corecursive_;
 };
 
 class test_all_types_edition2023 {
@@ -540,38 +572,6 @@ private:
   std::variant<std::monostate, uint32_t, test_all_types_edition2023_nested_message, ss::sstring, iobuf, bool, uint64_t, float, double, test_all_types_edition2023_nested_enum> oneof_field_{};
   test_all_types_edition2023_group_like_type groupliketype_;
   test_all_types_edition2023_group_like_type delimited_field_;
-};
-
-class foreign_message_edition2023 {
-public:
-  foreign_message_edition2023() noexcept;
-  foreign_message_edition2023(const foreign_message_edition2023&) = delete;
-  foreign_message_edition2023& operator=(const foreign_message_edition2023&) = delete;
-  foreign_message_edition2023(foreign_message_edition2023&&) noexcept;
-  foreign_message_edition2023& operator=(foreign_message_edition2023&&) noexcept;
-  ~foreign_message_edition2023() noexcept;
-  
-  bool operator==(const foreign_message_edition2023&) const;  
-  // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into a protocol buffer, in a way that will not cause stalls for large messages.
-  seastar::future<iobuf> to_proto() const;
-  // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into proto3 JSON, in a way that will not cause stalls for large messages.
-  seastar::future<iobuf> to_json() const;
-  // Deserializes protobuf_test_messages.editions.ForeignMessageEdition2023 from a protocol buffer, in a way that will not cause stalls for large messages.
-  static seastar::future<foreign_message_edition2023> from_proto(iobuf);
-  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
-  // Use the iobuf version instead.
-  static seastar::future<> from_proto(serde::pb::wire_format_parser*, foreign_message_edition2023*);
-  // Deserializes protobuf_test_messages.editions.ForeignMessageEdition2023 from json, in a way that will not cause stalls for large messages.
-  static seastar::future<foreign_message_edition2023> from_json(iobuf);
-  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
-  // Use the iobuf version instead.
-  static seastar::future<> from_json(serde::pb::json::peekable_parser*, foreign_message_edition2023*);
-  
-  int32_t get_c() const;
-  void set_c(int32_t v);
-
-private:
-  int32_t c_{};
 };
 
 } // protobuf_test_messages::editions


### PR DESCRIPTION
Use a SCC + Topological sort for attempting to prevent dependency cycle
issues in the generated C++. Within strongly connected graph components,
the order is just the order declared in the file. In that case use the
ptr option and manually order the messages that are co-recursive.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
