### PR TITLE
ct/l1: introduce means to partition objects in metastore

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
         ":metastore",
         ":state",
         "//src/v/base",
+        "//src/v/cloud_topics/level_one/common:object_id",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -63,20 +63,49 @@ public:
             size_t pos;
             size_t size;
         };
+        using ntp_metas_list_t = chunked_vector<ntp_metadata>;
 
         object_id oid;
         size_t footer_pos;
-        chunked_vector<ntp_metadata> ntp_metas;
+        ntp_metas_list_t ntp_metas;
     };
     struct object_response {
         object_id oid;
         size_t footer_pos;
     };
 
+    // Interface to build object metadata for the L1 metastore. Meant to be
+    // totally agnostic to the underlying implementation, whether it's
+    // logically partitioned or not.
+    class object_metadata_builder {
+    public:
+        using error = named_type<ss::sstring, struct builder_error_tag>;
+        virtual ~object_metadata_builder() = default;
+
+        // Returns an object ID that hasn't yet been finished that is
+        // appropriate for the given partition. Potentially shares the object
+        // with another partition, if the object is allowed by the metastore to
+        // be shared by the other partition.
+        virtual object_id
+        get_or_create_object_for(const model::topic_id_partition&)
+          = 0;
+
+        // Adds the given partition metadata for the given object. Expected
+        // that finish() has not yet been called on the object.
+        virtual std::expected<void, error>
+          add(object_id, object_metadata::ntp_metadata) = 0;
+
+        // Tracks the given object as finished. Further calls to
+        // get_or_create_object_for() will not return the finished object ID.
+        virtual std::expected<void, error>
+        finish(object_id, size_t footer_pos) = 0;
+    };
+
     struct offsets_response {
         kafka::offset start_offset;
         kafka::offset next_offset;
     };
+    virtual std::unique_ptr<object_metadata_builder> object_builder() = 0;
 
     // Returns offsets (e.g. start, next) for the given partition.
     virtual ss::future<std::expected<offsets_response, errc>>
@@ -86,7 +115,7 @@ public:
     // because they break an invariant of a partition's offset ranges, all
     // objects are rejected.
     virtual ss::future<std::expected<void, errc>>
-    add_objects(const chunked_vector<object_metadata>&) = 0;
+      add_objects(std::unique_ptr<object_metadata_builder>) = 0;
 
     // Adds the given objects to the metastore, expecting that the new extents
     // replace an extent or set of extents covering the same range.
@@ -97,7 +126,7 @@ public:
     // correctness, these simplify accounting and makes it easier to validate
     // that we haven't lost data.
     virtual ss::future<std::expected<void, errc>>
-    replace_objects(const chunked_vector<object_metadata>&) = 0;
+      replace_objects(std::unique_ptr<object_metadata_builder>) = 0;
 
     // Finds the first object of a given partition with data greater than or
     // equal to the given offset. If no such offset exists, returns
