### PR TITLE
rpc: remove requirement for `rpc_adl_exempt` tag

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -30,7 +30,6 @@ enum class errc : int16_t {
 struct add_objects_reply
   : serde::
       envelope<add_objects_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(ec); }
 
     errc ec;
@@ -40,7 +39,6 @@ struct add_objects_request
       add_objects_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = add_objects_reply;
     auto serde_fields() { return std::tie(update, metastore_partition); }
 
@@ -53,7 +51,6 @@ struct replace_objects_reply
       replace_objects_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(ec); }
 
     errc ec;
@@ -63,7 +60,6 @@ struct replace_objects_request
       replace_objects_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = replace_objects_reply;
     auto serde_fields() { return std::tie(update, metastore_partition); }
 
@@ -74,7 +70,6 @@ struct replace_objects_request
 struct object_metadata
   : serde::
       envelope<object_metadata, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(oid, footer_pos); }
 
     object_id oid;
@@ -86,7 +81,6 @@ struct get_first_offset_ge_reply
       get_first_offset_ge_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(ec, object); }
 
     errc ec;
@@ -97,7 +91,6 @@ struct get_first_offset_ge_request
       get_first_offset_ge_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = get_first_offset_ge_reply;
     auto serde_fields() { return std::tie(tp); }
 
@@ -109,7 +102,6 @@ struct get_first_timestamp_ge_reply
       get_first_timestamp_ge_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(ec, object); }
 
     errc ec;
@@ -120,7 +112,6 @@ struct get_first_timestamp_ge_request
       get_first_timestamp_ge_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = get_first_timestamp_ge_reply;
     auto serde_fields() { return std::tie(tp); }
 
@@ -130,7 +121,6 @@ struct get_first_timestamp_ge_request
 struct get_offsets_reply
   : serde::
       envelope<get_offsets_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(ec, start_offset, next_offset); }
 
     errc ec;
@@ -142,7 +132,6 @@ struct get_offsets_request
       get_offsets_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = get_offsets_reply;
     auto serde_fields() { return std::tie(tp); }
 
@@ -154,7 +143,6 @@ struct get_compaction_offsets_reply
       get_compaction_offsets_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() {
         return std::tie(ec, dirty_ranges, removable_tombstone_ranges);
     }
@@ -168,7 +156,6 @@ struct get_compaction_offsets_request
       get_compaction_offsets_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = get_compaction_offsets_reply;
     auto serde_fields() { return std::tie(tp); }
 

