### PR TITLE
raft: rename take_snapshot to take_raft_snapshot

### DIFF
--- a/src/v/datalake/coordinator/state_machine.cc
+++ b/src/v/datalake/coordinator/state_machine.cc
@@ -167,7 +167,7 @@ ss::future<> coordinator_stm::apply_raft_snapshot(const iobuf& snapshot_buf) {
     state_ = std::move(snapshot.topics);
 }
 
-ss::future<iobuf> coordinator_stm::take_snapshot() {
+ss::future<iobuf> coordinator_stm::take_raft_snapshot() {
     iobuf snapshot_buf;
     co_await serde::write_async(snapshot_buf, make_snapshot());
     co_return std::move(snapshot_buf);

--- a/src/v/datalake/coordinator/state_machine.h
+++ b/src/v/datalake/coordinator/state_machine.h
@@ -70,7 +70,7 @@ protected:
 
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 
-    ss::future<iobuf> take_snapshot() final;
+    ss::future<iobuf> take_raft_snapshot() final;
 
 private:
     void rearm_snapshot_timer();

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -168,7 +168,7 @@ class no_at_offset_snapshot_stm_base : public state_machine_base {
     /**
      * Method that will be called whenever a raft snapshot is required
      */
-    virtual ss::future<iobuf> take_snapshot() = 0;
+    virtual ss::future<iobuf> take_raft_snapshot() = 0;
 
     snapshot_at_offset_supported supports_snapshot_at_offset() const final {
         return snapshot_at_offset_supported::no;
@@ -184,7 +184,7 @@ class no_at_offset_snapshot_stm_base : public state_machine_base {
               offset,
               last_applied_offset()));
         }
-        return take_snapshot();
+        return take_raft_snapshot();
     }
 };
 

--- a/src/v/raft/tests/stm_manager_test.cc
+++ b/src/v/raft/tests/stm_manager_test.cc
@@ -444,8 +444,8 @@ struct controllable_throwing_kv : public simple_kv {
       const ssx::semaphore_units& apply_units) override {
         if (batch.last_offset() > _allow_apply) {
             throw std::runtime_error(fmt::format(
-              "not allowed to apply batches with last offset greater than {}. "
-              "Current batch last offset: {}",
+              "not allowed to apply batches with last offset greater than "
+              "{}. Current batch last offset: {}",
               _allow_apply,
               batch.last_offset()));
         }
@@ -572,7 +572,7 @@ public:
     explicit non_fast_movable_kv(raft_node_instance& rn)
       : simple_kv_base<no_at_offset_snapshot_stm_base>(rn) {}
 
-    ss::future<iobuf> take_snapshot() final {
+    ss::future<iobuf> take_raft_snapshot() final {
         co_return serde::to_iobuf(state);
     }
 


### PR DESCRIPTION
To clarify the difference between local and raft snapshots. This had
already happened in other places, but we missed this specific method.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
