### PR TITLE
chunked_vector part 3

### DIFF
--- a/src/v/base/BUILD
+++ b/src/v/base/BUILD
@@ -10,6 +10,7 @@ redpanda_cc_library(
         "oncore.h",
         "outcome.h",
         "outcome_future_utils.h",
+        "seastar_fwd.h",
         "seastarx.h",
         "source_location.h",
         "type_traits.h",

--- a/src/v/base/seastar_fwd.h
+++ b/src/v/base/seastar_fwd.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+// forward declarations for seastar stuff all in one place
+namespace seastar {
+
+template<typename T>
+class future;
+
+}

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2632,7 +2632,7 @@ partition_manifest_serde_from_partition_manifest(const partition_manifest& m)
         (([&]<typename Src>(auto& dest, const Src& src) {
              if constexpr (std::is_same_v<Src, segment_meta_cstore>) {
                  dest = src.to_iobuf();
-             } else if constexpr (reflection::is_fragmented_vector<Src>) {
+             } else if constexpr (reflection::is_chunked_vector<Src>) {
                  dest = src.copy();
              } else {
                  dest = src;

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -10,6 +10,8 @@
 
 #include "cloud_topics/app.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace experimental::cloud_topics {
 
 app::app(

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -14,6 +14,8 @@
 #include "cloud_topics/level_one/metastore/state_update.h"
 #include "cloud_topics/logger.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace experimental::cloud_topics::l1 {
 
 object_id simple_object_builder::get_or_create_object_for(

--- a/src/v/cloud_topics/level_zero/pipeline/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/BUILD
@@ -29,6 +29,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/common:extent_meta",
         "//src/v/container:chunked_vector",
         "//src/v/model",
+        "@seastar",
     ],
 )
 

--- a/src/v/cloud_topics/level_zero/pipeline/serializer.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/serializer.cc
@@ -14,6 +14,9 @@
 #include "model/timeout_clock.h"
 #include "storage/record_batch_utils.h"
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
 namespace experimental::cloud_topics::l0 {
 
 serialized_chunk::serialized_chunk(

--- a/src/v/cluster/cloud_metadata/offsets_lookup.h
+++ b/src/v/cluster/cloud_metadata/offsets_lookup.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "model/metadata.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/sharded.hh>
 
 namespace cluster::cloud_metadata {

--- a/src/v/cluster/cloud_metadata/offsets_uploader.h
+++ b/src/v/cluster/cloud_metadata/offsets_uploader.h
@@ -20,6 +20,7 @@
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -123,9 +123,8 @@ void read_value(const json::Value& v, ss::chunked_fifo<T, chunk_size>& target) {
     }
 }
 
-template<typename T, size_t fragment_size_bytes>
-void read_value(
-  const json::Value& v, fragmented_vector<T, fragment_size_bytes>& target) {
+template<typename T>
+void read_value(const json::Value& v, chunked_vector<T>& target) {
     for (const auto& e : v.GetArray()) {
         auto t = T{};
         read_value(e, t);

--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -16,6 +16,7 @@ redpanda_cc_library(
     name = "chunked_vector",
     hdrs = [
         "chunked_vector.h",
+        "chunked_vector_async.h",
     ],
     include_prefix = "container",
     visibility = ["//visibility:public"],

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -561,7 +561,7 @@ private:
     }
 
 private:
-    friend class fragmented_vector_validator;
+    friend class chunked_vector_validator;
     fragmented_vector(const fragmented_vector&) noexcept = default;
 
     template<typename TT, size_t SS>

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -10,11 +10,8 @@
  */
 #pragma once
 
+#include "base/seastar_fwd.h"
 #include "base/vassert.h"
-
-#include <seastar/core/coroutine.hh>
-#include <seastar/core/future.hh>
-#include <seastar/util/later.hh>
 
 #include <bit>
 #include <climits>
@@ -22,6 +19,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <iterator>
+#include <ostream>
 #include <ranges>
 #include <span>
 #include <stdexcept>
@@ -565,11 +563,11 @@ private:
     fragmented_vector(const fragmented_vector&) noexcept = default;
 
     template<typename TT, size_t SS>
-    friend seastar::future<>
+    friend seastar::future<void>
     fragmented_vector_fill_async(fragmented_vector<TT, SS>&, const TT&);
 
     template<typename TT, size_t SS>
-    friend seastar::future<>
+    friend seastar::future<void>
     fragmented_vector_clear_async(fragmented_vector<TT, SS>&);
 
     size_t _size{0};
@@ -593,50 +591,3 @@ private:
  */
 template<typename T>
 using chunked_vector = fragmented_vector<T, std::dynamic_extent>;
-
-/**
- * A futurized version of std::fill optimized for fragmented vector. It is
- * futurized to allow for large vectors to be filled without incurring reactor
- * stalls. It is optimized by circumventing the indexing indirection incurred by
- * using the fragmented vector interface directly.
- */
-template<typename T, size_t S>
-inline seastar::future<>
-fragmented_vector_fill_async(fragmented_vector<T, S>& vec, const T& value) {
-    auto remaining = vec._size;
-    for (auto& frag : vec._frags) {
-        const auto n = std::min(frag.size(), remaining);
-        if (n == 0) {
-            break;
-        }
-        std::fill_n(frag.begin(), n, value);
-        remaining -= n;
-        if (seastar::need_preempt()) {
-            co_await seastar::yield();
-        }
-    }
-    vassert(
-      remaining == 0,
-      "fragmented vector inconsistency filling remaining {} size {} cap {} "
-      "nfrags {}",
-      remaining,
-      vec._size,
-      vec._capacity,
-      vec._frags.size());
-}
-
-/**
- * A futurized version of fragmented_vector::clear that allows clearing a large
- * vector without incurring a reactor stall.
- */
-template<typename T, size_t S>
-inline seastar::future<>
-fragmented_vector_clear_async(fragmented_vector<T, S>& vec) {
-    while (!vec._frags.empty()) {
-        vec._frags.pop_back();
-        if (seastar::need_preempt()) {
-            co_await seastar::yield();
-        }
-    }
-    vec.clear();
-}

--- a/src/v/container/chunked_vector_async.h
+++ b/src/v/container/chunked_vector_async.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/chunked_vector.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/util/later.hh>
+
+// Async helpers for chunked_vector.
+// Not in the main header to avoid pulling in all of seastar if you just need
+// chunked_vector.
+
+/**
+ * A futurized version of std::fill optimized for fragmented vector. It is
+ * futurized to allow for large vectors to be filled without incurring reactor
+ * stalls. It is optimized by circumventing the indexing indirection incurred by
+ * using the fragmented vector interface directly.
+ */
+template<typename T, size_t S>
+inline seastar::future<>
+fragmented_vector_fill_async(fragmented_vector<T, S>& vec, const T& value) {
+    auto remaining = vec._size;
+    for (auto& frag : vec._frags) {
+        const auto n = std::min(frag.size(), remaining);
+        if (n == 0) {
+            break;
+        }
+        std::fill_n(frag.begin(), n, value);
+        remaining -= n;
+        if (seastar::need_preempt()) {
+            co_await seastar::yield();
+        }
+    }
+    vassert(
+      remaining == 0,
+      "fragmented vector inconsistency filling remaining {} size {} cap {} "
+      "nfrags {}",
+      remaining,
+      vec._size,
+      vec._capacity,
+      vec._frags.size());
+}
+
+/**
+ * A futurized version of fragmented_vector::clear that allows clearing a large
+ * vector without incurring a reactor stall.
+ */
+template<typename T, size_t S>
+inline seastar::future<>
+fragmented_vector_clear_async(fragmented_vector<T, S>& vec) {
+    while (!vec._frags.empty()) {
+        vec._frags.pop_back();
+        if (seastar::need_preempt()) {
+            co_await seastar::yield();
+        }
+    }
+    vec.clear();
+}

--- a/src/v/container/json.h
+++ b/src/v/container/json.h
@@ -15,9 +15,8 @@
 
 namespace json {
 
-template<typename Buffer, typename T, size_t max_fragment_size>
-void rjson_serialize(
-  json::Writer<Buffer>& w, const fragmented_vector<T, max_fragment_size>& v) {
+template<typename Buffer, typename T>
+void rjson_serialize(json::Writer<Buffer>& w, const chunked_vector<T>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/container/tests/fragmented_vector_async_test.cc
+++ b/src/v/container/tests/fragmented_vector_async_test.cc
@@ -9,6 +9,7 @@
 
 #include "base/seastarx.h"
 #include "container/chunked_vector.h"
+#include "container/chunked_vector_async.h"
 
 #include <seastar/testing/thread_test_case.hh>
 

--- a/src/v/container/tests/fragmented_vector_test.cc
+++ b/src/v/container/tests/fragmented_vector_test.cc
@@ -22,9 +22,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <limits>
-#include <memory>
 #include <numeric>
-#include <span>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>

--- a/src/v/container/tests/fragmented_vector_test.cc
+++ b/src/v/container/tests/fragmented_vector_test.cc
@@ -30,16 +30,16 @@
 using testing::AssertionFailure;
 using testing::AssertionResult;
 using testing::AssertionSuccess;
-using vec = fragmented_vector<int>;
+using vec = chunked_vector<int>;
 
 static_assert(std::forward_iterator<vec::iterator>);
 static_assert(std::forward_iterator<vec::const_iterator>);
 
-class fragmented_vector_validator {
+class chunked_vector_validator {
 public:
     // perform an internal consistency check of the vector structure
-    template<typename T, size_t S>
-    static AssertionResult validate(const fragmented_vector<T, S>& v) {
+    template<typename T>
+    static AssertionResult validate(const chunked_vector<T>& v) {
         if (v._size > v._capacity) {
             return AssertionFailure() << "size greater than capacity";
         }
@@ -93,16 +93,15 @@ public:
      * Lets tests access private members for when they
      * need to inspect internals.
      */
-    template<typename T, size_t Size, typename MemberType>
-    const MemberType& access(
-      const fragmented_vector<T, Size>& v,
-      MemberType fragmented_vector<T, Size>::* member) {
+    template<typename T, typename MemberType>
+    const MemberType&
+    access(const chunked_vector<T>& v, MemberType chunked_vector<T>::* member) {
         return v.*member;
     }
 };
 
 MATCHER(IsValid, "") {
-    AssertionResult result = fragmented_vector_validator::validate(arg);
+    AssertionResult result = chunked_vector_validator::validate(arg);
     *result_listener << result.message();
     return result;
 }
@@ -114,7 +113,7 @@ namespace {
  */
 template<typename T>
 struct checker {
-    using underlying = fragmented_vector<T>;
+    using underlying = chunked_vector<T>;
 
     static checker<T> make(std::vector<T> in) {
         checker ret;
@@ -125,7 +124,7 @@ struct checker {
     }
 
     underlying* operator->() {
-        auto is_valid = fragmented_vector_validator::validate(u);
+        auto is_valid = chunked_vector_validator::validate(u);
         if (!is_valid) {
             throw std::runtime_error(is_valid.message());
         }
@@ -152,8 +151,8 @@ using testing::Lt;
 using testing::Ne;
 using testing::Not;
 
-template<typename T, size_t S>
-AssertionResult is_eq(fragmented_vector<T, S>& impl, std::vector<T>& shadow) {
+template<typename T>
+AssertionResult is_eq(chunked_vector<T>& impl, std::vector<T>& shadow) {
     if (!std::equal(impl.begin(), impl.end(), shadow.begin(), shadow.end())) {
         return testing::AssertionFailure()
                << "iterators not equal: " << testing::PrintToString(impl)
@@ -169,12 +168,11 @@ AssertionResult is_eq(fragmented_vector<T, S>& impl, std::vector<T>& shadow) {
                << "size not equal: " << testing::PrintToString(impl) << " vs "
                << testing::PrintToString(shadow);
     }
-    return fragmented_vector_validator::validate(impl);
+    return chunked_vector_validator::validate(impl);
 }
 
-template<size_t S>
 AssertionResult
-push(fragmented_vector<int, S>& impl, std::vector<int>& shadow, int count) {
+push(chunked_vector<int>& impl, std::vector<int>& shadow, int count) {
     for (int i = 0; i < count; ++i) {
         shadow.push_back(i);
         impl.push_back(i);
@@ -192,9 +190,8 @@ push(fragmented_vector<int, S>& impl, std::vector<int>& shadow, int count) {
     return testing::AssertionSuccess();
 }
 
-template<size_t S>
 AssertionResult
-pop(fragmented_vector<int, S>& impl, std::vector<int>& shadow, int count) {
+pop(chunked_vector<int>& impl, std::vector<int>& shadow, int count) {
     for (int i = 0; i < count; ++i) {
         shadow.pop_back();
         impl.pop_back();
@@ -214,7 +211,7 @@ pop(fragmented_vector<int, S>& impl, std::vector<int>& shadow, int count) {
 
 TEST(Vector, PushPop) {
     std::vector<int> shadow;
-    fragmented_vector<int> impl;
+    chunked_vector<int> impl;
     EXPECT_TRUE(impl.empty());
     ASSERT_TRUE(push(impl, shadow, 2500));
     EXPECT_TRUE(pop(impl, shadow, 1234));
@@ -227,7 +224,7 @@ TEST(Vector, PushPop) {
 
 TEST(Vector, Iterator) {
     std::vector<int> shadow;
-    fragmented_vector<int> impl;
+    chunked_vector<int> impl;
 
     EXPECT_TRUE(push(impl, shadow, 2000));
     for (int i = 0; i < 6000; i++) {
@@ -260,7 +257,7 @@ TEST(Vector, Iterator) {
 }
 
 TEST(Vector, IteratorTypes) {
-    using vtype = fragmented_vector<int64_t>;
+    using vtype = chunked_vector<int64_t>;
     using iter = vtype::iterator;
     using citer = vtype::const_iterator;
     auto v = vtype{};
@@ -284,7 +281,7 @@ struct foo {
 };
 
 TEST(Vector, IteratorAccess) {
-    using vtype = fragmented_vector<foo>;
+    using vtype = chunked_vector<foo>;
     auto vec = vtype{};
     vec.push_back(foo{2});
 
@@ -336,7 +333,7 @@ TEST(Vector, IteratorCmp) {
 TEST(Vector, EmptyAfterMove) {
     // Checks that post move, the source vector is empty().
     // This is inline with std::vector guarantees.
-    fragmented_vector<int> v1;
+    chunked_vector<int> v1;
     v1.push_back(1);
     EXPECT_FALSE(v1.empty());
 
@@ -400,8 +397,7 @@ TEST(Vector, PopBackN) {
 }
 
 TEST(Vector, EraseToEnd) {
-    // small fragment size to stress multiple fragments
-    fragmented_vector<char, 2> v;
+    chunked_vector<char> v;
 
     EXPECT_THAT(v, IsValid());
 
@@ -431,7 +427,7 @@ TEST(Vector, EraseToEnd) {
 TEST(Vector, FromIterRangeConstructor) {
     std::vector<int> vals{1, 2, 3};
 
-    fragmented_vector<int> fv(vals.begin(), vals.end());
+    chunked_vector<int> fv(vals.begin(), vals.end());
 
     EXPECT_THAT(fv, IsValid());
     EXPECT_THAT(fv, ElementsAre(1, 2, 3));
@@ -439,14 +435,14 @@ TEST(Vector, FromIterRangeConstructor) {
 
 TEST(Vector, FromInitializerListConstructor) {
     {
-        fragmented_vector<int> fv({});
+        chunked_vector<int> fv({});
 
         EXPECT_THAT(fv, IsValid());
         EXPECT_THAT(fv, ElementsAre());
     }
 
     {
-        fragmented_vector<int> fv({1, 2, 3});
+        chunked_vector<int> fv({1, 2, 3});
 
         EXPECT_THAT(fv, IsValid());
         EXPECT_THAT(fv, ElementsAre(1, 2, 3));
@@ -473,7 +469,7 @@ TEST(ChunkedVector, PushPop) {
             } else {
                 vec.pop_back();
             }
-            EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+            EXPECT_TRUE(chunked_vector_validator::validate(vec));
         }
     }
 }
@@ -499,7 +495,7 @@ TEST(ChunkedVector, PushPopN) {
                 break;
             }
 
-            EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+            EXPECT_TRUE(chunked_vector_validator::validate(vec));
         }
     }
 }
@@ -508,7 +504,7 @@ TEST(ChunkedVector, FirstChunkCapacityDoubles) {
     chunked_vector<int32_t> vec;
     for (size_t i = 0; i < vec.elements_per_fragment(); ++i) {
         vec.push_back(i);
-        EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+        EXPECT_TRUE(chunked_vector_validator::validate(vec));
     }
 }
 
@@ -529,25 +525,25 @@ TEST(ChunkedVector, Reserve) {
          ++i) {
         growing_vec.reserve(i);
         EXPECT_EQ(growing_vec.capacity(), i);
-        EXPECT_TRUE(fragmented_vector_validator::validate(growing_vec));
+        EXPECT_TRUE(chunked_vector_validator::validate(growing_vec));
         // Also ensure "jumping" to that reserved size does the right thing.
         chunked_vector<int32_t> new_vec;
         new_vec.reserve(i);
         EXPECT_EQ(new_vec.capacity(), i);
-        EXPECT_TRUE(fragmented_vector_validator::validate(new_vec));
+        EXPECT_TRUE(chunked_vector_validator::validate(new_vec));
     }
 }
 
 TEST(ChunkedVector, ShrinkToFit) {
     chunked_vector<int32_t> vec;
     vec.reserve(32);
-    EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+    EXPECT_TRUE(chunked_vector_validator::validate(vec));
     for (int i = 0; i < 10; ++i) {
         vec.push_back(1);
-        EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+        EXPECT_TRUE(chunked_vector_validator::validate(vec));
     }
     vec.shrink_to_fit();
-    EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+    EXPECT_TRUE(chunked_vector_validator::validate(vec));
     EXPECT_EQ(vec.capacity(), 10);
 }
 

--- a/src/v/datalake/coordinator/tests/BUILD
+++ b/src/v/datalake/coordinator/tests/BUILD
@@ -18,6 +18,7 @@ redpanda_test_cc_library(
         "//src/v/model",
         "//src/v/random:generators",
         "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/datalake/coordinator/tests/state_test_utils.h
+++ b/src/v/datalake/coordinator/tests/state_test_utils.h
@@ -15,6 +15,8 @@
 #include "datalake/coordinator/translated_offset_range.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/coroutine.hh>
+
 #include <gtest/gtest.h>
 
 #include <vector>

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -624,6 +624,7 @@ redpanda_cc_library(
         "//src/v/container:chunked_vector",
         "//src/v/model",
         "//src/v/utils:prefix_logger",
+        "@seastar",
     ],
 )
 
@@ -781,6 +782,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/container:chunked_vector",
         "@boost//:container_hash",
+        "@fmt",
         "@seastar",
     ],
 )
@@ -1146,6 +1148,7 @@ redpanda_cc_library(
         ":table_metadata",
         ":unresolved_partition_spec",
         "//src/v/utils:prefix_logger",
+        "@seastar",
     ],
 )
 
@@ -1166,6 +1169,7 @@ redpanda_cc_library(
         ":action",
         ":schema",
         ":table_metadata",
+        "@seastar",
     ],
 )
 

--- a/src/v/iceberg/conversion/BUILD
+++ b/src/v/iceberg/conversion/BUILD
@@ -118,6 +118,7 @@ redpanda_cc_library(
         ":conversion_outcome",
         "//src/v/iceberg:values",
         "//src/v/serde/parquet:value",
+        "@seastar",
     ],
 )
 

--- a/src/v/iceberg/conversion/values_avro.cc
+++ b/src/v/iceberg/conversion/values_avro.cc
@@ -14,6 +14,7 @@
 #include "iceberg/avro_decimal.h"
 #include "serde/avro/parser.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/util/log.hh>
 
 namespace iceberg {

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -17,6 +17,8 @@
 #include "iceberg/values.h"
 #include "serde/json/parser.h"
 
+#include <seastar/core/coroutine.hh>
+
 #include <exception>
 #include <memory>
 #include <optional>

--- a/src/v/iceberg/conversion/values_parquet.cc
+++ b/src/v/iceberg/conversion/values_parquet.cc
@@ -9,6 +9,8 @@
  */
 #include "iceberg/conversion/values_parquet.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace iceberg {
 namespace {
 struct primitive_value_converting_visitor {

--- a/src/v/iceberg/remove_snapshots_action.cc
+++ b/src/v/iceberg/remove_snapshots_action.cc
@@ -16,6 +16,8 @@
 #include "iceberg/table_update.h"
 #include "model/timestamp.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace iceberg {
 
 namespace {

--- a/src/v/iceberg/table_identifier.cc
+++ b/src/v/iceberg/table_identifier.cc
@@ -9,6 +9,9 @@
  */
 #include "iceberg/table_identifier.h"
 
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+
 namespace iceberg {
 std::ostream& operator<<(std::ostream& o, const table_identifier& id) {
     fmt::print(o, "{{ns: {}, table: {}}}", fmt::join(id.ns, "/"), id.table);

--- a/src/v/iceberg/unresolved_partition_spec.cc
+++ b/src/v/iceberg/unresolved_partition_spec.cc
@@ -13,6 +13,7 @@
 #include "iceberg/transform.h"
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include <type_traits>
 

--- a/src/v/iceberg/update_partition_spec_action.cc
+++ b/src/v/iceberg/update_partition_spec_action.cc
@@ -12,6 +12,8 @@
 
 #include "iceberg/logger.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace iceberg {
 
 update_partition_spec_action::update_partition_spec_action(

--- a/src/v/iceberg/update_schema_action.cc
+++ b/src/v/iceberg/update_schema_action.cc
@@ -13,6 +13,8 @@
 #include "iceberg/table_requirement.h"
 #include "iceberg/table_update.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace iceberg {
 
 ss::future<action::action_outcome> update_schema_action::build_updates() && {

--- a/src/v/kafka/client/produce_batcher.h
+++ b/src/v/kafka/client/produce_batcher.h
@@ -18,6 +18,7 @@
 #include "storage/record_batch_builder.h"
 
 #include <seastar/core/circular_buffer.hh>
+#include <seastar/core/coroutine.hh>
 
 namespace kafka::client {
 

--- a/src/v/kafka/server/usage_aggregator.cc
+++ b/src/v/kafka/server/usage_aggregator.cc
@@ -175,7 +175,7 @@ usage_aggregator<clock_type>::usage_aggregator(
         window_closed();
         rearm_window_timer();
     });
-    /// TODO: This should be refactored when fragmented_vector::resize is
+    /// TODO: This should be refactored when chunked_vector::resize is
     /// implemented
     for (size_t i = 0; i < _usage_num_windows; ++i) {
         _buckets.push_back(usage_window{});

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -14,6 +14,7 @@
 #include "model/record_batch_types.h"
 
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>

--- a/src/v/redpanda/admin/services/BUILD
+++ b/src/v/redpanda/admin/services/BUILD
@@ -10,5 +10,6 @@ redpanda_cc_library(
     deps = [
         "//proto/redpanda/core/admin:admin_redpanda_proto",
         "//src/v/version",
+        "@seastar",
     ],
 )

--- a/src/v/redpanda/admin/services/admin.cc
+++ b/src/v/redpanda/admin/services/admin.cc
@@ -13,6 +13,8 @@
 
 #include "version/version.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace proto {
 using namespace proto::admin;
 }

--- a/src/v/reflection/adl.h
+++ b/src/v/reflection/adl.h
@@ -34,8 +34,8 @@ struct adl {
     static constexpr bool is_optional = is_std_optional<type>;
     static constexpr bool is_sstring = std::is_same_v<type, ss::sstring>;
     static constexpr bool is_vector = is_std_vector<type>;
-    static constexpr bool is_fragmented_vector
-      = reflection::is_fragmented_vector<type>;
+    static constexpr bool is_chunked_vector
+      = reflection::is_chunked_vector<type>;
     static constexpr bool is_chunked_fifo
       = reflection::is_ss_chunked_fifo<type>;
     static constexpr bool is_btree_set = is_absl_btree_set<type>;
@@ -93,7 +93,7 @@ struct adl {
                 ret.push_back(adl<value_type>{}.from(in));
             }
             return ret;
-        } else if constexpr (is_fragmented_vector || is_chunked_fifo) {
+        } else if constexpr (is_chunked_vector || is_chunked_fifo) {
             using value_type = typename type::value_type;
             int32_t n = in.template consume_type<int32_t>();
             type ret;
@@ -169,7 +169,7 @@ struct adl {
             out.append(t.data(), t.size());
             return;
         } else if constexpr (
-          is_vector || is_fragmented_vector || is_chunked_fifo) {
+          is_vector || is_chunked_vector || is_chunked_fifo) {
             using value_type = typename type::value_type;
             if (unlikely(t.size() > std::numeric_limits<int32_t>::max())) {
                 throw std::invalid_argument(fmt::format(

--- a/src/v/reflection/type_traits.h
+++ b/src/v/reflection/type_traits.h
@@ -57,7 +57,7 @@ template<typename T>
 concept is_std_vector = ::detail::is_specialization_of_v<T, std::vector>;
 
 template<typename T>
-concept is_fragmented_vector
+concept is_chunked_vector
   = ::detail::is_specialization_of_sized_v<T, fragmented_vector>;
 
 template<typename T>

--- a/src/v/serde/avro/parser.cc
+++ b/src/v/serde/avro/parser.cc
@@ -13,6 +13,7 @@
 
 #include "bytes/iobuf_parser.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/util/defer.hh>
 
 #include <boost/range/irange.hpp>

--- a/src/v/serde/json/tests/dom_rapidjson.cc
+++ b/src/v/serde/json/tests/dom_rapidjson.cc
@@ -15,6 +15,8 @@
 #include "json/istreamwrapper.h"
 #include "json/reader.h"
 
+#include <seastar/core/coroutine.hh>
+
 #include <rapidjson/error/en.h>
 
 namespace serde::json::test::dom {

--- a/src/v/serde/json/tests/dom_serde.cc
+++ b/src/v/serde/json/tests/dom_serde.cc
@@ -12,6 +12,8 @@
 #include "serde/json/parser.h"
 #include "serde/json/tests/dom.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace serde::json::test::dom {
 
 ss::future<value> parse_document_serde(iobuf buf) {

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -18,6 +18,7 @@
 #include "serde/parquet/column_stats_collector.h"
 #include "serde/parquet/encoding.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <limits>

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -15,6 +15,8 @@
 #include "serde/parquet/metadata.h"
 #include "serde/parquet/value.h"
 
+#include <seastar/core/future.hh>
+
 namespace serde::parquet {
 
 // A serialized page for a column along with the page header metadata

--- a/src/v/serde/protobuf/parser.cc
+++ b/src/v/serde/protobuf/parser.cc
@@ -14,6 +14,7 @@
 #include "bytes/iobuf_parser.h"
 #include "serde/protobuf/wire_format.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <google/protobuf/descriptor.h>

--- a/src/v/serde/rw/vector.h
+++ b/src/v/serde/rw/vector.h
@@ -27,7 +27,7 @@ namespace serde {
  * This concept applies to everything that behaves like a vector.
  * Requires push_back, begin/end iterators and size.
  * This applies also to:
- * ss::chunked_fifo, fragmented_vector, ss::circular_buffer, etc.
+ * ss::chunked_fifo, chunked_vector, ss::circular_buffer, etc.
  */
 template<typename T>
 concept Vector = requires(T t) {

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -795,7 +795,7 @@ SEASTAR_THREAD_TEST_CASE(serde_fields_test_struct_test) {
       == serde_fields_test_struct{123});
 }
 
-SEASTAR_THREAD_TEST_CASE(fragmented_vector_test) {
+SEASTAR_THREAD_TEST_CASE(chunked_vector_test) {
     std::vector<int> sizes(100);
     std::iota(sizes.begin(), sizes.end(), 0);
     sizes.push_back(4095);

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -10,6 +10,8 @@
  */
 #include "storage/key_offset_map.h"
 
+#include "container/chunked_vector_async.h"
+
 namespace storage {
 
 simple_key_offset_map::simple_key_offset_map(std::optional<size_t> max_keys)

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -15,6 +15,7 @@
 #include "model/timeout_clock.h"
 #include "storage/parser_utils.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 
 namespace storage {


### PR DESCRIPTION
Much more of the way there, but I wanted to fire this in as it's touching a fair few files to risky to keep outstanding for a while.

Details in commits.

AI:

This pull request introduces several changes aimed at improving the codebase by transitioning from `fragmented_vector` to `chunked_vector`, adding asynchronous utilities for vector operations, and enhancing Seastar integration. The key updates include replacing `fragmented_vector` with `chunked_vector` across the codebase, introducing a new header for asynchronous operations on chunked vectors, and adding forward declarations for Seastar components.

### Transition from `fragmented_vector` to `chunked_vector`:
* Replaced `fragmented_vector` with `chunked_vector` in serialization, deserialization, and related utility functions (`src/v/compat/json.h`, `src/v/container/json.h`, `src/v/cloud_storage/partition_manifest.cc`) [[1]](diffhunk://#diff-46330dc3c79b0886985d391b53d928753809b67e0a62878719b98b622ffe380fL126-R127) [[2]](diffhunk://#diff-d7792d98b18772f66f58d1098a45e4382ea2af9c6d58912f42a4504ad8465068L18-R19) [[3]](diffhunk://#diff-9284b0b8aebba5228faad2a6c2f98bb00d6078e4cf83a5774f51d8d0b915cfebL2635-R2635).
* Updated test cases to use `chunked_vector` and renamed validation classes and methods accordingly (`src/v/container/tests/fragmented_vector_test.cc`) [[1]](diffhunk://#diff-075b1c73f6655305d12309b117c847f76693432448814dd15a767539ed42334bL25-R42) [[2]](diffhunk://#diff-075b1c73f6655305d12309b117c847f76693432448814dd15a767539ed42334bL98-R104) [[3]](diffhunk://#diff-075b1c73f6655305d12309b117c847f76693432448814dd15a767539ed42334bL174-R175).

### Asynchronous utilities for `chunked_vector`:
* Added a new header file `chunked_vector_async.h` with asynchronous implementations of `fill` and `clear` operations to avoid reactor stalls during large vector operations (`src/v/container/chunked_vector_async.h`).
* Removed the synchronous implementations of these utilities from `fragmented_vector.h` and adjusted the friend declarations (`src/v/container/fragmented_vector.h`) [[1]](diffhunk://#diff-bca23c5e03856f21f2790009d22969f3f0094b54f90822f0c6b1d35fe1fa4f18L564-R570) [[2]](diffhunk://#diff-bca23c5e03856f21f2790009d22969f3f0094b54f90822f0c6b1d35fe1fa4f18L596-L642).

### Seastar integration improvements:
* Added forward declarations for Seastar components in a new header file `seastar_fwd.h` and included it in relevant files (`src/v/base/seastar_fwd.h`, `src/v/container/fragmented_vector.h`) [[1]](diffhunk://#diff-2c165054de99fe836a32c4e4f0b3791c1db6d0aaa9af4f1411ed690c6c639275R1-R20) [[2]](diffhunk://#diff-bca23c5e03856f21f2790009d22969f3f0094b54f90822f0c6b1d35fe1fa4f18R13-R22).
* Included Seastar coroutine headers in various files to enable coroutine-based asynchronous programming (`src/v/cloud_topics/app.cc`, `src/v/cloud_topics/level_one/metastore/simple_metastore.cc`, `src/v/cloud_topics/level_zero/pipeline/serializer.cc`, `src/v/cluster/cloud_metadata/offsets_lookup.h`, `src/v/cluster/cloud_metadata/offsets_uploader.h`) [[1]](diffhunk://#diff-9258934c88d3d9c98dd03708fa3e7e0d445c62e0547a31da50112589f4e81ac3R13-R14) [[2]](diffhunk://#diff-e68f7aa56957d993fc0ed0e44ae9f0d8e67b6dc2f92869722b7044ca2aa5335fR17-R18) [[3]](diffhunk://#diff-1dcfd542dbc55b7d0a9f7c1615c7310ab9cd09efbbcb5c390d1093415de38c1fR17-R19) [[4]](diffhunk://#diff-9d036077400b3e28ae5b3522df346b9e721c40a8c34e041c95df12d1f934ca27R16) [[5]](diffhunk://#diff-d1d04a2da54129aad9ae3e0ddcf9787a23381f686ea01a9e8e07abe2bdfcd315R23).

### Build system updates:
* Added new headers and dependencies to the build files, including `chunked_vector_async.h` and Seastar (`src/v/base/BUILD`, `src/v/container/BUILD`, `src/v/cloud_topics/level_zero/pipeline/BUILD`) [[1]](diffhunk://#diff-99e712412418682c1fdb84ec4bf1cce290cb373407ffc9b6f4ff08f87a87aacaR14) [[2]](diffhunk://#diff-2ee465cecd2a0651520ea48a4bad4b116fcd0790d6991e5784524cdac7d244c1R18) [[3]](diffhunk://#diff-b33c9933899505f6ba56e57da7e27edbd445093a4e3833413cd9a884b7620b2bR32).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
