### PR TITLE
ducktape: add TCO related usage stats

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import dataclasses
 import functools
 from re import Pattern
 import time
@@ -226,7 +227,9 @@ def cluster(log_allow_list: LogAllowList | None = None,
                 if self.redpanda._si_settings is not None and not self.redpanda.si_settings.skip_end_of_test_scrubbing:
                     try:
                         self.redpanda.maybe_do_internal_scrub()
-                        self.redpanda.stop_and_scrub_object_storage()
+                        usage = self.redpanda.stop_and_scrub_object_storage()
+                        test_results[
+                            "object_storage_usage"] = dataclasses.asdict(usage)
                     except:
                         self.redpanda.cloud_storage_diagnostics()
                         raise

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -100,6 +100,12 @@ class UsageStats:
     cloud_storage_gets: int = 0
 
 
+@dataclass
+class CloudStorageUsage:
+    object_count: int = 0
+    total_bytes_stored: int = 0
+
+
 class CloudStorageCleanupStrategy(enum.Enum):
     # I.e. if we are using a lifecycle rule, then we do NOT clean the bucket
     IF_NOT_USING_LIFECYCLE_RULE = "IF_NOT_USING_LIFECYCLE_RULE"
@@ -5175,9 +5181,10 @@ class RedpandaService(RedpandaServiceBase):
 
         return wait_until_result(check, timeout_sec=timeout_sec, backoff_sec=1)
 
-    def _get_object_storage_report(self,
-                                   tolerate_empty_object_storage=False,
-                                   timeout=300) -> dict[str, Any]:
+    def _get_object_storage_report(
+            self,
+            tolerate_empty_object_storage=False,
+            timeout=300) -> tuple[dict[str, Any], CloudStorageUsage]:
         """
         Uses rp-storage-tool to get the object storage report.
         If the cluster is running the tool could see some inconsistencies and report anomalies,
@@ -5236,7 +5243,11 @@ class RedpandaService(RedpandaServiceBase):
 
         bucket = self.si_settings.cloud_storage_bucket
         environment = ' '.join(f'{k}=\"{v}\"' for k, v in vars.items())
-        bucket_arity = sum(1 for _ in self.get_objects_from_si())
+        usage = CloudStorageUsage()
+        for obj in self.get_objects_from_si():
+            usage.object_count += 1
+            usage.total_bytes_stored += obj.content_length
+        bucket_arity = usage.object_count
         effective_timeout = min(max(bucket_arity * 5, 20), timeout)
         self.logger.info(
             f"num objects in the {bucket=}: {bucket_arity}, will apply {effective_timeout=}"
@@ -5265,7 +5276,7 @@ class RedpandaService(RedpandaServiceBase):
         else:
             self.logger.info(json.dumps(report, indent=2))
 
-        return report
+        return report, usage
 
     def raise_on_cloud_storage_inconsistencies(self,
                                                inconsistencies: list[str],
@@ -5274,7 +5285,7 @@ class RedpandaService(RedpandaServiceBase):
         like stop_and_scrub_object_storage, use rp-storage-tool to explicitly check for inconsistencies,
         but without stopping the cluster.
         """
-        report = self._get_object_storage_report(
+        report, _ = self._get_object_storage_report(
             tolerate_empty_object_storage=True, timeout=run_timeout)
         fatal_anomalies = set(k for k, v in report.items()
                               if len(v) > 0 and k in inconsistencies)
@@ -5286,7 +5297,8 @@ class RedpandaService(RedpandaServiceBase):
                 f"Object storage reports fatal anomalies of type {fatal_anomalies}"
             )
 
-    def stop_and_scrub_object_storage(self, run_timeout=300):
+    def stop_and_scrub_object_storage(self,
+                                      run_timeout=300) -> CloudStorageUsage:
         # Before stopping, ensure that all tiered storage partitions
         # have uploaded at least a manifest: we do not require that they
         # have uploaded until the head of their log, just that they have
@@ -5307,7 +5319,7 @@ class RedpandaService(RedpandaServiceBase):
         self.stop()
 
         scrub_timeout = max(run_timeout, self.cloud_storage_scrub_timeout_s)
-        report = self._get_object_storage_report(timeout=scrub_timeout)
+        report, usage = self._get_object_storage_report(timeout=scrub_timeout)
 
         # It is legal for tiered storage to leak objects under
         # certain circumstances: this will remain the case until
@@ -5337,7 +5349,7 @@ class RedpandaService(RedpandaServiceBase):
             # Tests may declare that they expect some anomalies, e.g. if they
             # intentionally damage the data.
             if self.si_settings.is_damage_expected(fatal_anomalies):
-                self.logger.warn(
+                self.logger.warning(
                     f"Tolerating anomalies in remote storage: {json.dumps(report, indent=2)}"
                 )
             else:
@@ -5347,6 +5359,7 @@ class RedpandaService(RedpandaServiceBase):
                 raise RuntimeError(
                     f"Object storage scrub detected fatal anomalies of type {fatal_anomalies}"
                 )
+        return usage
 
     def maybe_do_internal_scrub(self):
         if not self._si_settings:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -92,6 +92,12 @@ class UsageStats:
     disk_bytes_written: int = 0
     batches_read: int = 0
     batches_written: int = 0
+    internal_rpc_bytes_recv: int = 0
+    internal_rpc_bytes_sent: int = 0
+    # Number of PUT operations
+    cloud_storage_puts: int = 0
+    # Number of GET operations
+    cloud_storage_gets: int = 0
 
 
 class CloudStorageCleanupStrategy(enum.Enum):
@@ -4226,10 +4232,8 @@ class RedpandaService(RedpandaServiceBase):
         def _metrics_sum(name: str) -> int:
             try:
                 samples = self.metrics_sample(name, [node])
-
                 if samples is None:
                     return 0
-
                 return sum(s.value for s in samples.samples)
             except Exception as e:
                 self.logger.warning(f"Cannot check metrics - {e}")
@@ -4245,6 +4249,14 @@ class RedpandaService(RedpandaServiceBase):
 
         self._usage_stats.batches_written += _metrics_sum(
             "vectorized_storage_log_batches_written")
+        self._usage_stats.internal_rpc_bytes_sent += _metrics_sum(
+            "vectorized_internal_rpc_sent_bytes")
+        self._usage_stats.internal_rpc_bytes_recv += _metrics_sum(
+            "vectorized_internal_rpc_received_bytes")
+        self._usage_stats.cloud_storage_puts += _metrics_sum(
+            "vectorized_cloud_client_total_uploads")
+        self._usage_stats.cloud_storage_gets += _metrics_sum(
+            "vectorized_cloud_client_total_downloads")
 
     def stop_node(self, node, timeout=None, forced=False):
         # collect usage stats before the node is stopped, the usage stats

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -88,8 +88,8 @@ MetricSample = collections.namedtuple(
 
 @dataclass
 class UsageStats:
-    bytes_read: int = 0
-    bytes_written: int = 0
+    disk_bytes_read: int = 0
+    disk_bytes_written: int = 0
     batches_read: int = 0
     batches_written: int = 0
 
@@ -4235,10 +4235,10 @@ class RedpandaService(RedpandaServiceBase):
                 self.logger.warning(f"Cannot check metrics - {e}")
                 return 0
 
-        self._usage_stats.bytes_read += _metrics_sum(
+        self._usage_stats.disk_bytes_read += _metrics_sum(
             "vectorized_io_queue_total_read_bytes_total")
 
-        self._usage_stats.bytes_written += _metrics_sum(
+        self._usage_stats.disk_bytes_written += _metrics_sum(
             "vectorized_io_queue_total_write_bytes_total")
         self._usage_stats.batches_read += _metrics_sum(
             "vectorized_storage_log_batches_read")

--- a/tests/rptest/tests/usage_stats_test.py
+++ b/tests/rptest/tests/usage_stats_test.py
@@ -16,7 +16,9 @@ class UsageStatsReportingTest(RedpandaTest):
         stats = self.redpanda.usage_stats
         # validate stats are initially 0
         assert stats.batches_read == 0 and stats.batches_written == 0 and \
-            stats.disk_bytes_read == 0 and stats.disk_bytes_written == 0, \
+            stats.disk_bytes_read == 0 and stats.disk_bytes_written == 0 and \
+            stats.internal_rpc_bytes_recv == 0 and stats.internal_rpc_bytes_sent == 0 and \
+            stats.cloud_storage_gets == 0 and stats.cloud_storage_puts == 0, \
                 "Before restarting Redpanda, the usage stats should be 0"
 
         # restart nodes to trigger usage stats reporting
@@ -29,6 +31,9 @@ class UsageStatsReportingTest(RedpandaTest):
         assert stats.batches_read > 0 and stats.batches_written > 0 and \
             stats.disk_bytes_read > 0 and stats.disk_bytes_written > 0, \
                 "After initial restart the usage stats should be greater than 0"
+        if replication_factor > 1:
+            assert stats.internal_rpc_bytes_recv > 0 and stats.internal_rpc_bytes_sent > 0, \
+                    "After initial restart the internal rpc stats should be greater than 0"
 
         total_messages = 128
         msg_size = 512
@@ -58,9 +63,15 @@ class UsageStatsReportingTest(RedpandaTest):
             "disk_bytes_read"] - initial_stats["disk_bytes_read"]
         disk_bytes_written = stats_after_produce[
             "disk_bytes_written"] - initial_stats["disk_bytes_written"]
+        internal_rpc_bytes_recv = stats_after_produce[
+            "internal_rpc_bytes_recv"] - initial_stats[
+                "internal_rpc_bytes_recv"]
+        internal_rpc_bytes_sent = stats_after_produce[
+            "internal_rpc_bytes_sent"] - initial_stats[
+                "internal_rpc_bytes_sent"]
 
         self.logger.info(
-            f"batches_read: {batches_read}, batches_written: {batches_written}, bytes_read: {disk_bytes_read}, bytes_written: {disk_bytes_written}"
+            f"batches_read: {batches_read}, batches_written: {batches_written}, bytes_read: {disk_bytes_read}, bytes_written: {disk_bytes_written}, internal_rpc_bytes_recv: {internal_rpc_bytes_recv}, internal_rpc_bytes_sent: {internal_rpc_bytes_sent}"
         )
 
         assert batches_written >= total_batches * replication_factor, \

--- a/tests/rptest/tests/usage_stats_test.py
+++ b/tests/rptest/tests/usage_stats_test.py
@@ -16,7 +16,7 @@ class UsageStatsReportingTest(RedpandaTest):
         stats = self.redpanda.usage_stats
         # validate stats are initially 0
         assert stats.batches_read == 0 and stats.batches_written == 0 and \
-            stats.bytes_read == 0 and stats.bytes_written == 0, \
+            stats.disk_bytes_read == 0 and stats.disk_bytes_written == 0, \
                 "Before restarting Redpanda, the usage stats should be 0"
 
         # restart nodes to trigger usage stats reporting
@@ -27,7 +27,7 @@ class UsageStatsReportingTest(RedpandaTest):
         # cluster initialization
         stats = self.redpanda.usage_stats
         assert stats.batches_read > 0 and stats.batches_written > 0 and \
-            stats.bytes_read > 0 and stats.bytes_written > 0, \
+            stats.disk_bytes_read > 0 and stats.disk_bytes_written > 0, \
                 "After initial restart the usage stats should be greater than 0"
 
         total_messages = 128
@@ -54,17 +54,17 @@ class UsageStatsReportingTest(RedpandaTest):
             "batches_read"]
         batches_written = stats_after_produce[
             "batches_written"] - initial_stats["batches_written"]
-        bytes_read = stats_after_produce["bytes_read"] - initial_stats[
-            "bytes_read"]
-        bytes_written = stats_after_produce["bytes_written"] - initial_stats[
-            "bytes_written"]
+        disk_bytes_read = stats_after_produce[
+            "disk_bytes_read"] - initial_stats["disk_bytes_read"]
+        disk_bytes_written = stats_after_produce[
+            "disk_bytes_written"] - initial_stats["disk_bytes_written"]
 
         self.logger.info(
-            f"batches_read: {batches_read}, batches_written: {batches_written}, bytes_read: {bytes_read}, bytes_written: {bytes_written}"
+            f"batches_read: {batches_read}, batches_written: {batches_written}, bytes_read: {disk_bytes_read}, bytes_written: {disk_bytes_written}"
         )
 
         assert batches_written >= total_batches * replication_factor, \
             f"Expected batches_written to be greater than or equal to {total_batches * replication_factor}, but got {batches_written}"
 
-        assert bytes_written >= total_bytes * replication_factor, \
-            f"Expected bytes_written to be greater than or equal to {total_bytes * replication_factor}, but got {bytes_written}"
+        assert disk_bytes_written >= total_bytes * replication_factor, \
+            f"Expected bytes_written to be greater than or equal to {total_bytes * replication_factor}, but got {disk_bytes_written}"


### PR DESCRIPTION
- **rptest: s/bytes_{read,written}/disk_bytes_{read,written}**
- **rptest: add usage metrics for internal RPCs + cloud storage ops**
- **rptest: report on object storage usage**

Build upon https://github.com/redpanda-data/redpanda/pull/26045 to report additional metrics:
- cloud storage usage
- internal RPCs

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
