### PR TITLE
CORE-13007 - Implement topic properties sync

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -27,6 +27,7 @@ using ::cluster_link::model::add_mirror_topic_cmd;
 using ::cluster_link::model::id_t;
 using ::cluster_link::model::metadata;
 using ::cluster_link::model::name_t;
+using ::cluster_link::model::update_mirror_topic_properties_cmd;
 using ::cluster_link::model::update_mirror_topic_state_cmd;
 
 namespace {
@@ -126,6 +127,18 @@ ss::future<errc> frontend::update_mirror_topic_state(
     }
     cluster_link_cmd c{
       cluster::cluster_link_update_mirror_topic_state_cmd(id, std::move(cmd))};
+    co_return co_await do_mutation(std::move(c), timeout);
+}
+
+ss::future<errc> frontend::update_mirror_topic_properties(
+  id_t id,
+  update_mirror_topic_properties_cmd cmd,
+  model::timeout_clock::time_point timeout) {
+    if (!cluster_link_active()) {
+        co_return errc::feature_disabled;
+    }
+    cluster_link_cmd c{cluster::cluster_link_update_mirror_topic_properties_cmd(
+      id, std::move(cmd))};
     co_return co_await do_mutation(std::move(c), timeout);
 }
 
@@ -253,6 +266,28 @@ ss::future<errc> frontend::dispatch_mutation_to_remote(
                     .then(
                       [](
                         result<cluster::update_mirror_topic_state_response> r) {
+                          if (r.has_error()) {
+                              return result<void>(r.error());
+                          }
+                          return result<void>(r.value().ec);
+                      });
+              },
+              [client,
+               timeout](cluster::cluster_link_update_mirror_topic_properties_cmd
+                          cmd) mutable {
+                  return client
+                    .update_mirror_topic_properties(
+                      cluster::update_mirror_topic_properties_request{
+                        .link_id = cmd.key,
+                        .cmd = std::move(cmd.value),
+                        .timeout = timeout},
+                      rpc::client_opts(timeout))
+                    .then(&rpc::get_ctx_data<
+                          cluster::update_mirror_topic_properties_response>)
+                    .then(
+                      [](
+                        result<cluster::update_mirror_topic_properties_response>
+                          r) {
                           if (r.has_error()) {
                               return result<void>(r.error());
                           }
@@ -449,6 +484,61 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
                 cmd.value.topic);
               return errc::topic_being_mirrored_by_other_link;
           }
+          return errc::success;
+      },
+      [this](
+        const cluster::cluster_link_update_mirror_topic_properties_cmd& cmd) {
+          auto ec = model::validate_kafka_topic_name(cmd.value.topic);
+          if (ec) {
+              vlog(cluster::clusterlog.warn, "Invalid topic name: {}", ec);
+              return errc::mirror_topic_name_invalid;
+          }
+          auto meta = _table->find_link_by_id(cmd.key);
+          if (!meta.has_value()) {
+              return errc::does_not_exist;
+          }
+          auto id = _table->find_id_by_topic(cmd.value.topic);
+          if (!id.has_value()) {
+              vlog(
+                cluster::clusterlog.warn,
+                "Topic '{}' is not being mirrored",
+                cmd.value.topic);
+              return errc::topic_not_being_mirrored;
+          }
+          if (id.value() != cmd.key) {
+              vlog(
+                cluster::clusterlog.warn,
+                "Topic '{}' is being mirrored by another link",
+                cmd.value.topic);
+              return errc::topic_being_mirrored_by_other_link;
+          }
+          const auto& mirror_state = meta->get().state;
+          const auto it = mirror_state.mirror_topics.find(cmd.value.topic);
+
+          vassert(
+            it != mirror_state.mirror_topics.end(),
+            "State inconsistency detected, should have been able to find {}",
+            cmd.value.topic);
+
+          if (cmd.value.partition_count < it->second.partition_count) {
+              vlog(
+                cluster::clusterlog.warn,
+                "Attempting to update partition count of topic '{}' to {}, "
+                "which is less than the current partition count {}",
+                cmd.value.topic,
+                cmd.value.partition_count,
+                it->second.partition_count);
+              return errc::invalid_update;
+          }
+
+          if (cmd.value.replication_factor < 1) {
+              vlog(
+                cluster::clusterlog.warn,
+                "Invalid replication factor: {}",
+                cmd.value.replication_factor);
+              return errc::invalid_update;
+          }
+
           return errc::success;
       });
 }

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -169,6 +169,25 @@ chunked_vector<id_t> frontend::get_all_link_ids() const {
     return _table->get_all_link_ids();
 }
 
+std::optional<chunked_hash_map<
+  ::model::topic,
+  ::cluster_link::model::mirror_topic_metadata>>
+frontend::get_mirror_topics_for_link(id_t id) const {
+    auto link = _table->find_link_by_id(id);
+    if (!link) {
+        return std::nullopt;
+    }
+    chunked_hash_map<
+      ::model::topic,
+      ::cluster_link::model::mirror_topic_metadata>
+      mirror_topics;
+    mirror_topics.reserve(link->get().state.mirror_topics.size());
+    for (const auto& [topic, metadata] : link->get().state.mirror_topics) {
+        mirror_topics.emplace(topic, metadata.copy());
+    }
+    return mirror_topics;
+}
+
 ss::future<errc> frontend::do_mutation(
   cluster_link_cmd cmd, model::timeout_clock::time_point timeout) {
     auto cluster_leader = _leaders->get_leader(model::controller_ntp);

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -30,7 +30,8 @@ class frontend : public ss::peering_sharded_service<frontend> {
       cluster::cluster_link_upsert_cmd,
       cluster::cluster_link_remove_cmd,
       cluster::cluster_link_add_mirror_topic_cmd,
-      cluster::cluster_link_update_mirror_topic_state_cmd>;
+      cluster::cluster_link_update_mirror_topic_state_cmd,
+      cluster::cluster_link_update_mirror_topic_properties_cmd>;
 
 public:
     frontend(
@@ -56,6 +57,10 @@ public:
     ss::future<errc> update_mirror_topic_state(
       ::cluster_link::model::id_t,
       ::cluster_link::model::update_mirror_topic_state_cmd,
+      model::timeout_clock::time_point);
+    ss::future<errc> update_mirror_topic_properties(
+      ::cluster_link::model::id_t,
+      ::cluster_link::model::update_mirror_topic_properties_cmd,
       model::timeout_clock::time_point);
 
     bool cluster_link_active() const;

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -76,6 +76,11 @@ public:
 
     chunked_vector<::cluster_link::model::id_t> get_all_link_ids() const;
 
+    std::optional<chunked_hash_map<
+      ::model::topic,
+      ::cluster_link::model::mirror_topic_metadata>>
+    get_mirror_topics_for_link(::cluster_link::model::id_t id) const;
+
 private:
     ss::future<errc>
       do_mutation(cluster_link_cmd, model::timeout_clock::time_point);

--- a/src/v/cluster/cluster_link/table.cc
+++ b/src/v/cluster/cluster_link/table.cc
@@ -30,7 +30,8 @@ static constexpr auto accepted_commands = cluster::make_commands_list<
   cluster::cluster_link_upsert_cmd,
   cluster::cluster_link_remove_cmd,
   cluster::cluster_link_add_mirror_topic_cmd,
-  cluster::cluster_link_update_mirror_topic_state_cmd>();
+  cluster::cluster_link_update_mirror_topic_state_cmd,
+  cluster::cluster_link_update_mirror_topic_properties_cmd>();
 
 table::map_t copy_links(const table::map_t& links) {
     table::map_t copy;
@@ -199,6 +200,12 @@ ss::future<std::error_code> table::apply_update(model::record_batch b) {
           [&table](
             const cluster::cluster_link_update_mirror_topic_state_cmd& state) {
               return table.update_mirror_topic_state(state.key, state.value);
+          },
+          [&table](
+            const cluster::cluster_link_update_mirror_topic_properties_cmd&
+              state) {
+              return table.update_mirror_topic_properties(
+                state.key, state.value);
           });
     });
     auto first_res = results.front();
@@ -371,6 +378,47 @@ cluster::cluster_link::errc table::update_mirror_topic_state(
       id);
 
     it->second.state = cmd.state;
+    run_callbacks(id);
+    return errc::success;
+}
+
+cluster::cluster_link::errc table::update_mirror_topic_properties(
+  ::cluster_link::model::id_t id,
+  const ::cluster_link::model::update_mirror_topic_properties_cmd& cmd) {
+    auto link_id = find_id_by_topic(cmd.topic);
+    if (!link_id) {
+        vlog(
+          cluster::clusterlog.warn,
+          "Unable to update mirror topic {} properties as it is not registered",
+          cmd.topic);
+        return errc::topic_not_being_mirrored;
+    } else if (link_id.value() != id) {
+        vlog(
+          cluster::clusterlog.warn,
+          "Unable to update mirror topic {} properties as it is registered to "
+          "link {}",
+          cmd.topic,
+          link_id.value());
+        return errc::topic_being_mirrored_by_other_link;
+    }
+
+    auto& link_meta = _link_metadata[link_id.value()];
+    auto it = link_meta.state.mirror_topics.find(cmd.topic);
+    vassert(
+      it != link_meta.state.mirror_topics.end(),
+      "Inconsistent topic index for {} expected to exist in metadata id {}",
+      cmd.topic,
+      id);
+
+    auto& md = it->second;
+    md.partition_count = cmd.partition_count;
+    md.replication_factor = cmd.replication_factor;
+    md.topic_configs.clear();
+    md.topic_configs.reserve(cmd.topic_configs.size());
+    // Copy the topic configs from the command
+    for (const auto& [key, value] : cmd.topic_configs) {
+        md.topic_configs.emplace(key, value);
+    }
     run_callbacks(id);
     return errc::success;
 }

--- a/src/v/cluster/cluster_link/table.h
+++ b/src/v/cluster/cluster_link/table.h
@@ -93,6 +93,10 @@ private:
       ::cluster_link::model::id_t,
       const ::cluster_link::model::update_mirror_topic_state_cmd& cmd);
 
+    cluster::cluster_link::errc update_mirror_topic_properties(
+      ::cluster_link::model::id_t,
+      const ::cluster_link::model::update_mirror_topic_properties_cmd&);
+
     void run_callbacks(::cluster_link::model::id_t);
 
 private:

--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -26,6 +26,7 @@ using ::cluster_link::model::mirror_topic_state;
 using ::cluster_link::model::name_t;
 using ::cluster_link::model::tls_file_path;
 using ::cluster_link::model::tls_value;
+using ::cluster_link::model::update_mirror_topic_properties_cmd;
 using ::cluster_link::model::update_mirror_topic_state_cmd;
 using ::cluster_link::model::uuid_t;
 
@@ -110,6 +111,23 @@ public:
                 update_cmd.key, std::move(update_cmd.value)));
             vassert(
               !err, "Failed to update mirror topic state: {}", err.message());
+        }
+        co_return ec;
+    }
+
+    ss::future<cluster::cluster_link::errc> update_mirror_topic_properties(
+      id_t id, update_mirror_topic_properties_cmd cmd) {
+        cluster::cluster_link_update_mirror_topic_properties_cmd update_cmd{
+          id, cmd.copy()};
+        auto ec = _validator->validate_mutation(std::move(update_cmd));
+        if (ec == errc::success) {
+            auto err = co_await _table.local().apply_update(
+              testing::create_update_mirror_topic_properties_command(
+                id, std::move(cmd)));
+            vassert(
+              !err,
+              "Failed to update mirror topic properties: {}",
+              err.message());
         }
         co_return ec;
     }
