### PR TITLE
ct: ensure prompt creation of domain topic

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_supervisor.cc
@@ -100,42 +100,58 @@ public:
 private:
     ss::future<> do_topic_reconciliation_loop() {
         while (!_as.abort_requested()) {
-            bool aborted = co_await loop_sleep();
+            co_await ensure_domains_topic();
+
+            bool aborted = co_await loop_sleep(10min);
             if (aborted) {
                 // If we were aborted, we exit the loop.
                 co_return;
             }
+        }
+    }
+
+    ss::future<> ensure_domains_topic() {
+        auto backoff = make_exponential_backoff_policy<ss::lowres_clock>(
+          1s, 10s);
+        while (!_as.abort_requested()) {
             if (_controller->get_topics_state().local().contains(
                   model::l1_metastore_nt)) {
-                co_await ensure_domains_replication_factor();
+                if (co_await ensure_domains_replication_factor()) {
+                    break;
+                }
             } else {
-                co_await create_domains_topic();
+                if (co_await create_domains_topic()) {
+                    break;
+                }
+            }
+            backoff.next_backoff();
+            if (co_await loop_sleep(backoff.current_backoff_duration())) {
+                break;
             }
         }
     }
 
-    ss::future<bool> loop_sleep() {
-        constexpr auto interval = 10min;
-        simple_time_jitter<ss::lowres_clock> jitter(interval);
+    ss::future<bool> loop_sleep(std::chrono::milliseconds duration) {
+        simple_time_jitter<ss::lowres_clock> jitter(duration);
         try {
             co_await ss::sleep_abortable<ss::lowres_clock>(
               jitter.next_duration(), _as);
-            co_return true;
+            co_return false;
         } catch (const ss::sleep_aborted& ex) {
             // do nothing, the caller will handle exiting properly.
             std::ignore = ex;
-            co_return false;
+            co_return true;
         }
     }
 
-    ss::future<> ensure_domains_replication_factor() {
+    ss::future<bool> ensure_domains_replication_factor() {
         auto tp_ns = model::l1_metastore_nt;
         auto rf = _controller->get_topics_state()
                     .local()
                     .get_topic_replication_factor(tp_ns);
         if (!rf) {
             vlog(cd_log.warn, "unable to find {} replication factor", tp_ns);
-            co_return;
+            co_return false;
         }
         auto target_rf = cluster::replication_factor(
           _controller->internal_topic_replication());
@@ -150,9 +166,11 @@ private:
               = cluster::incremental_update_operation::set;
             update.custom_properties.replication_factor.value = target_rf;
             co_await update_topic(std::move(update));
+            co_return false;
         } else {
             vlog(
               cd_log.trace, "replication factor for {} is already set", tp_ns);
+            co_return true;
         }
     }
 
@@ -215,7 +233,7 @@ private:
                            config::shard_local_cfg().create_topic_timeout_ms());
             vassert(res.size() == 1, "expected a single result");
             ec = res[0].ec;
-            co_return true;
+            // fall through to handle ec value
         } catch (const std::exception& ex) {
             vlog(cd_log.warn, "unable to create topic {}: {}", tp_ns, ex);
             ec = cluster::errc::topic_operation_error;


### PR DESCRIPTION
1. For first-time creation in dev_cluster failure is common because controller isn't yet ready, but then we have a 10 min sleep before trying again. Address this with simple backoff policy.
2. Polarity of loop_sleep abort was backwards, causing early abort.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
