### PR TITLE
[v25.1.x] rpk: fix concurrent map writes in proto serde encodefn

### DIFF
--- a/src/go/rpk/pkg/serde/proto.go
+++ b/src/go/rpk/pkg/serde/proto.go
@@ -28,7 +28,7 @@ import (
 // generated while compiling the schema.
 const inMemFileName = "tmp.proto"
 
-// newAvroEncoder will generate a serializer function using the specified
+// newProtoEncoder will generate a serializer function using the specified
 // schema. It utilizes the message type identified by protoFQN. If the schema
 // includes references, it retrieves them using the supplied client. The
 // generated function returns the record encoded in the protobuf wire format.
@@ -42,12 +42,14 @@ func newProtoEncoder(compiledFiles linker.Files, protoFQN string, schemaID int) 
 	if !ok {
 		return nil, fmt.Errorf("unable to process message with name %q", protoFQN)
 	}
-	message := dynamicpb.NewMessage(msgDescriptor)
 
 	o := protojson.UnmarshalOptions{
 		Resolver: compiledFiles.AsResolver(),
 	}
 	return func(record []byte) ([]byte, error) {
+		// Create a new message instance for each encode call to avoid concurrent map write issues. //
+		message := dynamicpb.NewMessage(msgDescriptor)
+
 		// Unmarshal the record into the proto message. //
 		err := o.Unmarshal(record, message)
 		if err != nil {

--- a/src/go/rpk/pkg/serde/proto_test.go
+++ b/src/go/rpk/pkg/serde/proto_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -550,6 +551,53 @@ func protoReferenceHandler() http.HandlerFunc {
 			w.WriteHeader(http.StatusBadRequest)
 		}
 	}
+}
+
+// Tests that the proto encoder is thread-safe by running multiple goroutines
+// that concurrently encode different protobuf records. This test verifies that
+// concurrent calls to EncodeRecord don't cause race conditions or panics.
+func Test_encodeProtoRecordConcurrency(t *testing.T) {
+	const testSchema = `syntax = "proto3";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  bool isAdmin = 3;
+  optional string email = 4;
+}`
+
+	noopCl, _ := sr.NewClient()
+	schema := sr.Schema{
+		Schema: testSchema,
+		Type:   sr.TypeProtobuf,
+	}
+
+	serde, err := NewSerde(context.Background(), noopCl, &schema, 1, "Person")
+	require.NoError(t, err)
+
+	// Number of goroutines to run concurrently
+	numGoroutines := 10
+	numIterations := 100
+
+	// Use a sync.WaitGroup to wait for all goroutines
+	var wg sync.WaitGroup
+
+	// Launch multiple goroutines that encode records concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			// Each goroutine encodes the same record multiple times to simulate concurrent access.
+			for j := 0; j < numIterations; j++ {
+				_, err := serde.EncodeRecord([]byte(`{"name":"igor","id":123,"isAdmin":true,"email":"test@redpanda.com"}`))
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
 }
 
 // Long message, including all well-known types baked in rpk that we can


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/26619

Fixes: #26685

_Original commit message:_

When serde.EncodeRecord is called on a cached serde function across multiple goroutines, dynamicpb.Set panics with a concurrent map writes fatal. This is caused by the message previously being created outside of the returned encodefn and attempting to unmarshal the byte slice on the same dynamicpb message.

While not an issue for rpk per-se, if this package is imported into another project which does attempt concurrent encodes, this fails. By moving the creation of the dynamicpb object inside the returned encodefn, it does not impact the performance of rpk but allows concurrent encoding to happen if other packages chose to import it.

(cherry picked from commit d40a21152bc840fa991144e999b274e38b480bdc)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
