### PR TITLE
ssx: pull out sharded_service_container from application

### DIFF
--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -78,6 +78,7 @@ redpanda_cc_library(
         "//src/v/security/audit",
         "//src/v/ssx:abort_source",
         "//src/v/ssx:future_util",
+        "//src/v/ssx:sharded_service_container",
         "//src/v/ssx:thread_worker",
         "//src/v/ssx:watchdog",
         "//src/v/storage",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -144,6 +144,7 @@
 #include "rpc/rpc_utils.h"
 #include "security/audit/audit_log_manager.h"
 #include "ssx/abort_source.h"
+#include "ssx/sharded_service_container.h"
 #include "ssx/thread_worker.h"
 #include "storage/backlog_controller.h"
 #include "storage/chunk_cache.h"
@@ -281,13 +282,9 @@ static void set_auditing_kafka_client_defaults(
 }
 
 application::application(ss::sstring logger_name)
-  : _log(std::move(logger_name)) {};
+  : ssx::sharded_service_container(logger_name) {}
 
-application::~application() {
-    while (!_deferred.empty()) {
-        _deferred.pop_back();
-    }
-}
+application::~application() {}
 
 void application::shutdown() {
     storage.invoke_on_all(&storage::api::stop_cluster_uuid_waiters).get();
@@ -426,10 +423,7 @@ void application::shutdown() {
         });
     }
 
