### PR TITLE
kafka/client/data_queue: data_queue fairness test

### DIFF
--- a/src/v/kafka/client/test/data_queue_test.cc
+++ b/src/v/kafka/client/test/data_queue_test.cc
@@ -12,7 +12,12 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 using namespace kafka::client;
+using namespace std::chrono_literals;
+
+namespace {
 
 static constexpr size_t max_bytes = 1024;
 static constexpr size_t max_count = 10;
@@ -29,6 +34,14 @@ make_data(int topic_count, int bytes_per_topic) {
     }
     return data;
 }
+
+inline ss::future<> yield_a_few_times(uint times) {
+    for (uint i{0}; i < times; ++i) {
+        co_await ss::yield();
+    }
+}
+
+} // namespace
 
 TEST(DataQueueTest, TestIfCanInsertWorks) {
     data_queue queue(max_bytes, max_count);
@@ -196,6 +209,58 @@ TEST(DataQueueTest, TestEdgeCases) {
     ASSERT_EQ(queue.current_bytes(), 0);
 
     ASSERT_TRUE(queue.can_insert(1024));
+}
+
+// the queue as written will indefinitely starve out large operations in
+// exchange for smaller ones, to fix we probably need a fair condition_variable
+TEST_CORO(DataQueueTest, QueueUnfairness) {
+    // constants for making fetched_topic_data
+    static constexpr size_t small_size = 128u;
+    static constexpr auto make_small = +[] { return make_data(1, small_size); };
+    static constexpr size_t big_size = 2048;
+
+    data_queue queue(max_bytes, max_count);
+
+    // drop a small record in the queue
+    co_await queue.push(make_small(), small_size);
+
+    // attempt to push an oversized record, and keep tabs on its successful push
+    bool big_push_has_completed{false};
+    auto big_push = queue.push(make_data(1, big_size), big_size)
+                      .then([&big_push_has_completed] {
+                          big_push_has_completed = true;
+                          return ss::now();
+                      });
+
+    // float around the task queue a bit
+    co_await yield_a_few_times(10);
+    ASSERT_FALSE_CORO(big_push_has_completed);
+
+    // start a loop that will continuously put small data on and then take small
+    // data off. If the queue were fair, the small data pushes should be blocked
+    // until the large data gets a chance to enter the queue
+    bool should_keep_contending{true};
+    auto contention_lambda = [&should_keep_contending, &queue] -> ss::future<> {
+        while (should_keep_contending) {
+            co_await queue.push(make_small(), small_size);
+            std::ignore = queue.pop(100ms);
+        }
+    };
+    auto contention_fiber = contention_lambda();
+
+    // wait to see if big_push completes within a reasonable amount of time
+    try {
+        co_await ss::with_timeout(
+          seastar::lowres_clock::now() + 10s, std::move(big_push));
+    } catch (const ss::timed_out_error& /*ignored*/) {
+    }
+
+    // stop the contention fiber, and wait for its termination
+    should_keep_contending = false;
+    co_await std::move(contention_fiber);
+
+    // check if we every got big_push to complete
+    ASSERT_TRUE_CORO(big_push_has_completed);
 }
 
 TEST(DataQueueTest, TestSizeAndCurrentBytesTracking) {


### PR DESCRIPTION
Data queue has shortcut logic on push that allows for small sets of data to skip the line. In combination with logic for oversized elements (requires empty queue to successfully push), large data will be starved indefinitely.

This pr adds a test that checks fairness.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
