### PR TITLE
[CORE-1447] `config`: remove `delete_retention_ms` cluster alias for `log_retention_ms`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1028,9 +1028,7 @@ configuration::configuration()
       "milliseconds). If set to `-1`, no time limit is applied. This is a "
       "cluster-wide default when a topic does not set or disable "
       "`retention.ms`.",
-      {.needs_restart = needs_restart::no,
-       .visibility = visibility::user,
-       .aliases = {"delete_retention_ms"}},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       7 * 24h)
   , log_compaction_interval_ms(
       *this,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -2215,13 +2215,6 @@ cloud_storage_graceful_transfer_timeout = PropertyAliasData(
     test_values=(1234, 1235, 1236),
     expect_restart=False,
 )
-log_retention_ms = PropertyAliasData(
-    primary_name="log_retention_ms",
-    aliased_name="delete_retention_ms",
-    redpanda_version=(23, 3),
-    test_values=(1000000, 300000, 500000),
-    expect_restart=False,
-)
 # NOTE due to https://github.com/redpanda-data/redpanda/issues/13432 ,
 # test_values can't be -1 (a valid value nonetheless to signal infinite value)
 data_transforms_per_core_memory_reservation = PropertyAliasData(
@@ -2235,7 +2228,6 @@ data_transforms_per_core_memory_reservation = PropertyAliasData(
 # Mapping from identifier string to PropertyAliasData for use in @matrix annotations
 PROPERTY_ALIAS_SETS: dict[str, PropertyAliasData] = {
     "cloud_storage_graceful_transfer_timeout": cloud_storage_graceful_transfer_timeout,
-    "log_retention_ms": log_retention_ms,
     "data_transforms_per_core_memory_reservation": data_transforms_per_core_memory_reservation,
 }
 
@@ -2255,7 +2247,6 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
     @matrix(
         prop_set_name=[
             "cloud_storage_graceful_transfer_timeout",
-            "log_retention_ms",
             "data_transforms_per_core_memory_reservation",
         ]
     )
@@ -2317,7 +2308,7 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
     @cluster(num_nodes=3)
     @matrix(
         wipe_cache=[False, True],
-        prop_set_name=["cloud_storage_graceful_transfer_timeout", "log_retention_ms"],
+        prop_set_name=["cloud_storage_graceful_transfer_timeout"],
     )
     def test_aliasing_with_upgrade(self, wipe_cache: bool, prop_set_name: str):
         prop_set = PROPERTY_ALIAS_SETS[prop_set_name]

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -973,7 +973,7 @@ class ShadowIndexingInfiniteRetentionTest(EndToEndShadowIndexingBase):
                 # encourage cloud segment deletion, as we ensure
                 # nothing will be deleted for an infinite-retention
                 # topic.
-                "delete_retention_ms": self.small_interval_ms,
+                "log_retention_ms": self.small_interval_ms,
                 "retention_bytes": self.small_segment_size,
                 "cloud_storage_cache_chunk_size": self.chunk_size,
             },

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -959,7 +959,7 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                 # Disable leader balancer, as this test is doing its own
                 # partition movement and the balancer would interfere
                 "enable_leader_balancer": False,
-                "delete_retention_ms": 1000,
+                "log_retention_ms": 1000,
             },
             si_settings=si_settings,
             **kwargs,

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -382,7 +382,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
         """
         # set cloud retention to 10 seconds
         self.redpanda.set_cluster_config(
-            {"delete_retention_ms": 10000}, expect_restart=False
+            {"log_retention_ms": 10000}, expect_restart=False
         )
 
         # create topic with large local retention


### PR DESCRIPTION
These properties are _not_ the same in Kafka-land.

Remove the currently deprecated alias so `delete_retention_ms` no longer maps to the property `log_retention_ms`.

This may open the door to aliasing the cluster config `tombstone_retention_ms` with `delete_retention_ms` in the future.

Fixes: https://redpandadata.atlassian.net/browse/CORE-1447

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Deprecates the `delete_retention_ms` cluster config alias for unrelated property `log_retention_ms`.