### PR TITLE
tests/docker: run with azurite fork which does not leak conns

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -60,7 +60,8 @@ services:
     command: "azurite-blob -l /data --blobHost 0.0.0.0"
     ports:
     - 10000:10000
-    image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+    # image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+    image: public.ecr.aws/l9j0i2e0/azurite-no-leaks:latest
     environment:
       AZURITE_DB: mysql://root:panda-secret@mysql:3306/azurite_blob
     networks:


### PR DESCRIPTION
Temporary image built by plat eng team from
https://github.com/nvartolomei/Azurite/commit/c3b8e4f012fc77002f723ca40390752b1fb48ccb

---

In azurite all operations are put in an append queue (max 50 concurrent ops) or a read queue (max 100 concurrent ops).

There are couple of issues with these queues but the biggest one is that if ops are executed after client disconnects we try to attach event handlers on a readablestream (body) which has been closed long ago. No events are triggered for them any more (data/close/error) so we never finish processing them and we hang there.

The fix checks if the stream is readable (alive) before installing event handlers on it to make sure that these event handlers will get triggered.

I'm not confident in the fix but pretty confident in the bug :)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