@@ -542,6 +560,173 @@ TEST_F_CORO(
     EXPECT_EQ(
       co_await upsert_cluster_link(std::move(m1)),
       cluster::cluster_link::errc::topic_property_excluded_from_mirroring);
+}
+
+TEST_F_CORO(frontend_validation_test, update_mirror_topic_properties_success) {
+    ASSERT_EQ_CORO(
+      co_await upsert_cluster_link(create_base_metadata()), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    add_mirror_topic_cmd cmd{
+      .topic = model::topic("mirror-topic"),
+      .metadata = testing::create_mirror_topic_metadata(
+        mirror_topic_state::active, model::topic("mirror-topic"))};
+    EXPECT_EQ(
+      co_await add_mirror_topic(id.value(), std::move(cmd)), errc::success);
+
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = model::topic("mirror-topic"),
+      .partition_count = 3,
+      .replication_factor = 3,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(
+        id.value(), std::move(update_cmd)),
+      errc::success);
+}
+
+TEST_F_CORO(
+  frontend_validation_test, update_mirror_topic_properties_invalid_name) {
+    ASSERT_EQ_CORO(
+      co_await upsert_cluster_link(create_base_metadata()), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    add_mirror_topic_cmd cmd{
+      .topic = model::topic("mirror-topic"),
+      .metadata = testing::create_mirror_topic_metadata(
+        mirror_topic_state::active, model::topic("mirror-topic"))};
+    EXPECT_EQ(
+      co_await add_mirror_topic(id.value(), std::move(cmd)), errc::success);
+
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = model::topic("\xFF\xFF\xFF"), // Invalid UTF-8
+      .partition_count = 3,
+      .replication_factor = 3,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(
+        id.value(), std::move(update_cmd)),
+      errc::mirror_topic_name_invalid);
+}
+
+TEST_F_CORO(frontend_validation_test, update_mirror_topic_properties_no_link) {
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = model::topic("test-topic"),
+      .partition_count = 3,
+      .replication_factor = 3,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(id_t{5}, std::move(update_cmd)),
+      errc::does_not_exist);
+}
+
+TEST_F_CORO(
+  frontend_validation_test, update_mirror_topic_properties_mirrored_by_other) {
+    model::topic test_topic("mirror-link1");
+    mirror_topic_state mirror_state = mirror_topic_state::active;
+
+    auto m1 = create_base_metadata();
+    testing::set_link_mirror_topics(m1, test_topic, mirror_state, test_topic);
+
+    auto m2 = create_base_metadata(name_t("link2"));
+
+    ASSERT_EQ_CORO(
+      co_await _table.local().apply_update(
+        testing::create_upsert_command(model::offset{1}, std::move(m1))),
+      errc::success);
+
+    ASSERT_EQ_CORO(
+      co_await _table.local().apply_update(
+        testing::create_upsert_command(model::offset{2}, std::move(m2))),
+      errc::success);
+
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = test_topic,
+      .partition_count = 3,
+      .replication_factor = 3,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(id_t{2}, std::move(update_cmd)),
+      errc::topic_being_mirrored_by_other_link);
+}
+
+TEST_F_CORO(
+  frontend_validation_test, update_mirror_topic_properties_not_being_mirrored) {
+    model::topic test_topic("mirror-link1");
+    ASSERT_EQ_CORO(
+      co_await upsert_cluster_link(create_base_metadata()), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = test_topic,
+      .partition_count = 3,
+      .replication_factor = 3,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(id_t{1}, std::move(update_cmd)),
+      errc::topic_not_being_mirrored);
+}
+
+TEST_F_CORO(
+  frontend_validation_test,
+  update_mirror_topic_properties_invalid_partition_count) {
+    ASSERT_EQ_CORO(
+      co_await upsert_cluster_link(create_base_metadata()), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    add_mirror_topic_cmd cmd{
+      .topic = model::topic("mirror-topic"),
+      .metadata = testing::create_mirror_topic_metadata(
+        mirror_topic_state::active, model::topic("mirror-topic"))};
+    EXPECT_EQ(
+      co_await add_mirror_topic(id.value(), std::move(cmd)), errc::success);
+
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = model::topic("mirror-topic"),
+      .partition_count = -1,
+      .replication_factor = 3,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(
+        id.value(), std::move(update_cmd)),
+      errc::invalid_update);
+}
+
+TEST_F_CORO(
+  frontend_validation_test,
+  update_mirror_topic_properties_invalid_replication_factor) {
+    ASSERT_EQ_CORO(
+      co_await upsert_cluster_link(create_base_metadata()), errc::success);
+    auto id = _table.local().find_id_by_name(name_t("link1"));
+    ASSERT_TRUE_CORO(id.has_value());
+
+    add_mirror_topic_cmd cmd{
+      .topic = model::topic("mirror-topic"),
+      .metadata = testing::create_mirror_topic_metadata(
+        mirror_topic_state::active, model::topic("mirror-topic"))};
+    EXPECT_EQ(
+      co_await add_mirror_topic(id.value(), std::move(cmd)), errc::success);
+
+    update_mirror_topic_properties_cmd update_cmd{
+      .topic = model::topic("mirror-topic"),
+      .partition_count = 3,
+      .replication_factor = -1,
+    };
+
+    EXPECT_EQ(
+      co_await update_mirror_topic_properties(
+        id.value(), std::move(update_cmd)),
+      errc::invalid_update);
 }
 
 } // namespace cluster::cluster_link

--- a/src/v/cluster/cluster_link/tests/table_test.cc
+++ b/src/v/cluster/cluster_link/tests/table_test.cc
@@ -39,6 +39,7 @@ using ::cluster_link::model::id_t;
 using ::cluster_link::model::metadata;
 using ::cluster_link::model::mirror_topic_state;
 using ::cluster_link::model::name_t;
+using ::cluster_link::model::update_mirror_topic_properties_cmd;
 using ::cluster_link::model::update_mirror_topic_state_cmd;
 using ::cluster_link::model::uuid_t;
 
@@ -743,6 +744,119 @@ TEST_F_CORO(cluster_link_table_test, update_state_mirror_topic_other_link) {
     EXPECT_EQ(res.value(), int(errc::topic_being_mirrored_by_other_link))
       << "Expected error for topic being mirrored by other link, got: "
       << res.message();
+}
+
+TEST_F_CORO(
+  cluster_link_table_test, test_add_and_update_mirror_topic_properties) {
+    model::topic test_topic("mirror-link1");
+    mirror_topic_state mirror_state = mirror_topic_state::active;
+
+    metadata link1{
+      .name = name_t("link1"),
+      .uuid = uuid_t(::uuid_t::create()),
+      .connection = connection_config{}};
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_upsert_command(model::offset{1}, link1.copy()));
+    ASSERT_EQ_CORO(res.value(), int(errc::success))
+      << "Failed to upsert link1: " << res.message();
+
+    res = co_await _table.local().apply_update(
+      testing::create_add_mirror_topic_command(
+        id_t{1},
+        add_mirror_topic_cmd{
+          .topic = test_topic,
+          .metadata = testing::create_mirror_topic_metadata(
+            mirror_state, test_topic)}));
+
+    ASSERT_EQ_CORO(res.value(), int(errc::success))
+      << "Failed to add mirror topic: " << res.message();
+
+    auto link_id = _table.local().find_id_by_topic(test_topic);
+    ASSERT_EQ_CORO(link_id, id_t(1));
+
+    update_mirror_topic_properties_cmd cmd{
+      .topic = test_topic,
+      .partition_count = 5,
+      .replication_factor = 5,
+      .topic_configs = {{"key", "value"}}};
+
+    res = co_await _table.local().apply_update(
+      testing::create_update_mirror_topic_properties_command(
+        id_t{1}, std::move(cmd)));
+
+    ASSERT_EQ_CORO(res.value(), int(errc::success))
+      << "Failed to update mirror topic properties: " << res.message();
+
+    auto it = _table.local()
+                .find_link_by_id(id_t{1})
+                .value()
+                .get()
+                .state.mirror_topics.find(test_topic);
+    EXPECT_EQ(it->second.partition_count, 5);
+    EXPECT_EQ(it->second.replication_factor, 5);
+    EXPECT_EQ(it->second.topic_configs.size(), 1);
+    EXPECT_EQ(it->second.topic_configs.at("key"), "value");
+}
+
+TEST_F_CORO(
+  cluster_link_table_test,
+  test_update_mirror_topic_properties_topic_not_found) {
+    model::topic test_topic("mirror-link1");
+
+    metadata link1{
+      .name = name_t("link1"),
+      .uuid = uuid_t(::uuid_t::create()),
+      .connection = connection_config{}};
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_upsert_command(model::offset{1}, link1.copy()));
+    ASSERT_EQ_CORO(res.value(), int(errc::success))
+      << "Failed to upsert link1: " << res.message();
+
+    update_mirror_topic_properties_cmd cmd{
+      .topic = test_topic,
+      .partition_count = 5,
+      .replication_factor = 5,
+      .topic_configs = {{"key", "value"}}};
+
+    res = co_await _table.local().apply_update(
+      testing::create_update_mirror_topic_properties_command(
+        id_t{1}, std::move(cmd)));
+
+    EXPECT_EQ(res.value(), int(errc::topic_not_being_mirrored))
+      << "Expected error for non-existent topic, got: " << res.message();
+}
+
+TEST_F_CORO(
+  cluster_link_table_test, test_update_mirror_topic_properties_different_link) {
+    model::topic test_topic("mirror-link1");
+    metadata link1{
+      .name = name_t("link1"),
+      .uuid = uuid_t(::uuid_t::create()),
+      .connection = connection_config{}};
+    link1.state.mirror_topics.insert(
+      {test_topic,
+       testing::create_mirror_topic_metadata(
+         mirror_topic_state::active, test_topic)});
+
+    auto res = co_await _table.local().apply_update(
+      testing::create_upsert_command(model::offset{1}, link1.copy()));
+    ASSERT_EQ_CORO(res.value(), int(errc::success))
+      << "Failed to upsert link1: " << res.message();
+
+    update_mirror_topic_properties_cmd cmd{
+      .topic = test_topic,
+      .partition_count = 5,
+      .replication_factor = 5,
+      .topic_configs = {{"key", "value"}}};
+
+    res = co_await _table.local().apply_update(
+      testing::create_update_mirror_topic_properties_command(
+        id_t{2}, std::move(cmd)));
+
+    EXPECT_EQ(res.value(), int(errc::topic_being_mirrored_by_other_link))
+      << "Expected error for mirrored by other link, got: " << res.message();
 }
 
 } // namespace cluster::cluster_link

--- a/src/v/cluster/cluster_link/tests/utils.cc
+++ b/src/v/cluster/cluster_link/tests/utils.cc
@@ -48,6 +48,13 @@ model::record_batch create_update_mirror_topic_state_command(
     return cluster::serde_serialize_cmd(std::move(update_cmd));
 }
 
