### PR TITLE
`storage`: bump sliding window compaction log lines to `INFO`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1419,7 +1419,7 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
     // failed to index (the "unindexed" segment)
     auto seg = segs.back();
     vlog(
-      gclog.debug,
+      gclog.info,
       "Unable to fully index segment with max allowed keys {}. Performing "
       "chunked sliding window compaction for segment {}",
       map.capacity(),

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -722,7 +722,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         co_return has_self_compacted;
     }
     vlog(
-      gclog.debug,
+      gclog.info,
       "[{}] window compacting {} segments in interval [{}, {}]",
       config().ntp(),
       segs.size(),
@@ -1384,7 +1384,7 @@ ss::future<> disk_log_impl::do_compact(
         compact_fut = sliding_window_compact(compact_cfg, new_start_offset)
                         .then([&](bool compacted) {
                             vlog(
-                              gclog.debug,
+                              gclog.info,
                               "Sliding compaction of {} did {}compact "
                               "data, proceeding to adjacent "
                               "segment compaction",


### PR DESCRIPTION
More potentially useful log lines to have at `INFO` level.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
