### PR TITLE
[v25.2.x] tests/kgo: handle errors when polling for verifier status

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -2,6 +2,6 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
 cd /opt/kgo-verifier
-git reset --hard 319c69da3d7690e26d390261c4b331703b99260c
+git reset --hard f97884cb0815d60eca41950f818d51c70b665890
 go mod tidy
 make

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -15,11 +15,13 @@ import signal
 import threading
 import requests
 from typing import Any, Dict, Optional
+from requests.adapters import HTTPAdapter
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 from ducktape.cluster.remoteaccount import RemoteCommandError
+from urllib3 import Retry
 
 from rptest.services.redpanda import RedpandaService
 
@@ -442,11 +444,20 @@ class StatusThread(threading.Thread):
         self._parent._status = reduced
 
     def poll_status(self):
+        retry_strategy = Retry(total=5,
+                               connect=5,
+                               read=5,
+                               backoff_factor=0.3,
+                               status=5,
+                               allowed_methods=['GET'],
+                               status_forcelist=[503, 504])
+        session = requests.Session()
+        session.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+
         while not self._stop_requested.is_set():
             drop_out = self._shutdown_requested.is_set()
-
-            r = requests.get(self._parent._remote_url(self._node, "status"),
-                             timeout=5)
+            r = session.get(url=self._parent._remote_url(self._node, "status"),
+                            timeout=5)
             r.raise_for_status()
             worker_statuses = r.json()
             self._ingest_status(worker_statuses)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27013