@@ -168,7 +197,7 @@ public:
     // compaction metadata. See get_compaction_offsets() for more details on
     // expected usage.
     virtual ss::future<std::expected<void, errc>> compact_objects(
-      const chunked_vector<object_metadata>&, const compaction_map_t&)
+      std::unique_ptr<object_metadata_builder>, const compaction_map_t&)
       = 0;
 
     // Returns metadata required to determine what to compact for the given

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -9,11 +9,64 @@
  */
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 
+#include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/state.h"
 #include "cloud_topics/level_one/metastore/state_update.h"
 #include "cloud_topics/logger.h"
 
 namespace experimental::cloud_topics::l1 {
+
+object_id simple_object_builder::get_or_create_object_for(
+  const model::topic_id_partition&) {
+    // The simple metastore isn't partitioned at all, so have all partitions
+    // blindly share any existing object.
+    if (pending_objects_.empty()) {
+        auto oid = create_object_id();
+        pending_objects_[oid] = {};
+        return oid;
+    }
+    return pending_objects_.begin()->first;
+}
+
+std::expected<void, metastore::object_metadata_builder::error>
+simple_object_builder::add(
+  object_id oid, metastore::object_metadata::ntp_metadata ntp_meta) {
+    auto it = pending_objects_.find(oid);
+    if (it == pending_objects_.end()) {
+        return std::unexpected(
+          error{fmt::format("Object {} is not a pending object", oid)});
+    }
+    auto& pending_metas = it->second;
+    pending_metas.emplace_back(ntp_meta);
+    return {};
+}
+
+std::expected<void, metastore::object_metadata_builder::error>
+simple_object_builder::finish(object_id oid, size_t footer_pos) {
+    auto it = pending_objects_.find(oid);
+    if (it == pending_objects_.end()) {
+        return std::unexpected(
+          error{fmt::format("Object {} is not a pending object", oid)});
+    }
+    finished_objects_.emplace_back(metastore::object_metadata{
+      .oid = oid,
+      .footer_pos = footer_pos,
+      .ntp_metas = std::move(it->second),
+    });
+    pending_objects_.erase(it);
+    return {};
+}
+
+std::expected<
+  chunked_vector<metastore::object_metadata>,
+  metastore::object_metadata_builder::error>
+simple_object_builder::release() {
+    if (!pending_objects_.empty()) {
+        return std::unexpected(error{fmt::format(
+          "Builder still has {} pending object", pending_objects_.size())});
+    }
+    return std::exchange(finished_objects_, {});
+}
 
 new_object make_new_object(const metastore::object_metadata& o) {
     new_object new_o{
@@ -33,6 +86,11 @@ new_object make_new_object(const metastore::object_metadata& o) {
     return new_o;
 }
 
+std::unique_ptr<metastore::object_metadata_builder>
+simple_metastore::object_builder() {
+    return std::make_unique<simple_object_builder>();
+}
+
 ss::future<std::expected<metastore::offsets_response, metastore::errc>>
 simple_metastore::get_offsets(const model::topic_id_partition& tpr) {
     auto prt_ref = state_.partition_state(tpr);
@@ -45,6 +103,17 @@ simple_metastore::get_offsets(const model::topic_id_partition& tpr) {
       .start_offset = prt.start_offset,
       .next_offset = prt.next_offset,
     };
+}
+
+ss::future<std::expected<void, metastore::errc>> simple_metastore::add_objects(
+  std::unique_ptr<metastore::object_metadata_builder> builder) {
+    auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
+    auto objects_res = simple_builder->release();
+    if (!objects_res.has_value()) {
+        vlog(cd_log.error, "Failed to add: {}", objects_res.error());
+        co_return std::unexpected(metastore::errc::invalid_request);
+    }
+    co_return co_await add_objects(objects_res.value());
 }
 
 ss::future<std::expected<void, metastore::errc>>
@@ -61,6 +130,18 @@ simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
     auto apply_res = update_res->apply(state_);
     vassert(apply_res.has_value(), "Apply must succeed if can_apply() is true");
     co_return std::expected<void, metastore::errc>{};
+}
+
+ss::future<std::expected<void, metastore::errc>>
+simple_metastore::replace_objects(
+  std::unique_ptr<metastore::object_metadata_builder> builder) {
+    auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
+    auto objects_res = simple_builder->release();
+    if (!objects_res.has_value()) {
+        vlog(cd_log.error, "Failed to replace: {}", objects_res.error());
+        co_return std::unexpected(metastore::errc::invalid_request);
+    }
+    co_return co_await replace_objects(objects_res.value());
 }
 
 ss::future<std::expected<void, metastore::errc>>
@@ -157,6 +238,19 @@ simple_metastore::compact_objects(
     auto apply_res = update_res->apply(state_);
     vassert(apply_res.has_value(), "Apply must succeed if can_apply() is true");
     co_return std::expected<void, metastore::errc>{};
+}
+
+ss::future<std::expected<void, metastore::errc>>
+simple_metastore::compact_objects(
+  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const compaction_map_t& compaction_metas) {
+    auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
+    auto objects_res = simple_builder->release();
+    if (!objects_res.has_value()) {
+        vlog(cd_log.error, "Failed to compact: {}", objects_res.error());
+        co_return std::unexpected(metastore::errc::invalid_request);
+    }
+    co_return co_await compact_objects(objects_res.value(), compaction_metas);
 }
 
 ss::future<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -17,18 +17,50 @@
 
 namespace experimental::cloud_topics::l1 {
 
+class simple_metastore;
+class simple_object_builder : public metastore::object_metadata_builder {
+public:
+    simple_object_builder()
+      : object_metadata_builder() {}
+    ~simple_object_builder() override {}
+    simple_object_builder(const simple_object_builder&) = delete;
+    simple_object_builder(simple_object_builder&&) = delete;
+    simple_object_builder& operator=(const simple_object_builder&) = delete;
+    simple_object_builder& operator=(simple_object_builder&&) = delete;
+
+    object_id
+    get_or_create_object_for(const model::topic_id_partition&) override;
+    std::expected<void, error>
+      add(object_id, metastore::object_metadata::ntp_metadata) override;
+    std::expected<void, error> finish(object_id, size_t footer_pos) override;
+
+    std::expected<chunked_vector<metastore::object_metadata>, error> release();
+
+private:
+    friend class simple_metastore;
+    chunked_hash_map<object_id, metastore::object_metadata::ntp_metas_list_t>
+      pending_objects_;
+    chunked_vector<metastore::object_metadata> finished_objects_;
+};
+
 // Wrapper around state to implement the `metastore` interface.
 // Not replicated or persisted, used for tests only.
 class simple_metastore : public metastore {
 public:
+    std::unique_ptr<object_metadata_builder> object_builder() override;
+
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;
 
     ss::future<std::expected<void, errc>>
-    add_objects(const chunked_vector<object_metadata>&) override;
+      add_objects(std::unique_ptr<object_metadata_builder>) override;
+    ss::future<std::expected<void, errc>>
+    add_objects(const chunked_vector<object_metadata>&);
 
     ss::future<std::expected<void, errc>>
-    replace_objects(const chunked_vector<object_metadata>&) override;
+      replace_objects(std::unique_ptr<object_metadata_builder>) override;
+    ss::future<std::expected<void, errc>>
+    replace_objects(const chunked_vector<object_metadata>&);
 
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;
@@ -37,7 +69,10 @@ public:
     get_first_ge(const model::topic_id_partition&, model::timestamp) override;
 
     ss::future<std::expected<void, errc>> compact_objects(
-      const chunked_vector<object_metadata>&, const compaction_map_t&) override;
+      std::unique_ptr<object_metadata_builder>,
+      const compaction_map_t&) override;
+    ss::future<std::expected<void, errc>> compact_objects(
+      const chunked_vector<object_metadata>&, const compaction_map_t&);
 
     ss::future<std::expected<compaction_offsets_response, errc>>
     get_compaction_offsets(

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -833,3 +833,168 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     EXPECT_THAT(
       cmp_a->removable_tombstone_ranges.to_vec(), testing::ElementsAre());
 }
+
+TEST(SimpleMetastoreTest, TestObjectBuilder) {
+    simple_metastore m;
+    auto ob = m.object_builder();
+    auto tp_a = model::topic_id_partition::from(tid_a);
+
+    // Creating objects for the same partition will result in the same object.
+    auto o_a = ob->get_or_create_object_for(tp_a);
+    auto o_a_2 = ob->get_or_create_object_for(tp_a);
+    ASSERT_EQ(o_a, o_a_2);
+
+    // Creating objects for different partitions will result in the same
+    // object.
+    auto tp_b = model::topic_id_partition::from(tid_b);
+    auto o_b = ob->get_or_create_object_for(tp_b);
+    ASSERT_EQ(o_a, o_b);
+    auto o_b_2 = ob->get_or_create_object_for(tp_b);
+    ASSERT_EQ(o_b, o_b_2);
+
+    // Add a partition's metadata to the object.
+    ASSERT_TRUE(ob->add(o_a, {}).has_value());
+
+    // Finish the current object. The next object will be different.
+    ASSERT_TRUE(ob->finish(o_a, 0).has_value());
+
+    auto o_a_3 = ob->get_or_create_object_for(tp_a);
+    ASSERT_NE(o_a_2, o_a_3);
+
+    // We can't release the result until we finish all objects.
+    ASSERT_FALSE(dynamic_cast<simple_object_builder*>(ob.get())->release());
+    ASSERT_TRUE(ob->finish(o_a_3, 0).has_value());
+
+    auto release_res
+      = dynamic_cast<simple_object_builder*>(ob.get())->release();
+    ASSERT_TRUE(release_res.has_value());
+    ASSERT_EQ(2, release_res->size());
+    ASSERT_EQ(1, release_res.value()[0].ntp_metas.size());
+    ASSERT_EQ(0, release_res.value()[1].ntp_metas.size());
+}
+
+TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
+    // Test calls for objects that don't exist in the builder.
+    simple_metastore m;
+    auto ob = m.object_builder();
+    auto add_res = ob->add(create_object_id(), {});
+    ASSERT_FALSE(add_res.has_value());
+
+    auto finish_res = ob->finish(create_object_id(), 0);
+    ASSERT_FALSE(finish_res.has_value());
+
+    // Both operations failed -- the builder should be empty.
+    auto release_res
+      = dynamic_cast<simple_object_builder*>(ob.get())->release();
+    ASSERT_TRUE(release_res.has_value());
+    ASSERT_EQ(0, release_res->size());
+}
+
+TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
+    simple_metastore m;
+    auto tp_a = model::topic_id_partition::from(tid_a);
+    {
+        auto ob = m.object_builder();
+        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto add_res = ob->add(
+          o_a,
+          metastore::object_metadata::ntp_metadata{
+            .tidp = tp_a,
+            .base_offset = 0_o,
+            .last_offset = 9_o,
+            .max_timestamp = 1000_t,
+            .pos = 0,
+            .size = 0,
+          });
+        ASSERT_TRUE(add_res.has_value());
+        auto fin_res = ob->finish(o_a, 0);
+        ASSERT_TRUE(fin_res.has_value());
+        auto add_obj_res = m.add_objects(std::move(ob)).get();
+        ASSERT_TRUE(add_obj_res.has_value());
+
+        auto offsets_res = m.get_offsets(tp_a).get();
+        ASSERT_TRUE(offsets_res.has_value());
+        ASSERT_EQ(0_o, offsets_res->start_offset);
+        ASSERT_EQ(10_o, offsets_res->next_offset);
+    }
+    {
+        auto ob = m.object_builder();
+        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto add_res = ob->add(
+          o_a,
+          metastore::object_metadata::ntp_metadata{
+            .tidp = tp_a,
+            .base_offset = 10_o,
+            .last_offset = 19_o,
+            .max_timestamp = 1000_t,
+            .pos = 0,
+            .size = 0,
+          });
+        ASSERT_TRUE(add_res.has_value());
+        auto fin_res = ob->finish(o_a, 0);
+        ASSERT_TRUE(fin_res.has_value());
+        auto add_obj_res = m.add_objects(std::move(ob)).get();
+        ASSERT_TRUE(add_obj_res.has_value());
+
+        auto offsets_res = m.get_offsets(tp_a).get();
+        ASSERT_TRUE(offsets_res.has_value());
+        ASSERT_EQ(0_o, offsets_res->start_offset);
+        ASSERT_EQ(20_o, offsets_res->next_offset);
+    }
+    {
+        auto ob = m.object_builder();
+        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto add_res = ob->add(
+          o_a,
+          metastore::object_metadata::ntp_metadata{
+            .tidp = tp_a,
+            .base_offset = 0_o,
+            .last_offset = 19_o,
+            .max_timestamp = 1000_t,
+            .pos = 0,
+            .size = 0,
+          });
+        ASSERT_TRUE(add_res.has_value());
+        auto fin_res = ob->finish(o_a, 0);
+        ASSERT_TRUE(fin_res.has_value());
+        auto replace_obj_res = m.replace_objects(std::move(ob)).get();
+        ASSERT_TRUE(replace_obj_res.has_value());
+
+        auto offsets_res = m.get_offsets(tp_a).get();
+        ASSERT_TRUE(offsets_res.has_value());
+        ASSERT_EQ(0_o, offsets_res->start_offset);
+        ASSERT_EQ(20_o, offsets_res->next_offset);
+    }
+    {
+        auto ob = m.object_builder();
+        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto add_res = ob->add(
+          o_a,
+          metastore::object_metadata::ntp_metadata{
+            .tidp = tp_a,
+            .base_offset = 0_o,
+            .last_offset = 19_o,
+            .max_timestamp = 1000_t,
+            .pos = 0,
+            .size = 0,
+          });
+        ASSERT_TRUE(add_res.has_value());
+        auto fin_res = ob->finish(o_a, 0);
+        ASSERT_TRUE(fin_res.has_value());
+
+        cm_builder cmb;
+        cmb.clean(tid_a, 10_o, 19_o);
+        auto compact_obj_res
+          = m.compact_objects(std::move(ob), cmb.build()).get();
+        ASSERT_TRUE(compact_obj_res.has_value());
+
+        auto offsets_res = m.get_offsets(tp_a).get();
+        ASSERT_TRUE(offsets_res.has_value());
+        ASSERT_EQ(0_o, offsets_res->start_offset);
+        ASSERT_EQ(20_o, offsets_res->next_offset);
+
+        auto compact_offsets_res = m.get_compaction_offsets(tp_a, 1000_t).get();
+        auto dirty = compact_offsets_res->dirty_ranges.to_vec();
+        EXPECT_THAT(dirty, testing::ElementsAre(MatchesRange(0_o, 9_o)));
+    }
+}


### PR DESCRIPTION
This adds an object_metadata_builder to the metastore that, in future implementations, can transparently partition data. The idea is to roughly allow writing code code like the following:

```
map<object_id, object_builder> objects;
auto pending_objects = metastore.object_builder();
for (const auto& tp : tps) {
    // Internally maps domains...
    auto oid = pending_objects.object_id_for(tp);

    auto& object_builder = objects[oid];
    object_builder.add(...read tp...);
    pending_objects.add(oid, ...metadata for tp...);

    if (...object_builder size is sufficient...) {
        pending_objects.finish(oid);
    }
}
// Internally routes to the appropriate domains...
metastore.add_objects(std::move(pending_objects));
```

The interface is expressed to be agnostic to whether the metastore is actually partitioned, in the hopes that L1 domains can be left as an implementation detail that isn't exposed to the reconciler, compactors, etc. An implementaton is added for the simple_metastore that isn't partitioned at all.

See this thread[1] for discussion that landed us here.

[1] https://redpandadata.slack.com/archives/C08P57TJXRT/p1752858156972319

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
