### PR TITLE
`storage`: bump adjacent compaction log lines to `INFO`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1090,7 +1090,7 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     }
 
     vlog(
-      gclog.debug,
+      gclog.info,
       "Compacting {} adjacent segments over range: [{}:{}]",
       segments.size(),
       segments.front()->filename(),

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1224,7 +1224,7 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
       feature_table,
       kvs,
       true);
-    vlog(gclog.debug, "Final compacted segment {}", replacement);
+    vlog(gclog.info, "Final compacted segment {}", replacement);
 
     /*
      * remove index files (ignoring failures if they do not exist). they will be


### PR DESCRIPTION
These log lines could be helpful to have at the info level for posterity/ referring back to in a clusters history when debugging, and also do not add a ton of additional logging to the system relatively speaking (both will be output once per adjacent merge operation, for which we already output an `O(n)` number of lines per `n` `segment`s.)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