+model::record_batch create_update_mirror_topic_properties_command(
+  id_t id, ::cluster_link::model::update_mirror_topic_properties_cmd cmd) {
+    cluster::cluster_link_update_mirror_topic_properties_cmd update_cmd(
+      id, std::move(cmd));
+    return cluster::serde_serialize_cmd(std::move(update_cmd));
+}
+
 mirror_topic_metadata create_mirror_topic_metadata(
   mirror_topic_state state,
   ::model::topic source_topic_name,

--- a/src/v/cluster/cluster_link/tests/utils.h
+++ b/src/v/cluster/cluster_link/tests/utils.h
@@ -23,6 +23,9 @@ model::record_batch create_add_mirror_topic_command(
 model::record_batch create_update_mirror_topic_state_command(
   ::cluster_link::model::id_t,
   ::cluster_link::model::update_mirror_topic_state_cmd);
+model::record_batch create_update_mirror_topic_properties_command(
+  ::cluster_link::model::id_t,
+  ::cluster_link::model::update_mirror_topic_properties_cmd);
 
 ::cluster_link::model::mirror_topic_metadata create_mirror_topic_metadata(
   ::cluster_link::model::mirror_topic_state,

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -155,6 +155,8 @@ inline constexpr int8_t cluster_link_upsert_cmd_type = 0;
 inline constexpr int8_t cluster_link_remove_cmd_type = 1;
 inline constexpr int8_t cluster_link_add_mirror_topic_cmd_type = 2;
 inline constexpr int8_t cluster_link_update_mirror_topic_state_cmd_type = 3;
+inline constexpr int8_t cluster_link_update_mirror_topic_properties_cmd_type
+  = 4;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -473,6 +475,13 @@ using cluster_link_update_mirror_topic_state_cmd = controller_command<
   ::cluster_link::model::id_t,
   ::cluster_link::model::update_mirror_topic_state_cmd,
   cluster_link_update_mirror_topic_state_cmd_type,
+  model::record_batch_type::cluster_link,
+  serde_opts::serde_only>;
+
+using cluster_link_update_mirror_topic_properties_cmd = controller_command<
+  ::cluster_link::model::id_t,
+  ::cluster_link::model::update_mirror_topic_properties_cmd,
+  cluster_link_update_mirror_topic_properties_cmd_type,
   model::record_batch_type::cluster_link,
   serde_opts::serde_only>;
 

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -193,6 +193,11 @@
             "output_type": "update_mirror_topic_state_response"
         },
         {
+            "name": "update_mirror_topic_properties",
+            "input_type": "update_mirror_topic_properties_request",
+            "output_type": "update_mirror_topic_properties_response"
+        },
+        {
             "name": "get_current_cluster_epoch",
             "input_type": "get_current_cluster_epoch_request",
             "output_type": "get_current_cluster_epoch_response"

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -893,6 +893,16 @@ service::update_mirror_topic_state(
     co_return update_mirror_topic_state_response{.ec = result};
 }
 
+ss::future<update_mirror_topic_properties_response>
+service::update_mirror_topic_properties(
+  update_mirror_topic_properties_request req, rpc::streaming_context&) {
+    auto deadline = model::timeout_clock::now() + req.timeout;
+    auto result
+      = co_await _cluster_link_frontend.local().update_mirror_topic_properties(
+        req.link_id, std::move(req.cmd), deadline);
+    co_return update_mirror_topic_properties_response{.ec = result};
+}
+
 ss::future<get_current_cluster_epoch_response>
 service::get_current_cluster_epoch(
   get_current_cluster_epoch_request, ::rpc::streaming_context&) {

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -153,6 +153,9 @@ public:
     add_mirror_topic(add_mirror_topic_request, rpc::streaming_context&) final;
     ss::future<update_mirror_topic_state_response> update_mirror_topic_state(
       update_mirror_topic_state_request, rpc::streaming_context&) final;
+    ss::future<update_mirror_topic_properties_response>
+    update_mirror_topic_properties(
+      update_mirror_topic_properties_request, rpc::streaming_context&) final;
 
     ss::future<get_current_cluster_epoch_response> get_current_cluster_epoch(
       get_current_cluster_epoch_request, ::rpc::streaming_context&) final;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3537,6 +3537,38 @@ struct update_mirror_topic_state_response
     auto serde_fields() { return std::tie(ec); }
 };
 
+struct update_mirror_topic_properties_request
+  : serde::envelope<
+      update_mirror_topic_properties_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ::cluster_link::model::id_t link_id;
+    ::cluster_link::model::update_mirror_topic_properties_cmd cmd;
+    model::timeout_clock::duration timeout{};
+
+    friend bool operator==(
+      const update_mirror_topic_properties_request&,
+      const update_mirror_topic_properties_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(link_id, cmd, timeout); }
+};
+
+struct update_mirror_topic_properties_response
+  : serde::envelope<
+      update_mirror_topic_properties_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    cluster_link::errc ec{cluster_link::errc::success};
+
+    friend bool operator==(
+      const update_mirror_topic_properties_response&,
+      const update_mirror_topic_properties_response&)
+      = default;
+
+    auto serde_fields() { return std::tie(ec); }
+};
+
 // Request to get the current cluster epoch.
 struct get_current_cluster_epoch_request
   : serde::envelope<

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -46,6 +46,12 @@ public:
       model::add_mirror_topic_cmd,
       ::model::timeout_clock::time_point)
       = 0;
