### PR TITLE
[v25.2.x] `storage`: bump adjacent compaction log lines to `INFO`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1089,7 +1089,7 @@ ss::future<compaction_result> disk_log_impl::do_compact_adjacent_segments(
     }
 
     vlog(
-      gclog.debug,
+      gclog.info,
       "Compacting {} adjacent segments over range: [{}:{}]",
       segments.size(),
       segments.front()->filename(),

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1208,7 +1208,7 @@ ss::future<compaction_result> concatenate_and_rebuild_target_segment(
       resources,
       feature_table,
       true);
-    vlog(gclog.debug, "Final compacted segment {}", replacement);
+    vlog(gclog.info, "Final compacted segment {}", replacement);
 
     /*
      * remove index files (ignoring failures if they do not exist). they will be


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27065