-    // Shut down services in reverse order to which they were registered.
-    while (!_deferred.empty()) {
-        _deferred.pop_back();
-    }
+    ssx::sharded_service_container::shutdown();
 }
 
 static void log_system_resources(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -65,6 +65,7 @@
 #include "rpc/fwd.h"
 #include "rpc/rpc_server.h"
 #include "security/fwd.h"
+#include "ssx/sharded_service_container.h"
 #include "ssx/watchdog.h"
 #include "storage/api.h"
 #include "storage/fwd.h"
@@ -75,7 +76,6 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/util/defer.hh>
 
 #include <memory>
 
@@ -91,7 +91,7 @@ inline const auto redpanda_start_time{
   std::chrono::duration_cast<std::chrono::milliseconds>(
     std::chrono::system_clock::now().time_since_epoch())};
 
-class application {
+class application : public ssx::sharded_service_container {
 public:
     int run(int, char**);
 
@@ -220,14 +220,6 @@ public:
     }
 
 private:
-    // First warning timeout
-    static constexpr auto short_shutdown_warning_timeout = 15s;
-    // Time after which we will print the warning about the service shutdown
-    // taking too long.
-    static constexpr auto long_shutdown_warning_timeout = 120s;
-    using deferred_actions
-      = std::deque<ss::deferred_action<std::function<void()>>>;
-
     // Constructs and starts the services required to provide cryptographic
     // algorithm support to Redpanda
     void wire_up_and_start_crypto_services();
@@ -273,160 +265,6 @@ private:
 
     ss::shared_ptr<kafka::datalake_usage_api> make_datalake_usage_aggregator();
 
-    // Stop the service.
-    // The method should be invoked in the ss::thread context.
-    template<class Service>
-    void stop_service(
-      Service& s,
-      ss::sstring name,
-      std::optional<ss::sstring> next_to_stop = std::nullopt) {
-        // This watchdog is triggered after short period of time (30s). It
-        // adds message to the log that service is taking a long time to
-        // shutdown on INFO level.
-        ssx::watchdog short_wd(short_shutdown_warning_timeout, [this, name] {
-            vlog(
-              _log.info,
-              "Service {} is taking more than {} seconds to shut down.",
-              name,
-              std::chrono::duration_cast<std::chrono::seconds>(
-                short_shutdown_warning_timeout)
-                .count());
-        });
-        // This watchdog is triggered after long period of time. This indicates
-        // a bug (most likely).
-        ssx::watchdog long_wd(long_shutdown_warning_timeout, [this, name] {
-            vlog(
-              _log.info,
-              "Service {} is taking more than {} seconds to shut down!",
-              name,
-              std::chrono::duration_cast<std::chrono::seconds>(
-                long_shutdown_warning_timeout)
-                .count());
-        });
-        if (next_to_stop.has_value()) {
-            vlog(
-              _log.info,
-              "Stopping {}, ..next to shutdown is {}",
-              name,
-              *next_to_stop);
-        } else {
-            vlog(_log.info, "Stopping {}", name);
-        }
-        s.stop().get();
-        if (!next_to_stop.has_value()) {
-            vlog(_log.info, "Stopped {}", name);
-        }
-    }
-
-    template<class T>
-    static ss::sstring service_type_name() {
-        if constexpr (detail::is_specialization_of_v<T, std::unique_ptr>) {
-            return service_type_name<typename T::element_type>();
-        } else if constexpr (detail::is_specialization_of_v<T, std::vector>) {
-            return fmt::format(
-              "std::vector<{}>", service_type_name<typename T::value_type>());
-        }
-        return ss::pretty_type_name(typeid(T));
-    }
-
-    // Shutdown the service with custom method.
-    // The method should be invoked in the ss::thread context.
-    template<class Service, class StopFunc>
-    void shutdown_with_watchdog(
-      Service& s,
-      StopFunc stop_func,
-      const ss::sstring& name = service_type_name<Service>(),
-      std::source_location location = std::source_location::current()) {
-        auto start_watchdog = [&name, this](
-                                std::chrono::milliseconds timeout,
-                                ss::log_level log_level) {
-            return ssx::watchdog(timeout, [this, timeout, &name, log_level] {
-                vlogl(
-                  _log,
-                  log_level,
-                  "Service {} is taking more than {} seconds to shutdown",
-                  name,
-                  timeout / 1s);
-            });
-        };
-        // This watchdog is triggered after short period of time (30s). It
-        // adds message to the log that service is taking a long time to
-        // shutdown on INFO level.
-        ssx::watchdog short_wd = start_watchdog(
-          short_shutdown_warning_timeout, ss::log_level::info);
-        // This watchdog is triggered after long period of time. This indicates
-        // a bug (most likely).
-        ssx::watchdog long_wd = start_watchdog(
-          long_shutdown_warning_timeout, ss::log_level::error);
-
-        vlog(
-          _log.info,
-          "Shutting down: {} at {}:{}",
-          name,
-          location.file_name(),
-          location.line());
-        stop_func(s).get();
-        vlog(
-          _log.info,
-          "Shutdown completed: {} started at {}:{}",
-          name,
-          location.file_name(),
-          location.line());
-    }
-
-    /**
-     * @brief Construct service boilerplate.
-     *
-     * Construct the given service s, calling start with the given arguments
-     * and set up a shutdown callback to stop it.
-     *
-     * Returns the future from start(), typically you'll call get() on it
-     * immediately to wait for creation to complete.
-     *
-     * @return the future returned by start()
-     */
-    template<typename Service, typename... Args>
-    ss::future<> construct_service(ss::sharded<Service>& s, Args&&... args) {
-        auto name = ss::pretty_type_name(typeid(Service));
-        _deferred.emplace_back(
-          [this, &s, name, next_to_stop = _last_constructed_service_name] {
-              stop_service(s, name, next_to_stop);
-          });
-        _last_constructed_service_name = ss::sstring(name);
-        return s.start(std::forward<Args>(args)...);
-    }
-
-    template<typename Service, typename... Args>
-    void construct_single_service(std::unique_ptr<Service>& s, Args&&... args) {
-        auto name = ss::pretty_type_name(typeid(Service));
-        s = std::make_unique<Service>(std::forward<Args>(args)...);
-        _deferred.emplace_back(
-          [this, &s, name, next_to_stop = _last_constructed_service_name] {
-              stop_service(*s, name, next_to_stop);
-              s.reset();
-          });
-        _last_constructed_service_name = name;
-    }
-
-    template<typename Service, typename... Args>
-    ss::future<>
-    construct_single_service_sharded(ss::sharded<Service>& s, Args&&... args) {
-        auto name = ss::pretty_type_name(typeid(Service));
-        auto f = s.start_single(std::forward<Args>(args)...);
-        _deferred.emplace_back(
-          [this, &s, name, next_to_stop = _last_constructed_service_name] {
-              stop_service(s, name, next_to_stop);
-          });
-        _last_constructed_service_name = name;
-        return f;
-    }
-
-    template<typename ShardedComponent>
-    auto ref_to_local(ss::sharded<ShardedComponent>& component) {
-        return ss::sharded_parameter(
-          [&component] { return std::ref(component.local()); });
-    }
-
     void setup_metrics();
     void setup_public_metrics();
     void setup_internal_metrics();
@@ -451,7 +289,6 @@ private:
     std::optional<kafka::client::configuration> _schema_reg_client_config;
     std::optional<kafka::client::configuration> _audit_log_client_config;
     ss::sharded<scheduling_groups_probe> _scheduling_groups_probe;
-    ss::logger _log;
 
     std::optional<config::binding<bool>> _abort_on_oom;
 
@@ -493,10 +330,6 @@ private:
 
     ss::sharded<kafka::data::rpc::local_service> _kafka_data_rpc_service;
     ss::sharded<kafka::data::rpc::client> _kafka_data_rpc_client;
-
-    // run these first on destruction
-    deferred_actions _deferred;
-    std::optional<ss::sstring> _last_constructed_service_name;
 
     ss::sharded<aggregate_metrics_watcher> _aggregate_metrics_watcher;
 

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -28,6 +28,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "sharded_service_container",
+    hdrs = [
+        "sharded_service_container.h",
+    ],
+    include_prefix = "ssx",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":watchdog",
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "future_util",
     hdrs = [
         "future-util.h",

--- a/src/v/ssx/sharded_service_container.h
+++ b/src/v/ssx/sharded_service_container.h
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/type_traits.h"
+#include "base/vlog.h"
+#include "ssx/watchdog.h"
+
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/defer.hh>
+
+using namespace std::chrono_literals;
+
+namespace ssx {
+
+// Encapsulates metods for starting and stopping sharded services.
+// Child classes own the sharded services, but should construct them using the
+// appropriate construct_*_service call.
+//
+// NOTE: the destructor of this class and all shutdown methods must be run in a
+// Seastar thread.
+class sharded_service_container {
+public:
+    // First warning timeout
+    static constexpr auto short_shutdown_warning_timeout = 15s;
+    // Time after which we will print the warning about the service shutdown
+    // taking too long.
+    static constexpr auto long_shutdown_warning_timeout = 120s;
+    using deferred_actions
+      = std::deque<ss::deferred_action<std::function<void()>>>;
+
+    sharded_service_container(const sharded_service_container&) = delete;
+    sharded_service_container(sharded_service_container&&) = delete;
+    sharded_service_container operator=(const sharded_service_container&)
+      = delete;
+    sharded_service_container operator=(sharded_service_container&&) = delete;
+    explicit sharded_service_container(ss::sstring s)
+      : _log(s) {}
+    ~sharded_service_container() { shutdown(); }
+
+    void shutdown() {
+        // Shut down services in reverse order to which they were registered.
+        while (!_deferred.empty()) {
+            _deferred.pop_back();
+        }
+    }
+
+    // Stop the service.
+    // The method should be invoked in the ss::thread context.
+    template<class Service>
+    void stop_service(
+      Service& s,
+      ss::sstring name,
+      std::optional<ss::sstring> next_to_stop = std::nullopt) {
+        // This watchdog is triggered after short period of time (30s). It
+        // adds message to the log that service is taking a long time to
+        // shutdown on INFO level.
+        ssx::watchdog short_wd(short_shutdown_warning_timeout, [this, name] {
+            vlog(
+              _log.info,
+              "Service {} is taking more than {} seconds to shut down.",
+              name,
+              std::chrono::duration_cast<std::chrono::seconds>(
+                short_shutdown_warning_timeout)
+                .count());
+        });
+        // This watchdog is triggered after long period of time. This indicates
+        // a bug (most likely).
+        ssx::watchdog long_wd(long_shutdown_warning_timeout, [this, name] {
+            vlog(
+              _log.info,
+              "Service {} is taking more than {} seconds to shut down!",
+              name,
+              std::chrono::duration_cast<std::chrono::seconds>(
+                long_shutdown_warning_timeout)
+                .count());
+        });
+        if (next_to_stop.has_value()) {
+            vlog(
+              _log.info,
+              "Stopping {}, ..next to shutdown is {}",
+              name,
+              *next_to_stop);
+        } else {
+            vlog(_log.info, "Stopping {}", name);
+        }
+        s.stop().get();
+        if (!next_to_stop.has_value()) {
+            vlog(_log.info, "Stopped {}", name);
+        }
+    }
+
+    template<class T>
+    static ss::sstring service_type_name() {
+        if constexpr (::detail::is_specialization_of_v<T, std::unique_ptr>) {
+            return service_type_name<typename T::element_type>();
+        } else if constexpr (::detail::is_specialization_of_v<T, std::vector>) {
+            return fmt::format(
+              "std::vector<{}>", service_type_name<typename T::value_type>());
+        }
+        return ss::pretty_type_name(typeid(T));
+    }
+
+    // Shutdown the service with custom method.
+    // The method should be invoked in the ss::thread context.
+    template<class Service, class StopFunc>
+    void shutdown_with_watchdog(
+      Service& s,
+      StopFunc stop_func,
+      const ss::sstring& name = service_type_name<Service>(),
+      std::source_location location = std::source_location::current()) {
+        auto start_watchdog = [&name, this](
+                                std::chrono::milliseconds timeout,
+                                ss::log_level log_level) {
+            return ssx::watchdog(timeout, [this, timeout, &name, log_level] {
+                vlogl(
+                  _log,
+                  log_level,
+                  "Service {} is taking more than {} seconds to shutdown",
+                  name,
+                  timeout / 1s);
+            });
+        };
+        // This watchdog is triggered after short period of time (30s). It
+        // adds message to the log that service is taking a long time to
+        // shutdown on INFO level.
+        ssx::watchdog short_wd = start_watchdog(
+          short_shutdown_warning_timeout, ss::log_level::info);
+        // This watchdog is triggered after long period of time. This indicates
+        // a bug (most likely).
+        ssx::watchdog long_wd = start_watchdog(
+          long_shutdown_warning_timeout, ss::log_level::error);
+
+        vlog(
+          _log.info,
+          "Shutting down: {} at {}:{}",
+          name,
+          location.file_name(),
+          location.line());
+        stop_func(s).get();
+        vlog(
+          _log.info,
+          "Shutdown completed: {} started at {}:{}",
+          name,
+          location.file_name(),
+          location.line());
+    }
+
+    /**
+     * @brief Construct service boilerplate.
+     *
+     * Construct the given service s, calling start with the given arguments
+     * and set up a shutdown callback to stop it.
+     *
+     * Returns the future from start(), typically you'll call get() on it
+     * immediately to wait for creation to complete.
+     *
+     * @return the future returned by start()
+     */
+    template<typename Service, typename... Args>
+    ss::future<> construct_service(ss::sharded<Service>& s, Args&&... args) {
+        auto name = ss::pretty_type_name(typeid(Service));
+        _deferred.emplace_back(
+          [this, &s, name, next_to_stop = _last_constructed_service_name] {
+              stop_service(s, name, next_to_stop);
+          });
+        _last_constructed_service_name = ss::sstring(name);
+        return s.start(std::forward<Args>(args)...);
+    }
+
+    template<typename Service, typename... Args>
+    void construct_single_service(std::unique_ptr<Service>& s, Args&&... args) {
+        auto name = ss::pretty_type_name(typeid(Service));
+        s = std::make_unique<Service>(std::forward<Args>(args)...);
+        _deferred.emplace_back(
+          [this, &s, name, next_to_stop = _last_constructed_service_name] {
+              stop_service(*s, name, next_to_stop);
+              s.reset();
+          });
+        _last_constructed_service_name = name;
+    }
+
+    template<typename Service, typename... Args>
+    ss::future<>
+    construct_single_service_sharded(ss::sharded<Service>& s, Args&&... args) {
+        auto name = ss::pretty_type_name(typeid(Service));
+        auto f = s.start_single(std::forward<Args>(args)...);
+        _deferred.emplace_back(
+          [this, &s, name, next_to_stop = _last_constructed_service_name] {
+              stop_service(s, name, next_to_stop);
+          });
+        _last_constructed_service_name = name;
+        return f;
+    }
+
+    template<typename ShardedComponent>
+    auto ref_to_local(ss::sharded<ShardedComponent>& component) {
+        return ss::sharded_parameter(
+          [&component] { return std::ref(component.local()); });
+    }
+
+protected:
+    ss::logger _log;
+    deferred_actions _deferred;
+
+private:
+    std::optional<ss::sstring> _last_constructed_service_name;
+};
+
+} // namespace ssx


### PR DESCRIPTION
I want to pull some sharded services into cloud_topics::app rather than having them all be owned by application. To that end, this pulls out all of the utilities for constructing and shutting down sharded services so they may be reused.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
