### PR TITLE
ssx/async_algorithm: Add optional cost calculation

### DIFF
--- a/src/v/ssx/async_algorithm.h
+++ b/src/v/ssx/async_algorithm.h
@@ -17,10 +17,12 @@
 #include <seastar/core/future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
+#include <sys/types.h>
+
+#include <concepts>
 #include <iterator>
 #include <limits>
 #include <type_traits>
-
 //
 // async_algorithms.h
 //
@@ -54,6 +56,34 @@ struct async_algo_traits {
 };
 
 namespace detail {
+
+// Concept to force compliance for a cost function
+template<typename Candidate, typename Element>
+concept CostFuncType = requires(Candidate c, const Element& e) {
+    { c.operator()(e) } -> std::convertible_to<ssize_t>;
+};
+
+// default value
+template<typename Element>
+struct default_cost_func {
+    ssize_t operator()(const Element&) { return 1u; }
+};
+
+// quick traits to help parse out the cost function type from a container
+template<typename Container>
+using CElemBase = decltype(*std::begin(std::declval<Container>()));
+template<typename Container>
+using CElem = std::remove_cvref_t<CElemBase<Container>>;
+template<typename Container>
+using CDefaultCost = default_cost_func<CElem<Container>>;
+
+// quick traits to help parse out the cost function type from an iterator
+template<std::forward_iterator Iterator>
+using IElemBase = typename Iterator::value_type;
+template<std::forward_iterator Iterator>
+using IElem = std::remove_cvref_t<IElemBase<Iterator>>;
+template<std::forward_iterator Iterator>
+using IDefaultCost = default_cost_func<IElem<Iterator>>;
 
 // value-semantic counter for when no external counter was passed
 struct internal_counter {
@@ -103,7 +133,12 @@ struct iter_size {
  * as the termination condition.
  */
 template<std::random_access_iterator I, typename Fn>
-iter_size<I> for_each_limit(const I begin, const I end, ssize_t limit, Fn f) {
+iter_size<I> for_each_limit(
+  const I begin,
+  const I end,
+  ssize_t limit,
+  Fn f,
+  IDefaultCost<I> /*not used*/) {
     auto chunk_size = std::min(limit, end - begin);
     I chunk_end = begin + chunk_size;
     for (I i = begin; i != chunk_end; ++i) {
@@ -112,14 +147,15 @@ iter_size<I> for_each_limit(const I begin, const I end, ssize_t limit, Fn f) {
     return {chunk_end, chunk_size};
 }
 
-template<std::forward_iterator I, typename Fn>
-iter_size<I> for_each_limit(const I begin, const I end, ssize_t limit, Fn f) {
+template<std::forward_iterator I, typename Fn, CostFuncType<IElem<I>> CostFunc>
+iter_size<I> for_each_limit(
+  const I begin, const I end, ssize_t limit, Fn f, CostFunc cost_func) {
     ssize_t count = 0;
     auto i = begin;
     while (i != end && count < limit) {
+        count += cost_func(*i);
         f(*i);
         ++i;
-        ++count;
     }
     return {i, count};
 }
@@ -128,12 +164,13 @@ template<
   typename Traits,
   typename Counter,
   typename Fn,
-  std::forward_iterator Iterator>
-ss::future<>
-async_for_each_coro(Counter counter, Iterator begin, Iterator end, Fn f) {
+  std::forward_iterator Iterator,
+  detail::CostFuncType<IElem<Iterator>> CostFunc>
+ss::future<> async_for_each_coro(
+  Counter counter, Iterator begin, Iterator end, Fn f, CostFunc cost_func) {
     do {
         auto new_begin = for_each_limit(
-          begin, end, remaining<Traits>(counter), f);
+          begin, end, remaining<Traits>(counter), f, cost_func);
         begin = new_begin.iter;
         counter.count += new_begin.count;
         if (counter.count >= Traits::interval) {
@@ -151,23 +188,25 @@ template<
   typename Traits = async_algo_traits,
   typename Counter,
   typename Fn,
-  std::forward_iterator Iterator>
-ss::future<>
-async_for_each_fast(Counter counter, Iterator begin, Iterator end, Fn f) {
-    // This first part is an important optimization: if the input range is small
-    // enough, we don't want to create a coroutine frame as that's costly, so
-    // this function is not coroutine and we do the whole iteration here (as we
-    // won't yield), otherwise we defer to the coroutine-based helper.
+  std::forward_iterator Iterator,
+  typename CostFunc>
+ss::future<> async_for_each_fast(
+  Counter counter, Iterator begin, Iterator end, Fn f, CostFunc cost_func) {
+    //  This first part is an important optimization: if the input range is
+    //  small enough, we don't want to create a coroutine frame as that's
+    //  costly, so this function is not coroutine and we do the whole iteration
+    //  here (as we won't yield), otherwise we defer to the coroutine-based
+    //  helper.
 
     ssize_t limit = detail::remaining<Traits>(counter);
-    auto new_begin = for_each_limit(begin, end, limit, f);
+    auto new_begin = for_each_limit(begin, end, limit, f, cost_func);
     counter.count += new_begin.count + FIXED_COST;
     if (new_begin.iter == end && counter.count < Traits::interval) [[likely]] {
         return ss::make_ready_future();
     }
 
     return async_for_each_coro<Traits>(
-      counter, new_begin.iter, end, std::move(f));
+      counter, new_begin.iter, end, std::move(f), std::move(cost_func));
 }
 
 } // namespace detail
@@ -176,7 +215,7 @@ async_for_each_fast(Counter counter, Iterator begin, Iterator end, Fn f) {
  * @brief Call f on every element, yielding occasionally.
  *
  * This is equivalent to std::for_each, except that the computational
- * loop yields every Traits::interval (default 100) iterations in order
+ * loop yields every Traits::interval (default 100 iterations) in order
  * to avoid reactor stalls. The returned future resolves when all elements
  * have been processed.
  *
@@ -193,17 +232,24 @@ async_for_each_fast(Counter counter, Iterator begin, Iterator end, Fn f) {
 template<
   typename Traits = async_algo_traits,
   typename Fn,
-  std::forward_iterator Iterator>
-ss::future<> async_for_each(Iterator begin, Iterator end, Fn f) {
+  std::forward_iterator Iterator,
+  detail::CostFuncType<detail::IElem<Iterator>> CostFunc
+  = detail::IDefaultCost<Iterator>>
+ss::future<> async_for_each(
+  Iterator begin, Iterator end, Fn f, CostFunc cost_func = CostFunc{}) {
     return async_for_each_fast<Traits>(
-      detail::internal_counter{}, begin, end, std::move(f));
+      detail::internal_counter{},
+      begin,
+      end,
+      std::move(f),
+      std::move(cost_func));
 }
 
 /**
  * @brief Call f on every element, yielding occasionally.
  *
  * This is equivalent to std::for_each, except that the computational
- * loop yields every Traits::interval (default 100) iterations in order
+ * loop yields every Traits::interval (default 100 iterations) in order
  * to avoid reactor stalls. The returned future resolves when all elements
  * have been processed.
  *
@@ -214,20 +260,30 @@ ss::future<> async_for_each(Iterator begin, Iterator end, Fn f) {
  *
  * @param container universal reference to container
  * @param f the function to call on each element
+ * @param cost_func cost_func an optional argument intended to calculate the
+ cost per element (default 1), useful if not all elements have the same cpu
+ burden
  * @return ss::future<> a future which resolves when all elements have been
  * processed
  */
-template<typename Traits = async_algo_traits, typename Fn, typename Container>
-requires requires(Container c, Fn fn) {
+template<
+  typename Traits = async_algo_traits,
+  typename Fn,
+  typename Container,
+  typename CostFunc = detail::CDefaultCost<Container>>
+requires requires(Container c, Fn fn, CostFunc cost_func) {
     { ss::futurize_invoke(fn, *std::begin(c)) } -> std::same_as<ss::future<>>;
     std::end(c);
+    { std::invoke(cost_func, *std::begin(c)) } -> std::same_as<ssize_t>;
 }
-ss::future<> async_for_each(Container&& container, Fn f) {
+ss::future<>
+async_for_each(Container&& container, Fn f, CostFunc cost_func = CostFunc{}) {
     return async_for_each_fast<Traits>(
       detail::internal_counter{},
       std::begin(container),
       std::end(container),
-      std::move(f));
+      std::move(f),
+      std::move(cost_func));
 }
 
 /**
@@ -235,7 +291,7 @@ ss::future<> async_for_each(Container&& container, Fn f) {
  * an externally provided counter for yield control.
  *
  * This is equivalent to std::for_each, except that the computational
- * loop yields every Traits::interval (default 100) iterations in order
+ * loop yields every Traits::interval (default 100 iterations) in order
  * to avoid reactor stalls. The returned future resolves when all elements
  * have been processed.
  *
@@ -275,17 +331,29 @@ ss::future<> async_for_each(Container&& container, Fn f) {
  * @param begin the beginning of the range to process
  * @param end the end of the range to process
  * @param f the function to call on each element
+ * @param cost_func an optional argument intended to calculate the cost per
+ element (default 1), useful if not all elements have the same cpu burden
  * @return ss::future<> a future which resolves when all elements have been
  * processed
  */
 template<
   typename Traits = async_algo_traits,
   typename Fn,
-  std::forward_iterator Iterator>
+  std::forward_iterator Iterator,
+  detail::CostFuncType<detail::IElem<Iterator>> CostFunc
+  = detail::IDefaultCost<Iterator>>
 ss::future<> async_for_each_counter(
-  async_counter& counter, Iterator begin, Iterator end, Fn f) {
+  async_counter& counter,
+  Iterator begin,
+  Iterator end,
+  Fn f,
+  CostFunc cost_func = CostFunc{}) {
     return detail::async_for_each_fast<Traits>(
-      detail::ref_counter{counter.count}, begin, end, std::move(f));
+      detail::ref_counter{counter.count},
+      begin,
+      end,
+      std::move(f),
+      std::move(cost_func));
 }
 
 /**
@@ -293,7 +361,7 @@ ss::future<> async_for_each_counter(
  * an externally provided counter for yield control.
  *
  * This is equivalent to std::for_each, except that the computational
- * loop yields every Traits::interval (default 100) iterations in order
+ * loop yields every Traits::interval (default 100 iterations) in order
  * to avoid reactor stalls. The returned future resolves when all elements
  * have been processed.
  *
@@ -333,18 +401,33 @@ ss::future<> async_for_each_counter(
  * @param counter the counter object to use, may be reused across invocations
  * @param container universal reference to container
  * @param f the function to call on each element
+ * @param cost_func cost_func an optional argument intended to calculate the
+ cost per element (default 1), useful if not all elements have the same cpu
+ burden
  * @return ss::future<> a future which resolves when all elements have been
  * processed
  */
-template<typename Traits = async_algo_traits, typename Fn, typename Container>
-requires requires(Container c, Fn fn) {
+template<
+  typename Traits = async_algo_traits,
+  typename Fn,
+  typename Container,
+  typename CostFunc = detail::CDefaultCost<Container>>
+requires requires(Container c, Fn fn, CostFunc cost_func) {
     { ss::futurize_invoke(fn, *std::begin(c)) } -> std::same_as<ss::future<>>;
     std::end(c);
+    { std::invoke(cost_func, *std::begin(c)) } -> std::same_as<ssize_t>;
 }
-ss::future<>
-async_for_each_counter(async_counter& counter, Container&& container, Fn f) {
+ss::future<> async_for_each_counter(
+  async_counter& counter,
+  Container&& container,
+  Fn f,
+  CostFunc cost_func = CostFunc{}) {
     return detail::async_for_each_fast<Traits>(
-      counter, std::begin(container), std::end(container), std::move(f));
+      counter,
+      std::begin(container),
+      std::end(container),
+      std::move(f),
+      std::move(cost_func));
 }
 
 } // namespace ssx

--- a/src/v/ssx/tests/async_algorithm_test.cc
+++ b/src/v/ssx/tests/async_algorithm_test.cc
@@ -11,6 +11,7 @@
 #include "ssx/async-clear.h"
 #include "ssx/async_algorithm.h"
 #include "ssx/future-util.h"
+#include "test_utils/test.h"
 #include "utils/move_canary.h"
 
 #include <seastar/core/reactor.hh>
@@ -271,6 +272,46 @@ TYPED_TEST(AsyncAlgo, async_for_each_move_correctness) {
     // NOLINTNEXTLINE(bugprone-use-after-move)
     ASSERT_TRUE(func(-1));
     ASSERT_FALSE(other_func(-1));
+}
+
+// this test checks that an async counter responds appropriately to its cost
+// function
+TEST_CORO(async_algo_suite, test_nested_counter) {
+    yields = 0; // reset yields
+    async_counter a_counter{};
+
+    static constexpr size_t inner_vector_size = 100;
+    static constexpr size_t outer_vector_size = 10;
+    static constexpr int vector_default = 0;
+
+    // 10x10 matrix of ints
+    std::vector<int> initialization_vector(inner_vector_size, vector_default);
+    std::vector<std::vector<int>> compound_list(
+      outer_vector_size, initialization_vector);
+
+    // first check the expected behavior, that a default cost function will not
+    // yield because it only sees 10 elements to be processed
+    co_await async_for_each_counter<test_traits<100>>(
+      a_counter,
+      compound_list.begin(),
+      compound_list.end(),
+      [](const std::vector<int>&) {});
+    EXPECT_EQ(yields, 0);
+    yields = 0; // reset yields
+
+    // now check that with a cost function, we yield according to the size of
+    // the composed vector
+    static constexpr auto cost_function =
+      [](const std::vector<int>& vec) -> ssize_t {
+        return static_cast<ssize_t>(vec.size());
+    };
+    co_await async_for_each_counter<test_traits<100>>(
+      a_counter,
+      compound_list.begin(),
+      compound_list.end(),
+      [](const std::vector<int>&) {},
+      cost_function);
+    EXPECT_EQ(yields, 10);
 }
 
 } // namespace ssx


### PR DESCRIPTION
The family of async_for_each algorithms previously assigned a cost of '1' to each iteration.

This PR adds an optional cost function which will be applied to every element to offer a cost estimate for cases where not all elements are created equally with reference to cpu cost.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
