### PR TITLE
[v25.2.x] `storage`: pass `abort_source` to `log::start()`

### DIFF
--- a/src/v/datalake/translation/tests/translated_log_offset_test.cc
+++ b/src/v/datalake/translation/tests/translated_log_offset_test.cc
@@ -54,7 +54,8 @@ TEST(TranslatedLogOffsetTest, TestTranslatedOffsetsGrowingLog) {
     auto log = b.get_log();
 
     // Must initialize translator state.
-    log->start(std::nullopt).get();
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
 
     // A good property to check.
     ASSERT_TRUE(
@@ -162,7 +163,8 @@ TEST(TranslatedLogOffsetTest, TestTranslatedOffsetsGrowingLogConfigBatchStart) {
     auto log = b.get_log();
 
     // Must initialize translator state.
-    log->start(std::nullopt).get();
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
 
     // A good property to check.
     ASSERT_TRUE(
@@ -275,7 +277,8 @@ TEST(
     auto log = b.get_log();
 
     // Must initialize translator state.
-    log->start(std::nullopt).get();
+    ss::abort_source as;
+    log->start(std::nullopt, as).get();
 
     // A good property to check.
     ASSERT_TRUE(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1521,7 +1521,7 @@ consensus::do_start(std::optional<xshard_transfer_state> xst_state) {
             }
             _snapshot_size = co_await _snapshot_mgr.get_snapshot_size();
         }
-        co_await _log->start(start_truncate_cfg);
+        co_await _log->start(start_truncate_cfg, _as);
         snapshot_units.return_all();
 
         vlog(

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -17,8 +17,8 @@ failure_injectable_log::failure_injectable_log(
   , _underlying_log(std::move(underlying_log)) {}
 
 ss::future<> failure_injectable_log::start(
-  std::optional<storage::truncate_prefix_config> cfg) {
-    return _underlying_log->start(cfg);
+  std::optional<storage::truncate_prefix_config> cfg, ss::abort_source& as) {
+    return _underlying_log->start(cfg, as);
 }
 
 ss::future<>

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -33,8 +33,9 @@ public:
     failure_injectable_log& operator=(const failure_injectable_log&) = delete;
     ~failure_injectable_log() noexcept final = default;
 
-    ss::future<>
-    start(std::optional<storage::truncate_prefix_config> cfg) final;
+    ss::future<> start(
+      std::optional<storage::truncate_prefix_config> cfg,
+      ss::abort_source& as) final;
     ss::future<> housekeeping(storage::housekeeping_config cfg) final;
 
     ss::future<> truncate(storage::truncate_config) final;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -257,8 +257,8 @@ ss::future<> disk_log_impl::remove() {
       .finally([this] { _probe->clear_metrics(); });
 }
 
-ss::future<>
-disk_log_impl::start(std::optional<truncate_prefix_config> truncate_cfg) {
+ss::future<> disk_log_impl::start(
+  std::optional<truncate_prefix_config> truncate_cfg, ss::abort_source& as) {
     auto is_new = is_new_log();
     co_await offset_translator().start(
       storage::offset_translator::must_reset{is_new});
@@ -268,7 +268,7 @@ disk_log_impl::start(std::optional<truncate_prefix_config> truncate_cfg) {
     // Reset or load the offset translator state, depending on whether this is
     // a brand new log.
     if (!is_new) {
-        co_await offset_translator().sync_with_log(*this, _compaction_as);
+        co_await offset_translator().sync_with_log(*this, as);
     }
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -77,7 +77,8 @@ public:
     disk_log_impl(const disk_log_impl&) = delete;
     disk_log_impl& operator=(const disk_log_impl&) = delete;
 
-    ss::future<> start(std::optional<truncate_prefix_config>) final;
+    ss::future<>
+    start(std::optional<truncate_prefix_config>, ss::abort_source& as) final;
     ss::future<std::optional<ss::sstring>> close() final;
     ss::future<> remove() final;
     ss::future<> flush() final;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -45,7 +45,8 @@ public:
     log& operator=(const log&) = delete;
     virtual ~log() noexcept = default;
 
-    virtual ss::future<> start(std::optional<truncate_prefix_config>) = 0;
+    virtual ss::future<>
+    start(std::optional<truncate_prefix_config>, ss::abort_source& as) = 0;
 
     // it shouldn't block for a long time as it will block other logs
     // eviction

--- a/src/v/storage/tests/compaction_fuzz_test.cc
+++ b/src/v/storage/tests/compaction_fuzz_test.cc
@@ -147,7 +147,8 @@ ss::future<ot_state> arrange_and_compact(
     co_await b1.start(log_ntp);
 
     // Must initialize translator state.
-    co_await b1.get_disk_log_impl().start(std::nullopt);
+    ss::abort_source as;
+    co_await b1.get_disk_log_impl().start(std::nullopt, as);
 
     try {
         for (const auto& b : batches) {
@@ -158,7 +159,6 @@ ss::future<ot_state> arrange_and_compact(
                 co_await b1.get_disk_log_impl().force_roll();
             }
         }
-        ss::abort_source as;
         auto compact_cfg = storage::compaction_config(
           batches.back().last_offset(), std::nullopt, std::nullopt, as);
         std::ignore = co_await b1.apply_sliding_window_compaction(compact_cfg);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3114,7 +3114,7 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
                    raft::group_id{0},
                    model::offset_translator_batch_types())
                  .get();
-    log->start(std::nullopt).get();
+    log->start(std::nullopt, as).get();
 
     storage::log_append_config appender_cfg{
       .should_fsync = storage::log_append_config::fsync::no,
@@ -3192,7 +3192,7 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
               raft::group_id{0},
               model::offset_translator_batch_types())
             .get();
-    log->start(std::nullopt).get();
+    log->start(std::nullopt, as).get();
 
     // validate the translation by comparing it with state before
     // compaction.


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27050
