### PR TITLE
Fix cluster link task race

### DIFF
--- a/src/v/cluster_link/task.cc
+++ b/src/v/cluster_link/task.cc
@@ -51,6 +51,12 @@ public:
     void set_task_interval(ss::lowres_clock::duration interval) {
         vlog(
           _task->logger().trace, "set_task_interval called with {}", interval);
+        if (!_timer.armed()) {
+            // can only happen when a task is currently running;
+            // its continuation will rearm the timer
+            return;
+        }
+
         auto cur_timeout = _timer.get_timeout();
 
         // Re-arm the timer to run with the new interval, calculate the new


### PR DESCRIPTION
`task::runner::set_task_interval` rearmed the timer even if a task is
running. Both timer callback function and initial `start()` call
unconditionally rearm the timer after the task is complete. It may lead
to unsupported timer operations, such as double rearm and unarmed timer
timeout lookup. The solution is to skip rearming in
`task::runner::set_task_interval` if the timer is armed already.

I did not add a vassert to check the timer is not armed in the other two
places we arm it because such an assert is already in place in Seastar.
It only works in debug mode though.

deflakes `test_task_started_fixture.test_change_run_interval`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
