### PR TITLE
[CORE-1482] `storage`: make `vectorized_storage_log_compacted_segment` a public metric

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -209,6 +209,7 @@ disk_log_impl::disk_log_impl(
     }
     _probe->initial_segments_count(_segs.size());
     _probe->setup_metrics(this->config().ntp());
+    _probe->setup_public_metrics(this->config().ntp());
 }
 disk_log_impl::~disk_log_impl() {
     vassert(_closed, "log segment must be closed before deleting:{}", *this);

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -261,6 +261,12 @@ void probe::setup_metrics(const model::ntp& ntp) {
       });
 }
 
+void probe::setup_public_metrics(const model::ntp& ntp) {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+}
+
 void probe::add_initial_segment(const segment& s) {
     _partition_bytes += s.file_size();
 }

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -173,11 +173,6 @@ void probe::setup_metrics(const model::ntp& ntp) {
           sm::description("Number of times we had to re-construct the "
                           ".compaction index on a segment"),
           labels),
-        sm::make_counter(
-          "compacted_segment",
-          [this] { return _segment_compacted; },
-          sm::description("Number of compacted segments"),
-          labels),
         sm::make_gauge(
           "partition_size",
           [this] { return _partition_bytes; },
@@ -265,6 +260,28 @@ void probe::setup_public_metrics(const model::ntp& ntp) {
     if (config::shard_local_cfg().disable_metrics()) {
         return;
     }
+
+    namespace sm = ss::metrics;
+    auto labels = {
+      metrics::namespace_label(ntp.ns()),
+      metrics::topic_label(ntp.tp.topic()),
+      metrics::partition_label(ntp.tp.partition()),
+    };
+
+    auto aggregate_labels = {sm::shard_label, metrics::partition_label};
+
+    auto group_name = prometheus_sanitize::metrics_name("storage:log");
+
+    _public_metrics.add_group(
+      group_name,
+      {
+        sm::make_counter(
+          "compacted_segment",
+          [this] { return _segment_compacted; },
+          sm::description("Number of compacted segments"),
+          labels)
+          .aggregate(aggregate_labels),
+      });
 }
 
 void probe::add_initial_segment(const segment& s) {

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -118,6 +118,7 @@ public:
     void batch_parse_error() { ++_batch_parse_errors; }
 
     void setup_metrics(const model::ntp&);
+    void setup_public_metrics(const model::ntp&);
 
     void delete_segment(const segment&);
 
@@ -130,7 +131,10 @@ public:
     /**
      * Clears all probe related metrics
      */
-    void clear_metrics() { _metrics.clear(); }
+    void clear_metrics() {
+        _metrics.clear();
+        _public_metrics.clear();
+    }
 
     void add_bytes_prefix_truncated(size_t bytes) {
         _bytes_prefix_truncated += bytes;
@@ -177,5 +181,6 @@ private:
     ssize_t _compaction_removed_bytes = 0;
 
     metrics::internal_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
 };
 } // namespace storage

--- a/tests/rptest/tests/compacted_term_rolled_recovery_test.py
+++ b/tests/rptest/tests/compacted_term_rolled_recovery_test.py
@@ -13,6 +13,7 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.services.redpanda import MetricsEndpoint
 
 
 class CompactionTermRollRecoveryTest(RedpandaTest):
@@ -94,10 +95,11 @@ class CompactionTermRollRecoveryTest(RedpandaTest):
         """
         def fetch(node):
             count = 0
-            metrics = self.redpanda.metrics(node)
+            metrics = self.redpanda.metrics(
+                node, metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
             for family in metrics:
                 for sample in family.samples:
-                    if sample.name == "vectorized_storage_log_compacted_segment_total" and \
+                    if sample.name == "redpanda_storage_log_compacted_segment_total" and \
                             sample.labels["namespace"] == "kafka" and \
                             sample.labels["topic"] == topic:
                         count += int(sample.value)

--- a/tests/rptest/tests/compatibility/java_compression_test.py
+++ b/tests/rptest/tests/compatibility/java_compression_test.py
@@ -86,8 +86,8 @@ class JavaCompressionTest(EndToEndTest):
 
     def get_compacted_segments(self):
         num_compacted_segments = self.redpanda.metric_sum(
-            metric_name="vectorized_storage_log_compacted_segment_total",
-            metrics_endpoint=MetricsEndpoint.METRICS,
+            metric_name="redpanda_storage_log_compacted_segment_total",
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
             topic=self.topic_spec.name)
         self.redpanda.logger.debug(
             f"Saw {num_compacted_segments} compacted segments")

--- a/tests/rptest/tests/controller_partition_invariants_test.py
+++ b/tests/rptest/tests/controller_partition_invariants_test.py
@@ -14,6 +14,7 @@ from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
 
 from ducktape.mark import matrix
+from rptest.services.redpanda import MetricsEndpoint
 from rptest.services.metrics_check import MetricCheck
 
 import time
@@ -33,11 +34,22 @@ class ControllerLogInvariantsTest(RedpandaTest):
     def test_controller_is_not_compacted_nor_deleted(self,
                                                      cluster_cleanup_policy):
 
-        metrics = [
+        internal_metrics = [
             MetricCheck(self.logger, self.redpanda, n,
                         re.compile("vectorized_storage_log.*"),
                         {'topic': 'controller'}) for n in self.redpanda.nodes
         ]
+        public_metrics = [
+            MetricCheck(self.logger,
+                        self.redpanda,
+                        n,
+                        re.compile("redpanda_storage_log.*"),
+                        {'topic': 'controller'},
+                        metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+            for n in self.redpanda.nodes
+        ]
+
+        metrics = internal_metrics + public_metrics
 
         rpk = RpkTool(self.redpanda)
         for _ in range(10):
@@ -58,7 +70,7 @@ class ControllerLogInvariantsTest(RedpandaTest):
 
         time.sleep(30)
         for m in metrics:
-            m.expect([("vectorized_storage_log_compacted_segment_total",
+            m.expect([("redpanda_storage_log_compacted_segment_total",
                        lambda a, b: b == a == 0),
                       ("vectorized_storage_log_log_segments_removed_total",
                        lambda a, b: b == a == 0)])

--- a/tests/rptest/tests/log_compaction_test.py
+++ b/tests/rptest/tests/log_compaction_test.py
@@ -568,9 +568,8 @@ class LogCompactionEnableSlidingWindow(RedpandaTest):
 
             def seen_compacted_segments():
                 num_compacted_segments = self.redpanda.metric_sum(
-                    metric_name=
-                    "vectorized_storage_log_compacted_segment_total",
-                    metrics_endpoint=MetricsEndpoint.METRICS,
+                    metric_name="redpanda_storage_log_compacted_segment_total",
+                    metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
                     topic=topic_spec.name,
                     expect_metric=True)
                 ret = num_compacted_segments > self.prev_num_compacted_segments

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -25,7 +25,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.metrics_check import MetricCheck
-from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type
+from rptest.services.redpanda import CloudStorageType, SISettings, get_cloud_storage_type, MetricsEndpoint
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.util import wait_for_local_storage_truncate, firewall_blocked
 from rptest.services.admin import Admin
@@ -928,15 +928,19 @@ class TopicDeleteStressTest(RedpandaTest):
             producer.start()
 
             metrics = [
-                MetricCheck(self.logger, self.redpanda, n,
-                            'vectorized_storage_log_compacted_segment_total',
-                            {}, sum) for n in self.redpanda.nodes
+                MetricCheck(self.logger,
+                            self.redpanda,
+                            n,
+                            'redpanda_storage_log_compacted_segment_total', {},
+                            sum,
+                            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
+                for n in self.redpanda.nodes
             ]
 
             def check_compaction():
                 return all([
                     m.evaluate([
-                        ('vectorized_storage_log_compacted_segment_total',
+                        ('redpanda_storage_log_compacted_segment_total',
                          lambda a, b: b > 3)
                     ]) for m in metrics
                 ])

--- a/tests/rptest/transactions/compaction_e2e_test.py
+++ b/tests/rptest/transactions/compaction_e2e_test.py
@@ -18,7 +18,7 @@ from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
 from rptest.utils.mode_checks import skip_debug_mode
 from time import sleep
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, MetricsEndpoint
 
 from rptest.transactions.verifiers.compacted_verifier import CompactedVerifier, Workload
 from rptest.tests.partition_movement import PartitionMovementMixin
@@ -217,7 +217,8 @@ class CompactionWithRecoveryTest(RedpandaTest, PartitionMovementMixin):
                             'topic': self.topic,
                             'partition': '0',
                         },
-                        reduce=sum)
+                        reduce=sum,
+                        metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS)
 
         workload = CompactedVerifier(self.test_context, self.redpanda,
                                      Workload.TX)


### PR DESCRIPTION
This was requested by the cloud team to provide some sort of observability into the compaction subsystem for cloud clusters.

Fixes https://redpandadata.atlassian.net/browse/CORE-1482.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

