### PR TITLE
[v25.1.x] `storage`: bump sliding window compaction log lines to `INFO` (MANUAL BACKPORT)

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -682,7 +682,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         co_return has_self_compacted;
     }
     vlog(
-      gclog.debug,
+      gclog.info,
       "[{}] window compacting {} segments in interval [{}, {}]",
       config().ntp(),
       segs.size(),
@@ -1331,7 +1331,7 @@ ss::future<> disk_log_impl::do_compact(
     }
     bool compacted = did_compact_fut.get();
     vlog(
-      gclog.debug,
+      gclog.info,
       "Sliding compaction of {} did {}compact data, proceeding to adjacent "
       "segment compaction",
       config().ntp(),

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1347,7 +1347,7 @@ ss::future<bool> disk_log_impl::chunked_sliding_window_compact(
     // failed to index (the "unindexed" segment)
     auto seg = segs.back();
     vlog(
-      gclog.debug,
+      gclog.info,
       "Unable to fully index segment with max allowed keys {}. Performing "
       "chunked sliding window compaction for segment {}",
       map.capacity(),


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/27078. `cherry-pick` conflict due to other changes in `disk_log_impl` in future versions of `redpanda`.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