+
+    virtual ss::future<::cluster::cluster_link::errc> update_mirror_topic_state(
+      model::id_t,
+      model::update_mirror_topic_state_cmd,
+      ::model::timeout_clock::time_point)
+      = 0;
 };
 
 /**

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -66,9 +66,6 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata config,
-      kafka::data::rpc::partition_leader_cache* partition_leader_cache,
-      kafka::data::rpc::partition_manager* partition_manager,
-      kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection)
       = 0;
 };

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -59,6 +59,11 @@ public:
         model::update_mirror_topic_properties_cmd,
         ::model::timeout_clock::time_point)
       = 0;
+
+    virtual std::optional<chunked_hash_map<
+      ::model::topic,
+      ::cluster_link::model::mirror_topic_metadata>>
+    get_mirror_topics_for_link(model::id_t id) const = 0;
 };
 
 /**

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -52,6 +52,13 @@ public:
       model::update_mirror_topic_state_cmd,
       ::model::timeout_clock::time_point)
       = 0;
+
+    virtual ss::future<::cluster::cluster_link::errc>
+      update_mirror_topic_properties(
+        model::id_t,
+        model::update_mirror_topic_properties_cmd,
+        ::model::timeout_clock::time_point)
+      = 0;
 };
 
 /**

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -56,17 +56,11 @@ link::link(
   manager* manager,
   ss::lowres_clock::duration task_reconciler_interval,
   model::metadata config,
-  partition_leader_cache* partition_leader_cache,
-  partition_manager* partition_manager,
-  topic_metadata_cache* topic_metadata_cache,
   kafka::client::cluster cluster_connection)
   : _self(self)
   , _link_id(link_id)
   , _manager(manager)
   , _config(std::move(config))
-  , _partition_leader_cache(partition_leader_cache)
-  , _partition_manager(partition_manager)
-  , _topic_metadata_cache(topic_metadata_cache)
   , _cluster_connection(std::move(cluster_connection))
   , _task_reconciler_interval(task_reconciler_interval) {}
 
@@ -200,8 +194,24 @@ link::add_mirror_topic(model::add_mirror_topic_cmd cmd) {
 
 const model::metadata& link::get_config() const noexcept { return _config; }
 
-topic_metadata_cache* link::get_topic_metadata_cache() const noexcept {
-    return _topic_metadata_cache;
+topic_metadata_cache& link::topic_metadata_cache() noexcept {
+    return _manager->topic_metadata_cache();
+}
+
+partition_leader_cache& link::partition_leader_cache() noexcept {
+    return _manager->partition_leader_cache();
+}
+
+const partition_leader_cache& link::partition_leader_cache() const noexcept {
+    return _manager->partition_leader_cache();
+}
+
+partition_manager& link::partition_manager() noexcept {
+    return _manager->partition_manager();
+}
+
+const partition_manager& link::partition_manager() const noexcept {
+    return _manager->partition_manager();
 }
 
 kafka::client::cluster& link::get_cluster_connection() noexcept {

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -192,6 +192,16 @@ link::add_mirror_topic(model::add_mirror_topic_cmd cmd) {
     return _manager->add_mirror_topic(_link_id, std::move(cmd));
 }
 
+ss::future<::cluster::cluster_link::errc>
+link::update_mirror_topic_state(model::update_mirror_topic_state_cmd cmd) {
+    return _manager->update_mirror_topic_state(_link_id, std::move(cmd));
+}
+
+ss::future<::cluster::cluster_link::errc> link::update_mirror_topic_properties(
+  model::update_mirror_topic_properties_cmd cmd) {
+    return _manager->update_mirror_topic_properties(_link_id, std::move(cmd));
+}
+
 const model::metadata& link::get_config() const noexcept { return _config; }
 
 topic_metadata_cache& link::topic_metadata_cache() noexcept {
@@ -216,6 +226,11 @@ const partition_manager& link::partition_manager() const noexcept {
 
 kafka::client::cluster& link::get_cluster_connection() noexcept {
     return _cluster_connection;
+}
+
+std::optional<chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
+link::get_mirror_topics_for_link() const {
+    return _manager->get_mirror_topics_for_link(_link_id);
 }
 
 bool link::should_start_task(task* t) const {

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -70,6 +70,12 @@ public:
     ss::future<::cluster::cluster_link::errc>
     add_mirror_topic(model::add_mirror_topic_cmd cmd);
 
+    ss::future<::cluster::cluster_link::errc>
+    update_mirror_topic_state(model::update_mirror_topic_state_cmd cmd);
+
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_properties(
+      model::update_mirror_topic_properties_cmd cmd);
+
     const model::metadata& get_config() const noexcept;
 
     kafka::data::rpc::topic_metadata_cache& topic_metadata_cache() noexcept;
@@ -85,6 +91,10 @@ public:
     partition_manager() const noexcept;
 
     kafka::client::cluster& get_cluster_connection() noexcept;
+
+    std::optional<
+      chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
+    get_mirror_topics_for_link() const;
 
 private:
     bool should_start_task(task* t) const;

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -31,9 +31,6 @@ public:
       manager* manager,
       ss::lowres_clock::duration task_reconciler_interval,
       model::metadata config,
-      kafka::data::rpc::partition_leader_cache* partition_leader_cache,
-      kafka::data::rpc::partition_manager* partition_manager,
-      kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection);
     link(const link&) = delete;
     link(link&&) = delete;
@@ -75,20 +72,19 @@ public:
 
     const model::metadata& get_config() const noexcept;
 
-    kafka::data::rpc::topic_metadata_cache*
-    get_topic_metadata_cache() const noexcept;
+    kafka::data::rpc::topic_metadata_cache& topic_metadata_cache() noexcept;
 
-    kafka::client::cluster& get_cluster_connection() noexcept;
+    kafka::data::rpc::partition_leader_cache& partition_leader_cache() noexcept;
 
     const kafka::data::rpc::partition_leader_cache&
-    get_partition_leader_cache() const noexcept {
-        return *_partition_leader_cache;
-    }
+    partition_leader_cache() const noexcept;
+
+    kafka::data::rpc::partition_manager& partition_manager() noexcept;
 
     const kafka::data::rpc::partition_manager&
-    get_partition_manager() const noexcept {
-        return *_partition_manager;
-    }
+    partition_manager() const noexcept;
+
+    kafka::client::cluster& get_cluster_connection() noexcept;
 
 private:
     bool should_start_task(task* t) const;
@@ -102,9 +98,6 @@ private:
     manager* _manager;
     chunked_hash_map<ss::sstring, std::unique_ptr<task>> _tasks;
     model::metadata _config;
-    kafka::data::rpc::partition_leader_cache* _partition_leader_cache;
-    kafka::data::rpc::partition_manager* _partition_manager;
-    kafka::data::rpc::topic_metadata_cache* _topic_metadata_cache;
     kafka::client::cluster _cluster_connection;
 
     notification_list<task_state_change_cb, task_state_notification_id>

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -19,6 +19,10 @@
 
 using namespace std::chrono_literals;
 
+using kafka::data::rpc::partition_leader_cache;
+using kafka::data::rpc::partition_manager;
+using kafka::data::rpc::topic_metadata_cache;
+
 namespace cluster_link {
 manager::manager(
   ::model::node_id self,
@@ -140,9 +144,6 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
               id,
               this,
               link_metadata.copy(),
-              _partition_leader_cache.get(),
-              _partition_manager.get(),
-              _topic_metadata_cache.get(),
               _cluster_factory->create_cluster(link_metadata));
             vassert(
               new_link, "Link factory returned a null link for id={}", id);
@@ -185,6 +186,26 @@ ss::future<> manager::handle_on_link_change(model::id_t id) {
               retry_delay, [this, id] { return handle_on_link_change(id); });
         }
     }
+}
+
+topic_metadata_cache& manager::topic_metadata_cache() noexcept {
+    return *_topic_metadata_cache;
+}
+
+partition_leader_cache& manager::partition_leader_cache() noexcept {
+    return *_partition_leader_cache;
+}
+
+const partition_leader_cache& manager::partition_leader_cache() const noexcept {
+    return *_partition_leader_cache;
+}
+
+partition_manager& manager::partition_manager() noexcept {
+    return *_partition_manager;
+}
+
+const partition_manager& manager::partition_manager() const noexcept {
+    return *_partition_manager;
 }
 
 ss::future<> manager::link_task_reconciler() {

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -268,6 +268,30 @@ ss::future<::cluster::cluster_link::errc> manager::add_mirror_topic(
       ::model::timeout_clock::now() + mirror_topic_timeout);
 }
 
+ss::future<::cluster::cluster_link::errc> manager::update_mirror_topic_state(
+  model::id_t link_id, model::update_mirror_topic_state_cmd cmd) {
+    static constexpr auto mirror_topic_timeout = 5s;
+    return _registry->update_mirror_topic_state(
+      link_id,
+      std::move(cmd),
+      ::model::timeout_clock::now() + mirror_topic_timeout);
+}
+
+ss::future<::cluster::cluster_link::errc>
+manager::update_mirror_topic_properties(
+  model::id_t link_id, model::update_mirror_topic_properties_cmd cmd) {
+    static constexpr auto mirror_topic_timeout = 5s;
+    return _registry->update_mirror_topic_properties(
+      link_id,
+      std::move(cmd),
+      ::model::timeout_clock::now() + mirror_topic_timeout);
+}
+
+std::optional<chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
+manager::get_mirror_topics_for_link(model::id_t id) const {
+    return _registry->get_mirror_topics_for_link(id);
+}
+
 model::cluster_link_task_status_report manager::get_task_status_report() const {
     model::cluster_link_task_status_report report;
     report.link_reports.reserve(_links.size());

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -66,6 +66,14 @@ public:
     /// Used to add a mirror topic to a cluster link
     ss::future<::cluster::cluster_link::errc>
     add_mirror_topic(model::id_t link_id, model::add_mirror_topic_cmd cmd);
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_state(
+      model::id_t link_id, model::update_mirror_topic_state_cmd cmd);
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_properties(
+      model::id_t link_id, model::update_mirror_topic_properties_cmd cmd);
+
+    std::optional<
+      chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
+    get_mirror_topics_for_link(model::id_t id) const;
 
     /// Registers a task factory that will be used to create tasks when links
     /// are created

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -90,6 +90,18 @@ public:
 
     model::cluster_link_task_status_report get_task_status_report() const;
 
+    kafka::data::rpc::topic_metadata_cache& topic_metadata_cache() noexcept;
+
+    kafka::data::rpc::partition_leader_cache& partition_leader_cache() noexcept;
+
+    const kafka::data::rpc::partition_leader_cache&
+    partition_leader_cache() const noexcept;
+
+    kafka::data::rpc::partition_manager& partition_manager() noexcept;
+
+    const kafka::data::rpc::partition_manager&
+    partition_manager() const noexcept;
+
 private:
     /// Called periodically to reconcile registered tasks on created links
     ss::future<> link_task_reconciler();

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -100,6 +100,19 @@ add_mirror_topic_cmd add_mirror_topic_cmd::copy() const {
     copy.metadata = metadata.copy();
     return copy;
 }
+
+update_mirror_topic_properties_cmd
+update_mirror_topic_properties_cmd::copy() const {
+    update_mirror_topic_properties_cmd copy;
+    copy.topic = topic;
+    copy.partition_count = partition_count;
+    copy.replication_factor = replication_factor;
+    copy.topic_configs.reserve(topic_configs.size());
+    for (const auto& [key, value] : topic_configs) {
+        copy.topic_configs.emplace(key, value);
+    }
+    return copy;
+}
 } // namespace cluster_link::model
 
 auto fmt::formatter<cluster_link::model::mirror_topic_state>::format(
@@ -291,6 +304,20 @@ auto fmt::formatter<cluster_link::model::update_mirror_topic_state_cmd>::format(
   format_context& ctx) -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(), "{{topic: {}, state: {}}}", m.topic, m.state);
+}
+
+auto fmt::formatter<cluster_link::model::update_mirror_topic_properties_cmd>::
+  format(
+    const cluster_link::model::update_mirror_topic_properties_cmd& m,
+    format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{topic={}, partition_count={}, replication_factor={}, "
+      "topic_configs={}}}",
+      m.topic,
+      m.partition_count,
+      m.replication_factor,
+      m.topic_configs);
 }
 
 auto fmt::formatter<cluster_link::model::task_status_report>::format(

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -405,6 +405,34 @@ struct update_mirror_topic_state_cmd
     auto serde_fields() { return std::tie(topic, state); }
 };
 
+/// \brief Command used to update the properties of a mirror topic
+///
+/// Will be used by the cluster linking metadata sync test to update
+/// the properties of a mirror topic
+struct update_mirror_topic_properties_cmd
+  : serde::envelope<
+      update_mirror_topic_properties_cmd,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    /// Name of the topic
+    ::model::topic topic;
+    int32_t partition_count;
+    int16_t replication_factor;
+    chunked_hash_map<ss::sstring, ss::sstring> topic_configs;
+
+    friend bool operator==(
+      const update_mirror_topic_properties_cmd&,
+      const update_mirror_topic_properties_cmd&)
+      = default;
+
+    auto serde_fields() {
+        return std::tie(
+          topic, partition_count, replication_factor, topic_configs);
+    }
+
+    update_mirror_topic_properties_cmd copy() const;
+};
+
 /// Status report for a task
 struct task_status_report
   : serde::envelope<
@@ -635,6 +663,14 @@ struct fmt::formatter<cluster_link::model::update_mirror_topic_state_cmd>
   : fmt::formatter<string_view> {
     auto format(
       const cluster_link::model::update_mirror_topic_state_cmd& m,
+      format_context& ctx) -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::update_mirror_topic_properties_cmd>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::update_mirror_topic_properties_cmd& m,
       format_context& ctx) -> decltype(ctx.out());
 };
 

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -162,9 +162,9 @@ struct mirror_topic_metadata
     /// The topic ID of the destination topic
     ::model::topic_id destination_topic_id;
     /// The number of partitions on the source topic
-    size_t partition_count;
+    int32_t partition_count;
     /// The replication factor
-    size_t replication_factor;
+    int16_t replication_factor;
     /// The configuration for the topic
     chunked_hash_map<ss::sstring, ss::sstring> topic_configs;
 

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -64,9 +64,6 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata config,
-      partition_leader_cache* partition_leader_cache,
-      partition_manager* partition_manager,
-      topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection) override {
         return std::make_unique<link>(
           self,
@@ -74,9 +71,6 @@ public:
           manager,
           link_reconciler_period,
           std::move(config),
-          partition_leader_cache,
-          partition_manager,
-          topic_metadata_cache,
           std::move(cluster_connection));
     }
 };

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -52,6 +52,13 @@ public:
         return _plf->add_mirror_topic(id, std::move(cmd), timeout);
     }
 
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_state(
+      model::id_t id,
+      model::update_mirror_topic_state_cmd cmd,
+      ::model::timeout_clock::time_point timeout) override {
+        return _plf->update_mirror_topic_state(id, std::move(cmd), timeout);
+    }
+
 private:
     frontend* _plf;
 };

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -67,6 +67,13 @@ public:
           id, std::move(cmd), timeout);
     }
 
+    std::optional<chunked_hash_map<
+      ::model::topic,
+      ::cluster_link::model::mirror_topic_metadata>>
+    get_mirror_topics_for_link(model::id_t id) const override {
+        return _plf->get_mirror_topics_for_link(id);
+    }
+
 private:
     frontend* _plf;
 };

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -59,6 +59,14 @@ public:
         return _plf->update_mirror_topic_state(id, std::move(cmd), timeout);
     }
 
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_properties(
+      model::id_t id,
+      model::update_mirror_topic_properties_cmd cmd,
+      ::model::timeout_clock::time_point timeout) override {
+        return _plf->update_mirror_topic_properties(
+          id, std::move(cmd), timeout);
+    }
+
 private:
     frontend* _plf;
 };

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -258,8 +258,8 @@ source_topic_syncer::find_candidate_topics() {
           rf);
 
         if (get_link()
-              ->get_topic_metadata_cache()
-              ->find_topic_cfg({::model::kafka_namespace, topic})
+              ->topic_metadata_cache()
+              .find_topic_cfg({::model::kafka_namespace, topic})
               .has_value()) {
             vlog(logger().trace, "Topic {} already exists", topic);
             continue;

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -239,11 +239,13 @@ source_topic_syncer::find_candidate_topics() {
             continue;
         }
 
-        auto partition_count = it->second.partitions.size();
+        auto partition_count = static_cast<int32_t>(
+          it->second.partitions.size());
         if (partition_count < 1) {
             vlog(logger().trace, "Skipping topic {} with no partitions", topic);
             continue;
         }
+
         auto rf = it->second.replication_factor;
         if (rf < 1) {
             vlog(logger().trace, "Skipping topic {} with no replicas", topic);

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -34,6 +34,90 @@ bool has_required_permissions(
            == required_permissions;
 }
 
+template<typename K, typename V>
+chunked_hash_map<K, V> copy_hash_map(const chunked_hash_map<K, V>& source) {
+    chunked_hash_map<K, V> copy;
+    copy.reserve(source.size());
+    for (const auto& [key, value] : source) {
+        copy.emplace(key, value);
+    }
+    return copy;
+}
+
+// This function validates that the describe_configs response returned
+// successfully and contains a topic resource response
+std::optional<chunked_hash_map<ss::sstring, ss::sstring>>
+validate_and_get_configs_from_response(
+  prefix_logger& logger, const kafka::describe_configs_result& resp) {
+    if (resp.error_code != kafka::error_code::none) {
+        vlog(
+          logger.debug,
+          "Failed to fetch configs for topic {}: {}{}",
+          resp.resource_name,
+          resp.error_code,
+          resp.error_message.has_value() ? " - " + *resp.error_message : "");
+        return std::nullopt;
+    }
+    if (resp.resource_type != kafka::config_resource_type::topic) {
+        vlog(
+          logger.debug,
+          "Unexpected resource type {} for topic {}",
+          resp.resource_type,
+          resp.resource_name);
+        return std::nullopt;
+    }
+    chunked_hash_map<ss::sstring, ss::sstring> configs;
+    configs.reserve(resp.configs.size());
+    for (const auto& c : resp.configs) {
+        if (c.value.has_value()) {
+            configs.emplace(c.name, *c.value);
+        }
+    }
+    return configs;
+}
+
+// Validates the contents of the metadata cache from the source cluster.  If
+// partition count or replication count are invalid then will return
+// std::nullopt.  Otherwise returns the metadata information.
+std::optional<std::tuple<int32_t, int16_t, kafka::topic_authorized_operations>>
+validate_topic_cache_entry(
+  prefix_logger& logger,
+  const kafka::client::topic_cache& cache,
+  ::model::topic_view topic) {
+    const auto& topic_cache_map = cache.cache();
+    auto it = topic_cache_map.find(topic);
+    if (it == topic_cache_map.end()) {
+        vlog(logger.trace, "Topic {} not found in cache", topic);
+        return std::nullopt;
+    }
+
+    auto partition_count = static_cast<int32_t>(it->second.partitions.size());
+    if (partition_count < 1) {
+        vlog(logger.trace, "Skipping topic {} with no partitions", topic);
+        return std::nullopt;
+    }
+
+    auto replication_factor = it->second.replication_factor;
+    if (replication_factor < 1) {
+        vlog(
+          logger.trace,
+          "Skipping topic {} with invalid replication factor {}",
+          topic,
+          replication_factor);
+        return std::nullopt;
+    }
+
+    vlog(
+      logger.trace,
+      "Topic {} has {} partitions, RF={} and authorized operations {:08x}",
+      topic,
+      partition_count,
+      replication_factor,
+      it->second.authorized_operations);
+
+    return std::make_tuple(
+      partition_count, replication_factor, it->second.authorized_operations);
+}
 } // namespace
 
 source_topic_syncer::source_topic_syncer(
@@ -51,22 +135,12 @@ void source_topic_syncer::update_config(const model::metadata& config) {
 }
 
 ss::future<> source_topic_syncer::run_impl() {
-    /// The auto topic sensor task is responsible for identifying topics on the
-    /// source cluster that are candidates to be mirrored.  To determine if a
-    /// topic is a candidate the task will:
-    /// 1. Grab the metadata from the source cluster
-    /// 2. Check to see if the topic already exists or if it is already being
-    /// mirrored
-    /// 3. Check to see if there are inclusive filters for that topic
-    /// 4. Validate that the topic's permissions are sufficient for mirroring
-    /// Once that selection criteria is set, then the task will fetch the
-    /// configs for that topic and then add that topic to the table or mirror
-    /// topics.  A seperate task will then be responsible for reconciling the
-    /// contents of that table with the destination cluster
     vlog(logger().trace, "Running auto topic sensor task");
 
     auto& cluster = get_link()->get_cluster_connection();
 
+    // Perform a metadata update to get as fresh as possible data from the
+    // source cluster
     try {
         co_await cluster.request_metadata_update();
     } catch (const std::exception& e) {
@@ -76,6 +150,7 @@ ss::future<> source_topic_syncer::run_impl() {
         co_return;
     }
 
+    // Ensure there is a controller on the source cluster
     auto controller_id = cluster.get_controller_id();
     if (!controller_id) {
         auto msg = ssx::sformat(
@@ -86,6 +161,8 @@ ss::future<> source_topic_syncer::run_impl() {
         co_return;
     }
 
+    // Grab the version of DescribeConfigs that's supported on the source
+    // cluster and ensure we support it
     kafka::api_version describe_configs_version;
     try {
         auto supported_api_versions = co_await cluster.supported_api_versions(
@@ -93,6 +170,19 @@ ss::future<> source_topic_syncer::run_impl() {
         if (!supported_api_versions.has_value()) {
             auto msg = ssx::sformat(
               "Failed to get supported API version for describe_configs");
+            vlog(logger().warn, "{}", msg);
+            std::ignore = change_state(
+              model::task_state::link_unavailable, msg);
+            co_return;
+        }
+        // Make sure the minimum version supported on the cluster is not higher
+        // than the maximum version supported by the shadow cluster
+        if (
+          supported_api_versions.value().min
+          > kafka::describe_configs_api::max_valid) {
+            auto msg = ssx::sformat(
+              "Unsupported DescribeConfigs API version: {}",
+              supported_api_versions.value());
             vlog(logger().warn, "{}", msg);
             std::ignore = change_state(
               model::task_state::link_unavailable, msg);
@@ -114,23 +204,42 @@ ss::future<> source_topic_syncer::run_impl() {
         co_return;
     }
 
-    auto candidate_topics = find_candidate_topics();
+    // Now grab two lists of topics:
+    // * Topics that are candidates for creation - topics that do not currently
+    //   exist but are selected by the auto topic create filters
+    // * Topics that are candidates for updates - existing mirror topics
+    auto candidates_for_creation = find_candidate_topics_for_creation(cluster);
+    auto candidates_for_update = find_candidate_topics_for_update(cluster);
 
-    vlog(
-      logger().trace,
-      "Fetching topic configs for {}",
-      std::views::keys(candidate_topics));
+    if (candidates_for_creation.empty() && candidates_for_update.empty()) {
+        vlog(
+          logger().debug,
+          "No candidate topics for creation or update for link {}",
+          get_link()->get_config().name);
+        if (get_state() != model::task_state::active) {
+            std::ignore = change_state(
+              model::task_state::active, "Auto topic sensor task completed");
+        }
+        co_return;
+    }
+
+    // Build a list of topics to describe
+    chunked_vector<::model::topic> topics_to_describe;
+    topics_to_describe.reserve(
+      candidates_for_creation.size() + candidates_for_update.size());
+
+    std::ranges::copy(
+      std::views::keys(candidates_for_creation),
+      std::back_inserter(topics_to_describe));
+    std::ranges::copy(
+      std::views::keys(candidates_for_update),
+      std::back_inserter(topics_to_describe));
 
     kafka::describe_configs_response response;
     try {
-        chunked_vector<::model::topic> topics_to_describe;
-        topics_to_describe.reserve(candidate_topics.size());
-        for (const auto& [topic, _] : candidate_topics) {
-            topics_to_describe.emplace_back(topic);
-        }
         response = co_await describe_topics(
           cluster,
-          *controller_id,
+          controller_id.value(),
           describe_configs_version,
           topics_to_describe,
           _config.topic_properties_to_mirror);
@@ -143,74 +252,16 @@ ss::future<> source_topic_syncer::run_impl() {
         co_return;
     }
 
-    chunked_vector<model::add_mirror_topic_cmd> add_mirror_topic_cmds;
-    add_mirror_topic_cmds.reserve(response.data.results.size());
+    // Build a list of commands, fill it in with commands to add mirror topics,
+    // update mirror topic properties, or update mirror topic state
+    reconciler_commands_vector commands;
+    enqueue_create_mirror_topic_commands(
+      commands, candidates_for_creation, response.data.results);
+    enqueue_update_mirror_topic_commands(
+      commands, candidates_for_update, response.data.results);
 
-    for (auto& resp : response.data.results) {
-        vlog(
-          logger().trace,
-          "Processing results for topic: {}",
-          resp.resource_name);
-        if (resp.error_code != kafka::error_code::none) {
-            vlog(
-              logger().debug,
-              "Failed to fetch configs for topic {}: {}{}",
-              resp.resource_name,
-              resp.error_code,
-              resp.error_message.has_value() ? " - " + *resp.error_message
-                                             : "");
-            continue;
-        }
-        if (resp.resource_type != kafka::config_resource_type::topic) {
-            vlog(
-              logger().debug,
-              "Unexpected resource type {} for topic {}",
-              resp.resource_type,
-              resp.resource_name);
-            continue;
-        }
-        chunked_hash_map<ss::sstring, ss::sstring> configs;
-        configs.reserve(resp.configs.size());
-        for (auto& c : resp.configs) {
-            if (c.value.has_value()) {
-                configs.emplace(std::move(c.name), std::move(c.value).value());
-            }
-        }
-        vlog(
-          logger().trace,
-          "Configs for topic {}: {}",
-          resp.resource_name,
-          configs);
-        auto source_topic_name = ::model::topic{resp.resource_name};
-        auto it = candidate_topics.find(source_topic_name);
-        if (it == candidate_topics.end()) {
-            vlog(
-              logger().debug,
-              "Topic {} not found in candidate topics, skipping",
-              resp.resource_name);
-            continue;
-        }
-        add_mirror_topic_cmds.emplace_back(model::add_mirror_topic_cmd{
-          .topic = source_topic_name,
-          .metadata = model::mirror_topic_metadata{
-            .source_topic_name = source_topic_name,
-            .destination_topic_id = ::model::topic_id{::uuid_t::create()},
-            .partition_count = it->second.partition_count,
-            .replication_factor = it->second.rf,
-            .topic_configs = std::move(configs)}});
-    }
-
-    vlog(logger().trace, "Adding mirror topics");
-    for (auto& c : add_mirror_topic_cmds) {
-        auto topic_name = c.topic;
-        vlog(logger().trace, "Adding mirror topic {}", topic_name);
-        auto res = co_await get_link()->add_mirror_topic(std::move(c));
-        if (res != ::cluster::cluster_link::errc::success) {
-            vlog(logger().warn, "Failed to add mirror topic {}", res);
-            continue;
-        }
-        vlog(logger().debug, "Successfully added mirror topic {}", topic_name);
-    }
+    // Execute the commands
+    co_await submit_commands(std::move(commands));
 
     if (get_state() != model::task_state::active) {
         std::ignore = change_state(
@@ -219,45 +270,270 @@ ss::future<> source_topic_syncer::run_impl() {
     vlog(logger().trace, "Auto topic sensor task completed");
 }
 
-chunked_hash_map<::model::topic, source_topic_syncer::topic_metadata>
-source_topic_syncer::find_candidate_topics() {
-    auto& cluster = get_link()->get_cluster_connection();
-    auto& topic_cache = cluster.get_topics();
-    auto topics = topic_cache.topics();
-
-    /// Map of topics with partition count
-    chunked_hash_map<::model::topic, topic_metadata> candidate_topics;
-    candidate_topics.reserve(topics.size());
-
-    for (const auto& topic : topics) {
-        vlog(logger().trace, "Checking topic: {}", topic);
-
-        const auto& topic_cache_map = topic_cache.cache();
-        auto it = topic_cache_map.find(topic);
-        if (it == topic_cache_map.end()) {
-            vlog(logger().trace, "Skipping topic {} not in cache", topic);
+void source_topic_syncer::enqueue_create_mirror_topic_commands(
+  reconciler_commands_vector& commands,
+  const chunked_hash_map<::model::topic, topic_metadata>& candidates,
+  const chunked_vector<kafka::describe_configs_result>& describe_results) {
+    // This function will go through the describe result and select any topic
+    // that responded successfully and are not currently mirror topics
+    for (const auto& describe_result : describe_results) {
+        // Check to see if the describe result contains a candidates for topic
+        // creation
+        auto it = candidates.find(
+          ::model::topic_view{describe_result.resource_name});
+        if (it == candidates.end()) {
+            continue;
+        }
+        vlog(
+          logger().trace,
+          "Validating describe result for create topic candidate {}",
+          describe_result.resource_name);
+        auto configs = validate_and_get_configs_from_response(
+          logger(), describe_result);
+        if (!configs.has_value()) {
+            vlog(
+              logger().trace,
+              "Failed to validate describe result for topic {}",
+              describe_result.resource_name);
             continue;
         }
 
-        auto partition_count = static_cast<int32_t>(
-          it->second.partitions.size());
-        if (partition_count < 1) {
-            vlog(logger().trace, "Skipping topic {} with no partitions", topic);
-            continue;
-        }
+        commands.emplace_back(model::add_mirror_topic_cmd{
+          .topic = it->first,
+          .metadata = model::mirror_topic_metadata{
+            .source_topic_name = it->first,
+            .partition_count = it->second.partition_count,
+            .replication_factor = it->second.rf,
+            .topic_configs = std::move(*configs),
+          }});
+    }
+}
 
-        auto rf = it->second.replication_factor;
-        if (rf < 1) {
-            vlog(logger().trace, "Skipping topic {} with no replicas", topic);
+void source_topic_syncer::enqueue_update_mirror_topic_commands(
+  reconciler_commands_vector& commands,
+  const candidate_update_map& candidates,
+  const chunked_vector<kafka::describe_configs_result>& describe_results) {
+    // This function steps through the describe results and attempts to create
+    // update properites or update topic state commands.  It will first check
+    // that the partition count or replication factor have been changed and that
+    // the partition count did not go backwards.  If the partition count went
+    // down, it will add an update_topic_state command to set the mirror topic
+    // state to failed.
+    for (const auto& describe_result : describe_results) {
+        bool enqueue_command = false;
+        auto it = candidates.find(
+          ::model::topic_view{describe_result.resource_name});
+        if (it == candidates.end()) {
             continue;
         }
 
         vlog(
           logger().trace,
-          "Topic {} has {} partitions, RF={}",
+          "Validating describe result for update topic candidates {}",
+          describe_result.resource_name);
+
+        const auto& topic = it->first;
+        const auto& metadata_cache = it->second.first;
+        const auto& mirror_topic_cache = it->second.second;
+
+        if (mirror_topic_cache.state != model::mirror_topic_state::active) {
+            vlog(
+              logger().debug,
+              "Skipping update to topic {} which is in a non-active state: {}",
+              topic,
+              mirror_topic_cache.state);
+            continue;
+        }
+
+        // TODO: Once Topic IDs are supported, check that the Topic ID in the
+        // metadata response matches the expecteed Topic ID for this topic.
+
+        // If we detect that the partition count has gone down, this indicates
+        // that the topic may have been deleted and then re-created, so we will
+        // put the topic into the failed state
+        if (
+          mirror_topic_cache.partition_count > metadata_cache.partition_count) {
+            vlog(
+              logger().warn,
+              "Topic {} has fewer partitions than expected, marking as failed",
+              topic);
+            commands.emplace_back(model::update_mirror_topic_state_cmd{
+              .topic = topic,
+              .state = model::mirror_topic_state::failed,
+            });
+            continue;
+        }
+
+        // Detect if the partition count has changed
+        if (
+          mirror_topic_cache.partition_count
+          != metadata_cache.partition_count) {
+            vlog(
+              logger().trace,
+              "Topic {} has updated its partition count: {} -> {}",
+              topic,
+              mirror_topic_cache.partition_count,
+              metadata_cache.partition_count);
+            enqueue_command = true;
+        }
+
+        // Detect if RF has changed
+        if (mirror_topic_cache.replication_factor != metadata_cache.rf) {
+            vlog(
+              logger().trace,
+              "Topic {} has updated its RF: {} -> {}",
+              topic,
+              mirror_topic_cache.replication_factor,
+              metadata_cache.rf);
+            enqueue_command = true;
+        }
+
+        auto configs = validate_and_get_configs_from_response(
+          logger(), describe_result);
+
+        if (configs.has_value()) {
+            // Now check to see if the the properties on the topic have differed
+            for (const auto& [key, val] : *configs) {
+                auto cached_config_it = mirror_topic_cache.topic_configs.find(
+                  key);
+                if (
+                  cached_config_it == mirror_topic_cache.topic_configs.end()
+                  || cached_config_it->second != val) {
+                    vlog(
+                      logger().trace,
+                      "Topic {} property {} changed: {} -> {}",
+                      topic,
+                      key,
+                      cached_config_it->second,
+                      val);
+                    enqueue_command = true;
+                }
+            }
+        } else {
+            vlog(
+              logger().trace,
+              "Failed to validate describe result for topic {}. We will use "
+              "cached topic configs if needed.",
+              describe_result.resource_name);
+        }
+
+        // One or more of the partition count, replication factor, or some topic
+        // configs changed, so we should update the mirror topic properties
+        // forthwith. Note that in any case the new value(s) have been validated
+        // already.
+        if (enqueue_command) {
+            commands.emplace_back(model::update_mirror_topic_properties_cmd{
+              .topic = topic,
+              .partition_count = metadata_cache.partition_count,
+              .replication_factor = metadata_cache.rf,
+              .topic_configs = std::move(configs).value_or(
+                copy_hash_map(mirror_topic_cache.topic_configs)),
+            });
+        }
+    }
+}
+
+ss::future<>
+source_topic_syncer::submit_commands(reconciler_commands_vector commands) {
+    if (commands.empty()) {
+        co_return;
+    }
+
+    for (auto& c : commands) {
+        auto res = co_await ss::visit(
+          std::move(c),
+          [this](model::add_mirror_topic_cmd c) {
+              return get_link()->add_mirror_topic(std::move(c));
+          },
+          [this](model::update_mirror_topic_properties_cmd c) {
+              return get_link()->update_mirror_topic_properties(std::move(c));
+          },
+          [this](model::update_mirror_topic_state_cmd c) {
+              return get_link()->update_mirror_topic_state(std::move(c));
+          });
+        if (res != ::cluster::cluster_link::errc::success) {
+            vlog(
+              logger().error,
+              "Failed to process mirror topic command: {}",
+              res);
+        } else {
+            vlog(logger().trace, "Successfully processed mirror topic command");
+        }
+    }
+}
+
+source_topic_syncer::candidate_update_map
+source_topic_syncer::find_candidate_topics_for_update(
+  kafka::client::cluster& cluster) {
+    // All mirror topics this link is responsible for
+    auto mirror_topics = get_link()->get_mirror_topics_for_link();
+    if (!mirror_topics.has_value()) {
+        vlog(
+          logger().error,
+          "Cluster link table reporting that link does not exist!");
+        return {};
+    }
+    candidate_update_map candidate_topics;
+    candidate_topics.reserve(mirror_topics->size());
+
+    for (auto& [topic, mirror_metadata] : *mirror_topics) {
+        vlog(logger().trace, "Checking metadata cache for topic {}", topic);
+
+        auto metadata_value = validate_topic_cache_entry(
+          logger(), cluster.get_topics(), topic);
+
+        if (!metadata_value.has_value()) {
+            vlog(
+              logger().trace,
+              "Skipping topic {} with invalid partition count or RF",
+              topic);
+            continue;
+        }
+
+        auto [partition_count, rf, authorized_operations]
+          = metadata_value.value();
+
+        vlog(
+          logger().trace,
+          "Emplacing topic {} with {} partitions, RF={} for update candidate",
           topic,
           partition_count,
           rf);
+        candidate_topics.emplace(
+          std::move(topic),
+          std::make_pair(
+            topic_metadata{.partition_count = partition_count, .rf = rf},
+            std::move(mirror_metadata)));
+    }
+
+    return candidate_topics;
+}
+
+source_topic_syncer::candidate_create_map
+source_topic_syncer::find_candidate_topics_for_creation(
+  kafka::client::cluster& cluster) {
+    auto& topic_cache = cluster.get_topics();
+    auto topics = topic_cache.topics();
+
+    /// Map of topics with partition count
+    candidate_create_map candidate_topics;
+    candidate_topics.reserve(topics.size());
+
+    for (const auto& topic : topics) {
+        vlog(logger().trace, "Checking topic: {}", topic);
+
+        auto metadata_value = validate_topic_cache_entry(
+          logger(), topic_cache, topic);
+        if (!metadata_value.has_value()) {
+            vlog(
+              logger().trace,
+              "Skipping topic {} with invalid partition count or RF",
+              topic);
+            continue;
+        }
+
+        auto [partition_count, rf, authorized_operations]
+          = metadata_value.value();
 
         if (get_link()
               ->topic_metadata_cache()
@@ -290,20 +566,21 @@ source_topic_syncer::find_candidate_topics() {
             continue;
         }
 
-        auto authorized_ops = it->second.authorized_operations;
-        if (authorized_ops == kafka::topic_authorized_operations_not_set) {
+        if (
+          authorized_operations == kafka::topic_authorized_operations_not_set) {
             vlog(logger().trace, "Missing permissions for topic {}", topic);
             continue;
         }
 
-        if (!has_required_permissions(authorized_ops, required_permissions)) {
+        if (!has_required_permissions(
+              authorized_operations, required_permissions)) {
             vlog(
               logger().trace,
               "Insufficient permissions for topic {}.  Requires {:08x}, has "
               "{:08x}",
               topic,
               required_permissions,
-              authorized_ops);
+              authorized_operations);
             continue;
         }
 

--- a/src/v/cluster_link/source_topic_syncer.h
+++ b/src/v/cluster_link/source_topic_syncer.h
@@ -46,8 +46,8 @@ protected:
 
 private:
     struct topic_metadata {
-        size_t partition_count;
-        size_t rf;
+        int32_t partition_count;
+        int16_t rf;
     };
     chunked_hash_map<::model::topic, topic_metadata> find_candidate_topics();
     ss::future<kafka::describe_configs_response> describe_topics(

--- a/src/v/cluster_link/source_topic_syncer.h
+++ b/src/v/cluster_link/source_topic_syncer.h
@@ -49,7 +49,39 @@ private:
         int32_t partition_count;
         int16_t rf;
     };
-    chunked_hash_map<::model::topic, topic_metadata> find_candidate_topics();
+
+    using reconciler_commands = std::variant<
+      model::add_mirror_topic_cmd,
+      model::update_mirror_topic_properties_cmd,
+      model::update_mirror_topic_state_cmd>;
+    using reconciler_commands_vector = chunked_vector<reconciler_commands>;
+    // Map of topics who are candidates for mirror topic creation
+    using candidate_create_map
+      = chunked_hash_map<::model::topic, topic_metadata>;
+    // Map of topics who are candidates for updates, include the current
+    // mirror_topic_metadata for cached properties
+    using candidate_update_map = chunked_hash_map<
+      ::model::topic,
+      std::pair<topic_metadata, model::mirror_topic_metadata>>;
+    // Builds a list of topics that are candidates for creation
+    candidate_create_map
+    find_candidate_topics_for_creation(kafka::client::cluster& cluster);
+    // Builds a list of topics that are candidates for update
+    candidate_update_map
+    find_candidate_topics_for_update(kafka::client::cluster& cluster);
+    // Enqueue the add mirror topic commands into the list of commands
+    void enqueue_create_mirror_topic_commands(
+      reconciler_commands_vector& commands,
+      const candidate_create_map& candidates,
+      const chunked_vector<kafka::describe_configs_result>& describe_results);
+    // Enqueue the update mirror topic properties or update mirror topic state
+    // commands
+    void enqueue_update_mirror_topic_commands(
+      reconciler_commands_vector& commands,
+      const candidate_update_map& candidates,
+      const chunked_vector<kafka::describe_configs_result>& describe_results);
+    // Execute the commands
+    ss::future<> submit_commands(reconciler_commands_vector commands);
     ss::future<kafka::describe_configs_response> describe_topics(
       kafka::client::cluster& cluster,
       ::model::node_id controller_id,

--- a/src/v/cluster_link/task.cc
+++ b/src/v/cluster_link/task.cc
@@ -200,7 +200,7 @@ bool controller_locked_task::is_controller_leader(
     if (shard != ::cluster::controller_stm_shard) {
         return false;
     }
-    auto leader = get_link()->get_partition_leader_cache().get_leader_node(
+    auto leader = get_link()->partition_leader_cache().get_leader_node(
       ::model::controller_ntp);
     return leader == current_node;
 }

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -105,6 +105,7 @@ redpanda_cc_gtest(
     timeout = "short",
     srcs = [
         "source_topic_syncer_test.cc",
+        "topic_properties_syncer_test.cc",
     ],
     deps = [
         ":test_deps",

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -31,9 +31,6 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata metadata,
-      kafka::data::rpc::partition_leader_cache* leader_cache,
-      kafka::data::rpc::partition_manager* pm,
-      kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection) override {
         auto name = metadata.name;
         auto created_link = std::make_unique<link>(
@@ -42,9 +39,6 @@ public:
           manager,
           _task_reconciler_interval,
           std::move(metadata),
-          leader_cache,
-          pm,
-          topic_metadata_cache,
           std::move(cluster_connection));
 
         _links.emplace(std::move(name), created_link.get());

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -93,6 +93,21 @@ public:
         co_return ec.value();
     }
 
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_state(
+      model::id_t id,
+      model::update_mirror_topic_state_cmd cmd,
+      ::model::timeout_clock::time_point) override {
+        auto link = _table->find_link_by_id(id);
+        if (!link) {
+            co_return ::cluster::cluster_link::errc::does_not_exist;
+        }
+        auto batch = ::cluster::cluster_link::testing::
+          create_update_mirror_topic_state_command(id, std::move(cmd));
+
+        auto ec = co_await _table->apply_update(std::move(batch));
+        co_return ec.value();
+    }
+
 private:
     cluster::cluster_link::table* _table;
 };

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -122,6 +122,25 @@ public:
         co_return ec.value();
     }
 
+    std::optional<chunked_hash_map<
+      ::model::topic,
+      ::cluster_link::model::mirror_topic_metadata>>
+    get_mirror_topics_for_link(model::id_t id) const override {
+        auto link = _table->find_link_by_id(id);
+        if (!link) {
+            return std::nullopt;
+        }
+        chunked_hash_map<
+          ::model::topic,
+          ::cluster_link::model::mirror_topic_metadata>
+          mirror_topics;
+        mirror_topics.reserve(link->get().state.mirror_topics.size());
+        for (const auto& [topic, metadata] : link->get().state.mirror_topics) {
+            mirror_topics.emplace(topic, metadata.copy());
+        }
+        return mirror_topics;
+    }
+
 private:
     cluster::cluster_link::table* _table;
 };

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -108,6 +108,20 @@ public:
         co_return ec.value();
     }
 
+    ss::future<::cluster::cluster_link::errc> update_mirror_topic_properties(
+      model::id_t id,
+      model::update_mirror_topic_properties_cmd cmd,
+      ::model::timeout_clock::time_point) override {
+        auto link = _table->find_link_by_id(id);
+        if (!link) {
+            co_return ::cluster::cluster_link::errc::does_not_exist;
+        }
+        auto batch = ::cluster::cluster_link::testing::
+          create_update_mirror_topic_properties_command(id, std::move(cmd));
+        auto ec = co_await _table->apply_update(std::move(batch));
+        co_return ec.value();
+    }
+
 private:
     cluster::cluster_link::table* _table;
 };

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -26,9 +26,6 @@ using namespace std::chrono_literals;
 namespace cluster_link::tests {
 
 using ::cluster::cluster_link::table;
-using kafka::data::rpc::partition_leader_cache;
-using kafka::data::rpc::partition_manager;
-using kafka::data::rpc::topic_metadata_cache;
 
 class link_test;
 namespace {
@@ -42,9 +39,6 @@ public:
       ss::lowres_clock::duration task_reconciler_interval,
       link_test* link_test,
       model::metadata metadata,
-      partition_leader_cache* partition_leader_cache,
-      partition_manager* partition_manager,
-      topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection);
 
     ss::future<> start() override;
@@ -66,9 +60,6 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata metadata,
-      partition_leader_cache* partition_leader_cache,
-      partition_manager* partition_manager,
-      topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection) override {
         return std::make_unique<test_link>(
           self,
@@ -77,9 +68,6 @@ public:
           _task_reconciler_interval,
           _link_test,
           std::move(metadata),
-          partition_leader_cache,
-          partition_manager,
-          topic_metadata_cache,
           std::move(cluster_connection));
     }
 
@@ -223,9 +211,6 @@ test_link::test_link(
   ss::lowres_clock::duration task_reconciler_interval,
   link_test* link_test,
   model::metadata metadata,
-  partition_leader_cache* partition_leader_cache,
-  partition_manager* partition_manager,
-  topic_metadata_cache* topic_metadata_cache,
   kafka::client::cluster cluster_connection)
   : link(
       self,
@@ -233,9 +218,6 @@ test_link::test_link(
       manager,
       task_reconciler_interval,
       std::move(metadata),
-      partition_leader_cache,
-      partition_manager,
-      topic_metadata_cache,
       std::move(cluster_connection))
   , _link_test(link_test) {}
 
@@ -389,9 +371,6 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata metadata,
-      partition_leader_cache* partition_leader_cache,
-      partition_manager* partition_manager,
-      topic_metadata_cache* topic_metadata_cache,
       kafka::client::cluster cluster_connection) override {
         return std::make_unique<evil_link>(
           self,
@@ -399,9 +378,6 @@ public:
           manager,
           1s,
           std::move(metadata),
-          partition_leader_cache,
-          partition_manager,
-          topic_metadata_cache,
           std::move(cluster_connection));
     }
 };

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -11,6 +11,7 @@
 
 #include "cluster_link/source_topic_syncer.h"
 #include "cluster_link/tests/deps.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <algorithm>
@@ -136,12 +137,17 @@ TEST_F_CORO(source_topic_syncer_test, select_all_filter) {
       kafka::topic_authorized_operations(0x508));
 
     // Allow auto topic sensor to run
-    co_await ss::sleep(2s);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        auto& mirror_topics = link_metadata->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
+        return mirror_topic_it != mirror_topics.end();
+    });
 
     link_metadata = fixture()->find_link_by_name(model::name_t("test_link"));
     auto& mirror_topics = link_metadata->get().state.mirror_topics;
     auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
-    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
     EXPECT_EQ(
       mirror_topic_it->second.source_topic_name, ::model::topic("test_topic"));
     EXPECT_EQ(mirror_topic_it->second.partition_count, 3);
@@ -174,13 +180,18 @@ TEST_F_CORO(source_topic_syncer_test, select_all_with_exclude) {
 
     // Allow auto topic sensor to run
     co_await ss::sleep(2s);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        auto& mirror_topics = link_metadata->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
+        return mirror_topic_it != mirror_topics.end();
+    });
 
     auto link_metadata = fixture()->find_link_by_name(
       model::name_t("test_link"));
     auto& mirror_topics = link_metadata->get().state.mirror_topics;
-    auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
-    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
-    mirror_topic_it = mirror_topics.find(::model::topic("excluded-topic"));
+    auto mirror_topic_it = mirror_topics.find(::model::topic("excluded-topic"));
     EXPECT_EQ(mirror_topic_it, mirror_topics.end())
       << "Excluded topic should not be mirrored";
 }
@@ -384,13 +395,19 @@ TEST_F_CORO(invalid_describe_configs_test, bad_describe_config_response) {
 
     // Allow auto topic sensor to run
     co_await ss::sleep(2s);
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        auto& mirror_topics = link_metadata->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
+        return mirror_topic_it != mirror_topics.end();
+    });
 
     auto link_metadata = fixture()->find_link_by_name(
       model::name_t("test_link"));
     auto& mirror_topics = link_metadata->get().state.mirror_topics;
-    auto mirror_topic_it = mirror_topics.find(::model::topic("test_topic"));
-    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
-    mirror_topic_it = mirror_topics.find(::model::topic("not_requested_topic"));
+    auto mirror_topic_it = mirror_topics.find(
+      ::model::topic("not_requested_topic"));
     EXPECT_EQ(mirror_topic_it, mirror_topics.end())
       << "Excluded topic should not be mirrored";
 }

--- a/src/v/cluster_link/tests/topic_properties_syncer_test.cc
+++ b/src/v/cluster_link/tests/topic_properties_syncer_test.cc
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/source_topic_syncer.h"
+#include "cluster_link/tests/deps.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::tests {
+using model::filter_pattern_type;
+using model::filter_type;
+using model::resource_name_filter_pattern;
+namespace {
+const ::model::topic test_topic{"test_topic"};
+const model::name_t test_link_name{"test_link"};
+model::metadata get_default_metadata() {
+    model::link_state link_state;
+    model::link_configuration link_configuration;
+    link_configuration.topic_metadata_mirroring_cfg.task_interval = 1s;
+    link_configuration.topic_metadata_mirroring_cfg.topic_name_filters
+      .emplace_back(resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::literal,
+        .filter = filter_type::include,
+        .pattern = resource_name_filter_pattern::wildcard});
+    link_state.mirror_topics.emplace(
+      test_topic,
+      model::mirror_topic_metadata{
+        .source_topic_name = test_topic,
+        .partition_count = 1,
+        .replication_factor = 1,
+        .topic_configs = {
+          {"max.message.bytes", "1048576"},
+          {"cleanup.policy", "delete"},
+          {"message.timestamp.type", "CreateTime"}}});
+    model::metadata metadata{
+      .name = test_link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::
+        connection_config{.bootstrap_servers = {net::unresolved_address("localhost", 9092)}},
+      .state = std::move(link_state),
+      .configuration = std::move(link_configuration),
+    };
+
+    return metadata;
+}
+} // namespace
+
+class topic_properties_syncer_test : public seastar_test {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+
+    ss::future<> SetUpAsync() override {
+        _clmtf = std::make_unique<cluster_link_manager_test_fixture>(self());
+        co_await _clmtf->wire_up_and_start(
+          std::make_unique<test_link_factory>(task_reconciler_interval));
+
+        co_await _clmtf->get_manager().invoke_on_all([](manager& m) {
+            return m.register_task_factory<source_topic_syncer_factory>();
+        });
+
+        fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+
+        co_await fixture()->upsert_link(get_default_metadata());
+        fixture()->get_cluster_mock().add_topic(
+          test_topic, 1, 1, kafka::topic_authorized_operations(0x508));
+    }
+    ss::future<> TearDownAsync() override {
+        co_await _clmtf->reset();
+        _clmtf.reset();
+    }
+    cluster_link_manager_test_fixture* fixture() { return _clmtf.get(); }
+    ::model::node_id self() const { return ::model::node_id{0}; }
+
+private:
+    std::unique_ptr<cluster_link_manager_test_fixture> _clmtf;
+};
+
+TEST_F_CORO(topic_properties_syncer_test, topic_properties_sync) {
+    fixture()->get_cluster_mock().set_topic_partition_count(test_topic, 3);
+    fixture()->get_cluster_mock().set_topic_replication_factor(test_topic, 3);
+    ::cluster::topic_properties properties;
+    properties.batch_max_bytes = 1024;
+    fixture()->get_cluster_mock().set_topic_properties(
+      test_topic, std::move(properties));
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 3
+                   && topic_metadata.replication_factor == 3
+                   && topic_metadata.topic_configs.at("max.message.bytes")
+                        == "1024";
+        }
+        return false;
+    });
+
+    // Now remove the topic and add it back in with a partition count of 1 -
+    // this will result in the mirror topic going into the failed state
+    fixture()->get_cluster_mock().remove_topic(test_topic);
+    fixture()->get_cluster_mock().add_topic(
+      test_topic, 1, 1, kafka::topic_authorized_operations(0x508));
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            return mirror_topic_it->second.state
+                   == model::mirror_topic_state::failed;
+        }
+        return false;
+    });
+
+    // Now update the topic properties again, but there should be no change
+    fixture()->get_cluster_mock().set_topic_partition_count(test_topic, 5);
+    co_await ss::sleep(2s);
+    auto link = fixture()->find_link_by_name(test_link_name);
+    const auto& mirror_topics = link->get().state.mirror_topics;
+    auto mirror_topic_it = mirror_topics.find(test_topic);
+    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
+    EXPECT_EQ(mirror_topic_it->second.partition_count, 3);
+    EXPECT_EQ(mirror_topic_it->second.state, model::mirror_topic_state::failed);
+}
+
+class update_properties_invalid_describe_configs_test
+  : public topic_properties_syncer_test {
+public:
+    void set_describe_configs_results(
+      chunked_vector<kafka::describe_configs_result> results) {
+        _describe_configs_results = std::move(results);
+    }
+
+    virtual ss::future<> SetUpAsync() override {
+        co_await topic_properties_syncer_test::SetUpAsync();
+        fixture()->get_cluster_mock().register_handler(
+          kafka::describe_configs_api::key,
+          [this](
+            ::model::node_id id,
+            kafka::client::request_t req,
+            kafka::api_version v) {
+              return handle_describe_configs(id, std::move(req), v);
+          });
+    }
+
+    ss::future<kafka::client::response_t> handle_describe_configs(
+      ::model::node_id id, kafka::client::request_t req, kafka::api_version v) {
+        if (_describe_configs_results.empty()) {
+            co_return co_await fixture()
+              ->get_cluster_mock()
+              .handle_describe_configs_request(id, std::move(req), v);
+        } else {
+            kafka::describe_configs_response resp;
+            std::ranges::move(
+              _describe_configs_results, std::back_inserter(resp.data.results));
+            _describe_configs_results.clear();
+            co_return resp;
+        }
+    }
+
+private:
+    chunked_vector<kafka::describe_configs_result> _describe_configs_results;
+};
+
+TEST_F_CORO(
+  update_properties_invalid_describe_configs_test,
+  do_not_return_topic_config_mod_partition_count) {
+    chunked_vector<kafka::describe_configs_result> response;
+    response.emplace_back(kafka::describe_configs_result{
+      .error_code = kafka::error_code::none,
+      .resource_type = kafka::config_resource_type::topic,
+      .resource_name = "no-such-topic",
+    });
+    set_describe_configs_results(std::move(response));
+    fixture()->get_cluster_mock().set_topic_partition_count(test_topic, 3);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 3;
+        }
+        return false;
+    });
+}
+
+TEST_F_CORO(
+  update_properties_invalid_describe_configs_test,
+  do_not_return_topic_config_no_mod) {
+    auto properties = [this]() {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it == mirror_topics.end()) {
+            throw std::runtime_error("Mirror topic not found in test setup");
+        }
+        return mirror_topic_it->second.copy();
+    }();
+
+    chunked_vector<kafka::describe_configs_result> response;
+    response.emplace_back(kafka::describe_configs_result{
+      .error_code = kafka::error_code::none,
+      .resource_type = kafka::config_resource_type::topic,
+      .resource_name = "no-such-topic",
+    });
+    set_describe_configs_results(std::move(response));
+
+    // Nothing should change since no properties were changed
+    co_await ss::sleep(2s);
+
+    auto link = fixture()->find_link_by_name(test_link_name);
+    const auto& mirror_topics = link->get().state.mirror_topics;
+    auto mirror_topic_it = mirror_topics.find(test_topic);
+    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
+    EXPECT_EQ(properties, mirror_topic_it->second)
+      << "Properties should not have changed";
+}
+
+TEST_F_CORO(
+  update_properties_invalid_describe_configs_test, return_error_with_mod) {
+    auto properties = [this]() {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it == mirror_topics.end()) {
+            throw std::runtime_error("Mirror topic not found in test setup");
+        }
+        return mirror_topic_it->second.copy();
+    }();
+    chunked_vector<kafka::describe_configs_result> response;
+    response.emplace_back(kafka::describe_configs_result{
+      .error_code = kafka::error_code::topic_authorization_failed,
+      .resource_type = kafka::config_resource_type::topic,
+      .resource_name = test_topic,
+      .configs = {kafka::describe_configs_resource_result{
+        .name = "max.message.bytes", .value = "1024"}}});
+    set_describe_configs_results(std::move(response));
+    fixture()->get_cluster_mock().set_topic_partition_count(test_topic, 3);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 3;
+        }
+        return false;
+    });
+
+    auto link = fixture()->find_link_by_name(test_link_name);
+    const auto& mirror_topics = link->get().state.mirror_topics;
+    auto mirror_topic_it = mirror_topics.find(test_topic);
+    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
+    EXPECT_EQ(properties.topic_configs, mirror_topic_it->second.topic_configs)
+      << "Properties should not have changed";
+}
+
+TEST_F_CORO(
+  update_properties_invalid_describe_configs_test, return_wrong_resource_type) {
+    auto properties = [this]() {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it == mirror_topics.end()) {
+            throw std::runtime_error("Mirror topic not found in test setup");
+        }
+        return mirror_topic_it->second.copy();
+    }();
+    chunked_vector<kafka::describe_configs_result> response;
+    response.emplace_back(kafka::describe_configs_result{
+      .error_code = kafka::error_code::none,
+      .resource_type = kafka::config_resource_type::broker,
+      .resource_name = test_topic,
+      .configs = {kafka::describe_configs_resource_result{
+        .name = "max.message.bytes", .value = "1024"}}});
+    set_describe_configs_results(std::move(response));
+    fixture()->get_cluster_mock().set_topic_partition_count(test_topic, 3);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 3;
+        }
+        return false;
+    });
+
+    auto link = fixture()->find_link_by_name(test_link_name);
+    const auto& mirror_topics = link->get().state.mirror_topics;
+    auto mirror_topic_it = mirror_topics.find(test_topic);
+    ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
+    EXPECT_EQ(properties.topic_configs, mirror_topic_it->second.topic_configs)
+      << "Properties should not have changed";
+}
+
+} // namespace cluster_link::tests

--- a/src/v/kafka/client/test/cluster_mock.cc
+++ b/src/v/kafka/client/test/cluster_mock.cc
@@ -392,6 +392,118 @@ void cluster_mock::add_topic(
     _topics.emplace(topic_name, std::move(md));
 }
 
+void cluster_mock::remove_topic(model::topic_view topic_name) {
+    auto topics_it = _topics.find(topic_name);
+    if (topics_it == _topics.end()) {
+        throw std::invalid_argument(
+          fmt::format("Topic {} does not exist", topic_name));
+    }
+    _topics.erase(topics_it);
+}
+
+void cluster_mock::set_topic_partition_count(
+  model::topic_view topic_name, int32_t partition_count) {
+    auto topics_it = _topics.find(topic_name);
+    if (topics_it == _topics.end()) {
+        throw std::invalid_argument(
+          fmt::format("Topic {} does not exist", topic_name));
+    }
+
+    if (partition_count < 1) {
+        throw std::invalid_argument(fmt::format(
+          "Invalid partition count {} for topic {}",
+          partition_count,
+          topic_name));
+    }
+
+    if (
+      topics_it->second.partitions.size()
+      > static_cast<size_t>(partition_count)) {
+        throw std::invalid_argument(fmt::format(
+          "Cannot reduce partition count for topic {} from {} to {}",
+          topic_name,
+          topics_it->second.partitions.size(),
+          partition_count));
+    }
+
+    if (
+      topics_it->second.partitions.size()
+      == static_cast<size_t>(partition_count)) {
+        // No change needed
+        return;
+    }
+
+    auto rf = topics_it->second.partitions.begin()->second.replicas.size();
+
+    auto cluster_nodes = get_broker_ids();
+    std::ranges::sort(cluster_nodes);
+
+    for (auto p_id : std::views::iota(
+           topics_it->second.partitions.size(),
+           static_cast<size_t>(partition_count))) {
+        partition_metadata p_md{
+          .id = model::partition_id(p_id), .leader = model::node_id(-1)};
+        std::copy_n(
+          cluster_nodes.begin(), rf, std::back_inserter(p_md.replicas));
+        if (!p_md.replicas.empty()) {
+            p_md.leader = p_md.replicas[0];
+        }
+        p_md.leader_epoch = kafka::invalid_leader_epoch;
+        topics_it->second.partitions.emplace(
+          model::partition_id(p_id), std::move(p_md));
+    }
+}
+
+void cluster_mock::set_topic_replication_factor(
+  model::topic_view topic_name, int16_t rf) {
+    auto topics_it = _topics.find(topic_name);
+    if (topics_it == _topics.end()) {
+        throw std::invalid_argument(
+          fmt::format("Topic {} does not exist", topic_name));
+    }
+    if (rf < 1) {
+        throw std::invalid_argument(fmt::format(
+          "Invalid replication factor {} for topic {}", rf, topic_name));
+    }
+    if (static_cast<size_t>(rf) > _brokers.size()) {
+        throw std::invalid_argument(fmt::format(
+          "Replication factor {} exceeds available brokers for topic {}",
+          rf,
+          topic_name));
+    }
+
+    auto cur_rf = topics_it->second.partitions.begin()->second.replicas.size();
+    if (cur_rf == static_cast<size_t>(rf)) {
+        // No change needed
+        return;
+    }
+
+    auto cluster_nodes = get_broker_ids();
+    std::ranges::sort(cluster_nodes);
+    for (auto& [_, meta] : topics_it->second.partitions) {
+        if (cur_rf > static_cast<size_t>(rf)) {
+            // Reduce replication factor
+            meta.replicas.resize(static_cast<size_t>(rf));
+        } else {
+            auto diff = static_cast<size_t>(rf) - cur_rf;
+            std::copy_n(
+              cluster_nodes.begin() + cur_rf,
+              diff,
+              std::back_inserter(meta.replicas));
+        }
+    }
+}
+
+void cluster_mock::set_topic_properties(
+  model::topic_view topic_name, cluster::topic_properties properties) {
+    auto topics_it = _topics.find(topic_name);
+    if (topics_it == _topics.end()) {
+        throw std::invalid_argument(
+          fmt::format("Topic {} does not exist", topic_name));
+    }
+    topics_it->second.topic_properties = std::move(properties);
+}
+
 cluster_mock::cluster_mock()
   : _logger(kclog, "cluster-mock") {
     default_supported_versions[metadata_api::key] = {

--- a/src/v/kafka/client/test/cluster_mock.h
+++ b/src/v/kafka/client/test/cluster_mock.h
@@ -122,6 +122,13 @@ public:
       size_t replication_factor,
       kafka::topic_authorized_operations authorized_operations
       = kafka::topic_authorized_operations_not_set);
+    void remove_topic(model::topic_view topic_name);
+
+    void set_topic_partition_count(
+      model::topic_view topic_name, int32_t partition_count);
+    void set_topic_replication_factor(model::topic_view topic_name, int16_t rf);
+    void set_topic_properties(
+      model::topic_view topic_name, ::cluster::topic_properties properties);
 
     std::vector<model::node_id> get_broker_ids() const {
         return std::ranges::views::keys(_brokers)

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -89,7 +89,8 @@ topic_cache::authorized_operations_for_topic(model::topic_view tp) const {
     return topic_it->second.authorized_operations;
 }
 
-std::optional<size_t> topic_cache::partition_count(model::topic_view tp) const {
+std::optional<int32_t>
+topic_cache::partition_count(model::topic_view tp) const {
     auto topic_it = _topics.find(tp);
     if (topic_it == _topics.end()) {
         return std::nullopt;
@@ -97,7 +98,7 @@ std::optional<size_t> topic_cache::partition_count(model::topic_view tp) const {
     return topic_it->second.partitions.size();
 }
 
-std::optional<size_t>
+std::optional<int16_t>
 topic_cache::replication_factor(model::topic_view tp) const {
     auto topic_it = _topics.find(tp);
     if (topic_it == _topics.end()) {

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -31,7 +31,7 @@ class topic_cache {
         chunked_hash_map<model::partition_id, partition_data> partitions;
         kafka::topic_authorized_operations authorized_operations
           = kafka::topic_authorized_operations_not_set;
-        size_t replication_factor;
+        int16_t replication_factor;
     };
 
     using topics_t = chunked_hash_map<model::topic, topic_data>;
@@ -57,9 +57,9 @@ public:
     std::optional<kafka::topic_authorized_operations>
     authorized_operations_for_topic(model::topic_view tp) const;
 
-    std::optional<size_t> partition_count(model::topic_view tp) const;
+    std::optional<int32_t> partition_count(model::topic_view tp) const;
 
-    std::optional<size_t> replication_factor(model::topic_view tp) const;
+    std::optional<int16_t> replication_factor(model::topic_view tp) const;
 
     const topics_t& cache() const noexcept;
 

--- a/src/v/test_utils/async.h
+++ b/src/v/test_utils/async.h
@@ -33,7 +33,7 @@ using namespace std::chrono_literals;
 #define RPTEST_REQUIRE_EVENTUALLY_CORO(...)                                    \
     do {                                                                       \
         try {                                                                  \
-            co_await tests::cooperative_spin_wait_with_timeout(__VA_ARGS__);   \
+            co_await ::tests::cooperative_spin_wait_with_timeout(__VA_ARGS__); \
         } catch (const ss::timed_out_error&) {                                 \
             RPTEST_FAIL_CORO(                                                  \
               ssx::sformat("Timed out at {}:{}", __FILE__, __LINE__));         \
@@ -44,7 +44,7 @@ using namespace std::chrono_literals;
 #define RPTEST_REQUIRE_EVENTUALLY(...)                                         \
     do {                                                                       \
         try {                                                                  \
-            tests::cooperative_spin_wait_with_timeout(__VA_ARGS__).get();      \
+            ::tests::cooperative_spin_wait_with_timeout(__VA_ARGS__).get();    \
         } catch (const ss::timed_out_error&) {                                 \
             RPTEST_FAIL(                                                       \
               ssx::sformat("Timed out at {}:{}", __FILE__, __LINE__));         \


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR updates the `source_topic_syncer` task to, in addition to create mirror topics, keeping existing mirror topic properties in sync with the source topic.  This sync occurs before new mirror topics are created.  It will step through existing mirror topics, and fetch the metadata and topic properties of the source topic and, if it detects a difference, updates the mirror topic in the cluster link table.  It will also mark mirror topics as failed if it determines that the original topic was removed and re-added.  Right now that's done by seeing if the partition count has gone down.  In the future once Topic IDs are implemented, it will check the cached topic ID with that reported back by metadata.

Also additional clean ups were done.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
