### PR TITLE
ct/l1: support reading partial objects cleanly

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -428,7 +428,16 @@ public:
       : _input(std::move(input)) {}
 
     ss::future<result> read_next() final {
+        if (_saw_footer) {
+            // After the footer we have 4 bytes for the size of the footer, so
+            // we need to make sure that we don't try and interpret those bytes
+            // as a `data_type`.
+            co_return eof{};
+        }
         auto dt_buf = co_await _input.read_exactly(sizeof(data_type));
+        if (dt_buf.empty() && _input.eof()) {
+            co_return eof{};
+        }
         if (dt_buf.size() != sizeof(data_type)) {
             throw std::runtime_error(fmt::format(
               "expected {} bytes for data type, got: {}",
@@ -442,6 +451,7 @@ public:
         case data_type::partition_marker:
             co_return co_await read_next_serde<model::ntp>();
         case data_type::footer:
+            _saw_footer = true;
             co_return co_await read_next_serde<footer>();
         }
         throw std::runtime_error(fmt::format(
@@ -488,6 +498,7 @@ private:
     }
 
     ss::input_stream<char> _input;
+    bool _saw_footer = false;
 };
 
 } // namespace

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -289,6 +289,9 @@ public:
 // it can also represent the tail of an L1 object (see object_seeker for more).
 class object_reader {
 public:
+    // A marker struct that indicates we've reached the end of the file.
+    struct eof {};
+
     object_reader() = default;
     object_reader(const object_reader&) = delete;
     object_reader(object_reader&&) = delete;
@@ -317,7 +320,7 @@ public:
     // and we are about to start reading the next partition. If an footer
     // is returned, then we've reached the end of the file and the footer is
     // returned.
-    using result = std::variant<model::ntp, model::record_batch, footer>;
+    using result = std::variant<model::ntp, model::record_batch, footer, eof>;
 
     // Read the "next" item from the L1 object.
     //

--- a/src/v/cloud_topics/level_one/common/tests/object_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_test.cc
@@ -372,22 +372,29 @@ namespace {
 testing::AssertionResult expect_read_results(
   std::unique_ptr<object_reader> reader,
   const std::vector<batches_by_ntp>& expected,
-  const footer& index) {
+  std::optional<std::reference_wrapper<footer>> object_footer,
+  bool expect_ntp_markers = true) {
     auto _ = ss::defer([&reader] { reader->close().get(); });
     for (const auto& [ntp, specs] : expected) {
-        auto partition = reader->read_next().get();
-        if (!std::holds_alternative<model::ntp>(partition)) {
-            return testing::AssertionFailure()
-                   << "Expected partition for ntp: " << ntp << ", but got "
-                   << partition.index();
-        }
-        if (std::get<model::ntp>(partition) != ntp) {
-            return testing::AssertionFailure()
-                   << "Expected partition for ntp: " << ntp
-                   << ", but got: " << std::get<model::ntp>(partition);
+        if (expect_ntp_markers) {
+            SCOPED_TRACE(fmt::format("reading: {}", ntp));
+            object_reader::result partition;
+            EXPECT_NO_THROW(partition = reader->read_next().get());
+            if (!std::holds_alternative<model::ntp>(partition)) {
+                return testing::AssertionFailure()
+                       << "Expected partition for ntp: " << ntp << ", but got "
+                       << partition.index();
+            }
+            if (std::get<model::ntp>(partition) != ntp) {
+                return testing::AssertionFailure()
+                       << "Expected partition for ntp: " << ntp
+                       << ", but got: " << std::get<model::ntp>(partition);
+            }
         }
         for (const auto& spec : specs) {
-            auto result = reader->read_next().get();
+            SCOPED_TRACE(fmt::format("reading batch @{}", spec.base_offset));
+            object_reader::result result;
+            EXPECT_NO_THROW(result = reader->read_next().get());
             if (!std::holds_alternative<model::record_batch>(result)) {
                 return testing::AssertionFailure()
                        << "Expected batch for offset range: "
@@ -411,17 +418,29 @@ testing::AssertionResult expect_read_results(
             }
         }
     }
-    auto result = reader->read_next().get();
-    if (!std::holds_alternative<footer>(result)) {
-        return testing::AssertionFailure()
-               << "Expected object index at the end, but got "
-               << result.index();
-    }
+    if (object_footer.has_value()) {
+        SCOPED_TRACE(fmt::format("reading footer"));
+        object_reader::result result;
+        EXPECT_NO_THROW(result = reader->read_next().get());
+        if (!std::holds_alternative<footer>(result)) {
+            return testing::AssertionFailure()
+                   << "Expected object index at the end, but got "
+                   << result.index();
+        }
 
-    if (std::get<footer>(result) != index) {
+        if (std::get<footer>(result) != object_footer.value()) {
+            return testing::AssertionFailure()
+                   << "Expected matching object index: "
+                   << fmt::format("{}", object_footer.value().get())
+                   << ", got: " << fmt::format("{}", std::get<footer>(result));
+        }
+    }
+    SCOPED_TRACE(fmt::format("reading eof"));
+    object_reader::result result;
+    EXPECT_NO_THROW(result = reader->read_next().get());
+    if (!std::holds_alternative<object_reader::eof>(result)) {
         return testing::AssertionFailure()
-               << "Expected matching object index: " << fmt::format("{}", index)
-               << ", got: " << fmt::format("{}", std::get<footer>(result));
+               << "Expected eof after the end, but got " << result.index();
     }
     return testing::AssertionSuccess();
 }
@@ -496,4 +515,61 @@ TEST(L1Objects, FullScan) {
     }
     EXPECT_TRUE(
       expect_read_results(make_reader(object), specs_by_ntp, info.index));
+}
+
+TEST(L1Objects, PartialScan) {
+    std::vector<batches_by_ntp> specs_by_ntp = {
+      {
+        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .batches = {
+          {
+            .base_offset = 0_o,
+            .last_offset = 10_o,
+            .max_timestamp = model::timestamp{1000},
+          },
+          {
+            .base_offset = 11_o,
+            .last_offset = 20_o,
+            .max_timestamp = model::timestamp{2000},
+          },
+          {
+            .base_offset = 21_o,
+            .last_offset = 30_o,
+            .max_timestamp = model::timestamp{3000},
+          },
+        },
+      },
+      {
+        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(1)},
+        .batches = {
+          {
+            .base_offset = 99_o,
+            .last_offset = 100_o,
+            .max_timestamp = model::timestamp{1001},
+          },
+          {
+            .base_offset = 101_o,
+            .last_offset = 110_o,
+            .max_timestamp = model::timestamp{2001},
+          },
+          {
+            .base_offset = 120_o,
+            .last_offset = 130_o,
+            .max_timestamp = model::timestamp{3001},
+          },
+        },
+      },
+    };
+    auto [info, object] = make_object(specs_by_ntp);
+    for (const auto& spec : specs_by_ntp) {
+        auto it = info.index.partitions.find(spec.ntp);
+        ASSERT_NE(it, info.index.partitions.end());
+        auto reader = object_reader::create(make_iobuf_input_stream(
+          object.share(it->second.file_position, it->second.length)));
+        EXPECT_TRUE(expect_read_results(
+          std::move(reader),
+          {spec},
+          std::nullopt,
+          /*expect_ntp_markers=*/false));
+    }
 }


### PR DESCRIPTION
If we only download part of an object we want to be able to know when we
reach the end (instead of throwing). The end in this case might be
before the footer, so add a new result type for EOF in this case.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
