### PR TITLE
base/format_to: fix ostream support

### DIFF
--- a/src/v/base/format_to.h
+++ b/src/v/base/format_to.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 namespace fmt {
 
@@ -33,7 +34,7 @@ concept HasFormatToMethod = requires(const T& obj, iterator out) {
  *   int32_t b;
  *
  *   fmt::iterator format_to(fmt::iterator it) const {
- *     return fmt::print(it, "{{a: {}, b: {}}}", a, b)
+ *     return fmt::format_to(it, "{{a: {}, b: {}}}", a, b)
  *   }
  * };
  * ```
@@ -67,10 +68,17 @@ struct formatter<T> {
 
 } // namespace fmt
 
+namespace std {
 // For both googletest and for other external libraries that may use
 // `operator<<` to print stuff, give a blanket implementation that delegates to
 // the `format_to` method.
+//
+// We have to put this in the std namespace for overload resolution rules to be
+// able to find it for arbitrary T.
 template<fmt::HasFormatToMethod T>
-std::ostream& operator<<(std::ostream& os, const T& obj) {
-    return fmt::format_to(os, "{}", obj);
+// NOLINTNEXTLINE(*-dcl58-*)
+ostream& operator<<(ostream& os, const T& obj) {
+    fmt::print(os, "{}", obj);
+    return os;
 }
+} // namespace std

--- a/src/v/base/tests/format_to_test.cc
+++ b/src/v/base/tests/format_to_test.cc
@@ -26,5 +26,39 @@ static_assert(fmt::HasFormatToMethod<foo>);
 
 TEST(Formatter, FormatTo) {
     foo f{.a = "bar", .b = 3};
-    EXPECT_EQ("hello: {a: bar, b: 3}", fmt::format("hello: {}", f));
+    EXPECT_EQ("hello: {a: bar, b: 3}", fmt::format("hello: {}", f)) << f;
+}
+
+namespace ns {
+struct foo {
+    std::string a;
+    int32_t b;
+
+    fmt::iterator format_to(fmt::iterator it) const {
+        return fmt::format_to(it, "{{a: {}, b: {}}}", a, b);
+    }
+};
+
+struct bar {
+    foo f;
+};
+
+std::ostream& operator<<(std::ostream& os, const bar& b) {
+    return os << "{f: " << b.f << "}";
+}
+
+TEST(Formatter, InsideNamespacedFormatTo) {
+    ns::foo f{.a = "bar", .b = 3};
+    EXPECT_EQ("hello: {a: bar, b: 3}", fmt::format("hello: {}", f)) << f;
+    ns::bar b{.f = f};
+    EXPECT_EQ(
+      "world: {f: {a: bar, b: 3}}", fmt::format("world: {}", fmt::streamed(b)))
+      << b;
+}
+
+} // namespace ns
+
+TEST(Formatter, OutsideNamespacedFormatTo) {
+    ns::foo f{.a = "bar", .b = 3};
+    EXPECT_EQ("hello: {a: bar, b: 3}", fmt::format("hello: {}", f)) << f;
 }


### PR DESCRIPTION
Doesn't fix all the cases, but fixes some of them.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
