### PR TITLE
raft/tests/raft_reconfiguration_test deflake leak

### DIFF
--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -346,6 +346,8 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
         break;
     }
 
+    // lets us await any cleanup operation needed at the end
+    ss::future<> cleanup_operation = ss::now();
     if (!isolated_nodes->empty()) {
         vlog(test_log.info, "isolating nodes: {}", *isolated_nodes);
 
@@ -360,8 +362,8 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
             });
         }
 
-        // heal the partition 5s later
-        (void)ss::sleep(20s).then([isolated_nodes] {
+        // heal the partition 20s later
+        cleanup_operation = ss::sleep(20s).then([isolated_nodes] {
             vlog(test_log.info, "healing the network partition");
             isolated_nodes->clear();
         });
@@ -409,6 +411,8 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
         current_node_ptrs.push_back(&node(id));
     }
     assert_offset_translator_state_is_consistent(current_node_ptrs);
+
+    co_await std::move(cleanup_operation);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
PR 26996 changed the timing of heartbeats which in turn changed the timing of reconfigurations. As a result raft_reconfiguration_test flakily leaked because it relied on a sleep to clean up test resources.

This pr has the test await its resource cleanup before termination.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
