### PR TITLE
base: introduce format_to helper

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -6,6 +6,7 @@ redpanda_cc_library(
         "vassert.cc",
     ],
     hdrs = [
+        "format_to.h",
         "likely.h",
         "oncore.h",
         "outcome.h",

--- a/src/v/base/format_to.h
+++ b/src/v/base/format_to.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+
+namespace fmt {
+
+using iterator = format_context::iterator;
+
+template<typename T>
+concept HasFormatToMethod = requires(const T& obj, iterator out) {
+    { obj.format_to(out) } -> std::same_as<iterator>;
+};
+
+/**
+ * A formatter that supports any type that implements a `format_to` method.
+ *
+ * For example:
+ *
+ * ```
+ * struct foo {
+ *   std::string a;
+ *   int32_t b;
+ *
+ *   fmt::iterator format_to(fmt::iterator it) const {
+ *     return fmt::print(it, "{{a: {}, b: {}}}", a, b)
+ *   }
+ * };
+ * ```
+ */
+template<HasFormatToMethod T>
+struct formatter<T> {
+    /**
+     * When using `format_to`, there is no support for custom modifiers like
+     * `{:d}` or `{:.2f}`. So only accept `{}`
+     */
+    constexpr fmt::format_parse_context::iterator
+    parse(fmt::format_parse_context& ctx) const {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw fmt::format_error("invalid format specifier for this type");
+        }
+        return it;
+    }
+
+    /**
+     * Formats the object using its own `format_to` method.
+     *
+     * This function is called by the {fmt} library to perform the actual
+     * formatting. It delegates the work entirely to the object's `format_to`
+     * method.
+     */
+    iterator format(const T& obj, format_context& ctx) const {
+        return obj.format_to(ctx.out());
+    }
+};
+
+} // namespace fmt
+
+// For both googletest and for other external libraries that may use
+// `operator<<` to print stuff, give a blanket implementation that delegates to
+// the `format_to` method.
+template<fmt::HasFormatToMethod T>
+std::ostream& operator<<(std::ostream& os, const T& obj) {
+    return fmt::format_to(os, "{}", obj);
+}

--- a/src/v/base/tests/BUILD
+++ b/src/v/base/tests/BUILD
@@ -37,3 +37,17 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "format_to_test",
+    timeout = "short",
+    srcs = [
+        "format_to_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/base/tests/format_to_test.cc
+++ b/src/v/base/tests/format_to_test.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/format_to.h"
+
+#include <gtest/gtest.h>
+
+struct foo {
+    std::string a;
+    int32_t b;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "{{a: {}, b: {}}}", a, b);
+    }
+};
+
+static_assert(fmt::HasFormatToMethod<foo>);
+
+TEST(Formatter, FormatTo) {
+    foo f{.a = "bar", .b = 3};
+    EXPECT_EQ("hello: {a: bar, b: 3}", fmt::format("hello: {}", f));
+}


### PR DESCRIPTION
To make creating formatters less verbose, we're creating a custom
extension method that is much simpler to make types formattable using.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
