### PR TITLE
cl/model: moved configuration out of the topic state

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -341,7 +341,7 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
               }
 
               return validate_metadata_mirroring_config(
-                cmd.value.state.topic_metadata_mirroring_cfg);
+                cmd.value.configuration.topic_metadata_mirroring_cfg);
           }
           // New item!
           if (cmd.value.name().empty()) {
@@ -385,7 +385,7 @@ errc frontend::validator::validate_mutation(const cluster_link_cmd& cmd) const {
           }
 
           return validate_metadata_mirroring_config(
-            cmd.value.state.topic_metadata_mirroring_cfg);
+            cmd.value.configuration.topic_metadata_mirroring_cfg);
       },
       [this](const cluster::cluster_link_remove_cmd& cmd) {
           auto meta = _table->find_link_by_name(cmd.key);

--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -429,9 +429,9 @@ TEST_F_CORO(frontend_validation_test, update_mirror_topic_mirrored_by_other) {
 
 TEST_F_CORO(frontend_validation_test, test_mirror_properties) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"segment.ms"};
-    m1.state.topic_metadata_mirroring_cfg.topic_name_filters = {
+    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {
       {
         .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
         .filter = ::cluster_link::model::filter_type::include,
@@ -451,9 +451,9 @@ TEST_F_CORO(frontend_validation_test, test_mirror_properties) {
 
 TEST_F_CORO(frontend_validation_test, test_mirror_properties_empty_pattern) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"segment.ms"};
-    m1.state.topic_metadata_mirroring_cfg.topic_name_filters = {
+    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {
       {
         .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
         .filter = ::cluster_link::model::filter_type::include,
@@ -473,9 +473,9 @@ TEST_F_CORO(frontend_validation_test, test_mirror_properties_empty_pattern) {
 
 TEST_F_CORO(frontend_validation_test, test_mirror_properties_invalid_wildcard) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"segment.ms"};
-    m1.state.topic_metadata_mirroring_cfg.topic_name_filters = {{
+    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
       .filter = ::cluster_link::model::filter_type::include,
       .pattern = "*something",
@@ -488,9 +488,9 @@ TEST_F_CORO(frontend_validation_test, test_mirror_properties_invalid_wildcard) {
 TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_wildcard_in_prefix) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"segment.ms"};
-    m1.state.topic_metadata_mirroring_cfg.topic_name_filters = {{
+    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::prefix,
       .filter = ::cluster_link::model::filter_type::include,
       .pattern = ::cluster_link::model::resource_name_filter_pattern::wildcard,
@@ -504,9 +504,9 @@ TEST_F_CORO(
 TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_characters) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"segment.ms"};
-    m1.state.topic_metadata_mirroring_cfg.topic_name_filters = {{
+    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
       .filter = ::cluster_link::model::filter_type::include,
       .pattern = "\xFF",
@@ -520,9 +520,9 @@ TEST_F_CORO(
 TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_topic_name) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"segment.ms"};
-    m1.state.topic_metadata_mirroring_cfg.topic_name_filters = {{
+    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
       .filter = ::cluster_link::model::filter_type::include,
       .pattern = "__redpanda.internal",
@@ -536,7 +536,7 @@ TEST_F_CORO(
 TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_topic_property) {
     auto m1 = create_base_metadata();
-    m1.state.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
       = absl::flat_hash_set<ss::sstring>{"redpanda.remote.readreplica"};
 
     EXPECT_EQ(

--- a/src/v/cluster_link/model/tests/test_model.cc
+++ b/src/v/cluster_link/model/tests/test_model.cc
@@ -20,7 +20,7 @@ TEST(test_model, test_no_leak_private_data) {
       .username = "user", .password = "pass", .mechanism = "SCRAM-SHA-256"};
 
     EXPECT_EQ(
-      "{username=user, password=****, mechanism=SCRAM-SHA-256}",
+      "{username: user, password: ****, mechanism: SCRAM-SHA-256}",
       fmt::format("{}", creds));
 
     connection_config config_files{
@@ -32,10 +32,11 @@ TEST(test_model, test_no_leak_private_data) {
       .client_id = "client-id"};
 
     EXPECT_EQ(
-      "{bootstrap_servers=[{host: localhost, port: 9092}], "
-      "authn_config={username=user, password=****, mechanism=SCRAM-SHA-256}, "
-      "cert={file=cert.pem}, key={file=key.pem}, ca={file=ca.pem}, "
-      "client_id=client-id}",
+      "{bootstrap_servers: [{host: localhost, port: 9092}], "
+      "authn_config: {username: user, password: ****, mechanism: "
+      "SCRAM-SHA-256}, "
+      "cert: {file: cert.pem}, key: {file: key.pem}, ca: {file: ca.pem}, "
+      "client_id: client-id}",
       fmt::format("{}", config_files));
 
     connection_config config_values{
@@ -46,10 +47,11 @@ TEST(test_model, test_no_leak_private_data) {
       .ca = tls_value{"ca.pem"},
       .client_id = "client-id"};
     EXPECT_EQ(
-      "{bootstrap_servers=[{host: localhost, port: 9092}], "
-      "authn_config={username=user, password=****, mechanism=SCRAM-SHA-256}, "
-      "cert={value=cert.pem}, key={value=****}, ca={value=ca.pem}, "
-      "client_id=client-id}",
+      "{bootstrap_servers: [{host: localhost, port: 9092}], "
+      "authn_config: {username: user, password: ****, mechanism: "
+      "SCRAM-SHA-256}, "
+      "cert: {value: cert.pem}, key: {value: ****}, ca: {value: ca.pem}, "
+      "client_id: client-id}",
       fmt::format("{}", config_values));
 }
 } // namespace cluster_link::model::tests

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -47,6 +47,22 @@ topic_metadata_mirroring_config topic_metadata_mirroring_config::copy() const {
     return copy;
 }
 
+consumer_groups_mirroring_config
+consumer_groups_mirroring_config::copy() const {
+    consumer_groups_mirroring_config copy;
+
+    copy.is_enabled = is_enabled;
+    copy.task_interval = task_interval;
+    copy.filters = filters.copy();
+    return copy;
+}
+
+link_configuration link_configuration::copy() const {
+    link_configuration copy;
+    copy.topic_metadata_mirroring_cfg = topic_metadata_mirroring_cfg.copy();
+    return copy;
+}
+
 void link_state::set_mirror_topics(const mirror_topics_t& topics) {
     mirror_topics.reserve(topics.size());
     for (const auto& [topic, state] : topics) {
@@ -65,7 +81,6 @@ link_state link_state::copy() const {
     for (const auto& [topic, state] : mirror_topics) {
         copy.mirror_topics.emplace(topic, state.copy());
     }
-    copy.topic_metadata_mirroring_cfg = topic_metadata_mirroring_cfg.copy();
     return copy;
 }
 
@@ -75,6 +90,7 @@ metadata metadata::copy() const {
     copy.uuid = uuid;
     copy.connection = connection;
     copy.state = state.copy();
+    copy.configuration = configuration.copy();
     return copy;
 }
 
@@ -246,10 +262,9 @@ auto fmt::formatter<cluster_link::model::link_state>::format(
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{paused: {}, mirror_topics: {}, auto_mirror_topic_task_config: {}}}",
+      "{{paused: {}, mirror_topics: {}}}",
       s.paused,
-      fmt::join(s.mirror_topics.begin(), s.mirror_topics.end(), ","),
-      s.topic_metadata_mirroring_cfg);
+      fmt::join(s.mirror_topics.begin(), s.mirror_topics.end(), ","));
 }
 
 auto fmt::formatter<cluster_link::model::metadata>::format(
@@ -332,4 +347,13 @@ auto fmt::formatter<cluster_link::model::cluster_link_task_status_report>::
       ctx.out(),
       "{{link_reports={}}}",
       fmt::join(r.link_reports.begin(), r.link_reports.end(), ","));
+}
+
+auto fmt::formatter<cluster_link::model::link_configuration>::format(
+  const cluster_link::model::link_configuration& cfg, format_context& ctx) const
+  -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{topic_metadata_mirroring_cfg: {}}}",
+      cfg.topic_metadata_mirroring_cfg);
 }

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -119,7 +119,7 @@ auto fmt::formatter<cluster_link::model::scram_credentials>::format(
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{username={}, password=****, mechanism={}}}",
+      "{{username: {}, password: ****, mechanism: {}}}",
       c.username,
       c.mechanism);
 }
@@ -144,15 +144,15 @@ auto fmt::formatter<cluster_link::model::tls_file_or_value>::format(
     return ss::visit(
       t,
       [&ctx](const cluster_link::model::tls_file_path& p) {
-          return fmt::format_to(ctx.out(), "{{file={}}}", p());
+          return fmt::format_to(ctx.out(), "{{file: {}}}", p());
       },
       [this, &ctx](const cluster_link::model::tls_value& v) {
           if (_is_sensitive) {
-              return fmt::format_to(ctx.out(), "{{value=****}}");
+              return fmt::format_to(ctx.out(), "{{value: ****}}");
           }
           // If not sensitive, we can show the value
           // This is useful for debugging purposes.
-          return fmt::format_to(ctx.out(), "{{value={}}}", v());
+          return fmt::format_to(ctx.out(), "{{value: {}}}", v());
       });
 }
 
@@ -174,8 +174,8 @@ auto fmt::formatter<cluster_link::model::connection_config>::format(
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{bootstrap_servers={}, authn_config={}, cert={}, key={:s}, ca={}, "
-      "client_id={}}}",
+      "{{bootstrap_servers: {}, authn_config: {}, cert: {}, key: {:s}, ca: {}, "
+      "client_id: {}}}",
       c.bootstrap_servers,
       c.authn_config,
       c.cert,
@@ -198,9 +198,9 @@ auto fmt::formatter<cluster_link::model::mirror_topic_metadata>::format(
   format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{state={}, source_topic_id={}, source_topic_name={}, "
-      "destination_topic_id={}, partition_count={}, replication_factor={}, "
-      "topic_configs={}}}",
+      "{{state: {}, source_topic_id: {}, source_topic_name: {}, "
+      "destination_topic_id: {}, partition_count: {}, replication_factor: {}, "
+      "topic_configs: {}}}",
       m.state,
       m.source_topic_id,
       m.source_topic_name,
@@ -272,7 +272,7 @@ auto fmt::formatter<cluster_link::model::metadata>::format(
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{name={}, uuid={}, connection={}, state={}}}",
+      "{{name: {}, uuid: {}, connection: {}, state: {}}}",
       m.name,
       m.uuid,
       m.connection,
@@ -283,14 +283,14 @@ auto fmt::formatter<cluster_link::model::add_mirror_topic_cmd>::format(
   const cluster_link::model::add_mirror_topic_cmd& m, format_context& ctx)
   -> decltype(ctx.out()) {
     return fmt::format_to(
-      ctx.out(), "{{topic={}, metadata={}}}", m.topic, m.metadata);
+      ctx.out(), "{{topic: {}, metadata: {}}}", m.topic, m.metadata);
 }
 
 auto fmt::formatter<cluster_link::model::update_mirror_topic_state_cmd>::format(
   const cluster_link::model::update_mirror_topic_state_cmd& m,
   format_context& ctx) -> decltype(ctx.out()) {
     return fmt::format_to(
-      ctx.out(), "{{topic={}, state={}}}", m.topic, m.state);
+      ctx.out(), "{{topic: {}, state: {}}}", m.topic, m.state);
 }
 
 auto fmt::formatter<cluster_link::model::task_status_report>::format(
@@ -298,7 +298,7 @@ auto fmt::formatter<cluster_link::model::task_status_report>::format(
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{task_name={}, task_state={}, task_state_reason={}}}",
+      "{{task_name: {}, task_state: {}, task_state_reason: {}}}",
       r.task_name,
       r.task_state,
       r.task_state_reason);
@@ -322,7 +322,7 @@ auto fmt::formatter<cluster_link::model::link_task_status_report>::format(
   format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{link_name={}, task_status_reports={}}}",
+      "{{link_name: {}, task_status_reports: {}}}",
       r.link_name,
       fmt::join(
         r.task_status_reports.begin(), r.task_status_reports.end(), ","));
@@ -345,7 +345,7 @@ auto fmt::formatter<cluster_link::model::cluster_link_task_status_report>::
     format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{link_reports={}}}",
+      "{{link_reports: {}}}",
       fmt::join(r.link_reports.begin(), r.link_reports.end(), ","));
 }
 

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -267,6 +267,50 @@ struct topic_metadata_mirroring_config
     topic_metadata_mirroring_config copy() const;
 };
 
+struct consumer_groups_mirroring_config
+  : serde::envelope<
+      consumer_groups_mirroring_config,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    /// Flag to indicate if the task is enabled or not
+    enabled_t is_enabled{enabled_t::yes};
+    ss::lowres_clock::duration task_interval{std::chrono::seconds(30)};
+    /// Filters
+    chunked_vector<resource_name_filter_pattern> filters;
+
+    friend bool operator==(
+      const consumer_groups_mirroring_config&,
+      const consumer_groups_mirroring_config&)
+      = default;
+
+    auto serde_fields() { return std::tie(is_enabled, task_interval, filters); }
+
+    consumer_groups_mirroring_config copy() const;
+};
+
+/**
+ * Configuration of a cluster link. Configuration changes are driven by the API
+ * and are a result of user actions.
+ */
+struct link_configuration
+  : serde::envelope<
+      link_configuration,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    /// Configuration for the auto mirror topic creation task
+    topic_metadata_mirroring_config topic_metadata_mirroring_cfg;
+
+    friend bool operator==(const link_configuration&, const link_configuration&)
+      = default;
+
+    auto serde_fields() { return std::tie(topic_metadata_mirroring_cfg); }
+
+    link_configuration copy() const;
+};
+/**
+ * Link state. The state is modified by the cluster link tasks and is
+ * persisted to the cluster link table.
+ */
 struct link_state
   : serde::envelope<link_state, serde::version<0>, serde::compat_version<0>> {
     /// The set of topics that are being mirrored by this link and their state
@@ -285,17 +329,13 @@ struct link_state
       = chunked_hash_map<::model::topic, mirror_topic_metadata>;
     /// Map of topics that this link is mirroring and their state
     chunked_hash_map<::model::topic, mirror_topic_metadata> mirror_topics;
-    /// Configuration for the auto mirror topic creation task
-    topic_metadata_mirroring_config topic_metadata_mirroring_cfg;
 
     void set_mirror_topics(const mirror_topics_t& topics);
     void set_mirror_topics(mirror_topics_t&& topics);
 
     friend bool operator==(const link_state&, const link_state&) = default;
 
-    auto serde_fields() {
-        return std::tie(paused, mirror_topics, topic_metadata_mirroring_cfg);
-    }
+    auto serde_fields() { return std::tie(paused, mirror_topics); }
 
     link_state copy() const;
 };
@@ -309,10 +349,14 @@ struct metadata
     connection_config connection;
     /// The state of the link
     link_state state;
+    /// Configuration for the cluster link
+    link_configuration configuration;
 
     friend bool operator==(const metadata&, const metadata&) = default;
 
-    auto serde_fields() { return std::tie(name, uuid, connection, state); }
+    auto serde_fields() {
+        return std::tie(name, uuid, connection, state, configuration);
+    }
 
     metadata copy() const;
 };
@@ -636,5 +680,13 @@ struct fmt::formatter<cluster_link::model::cluster_link_task_status_report>
   : fmt::formatter<string_view> {
     auto format(
       const cluster_link::model::cluster_link_task_status_report& m,
+      format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::link_configuration>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::link_configuration& m,
       format_context& ctx) const -> decltype(ctx.out());
 };

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -313,7 +313,6 @@ struct link_configuration
  */
 struct link_state
   : serde::envelope<link_state, serde::version<0>, serde::compat_version<0>> {
-    /// The set of topics that are being mirrored by this link and their state
     link_state() noexcept = default;
     link_state(link_state&&) noexcept = default;
     link_state(const link_state&) = delete;

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -40,9 +40,9 @@ source_topic_syncer::source_topic_syncer(
   link* link, const model::metadata& config)
   : task(
       link,
-      config.state.topic_metadata_mirroring_cfg.task_interval,
+      config.configuration.topic_metadata_mirroring_cfg.task_interval,
       source_topic_syncer::task_name)
-  , _config(config.state.topic_metadata_mirroring_cfg.copy()) {}
+  , _config(config.configuration.topic_metadata_mirroring_cfg.copy()) {}
 
 task::is_locked_to_controller
 source_topic_syncer::locked_to_controller() const noexcept {
@@ -50,8 +50,9 @@ source_topic_syncer::locked_to_controller() const noexcept {
 }
 
 void source_topic_syncer::update_config(const model::metadata& config) {
-    _config = config.state.topic_metadata_mirroring_cfg.copy();
-    set_run_interval(config.state.topic_metadata_mirroring_cfg.task_interval);
+    _config = config.configuration.topic_metadata_mirroring_cfg.copy();
+    set_run_interval(
+      config.configuration.topic_metadata_mirroring_cfg.task_interval);
 }
 
 ss::future<> source_topic_syncer::run_impl() {

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -26,19 +26,18 @@ using model::resource_name_filter_pattern;
 namespace {
 model::metadata get_default_metadata() {
     model::link_state link_state;
-    link_state.topic_metadata_mirroring_cfg.task_interval = 1s;
-    link_state.topic_metadata_mirroring_cfg.topic_name_filters.emplace_back(
-      resource_name_filter_pattern{
-        .pattern_type = filter_pattern_type::literal,
-        .filter = filter_type::include,
-        .pattern = resource_name_filter_pattern::wildcard});
     model::metadata metadata{
       .name = model::name_t("test_link"),
       .uuid = model::uuid_t(::uuid_t::create()),
       .connection = model::
         connection_config{.bootstrap_servers = {net::unresolved_address("localhost", 9092)}},
       .state = std::move(link_state)};
-
+    metadata.configuration.topic_metadata_mirroring_cfg.task_interval = 1s;
+    metadata.configuration.topic_metadata_mirroring_cfg.topic_name_filters
+      .emplace_back(resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::literal,
+        .filter = filter_type::include,
+        .pattern = resource_name_filter_pattern::wildcard});
     return metadata;
 }
 } // namespace
@@ -166,8 +165,8 @@ TEST_F_CORO(source_topic_syncer_test, select_all_with_exclude) {
       kafka::topic_authorized_operations(0x508));
 
     auto md = get_default_metadata();
-    md.state.topic_metadata_mirroring_cfg.topic_name_filters.emplace_back(
-      resource_name_filter_pattern{
+    md.configuration.topic_metadata_mirroring_cfg.topic_name_filters
+      .emplace_back(resource_name_filter_pattern{
         .pattern_type = filter_pattern_type::literal,
         .filter = filter_type::exclude,
         .pattern = "excluded-topic"});


### PR DESCRIPTION
The configuration of cluster link is fully driven by user interaction with yet to be added external API. The state change can be a result of either a configuration change (user interaction) or internal mechanics of cluster link.

Separated configuration from state to draw the boundary between the two.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none