### PR TITLE
ct/l1: plumbing for Raft-backed metastore STM

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -32,4 +32,8 @@ seastar::future<> app::stop() {
 
 ss::shared_ptr<data_plane_api> app::get_data_plane_api() { return _data_plane; }
 
+l1::domain_supervisor* app::get_l1_domain_supervisor() {
+    return _domain_supervisor.get();
+}
+
 } // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -36,6 +36,7 @@ public:
     seastar::future<> stop();
 
     ss::shared_ptr<data_plane_api> get_data_plane_api();
+    l1::domain_supervisor* get_l1_domain_supervisor();
 
     // TODO: add 'get_control_plane_api' etc
 

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -10,12 +10,19 @@ redpanda_cc_library(
     hdrs = [
         "domain_supervisor.h",
     ],
+    implementation_deps = [
+        ":domain_manager",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cluster",
+        "//src/v/cluster/utils:partition_change_notifier_api",
+        "//src/v/cluster/utils:partition_change_notifier_impl",
+        "//src/v/model",
+        "//src/v/ssx:work_queue",
+    ],
     include_prefix = "cloud_topics/level_one/domain",
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
-        "//src/v/cloud_topics:logger",
-        "//src/v/cluster",
         "//src/v/model",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -1,5 +1,7 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
+package(default_visibility = ["//src/v/cloud_topics/level_one:__subpackages__"])
+
 redpanda_cc_library(
     name = "domain_supervisor",
     srcs = [
@@ -15,6 +17,27 @@ redpanda_cc_library(
         "//src/v/cloud_topics:logger",
         "//src/v/cluster",
         "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "domain_manager",
+    srcs = [
+        "domain_manager.cc",
+    ],
+    hdrs = [
+        "domain_manager.h",
+    ],
+    implementation_deps = [
+        "//src/v/cloud_topics:logger",
+    ],
+    include_prefix = "cloud_topics/level_one/domain",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_topics/level_one/metastore:rpc_types",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/cloud_topics/level_one/metastore:simple_stm",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/domain/domain_manager.h"
+
+#include "cloud_topics/level_one/metastore/rpc_types.h"
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/logger.h"
+
+namespace experimental::cloud_topics::l1 {
+namespace {
+rpc::errc convert_stm_errc(simple_stm::errc e) {
+    switch (e) {
+    case simple_stm::errc::shutting_down:
+    case simple_stm::errc::not_leader:
+        return rpc::errc::not_leader;
+    case simple_stm::errc::apply_error:
+        return rpc::errc::concurrent_requests;
+    case simple_stm::errc::raft_error:
+        return rpc::errc::timed_out;
+    }
+}
+} // namespace
+
+ss::future<> domain_manager::stop_and_wait() {
+    vlog(cd_log.debug, "Domain manager stopping...");
+    as_.request_abort();
+    co_await gate_.close();
+    vlog(cd_log.debug, "Domain manager stopped...");
+}
+
+std::optional<ss::gate::holder> domain_manager::maybe_gate() {
+    ss::gate::holder h;
+    if (as_.abort_requested() || gate_.is_closed()) {
+        return std::nullopt;
+    }
+    return gate_.hold();
+}
+
+ss::future<rpc::add_objects_reply>
+domain_manager::add_objects(rpc::add_objects_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::add_objects_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::add_objects_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    chunked_hash_set<object_id> added_oids;
+    for (const auto& obj : req.new_objects) {
+        added_oids.emplace(obj.oid);
+    }
+    auto update_res = add_objects_update::build(
+      stm_state, std::move(req.new_objects));
+    if (!update_res.has_value()) {
+        vlog(
+          cd_log.debug,
+          "Rejecting request to add objects: {}",
+          update_res.error());
+        co_return rpc::add_objects_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    storage::record_batch_builder builder(
+      model::record_batch_type::l1_stm, model::offset{0});
+    builder.add_raw_kv(
+      serde::to_iobuf(add_objects_update::key),
+      serde::to_iobuf(std::move(update_res.value())));
+    auto repl_res = co_await stm_->replicate_and_wait(
+      sync_res.value(), std::move(builder).build(), as_);
+    if (!repl_res.has_value()) {
+        co_return rpc::add_objects_reply{
+          .ec = convert_stm_errc(repl_res.error()),
+        };
+    }
+    // Check if any of the objects were successfully added. Presumably the
+    // presence of any objects is signal enough that the update was
+    // successfully applied, given these updates are atomic.
+    bool any_added = false;
+    for (const auto& oid : added_oids) {
+        if (stm_->state().objects.contains(oid)) {
+            any_added = true;
+            break;
+        }
+    }
+    if (!any_added) {
+        co_return rpc::add_objects_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    co_return rpc::add_objects_reply{
+      .ec = rpc::errc::ok,
+    };
+}
+
+ss::future<rpc::replace_objects_reply>
+domain_manager::replace_objects(rpc::replace_objects_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::replace_objects_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::replace_objects_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    chunked_hash_set<object_id> added_oids;
+    for (const auto& obj : req.new_objects) {
+        added_oids.emplace(obj.oid);
+    }
+    auto& stm_state = stm_->state();
+    auto update_res = replace_objects_update::build(
+      stm_state, std::move(req.new_objects), std::move(req.compaction_updates));
+    if (!update_res.has_value()) {
+        vlog(
+          cd_log.debug,
+          "Rejecting request to replace objects: {}",
+          update_res.error());
+        co_return rpc::replace_objects_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    storage::record_batch_builder builder(
+      model::record_batch_type::l1_stm, model::offset{0});
+    builder.add_raw_kv(
+      serde::to_iobuf(replace_objects_update::key),
+      serde::to_iobuf(std::move(update_res.value())));
+    auto repl_res = co_await stm_->replicate_and_wait(
+      sync_res.value(), std::move(builder).build(), as_);
+    if (!repl_res.has_value()) {
+        co_return rpc::replace_objects_reply{
+          .ec = convert_stm_errc(repl_res.error()),
+        };
+    }
+    // Check if any of the objects were successfully added. Presumably the
+    // presence of any objects is signal enough that the update was
+    // successfully applied, given these updates are atomic.
+    bool any_added = false;
+    for (const auto& oid : added_oids) {
+        if (stm_->state().objects.contains(oid)) {
+            any_added = true;
+            break;
+        }
+    }
+    if (!any_added) {
+        co_return rpc::replace_objects_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    co_return rpc::replace_objects_reply{
+      .ec = rpc::errc::ok,
+    };
+}
+
+ss::future<rpc::get_first_offset_ge_reply>
+domain_manager::get_first_offset_ge(rpc::get_first_offset_ge_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_first_offset_ge_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_first_offset_ge_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    auto get_res = simple_metastore::get_first_ge(stm_state, req.tp, req.o);
+    if (!get_res.has_value()) {
+        co_return rpc::get_first_offset_ge_reply{
+          .ec = rpc::errc::state_error,
+        };
+    }
+    auto& obj = get_res.value();
+    co_return rpc::get_first_offset_ge_reply{
+        .ec = rpc::errc::ok,
+        .object = rpc::object_metadata{
+            .oid = obj.oid,
+            .footer_pos = obj.footer_pos,
+        },
+    };
+}
+
+ss::future<rpc::get_first_timestamp_ge_reply>
+domain_manager::get_first_timestamp_ge(
+  rpc::get_first_timestamp_ge_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_first_timestamp_ge_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_first_timestamp_ge_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    auto get_res = simple_metastore::get_first_ge(stm_state, req.tp, req.ts);
+    if (!get_res.has_value()) {
+        co_return rpc::get_first_timestamp_ge_reply{
+          .ec = rpc::errc::state_error,
+        };
+    }
+    auto& obj = get_res.value();
+    co_return rpc::get_first_timestamp_ge_reply{
+        .ec = rpc::errc::ok,
+        .object = rpc::object_metadata{
+            .oid = obj.oid,
+            .footer_pos = obj.footer_pos,
+        },
+    };
+}
+
+ss::future<rpc::get_offsets_reply>
+domain_manager::get_offsets(rpc::get_offsets_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_offsets_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_offsets_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    auto get_res = simple_metastore::get_offsets(stm_state, req.tp);
+    if (!get_res.has_value()) {
+        co_return rpc::get_offsets_reply{
+          .ec = rpc::errc::state_error,
+        };
+    }
+    co_return rpc::get_offsets_reply{
+      .ec = rpc::errc::ok,
+      .start_offset = get_res->start_offset,
+      .next_offset = get_res->next_offset,
+    };
+}
+
+ss::future<rpc::get_compaction_offsets_reply>
+domain_manager::get_compaction_offsets(
+  rpc::get_compaction_offsets_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_compaction_offsets_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_compaction_offsets_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    auto get_res = simple_metastore::get_compaction_offsets(
+      stm_state, req.tp, req.tombstone_removal_upper_bound_ts);
+    if (!get_res.has_value()) {
+        co_return rpc::get_compaction_offsets_reply{
+          .ec = rpc::errc::state_error,
+        };
+    }
+    co_return rpc::get_compaction_offsets_reply{
+      .ec = rpc::errc::ok,
+      .dirty_ranges = std::move(get_res->dirty_ranges),
+      .removable_tombstone_ranges = std::move(
+        get_res->removable_tombstone_ranges),
+    };
+}
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/metastore/rpc_types.h"
+#include "cloud_topics/level_one/metastore/simple_stm.h"
+
+namespace experimental::cloud_topics::l1 {
+
+// Encapsulates management of a given L1 metastore domain by wrapping a STM.
+// Expected to be running on the leader replicas of the partition that backs
+// the STM.
+//
+// The underlying STM itself focuses solely on persisting deterministic
+// updates, while this:
+// 1. wrangles additional aspects of these updates like concurrency, and
+// 2. TODO: reconciles the STM state with cloud-recoverable state.
+class domain_manager {
+public:
+    explicit domain_manager(ss::shared_ptr<simple_stm> stm)
+      : stm_(std::move(stm)) {}
+
+    ss::future<> stop_and_wait();
+
+    ss::future<rpc::add_objects_reply> add_objects(rpc::add_objects_request);
+
+    ss::future<rpc::replace_objects_reply>
+      replace_objects(rpc::replace_objects_request);
+
+    ss::future<rpc::get_first_offset_ge_reply>
+      get_first_offset_ge(rpc::get_first_offset_ge_request);
+
+    ss::future<rpc::get_first_timestamp_ge_reply>
+      get_first_timestamp_ge(rpc::get_first_timestamp_ge_request);
+
+    ss::future<rpc::get_offsets_reply> get_offsets(rpc::get_offsets_request);
+
+    ss::future<rpc::get_compaction_offsets_reply>
+      get_compaction_offsets(rpc::get_compaction_offsets_request);
+
+private:
+    std::optional<ss::gate::holder> maybe_gate();
+
+    ss::gate gate_;
+    ss::abort_source as_;
+    ss::shared_ptr<simple_stm> stm_;
+};
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -10,12 +10,16 @@
 
 #include "cloud_topics/level_one/domain/domain_supervisor.h"
 
+#include "cloud_topics/level_one/domain/domain_manager.h"
 #include "cloud_topics/logger.h"
 #include "cluster/controller.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
+#include "cluster/utils/partition_change_notifier.h"
+#include "cluster/utils/partition_change_notifier_impl.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
+#include "ssx/work_queue.h"
 
 #include <seastar/coroutine/as_future.hh>
 
@@ -26,15 +30,41 @@ namespace experimental::cloud_topics::l1 {
 class domain_supervisor::impl {
 public:
     explicit impl(cluster::controller* controller)
-      : _controller(controller) {}
+      : _controller(controller)
+      , _partition_notifications(
+          cluster::partition_change_notifier_impl::make_default(
+            _controller->get_raft_manager(),
+            _controller->get_partition_manager(),
+            _controller->get_topics_state()))
+      , _queue([](const std::exception_ptr& ex) {
+          vlog(cd_log.error, "Unexpected domain supervisor error: {}", ex);
+      }) {}
 
     ss::future<> start() {
         if (ss::this_shard_id() == 0) {
             _as = {};
             _loop = do_topic_reconciliation_loop();
         }
-        // TODO(cloud-topics): We should also create domain supervisors if this
-        // shard owns a domain partition.
+        _partition_notifications_id
+          = _partition_notifications->register_partition_notifications(
+            [this](
+              cluster::partition_change_notifier::notification_type,
+              const model::ntp& ntp,
+              std::optional<cluster::partition_change_notifier::partition_state>
+                partition) {
+                auto is_l1_topic = ntp.ns == model::kafka_internal_namespace
+                                   && ntp.tp.topic == model::l1_metastore_topic;
+                if (!is_l1_topic) {
+                    return;
+                }
+                // NOTE: listen on all partition notification types.
+                _queue.submit([this,
+                               ntp = ntp,
+                               partition = std::move(partition)]() mutable {
+                    return reset_domain_manager(
+                      std::move(ntp), std::move(partition));
+                });
+            });
         co_return;
     }
 
@@ -43,6 +73,20 @@ public:
             _as.request_abort();
             co_await *std::exchange(_loop, std::nullopt);
         }
+        _partition_notifications->unregister_partition_notifications(
+          _partition_notifications_id);
+        co_await _queue.shutdown();
+        for (auto& [_, domain_mgr] : _domains) {
+            co_await domain_mgr->stop_and_wait();
+        }
+    }
+
+    ss::lw_shared_ptr<domain_manager> get(const model::ntp& ntp) const {
+        auto it = _domains.find(ntp);
+        if (it == _domains.end()) {
+            return nullptr;
+        }
+        return it->second;
     }
 
 private:
@@ -175,7 +219,60 @@ private:
         }
     }
 
+    ss::future<> reset_domain_manager(
+      model::ntp ntp,
+      std::optional<cluster::partition_change_notifier::partition_state>
+        partition) {
+        auto dm_id = domain_manager_id{ntp};
+        auto dm_it = _domains.find(dm_id);
+        auto dm_exists = dm_it != _domains.end();
+        if (dm_exists) {
+            auto dm = std::move(dm_it->second);
+            _domains.erase(dm_it);
+            auto stop_fut = co_await ss::coroutine::as_future(
+              dm->stop_and_wait());
+            if (stop_fut.failed()) {
+                vlog(
+                  cd_log.error,
+                  "Removing domain manager {} failed: {}",
+                  dm_id,
+                  stop_fut.get_exception());
+            }
+            co_return;
+        }
+        auto requires_domain_mgr = partition && partition->is_leader;
+        if (!requires_domain_mgr) {
+            co_return;
+        }
+        auto& pm = _controller->get_partition_manager().local();
+        auto partition_ptr = pm.get(ntp);
+        if (!partition_ptr) {
+            co_return;
+        }
+        auto domain_mgr = ss::make_lw_shared<domain_manager>(
+          partition_ptr->raft()->stm_manager()->get<simple_stm>());
+        _domains.emplace(dm_id, std::move(domain_mgr));
+    }
+
     cluster::controller* _controller;
+
+    // Notification hook to start domain managers on leaders of the L1
+    // metastore topic partitions.
+    std::unique_ptr<cluster::partition_change_notifier>
+      _partition_notifications;
+    cluster::notification_id_type _partition_notifications_id
+      = cluster::notification_id_type_invalid;
+
+    // Queue to process async work associated with starting and stopping domain
+    // managers when handling partition notifications.
+    ssx::work_queue _queue;
+
+    // Container for domain managers, one per leader of L1 metastore topic
+    // partition.
+    using domain_manager_id = model::ntp;
+    chunked_hash_map<domain_manager_id, ss::lw_shared_ptr<domain_manager>>
+      _domains;
+
     std::optional<ss::future<>> _loop;
     ss::abort_source _as;
 };
@@ -188,5 +285,10 @@ domain_supervisor::~domain_supervisor() = default;
 ss::future<> domain_supervisor::start() { return _impl->start(); }
 
 ss::future<> domain_supervisor::stop() { return _impl->stop(); }
+
+ss::lw_shared_ptr<domain_manager>
+domain_supervisor::get(const model::ntp& ntp) const {
+    return _impl->get(ntp);
+}
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -89,6 +89,14 @@ public:
         return it->second;
     }
 
+    ss::future<bool> maybe_create_metastore_topic() {
+        if (_controller->get_topics_state().local().contains(
+              model::l1_metastore_nt)) {
+            co_return true;
+        }
+        co_return co_await create_domains_topic();
+    }
+
 private:
     ss::future<> do_topic_reconciliation_loop() {
         while (!_as.abort_requested()) {
@@ -98,9 +106,7 @@ private:
                 co_return;
             }
             if (_controller->get_topics_state().local().contains(
-                  model::topic_namespace{
-                    model::kafka_internal_namespace,
-                    model::l1_metastore_topic})) {
+                  model::l1_metastore_nt)) {
                 co_await ensure_domains_replication_factor();
             } else {
                 co_await create_domains_topic();
@@ -150,7 +156,7 @@ private:
         }
     }
 
-    ss::future<> create_domains_topic() {
+    ss::future<bool> create_domains_topic() {
         auto tp_ns = model::l1_metastore_nt;
         cluster::topic_properties topic_props;
         // Mark all these as disabled
@@ -161,8 +167,9 @@ private:
           = tristate<std::chrono::milliseconds>();
         topic_props.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::none;
-        // NOTE: For now we just have a single domain for the entire cluster.
-        co_await create_topic(tp_ns, 1, topic_props);
+        // NOTE: For now we just have a fixed number of domains for the entire
+        // cluster.
+        co_return co_await create_topic(tp_ns, 3, topic_props);
     }
 
     ss::future<> update_topic(cluster::topic_properties_update update) {
@@ -188,7 +195,7 @@ private:
         }
     }
 
-    ss::future<> create_topic(
+    ss::future<bool> create_topic(
       model::topic_namespace_view tp_ns,
       int32_t partition_count,
       cluster::topic_properties properties) {
@@ -208,15 +215,20 @@ private:
                            config::shard_local_cfg().create_topic_timeout_ms());
             vassert(res.size() == 1, "expected a single result");
             ec = res[0].ec;
+            co_return true;
         } catch (const std::exception& ex) {
             vlog(cd_log.warn, "unable to create topic {}: {}", tp_ns, ex);
             ec = cluster::errc::topic_operation_error;
+            co_return false;
         }
-        if (ec != cluster::errc::success) {
-            vlog(cd_log.warn, "failed to create topic {}: {}", tp_ns, ec);
-        } else if (ec != cluster::errc::topic_already_exists) {
+        if (
+          ec == cluster::errc::success
+          || ec == cluster::errc::topic_already_exists) {
             vlog(cd_log.debug, "created topic {}", tp_ns);
+            co_return true;
         }
+        vlog(cd_log.warn, "failed to create topic {}: {}", tp_ns, ec);
+        co_return false;
     }
 
     ss::future<> reset_domain_manager(
@@ -289,6 +301,10 @@ ss::future<> domain_supervisor::stop() { return _impl->stop(); }
 ss::lw_shared_ptr<domain_manager>
 domain_supervisor::get(const model::ntp& ntp) const {
     return _impl->get(ntp);
+}
+
+ss::future<bool> domain_supervisor::maybe_create_metastore_topic() {
+    return _impl->maybe_create_metastore_topic();
 }
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.h
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.h
@@ -9,6 +9,7 @@
  */
 
 #include "base/seastarx.h"
+#include "model/fundamental.h"
 
 #include <seastar/core/future.hh>
 
@@ -17,11 +18,10 @@ class controller;
 }
 
 namespace experimental::cloud_topics::l1 {
+class domain_manager;
 
-// The control plane of cloud topics is responsible for creating
-// domains.
-//
-// There is only a single control plane per node and it runs on shard 0.
+// Responsible for creating and managing domain managers on the leaders of the
+// L1 topic partitions.
 class domain_supervisor {
     class impl;
 
@@ -35,6 +35,11 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+
+    // Returns nullopt if the domain manager for the given L1 metastore NTP, if
+    // one exists (e.g. if it is currently leader and has processed the
+    // appropriate leadership notification).
+    ss::lw_shared_ptr<domain_manager> get(const model::ntp&) const;
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.h
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.h
@@ -41,6 +41,10 @@ public:
     // appropriate leadership notification).
     ss::lw_shared_ptr<domain_manager> get(const model::ntp&) const;
 
+    // Creates the L1 metastore topic, returning false if there was an issue
+    // while creating.
+    ss::future<bool> maybe_create_metastore_topic();
+
 private:
     std::unique_ptr<impl> _impl;
 };

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -21,6 +21,8 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/domain:domain_manager",
+        "//src/v/cloud_topics/level_one/domain:domain_supervisor",
         "//src/v/hashing:murmur",
         "@fmt",
     ],

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -34,7 +34,6 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cluster",
         "//src/v/model",
-        "//src/v/raft",
         "//src/v/rpc",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -97,6 +97,33 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "simple_stm",
+    srcs = [
+        "simple_stm.cc",
+    ],
+    hdrs = [
+        "simple_stm.h",
+    ],
+    implementation_deps = [
+        ":state_update",
+        "//src/v/cloud_topics:logger",
+        "//src/v/serde",
+        "//src/v/ssx:future_util",
+        "//src/v/utils:prefix_logger",
+    ],
+    include_prefix = "cloud_topics/level_one/metastore",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":state",
+        "//src/v/base",
+        "//src/v/cluster:state_machine_registry",
+        "//src/v/model",
+        "//src/v/raft",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "state",
     srcs = [
         "state.cc",

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -9,6 +9,8 @@
  */
 #include "cloud_topics/level_one/metastore/frontend.h"
 
+#include "cloud_topics/level_one/domain/domain_manager.h"
+#include "cloud_topics/level_one/domain/domain_supervisor.h"
 #include "cloud_topics/level_one/metastore/rpc_types.h"
 #include "cloud_topics/logger.h"
 #include "cluster/metadata_cache.h"
@@ -26,37 +28,71 @@ namespace experimental::cloud_topics::l1 {
 namespace {
 
 ss::future<rpc::add_objects_reply> do_add_objects(
-  cluster::partition_manager&, model::ntp, rpc::add_objects_request) {
-    co_return rpc::add_objects_reply{.ec = rpc::errc::ok};
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::add_objects_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::add_objects_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->add_objects(std::move(req));
 }
 
 ss::future<rpc::replace_objects_reply> do_replace_objects(
-  cluster::partition_manager&, model::ntp, rpc::replace_objects_request) {
-    co_return rpc::replace_objects_reply{.ec = rpc::errc::ok};
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::replace_objects_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::replace_objects_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->replace_objects(std::move(req));
 }
 
 ss::future<rpc::get_first_offset_ge_reply> do_get_first_offset_ge(
-  cluster::partition_manager&, model::ntp, rpc::get_first_offset_ge_request) {
-    co_return rpc::get_first_offset_ge_reply{.ec = rpc::errc::ok};
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_first_offset_ge_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_first_offset_ge_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_first_offset_ge(std::move(req));
 }
 
 ss::future<rpc::get_first_timestamp_ge_reply> do_get_first_timestamp_ge(
-  cluster::partition_manager&,
-  model::ntp,
-  rpc::get_first_timestamp_ge_request) {
-    co_return rpc::get_first_timestamp_ge_reply{.ec = rpc::errc::ok};
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_first_timestamp_ge_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_first_timestamp_ge_reply{
+          .ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_first_timestamp_ge(std::move(req));
 }
 
 ss::future<rpc::get_offsets_reply> do_get_offsets(
-  cluster::partition_manager&, model::ntp, rpc::get_offsets_request) {
-    co_return rpc::get_offsets_reply{.ec = rpc::errc::ok};
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_offsets_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_offsets_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_offsets(std::move(req));
 }
 
 ss::future<rpc::get_compaction_offsets_reply> do_get_compaction_offsets(
-  cluster::partition_manager&,
-  model::ntp,
-  rpc::get_compaction_offsets_request) {
-    co_return rpc::get_compaction_offsets_reply{.ec = rpc::errc::ok};
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_compaction_offsets_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_compaction_offsets_reply{
+          .ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_compaction_offsets(std::move(req));
 }
 
 } // namespace
@@ -191,7 +227,8 @@ frontend::frontend(
   ss::sharded<cluster::metadata_cache>* metadata,
   ss::sharded<cluster::partition_leaders_table>* leaders,
   ss::sharded<cluster::shard_table>* shards,
-  ss::sharded<::rpc::connection_cache>* connections)
+  ss::sharded<::rpc::connection_cache>* connections,
+  domain_supervisor* domain_supervisor)
   : _self(self)
   , _group_mgr(group_mgr)
   , _partition_mgr(partition_mgr)
@@ -199,7 +236,8 @@ frontend::frontend(
   , _metadata(metadata)
   , _leaders(leaders)
   , _shard_table(shards)
-  , _connection_cache(connections) {}
+  , _connection_cache(connections)
+  , _domain_supervisor(domain_supervisor) {}
 
 ss::future<> frontend::stop() { return _gate.close(); }
 
@@ -283,11 +321,10 @@ ss::future<rpc::add_objects_reply> frontend::add_objects_locally(
   rpc::add_objects_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    co_return co_await _partition_mgr->invoke_on(
-      shard,
-      [metastore_ntp,
-       req = std::move(request)](cluster::partition_manager& pm) mutable {
-          return do_add_objects(pm, metastore_ntp, std::move(req));
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_add_objects(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
@@ -303,11 +340,10 @@ ss::future<rpc::replace_objects_reply> frontend::replace_objects_locally(
   rpc::replace_objects_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    co_return co_await _partition_mgr->invoke_on(
-      shard,
-      [metastore_ntp,
-       req = std::move(request)](cluster::partition_manager& pm) mutable {
-          return do_replace_objects(pm, metastore_ntp, std::move(req));
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_replace_objects(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
@@ -324,11 +360,10 @@ frontend::get_first_offset_ge_locally(
   rpc::get_first_offset_ge_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    co_return co_await _partition_mgr->invoke_on(
-      shard,
-      [metastore_ntp,
-       req = std::move(request)](cluster::partition_manager& pm) mutable {
-          return do_get_first_offset_ge(pm, metastore_ntp, std::move(req));
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_get_first_offset_ge(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
@@ -345,11 +380,10 @@ frontend::get_first_timestamp_ge_locally(
   rpc::get_first_timestamp_ge_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    co_return co_await _partition_mgr->invoke_on(
-      shard,
-      [metastore_ntp,
-       req = std::move(request)](cluster::partition_manager& pm) mutable {
-          return do_get_first_timestamp_ge(pm, metastore_ntp, std::move(req));
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_get_first_timestamp_ge(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
@@ -366,11 +400,10 @@ ss::future<rpc::get_offsets_reply> frontend::get_offsets_locally(
   rpc::get_offsets_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    co_return co_await _partition_mgr->invoke_on(
-      shard,
-      [metastore_ntp,
-       req = std::move(request)](cluster::partition_manager& pm) mutable {
-          return do_get_offsets(pm, metastore_ntp, std::move(req));
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_get_offsets(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
@@ -387,11 +420,10 @@ frontend::get_compaction_offsets_locally(
   rpc::get_compaction_offsets_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
-    co_return co_await _partition_mgr->invoke_on(
-      shard,
-      [metastore_ntp,
-       req = std::move(request)](cluster::partition_manager& pm) mutable {
-          return do_get_compaction_offsets(pm, metastore_ntp, std::move(req));
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_get_compaction_offsets(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -15,12 +15,9 @@
 #include "cloud_topics/logger.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_leaders_table.h"
-#include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
-#include "cluster/topics_frontend.h"
 #include "hashing/murmur.h"
 #include "model/namespace.h"
-#include "raft/group_manager.h"
 #include "rpc/connection_cache.h"
 
 namespace experimental::cloud_topics::l1 {
@@ -221,18 +218,12 @@ template ss::future<rpc::get_compaction_offsets_reply> frontend::process<
 
 frontend::frontend(
   model::node_id self,
-  ss::sharded<raft::group_manager>* group_mgr,
-  ss::sharded<cluster::partition_manager>* partition_mgr,
-  ss::sharded<cluster::topics_frontend>* topics_frontend,
   ss::sharded<cluster::metadata_cache>* metadata,
   ss::sharded<cluster::partition_leaders_table>* leaders,
   ss::sharded<cluster::shard_table>* shards,
   ss::sharded<::rpc::connection_cache>* connections,
   domain_supervisor* domain_supervisor)
   : _self(self)
-  , _group_mgr(group_mgr)
-  , _partition_mgr(partition_mgr)
-  , _topics_frontend(topics_frontend)
   , _metadata(metadata)
   , _leaders(leaders)
   , _shard_table(shards)
@@ -242,64 +233,7 @@ frontend::frontend(
 ss::future<> frontend::stop() { return _gate.close(); }
 
 ss::future<bool> frontend::ensure_topic_exists() {
-    // todo: make these configurable.
-    static constexpr int16_t default_replication_factor = 3;
-    static constexpr int32_t default_metastore_partitions = 3;
-
-    const auto& metadata = _metadata->local();
-    if (metadata.get_topic_metadata_ref(model::l1_metastore_nt)) {
-        co_return true;
-    }
-    auto replication_factor = default_replication_factor;
-    if (replication_factor > static_cast<int16_t>(metadata.node_count())) {
-        replication_factor = 1;
-    }
-
-    cluster::topic_configuration topic{
-      model::kafka_internal_namespace,
-      model::l1_metastore_topic,
-      default_metastore_partitions,
-      replication_factor};
-
-    // todo: fix this by implementing on demand raft
-    // snapshots.
-    topic.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::none;
-    topic.properties.retention_bytes = tristate<size_t>();
-    topic.properties.retention_local_target_bytes = tristate<size_t>();
-    topic.properties.retention_duration = tristate<std::chrono::milliseconds>();
-    topic.properties.retention_local_target_ms
-      = tristate<std::chrono::milliseconds>();
-
-    try {
-        auto res = co_await _topics_frontend->local().autocreate_topics(
-          {std::move(topic)},
-          config::shard_local_cfg().create_topic_timeout_ms());
-        vassert(
-          res.size() == 1,
-          "Incorrect result when creating {}, expected 1 response, "
-          "got: {}",
-          model::l1_metastore_topic,
-          res.size());
-        if (
-          res[0].ec != cluster::errc::success
-          && res[0].ec != cluster::errc::topic_already_exists) {
-            vlog(
-              cd_log.warn,
-              "can not create topic: {} - error: {}",
-              model::l1_metastore_topic,
-              cluster::make_error_code(res[0].ec).message());
-            co_return false;
-        }
-        co_return true;
-    } catch (const std::exception_ptr& e) {
-        vlog(
-          cd_log.warn,
-          "can not create topic: {} - error: {}",
-          model::l1_metastore_topic,
-          e);
-        co_return false;
-    }
+    return _domain_supervisor->maybe_create_metastore_topic();
 }
 
 std::optional<model::partition_id>

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -34,6 +34,7 @@ concept request_has_topic_id_partition = requires(T t) {
 };
 
 namespace experimental::cloud_topics::l1 {
+class domain_supervisor;
 
 /*
  * Frontend is the gateway into a partition of a partitioned metastore on a
@@ -53,7 +54,8 @@ public:
       ss::sharded<cluster::metadata_cache>*,
       ss::sharded<cluster::partition_leaders_table>*,
       ss::sharded<cluster::shard_table>*,
-      ss::sharded<::rpc::connection_cache>*);
+      ss::sharded<::rpc::connection_cache>*,
+      domain_supervisor*);
 
     ss::future<> stop();
 
@@ -145,6 +147,7 @@ private:
     ss::sharded<cluster::partition_leaders_table>* _leaders;
     ss::sharded<cluster::shard_table>* _shard_table;
     ss::sharded<::rpc::connection_cache>* _connection_cache;
+    domain_supervisor* _domain_supervisor;
 };
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -15,7 +15,6 @@
 #include "cloud_topics/level_one/metastore/rpc_types.h"
 #include "cluster/fwd.h"
 #include "model/fundamental.h"
-#include "raft/fwd.h"
 #include "rpc/fwd.h"
 
 #include <seastar/core/abort_source.hh>
@@ -48,9 +47,6 @@ public:
 
     frontend(
       model::node_id self,
-      ss::sharded<raft::group_manager>*,
-      ss::sharded<cluster::partition_manager>*,
-      ss::sharded<cluster::topics_frontend>*,
       ss::sharded<cluster::metadata_cache>*,
       ss::sharded<cluster::partition_leaders_table>*,
       ss::sharded<cluster::shard_table>*,
@@ -140,9 +136,6 @@ private:
 
     ss::gate _gate;
     model::node_id _self;
-    ss::sharded<raft::group_manager>* _group_mgr;
-    ss::sharded<cluster::partition_manager>* _partition_mgr;
-    ss::sharded<cluster::topics_frontend>* _topics_frontend;
     ss::sharded<cluster::metadata_cache>* _metadata;
     ss::sharded<cluster::partition_leaders_table>* _leaders;
     ss::sharded<cluster::shard_table>* _shard_table;

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -201,7 +201,11 @@ public:
       = 0;
 
     // Returns metadata required to determine what to compact for the given
-    // partition. Below is pseudocode for sample usage:
+    // partition. Cleaned ranges with tombstones that were cleaned at or below
+    // tombstone_removal_upper_bound_ts are eligible to have tombstones
+    // entirely removed. These ranges will be returned in the response.
+    //
+    // Below is pseudocode for sample usage:
     //
     // offsets = co_await metastore.get_compaction_offsets( \
     //   partition, tombstone_removal_upper_bound_ts);
@@ -233,7 +237,9 @@ public:
     // co_await metastore.compact_objects( \
     //   objects, {{tp, {new_cleaned_ranges, removed_tombstones_ranges}}})
     virtual ss::future<std::expected<compaction_offsets_response, errc>>
-    get_compaction_offsets(const model::topic_id_partition&, model::timestamp)
+    get_compaction_offsets(
+      const model::topic_id_partition&,
+      model::timestamp tombstone_removal_upper_bound_ts)
       = 0;
 };
 

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -25,6 +25,7 @@ enum class errc : int16_t {
     timed_out,
     not_leader,
     concurrent_requests,
+    state_error,
 };
 
 struct add_objects_reply
@@ -40,10 +41,10 @@ struct add_objects_request
       serde::version<0>,
       serde::compat_version<0>> {
     using resp_t = add_objects_reply;
-    auto serde_fields() { return std::tie(update, metastore_partition); }
+    auto serde_fields() { return std::tie(metastore_partition, new_objects); }
 
-    add_objects_update update;
     model::partition_id metastore_partition;
+    chunked_vector<new_object> new_objects;
 };
 
 struct replace_objects_reply
@@ -61,10 +62,14 @@ struct replace_objects_request
       serde::version<0>,
       serde::compat_version<0>> {
     using resp_t = replace_objects_reply;
-    auto serde_fields() { return std::tie(update, metastore_partition); }
+    auto serde_fields() {
+        return std::tie(metastore_partition, new_objects, compaction_updates);
+    }
 
-    replace_objects_update update;
     model::partition_id metastore_partition;
+    chunked_vector<new_object> new_objects;
+    chunked_hash_map<model::topic_id_partition, compaction_state_update>
+      compaction_updates;
 };
 
 struct object_metadata
@@ -92,9 +97,10 @@ struct get_first_offset_ge_request
       serde::version<0>,
       serde::compat_version<0>> {
     using resp_t = get_first_offset_ge_reply;
-    auto serde_fields() { return std::tie(tp); }
+    auto serde_fields() { return std::tie(tp, o); }
 
     model::topic_id_partition tp;
+    kafka::offset o;
 };
 
 struct get_first_timestamp_ge_reply
@@ -113,9 +119,10 @@ struct get_first_timestamp_ge_request
       serde::version<0>,
       serde::compat_version<0>> {
     using resp_t = get_first_timestamp_ge_reply;
-    auto serde_fields() { return std::tie(tp); }
+    auto serde_fields() { return std::tie(tp, ts); }
 
     model::topic_id_partition tp;
+    model::timestamp ts;
 };
 
 struct get_offsets_reply
@@ -157,9 +164,16 @@ struct get_compaction_offsets_request
       serde::version<0>,
       serde::compat_version<0>> {
     using resp_t = get_compaction_offsets_reply;
-    auto serde_fields() { return std::tie(tp); }
+    auto serde_fields() {
+        return std::tie(tp, tombstone_removal_upper_bound_ts);
+    }
 
     model::topic_id_partition tp;
+
+    // Cleaned ranges with tombstones that were cleaned at or below this
+    // timestamp are eligible to have tombstones entirely removed. These ranges
+    // will be returned in the removable_tombstone_ranges field.
+    model::timestamp tombstone_removal_upper_bound_ts;
 };
 
 } //  namespace experimental::cloud_topics::l1::rpc

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -95,13 +95,19 @@ simple_metastore::object_builder() {
 
 ss::future<std::expected<metastore::offsets_response, metastore::errc>>
 simple_metastore::get_offsets(const model::topic_id_partition& tpr) {
-    auto prt_ref = state_.partition_state(tpr);
+    co_return get_offsets(state_, tpr);
+}
+
+std::expected<metastore::offsets_response, metastore::errc>
+simple_metastore::get_offsets(
+  const state& state, const model::topic_id_partition& tpr) {
+    auto prt_ref = state.partition_state(tpr);
     if (!prt_ref.has_value()) {
         vlog(cd_log.debug, "Partition {} not tracked", tpr);
-        co_return std::unexpected(metastore::errc::missing_ntp);
+        return std::unexpected(metastore::errc::missing_ntp);
     }
     const auto& prt = prt_ref->get();
-    co_return offsets_response{
+    return offsets_response{
       .start_offset = prt.start_offset,
       .next_offset = prt.next_offset,
     };
@@ -167,43 +173,65 @@ simple_metastore::replace_objects(
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 simple_metastore::get_first_ge(
   const model::topic_id_partition& tpr, kafka::offset o) {
-    auto prt_ref = state_.partition_state(tpr);
+    co_return get_first_ge(state_, tpr, o);
+}
+
+std::expected<metastore::object_response, metastore::errc>
+simple_metastore::get_first_ge(
+  const state& state, const model::topic_id_partition& tpr, kafka::offset o) {
+    auto prt_ref = state.partition_state(tpr);
     if (!prt_ref.has_value()) {
         vlog(cd_log.debug, "Partition {} not tracked", tpr);
-        co_return std::unexpected(metastore::errc::missing_ntp);
+        return std::unexpected(metastore::errc::missing_ntp);
     }
     auto& prt = prt_ref->get();
     auto it = std::ranges::lower_bound(
       prt.extents, o, std::less<>{}, &extent::last_offset);
     if (it != prt.extents.end()) {
-        auto footer_pos = state_.objects[it->oid].footer_pos;
-        co_return metastore::object_response{
+        auto object_it = state.objects.find(it->oid);
+        if (object_it == state.objects.end()) {
+            return std::unexpected(metastore::errc::out_of_range);
+        }
+        auto footer_pos = object_it->second.footer_pos;
+        return metastore::object_response{
           .oid = it->oid,
           .footer_pos = footer_pos,
         };
     }
-    co_return std::unexpected(metastore::errc::out_of_range);
+    return std::unexpected(metastore::errc::out_of_range);
 }
 
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 simple_metastore::get_first_ge(
   const model::topic_id_partition& tpr, model::timestamp ts) {
-    auto prt_ref = state_.partition_state(tpr);
+    co_return get_first_ge(state_, tpr, ts);
+}
+
+std::expected<metastore::object_response, metastore::errc>
+simple_metastore::get_first_ge(
+  const state& state,
+  const model::topic_id_partition& tpr,
+  model::timestamp ts) {
+    auto prt_ref = state.partition_state(tpr);
     if (!prt_ref.has_value()) {
         vlog(cd_log.debug, "Partition {} not tracked", tpr);
-        co_return std::unexpected(metastore::errc::missing_ntp);
+        return std::unexpected(metastore::errc::missing_ntp);
     }
     auto& prt = prt_ref->get();
     for (const auto& obj : prt.extents) {
         if (obj.max_timestamp >= ts) {
-            auto footer_pos = state_.objects[obj.oid].footer_pos;
-            co_return metastore::object_response{
+            auto object_it = state.objects.find(obj.oid);
+            if (object_it == state.objects.end()) {
+                return std::unexpected(metastore::errc::out_of_range);
+            }
+            auto footer_pos = object_it->second.footer_pos;
+            return metastore::object_response{
               .oid = obj.oid,
               .footer_pos = footer_pos,
             };
         }
     }
-    co_return std::unexpected(metastore::errc::out_of_range);
+    return std::unexpected(metastore::errc::out_of_range);
 }
 
 ss::future<std::expected<void, metastore::errc>>
@@ -260,22 +288,30 @@ ss::future<
 simple_metastore::get_compaction_offsets(
   const model::topic_id_partition& tp,
   model::timestamp tombstone_removal_upper_bound_ts) {
-    auto prt_ref = state_.partition_state(tp);
+    co_return get_compaction_offsets(
+      state_, tp, tombstone_removal_upper_bound_ts);
+}
+std::expected<metastore::compaction_offsets_response, metastore::errc>
+simple_metastore::get_compaction_offsets(
+  const state& state,
+  const model::topic_id_partition& tp,
+  model::timestamp tombstone_removal_upper_bound_ts) {
+    auto prt_ref = state.partition_state(tp);
     if (!prt_ref.has_value()) {
         vlog(cd_log.debug, "Partition {} not tracked", tp);
-        co_return std::unexpected(metastore::errc::missing_ntp);
+        return std::unexpected(metastore::errc::missing_ntp);
     }
     auto& prt = prt_ref->get();
     compaction_offsets_response resp;
     if (prt.start_offset >= prt.next_offset) {
         // The log is empty, nothing to compact.
-        co_return resp;
+        return resp;
     }
     if (!prt.compaction_state.has_value()) {
         // Nothing has been compacted yet, the whole log is dirty.
         resp.dirty_ranges.insert(
           prt.start_offset, kafka::prev_offset(prt.next_offset));
-        co_return resp;
+        return resp;
     }
 
     // Iterate through the clean ranges to produce the dirty ranges.
@@ -303,7 +339,7 @@ simple_metastore::get_compaction_offsets(
               r.base_offset, r.last_offset);
         }
     }
-    co_return resp;
+    return resp;
 }
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -45,6 +45,7 @@ private:
 
 // Wrapper around state to implement the `metastore` interface.
 // Not replicated or persisted, used for tests only.
+class domain_manager;
 class simple_metastore : public metastore {
 public:
     std::unique_ptr<object_metadata_builder> object_builder() override;
@@ -79,6 +80,7 @@ public:
       const model::topic_id_partition&, model::timestamp) override;
 
 private:
+    friend class domain_manager;
     static std::expected<offsets_response, errc>
     get_offsets(const state&, const model::topic_id_partition&);
     static std::expected<object_response, errc>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -79,6 +79,16 @@ public:
       const model::topic_id_partition&, model::timestamp) override;
 
 private:
+    static std::expected<offsets_response, errc>
+    get_offsets(const state&, const model::topic_id_partition&);
+    static std::expected<object_response, errc>
+    get_first_ge(const state&, const model::topic_id_partition&, kafka::offset);
+    static std::expected<object_response, errc> get_first_ge(
+      const state&, const model::topic_id_partition&, model::timestamp);
+    static std::expected<compaction_offsets_response, errc>
+    get_compaction_offsets(
+      const state&, const model::topic_id_partition&, model::timestamp);
+
     state state_;
 };
 

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/metastore/simple_stm.h"
+
+#include "cloud_topics/level_one/metastore/state.h"
+#include "cloud_topics/level_one/metastore/state_update.h"
+#include "cloud_topics/logger.h"
+#include "model/namespace.h"
+#include "model/record_batch_types.h"
+#include "serde/async.h"
+#include "ssx/future-util.h"
+#include "utils/prefix_logger.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+namespace experimental::cloud_topics::l1 {
+
+namespace {
+template<typename Res>
+void maybe_log_update_error(
+  prefix_logger& log,
+  update_key key,
+  model::offset o,
+  const std::expected<Res, stm_update_error>& r) {
+    if (r.has_value()) {
+        return;
+    }
+    // NOTE: inability to update the STM is not necessarily a bug! It indicates
+    // that this update's construction raced with another update that broke an
+    // invariant required to apply update. Expectation is that this update's
+    // caller constructs a new update and tries again if needed.
+    vlog(
+      log.debug,
+      "L1 metastore STM {} update at offset {} didn't apply: {}",
+      key,
+      o,
+      r.error());
+}
+} // namespace
+
+simple_stm::simple_stm(
+  ss::logger& logger,
+  raft::consensus* raft,
+  config::binding<std::chrono::seconds> snapshot_delay)
+  : metastore_stm_base("l1_simple_stm.snapshot", logger, raft)
+  , snapshot_delay_secs_(std::move(snapshot_delay)) {
+    snapshot_timer_.set_callback([this] { write_snapshot_async(); });
+}
+
+ss::future<std::expected<model::term_id, simple_stm::errc>>
+simple_stm::sync(model::timeout_clock::duration timeout) {
+    auto sync_res = co_await ss::coroutine::as_future(
+      metastore_stm_base::sync(timeout));
+    if (sync_res.failed()) {
+        auto eptr = sync_res.get_exception();
+        auto msg = fmt::format("Exception caught while syncing: {}", eptr);
+        if (ssx::is_shutdown_exception(eptr)) {
+            vlog(cd_log.debug, "Ignoring shutdown error: {}", msg);
+            co_return std::unexpected(errc::shutting_down);
+        }
+        vlog(cd_log.warn, "{}", msg);
+        co_return std::unexpected(errc::raft_error);
+    }
+
+    if (!sync_res.get()) {
+        co_return std::unexpected(errc::not_leader);
+    }
+    // At this point we're guaranteed that this node is the leader and that the
+    // STM has been caught up in the current term before (this doesn't mean the
+    // STM is currently caught up right now though!)
+    co_return _insync_term;
+}
+
+ss::future<std::expected<void, simple_stm::errc>>
+simple_stm::replicate_and_wait(
+  model::term_id term, model::record_batch batch, ss::abort_source& as) {
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, std::ref(as));
+    opts.set_force_flush();
+    auto res = co_await _raft->replicate(term, std::move(batch), opts);
+    if (res.has_error()) {
+        co_return std::unexpected(errc::raft_error);
+    }
+    auto replicated_offset = res.value().last_offset;
+    co_await wait_no_throw(
+      replicated_offset, ss::lowres_clock::now() + 30s, as);
+    co_return std::expected<void, errc>{};
+}
+
+ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
+    if (batch.header().type != model::record_batch_type::l1_stm) {
+        co_return;
+    }
+
+    auto iter = model::record_batch_iterator::create(batch);
+    while (iter.has_next()) {
+        auto r = iter.next();
+        auto key_buf = r.release_key();
+        if (key_buf.size_bytes() == 0) {
+            continue;
+        }
+
+        iobuf_parser key_parser(std::move(key_buf));
+        auto key = serde::read<update_key>(key_parser);
+
+        iobuf value_buf = r.release_value();
+        iobuf_parser value_parser(std::move(value_buf));
+
+        auto o = batch.base_offset() + model::offset_delta{r.offset_delta()};
+        switch (key) {
+        case update_key::add_objects: {
+            auto update = serde::read<add_objects_update>(value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+            break;
+        }
+        case update_key::replace_objects: {
+            auto update = serde::read<replace_objects_update>(value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+            break;
+        }
+        }
+    }
+
+    rearm_snapshot_timer();
+}
+
+model::offset simple_stm::max_removable_local_log_offset() { return {}; }
+
+ss::future<raft::local_snapshot_applied> simple_stm::apply_local_snapshot(
+  raft::stm_snapshot_header, iobuf&& snapshot_buf) {
+    auto parser = iobuf_parser(std::move(snapshot_buf));
+    auto snapshot = co_await serde::read_async<stm_snapshot>(parser);
+    state_ = std::move(snapshot.state);
+    co_return raft::local_snapshot_applied::yes;
+}
+
+ss::future<raft::stm_snapshot>
+simple_stm::take_local_snapshot(ssx::semaphore_units units) {
+    auto snapshot_offset = last_applied_offset();
+    auto snapshot = make_snapshot();
+    units.return_all();
+    iobuf snapshot_buf;
+    co_await serde::write_async(snapshot_buf, std::move(snapshot));
+    co_return raft::stm_snapshot::create(
+      0, snapshot_offset, std::move(snapshot_buf));
+}
+
+ss::future<> simple_stm::apply_raft_snapshot(const iobuf& snapshot_buf) {
+    auto parser = iobuf_parser(snapshot_buf.copy());
+    auto snapshot = co_await serde::read_async<stm_snapshot>(parser);
+    state_ = std::move(snapshot.state);
+}
+
+ss::future<iobuf> simple_stm::take_raft_snapshot() {
+    iobuf snapshot_buf;
+    co_await serde::write_async(snapshot_buf, make_snapshot());
+    co_return std::move(snapshot_buf);
+}
+
+stm_snapshot simple_stm::make_snapshot() const {
+    return {.state = state_.copy()};
+}
+
+ss::future<> simple_stm::stop() {
+    snapshot_timer_.cancel();
+    co_return co_await metastore_stm_base::stop();
+}
+
+ss::future<> simple_stm::maybe_write_snapshot() {
+    if (_raft->last_snapshot_index() >= last_applied()) {
+        co_return;
+    }
+    auto snapshot = co_await _raft->stm_manager()->take_snapshot();
+    vlog(
+      _log.debug,
+      "creating snapshot at offset: {}",
+      snapshot.last_included_offset);
+    co_await _raft->write_snapshot(raft::write_snapshot_cfg(
+      snapshot.last_included_offset, std::move(snapshot.data)));
+}
+
+void simple_stm::write_snapshot_async() {
+    ssx::background = ssx::spawn_with_gate_then(
+                        _gate, [this] { return maybe_write_snapshot(); })
+                        .handle_exception([this](const std::exception_ptr& e) {
+                            vlog(_log.warn, "failed to write snapshot: {}", e);
+                        })
+                        .finally([holder = _gate.hold()] {});
+}
+
+void simple_stm::rearm_snapshot_timer() {
+    if (_gate.is_closed() || snapshot_timer_.armed()) {
+        return;
+    }
+    snapshot_timer_.arm(ss::lowres_clock::now() + snapshot_delay_secs_());
+}
+
+bool stm_factory::is_applicable_for(const storage::ntp_config& ntp_cfg) const {
+    const auto& ntp = ntp_cfg.ntp();
+    return (ntp.ns == model::kafka_internal_namespace)
+           && (ntp.tp.topic == model::l1_metastore_topic);
+}
+
+void stm_factory::create(
+  raft::state_machine_manager_builder& builder,
+  raft::consensus* raft,
+  const cluster::stm_instance_config&) {
+    auto stm = builder.create_stm<simple_stm>(
+      cd_log, raft, config::mock_binding(10s));
+    raft->log()->stm_manager()->add_stm(stm);
+}
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/metastore/state.h"
+#include "cluster/state_machine_registry.h"
+#include "raft/persisted_stm.h"
+
+namespace experimental::cloud_topics::l1 {
+
+using metastore_stm_base = raft::persisted_stm_no_snapshot_at_offset<>;
+
+// Replicated state machine for tracking L1 metastore state. This is meant to
+// back a metastore implementation, similar to simple_metastore, but is
+// persisted and replicated, making it slightly more useful for end-to-end
+// testing that may involve multiple nodes.
+//
+// This is not a full solution though, since it keeps everything in memory. It
+// is only meant for use in tests.
+//
+// TODO: lots of this code is torn exactly from coordinator/state_machine.*.
+// There is likely an abstraction to pull out.
+class simple_stm final : public metastore_stm_base {
+public:
+    static constexpr std::string_view name = "l1_simple_stm";
+    enum class errc {
+        not_leader,
+        apply_error,
+        raft_error,
+        shutting_down,
+    };
+
+    explicit simple_stm(
+      ss::logger&, raft::consensus*, config::binding<std::chrono::seconds>);
+    raft::consensus* raft() { return _raft; }
+
+    // Syncs the STM such that we're guaranteed that it has applied all records
+    // from the previous terms. Calling does _not_ ensure that all records from
+    // the current term have been applied. But it does establish for new
+    // leaders that they are up-to-date.
+    //
+    // Returns the current term.
+    ss::future<std::expected<model::term_id, errc>>
+    sync(model::timeout_clock::duration timeout);
+
+    // Replicates the given batch and waits for it to finish replicating.
+    // Success here does not guarantee that the replicated operation succeeded
+    // in updating the STM -- only that the apply was attempted.
+    ss::future<std::expected<void, errc>> replicate_and_wait(
+      model::term_id, model::record_batch batch, ss::abort_source&);
+
+    const state& state() const { return state_; }
+
+    raft::stm_initial_recovery_policy
+    get_initial_recovery_policy() const final {
+        return raft::stm_initial_recovery_policy::read_everything;
+    }
+
+protected:
+    ss::future<> stop() override;
+
+    stm_snapshot make_snapshot() const;
+
+    ss::future<> do_apply(const model::record_batch&) override;
+
+    model::offset max_removable_local_log_offset() override;
+
+    ss::future<raft::local_snapshot_applied>
+    apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override;
+
+    ss::future<raft::stm_snapshot>
+      take_local_snapshot(ssx::semaphore_units) override;
+
+    ss::future<> apply_raft_snapshot(const iobuf&) final;
+
+    ss::future<iobuf> take_raft_snapshot() final;
+
+private:
+    void rearm_snapshot_timer();
+    void write_snapshot_async();
+    ss::future<> maybe_write_snapshot();
+
+    // The deterministic state managed by this STM.
+    struct state state_;
+    config::binding<std::chrono::seconds> snapshot_delay_secs_;
+    ss::timer<ss::lowres_clock> snapshot_timer_;
+};
+
+class stm_factory : public cluster::state_machine_factory {
+public:
+    stm_factory() = default;
+    bool is_applicable_for(const storage::ntp_config&) const final;
+    void create(
+      raft::state_machine_manager_builder&,
+      raft::consensus*,
+      const cluster::stm_instance_config&) final;
+};
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -229,4 +229,12 @@ struct state
     partition_state(const model::topic_id_partition&) const;
 };
 
+struct stm_snapshot
+  : public serde::
+      envelope<stm_snapshot, serde::version<0>, serde::compat_version<0>> {
+    state state;
+
+    auto serde_fields() { return std::tie(state); }
+};
+
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -130,6 +130,10 @@ public:
 
     ss::sharded<drain_manager>& get_drain_manager() { return _drain_manager; }
 
+    ss::sharded<raft::group_manager>& get_raft_manager() {
+        return _raft_manager;
+    }
+
     ss::sharded<partition_manager>& get_partition_manager() {
         return _partition_manager;
     }

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -417,6 +417,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "cluster_link";
     case record_batch_type::group_block:
         return o << "group_block";
+    case record_batch_type::l1_stm:
+        return o << "l1_stm";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -61,7 +61,8 @@ enum class record_batch_type : int8_t {
     datalake_translation_state = 38, // maintains state for translation progress
     cluster_link = 39,               // cluster link update batches
     group_block = 40, // (un)blocks group names in a consumer offsets partition
-    MAX = group_block,
+    l1_stm = 41,      // cloud_topics::l1::*
+    MAX = l1_stm,
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -24,6 +24,8 @@ redpanda_cc_library(
         "//src/v/cloud_topics:cluster_services_interface",
         "//src/v/cloud_topics:data_plane_impl",
         "//src/v/cloud_topics:app",
+        "//src/v/cloud_topics/level_one/metastore:frontend",
+        "//src/v/cloud_topics/level_one/metastore:simple_stm",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_factory",
         "//src/v/cluster",
         "//src/v/cluster/utils:partition_change_notifier_impl",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -22,6 +22,8 @@
 #include "cloud_storage_clients/configuration.h"
 #include "cloud_topics/cluster_services.h"
 #include "cloud_topics/data_plane_impl.h"
+#include "cloud_topics/level_one/metastore/service.h"
+#include "cloud_topics/level_one/metastore/simple_stm.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_factory.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/archiver_manager.h"
@@ -2169,6 +2171,18 @@ void application::wire_up_redpanda_services(
                 controller.get());
           }))
           .get();
+
+        construct_service(
+          l1_metastore_fe,
+          node_id,
+          &metadata_cache,
+          &controller->get_partition_leaders(),
+          &controller->get_shard_table(),
+          &_connection_cache,
+          ss::sharded_parameter([this] {
+              return cloud_topics_api.local().get_l1_domain_supervisor();
+          }))
+          .get();
     }
 
     // group membership
@@ -3118,6 +3132,8 @@ void application::start_runtime_services(
           if (config::shard_local_cfg().development_enable_cloud_topics()) {
               pm.register_factory<
                 experimental::cloud_topics::ctp_stm_factory>();
+              pm.register_factory<
+                experimental::cloud_topics::l1::stm_factory>();
           }
       })
       .get();
@@ -3337,6 +3353,13 @@ void application::start_runtime_services(
               sched_groups.cluster_sg(),
               smp_service_groups.cluster_smp_sg(),
               std::ref(_consumer_group_lag_metrics_frontend)));
+          if (config::shard_local_cfg().development_enable_cloud_topics()) {
+              runtime_services.push_back(
+                std::make_unique<experimental::cloud_topics::l1::rpc::service>(
+                  sched_groups.datalake_sg(),
+                  smp_service_groups.datalake_sg(),
+                  &l1_metastore_fe));
+          }
 
           s.add_services(std::move(runtime_services));
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "cloud_topics/app.h"
+#include "cloud_topics/level_one/metastore/frontend.h"
 #include "cluster/archival/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
@@ -203,6 +204,7 @@ public:
     ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<experimental::cloud_topics::app> cloud_topics_api;
+    ss::sharded<experimental::cloud_topics::l1::frontend> l1_metastore_fe;
 
     const std::unique_ptr<pandaproxy::schema_registry::api>& schema_registry() {
         return _schema_registry;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds plumbing and boilerplate code as a precursor for a metastore implementation that is backed by Raft-backed partitions of the L1 metastore topic. Namely, this PR:
- introduces a persisted STM for the L1 metastore, with mostly trivial calls into the existing `state` class, reusing existing code from `simple_metastore`
- introduces a "domain manager" that wraps the STM (the spiritual equivalent of datalake::coordinator or the NTP archiver)
- manages domain managers with the domain supervisor on leaders of the metastore topic partitions
- passes through requests from the frontend to the domain managers

Conceptually, all the plumbing (frontend, domain manager, supervisor, STM) is now there to implement the metastore interface with the STMs. This PR stops short of actually implementing it though, since the amount of code just for this plumbing is pretty non-trivial.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
