### PR TITLE
rptest: better error propagation from rp_storage_tool

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -5243,11 +5243,13 @@ class RedpandaService(RedpandaServiceBase):
         report = {}
         try:
             report = json.loads(output)
-        except:
+        except Exception as exc:
             self.logger.error(
                 f"Error running bucket scrub: {output=} {stderr=}")
             if not tolerate_empty_object_storage:
-                raise
+                raise RuntimeError(
+                    f"Failed to json parse report: {output=}, {stderr=}"
+                ) from exc
         else:
             self.logger.info(json.dumps(report, indent=2))
 

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -562,7 +562,7 @@ def ssh_output_stderr(source_service,
         exit_status = stdin.channel.recv_exit_status()
         if exit_status != 0:
             if not allow_fail:
-                raise RemoteCommandError(source_service, cmd, exit_status,
+                raise RemoteCommandError(node.account, cmd, exit_status,
                                          stderrdata)
             else:
                 source_service.logger.debug(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
