### PR TITLE
archival: remove upload retry limit for segments

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1694,13 +1694,7 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
     // index in the background.
     auto upload_segment_ready = co_await ss::coroutine::as_future(
       _remote.upload_segment(
-        get_bucket_name(),
-        path,
-        meta.size_bytes,
-        get_stream,
-        rtc,
-        lazy_abort,
-        1));
+        get_bucket_name(), path, meta.size_bytes, get_stream, rtc, lazy_abort));
 
     // As noted above, check whether 'get_stream' was called. If not, close the
     // upload stream.


### PR DESCRIPTION
In a previous PR[1] we began to rely on the archiver loop to retry, and moved away from relying on `cloud_io::remote` for retries in two ways:
1. setting an explicit `disallow` retry policy on the retry node passed to the remote, and
2. setting the `max_retries` passed to `remote::upload_segment()` to 1.

In practice, we saw that _not_ relying on the remote resulted in an uptick in the `vectorized_cloud_storage_failed_uploads` metric, which is monitored and alerted on. In [2] we reverted #1, but didn't notice #2. This commit reverts #2.

[1] https://github.com/redpanda-data/redpanda/pull/25951
[2] https://github.com/redpanda-data/redpanda/pull/26969

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

### Bug Fixes

* A bug has been fixed that previously resulted in segment upload failures to take longer to be retried.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
