### PR TITLE
`storage`: rework `compaction_backlog()` logic 

### DIFF
--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -215,7 +215,7 @@ bool failure_injectable_log::notify_compaction_update() {
     return _underlying_log->notify_compaction_update();
 }
 
-int64_t failure_injectable_log::compaction_backlog() const {
+int64_t failure_injectable_log::compaction_backlog() {
     return _underlying_log->compaction_backlog();
 }
 

--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -284,4 +284,8 @@ failure_injectable_log::max_removed_offset() const {
     return _underlying_log->max_removed_offset();
 }
 
+bool failure_injectable_log::needs_compaction() {
+    return _underlying_log->needs_compaction();
+}
+
 } // namespace raft

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -117,7 +117,7 @@ public:
 
     bool notify_compaction_update() final;
 
-    int64_t compaction_backlog() const final;
+    int64_t compaction_backlog() final;
 
     ss::future<storage::usage_report> disk_usage(storage::gc_config) final;
 

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -151,6 +151,8 @@ public:
 
     virtual std::optional<model::offset> max_removed_offset() const final;
 
+    bool needs_compaction() final;
+
 private:
     ss::shared_ptr<storage::log> _underlying_log;
     std::optional<append_delay_generator> _append_delay_generator;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3611,143 +3611,37 @@ void disk_log_impl::set_overrides(ntp_config::default_overrides o) {
     mutable_config().set_overrides(o);
 }
 
-/// Calculate the compaction backlog of the segments within a particular term
-///
-/// This is the inner part of compaction_backlog()
-int64_t compaction_backlog_term(
-  std::vector<ss::lw_shared_ptr<segment>> segs, double cf) {
-    int64_t backlog = 0;
-
-    // Only compare each segment to a limited number of other segments, to
-    // avoid the loop below blowing up in runtime when there are many segments
-    // in the same term.
-    static constexpr size_t limit_lookahead = 8;
-
-    auto segment_count = segs.size();
-    if (segment_count <= 1) {
-        return 0;
-    }
-
-    for (size_t n = 1; n <= segment_count; ++n) {
-        auto& s = segs[n - 1];
-        auto sz = s->has_self_compact_timestamp() ? s->size_bytes()
-                                                  : s->size_bytes() * cf;
-        for (size_t k = 0; k <= segment_count - n && k < limit_lookahead; ++k) {
-            if (k == segment_count - 1) {
-                continue;
-            }
-            if (k == 0) {
-                backlog += static_cast<int64_t>(sz);
-            } else {
-                backlog += static_cast<int64_t>(std::pow(cf, k) * sz);
-            }
-        }
-    }
-
-    return backlog;
-}
-
 /**
- * We express compaction backlog as the size of a data that have to be read to
+ * We express compaction backlog as the size of data that has to be read to
  * perform full compaction.
- *
- * According to this assumption compaction backlog consist of two components
- *
- * 1) size of not yet self compacted segments
- * 2) size of all possible adjacent segments compactions
- *
- * Component 1. of a compaction backlog is simply a sum of sizes of all not self
- * compacted segments.
- *
- * Calculation of 2nd part of compaction backlog is based on the observation
- * that adjacent segment compactions can be presented as a tree
- * (each leaf represents a log segment)
- *                              ┌────┐
- *                        ┌────►│ s5 │◄┐
- *                        │     └────┘ │
- *                        │            │
- *                        │            │
- *                        │            │
- *                      ┌─┴──┐         │
- *                    ┌►│ s4 │◄┐       │
- *                    │ └────┘ │       │
- *                    │        │       │
- *                    │        │       │
- *                    │        │       │
- *                    │        │       │
- *                  ┌─┴──┐  ┌──┴─┐  ┌──┴─┐
- *                  │ s1 │  │ s2 │  │ s3 │
- *                  └────┘  └────┘  └────┘
- *
- * To create segment from upper tree level two self compacted adjacent segments
- * from level below are concatenated and then resulting segment is self
- * compacted.
- *
- * In presented example size of s4:
- *
- *          sizeof(s4) = sizeof(s1) + sizeof(s2)
- *
- * Estimation of an s4 size after it will be self compacted is based on the
- * average compaction factor - `cf`. After self compaction size of
- * s4 will be estimated as
- *
- *         sizeof(s4) = cf * s4
- *
- * This allows calculating next compaction step which would be:
- *
- *         sizeof(s5) = cf * sizeof(s4) + s3 = cf * (sizeof(s1) + sizeof(s2))
- *
- * In order to calculate the backlog we have to sum both terms.
- *
- * Continuing those operation for upper tree levels we can obtain an equation
- * describing adjacent segments compaction backlog:
- *
- * cnt - segments count
- *
- *  backlog = sum(n=1,cnt) [sum(k=0, cnt - n + 1)][cf^k * sizeof(sn)] -
- *  cf^(cnt-1) * s1
  */
