### PR TITLE
`storage`: pass `abort_source` to `log::start()`

### DIFF
--- a/src/v/datalake/translation/tests/translated_log_offset_test.cc
+++ b/src/v/datalake/translation/tests/translated_log_offset_test.cc
@@ -54,7 +54,8 @@ TEST(TranslatedLogOffsetTest, TestTranslatedOffsetsGrowingLog) {
     auto log = b.get_log();
 
     // Must initialize translator state.
-    log->start(std::nullopt).get();
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
 
     // A good property to check.
     ASSERT_TRUE(
@@ -162,7 +163,8 @@ TEST(TranslatedLogOffsetTest, TestTranslatedOffsetsGrowingLogConfigBatchStart) {
     auto log = b.get_log();
 
     // Must initialize translator state.
-    log->start(std::nullopt).get();
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
 
     // A good property to check.
     ASSERT_TRUE(
@@ -275,7 +277,8 @@ TEST(
     auto log = b.get_log();
 
     // Must initialize translator state.
-    log->start(std::nullopt).get();
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
 
     // A good property to check.
     ASSERT_TRUE(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1523,7 +1523,7 @@ consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
             }
             _snapshot_size = co_await _snapshot_mgr.get_snapshot_size();
         }
-        co_await _log->start(start_truncate_cfg);
+        co_await _log->start(start_truncate_cfg, _as);
         snapshot_units.return_all();
 
         vlog(

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -17,8 +17,8 @@ failure_injectable_log::failure_injectable_log(
   , _underlying_log(std::move(underlying_log)) {}
 
 ss::future<> failure_injectable_log::start(
-  std::optional<storage::truncate_prefix_config> cfg) {
-    return _underlying_log->start(cfg);
+  std::optional<storage::truncate_prefix_config> cfg, ss::abort_source& as) {
+    return _underlying_log->start(cfg, as);
 }
 
 ss::future<>

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -33,8 +33,9 @@ public:
     failure_injectable_log& operator=(const failure_injectable_log&) = delete;
     ~failure_injectable_log() noexcept final = default;
 
-    ss::future<>
-    start(std::optional<storage::truncate_prefix_config> cfg) final;
+    ss::future<> start(
+      std::optional<storage::truncate_prefix_config> cfg,
+      ss::abort_source& as) final;
     ss::future<> housekeeping(storage::housekeeping_config cfg) final;
 
     ss::future<> truncate(storage::truncate_config) final;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -257,8 +257,8 @@ ss::future<> disk_log_impl::remove() {
       .finally([this] { _probe->clear_metrics(); });
 }
 
-ss::future<>
-disk_log_impl::start(std::optional<truncate_prefix_config> truncate_cfg) {
+ss::future<> disk_log_impl::start(
+  std::optional<truncate_prefix_config> truncate_cfg, ss::abort_source& as) {
     auto is_new = is_new_log();
     co_await offset_translator().start(
       storage::offset_translator::must_reset{is_new});
@@ -268,7 +268,7 @@ disk_log_impl::start(std::optional<truncate_prefix_config> truncate_cfg) {
     // Reset or load the offset translator state, depending on whether this is
     // a brand new log.
     if (!is_new) {
-        co_await offset_translator().sync_with_log(*this, _compaction_as);
+        co_await offset_translator().sync_with_log(*this, as);
     }
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -77,7 +77,8 @@ public:
     disk_log_impl(const disk_log_impl&) = delete;
     disk_log_impl& operator=(const disk_log_impl&) = delete;
 
-    ss::future<> start(std::optional<truncate_prefix_config>) final;
+    ss::future<>
+    start(std::optional<truncate_prefix_config>, ss::abort_source& as) final;
     ss::future<std::optional<ss::sstring>> close() final;
     ss::future<> remove() final;
     ss::future<> flush() final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -45,7 +45,8 @@ public:
     log& operator=(const log&) = delete;
     virtual ~log() noexcept = default;
 
-    virtual ss::future<> start(std::optional<truncate_prefix_config>) = 0;
+    virtual ss::future<>
+    start(std::optional<truncate_prefix_config>, ss::abort_source& as) = 0;
 
     // it shouldn't block for a long time as it will block other logs
     // eviction

--- a/src/v/storage/tests/compaction_fuzz_test.cc
+++ b/src/v/storage/tests/compaction_fuzz_test.cc
@@ -147,7 +147,8 @@ ss::future<ot_state> arrange_and_compact(
     co_await b1.start(log_ntp);
 
     // Must initialize translator state.
-    co_await b1.get_disk_log_impl().start(std::nullopt);
+    ss::abort_source as;
+    co_await b1.get_disk_log_impl().start(std::nullopt, as);
 
     try {
         for (const auto& b : batches) {
@@ -158,7 +159,6 @@ ss::future<ot_state> arrange_and_compact(
                 co_await b1.get_disk_log_impl().force_roll();
             }
         }
-        ss::abort_source as;
         auto compact_cfg = storage::compaction_config(
           batches.back().last_offset(), std::nullopt, std::nullopt, as);
         std::ignore = co_await b1.apply_sliding_window_compaction(compact_cfg);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3117,7 +3117,7 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
                    raft::group_id{0},
                    model::offset_translator_batch_types())
                  .get();
-    log->start(std::nullopt).get();
+    log->start(std::nullopt, as).get();
 
     storage::log_append_config appender_cfg{
       .should_fsync = storage::log_append_config::fsync::no,
@@ -3195,7 +3195,7 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
               raft::group_id{0},
               model::offset_translator_batch_types())
             .get();
-    log->start(std::nullopt).get();
+    log->start(std::nullopt, as).get();
 
     // validate the translation by comparing it with state before
     // compaction.


### PR DESCRIPTION
`_log->start()` is called from `consensus::do_start()`. Within `log::start()` is a call to `offset_translator().sync_with_log()`, which also passes an `abort_source`. This synchronization function may be a somewhat heavy operation, as a `log_reader` over the range `(_highest_known_offset, dirty_offset]` is used to read the `log`.

Previously, the `abort_source` passed to `sync_with_log()` was the `disk_log_impl::_compaction_as`. However, this isn't very helpful because this `abort_source` only has `request_abort()` called upon it within `disk_log_impl::remove()` and `disk_log_impl::close()`- both of which are called at the _end_ of the typical high-level `partition` removal process starting from the `partition_manager`.

https://github.com/redpanda-data/redpanda/blob/94516b662f01a512faef63c121357b5bcadbba3a/src/v/cluster/partition_manager.cc#L396-L406

What this can lead to is the following:

1. `redpanda` is launched. A relatively heavy `partition` with a lagging `_highest_known_offset` enters the `sync_with_log()` operation.
2. The user hits ^C to kill `redpanda`.
3. The high level shutdown process is entered from `application.cc`.
4. Within `partition_manager::do_shutdown(partition)`, we first wait for the `_raft_manager` to shutdown the `partition->raft()` pointer before proceeding to stop the `partition` and then its underlying `log`.
5. In reality, the `raft` pointer hasn't even finished its starting process yet, because the `sync_with_log()` process is taking so long!
6. The user waits for `sync_with_log()` to complete, and only then does shutdown of the `raft` object finish (as the `_compaction_as` only requests abort when the `log` is closed).
7. `log` is closed, `_compaction_as.request_abort()` is called.

Clearly, passing `_compaction_as` to `sync_with_log()` is essentially a no-op, since it is guaranteed that `sync_with_log()` _has_ to complete before an abort of `_compaction_as` can be requested.

An example of this hang can be seen in the logs shown below, where the `sync_with_log()` process takes around 5 seconds to complete.

To make the shutdown process smoother and avoid this sub-optimal behavior, pass the `consensus::_as` as an argument to `_log->start()` instead. Then, when an abort is requested of `redpanda` early on, the `sync_with_log()` process will be correctly terminated early instead of potentially appearing as a long winded hang.

```
^C
INFO  2025-07-28 22:30:03,397 [shard  0:main] main - application.cc:567 - Stopping...
DEBUG 2025-07-28 22:30:04,925 [shard 13:main] cluster - partition_manager.cc:287 - Log created manage completed, ntp: {kafka/__consumer_offsets/0}, rev: 71, 75 segments, 40910978 bytes
INFO  2025-07-28 22:30:04,926 [shard 13:rs  ] offset_translator - ntp: {kafka/__consumer_offsets/0} - offset_translator.cc:166 - started, state: {base offset/delta: -9223372036854775808/0, map size: 1, last delta: 0}, highest_known_offset: -9223372036854775808
INFO  2025-07-28 22:30:09,769 [shard 13:main] raft - [group_id:3, {kafka/__consumer_offsets/0}] consensus.cc:1685 - started raft, log offsets: {start_offset:0, committed_offset:19156188407, committed_offset_term:74, dirty_offset:19156188407, dirty_offset_term:74}, term: 74, configuration: {current: {voters: {{id: 43, revision: 103804}, {id: 59, revision: 234001}, {id: 44, revision: 395536}}, learners: {}}, old:{nullopt}, revision: 395536, update: {nullopt}, version: 6}}
DEBUG 2025-07-28 22:30:09,770 [shard 13:main] cluster - partition_manager.cc:397 - shutdown partition {kafka/__consumer_offsets/0} - stopping raft
DEBUG 2025-07-28 22:30:09,783 [shard 13:main] cluster - partition_manager.cc:408 - shutdown partition {kafka/__consumer_offsets/0} - stopped
```


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Improvements

* Prevent `redpanda` from occasionally hanging when the application is exited soon after starting.
