### PR TITLE
`storage`: `const`-ify some functions with `mutable` `_bytes`

### DIFF
--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -265,7 +265,7 @@ ssize_t failure_injectable_log::closed_segment_bytes() const {
     return _underlying_log->closed_segment_bytes();
 }
 
-double failure_injectable_log::dirty_ratio() {
+double failure_injectable_log::dirty_ratio() const {
     return _underlying_log->dirty_ratio();
 }
 
@@ -284,7 +284,7 @@ failure_injectable_log::max_removed_offset() const {
     return _underlying_log->max_removed_offset();
 }
 
-bool failure_injectable_log::needs_compaction() {
+bool failure_injectable_log::needs_compaction() const {
     return _underlying_log->needs_compaction();
 }
 

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -141,7 +141,7 @@ public:
     ssize_t dirty_segment_bytes() const final;
     ssize_t closed_segment_bytes() const final;
 
-    double dirty_ratio() final;
+    double dirty_ratio() const final;
 
     virtual std::optional<model::timestamp>
     earliest_dirty_segment_ts() const final;
@@ -151,7 +151,7 @@ public:
 
     virtual std::optional<model::offset> max_removed_offset() const final;
 
-    bool needs_compaction() final;
+    bool needs_compaction() const final;
 
 private:
     ss::shared_ptr<storage::log> _underlying_log;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -4426,7 +4426,7 @@ ss::future<> disk_log_impl::remove_kvstore_state(
       .discard_result();
 }
 
-double disk_log_impl::dirty_ratio() {
+double disk_log_impl::dirty_ratio() const {
     // Sanity check/safety hatch against negative values
     if (_dirty_segment_bytes < 0 || _closed_segment_bytes < 0) {
         vlog(
@@ -4489,7 +4489,7 @@ void disk_log_impl::subtract_segment_bytes(
     subtract_closed_segment_bytes(bytes);
 }
 
-void disk_log_impl::reset_dirty_and_closed_bytes() {
+void disk_log_impl::reset_dirty_and_closed_bytes() const {
     ssize_t dirty{0};
     ssize_t closed{0};
     for (const auto& seg : _segs) {
@@ -4573,7 +4573,7 @@ std::optional<model::offset> disk_log_impl::max_removed_offset() const {
     return internal::read_max_removed_offset(_kvstore, config().ntp());
 }
 
-bool disk_log_impl::needs_compaction() {
+bool disk_log_impl::needs_compaction() const {
     auto max_lag = config().max_compaction_lag_ms();
     const auto now = to_time_point(model::timestamp::now());
     const auto earliest_dirty_ts = earliest_dirty_segment_ts();

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -278,7 +278,7 @@ public:
     // Returns the dirty ratio of the log.
     // The dirty ratio is the ratio of bytes in closed, dirty segments to the
     // total number of bytes in all closed segments in the log.
-    double dirty_ratio() final;
+    double dirty_ratio() const final;
 
     std::optional<model::timestamp> earliest_dirty_segment_ts() const final;
 
@@ -445,7 +445,7 @@ private:
     //    the max compaction lag.
     // 2. It's dirty enough: the dirty ratio is at least the minimum
     //    cleanable dirty ratio.
-    bool needs_compaction() final;
+    bool needs_compaction() const final;
 
 private:
     // Computes the segment size based on the latest max_segment_size
@@ -513,8 +513,8 @@ private:
 
     size_t _reclaimable_size_bytes{0};
 
-    ssize_t _dirty_segment_bytes{0};
-    ssize_t _closed_segment_bytes{0};
+    mutable ssize_t _dirty_segment_bytes{0};
+    mutable ssize_t _closed_segment_bytes{0};
 
     // Update the number of bytes in dirty segments.
     //
@@ -553,8 +553,9 @@ private:
     // Performs a manual O(n) reset of the dirty and closed bytes in the log by
     // iterating over segment in the log. Used as a safety hatch in
     // dirty_ratio() to prevent returning a bogus value due to improper
-    // book-keeping.
-    void reset_dirty_and_closed_bytes();
+    // book-keeping. Marked as `const` to make call from `dirty_ratio()` compile
+    // (`_bytes` are marked as `mutable`).
+    void reset_dirty_and_closed_bytes() const;
 
     bool _compaction_enabled;
 };

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -263,7 +263,7 @@ public:
     // Returns the dirty ratio of the log. The dirty ratio is the ratio of bytes
     // in closed, dirty segments to the total number of bytes in all closed
     // segments in the log.
-    virtual double dirty_ratio() = 0;
+    virtual double dirty_ratio() const = 0;
 
     // Return the earliest batch timestamp among all dirty segments.
     virtual std::optional<model::timestamp>
@@ -273,7 +273,7 @@ public:
       earliest_removable_timestamp(model::offset) const = 0;
 
     virtual std::optional<model::offset> max_removed_offset() const = 0;
-    virtual bool needs_compaction() = 0;
+    virtual bool needs_compaction() const = 0;
 
 private:
     ntp_config _config;


### PR DESCRIPTION
As requested in https://github.com/redpanda-data/redpanda/pull/27099#discussion_r2252168261.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
