### PR TITLE
rptest/direct_consumer_tests leadership transfer test & fixes

### DIFF
--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -57,6 +57,7 @@ direct_consumer::update_fetchers(topic_partition_map<subscription> removals) {
         co_return;
     }
     auto holder = _gate.hold();
+    auto subscription_lock_holder = co_await _subscriptions_lock.get_units();
     /**
      * Unassign partitions from fetchers that are no longer needed.
      */
@@ -154,6 +155,8 @@ ss::future<> direct_consumer::start() {
 ss::future<> direct_consumer::stop() {
     _cluster->unregister_metadata_cb(_metadata_callback_id);
     _fetched_data_queue->stop();
+
+    _subscriptions_lock.broken();
     co_await _gate.close();
 
     co_await ss::parallel_for_each(

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -144,6 +144,8 @@ private:
 
     configuration _config;
 
+    // serialize updates to _subscriptions
+    mutex _subscriptions_lock{"direct_consumer::_subscriptions_lock"};
     topic_partition_map<subscription> _subscriptions;
     chunked_hash_map<model::node_id, std::unique_ptr<fetcher>> _broker_fetchers;
     std::unique_ptr<data_queue> _fetched_data_queue;

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -795,6 +795,27 @@ ss::future<> fetcher::assign_partition(
       .assignment_epoch = next_epoch(),
       .incremental_include = true};
 
+    // in the case of fast leadership transfers, we may have a partition both
+    // being added and forgotten, in which case, make sure that it is only being
+    // added
+    auto forget_topic_iterator = _partitions_to_forget.find(tp.topic);
+    if (forget_topic_iterator != _partitions_to_forget.end()) {
+        // topic is in the 'to forget map', now is the partition in the topic's
+        // map
+        auto& partitions_to_forget = forget_topic_iterator->second;
+        auto forget_partition_iterator = partitions_to_forget.find(
+          tp.partition);
+        if (forget_partition_iterator != partitions_to_forget.end()) {
+            // the ntp is both being added and forgotten, make sure its only
+            // added
+            partitions_to_forget.erase(forget_partition_iterator);
+            if (partitions_to_forget.empty()) {
+                // cleanup if this was the last partition
+                _partitions_to_forget.erase(forget_topic_iterator);
+            }
+        }
+    }
+
     _partitions_updated.signal();
     co_return;
 }

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -274,7 +274,7 @@ bool fetcher::maybe_update_fetch_offset(
   model::partition_id partition_id,
   kafka::offset last_received,
   kafka::offset high_watermark,
-  assignment_epoch assignment_epoch) {
+  std::optional<assignment_epoch> maybe_response_epoch) {
     auto t_it = _partitions.find(topic);
     if (t_it == _partitions.end()) {
         return false;
@@ -283,7 +283,28 @@ bool fetcher::maybe_update_fetch_offset(
     if (p_it == t_it->second.end()) {
         return false;
     }
-    if (p_it->second.assignment_epoch != assignment_epoch) {
+
+    // possible in a tight race
+    // 1. unassign from A
+    // 2. begin fetch
+    // 3. assign to A
+    // 4. broker receives update
+    // 5. the fetch will receive a response for which it did not have an epoch
+    // this is logically the same as epoch mismatch
+    if (!maybe_response_epoch) {
+        vlog(
+          logger().info,
+          "[broker: {}] Ignoring unbidden {}/{} current epoch: {}",
+          _id,
+          topic,
+          partition_id,
+          p_it->second.assignment_epoch);
+        return false;
+    }
+
+    const auto response_epoch = maybe_response_epoch.value();
+
+    if (p_it->second.assignment_epoch != response_epoch) {
         vlog(
           logger().trace,
           "[broker: {}] Ignoring {}/{} reply, assignment epoch changed, "
@@ -291,7 +312,7 @@ bool fetcher::maybe_update_fetch_offset(
           _id,
           topic,
           partition_id,
-          assignment_epoch,
+          response_epoch,
           p_it->second.assignment_epoch);
         return false;
     }
@@ -406,22 +427,24 @@ ss::future<> fetcher::do_fetch() {
     }
 }
 
-fetcher::assignment_epoch fetcher::find_assignment_epoch(
+std::optional<fetcher::assignment_epoch> fetcher::find_assignment_epoch(
   const model::topic& topic,
   model::partition_id partition,
   const topic_partition_map<assignment_epoch>& epochs) {
-    auto it = epochs.find(topic);
-    vassert(
-      it != epochs.end(), "assignment epoch for topic {} not found", topic);
+    auto topic_iterator = epochs.find(topic);
 
-    auto p_it = it->second.find(partition);
-    vassert(
-      p_it != it->second.end(),
-      "assignment epoch for partition {}/{} not found",
-      topic,
-      partition);
+    if (topic_iterator == epochs.end()) {
+        return std::nullopt;
+    }
 
-    return p_it->second;
+    const auto& partition_map = topic_iterator->second;
+    auto partition_iterator = partition_map.find(partition);
+
+    if (partition_iterator == partition_map.end()) {
+        return std::nullopt;
+    }
+
+    return partition_iterator->second;
 }
 
 ss::future<kafka_result<fetcher::fetch_response_content>>
@@ -432,8 +455,10 @@ fetcher::process_fetch_response(
     if (resp.data.error_code != kafka::error_code::none) {
         co_return resp.data.error_code;
     }
+
     // Hold the lock here as the fetch response processing updates the fetch
     // offsets, we do not want this to interfere with assignment updates.
+
     auto lock = co_await _state_lock.get_units();
 
     // For fetch session maintenance, the goal is to omit partitions from each
@@ -522,13 +547,15 @@ fetcher::process_fetch_response(
                 part_data.data = co_await reader_to_chunked_vector(
                   std::move(part_response.records.value()));
 
+                auto maybe_response_epoch = find_assignment_epoch(
+                  topic_data.topic, part_data.partition_id, epochs);
+
                 bool updated_offset = maybe_update_fetch_offset(
                   topic_data.topic,
                   part_data.partition_id,
                   model::offset_cast(part_data.data.back().last_offset()),
                   part_data.high_watermark,
-                  find_assignment_epoch(
-                    topic_data.topic, part_data.partition_id, epochs));
+                  maybe_response_epoch);
                 if (!updated_offset) {
                     // case when partition is either
                     // 1. partition is not assigned to this fetcher
@@ -586,12 +613,25 @@ fetcher::process_fetch_response(
                 if (
                   partition_iterator != partition_map.end() && !partition_err) {
                     // compare the epochs before we make an edit
-                    const auto current_epoch
+                    const auto assigned_epoch
                       = partition_iterator->second.assignment_epoch;
-                    const auto fetched_epoch
-                      = epochs.find(topic)->second.find(p.partition_id)->second;
 
-                    if (current_epoch == fetched_epoch) {
+                    auto maybe_request_epoch = find_assignment_epoch(
+                      topic, p.partition_id, epochs);
+
+                    if (!maybe_request_epoch) {
+                        // see maybe_update_fetch_offset for explanation
+                        vlog(
+                          logger().info,
+                          "unbidden response on ntp: {}/{}",
+                          topic,
+                          p.partition_id);
+                        continue;
+                    }
+
+                    const auto request_epoch = maybe_request_epoch.value();
+
+                    if (assigned_epoch == request_epoch) {
                         partition_iterator->second.incremental_include = false;
                     } else {
                         vlog(
@@ -600,8 +640,8 @@ fetcher::process_fetch_response(
                           "fetched_epoch, {}, current_epoch: {}",
                           topic,
                           p.partition_id,
-                          fetched_epoch,
-                          current_epoch);
+                          request_epoch,
+                          assigned_epoch);
                     }
                 }
             }
@@ -678,78 +718,94 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
         co_return error_code::none;
     }
 
-    auto offsets = co_await do_list_offsets(std::move(req));
-    if (offsets.has_error()) {
-        if (is_retriable_error(offsets.error())) {
+    auto list_offsets_response = co_await do_list_offsets(std::move(req));
+    if (list_offsets_response.has_error()) {
+        if (is_retriable_error(list_offsets_response.error())) {
             vlog(
               logger().info,
               "list_offsets request failed with retriable error: {}",
-              offsets.error());
+              list_offsets_response.error());
         } else {
             vlog(
               logger().warn,
               "list_offsets request failed with an error: {}",
-              offsets.error());
+              list_offsets_response.error());
         }
-        co_return offsets.error();
+        co_return list_offsets_response.error();
     }
     // TODO: what should we do with the error code in the response?
     kafka::error_code error = kafka::error_code::none;
-    for (auto& topic : offsets.value()) {
-        for (auto& partition_offset : topic.offsets) {
-            if (partition_offset.error_code != kafka::error_code::none) {
-                if (is_retriable_error(partition_offset.error_code)) {
+    for (auto& response_topic : list_offsets_response.value()) {
+        for (auto& response_partition : response_topic.offsets) {
+            if (response_partition.error_code != kafka::error_code::none) {
+                if (is_retriable_error(response_partition.error_code)) {
                     vlog(
                       logger().debug,
                       "[broker: {}] {}/{} retriable list_offsets error: {}",
                       _id,
-                      topic.topic,
-                      partition_offset.partition_id,
-                      partition_offset.error_code);
+                      response_topic.topic,
+                      response_partition.partition_id,
+                      response_partition.error_code);
                 }
                 // Only overwrite if we don't have an error, or if current error
                 // is retriable but new error is not retriable
                 if (error == kafka::error_code::none ||
-                  (is_retriable_error(error) && !is_retriable_error(partition_offset.error_code))) {
-                    error = partition_offset.error_code;
+                  (is_retriable_error(error) && !is_retriable_error(response_partition.error_code))) {
+                    error = response_partition.error_code;
                 }
                 continue;
             }
 
-            auto t_it = _partitions.find(topic.topic);
+            // global state may have changed, we're not locked
+            auto t_it = _partitions.find(response_topic.topic);
             if (t_it == _partitions.end()) {
                 continue;
             }
-            auto p_it = t_it->second.find(partition_offset.partition_id);
+            auto p_it = t_it->second.find(response_partition.partition_id);
             if (p_it == t_it->second.end()) {
                 continue;
             }
-            auto request_epoch = find_assignment_epoch(
-              topic.topic, partition_offset.partition_id, epochs);
-            if (
-              find_assignment_epoch(
-                topic.topic, partition_offset.partition_id, epochs)
-              != p_it->second.assignment_epoch) {
+
+            const auto assigned_epoch = p_it->second.assignment_epoch;
+
+            auto maybe_response_epoch = find_assignment_epoch(
+              response_topic.topic, response_partition.partition_id, epochs);
+
+            if (!maybe_response_epoch) {
+                vlog(
+                  logger().warn,
+                  "[broker: {} received a list topics response which was not "
+                  "requested on ntp: {}/{}",
+                  _id,
+                  response_topic.topic,
+                  response_partition.partition_id);
+                continue;
+            }
+
+            const auto request_epoch = maybe_response_epoch.value();
+
+            if (request_epoch != assigned_epoch) {
                 vlog(
                   logger().trace,
                   "[broker: {}] Skipping partition {}/{} list offset response "
                   "as assignment epoch has changed. request_epoch: {}, "
                   "current_epoch: {}",
                   _id,
-                  topic.topic,
-                  partition_offset.partition_id,
-                  partition_offset.offset,
+                  response_topic.topic,
+                  response_partition.partition_id,
+                  response_partition.offset,
                   request_epoch,
                   p_it->second.assignment_epoch);
+                continue;
             }
             vlog(
               logger().info,
               "[broker: {}] Resetting partition {}/{} fetch offset to: {}",
               _id,
-              topic.topic,
-              partition_offset.partition_id,
-              partition_offset.offset);
-            p_it->second.fetch_offset = partition_offset.offset;
+              response_topic.topic,
+              response_partition.partition_id,
+              response_partition.offset);
+            p_it->second.fetch_offset = response_partition.offset;
             p_it->second.high_watermark.reset();
             p_it->second.incremental_include = true;
         }

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -529,10 +529,15 @@ fetcher::process_fetch_response(
                   part_data.high_watermark,
                   find_assignment_epoch(
                     topic_data.topic, part_data.partition_id, epochs));
-                if (updated_offset) {
-                    dirty_partitions[topic_data.topic].insert(
-                      part_data.partition_id);
+                if (!updated_offset) {
+                    // case when partition is either
+                    // 1. partition is not assigned to this fetcher
+                    // 2. assignment epoch changed
+                    // for either skip
+                    continue;
                 }
+                dirty_partitions[topic_data.topic].insert(
+                  part_data.partition_id);
             }
             topic_data.partitions.push_back(std::move(part_data));
         }

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -769,7 +769,7 @@ ss::future<> fetcher::assign_partition(
       .partition_id = tp.partition,
       .fetch_offset = offset,
       .assignment_epoch = next_epoch(),
-    };
+      .incremental_include = true};
 
     _partitions_updated.signal();
     co_return;

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -565,20 +565,44 @@ fetcher::process_fetch_response(
           "partitions, not both");
 
         if (!included.empty()) {
-            auto tp_it = _partitions.find(topic);
-            if (tp_it == _partitions.end()) {
+            // _partitions maps topic -> parition map
+            // partition map maps partition -> subscription info
+            // get an iterator to the topic map
+            auto topic_iterator = _partitions.find(topic);
+            if (topic_iterator == _partitions.end()) {
                 continue;
             }
+
             auto errs_it = dirty_partitions.find(topic);
             bool topic_err = errs_it != dirty_partitions.end();
-            auto& ps = tp_it->second;
+
+            auto& partition_map = topic_iterator->second;
+
             for (const auto& p : included) {
                 bool partition_err = topic_err
                                      && errs_it->second.contains(
                                        p.partition_id);
-                auto p_it = ps.find(p.partition_id);
-                if (p_it != ps.end() && !partition_err) {
-                    p_it->second.incremental_include = false;
+                auto partition_iterator = partition_map.find(p.partition_id);
+                if (
+                  partition_iterator != partition_map.end() && !partition_err) {
+                    // compare the epochs before we make an edit
+                    const auto current_epoch
+                      = partition_iterator->second.assignment_epoch;
+                    const auto fetched_epoch
+                      = epochs.find(topic)->second.find(p.partition_id)->second;
+
+                    if (current_epoch == fetched_epoch) {
+                        partition_iterator->second.incremental_include = false;
+                    } else {
+                        vlog(
+                          logger().trace,
+                          "disclusion epoch mismatch on ntp: {}, "
+                          "fetched_epoch, {}, current_epoch: {}",
+                          topic,
+                          p.partition_id,
+                          fetched_epoch,
+                          current_epoch);
+                    }
                 }
             }
         }

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -27,6 +27,8 @@
 
 #include <fmt/format.h>
 
+#include <optional>
+
 namespace kafka::client {
 class direct_consumer;
 
@@ -220,7 +222,7 @@ private:
         kafka::fetch_session_id session_id{0};
     };
 
-    static assignment_epoch find_assignment_epoch(
+    static std::optional<assignment_epoch> find_assignment_epoch(
       const model::topic& topic,
       model::partition_id partition,
       const topic_partition_map<assignment_epoch>& epochs);
@@ -250,7 +252,7 @@ private:
       model::partition_id,
       kafka::offset,
       kafka::offset,
-      assignment_epoch);
+      std::optional<assignment_epoch>);
 
     ss::future<kafka_result<chunked_vector<topic_partition_offsets>>>
       do_list_offsets(list_offsets_request);

--- a/src/v/kafka/client/direct_consumer/tests/BUILD
+++ b/src/v/kafka/client/direct_consumer/tests/BUILD
@@ -66,6 +66,7 @@ redpanda_cc_gtest(
     srcs = [
         "direct_consumer_fixture_test.cc",
     ],
+    cpu = 1,
     deps = [
         ":direct_consumer_fixture",
         "//src/v/model",

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture.cc
@@ -156,6 +156,28 @@ void consumer_fixture::unassign_topic(model::topic topic) {
       .get();
 }
 
+// shuffle leadership, wait for leadership change to become visible to the
+// test
+void consumer_fixture::wait_for_visible_leadership_shuffle(
+  const model::ntp& ntp) {
+    constexpr auto leadership_swap_wait = 300ms;
+    const auto original_leader = get_leader(ntp);
+    auto current_leader = original_leader;
+
+    shuffle_leadership(ntp).get();
+
+    for (const auto iteration : std::array{0, 1, 2, 3, 4, 5}) {
+        logger.info("polling for leadership change iteration: {}", iteration);
+        current_leader = get_leader(ntp);
+        ss::sleep(leadership_swap_wait).get();
+        if (current_leader != original_leader) {
+            break;
+        }
+    }
+    ASSERT_NE(current_leader, original_leader)
+      << "never detected leadership change, test precondition failed";
+}
+
 void basic_consumer_fixture::SetUp() {
     create_node_application(model::node_id{0});
     create_node_application(model::node_id{1});

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture.h
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture.h
@@ -47,6 +47,10 @@ public:
     void unassign_partition(model::topic_partition tp);
     void unassign_topic(model::topic topic);
 
+    // shuffle leadership, wait for leadership change to become visible to the
+    // test
+    void wait_for_visible_leadership_shuffle(const model::ntp& ntp);
+
 protected:
     redpanda_thread_fixture* rp;
     std::unique_ptr<kafka::client::cluster> cluster;

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
@@ -80,6 +80,46 @@ TEST_P(BasicConsumerFixture, TestBasicConsumption) {
       model::offset(1019));
 }
 
+TEST_P(BasicConsumerFixture, TestBasicLeadershipTransfer) {
+    // constants
+    constexpr uint first_produce_count = 10;
+    constexpr uint second_produce_count = 20;
+    const auto test_partition_number = 0;
+    const auto test_partition_id = model::partition_id(test_partition_number);
+    const auto test_ntp = model::ntp(
+      model::kafka_namespace, topic, test_partition_id);
+
+    assign_partitions(make_assignment(topic, {test_partition_number}));
+
+    produce_to_partition(topic, test_partition_number, first_produce_count);
+
+    { // fist fetch and assert
+        auto fetched = fetch_until_empty(*consumer);
+
+        ASSERT_EQ(
+          fetched[model::topic_partition(topic, test_partition_id)]
+            .back()
+            .last_offset(),
+          model::offset(first_produce_count - 1));
+    }
+
+    // kick off a leadership shuffle and wait for the effect to be noticable
+    wait_for_visible_leadership_shuffle(test_ntp);
+
+    produce_to_partition(topic, test_partition_number, second_produce_count);
+
+    { // second fetch and assert
+        auto fetched = fetch_until_empty(*consumer);
+        ASSERT_EQ(fetched.size(), 1);
+
+        ASSERT_EQ(
+          fetched[model::topic_partition(topic, test_partition_id)]
+            .back()
+            .last_offset(),
+          model::offset(first_produce_count + second_produce_count - 1));
+    }
+}
+
 TEST_P(BasicConsumerFixture, TestUnassignPartition) {
     assign_partitions(make_assignment(topic, {0, 1}));
 

--- a/src/v/kafka/client/direct_consumer/verifier/application.cc
+++ b/src/v/kafka/client/direct_consumer/verifier/application.cc
@@ -94,6 +94,13 @@ ss::future<> consumer_runner::do_fetch() {
             if (fetched_partition_data.data.empty()) {
                 continue; // no data to process
             }
+
+            vlog(
+              v_logger.trace,
+              "found data for ntp: {}/{}",
+              fetched_topic_data.topic,
+              fetched_partition_data.partition_id);
+
             auto& partition_stats = _stats[fetched_topic_data.topic]
                                           [fetched_partition_data.partition_id];
             if (fetched_partition_data.error != kafka::error_code::none) {
@@ -115,6 +122,14 @@ ss::future<> consumer_runner::do_fetch() {
             _total_records += totals.count;
             auto last_fetched_offset = model::offset_cast(
               fetched_partition_data.data.back().last_offset());
+
+            vlog(
+              v_logger.trace,
+              "fetched ntp: {}/{}, offset: {}",
+              fetched_topic_data.topic,
+              fetched_partition_data.partition_id,
+              last_fetched_offset);
+
             if (last_fetched_offset <= partition_stats.last_fetched_offset) {
                 _non_monotonic_fetches++;
                 vlog(

--- a/src/v/kafka/client/direct_consumer/verifier/application.cc
+++ b/src/v/kafka/client/direct_consumer/verifier/application.cc
@@ -96,7 +96,7 @@ ss::future<> consumer_runner::do_fetch() {
             }
 
             vlog(
-              v_logger.trace,
+              v_logger.info,
               "found data for ntp: {}/{}",
               fetched_topic_data.topic,
               fetched_partition_data.partition_id);
@@ -124,11 +124,28 @@ ss::future<> consumer_runner::do_fetch() {
               fetched_partition_data.data.back().last_offset());
 
             vlog(
-              v_logger.trace,
+              v_logger.info,
               "fetched ntp: {}/{}, offset: {}",
               fetched_topic_data.topic,
               fetched_partition_data.partition_id,
               last_fetched_offset);
+
+            auto first_fetched_offset = model::offset_cast(
+              fetched_partition_data.data.front().last_offset());
+            if (first_fetched_offset <= partition_stats.last_fetched_offset) {
+                // this is legal but too much of this is undesirable
+                vlog(
+                  v_logger.info,
+                  "[client: {}] duplicate offsets detected for topic: {}, "
+                  "partition: {}, fetched start: {}, fetched end: {}, "
+                  "application last fetched offset: {}",
+                  _id,
+                  fetched_topic_data.topic,
+                  fetched_partition_data.partition_id,
+                  first_fetched_offset,
+                  last_fetched_offset,
+                  partition_stats.last_fetched_offset);
+            }
 
             if (last_fetched_offset <= partition_stats.last_fetched_offset) {
                 _non_monotonic_fetches++;

--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -9,9 +9,16 @@
 
 from typing import Any
 
+import time
+import random
+import threading
+from typing import Callable
+
 from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
 from ducktape.utils.util import wait_until
 from ducktape.tests.test import TestContext
+from ducktape.errors import TimeoutError
 
 from rptest.services.direct_consumer_verifier import (
     DirectConsumerVerifier, CreateDirectConsumerRequest, BrokerAddress,
@@ -24,13 +31,55 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_with_progress_check
 
 
+class LoopThread(threading.Thread):
+    """Run loop func until graceful cancellation is requested"""
+    def _loop(self, *args, **kwargs):
+        while not self.stopped():
+            self._loop_func(*args, **kwargs)
+
+    def __init__(self, *args, loop_func: Callable[[], None], **kwargs):
+        super(LoopThread, self).__init__(*args, target=self._loop, **kwargs)
+        self._stop_event = threading.Event()
+        self._loop_func = loop_func
+
+    def stop(self):
+        self._stop_event.set()
+
+    def stopped(self):
+        return self._stop_event.is_set()
+
+
 #TODO: This test must be enabled once the direct consumer verifier support
 # is added to vtools.
 class DirectConsumerVerifierTest(RedpandaTest):
     def __init__(self, test_context: TestContext, **kwargs: Any):
         super().__init__(test_context, **kwargs)
 
-    @cluster(num_nodes=4)
+    def shuffle_one_leader(self, topic_spec: TopicSpec) -> None:
+        '''randomly chooses a partition in the given topic spec and moves its leader one replica over'''
+        namespace = "kafka"
+        topic_name = topic_spec.name
+        partition_number = random.choice(range(topic_spec.partition_count))
+        admin = Admin(self.redpanda)
+        # logs to debug
+        transfer_succeeded = admin.transfer_leadership_to(
+            namespace="kafka",
+            topic=topic_spec.name,
+            partition=random.randrange(0, topic_spec.partition_count))
+        self.redpanda.logger.debug(
+            f"transfer of ntp {namespace}/{topic_name}/{partition_number} success? {transfer_succeeded}"
+        )
+
+    def create_troublemaker_thread(self,
+                                   topic_spec: TopicSpec,
+                                   thread_name="stream_thread") -> LoopThread:
+        '''creates a background thread to drive paritition leadership transfers'''
+        thread = LoopThread(name=thread_name,
+                            loop_func=self.shuffle_one_leader,
+                            args=(topic_spec, ))
+        return thread
+
+    @cluster(num_nodes=5)
     def test_basic_consuming_from_topic(self):
         topic_name = "test-topic"
         msg_count = 200000
@@ -43,14 +92,18 @@ class DirectConsumerVerifierTest(RedpandaTest):
 
         self.client().create_topic(topic_spec)
 
-        KgoVerifierProducer.oneshot(self.test_context,
-                                    self.redpanda,
-                                    topic_name,
-                                    msg_size=msg_size,
-                                    msg_count=msg_count)
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic_name,
+                                       msg_size=msg_size,
+                                       msg_count=msg_count)
+        producer.start()
 
         verifier = DirectConsumerVerifier(self.test_context, log_level="DEBUG")
         verifier.start()
+
+        troublemaker = self.create_troublemaker_thread(topic_spec=topic_spec)
+        troublemaker.start()
 
         try:
             # check if the verifier is alive
@@ -95,15 +148,15 @@ class DirectConsumerVerifierTest(RedpandaTest):
 
             def get_consumption():
                 state = verifier.get_consumer_state(state_request)
-                self.logger.info(
-                    f"Consumer state: consumed {state.total_consumed_messages} messages"
+                self.logger.debug(
+                    f"Expecting: {msg_count} Consumer state: consumed {state.total_consumed_messages} messages"
                 )
                 return state.total_consumed_messages
 
             wait_until_with_progress_check(
                 get_consumption,
                 condition=lambda: get_consumption() >= msg_count,
-                timeout_sec=60,
+                timeout_sec=600,
                 progress_sec=10,
                 backoff_sec=2,
                 err_msg=f"Stopped consuming",
@@ -111,12 +164,21 @@ class DirectConsumerVerifierTest(RedpandaTest):
             )
 
             final_state = verifier.get_consumer_state(state_request)
-            assert final_state.total_consumed_messages == msg_count, \
+
+            # assertions
+            # must have seen at least msg_count, duplicate offsets are legal but undesirable
+            assert final_state.total_consumed_messages >= msg_count, \
                 f"Expected {msg_count} messages, got {final_state.total_consumed_messages}"
+
+            assert int(final_state.non_monotonic_fetches) == 0, \
+                f"Non-monotonic fetches found, number of nm fetches: {final_state.non_monotonic_fetches}"
 
             self.logger.info(
                 f"Successfully consumed {final_state.total_consumed_messages} messages"
             )
 
         finally:
+            troublemaker.stop()
+            producer.stop()
             verifier.stop()
+            producer.wait(timeout_sec=600)


### PR DESCRIPTION
Adds test which repeatedly and randomly transfers leadership in the
background

Fixes for leadership transfer related problems
Issues fixed:
1. mutex lock update direct_consumer::update_fetchers
   - fast leadership transfers launched concurrent update_fetchers
     executions. interleaved execution mangled the fetch_offsets value
     for the parition and resulted in a reset to 0
2. skip adding to the data_queue if the fetch offset was not updated
   - when maybe_update_fetch_offset returns false, it indicates an
     assignment change. Namely for quick A->B->A broken transfers this
     resulted redundant offsets.
     - for the ABA case, the next fetch will supercede the old fetch
   - resolution is to discard the old fetch
3. newly assigned partitions should always be a part of the next fetch
   request
4. a partition should only be removed from the next fetch request if
    the fetcher assignment epochs are the same, this avoids A->B->A
    reassignment race conditions
5. a partition should be removed from the 'to_forget' index
    if has been reassigned to the fetcher
6. its possible for a request to receive a response which was
    previously part of its assignment set if a 'forget' has not yet been
    sent. Treat this case the same as 'changed assignment epoch'

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes

* fixes leadership transfer related problems in direct consumer

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