-int64_t disk_log_impl::compaction_backlog() const {
+int64_t disk_log_impl::compaction_backlog() {
     if (!config().is_compacted() || _segs.empty()) {
         return 0;
     }
 
-    auto current_term = _segs.front()->offsets().get_term();
-    auto cf = _compaction_ratio.get();
-    int64_t backlog = 0;
-    std::vector<ss::lw_shared_ptr<segment>> segments_this_term;
-
-    // Limit how large we will try to allocate the sgements_this_term vector:
-    // this protects us against corner cases where a term has a really large
-    // number of segments.  Typical compaction use cases will have many fewer
-    // segments per term than this (because segments are continuously compacted
-    // away).  Corner cases include non-compactible data in a compacted topic,
-    // or enabling compaction on a previously non-compacted topic.
-    static constexpr size_t limit_segments_this_term = 1024;
-
-    for (auto& s : _segs) {
-        if (!s->has_self_compact_timestamp()) {
-            backlog += static_cast<int64_t>(s->size_bytes());
-        }
-        // if has appender do not include into adjacent segments calculation
-        if (s->has_appender()) {
-            continue;
-        }
-
-        if (current_term != s->offsets().get_term()) {
-            // New term: consume segments from the previous term.
-            backlog += compaction_backlog_term(
-              std::move(segments_this_term), cf);
-            segments_this_term.clear();
-        }
-
-        if (segments_this_term.size() < limit_segments_this_term) {
-            segments_this_term.push_back(s);
-        }
+    if (!needs_compaction()) {
+        return 0;
     }
 
-    // Consume segments from last term in the log after falling out of loop
-    backlog += compaction_backlog_term(std::move(segments_this_term), cf);
+    // Find the last closed yet dirty segment in the log, and sum over all bytes
+    // before it.
+    auto last_dirty_it = std::find_if(
+      _segs.rbegin(), _segs.rend(), [](const segment_set::type& s) {
+          return !s->has_appender() && !s->has_clean_compact_timestamp();
+      });
+
+    if (last_dirty_it == _segs.rend()) {
+        return 0;
+    }
+
+    int64_t backlog = std::accumulate(
+      _segs.begin(),
+      last_dirty_it.base(),
+      int64_t{0},
+      [](int64_t acc, ss::lw_shared_ptr<segment>& seg) {
+          return acc + seg->size_bytes();
+      });
 
     return backlog;
 }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4679,4 +4679,16 @@ std::optional<model::offset> disk_log_impl::max_removed_offset() const {
     return internal::read_max_removed_offset(_kvstore, config().ntp());
 }
 
+bool disk_log_impl::needs_compaction() {
+    auto max_lag = config().max_compaction_lag_ms();
+    const auto now = to_time_point(model::timestamp::now());
+    const auto earliest_dirty_ts = earliest_dirty_segment_ts();
+    const auto exceed_compact_lag
+      = earliest_dirty_ts.has_value()
+        && (now - to_time_point(earliest_dirty_ts.value()) > max_lag);
+
+    auto dr = dirty_ratio();
+    return dr >= config().min_cleanable_dirty_ratio() || exceed_compact_lag;
+}
+
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -438,6 +438,15 @@ private:
     bool log_contains_offset_range(
       model::offset first, model::offset last) const noexcept;
 
+    // A log is eligible for compaction if at least one of the following
+    // is true:
+    // 1. It's gone long enough without compaction: the earliest first
+    //    batch timestamp of a dirty segment is longer ago than
+    //    the max compaction lag.
+    // 2. It's dirty enough: the dirty ratio is at least the minimum
+    //    cleanable dirty ratio.
+    bool needs_compaction() final;
+
 private:
     // Computes the segment size based on the latest max_segment_size
     // configuration. This takes into consideration any segment size

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -167,7 +167,7 @@ public:
     void set_overrides(ntp_config::default_overrides) final;
     bool notify_compaction_update() final;
 
-    int64_t compaction_backlog() const final;
+    int64_t compaction_backlog() final;
 
     ss::future<usage_report> disk_usage(gc_config) override;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -232,7 +232,7 @@ public:
     /// Returns true if the log compaction changed.
     virtual bool notify_compaction_update() = 0;
 
-    virtual int64_t compaction_backlog() const = 0;
+    virtual int64_t compaction_backlog() = 0;
 
     virtual ss::future<usage_report> disk_usage(gc_config) = 0;
     virtual ss::future<reclaimable_offsets>

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -273,6 +273,7 @@ public:
       earliest_removable_timestamp(model::offset) const = 0;
 
     virtual std::optional<model::offset> max_removed_offset() const = 0;
+    virtual bool needs_compaction() = 0;
 
 private:
     ntp_config _config;

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -305,36 +305,19 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         compaction_heuristic_to_log_metas;
     for (auto& log_meta : _logs_list) {
         auto should_compact_log = [](ss::shared_ptr<log> l) {
-            // A log is eligible for compaction if at least one of the following
-            // is true:
-            // 1. It's gone long enough without compaction: the earliest first
-            //    batch timestamp of a dirty segment is longer ago than
-            //    the max compaction lag.
-            // 2. It's dirty enough: the dirty ratio is at least the minimum
-            //    cleanable dirty ratio.
-            const auto max_lag = l->config().max_compaction_lag_ms();
-            const auto now = to_time_point(model::timestamp::now());
-            const auto earliest_dirty_ts = l->earliest_dirty_segment_ts();
-            if (
-              earliest_dirty_ts
-              && (now - to_time_point(earliest_dirty_ts.value()) > max_lag)) {
-                return true;
+            auto needs_compact = l->needs_compaction();
+            if (!needs_compact) {
+                vlog(
+                  gclog.trace,
+                  "{}: dirty ratio ({}) < min.cleanable.dirty.ratio ({}) and "
+                  "time since earliest dirty timestamp does not exceed "
+                  "max.compaction.lag.ms ({}), skipping compaction.",
+                  l->config().ntp(),
+                  l->dirty_ratio(),
+                  l->config().min_cleanable_dirty_ratio(),
+                  l->config().max_compaction_lag_ms());
             }
-            const auto min_cleanable_dirty_ratio
-              = l->config().min_cleanable_dirty_ratio().value_or(0.0);
-            const auto dirty_ratio = l->dirty_ratio();
-            if (dirty_ratio >= min_cleanable_dirty_ratio) {
-                return true;
-            }
-
-            vlog(
-              gclog.trace,
-              "{}: dirty ratio ({}) < min.cleanable.dirty.ratio ({}), skipping "
-              "compaction.",
-              l->config().ntp(),
-              dirty_ratio,
-              min_cleanable_dirty_ratio);
-            return false;
+            return needs_compact;
         };
 
         const auto compact_log = should_compact_log(log_meta.handle);

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2161,6 +2161,7 @@ TEST_F(storage_test_fixture, compaction_backlog_calculation) {
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
+    overrides.min_cleanable_dirty_ratio = tristate<double>{0.0};
 
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -2204,34 +2205,43 @@ TEST_F(storage_test_fixture, compaction_backlog_calculation) {
       std::nullopt,
       0ms,
       as);
-    /**
-     * Initially all compaction rations are equal to 1.0 so it is easy to
-     * calculate backlog size.
-     */
     auto& segments = disk_log->segments();
-    auto backlog_size = log->compaction_backlog();
-    size_t self_seg_compaction_sz = 0;
-    for (auto& s : segments) {
-        self_seg_compaction_sz += s->size_bytes();
+    {
+        auto backlog_size = log->compaction_backlog();
+        size_t expected_backlog = 0;
+        for (auto& s : segments) {
+            if (!s->has_appender()) {
+                expected_backlog += s->size_bytes();
+            }
+        }
+        ASSERT_EQ(backlog_size, expected_backlog);
     }
-    ASSERT_EQ(
-      backlog_size,
-      3 * segments[0]->size_bytes() + 3 * segments[1]->size_bytes()
-        + 2 * segments[2]->size_bytes() + segments[3]->size_bytes()
-        + self_seg_compaction_sz);
-    // self compaction steps
+
+    // Perform compaction.
     log->housekeeping(c_cfg).get();
 
     ASSERT_EQ(disk_log->segment_count(), 2);
-    auto new_backlog_size = log->compaction_backlog();
-    /**
-     * after all self segments are compacted they shouldn't be included into the
-     * backlog (only last segment is since it has appender and isn't self
-     * compacted)
-     */
-    ASSERT_LT(
-      new_backlog_size,
-      backlog_size - self_seg_compaction_sz + segments[1]->size_bytes());
+    {
+        auto backlog_size = log->compaction_backlog();
+        // Log should be fully clean.
+        ASSERT_EQ(backlog_size, 0);
+    }
+
+    // Addition of a new segment results in all of the bytes of the log being
+    // added to backlog due to min.cleanable.dirty.ratio=0.0
+    add_segment(16_KiB, model::term_id(1));
+    disk_log->force_roll().get();
+    ASSERT_EQ(disk_log->segment_count(), 3);
+    {
+        auto backlog_size = log->compaction_backlog();
+        size_t expected_backlog = 0;
+        for (auto& s : segments) {
+            if (!s->has_appender()) {
+                expected_backlog += s->size_bytes();
+            }
+        }
+        ASSERT_EQ(backlog_size, expected_backlog);
+    }
 }
 
 TEST_F(storage_test_fixture, not_compacted_log_backlog) {


### PR DESCRIPTION
The previous logic for `disk_log_impl::compaction_backlog()` was quite involved and was mostly predicated on the fact that adjacent `segment` compaction was the only form of compaction in `redpanda` at the time.

To estimate the number of bytes that must be read to fully compact the `log`, search for the last dirty `segment` in the `log`, and sum over all of the bytes that proceed it. This is an over-estimation of the number of bytes that may be processed during compaction, as it does not take into account which keys may be present or not in the dirty/clean `segment`s (ergo which `segment`s will actually be read/rewritten by the built key-offset map during a round of compaction), but this is fine for our purposes.

The `compaction_backlog()` is estimated as 0 if the `log` is not currently eligible for compaction (i.e due to a dirty ratio below `min.cleanable.dirty.ratio` and without a dirty timestamp exceeding `max.compaction.lag.ms`).

This should give a much cleaner and easier to grok estimate of the compaction backlog for a given `log`. The rest of the `compaction_controller` logic is left untouched (i.e backlog is still normalized by the disk capacity, desired backlog size is left as 10%).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