--- a/src/v/cluster/bootstrap_types.h
+++ b/src/v/cluster/bootstrap_types.h
@@ -23,8 +23,6 @@ struct cluster_bootstrap_info_request
       cluster_bootstrap_info_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend std::ostream&
     operator<<(std::ostream& o, const cluster_bootstrap_info_request&) {
         fmt::print(o, "{{}}");
@@ -39,8 +37,6 @@ struct cluster_bootstrap_info_reply
       cluster_bootstrap_info_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::broker broker;
     cluster_version version;
     std::vector<net::unresolved_address> seed_servers;

--- a/src/v/cluster/client_quota_serde.h
+++ b/src/v/cluster/client_quota_serde.h
@@ -294,8 +294,6 @@ struct alter_quotas_request
       alter_quotas_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     alter_delta_cmd_data cmd_data;
     model::timeout_clock::duration timeout{};
 
@@ -311,8 +309,6 @@ struct alter_quotas_response
       alter_quotas_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cluster::errc ec;
     auto serde_fields() { return std::tie(ec); }
 

--- a/src/v/cluster/cloud_metadata/offsets_lookup_rpc_types.h
+++ b/src/v/cluster/cloud_metadata/offsets_lookup_rpc_types.h
@@ -22,7 +22,6 @@ struct offsets_lookup_request
       offsets_lookup_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cluster::errc error;
 
     // Node ID to which this request is sent.
@@ -43,13 +42,9 @@ struct offsets_lookup_reply
       offsets_lookup_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     struct ntp_offset
       : public serde::
           envelope<ntp_offset, serde::version<0>, serde::compat_version<0>> {
-        using rpc_adl_exempt = std::true_type;
-
         model::ntp ntp;
         kafka::offset offset;
 

--- a/src/v/cluster/cloud_metadata/offsets_recovery_rpc_types.h
+++ b/src/v/cluster/cloud_metadata/offsets_recovery_rpc_types.h
@@ -26,8 +26,6 @@ struct offsets_recovery_request
       offsets_recovery_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp offsets_ntp;
     cloud_storage_clients::bucket_name bucket;
     std::vector<ss::sstring> offsets_snapshot_paths;
@@ -57,8 +55,6 @@ struct offsets_recovery_reply
       offsets_recovery_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cluster::errc ec{};
 
     auto serde_fields() { return std::tie(ec); }

--- a/src/v/cluster/cloud_metadata/offsets_snapshot.h
+++ b/src/v/cluster/cloud_metadata/offsets_snapshot.h
@@ -21,14 +21,11 @@ namespace cluster::cloud_metadata {
 struct group_offsets
   : public serde::
       envelope<group_offsets, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     struct partition_offset
       : public serde::envelope<
           partition_offset,
           serde::version<0>,
           serde::compat_version<0>> {
-        using rpc_adl_exempt = std::true_type;
         partition_offset(model::partition_id p, kafka::offset o)
           : partition(p)
           , offset(o) {}
@@ -46,7 +43,6 @@ struct group_offsets
           topic_partitions,
           serde::version<0>,
           serde::compat_version<0>> {
-        using rpc_adl_exempt = std::true_type;
         topic_partitions(model::topic t, chunked_vector<partition_offset> ps)
           : topic(std::move(t))
           , partitions(std::move(ps)) {}
@@ -77,8 +73,6 @@ struct group_offsets_snapshot
       group_offsets_snapshot,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     // Partition ID of the offsets topic that managed these groups.
     model::partition_id offsets_topic_pid;
 

--- a/src/v/cluster/cloud_metadata/offsets_upload_rpc_types.h
+++ b/src/v/cluster/cloud_metadata/offsets_upload_rpc_types.h
@@ -24,8 +24,6 @@ struct offsets_upload_request
       offsets_upload_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     // Cluster UUID with which to associate the uploaded metadata.
     model::cluster_uuid cluster_uuid;
 
@@ -47,8 +45,6 @@ struct offsets_upload_reply
       offsets_upload_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cluster::errc ec{};
 
     // Remote paths that were successfully uploaded.

--- a/src/v/cluster/data_migration_types.h
+++ b/src/v/cluster/data_migration_types.h
@@ -386,7 +386,6 @@ struct data_migration_ntp_state
       data_migration_ntp_state,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using self = data_migration_ntp_state;
 
     model::ntp ntp;
@@ -458,7 +457,6 @@ struct create_migration_request
       create_migration_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     data_migration migration;
 
     auto serde_fields() { return std::tie(migration); }
@@ -473,8 +471,6 @@ struct create_migration_reply
       create_migration_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     id id{-1};
     cluster::errc ec;
     auto serde_fields() { return std::tie(id, ec); }
@@ -492,7 +488,6 @@ struct update_migration_state_request
       update_migration_state_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     id id;
     state state;
     auto serde_fields() { return std::tie(id, state); }
@@ -510,7 +505,6 @@ struct update_migration_state_reply
       update_migration_state_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cluster::errc ec;
     auto serde_fields() { return std::tie(ec); }
 
@@ -526,7 +520,6 @@ struct remove_migration_request
       remove_migration_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     id id;
     auto serde_fields() { return std::tie(id); }
     friend bool
@@ -541,7 +534,6 @@ struct remove_migration_reply
       remove_migration_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cluster::errc ec;
 
     auto serde_fields() { return std::tie(ec); }
@@ -559,7 +551,6 @@ struct check_ntp_states_request
       check_ntp_states_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using self = check_ntp_states_request;
 
     chunked_vector<data_migration_ntp_state> sought_states;
@@ -576,7 +567,6 @@ struct check_ntp_states_reply
       check_ntp_states_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using self = check_ntp_states_reply;
 
     chunked_vector<data_migration_ntp_state> actual_states;

--- a/src/v/cluster/ephemeral_credential_serde.h
+++ b/src/v/cluster/ephemeral_credential_serde.h
@@ -24,8 +24,6 @@ struct put_ephemeral_credential_request
       put_ephemeral_credential_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     put_ephemeral_credential_request() = default;
     explicit put_ephemeral_credential_request(
       security::acl_principal principal,
@@ -47,8 +45,6 @@ struct put_ephemeral_credential_reply
       put_ephemeral_credential_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     put_ephemeral_credential_reply() = default;
     explicit put_ephemeral_credential_reply(errc err)
       : err(err) {}

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -490,7 +490,6 @@ class get_node_health_request
       serde::version<1>,
       serde::compat_version<0>> {
 public:
-    using rpc_adl_exempt = std::true_type;
     get_node_health_request() = default;
     explicit get_node_health_request(model::node_id target_node_id)
       : _target_node_id(target_node_id) {}
@@ -522,8 +521,6 @@ struct get_node_health_reply
       get_node_health_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc error = cluster::errc::success;
     std::optional<node_health_report_serde> report;
 
@@ -549,7 +546,6 @@ struct get_cluster_health_request
       get_cluster_health_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     static constexpr int8_t initial_version = 0;
     // version -1: included revision id in partition status
     static constexpr int8_t revision_id_version = -1;
@@ -594,7 +590,6 @@ struct get_cluster_health_reply
       get_cluster_health_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     static constexpr int8_t current_version = 0;
 
     errc error = cluster::errc::success;

--- a/src/v/cluster/metadata_dissemination_types.h
+++ b/src/v/cluster/metadata_dissemination_types.h
@@ -108,7 +108,6 @@ struct update_leadership_request_v2
       update_leadership_request_v2,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     static constexpr int8_t version = 0;
     chunked_vector<ntp_leader_revision> leaders;
 
@@ -151,7 +150,6 @@ struct update_leadership_reply
       update_leadership_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     update_leadership_reply() noexcept = default;
 
     friend std::ostream&
@@ -168,7 +166,6 @@ struct get_leadership_request
       get_leadership_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     get_leadership_request() noexcept = default;
 
     friend std::ostream&
@@ -185,7 +182,6 @@ struct get_leadership_reply
       get_leadership_reply,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using is_success = ss::bool_class<struct glr_tag>;
     chunked_vector<ntp_leader> leaders;
     is_success success = is_success::yes;

--- a/src/v/cluster/migrations/tx_manager_migrator_types.h
+++ b/src/v/cluster/migrations/tx_manager_migrator_types.h
@@ -29,8 +29,6 @@ struct tx_manager_read_request
       tx_manager_read_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     model::offset start_offset;
 
@@ -46,8 +44,6 @@ struct tx_manager_read_reply
       tx_manager_read_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx_manager_read_reply() = default;
     explicit tx_manager_read_reply(errc ec)
       : ec(ec) {}
@@ -91,8 +87,6 @@ struct tx_manager_replicate_request
       tx_manager_replicate_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx_manager_replicate_request() = default;
 
     tx_manager_replicate_request(
@@ -137,7 +131,6 @@ struct tx_manager_replicate_reply
       tx_manager_replicate_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc ec;
 
     friend bool operator==(

--- a/src/v/cluster/node_status_rpc_types.h
+++ b/src/v/cluster/node_status_rpc_types.h
@@ -23,8 +23,6 @@ struct node_status_metadata
       node_status_metadata,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::node_id node_id;
 
     auto serde_fields() { return std::tie(node_id); }
@@ -41,8 +39,6 @@ struct node_status_request
       node_status_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     node_status_metadata sender_metadata;
 
     auto serde_fields() { return std::tie(sender_metadata); }
@@ -57,8 +53,6 @@ struct node_status_request
 struct node_status_reply
   : serde::
       envelope<node_status_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     node_status_metadata replier_metadata;
 
     auto serde_fields() { return std::tie(replier_metadata); }

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -124,8 +124,6 @@ struct partition_balancer_overview_request
       partition_balancer_overview_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend std::ostream&
     operator<<(std::ostream& o, const partition_balancer_overview_request&);
     auto serde_fields() { return std::tie(); }
@@ -188,8 +186,6 @@ struct partition_balancer_overview_reply
       partition_balancer_overview_reply,
       serde::version<3>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     partition_balancer_overview_reply() noexcept = default;
     partition_balancer_overview_reply(const partition_balancer_overview_reply&)
       = delete;

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -333,8 +333,6 @@ struct self_test_result
 struct empty_request
   : serde::
       envelope<empty_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     auto serde_fields() { return std::tie(); }
 };
 
@@ -343,8 +341,6 @@ struct start_test_request
       start_test_request,
       serde::version<2>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     uuid_t id;
     std::vector<diskcheck_opts> dtos;
     std::vector<netcheck_opts> ntos;
@@ -380,8 +376,6 @@ struct get_status_response
       get_status_response,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     uuid_t id{};
     self_test_status status{};
     std::vector<self_test_result> results;
@@ -405,7 +399,6 @@ struct get_status_response
 struct netcheck_request
   : serde::
       envelope<netcheck_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::node_id source;
     iobuf buf;
     auto serde_fields() { return std::tie(source, buf); }
@@ -419,7 +412,6 @@ struct netcheck_request
 struct netcheck_response
   : serde::
       envelope<netcheck_response, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     size_t bytes_read{0};
 
     auto serde_fields() { return std::tie(bytes_read); }

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -42,8 +42,6 @@ struct fake_serde_only_key
       fake_serde_only_key,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ss::sstring str;
 
     auto serde_fields() { return std::tie(str); }
@@ -53,8 +51,6 @@ struct fake_serde_only_val
       fake_serde_only_val,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ss::sstring str;
 
     auto serde_fields() { return std::tie(str); }

--- a/src/v/cluster/topic_recovery_status_types.h
+++ b/src/v/cluster/topic_recovery_status_types.h
@@ -21,8 +21,6 @@ namespace cluster {
 struct status_request
   : serde::
       envelope<status_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     auto serde_fields() { return std::tie(); }
 };
 
@@ -68,7 +66,6 @@ std::ostream& operator<<(std::ostream&, const recovery_request_params&);
 struct single_status
   : serde::
       envelope<single_status, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cloud_storage::topic_recovery_service::state state;
     std::vector<topic_downloads> download_counts;
     recovery_request_params request;
@@ -83,7 +80,6 @@ struct single_status
 struct status_response
   : serde::
       envelope<status_response, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<single_status> status_log;
     auto serde_fields() { return std::tie(status_log); }
 

--- a/src/v/cluster/tx_protocol_types.h
+++ b/src/v/cluster/tx_protocol_types.h
@@ -30,8 +30,6 @@ struct try_abort_reply
     using committed_type = ss::bool_class<struct committed_type_tag>;
     using aborted_type = ss::bool_class<struct aborted_type_tag>;
 
-    using rpc_adl_exempt = std::true_type;
-
     committed_type commited;
     aborted_type aborted;
     tx::errc ec;
@@ -65,7 +63,6 @@ struct try_abort_reply
 struct try_abort_request
   : serde::
       envelope<try_abort_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using reply = try_abort_reply;
     static constexpr const std::string_view name = "try_abort";
 
@@ -100,8 +97,6 @@ struct init_tm_tx_request
       init_tm_tx_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     kafka::transactional_id tx_id{};
     std::chrono::milliseconds transaction_timeout_ms{};
     model::timeout_clock::duration timeout{};
@@ -130,8 +125,6 @@ struct init_tm_tx_request
 struct init_tm_tx_reply
   : serde::
       envelope<init_tm_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     // partition_not_exists, not_leader, topic_not_exists
     model::producer_identity pid;
     tx::errc ec;
@@ -196,8 +189,6 @@ struct end_tx_reply {
 struct fetch_tx_request
   : serde::
       envelope<fetch_tx_request, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     kafka::transactional_id tx_id{};
     model::term_id term{};
     model::partition_id tm{0};
@@ -223,8 +214,6 @@ struct fetch_tx_request
 struct fetch_tx_reply
   : serde::
       envelope<fetch_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     enum class tx_status : int32_t {
         ongoing,
         preparing,
@@ -238,8 +227,6 @@ struct fetch_tx_reply
     struct tx_partition
       : serde::
           envelope<tx_partition, serde::version<0>, serde::compat_version<0>> {
-        using rpc_adl_exempt = std::true_type;
-
         model::ntp ntp;
         model::term_id etag;
         model::revision_id topic_revision;
@@ -264,8 +251,6 @@ struct fetch_tx_reply
 
     struct tx_group
       : serde::envelope<tx_group, serde::version<0>, serde::compat_version<0>> {
-        using rpc_adl_exempt = std::true_type;
-
         kafka::group_id group_id;
         model::term_id etag;
 
@@ -328,7 +313,6 @@ struct fetch_tx_reply
 struct begin_tx_request
   : serde::
       envelope<begin_tx_request, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -362,7 +346,6 @@ struct begin_tx_request
 struct begin_tx_reply
   : serde::
       envelope<begin_tx_reply, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::ntp ntp;
     model::term_id etag;
     tx::errc ec;
@@ -402,8 +385,6 @@ struct prepare_tx_request
       prepare_tx_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     model::term_id etag;
     model::partition_id tm;
@@ -441,8 +422,6 @@ struct prepare_tx_request
 struct prepare_tx_reply
   : serde::
       envelope<prepare_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx::errc ec{};
 
     prepare_tx_reply() noexcept = default;
@@ -461,8 +440,6 @@ struct prepare_tx_reply
 struct commit_tx_request
   : serde::
       envelope<commit_tx_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -492,8 +469,6 @@ struct commit_tx_request
 struct commit_tx_reply
   : serde::
       envelope<commit_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx::errc ec{};
 
     commit_tx_reply() noexcept = default;
@@ -512,8 +487,6 @@ struct commit_tx_reply
 struct abort_tx_request
   : serde::
       envelope<abort_tx_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -542,8 +515,6 @@ struct abort_tx_request
 struct abort_tx_reply
   : serde::
       envelope<abort_tx_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx::errc ec{};
 
     abort_tx_reply() noexcept = default;
@@ -564,8 +535,6 @@ struct begin_group_tx_request
       begin_group_tx_request,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     kafka::group_id group_id;
     model::producer_identity pid;
@@ -619,8 +588,6 @@ struct begin_group_tx_reply
       begin_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::term_id etag;
     tx::errc ec{};
 
@@ -648,8 +615,6 @@ struct prepare_group_tx_request
       prepare_group_tx_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     kafka::group_id group_id;
     model::term_id etag;
@@ -703,8 +668,6 @@ struct prepare_group_tx_reply
       prepare_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx::errc ec{};
 
     prepare_group_tx_reply() noexcept = default;
@@ -727,8 +690,6 @@ struct commit_group_tx_request
       commit_group_tx_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
@@ -778,7 +739,6 @@ struct commit_group_tx_reply
       commit_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     tx::errc ec{};
 
     commit_group_tx_reply() noexcept = default;
@@ -801,7 +761,6 @@ struct abort_group_tx_request
       abort_group_tx_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::ntp ntp;
     kafka::group_id group_id;
     model::producer_identity pid;
@@ -851,7 +810,6 @@ struct abort_group_tx_reply
       abort_group_tx_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     tx::errc ec{};
 
     abort_group_tx_reply() noexcept = default;
@@ -874,8 +832,6 @@ struct find_coordinator_reply
       find_coordinator_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     std::optional<model::node_id> coordinator{std::nullopt};
     std::optional<model::ntp> ntp{std::nullopt};
     errc ec{errc::generic_tx_error}; // this should have been tx::errc
@@ -923,7 +879,6 @@ struct find_coordinator_request
       find_coordinator_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using reply = find_coordinator_reply;
     static constexpr const std::string_view name = "find_coordinator";
 
@@ -949,8 +904,6 @@ struct idempotent_request_info
       idempotent_request_info,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     int32_t first_sequence;
     int32_t last_sequence;
     model::term_id term;
@@ -972,8 +925,6 @@ struct producer_state_info
       producer_state_info,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::producer_identity pid;
     // idempotent request information only filled for data partitions
     // that support idempotency.
@@ -1017,8 +968,6 @@ struct get_producers_reply
       get_producers_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     tx::errc error_code{};
     chunked_vector<producer_state_info> producers;
     // Not all producers are sent as a guard rail in extreme cases
@@ -1043,8 +992,6 @@ struct get_producers_request
       get_producers_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     get_producers_request() noexcept = default;
 
     explicit get_producers_request(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -206,7 +206,6 @@ enum class partition_removal_mode : uint8_t {
 struct join_node_request
   : serde::
       envelope<join_node_request, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     join_node_request() noexcept = default;
 
     explicit join_node_request(
@@ -264,8 +263,6 @@ struct join_node_request
 struct join_node_reply
   : serde::
       envelope<join_node_reply, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     enum class status_code : uint8_t {
         success = 0,
         // Non-specific error
@@ -408,7 +405,6 @@ struct configuration_update_request
       configuration_update_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     configuration_update_request() noexcept = default;
     explicit configuration_update_request(model::broker b, model::node_id tid)
       : node(std::move(b))
@@ -432,7 +428,6 @@ struct configuration_update_reply
       configuration_update_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     configuration_update_reply() noexcept = default;
     explicit configuration_update_reply(bool success)
       : success(success) {}
@@ -1032,8 +1027,6 @@ struct create_topics_request
       create_topics_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     topic_configuration_vector topics;
     model::timeout_clock::duration timeout;
 
@@ -1056,8 +1049,6 @@ struct create_topics_reply
       create_topics_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     std::vector<topic_result> results;
     std::vector<model::topic_metadata> metadata;
     topic_configuration_vector configs;
@@ -1089,8 +1080,6 @@ struct purged_topic_request
       purged_topic_request,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     nt_revision topic;
     model::timeout_clock::duration timeout;
     topic_purge_domain domain = topic_purge_domain::cloud_storage;
@@ -1109,8 +1098,6 @@ struct purged_topic_reply
       purged_topic_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     topic_result result;
 
     purged_topic_reply() noexcept = default;
@@ -1130,7 +1117,6 @@ struct finish_partition_update_request
       finish_partition_update_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::ntp ntp;
     replicas_t new_replica_set;
 
@@ -1150,7 +1136,6 @@ struct finish_partition_update_reply
       finish_partition_update_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cluster::errc result;
 
     friend bool operator==(
@@ -1169,7 +1154,6 @@ struct update_topic_properties_request
       update_topic_properties_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     topic_properties_update_vector updates;
 
     friend std::ostream&
@@ -1192,7 +1176,6 @@ struct update_topic_properties_reply
       update_topic_properties_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     chunked_vector<topic_result> results;
 
     friend std::ostream&
@@ -1410,7 +1393,6 @@ struct create_acls_request
       create_acls_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     create_acls_cmd_data data;
     model::timeout_clock::duration timeout;
 
@@ -1436,8 +1418,6 @@ struct create_acls_request
 struct create_acls_reply
   : serde::
       envelope<create_acls_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     std::vector<errc> results;
 
     friend bool operator==(const create_acls_reply&, const create_acls_reply&)
@@ -1479,7 +1459,6 @@ struct delete_acls_result
       delete_acls_result,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc error;
     std::vector<security::acl_binding> bindings;
 
@@ -1500,7 +1479,6 @@ struct delete_acls_request
       delete_acls_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     delete_acls_cmd_data data;
     model::timeout_clock::duration timeout;
 
@@ -1526,7 +1504,6 @@ struct delete_acls_request
 struct delete_acls_reply
   : serde::
       envelope<delete_acls_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<delete_acls_result> results;
 
     friend bool operator==(const delete_acls_reply&, const delete_acls_reply&)
@@ -1579,7 +1556,6 @@ struct recovery_state
 struct backend_operation
   : serde::
       envelope<backend_operation, serde::version<2>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ss::shard_id source_shard;
     partition_assignment p_as;
     partition_operation_type type;
@@ -1790,8 +1766,6 @@ struct feature_update_license_update_cmd_data
       feature_update_license_update_cmd_data,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     // Struct encoding version
     static constexpr int8_t current_version = 1;
 
@@ -1808,7 +1782,6 @@ struct user_and_credential
       user_and_credential,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     static constexpr int8_t current_version = 0;
 
     user_and_credential() = default;
@@ -1831,7 +1804,6 @@ struct cluster_recovery_init_state
       cluster_recovery_init_state,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     friend bool operator==(
       const cluster_recovery_init_state&, const cluster_recovery_init_state&)
       = default;
@@ -1851,8 +1823,6 @@ struct bootstrap_cluster_cmd_data
       bootstrap_cluster_cmd_data,
       serde::version<3>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend bool operator==(
       const bootstrap_cluster_cmd_data&, const bootstrap_cluster_cmd_data&)
       = default;
@@ -1886,8 +1856,6 @@ struct cluster_recovery_init_cmd_data
       cluster_recovery_init_cmd_data,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend bool operator==(
       const cluster_recovery_init_cmd_data&,
       const cluster_recovery_init_cmd_data&)
@@ -1938,7 +1906,6 @@ struct cluster_recovery_update_cmd_data
       cluster_recovery_update_cmd_data,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     friend bool operator==(
       const cluster_recovery_update_cmd_data&,
       const cluster_recovery_update_cmd_data&)
@@ -1966,7 +1933,6 @@ class ntp_reconciliation_state
       serde::version<0>,
       serde::compat_version<0>> {
 public:
-    using rpc_adl_exempt = std::true_type;
     ntp_reconciliation_state() noexcept = default;
 
     // success case
@@ -2073,8 +2039,6 @@ struct reconciliation_state_request
       reconciliation_state_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     chunked_vector<model::ntp> ntps;
 
     friend bool operator==(
@@ -2133,8 +2097,6 @@ struct bulk_force_reconfiguration_cmd_data
       bulk_force_reconfiguration_cmd_data,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     bulk_force_reconfiguration_cmd_data() = default;
     ~bulk_force_reconfiguration_cmd_data() noexcept = default;
     bulk_force_reconfiguration_cmd_data(bulk_force_reconfiguration_cmd_data&&)
@@ -2168,7 +2130,6 @@ struct reconciliation_state_reply
       reconciliation_state_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     chunked_vector<ntp_reconciliation_state> results;
 
     friend bool operator==(
@@ -2199,8 +2160,6 @@ struct decommission_node_request
       decommission_node_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::node_id id;
 
     friend bool operator==(
@@ -2221,8 +2180,6 @@ struct decommission_node_reply
       decommission_node_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc error;
 
     friend bool
@@ -2243,8 +2200,6 @@ struct recommission_node_request
       recommission_node_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::node_id id;
 
     friend bool operator==(
@@ -2265,8 +2220,6 @@ struct recommission_node_reply
       recommission_node_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc error;
 
     friend bool
@@ -2287,7 +2240,6 @@ struct finish_reallocation_request
       finish_reallocation_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::node_id id;
 
     friend bool operator==(
@@ -2308,8 +2260,6 @@ struct finish_reallocation_reply
       finish_reallocation_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc error;
 
     friend bool operator==(
@@ -2330,8 +2280,6 @@ struct set_maintenance_mode_request
       set_maintenance_mode_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     static constexpr int8_t current_version = 1;
     model::node_id id;
     bool enabled;
@@ -2354,8 +2302,6 @@ struct set_maintenance_mode_reply
       set_maintenance_mode_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     static constexpr int8_t current_version = 1;
     errc error;
 
@@ -2377,7 +2323,6 @@ struct config_status_request
       config_status_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     config_status status;
 
     friend std::ostream&
@@ -2395,7 +2340,6 @@ struct config_status_reply
       config_status_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc error;
 
     friend std::ostream& operator<<(std::ostream&, const config_status_reply&);
@@ -2412,7 +2356,6 @@ struct feature_action_request
       feature_action_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     feature_update_action action;
 
     friend bool
@@ -2430,7 +2373,6 @@ struct feature_action_response
       feature_action_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc error;
 
     friend bool
@@ -2451,7 +2393,6 @@ struct feature_barrier_request
       feature_barrier_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     static constexpr int8_t current_version = 1;
     feature_barrier_tag tag; // Each cooperative barrier must use a unique tag
     model::node_id peer;
@@ -2472,7 +2413,6 @@ struct feature_barrier_response
       feature_barrier_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     static constexpr int8_t current_version = 1;
     bool entered;  // Has the respondent entered?
     bool complete; // Has the respondent exited?
@@ -2492,7 +2432,6 @@ struct config_update_request final
       config_update_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<cluster_property_kv> upsert;
     std::vector<ss::sstring> remove;
 
@@ -2511,7 +2450,6 @@ struct config_update_reply
       config_update_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc error;
     cluster::config_version latest_version{config_version_unset};
 
@@ -2527,8 +2465,6 @@ struct config_update_reply
 struct hello_request final
   : serde::
       envelope<hello_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::node_id peer;
 
     // milliseconds since epoch
@@ -2544,8 +2480,6 @@ struct hello_request final
 
 struct hello_reply
   : serde::envelope<hello_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc error;
 
     friend bool operator==(const hello_reply&, const hello_reply&) = default;
@@ -2670,8 +2604,6 @@ struct cancel_all_partition_movements_request
       cancel_all_partition_movements_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cancel_all_partition_movements_request() = default;
 
     auto serde_fields() { return std::tie(); }
@@ -2692,8 +2624,6 @@ struct cancel_node_partition_movements_request
       cancel_node_partition_movements_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::node_id node_id;
     partition_move_direction direction;
 
@@ -2713,8 +2643,6 @@ struct cancel_partition_movements_reply
       cancel_partition_movements_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend bool operator==(
       const cancel_partition_movements_reply&,
       const cancel_partition_movements_reply&)
@@ -2734,8 +2662,6 @@ struct cloud_storage_usage_request
       cloud_storage_usage_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     std::vector<model::ntp> partitions;
 
     friend bool operator==(
@@ -2750,8 +2676,6 @@ struct cloud_storage_usage_reply
       cloud_storage_usage_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     uint64_t total_size_bytes{0};
 
     // When replies are handled in 'cloud_storage_size_reducer'
@@ -2774,8 +2698,6 @@ struct producer_id_lookup_request
       producer_id_lookup_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     producer_id_lookup_request() noexcept = default;
     auto serde_fields() { return std::tie(); }
 };
@@ -2785,8 +2707,6 @@ struct producer_id_lookup_reply
       producer_id_lookup_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cluster::errc ec{};
     model::producer_id highest_producer_id{};
 
@@ -2804,8 +2724,6 @@ struct partition_state_request
       partition_state_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     friend bool
     operator==(const partition_state_request&, const partition_state_request&)
@@ -2819,8 +2737,6 @@ struct partition_stm_state
       partition_stm_state,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ss::sstring name;
     model::offset last_applied_offset;
     model::offset max_removable_local_log_offset;
@@ -2836,8 +2752,6 @@ struct partition_raft_state
       partition_raft_state,
       serde::version<5>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::node_id node;
     model::term_id term;
     ss::sstring offset_translator_state;
@@ -2867,8 +2781,6 @@ struct partition_raft_state
           follower_state,
           serde::version<0>,
           serde::compat_version<0>> {
-        using rpc_adl_exempt = std::true_type;
-
         model::node_id node;
         model::offset last_flushed_log_index;
         model::offset last_dirty_log_index;
@@ -2965,8 +2877,6 @@ struct partition_raft_state
 struct partition_state
   : serde::
       envelope<partition_state, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::offset start_offset;
     model::offset committed_offset;
     model::offset last_stable_offset;
@@ -3015,8 +2925,6 @@ struct partition_state_reply
       partition_state_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     std::optional<partition_state> state;
     errc error_code;
@@ -3048,7 +2956,6 @@ struct revert_cancel_partition_move_request
       revert_cancel_partition_move_request,
       serde::version<0>,
       serde::version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::ntp ntp;
 
     auto serde_fields() { return std::tie(ntp); }
@@ -3064,7 +2971,6 @@ struct revert_cancel_partition_move_reply
       revert_cancel_partition_move_reply,
       serde::version<0>,
       serde::version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc result;
 
     auto serde_fields() { return std::tie(result); }
@@ -3078,7 +2984,6 @@ struct revert_cancel_partition_move_reply
 struct upsert_role_cmd_data
   : serde::
       envelope<upsert_role_cmd_data, serde::version<0>, serde::version<0>> {
-    using rpc_adl_exempt = std::true_type;
     security::role_name name;
     security::role role;
 
@@ -3092,7 +2997,6 @@ struct upsert_role_cmd_data
 struct delete_role_cmd_data
   : serde::
       envelope<delete_role_cmd_data, serde::version<0>, serde::version<0>> {
-    using rpc_adl_exempt = std::true_type;
     security::role_name name;
 
     auto serde_fields() { return std::tie(name); }
@@ -3312,8 +3216,6 @@ struct controller_committed_offset_request
       controller_committed_offset_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     auto serde_fields() { return std::tie(); }
 };
 
@@ -3322,7 +3224,6 @@ struct controller_committed_offset_reply
       controller_committed_offset_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::offset last_committed;
     errc result;
 
@@ -3348,8 +3249,6 @@ struct upsert_plugin_request
       upsert_plugin_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::transform_metadata transform;
     model::timeout_clock::duration timeout{};
 
@@ -3364,7 +3263,6 @@ struct upsert_plugin_response
       upsert_plugin_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     errc ec;
 
     friend bool
@@ -3382,7 +3280,6 @@ struct remove_plugin_request
       remove_plugin_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     model::transform_name name;
     model::timeout_clock::duration timeout{};
 
@@ -3397,7 +3294,6 @@ struct remove_plugin_response
       remove_plugin_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     uuid_t uuid;
     errc ec;
 
@@ -3415,8 +3311,6 @@ struct update_partition_replicas_cmd_data
       update_partition_replicas_cmd_data,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     replicas_t replicas;
     reconfiguration_policy policy;
@@ -3472,7 +3366,6 @@ struct delete_topics_request
       delete_topics_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<model::topic_namespace> topics_to_delete;
     std::chrono::milliseconds timeout;
 
@@ -3488,7 +3381,6 @@ struct delete_topics_reply
       delete_topics_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<topic_result> results;
 
     friend bool
@@ -3503,8 +3395,6 @@ struct set_partition_shard_request
       set_partition_shard_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::ntp ntp;
     uint32_t shard = -1;
 
@@ -3520,8 +3410,6 @@ struct set_partition_shard_reply
       set_partition_shard_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc ec;
 
     friend bool operator==(
@@ -3536,7 +3424,6 @@ struct upsert_cluster_link_request
       upsert_cluster_link_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ::cluster_link::model::metadata metadata;
     model::timeout_clock::duration timeout{};
 
@@ -3551,7 +3438,6 @@ struct upsert_cluster_link_response
       upsert_cluster_link_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cluster::cluster_link::errc ec;
 
     friend bool operator==(
@@ -3565,7 +3451,6 @@ struct remove_cluster_link_request
       remove_cluster_link_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ::cluster_link::model::name_t name;
     model::timeout_clock::duration timeout{};
 
@@ -3581,7 +3466,6 @@ struct remove_cluster_link_response
       remove_cluster_link_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     cluster::cluster_link::errc ec;
 
     friend bool operator==(
@@ -3596,8 +3480,6 @@ struct add_mirror_topic_request
       add_mirror_topic_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ::cluster_link::model::id_t link_id;
     ::cluster_link::model::add_mirror_topic_cmd cmd;
     model::timeout_clock::duration timeout{};
@@ -3614,8 +3496,6 @@ struct add_mirror_topic_response
       add_mirror_topic_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cluster_link::errc ec{cluster_link::errc::success};
 
     friend bool operator==(
@@ -3630,8 +3510,6 @@ struct update_mirror_topic_state_request
       update_mirror_topic_state_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ::cluster_link::model::id_t link_id;
     ::cluster_link::model::update_mirror_topic_state_cmd cmd;
     model::timeout_clock::duration timeout{};
@@ -3649,8 +3527,6 @@ struct update_mirror_topic_state_response
       update_mirror_topic_state_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     cluster_link::errc ec{cluster_link::errc::success};
 
     friend bool operator==(
@@ -3667,8 +3543,6 @@ struct get_current_cluster_epoch_request
       get_current_cluster_epoch_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     model::timeout_clock::duration timeout{};
 
     friend bool operator==(
@@ -3685,8 +3559,6 @@ struct get_current_cluster_epoch_response
       get_current_cluster_epoch_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     errc ec{errc::success};
     int64_t epoch{-1};
 

--- a/src/v/datalake/coordinator/types.h
+++ b/src/v/datalake/coordinator/types.h
@@ -46,8 +46,6 @@ struct ensure_table_exists_reply
       ensure_table_exists_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ensure_table_exists_reply() = default;
     explicit ensure_table_exists_reply(errc err)
       : errc(err) {}
@@ -64,7 +62,6 @@ struct ensure_table_exists_request
       ensure_table_exists_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = ensure_table_exists_reply;
 
     ensure_table_exists_request() = default;
@@ -95,8 +92,6 @@ struct ensure_dlq_table_exists_reply
       ensure_dlq_table_exists_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     ensure_dlq_table_exists_reply() = default;
     explicit ensure_dlq_table_exists_reply(errc err)
       : errc(err) {}
@@ -114,7 +109,6 @@ struct ensure_dlq_table_exists_request
       ensure_dlq_table_exists_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = ensure_dlq_table_exists_reply;
 
     ensure_dlq_table_exists_request() = default;
@@ -139,8 +133,6 @@ struct add_translated_data_files_reply
       add_translated_data_files_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     add_translated_data_files_reply() = default;
     explicit add_translated_data_files_reply(errc err)
       : errc(err) {}
@@ -157,7 +149,6 @@ struct add_translated_data_files_request
       add_translated_data_files_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = add_translated_data_files_reply;
 
     add_translated_data_files_request() = default;
@@ -207,8 +198,6 @@ struct fetch_latest_translated_offset_reply
       fetch_latest_translated_offset_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     fetch_latest_translated_offset_reply() = default;
     explicit fetch_latest_translated_offset_reply(errc err)
       : errc(err) {}
@@ -242,7 +231,6 @@ struct fetch_latest_translated_offset_request
       fetch_latest_translated_offset_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = fetch_latest_translated_offset_reply;
 
     fetch_latest_translated_offset_request() = default;
@@ -271,8 +259,6 @@ struct per_topic_usage_stats
       per_topic_usage_stats,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     per_topic_usage_stats() = default;
     explicit per_topic_usage_stats(
       model::topic topic,
@@ -299,8 +285,6 @@ struct datalake_usage_stats
       datalake_usage_stats,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend std::ostream& operator<<(std::ostream&, const datalake_usage_stats&);
 
     chunked_vector<per_topic_usage_stats> topic_usages;
@@ -311,8 +295,6 @@ struct datalake_usage_stats
 struct usage_stats_reply
   : serde::
       envelope<usage_stats_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     usage_stats_reply() = default;
     explicit usage_stats_reply(errc err)
       : errc(err) {}
@@ -333,7 +315,6 @@ struct usage_stats_request
       usage_stats_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using resp_t = usage_stats_reply;
 
     model::partition_id coordinator_partition;

--- a/src/v/datalake/schema_identifier.h
+++ b/src/v/datalake/schema_identifier.h
@@ -23,7 +23,6 @@ namespace datalake {
 struct schema_identifier
   : serde::
       envelope<schema_identifier, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(schema_id, protobuf_offsets); }
 
     pandaproxy::schema_registry::schema_id schema_id;
@@ -37,7 +36,6 @@ struct record_schema_components
       record_schema_components,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     auto serde_fields() { return std::tie(key_identifier, val_identifier); }
 
     std::optional<schema_identifier> key_identifier;

--- a/src/v/kafka/data/rpc/serde.h
+++ b/src/v/kafka/data/rpc/serde.h
@@ -24,8 +24,6 @@ namespace kafka::data::rpc {
 struct kafka_topic_data
   : serde::
       envelope<kafka_topic_data, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     kafka_topic_data() = default;
     kafka_topic_data(model::topic_partition, model::record_batch);
     kafka_topic_data(
@@ -42,8 +40,6 @@ struct kafka_topic_data
 struct produce_request
   : serde::
       envelope<produce_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     produce_request() = default;
     produce_request(
       ss::chunked_fifo<kafka_topic_data> topic_data,
@@ -78,8 +74,6 @@ struct kafka_topic_data_result
 struct produce_reply
   : serde::
       envelope<produce_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     produce_reply() = default;
     explicit produce_reply(ss::chunked_fifo<kafka_topic_data_result> r)
       : results(std::move(r)) {}

--- a/src/v/kafka/server/consumer_group_lag_metrics_rpc_types.h
+++ b/src/v/kafka/server/consumer_group_lag_metrics_rpc_types.h
@@ -24,8 +24,6 @@ struct partition_offsets_request
       partition_offsets_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     using partitions
       = chunked_hash_map<model::topic, chunked_hash_set<model::partition_id>>;
     partitions data;
@@ -38,8 +36,6 @@ struct partition_offsets_reply
       partition_offsets_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     using offsets = chunked_hash_map<
       model::topic,
       chunked_hash_map<model::partition_id, kafka::offset>>;

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -259,7 +259,6 @@ struct transform_offsets_key
       transform_offsets_key,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     transform_id id;
     // id of the partition from transform's input/source topic.
     partition_id partition;

--- a/src/v/raft/heartbeats.h
+++ b/src/v/raft/heartbeats.h
@@ -320,8 +320,6 @@ class heartbeat_request_v2
       serde::version<0>,
       serde::compat_version<0>> {
 public:
-    using rpc_adl_exempt = std::true_type;
-
     using lw_column_t
       = deltafor_column<int64_t, ::details::delta_delta<int64_t>, int64_t>;
 
@@ -398,8 +396,6 @@ class heartbeat_reply_v2
       serde::version<0>,
       serde::compat_version<0>> {
 public:
-    using rpc_adl_exempt = std::true_type;
-
     using lw_column_t = deltafor_column<int64_t, ::details::delta_xor, int64_t>;
     using result_column_t = deltafor_column<int8_t, ::details::delta_xor>;
 

--- a/src/v/raft/transfer_leadership.h
+++ b/src/v/raft/transfer_leadership.h
@@ -28,7 +28,6 @@ struct transfer_leadership_request
       transfer_leadership_request,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     group_id group;
     std::optional<model::node_id> target;
     std::optional<std::chrono::milliseconds> timeout;
@@ -50,7 +49,6 @@ struct transfer_leadership_reply
       transfer_leadership_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     bool success{false};
     raft::errc result;
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -214,8 +214,6 @@ struct append_entries_request
       append_entries_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     // required for the cases where we will set the target node id before
     // sending request to the node
     append_entries_request(
@@ -288,7 +286,6 @@ class append_entries_request_serde_wrapper
       serde::version<0>,
       serde::compat_version<0>> {
 public:
-    using rpc_adl_exempt = std::true_type;
     explicit append_entries_request_serde_wrapper(append_entries_request req)
       : _request(std::move(req)) {}
 
@@ -314,8 +311,6 @@ struct append_entries_reply
       append_entries_reply,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's node_id; work-around for batched heartbeats
@@ -382,7 +377,6 @@ struct heartbeat_metadata {
 struct heartbeat_request
   : serde::
       envelope<heartbeat_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<heartbeat_metadata> heartbeats;
 
     heartbeat_request() noexcept = default;
@@ -402,7 +396,6 @@ struct heartbeat_request
 struct heartbeat_reply
   : serde::
       envelope<heartbeat_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     std::vector<append_entries_reply> meta;
 
     heartbeat_reply() noexcept = default;
@@ -420,7 +413,6 @@ struct heartbeat_reply
 
 struct vote_request
   : serde::envelope<vote_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     vnode node_id;
     // node id to validate on receiver
     vnode target_node_id;
@@ -455,7 +447,6 @@ struct vote_request
 
 struct vote_reply
   : serde::envelope<vote_reply, serde::version<1>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's term, for the caller to upate itself
@@ -525,7 +516,6 @@ struct install_snapshot_request
       install_snapshot_request,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     // node id to validate on receiver
     vnode target_node_id;
     // leader’s term
@@ -603,7 +593,6 @@ struct install_snapshot_reply
       install_snapshot_reply,
       serde::version<1>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     // node id to validate on receiver
     vnode target_node_id;
     // current term, for leader to update itself
@@ -654,7 +643,6 @@ struct timeout_now_request
       timeout_now_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     // node id to validate on receiver
     vnode target_node_id;
 
@@ -690,7 +678,6 @@ struct timeout_now_request
 struct timeout_now_reply
   : serde::
       envelope<timeout_now_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     enum class status : uint8_t { success, failure };
     // node id to validate on receiver
     vnode target_node_id;
@@ -762,8 +749,6 @@ struct remake_learner_state_request
       remake_learner_state_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     friend std::ostream&
     operator<<(std::ostream& o, const remake_learner_state_request& r) {
         fmt::print(
@@ -795,7 +780,6 @@ struct remake_learner_state_reply
       remake_learner_state_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     using is_success = ss::bool_class<struct remake_learner_state_tag>;
 
     friend std::ostream&

--- a/src/v/rpc/parse_utils.h
+++ b/src/v/rpc/parse_utils.h
@@ -131,32 +131,19 @@ concept is_rpc_serde_exempt = requires { typename T::rpc_serde_exempt; };
 template<typename T>
 ss::future<transport_version>
 encode_for_version(iobuf& out, T msg, transport_version version) {
-    static_assert(!is_rpc_adl_exempt<T> || !is_rpc_serde_exempt<T>);
+    /*
+     * RPC messages are now serde envelopes, without exceptions.
+     */
+    static_assert(!is_rpc_adl_exempt<T>);
+    static_assert(!is_rpc_serde_exempt<T>);
+    static_assert(serde::is_envelope<T>);
 
-    if constexpr (is_rpc_serde_exempt<T>) {
-        return reflection::async_adl<T>{}.to(out, std::move(msg)).then([] {
-            return transport_version::v0;
+    vassert(version >= transport_version::v2, "Can't encode serde <= v2");
+    return ss::do_with(std::move(msg), [&out, version](T& msg) {
+        return serde::write_async(out, std::move(msg)).then([version] {
+            return version;
         });
-    } else if constexpr (is_rpc_adl_exempt<T>) {
-        vassert(version >= transport_version::v2, "Can't encode serde <= v2");
-        return ss::do_with(std::move(msg), [&out, version](T& msg) {
-            return serde::write_async(out, std::move(msg)).then([version] {
-                return version;
-            });
-        });
-    } else {
-        if (version < transport_version::v2) {
-            return reflection::async_adl<T>{}
-              .to(out, std::move(msg))
-              .then([version] { return version; });
-        } else {
-            return ss::do_with(std::move(msg), [&out, version](T& msg) {
-                return serde::write_async(out, std::move(msg)).then([version] {
-                    return version;
-                });
-            });
-        }
-    }
+    });
 }
 
 /*
@@ -165,31 +152,20 @@ encode_for_version(iobuf& out, T msg, transport_version version) {
 template<typename T>
 ss::future<T>
 decode_for_version(iobuf_parser& parser, transport_version version) {
-    static_assert(!is_rpc_adl_exempt<T> || !is_rpc_serde_exempt<T>);
+    /*
+     * RPC messages are now serde envelopes, without exceptions.
+     */
+    static_assert(!is_rpc_adl_exempt<T>);
+    static_assert(!is_rpc_serde_exempt<T>);
+    static_assert(serde::is_envelope<T>);
 
-    if constexpr (is_rpc_serde_exempt<T>) {
-        if (version != transport_version::v0) {
-            return ss::make_exception_future<T>(std::runtime_error(fmt::format(
-              "Unexpected adl-only message {} at {} != v0",
-              typeid(T).name(),
-              version)));
-        }
-        return reflection::async_adl<T>{}.from(parser);
-    } else if constexpr (is_rpc_adl_exempt<T>) {
-        if (version < transport_version::v2) {
-            return ss::make_exception_future<T>(std::runtime_error(fmt::format(
-              "Unexpected serde-only message {} at {} < v2",
-              typeid(T).name(),
-              version)));
-        }
-        return serde::read_async<T>(parser);
-    } else {
-        if (version < transport_version::v2) {
-            return reflection::async_adl<T>{}.from(parser);
-        } else {
-            return serde::read_async<T>(parser);
-        }
+    if (version < transport_version::v2) {
+        return ss::make_exception_future<T>(std::runtime_error(fmt::format(
+          "Unexpected serde-only message {} at {} < v2",
+          typeid(T).name(),
+          version)));
     }
+    return serde::read_async<T>(parser);
 }
 
 /*

--- a/src/v/rpc/service.h
+++ b/src/v/rpc/service.h
@@ -58,23 +58,14 @@ struct service::execution_helper {
     using output = Output;
 
     /*
-     * ensure that request and response types are compatible. this solves a
-     * particular class of issue where someone marks for example the request as
-     * exempt but forgets to mark the response. in this scenario it is then
-     * possible for the assertion regarding unexpected encodings to fire.
+     * RPC messages are now serde envelopes, without exceptions.
      */
-    static_assert(is_rpc_adl_exempt<Input> == is_rpc_adl_exempt<Output>);
-    static_assert(is_rpc_serde_exempt<Input> == is_rpc_serde_exempt<Output>);
-
-    /*
-     * provided that input/output are no exempt from serde support, require that
-     * they are both serde envelopes. this prevents a class of situation in
-     * which a request/response is a natively supported type, but not actually
-     * an envelope, such as a request being a raw integer or a named_type. we
-     * want our rpc's to be versioned.
-     */
-    static_assert(is_rpc_serde_exempt<Input> || serde::is_envelope<Input>);
-    static_assert(is_rpc_serde_exempt<Output> || serde::is_envelope<Output>);
+    static_assert(!is_rpc_adl_exempt<Input>);
+    static_assert(!is_rpc_adl_exempt<Output>);
+    static_assert(!is_rpc_serde_exempt<Input>);
+    static_assert(!is_rpc_serde_exempt<Output>);
+    static_assert(serde::is_envelope<Input>);
+    static_assert(serde::is_envelope<Output>);
 
     template<typename Func>
     static ss::future<netbuf> exec(

--- a/src/v/rpc/test/BUILD
+++ b/src/v/rpc/test/BUILD
@@ -18,16 +18,30 @@ redpanda_test_cc_library(
     ],
 )
 
+redpanda_test_cc_library(
+    name = "test_types",
+    hdrs = [
+        "test_types.h",
+    ],
+    include_prefix = "rpc/test",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "netbuf_test",
     timeout = "short",
     srcs = [
         "netbuf_tests.cc",
-        "test_types.h",
     ],
     deps = [
+        ":test_types",
         "//src/v/bytes:iobuf",
         "//src/v/rpc",
+        "//src/v/serde",
+        "//src/v/serde:sstring",
         "//src/v/test_utils:seastar_boost",
         "@fmt",
         "@seastar",
@@ -40,9 +54,9 @@ redpanda_cc_btest(
     timeout = "short",
     srcs = [
         "roundtrip_tests.cc",
-        "test_types.h",
     ],
     deps = [
+        ":test_types",
         "//src/v/bytes:iobuf",
         "//src/v/reflection:adl",
         "//src/v/test_utils:seastar_boost",
@@ -70,9 +84,9 @@ redpanda_cc_btest(
     timeout = "short",
     srcs = [
         "serialization_test.cc",
-        "test_types.h",
     ],
     deps = [
+        ":test_types",
         "//src/v/bytes:iobuf",
         "//src/v/reflection:adl",
         "//src/v/reflection:arity",

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -24,7 +24,6 @@
 
 struct envelope_pod
   : serde::envelope<envelope_pod, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     int16_t x = 1;
     int32_t y = 2;
     int64_t z = 3;

--- a/src/v/rpc/test/netbuf_tests.cc
+++ b/src/v/rpc/test/netbuf_tests.cc
@@ -8,6 +8,11 @@
 // by the Apache License, Version 2.0
 
 #include "rpc/parse_utils.h"
+#include "serde/envelope.h"
+#include "serde/rw/envelope.h"
+#include "serde/rw/rw.h"
+#include "serde/rw/scalar.h"
+#include "serde/rw/sstring.h"
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -16,6 +21,15 @@
 #include "test_types.h"
 
 #include <fmt/ostream.h>
+
+struct envelope_pod
+  : serde::envelope<envelope_pod, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    int16_t x = 1;
+    int32_t y = 2;
+    int64_t z = 3;
+    auto serde_fields() { return std::tie(x, y, z); }
+};
 
 namespace rpc {
 /// \brief expects the inputstream to be prefixed by an rpc::header
@@ -30,17 +44,18 @@ ss::future<T> parse_framed(ss::input_stream<char>& in) {
 SEASTAR_THREAD_TEST_CASE(netbuf_pod) {
     auto n = rpc::netbuf();
     // type to serialize out
-    pod src;
+    envelope_pod src;
     src.x = 88;
     src.y = 88;
     src.z = 88;
     n.set_correlation_id(42);
     n.set_service_method({"test::test", 66});
-    reflection::async_adl<pod>{}.to(n.buffer(), src).get();
+    n.set_version(rpc::transport_version::v2);
+    n.buffer() = serde::to_iobuf(src);
     // forces the computation of the header
     auto bufs = std::move(n).as_scattered().get().release().release();
     auto in = make_iobuf_input_stream(iobuf(std::move(bufs)));
-    const pod dst = rpc::parse_framed<pod>(in).get();
+    const envelope_pod dst = rpc::parse_framed<envelope_pod>(in).get();
     BOOST_REQUIRE_EQUAL(src.x, dst.x);
     BOOST_REQUIRE_EQUAL(src.y, dst.y);
     BOOST_REQUIRE_EQUAL(src.z, dst.z);

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -67,28 +67,24 @@ struct mount_tamalpais
 namespace echo {
 struct echo_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
     auto serde_fields() { return std::tie(str); }
 };
 
 struct echo_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
     auto serde_fields() { return std::tie(str); }
 };
 
 struct cnt_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     uint64_t expected;
     auto serde_fields() { return std::tie(expected); }
 };
 
 struct cnt_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     uint64_t expected;
     uint64_t current;
     auto serde_fields() { return std::tie(expected, current); }
@@ -96,14 +92,12 @@ struct cnt_resp
 
 struct sleep_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     uint64_t secs;
     auto serde_fields() { return std::tie(secs); }
 };
 
 struct sleep_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
     auto serde_fields() { return std::tie(str); }
 };
@@ -112,14 +106,12 @@ enum class failure_type { throw_exception, exceptional_future, none };
 
 struct throw_req
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     failure_type type;
     auto serde_fields() { return std::tie(type); }
 };
 
 struct throw_resp
   : serde::envelope<echo_req, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring reply;
 
     auto serde_fields() { return std::tie(reply); }
@@ -130,7 +122,6 @@ struct echo_req_serde_only
       echo_req_serde_only,
       serde::version<1>,
       serde::compat_version<1>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
 
     void serde_write(iobuf& out) const {
@@ -152,7 +143,6 @@ struct echo_resp_serde_only
       echo_resp_serde_only,
       serde::version<1>,
       serde::compat_version<1>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
 
     void serde_write(iobuf& out) const {
@@ -169,10 +159,6 @@ struct echo_resp_serde_only
     }
 };
 
-// serde-only type needs to be example from adl
-static_assert(rpc::is_rpc_adl_exempt<echo_req_serde_only>);
-static_assert(rpc::is_rpc_adl_exempt<echo_resp_serde_only>);
-
 } // namespace echo
 
 namespace echo_v2 {
@@ -188,7 +174,6 @@ namespace echo_v2 {
 /// servers
 struct echo_req
   : serde::envelope<echo_req, serde::version<2>, serde::compat_version<1>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
     ss::sstring str_two;
 
@@ -213,7 +198,6 @@ struct echo_req
 
 struct echo_resp
   : serde::envelope<echo_resp, serde::version<2>, serde::compat_version<1>> {
-    using rpc_adl_exempt = std::true_type;
     ss::sstring str;
     ss::sstring str_two;
 
@@ -235,8 +219,5 @@ struct echo_resp
         }
     }
 };
-
-static_assert(rpc::is_rpc_adl_exempt<echo_req>);
-static_assert(rpc::is_rpc_adl_exempt<echo_resp>);
 
 } // namespace echo_v2

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -26,21 +26,41 @@
 #include <cstdint>
 
 namespace cycling {
-struct ultimate_cf_slx {
-    using rpc_serde_exempt = std::true_type;
+struct ultimate_cf_slx
+  : serde::
+      envelope<ultimate_cf_slx, serde::version<0>, serde::compat_version<0>> {
+    ultimate_cf_slx() = default;
+    ultimate_cf_slx(int x)
+      : x(x) {}
     int x = 42;
+    auto serde_fields() { return std::tie(x); }
 };
-struct nairo_quintana {
-    using rpc_serde_exempt = std::true_type;
+struct nairo_quintana
+  : serde::
+      envelope<nairo_quintana, serde::version<0>, serde::compat_version<0>> {
+    nairo_quintana() = default;
+    nairo_quintana(int x)
+      : x(x) {}
     int x = 43;
+    auto serde_fields() { return std::tie(x); }
 };
-struct san_francisco {
-    using rpc_serde_exempt = std::true_type;
+struct san_francisco
+  : serde::
+      envelope<san_francisco, serde::version<0>, serde::compat_version<0>> {
+    san_francisco() = default;
+    san_francisco(int x)
+      : x(x) {}
     int x = 44;
+    auto serde_fields() { return std::tie(x); }
 };
-struct mount_tamalpais {
-    using rpc_serde_exempt = std::true_type;
+struct mount_tamalpais
+  : serde::
+      envelope<mount_tamalpais, serde::version<0>, serde::compat_version<0>> {
+    mount_tamalpais() = default;
+    mount_tamalpais(int x)
+      : x(x) {}
     int x = 45;
+    auto serde_fields() { return std::tie(x); }
 };
 } // namespace cycling
 

--- a/src/v/rpc/test/test_types.h
+++ b/src/v/rpc/test/test_types.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 struct pod {
-    using rpc_serde_exempt = std::true_type;
     int16_t x = 1;
     int32_t y = 2;
     int64_t z = 3;

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -32,8 +32,6 @@ struct transformed_topic_data
       transformed_topic_data,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     transformed_topic_data() = default;
     transformed_topic_data(model::topic_partition, model::record_batch);
     transformed_topic_data(
@@ -52,8 +50,6 @@ struct transformed_topic_data
 struct produce_request
   : serde::
       envelope<produce_request, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     produce_request() = default;
     produce_request(
       ss::chunked_fifo<transformed_topic_data> topic_data,
@@ -91,8 +87,6 @@ struct transformed_topic_data_result
 struct produce_reply
   : serde::
       envelope<produce_reply, serde::version<0>, serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     produce_reply() = default;
     explicit produce_reply(ss::chunked_fifo<transformed_topic_data_result> r)
       : results(std::move(r)) {}
@@ -109,8 +103,6 @@ struct store_wasm_binary_request
       store_wasm_binary_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     store_wasm_binary_request() = default;
     explicit store_wasm_binary_request(
       model::wasm_binary_iobuf d, model::timeout_clock::duration t)
@@ -131,8 +123,6 @@ struct stored_wasm_binary_metadata
       stored_wasm_binary_metadata,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     stored_wasm_binary_metadata() = default;
     stored_wasm_binary_metadata(uuid_t k, model::offset o)
       : key(k)
@@ -152,8 +142,6 @@ struct store_wasm_binary_reply
       store_wasm_binary_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     store_wasm_binary_reply() = default;
     explicit store_wasm_binary_reply(
       cluster::errc e, stored_wasm_binary_metadata s)
@@ -174,8 +162,6 @@ struct delete_wasm_binary_request
       delete_wasm_binary_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     delete_wasm_binary_request() = default;
     explicit delete_wasm_binary_request(
       uuid_t k, model::timeout_clock::duration t)
@@ -196,8 +182,6 @@ struct delete_wasm_binary_reply
       store_wasm_binary_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     delete_wasm_binary_reply() = default;
     explicit delete_wasm_binary_reply(cluster::errc e)
       : ec(e) {}
@@ -215,8 +199,6 @@ struct load_wasm_binary_request
       store_wasm_binary_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     load_wasm_binary_request() = default;
     explicit load_wasm_binary_request(
       model::offset o, model::timeout_clock::duration t)
@@ -237,8 +219,6 @@ struct load_wasm_binary_reply
       store_wasm_binary_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     load_wasm_binary_reply() = default;
     explicit load_wasm_binary_reply(cluster::errc e, model::wasm_binary_iobuf b)
       : ec(e)
@@ -258,8 +238,6 @@ struct find_coordinator_request
       find_coordinator_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     find_coordinator_request() = default;
 
     void add(model::transform_offsets_key key) { keys.insert(key); }
@@ -277,8 +255,6 @@ struct find_coordinator_response
       find_coordinator_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     find_coordinator_response() = default;
 
     absl::flat_hash_map<model::transform_offsets_key, model::partition_id>
@@ -296,8 +272,6 @@ struct offset_commit_request
       offset_commit_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     offset_commit_request() = default;
     explicit offset_commit_request(
       model::partition_id c,
@@ -323,8 +297,6 @@ struct offset_commit_response
       offset_commit_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     offset_commit_response() = default;
     explicit offset_commit_response(cluster::errc e)
       : errc(e) {}
@@ -342,8 +314,6 @@ struct offset_fetch_request
       offset_commit_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     offset_fetch_request() = default;
     offset_fetch_request(model::transform_offsets_key k, model::partition_id c)
       : coordinator(c)
@@ -367,8 +337,6 @@ struct offset_fetch_response
       offset_commit_response,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     offset_fetch_response() = default;
 
     absl::flat_hash_map<
@@ -388,8 +356,6 @@ struct generate_report_request
       generate_report_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     generate_report_request() = default;
 
     auto serde_fields() { return std::tie(); }
@@ -403,8 +369,6 @@ struct generate_report_reply
       generate_report_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     generate_report_reply() = default;
     explicit generate_report_reply(model::cluster_transform_report r)
       : report(std::move(r)) {}
@@ -422,8 +386,6 @@ struct list_commits_request
       list_commits_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     list_commits_request() = default;
     explicit list_commits_request(model::partition_id partition)
       : partition(partition) {}
@@ -440,8 +402,6 @@ struct list_commits_reply
       list_commits_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     list_commits_reply() = default;
     explicit list_commits_reply(
       cluster::errc ec, model::transform_offsets_map m)
@@ -467,8 +427,6 @@ struct delete_commits_request
       delete_commits_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     delete_commits_request() = default;
     delete_commits_request(
       model::partition_id partition, absl::btree_set<model::transform_id> ids)
@@ -493,8 +451,6 @@ struct delete_commits_reply
       delete_commits_reply,
       serde::version<0>,
       serde::compat_version<0>> {
-    using rpc_adl_exempt = std::true_type;
-
     delete_commits_reply() = default;
 
     auto serde_fields() { return std::tie(errc); }


### PR DESCRIPTION
* rpc: remove requirement for `rpc_adl_exempt` tag
* we've long along been serde-only in rpc

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.


Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none