### PR TITLE
`config`: make all `backlog_controller` properties `needs_restart::no`

### DIFF
--- a/src/v/cluster/archival/upload_controller.cc
+++ b/src/v/cluster/archival/upload_controller.cc
@@ -36,7 +36,7 @@ upload_controller::upload_controller(
   : _ctrl(
       std::make_unique<upload_backlog_sampler>(partition_manager),
       upload_ctrl_log,
-      cfg) {
+      std::move(cfg)) {
     _ctrl.setup_metrics("archival:upload");
 }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1753,7 +1753,7 @@ configuration::configuration()
       *this,
       "compaction_ctrl_update_interval_ms",
       "",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30s)
   , compaction_ctrl_p_coeff(
       *this,
@@ -1761,38 +1761,38 @@ configuration::configuration()
       "Proportional coefficient for compaction PID controller. This must be "
       "negative, because the compaction backlog should decrease when the "
       "number of compaction shares increases.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       -12.5)
   , compaction_ctrl_i_coeff(
       *this,
       "compaction_ctrl_i_coeff",
       "Integral coefficient for compaction PID controller.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0.0)
   , compaction_ctrl_d_coeff(
       *this,
       "compaction_ctrl_d_coeff",
       "Derivative coefficient for compaction PID controller.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0.2)
   , compaction_ctrl_min_shares(
       *this,
       "compaction_ctrl_min_shares",
       "Minimum number of I/O and CPU shares that compaction process can use.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10)
   , compaction_ctrl_max_shares(
       *this,
       "compaction_ctrl_max_shares",
       "Maximum number of I/O and CPU shares that compaction process can use.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1000)
   , compaction_ctrl_backlog_size(
       *this,
       "compaction_ctrl_backlog_size",
       "Target backlog size for compaction controller. If not set the max "
       "backlog size is configured to 80% of total disk space available.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , members_backend_retry_ms(
       *this,
@@ -2655,31 +2655,31 @@ configuration::configuration()
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",
       "",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       60s)
   , cloud_storage_upload_ctrl_p_coeff(
       *this,
       "cloud_storage_upload_ctrl_p_coeff",
       "proportional coefficient for upload PID controller",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       -2.0)
   , cloud_storage_upload_ctrl_d_coeff(
       *this,
       "cloud_storage_upload_ctrl_d_coeff",
       "derivative coefficient for upload PID controller.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0.0)
   , cloud_storage_upload_ctrl_min_shares(
       *this,
       "cloud_storage_upload_ctrl_min_shares",
       "minimum number of IO and CPU shares that archival upload can use",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100)
   , cloud_storage_upload_ctrl_max_shares(
       *this,
       "cloud_storage_upload_ctrl_max_shares",
       "maximum number of IO and CPU shares that archival upload can use",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1000)
   , retention_local_target_bytes_default(
       *this,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -87,6 +87,7 @@
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
 #include "config/node_config.h"
+#include "config/property.h"
 #include "config/seed_server.h"
 #include "config/types.h"
 #include "crash_tracker/signals.h"
@@ -1213,14 +1214,16 @@ static storage::log_config manager_config_from_global_config(
 
 static storage::backlog_controller_config
 compaction_controller_config(ss::scheduling_group sg, uint64_t fs_avail) {
-    /**
-     * By default we set desired compaction backlog size to 10% of disk
-     * availability.
-     */
-    static const int64_t backlog_avail_percents = 10;
-    int64_t backlog_size
-      = config::shard_local_cfg().compaction_ctrl_backlog_size().value_or(
-        (fs_avail / 100) * backlog_avail_percents / ss::smp::count);
+    auto backlog_size_function = [fs_avail] {
+        /**
+         * By default we set desired compaction backlog size to 10% of disk
+         * availability.
+         */
+        static const int64_t backlog_avail_percents = 10;
+        return config::shard_local_cfg()
+          .compaction_ctrl_backlog_size()
+          .value_or((fs_avail / 100) * backlog_avail_percents / ss::smp::count);
+    };
 
     /**
      * We normalize internals using disk availability to make controller
@@ -1242,16 +1245,16 @@ compaction_controller_config(ss::scheduling_group sg, uint64_t fs_avail) {
     auto normalization = fs_avail / (1000 * ss::smp::count);
 
     return storage::backlog_controller_config(
-      config::shard_local_cfg().compaction_ctrl_p_coeff(),
-      config::shard_local_cfg().compaction_ctrl_i_coeff(),
-      config::shard_local_cfg().compaction_ctrl_d_coeff(),
+      config::shard_local_cfg().compaction_ctrl_p_coeff.bind(),
+      config::shard_local_cfg().compaction_ctrl_i_coeff.bind(),
+      config::shard_local_cfg().compaction_ctrl_d_coeff.bind(),
       normalization,
-      backlog_size,
+      std::move(backlog_size_function),
       200,
-      config::shard_local_cfg().compaction_ctrl_update_interval_ms(),
+      config::shard_local_cfg().compaction_ctrl_update_interval_ms.bind(),
       sg,
-      config::shard_local_cfg().compaction_ctrl_min_shares(),
-      config::shard_local_cfg().compaction_ctrl_max_shares());
+      config::shard_local_cfg().compaction_ctrl_min_shares.bind(),
+      config::shard_local_cfg().compaction_ctrl_max_shares.bind());
 }
 
 static storage::backlog_controller_config
@@ -1267,20 +1270,21 @@ make_upload_controller_config(ss::scheduling_group sg, uint64_t fs_avail) {
     // once integral part will rump up high enough it won't be able to go down
     // even if everything is uploaded.
 
-    int64_t setpoint = 0;
+    auto setpoint_function = []() { return 0; };
     int64_t normalization = static_cast<int64_t>(fs_avail)
                             / (1000 * ss::smp::count);
     return {
-      config::shard_local_cfg().cloud_storage_upload_ctrl_p_coeff(),
-      0,
-      config::shard_local_cfg().cloud_storage_upload_ctrl_d_coeff(),
+      config::shard_local_cfg().cloud_storage_upload_ctrl_p_coeff.bind(),
+      config::mock_binding(0.0),
+      config::shard_local_cfg().cloud_storage_upload_ctrl_d_coeff.bind(),
       normalization,
-      setpoint,
+      std::move(setpoint_function),
       static_cast<int>(sg.get_shares()),
-      config::shard_local_cfg().cloud_storage_upload_ctrl_update_interval_ms(),
+      config::shard_local_cfg()
+        .cloud_storage_upload_ctrl_update_interval_ms.bind(),
       sg,
-      config::shard_local_cfg().cloud_storage_upload_ctrl_min_shares(),
-      config::shard_local_cfg().cloud_storage_upload_ctrl_max_shares()};
+      config::shard_local_cfg().cloud_storage_upload_ctrl_min_shares.bind(),
+      config::shard_local_cfg().cloud_storage_upload_ctrl_max_shares.bind()};
 }
 
 // add additional services in here
@@ -2024,8 +2028,10 @@ void application::wire_up_redpanda_services(
         construct_service(
           _archival_upload_controller,
           std::ref(partition_manager),
-          make_upload_controller_config(
-            sched_groups.archival_upload(), fs_avail))
+          ss::sharded_parameter(
+            [sg = sched_groups.archival_upload(), fs_avail] {
+                return make_upload_controller_config(sg, fs_avail);
+            }))
           .get();
 
         construct_service(
@@ -2475,7 +2481,9 @@ void application::wire_up_redpanda_services(
     construct_service(
       _compaction_controller,
       std::ref(storage),
-      compaction_controller_config(sched_groups.compaction_sg(), fs_avail))
+      ss::sharded_parameter([sg = sched_groups.compaction_sg(), fs_avail] {
+          return compaction_controller_config(sg, fs_avail);
+      }))
       .get();
 }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1212,25 +1212,23 @@ static storage::log_config manager_config_from_global_config(
 }
 
 static storage::backlog_controller_config
-compaction_controller_config(ss::scheduling_group sg) {
-    auto space_info = std::filesystem::space(
-      config::node().data_directory().path);
+compaction_controller_config(ss::scheduling_group sg, uint64_t fs_avail) {
     /**
      * By default we set desired compaction backlog size to 10% of disk
-     * capacity.
+     * availability.
      */
-    static const int64_t backlog_capacity_percents = 10;
+    static const int64_t backlog_avail_percents = 10;
     int64_t backlog_size
       = config::shard_local_cfg().compaction_ctrl_backlog_size().value_or(
-        (space_info.capacity / 100) * backlog_capacity_percents
-        / ss::smp::count);
+        (fs_avail / 100) * backlog_avail_percents / ss::smp::count);
 
     /**
-     * We normalize internals using disk capacity to make controller settings
-     * independent from disk space. After normalization all values equal to disk
-     * capacity will be represented in the controller with value equal 1000.
+     * We normalize internals using disk availability to make controller
+     * settings independent from disk space. After normalization all values
+     * equal to disk availability will be represented in the controller with
+     * value equal 1000.
      *
-     * Set point = 10% of disk capacity will always be equal to 100.
+     * Set point = 10% of disk availability will always be equal to 100.
      *
      * This way we can calculate proportional coefficient.
      *
@@ -1241,7 +1239,7 @@ compaction_controller_config(ss::scheduling_group sg) {
      *  k_p = 1000 / 80 = 12.5
      *
      */
-    auto normalization = space_info.capacity / (1000 * ss::smp::count);
+    auto normalization = fs_avail / (1000 * ss::smp::count);
 
     return storage::backlog_controller_config(
       config::shard_local_cfg().compaction_ctrl_p_coeff(),
@@ -1257,7 +1255,7 @@ compaction_controller_config(ss::scheduling_group sg) {
 }
 
 static storage::backlog_controller_config
-make_upload_controller_config(ss::scheduling_group sg) {
+make_upload_controller_config(ss::scheduling_group sg, uint64_t fs_avail) {
     // This settings are similar to compaction_controller_config.
     // The desired setpoint for archival is set to 0 since the goal is to upload
     // all data that we have.
@@ -1269,10 +1267,8 @@ make_upload_controller_config(ss::scheduling_group sg) {
     // once integral part will rump up high enough it won't be able to go down
     // even if everything is uploaded.
 
-    auto available
-      = ss::fs_avail(config::node().data_directory().path.string()).get();
     int64_t setpoint = 0;
-    int64_t normalization = static_cast<int64_t>(available)
+    int64_t normalization = static_cast<int64_t>(fs_avail)
                             / (1000 * ss::smp::count);
     return {
       config::shard_local_cfg().cloud_storage_upload_ctrl_p_coeff(),
@@ -1976,6 +1972,8 @@ void application::wire_up_redpanda_services(
       std::ref(feature_table))
       .get();
 
+    auto fs_avail
+      = ss::fs_avail(config::node().data_directory().path.string()).get();
     if (archival_storage_enabled()) {
         syschecks::systemd_message("Starting shadow indexing cache").get();
         auto redpanda_dir = config::node().data_directory.value();
@@ -2026,7 +2024,8 @@ void application::wire_up_redpanda_services(
         construct_service(
           _archival_upload_controller,
           std::ref(partition_manager),
-          make_upload_controller_config(sched_groups.archival_upload()))
+          make_upload_controller_config(
+            sched_groups.archival_upload(), fs_avail))
           .get();
 
         construct_service(
@@ -2476,7 +2475,7 @@ void application::wire_up_redpanda_services(
     construct_service(
       _compaction_controller,
       std::ref(storage),
-      compaction_controller_config(sched_groups.compaction_sg()))
+      compaction_controller_config(sched_groups.compaction_sg(), fs_avail))
       .get();
 }
 

--- a/src/v/storage/backlog_controller.cc
+++ b/src/v/storage/backlog_controller.cc
@@ -10,6 +10,7 @@
 
 #include "base/vlog.h"
 #include "config/configuration.h"
+#include "config/property.h"
 #include "metrics/prometheus_sanitize.h"
 #include "ssx/future-util.h"
 #include "ssx/sformat.h"
@@ -23,21 +24,21 @@
 namespace storage {
 
 backlog_controller_config::backlog_controller_config(
-  double kp,
-  double ki,
-  double kd,
+  config::binding<double> kp,
+  config::binding<double> ki,
+  config::binding<double> kd,
   int64_t normalization_factor,
-  int64_t sp,
+  std::function<int64_t()> sp_function,
   int initial_shares,
-  std::chrono::milliseconds interval,
+  config::binding<std::chrono::milliseconds> interval,
   ss::scheduling_group sg,
-  int min,
-  int max)
+  config::binding<int16_t> min,
+  config::binding<int16_t> max)
   : proportional_coeff(kp)
   , integral_coeff(ki)
   , derivative_coeff(kd)
   , normalization_factor(normalization_factor)
-  , setpoint(sp)
+  , setpoint_cb(std::move(sp_function))
   , initial_shares(initial_shares)
   , sampling_interval(interval)
   , scheduling_group(sg)
@@ -50,30 +51,33 @@ backlog_controller::backlog_controller(
   backlog_controller_config cfg)
   : _sampler(std::move(sampler))
   , _log(logger)
-  , _proportional_coeff(cfg.proportional_coeff)
-  , _integral_coeff(cfg.integral_coeff)
-  , _derivative_coeff(cfg.derivative_coeff)
-  , _norm(cfg.normalization_factor)
-  , _sampling_interval(cfg.sampling_interval)
-  , _scheduling_group(cfg.scheduling_group)
-  , _setpoint(cfg.setpoint / _norm)
   , _current_shares(cfg.initial_shares)
-  , _min_shares(cfg.min_shares)
-  , _max_shares(cfg.max_shares) {}
+  , _cfg(std::move(cfg)) {}
 
 ss::future<> backlog_controller::start() {
-    _current_backlog = co_await _sampler->sample_backlog() / _norm;
-    _prev_error = _setpoint - _current_backlog;
+    auto norm = _cfg.normalization_factor;
+    auto setpoint = _cfg.setpoint_cb() / norm;
+    _current_backlog = co_await _sampler->sample_backlog() / norm;
+
+    _prev_error = setpoint - _current_backlog;
     _sampling_timer.set_callback([this] {
         ssx::spawn_with_gate(_gate, [this] {
             return update().then([this] {
                 if (!_gate.is_closed()) {
-                    _sampling_timer.arm(_sampling_interval);
+                    _sampling_timer.arm(_cfg.sampling_interval());
                 }
             });
         });
     });
-    _sampling_timer.arm(_sampling_interval);
+    _sampling_timer.arm(_cfg.sampling_interval());
+
+    // Rearm sampling timer on interval change.
+    _cfg.sampling_interval.watch([this] {
+        if (_sampling_timer.armed()) {
+            _sampling_timer.cancel();
+            _sampling_timer.arm(_cfg.sampling_interval());
+        }
+    });
 }
 
 ss::future<> backlog_controller::stop() {
@@ -82,29 +86,34 @@ ss::future<> backlog_controller::stop() {
 }
 
 ss::future<> backlog_controller::update() {
-    _current_backlog = co_await _sampler->sample_backlog() / _norm;
-    auto current_err = _setpoint - _current_backlog;
+    auto norm = _cfg.normalization_factor;
+    auto setpoint = _cfg.setpoint_cb() / norm;
+    _current_backlog = co_await _sampler->sample_backlog() / norm;
+
+    auto current_err = setpoint - _current_backlog;
 
     static constexpr int64_t max_error = std::numeric_limits<int32_t>::max();
     _error_integral = std::clamp(
       _error_integral + current_err, -max_error, max_error);
 
     auto update = static_cast<double>(current_err);
-    if (_integral_coeff != 0.00) {
-        update += _integral_coeff * static_cast<double>(_error_integral);
+    if (_cfg.integral_coeff() != 0.00) {
+        update += _cfg.integral_coeff() * static_cast<double>(_error_integral);
     }
-    if (_derivative_coeff != 0.00) {
-        update += _derivative_coeff
+    if (_cfg.derivative_coeff() != 0.00) {
+        update += _cfg.derivative_coeff()
                   * static_cast<double>(current_err - _prev_error);
     }
-    update *= _proportional_coeff;
+    update *= _cfg.proportional_coeff();
     _current_shares = std::clamp(
-      static_cast<int>(update), _min_shares, _max_shares);
+      static_cast<int>(update),
+      static_cast<int>(_cfg.min_shares()),
+      static_cast<int>(_cfg.max_shares()));
     vlog(
       _log.trace,
       "state update: {{setpoint: {}, current_backlog: {}, current_error: {}, "
       "prev_error: {}, shares_update: {}, current_share: {} }}",
-      _setpoint,
+      setpoint,
       _current_backlog,
       current_err,
       _prev_error,
@@ -119,7 +128,7 @@ ss::future<> backlog_controller::update() {
 
 ss::future<> backlog_controller::set() {
     vlog(_log.debug, "updating shares {}", _current_shares);
-    _scheduling_group.set_shares(static_cast<float>(_current_shares));
+    _cfg.scheduling_group.set_shares(static_cast<float>(_current_shares));
     co_return;
 }
 

--- a/src/v/storage/backlog_controller.cc
+++ b/src/v/storage/backlog_controller.cc
@@ -76,11 +76,6 @@ ss::future<> backlog_controller::start() {
     _sampling_timer.arm(_sampling_interval);
 }
 
-void backlog_controller::update_setpoint(int64_t v) {
-    vlog(_log.info, "new setpoint value: {}", v);
-    _setpoint = v;
-}
-
 ss::future<> backlog_controller::stop() {
     _sampling_timer.cancel();
     return _gate.close();

--- a/src/v/storage/backlog_controller.h
+++ b/src/v/storage/backlog_controller.h
@@ -9,6 +9,7 @@
 
 #pragma once
 #include "base/seastarx.h"
+#include "config/property.h"
 #include "metrics/metrics.h"
 
 #include <seastar/core/gate.hh>
@@ -19,27 +20,27 @@
 namespace storage {
 struct backlog_controller_config {
     backlog_controller_config(
-      double proportional_coeff,
-      double integral_coeff,
-      double derivative_coeff,
+      config::binding<double> proportional_coeff,
+      config::binding<double> integral_coeff,
+      config::binding<double> derivative_coeff,
       int64_t normalization_factor,
-      int64_t setpoint,
+      std::function<int64_t()> sp_function,
       int initial_shares,
-      std::chrono::milliseconds sampling_interval,
+      config::binding<std::chrono::milliseconds> sampling_interval,
       ss::scheduling_group sg,
-      int min_shares,
-      int max_shares);
+      config::binding<int16_t> min_shares,
+      config::binding<int16_t> max_shares);
 
-    double proportional_coeff;
-    double integral_coeff;
-    double derivative_coeff;
+    config::binding<double> proportional_coeff;
+    config::binding<double> integral_coeff;
+    config::binding<double> derivative_coeff;
     int64_t normalization_factor;
-    int64_t setpoint;
+    std::function<int64_t()> setpoint_cb;
     int initial_shares;
-    std::chrono::milliseconds sampling_interval;
+    config::binding<std::chrono::milliseconds> sampling_interval;
     ss::scheduling_group scheduling_group;
-    int min_shares;
-    int max_shares;
+    config::binding<int16_t> min_shares;
+    config::binding<int16_t> max_shares;
 };
 /**
  * Backlog controller is PID controller implementation to manage amount of
@@ -104,22 +105,14 @@ private:
 
     std::unique_ptr<sampler> _sampler;
     ss::logger& _log;
-    double _proportional_coeff; // controller 'gain' -  proportional coefficient
-    double _integral_coeff;     // integral part coefficient
-    double _derivative_coeff;   // derivative part coefficient
-    int64_t _norm;
-    std::chrono::milliseconds _sampling_interval;
     ss::timer<> _sampling_timer;
-    // controlled resources
-    ss::scheduling_group _scheduling_group;
     // state
+    int _current_shares;
     int64_t _current_backlog{0};
     int64_t _prev_error{0};
     int64_t _error_integral{0};
-    int64_t _setpoint;
-    int _current_shares;
-    int _min_shares;
-    int _max_shares;
+    // configuration
+    backlog_controller_config _cfg;
     ss::gate _gate;
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/storage/backlog_controller.h
+++ b/src/v/storage/backlog_controller.h
@@ -91,7 +91,6 @@ public:
     backlog_controller(
       std::unique_ptr<sampler>, ss::logger&, backlog_controller_config);
 
-    void update_setpoint(int64_t);
     ss::future<> start();
     ss::future<> stop();
 

--- a/src/v/storage/compaction_controller.cc
+++ b/src/v/storage/compaction_controller.cc
@@ -25,7 +25,9 @@ ss::future<int64_t> compaction_backlog_sampler::sample_backlog() {
 compaction_controller::compaction_controller(
   ss::sharded<api>& api, backlog_controller_config cfg)
   : _ctrl(
-      std::make_unique<compaction_backlog_sampler>(api), compaction_log, cfg) {
+      std::make_unique<compaction_backlog_sampler>(api),
+      compaction_log,
+      std::move(cfg)) {
     _ctrl.setup_metrics("storage:compaction");
 }
 

--- a/src/v/storage/tests/BUILD
+++ b/src/v/storage/tests/BUILD
@@ -353,6 +353,7 @@ redpanda_cc_gtest(
     ],
     deps = [
         "//src/v/base",
+        "//src/v/config",
         "//src/v/storage",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/storage/tests/backlog_controller_test.cc
+++ b/src/v/storage/tests/backlog_controller_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "base/seastarx.h"
+#include "config/property.h"
 #include "storage/backlog_controller.h"
 #include "test_utils/async.h"
 
@@ -50,11 +51,24 @@ public:
          * min shares = 10
          * max shares = 800
          */
+        auto mb = [](auto v) { return config::mock_binding(std::move(v)); };
+        auto sp = []() { return 20; };
         auto cfg = storage::backlog_controller_config(
-          -1.0, 0.4, 0.2, 1, 20, 100, 10ms, sg, 10, 800);
+          mb(-1.0),
+          mb(0.4),
+          mb(0.2),
+          1,
+          std::move(sp),
+          100,
+          mb(10ms),
+          sg,
+          mb(int16_t{10}),
+          mb(int16_t{800}));
 
         ctrl = std::make_unique<storage::backlog_controller>(
-          std::make_unique<simple_backlog_sampler>(backlog), ctrl_logger, cfg);
+          std::make_unique<simple_backlog_sampler>(backlog),
+          ctrl_logger,
+          std::move(cfg));
     }
 
     ~backlog_controller_fixture() { ctrl->stop().get(); }


### PR DESCRIPTION
The two use cases of the `backlog_controller` in the code presently are the `compaction_controller` and the `upload_controller`. In both cases, there are cluster properties associated with the PID values used in the `backlog_controller_config`, which presently require a restart to take effect.

There is no strong reason for this to be the case. To enable making these values changeable at run-time, alter the `backlog_controller_config` and use of it in the `backlog_controller` to instead use `config::binding`s around the raw value types.

While this does throw away some of the bare value type simplicity of the `backlog_controller` design, the benefits and actual use cases of this class in the codebase are a good motivation for making this change.

The properties for the `upload_controller` and `compaction_controller` can now be marked as not needing a restart to take effect, since all of their uses are now bindings.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x
- [ ] v24.2.x

## Release Notes

* none
