### PR TITLE
ct: reorganize cloud_topics::app

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -95,6 +95,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/domain:domain_supervisor",
         "//src/v/cloud_topics/level_one/metastore:frontend",
         "//src/v/cloud_topics/level_zero/common:extent_meta",
+        "//src/v/cloud_topics/level_zero/reconciler",
         "//src/v/cluster",
         "//src/v/container:chunked_vector",
         "//src/v/model",

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -147,6 +147,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "state_accessors",
+    hdrs = [
+        "state_accessors.h",
+    ],
+    include_prefix = "cloud_topics",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":data_plane_api",
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "cluster_services_interface",
     hdrs = [
         "cluster_services.h",

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -77,6 +77,10 @@ redpanda_cc_library(
     hdrs = [
         "app.h",
     ],
+    implementation_deps = [
+        ":cluster_services_interface",
+        ":data_plane_impl",
+    ],
     include_prefix = "cloud_topics",
     visibility = [
         "//src/v/cloud_topics/frontend:__pkg__",
@@ -87,11 +91,14 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/base",
-        "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/level_one/domain:domain_supervisor",
+        "//src/v/cloud_topics/level_one/metastore:frontend",
         "//src/v/cloud_topics/level_zero/common:extent_meta",
+        "//src/v/cluster",
         "//src/v/container:chunked_vector",
         "//src/v/model",
+        "//src/v/ssx:sharded_service_container",
         "//src/v/storage",
         "@seastar",
     ],

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -55,6 +55,7 @@ redpanda_cc_library(
     visibility = [
         "//src/v/cloud_topics/frontend:__pkg__",
         "//src/v/cloud_topics/level_zero/reader:__pkg__",
+        "//src/v/cloud_topics/level_zero/reconciler:__pkg__",
         "//src/v/kafka/data:__pkg__",
         "//src/v/redpanda:__pkg__",
     ],

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -115,7 +115,6 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
         "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
         "//src/v/cloud_topics/level_zero/reader:fetch_handler",
-        "//src/v/cloud_topics/level_zero/reconciler",
         "//src/v/cloud_topics/level_zero/throttler",
         "//src/v/model",
         "//src/v/storage",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -69,6 +69,12 @@ ss::future<> app::construct(
             std::make_unique<real_cluster_services>(
               &controller->get_cluster_epoch_generator()));
       }));
+    co_await construct_service(
+      reconciler,
+      partition_mgr,
+      remote,
+      ss::sharded_parameter([this] { return state.local().get_data_plane(); }),
+      bucket);
     co_await construct_service(domain_supervisor, controller);
     co_await construct_service(
       l1_metastore_fe,
@@ -82,6 +88,7 @@ ss::future<> app::construct(
 
 ss::future<> app::start() {
     co_await state.invoke_on_all([](auto& s) { return s.start(); });
+    co_await reconciler.invoke_on_all([](auto& r) { return r.start(); });
     co_await domain_supervisor.invoke_on_all(
       [](auto& ds) { return ds.start(); });
 }

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -10,30 +10,91 @@
 
 #include "cloud_topics/app.h"
 
+#include "cloud_topics/cluster_services.h"
+#include "cloud_topics/data_plane_impl.h"
+#include "cluster/cluster_epoch_service.h"
+#include "cluster/controller.h"
+#include "ssx/sharded_service_container.h"
+
 #include <seastar/core/coroutine.hh>
 
 namespace experimental::cloud_topics {
 
-app::app(
-  ss::shared_ptr<data_plane_api> dp,
-  std::unique_ptr<l1::domain_supervisor> l1_cp)
-  : _data_plane(std::move(dp))
-  , _domain_supervisor(std::move(l1_cp)) {}
+namespace {
+class real_cluster_services
+  : public experimental::cloud_topics::cluster_services {
+public:
+    explicit real_cluster_services(
+      ss::sharded<cluster::cluster_epoch_service<>>* epoch_generator)
+      : _epoch_service(epoch_generator) {}
 
-seastar::future<> app::start() {
-    co_await _domain_supervisor->start();
-    co_await _data_plane->start();
+    seastar::future<experimental::cloud_topics::cluster_epoch>
+    current_epoch(seastar::abort_source* as) override {
+        std::expected<int64_t, std::error_code> epoch
+          = co_await _epoch_service->local().get_cached_epoch(as);
+        if (!epoch) {
+            throw std::system_error(epoch.error());
+        }
+        co_return experimental::cloud_topics::cluster_epoch(epoch.value());
+    }
+
+private:
+    ss::sharded<cluster::cluster_epoch_service<>>* _epoch_service;
+};
+} // namespace
+
+app::app()
+  : ssx::sharded_service_container("cloud_topics::app") {}
+
+ss::future<> app::construct(
+  model::node_id self,
+  cluster::controller* controller,
+  ss::sharded<cluster::partition_manager>* partition_mgr,
+  ss::sharded<cluster::partition_leaders_table>* leaders_table,
+  ss::sharded<cluster::shard_table>* shard_table,
+  ss::sharded<cloud_io::remote>* remote,
+  ss::sharded<cloud_storage::cache>* cloud_cache,
+  ss::sharded<cluster::metadata_cache>* metadata_cache,
+  ss::sharded<rpc::connection_cache>* connection_cache,
+  cloud_storage_clients::bucket_name bucket,
+  ss::sharded<storage::api>* storage) {
+    co_await construct_service(
+      state,
+      ss::sharded_parameter([remote, cloud_cache, bucket, storage, controller] {
+          return experimental::cloud_topics::make_data_plane(
+            remote,
+            cloud_cache,
+            bucket,
+            storage,
+            std::make_unique<real_cluster_services>(
+              &controller->get_cluster_epoch_generator()));
+      }));
+    co_await construct_service(domain_supervisor, controller);
+    co_await construct_service(
+      l1_metastore_fe,
+      self,
+      metadata_cache,
+      leaders_table,
+      shard_table,
+      connection_cache,
+      &domain_supervisor);
 }
 
-seastar::future<> app::stop() {
-    co_await _domain_supervisor->stop();
-    co_await _data_plane->stop();
+ss::future<> app::start() {
+    co_await state.invoke_on_all([](auto& s) { return s.start(); });
+    co_await domain_supervisor.invoke_on_all(
+      [](auto& ds) { return ds.start(); });
 }
 
-ss::shared_ptr<data_plane_api> app::get_data_plane_api() { return _data_plane; }
-
-l1::domain_supervisor* app::get_l1_domain_supervisor() {
-    return _domain_supervisor.get();
+ss::future<> app::stop() {
+    ssx::sharded_service_container::shutdown();
+    co_return;
 }
+
+ss::sharded<l1::frontend>* app::get_sharded_l1_metastore_fe() {
+    return &l1_metastore_fe;
+}
+
+ss::sharded<state_accessors>* app::get_state() { return &state; }
 
 } // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -12,6 +12,7 @@
 
 #include "cloud_topics/level_one/domain/domain_supervisor.h"
 #include "cloud_topics/level_one/metastore/frontend.h"
+#include "cloud_topics/level_zero/reconciler/reconciler.h"
 #include "cloud_topics/state_accessors.h"
 #include "ssx/sharded_service_container.h"
 
@@ -66,6 +67,7 @@ public:
 
 private:
     ss::sharded<state_accessors> state;
+    ss::sharded<reconciler::reconciler> reconciler;
     ss::sharded<l1::domain_supervisor> domain_supervisor;
     ss::sharded<l1::frontend> l1_metastore_fe;
 };

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -10,21 +10,30 @@
 
 #pragma once
 
-#include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/level_one/domain/domain_supervisor.h"
+#include "cloud_topics/level_one/metastore/frontend.h"
+#include "cloud_topics/state_accessors.h"
+#include "ssx/sharded_service_container.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 
+namespace cloud_io {
+class remote;
+} // namespace cloud_io
+namespace cloud_storage {
+class cache;
+} // namespace cloud_storage
+namespace storage {
+class api;
+} // namespace storage
+
 namespace experimental::cloud_topics {
 
-// Simple container to use with seastar::sharded.
-// The seastar::sharded wants to know the size of the object at compile time.
-class app {
+class app : public ssx::sharded_service_container {
 public:
-    explicit app(
-      ss::shared_ptr<data_plane_api>, std::unique_ptr<l1::domain_supervisor>);
+    explicit app();
 
     app(const app&) = delete;
     app& operator=(const app&) = delete;
@@ -32,17 +41,33 @@ public:
     app& operator=(app&&) noexcept = delete;
     ~app() = default;
 
-    seastar::future<> start();
-    seastar::future<> stop();
+    ss::future<> construct(
+      model::node_id,
+      cluster::controller*,
+      ss::sharded<cluster::partition_manager>*,
+      ss::sharded<cluster::partition_leaders_table>*,
+      ss::sharded<cluster::shard_table>*,
+      ss::sharded<cloud_io::remote>*,
+      ss::sharded<cloud_storage::cache>*,
+      ss::sharded<cluster::metadata_cache>*,
+      ss::sharded<rpc::connection_cache>*,
+      cloud_storage_clients::bucket_name,
+      ss::sharded<storage::api>*);
 
-    ss::shared_ptr<data_plane_api> get_data_plane_api();
-    l1::domain_supervisor* get_l1_domain_supervisor();
+    ss::future<> start();
+
+    // Call stop on each sharded service and call their destructors.
+    ss::future<> stop();
+
+    ss::sharded<l1::frontend>* get_sharded_l1_metastore_fe();
+    ss::sharded<state_accessors>* get_state();
 
     // TODO: add 'get_control_plane_api' etc
 
 private:
-    ss::shared_ptr<data_plane_api> _data_plane;
-    std::unique_ptr<l1::domain_supervisor> _domain_supervisor;
+    ss::sharded<state_accessors> state;
+    ss::sharded<l1::domain_supervisor> domain_supervisor;
+    ss::sharded<l1::frontend> l1_metastore_fe;
 };
 
 } // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -17,11 +17,10 @@
 #include "cloud_topics/level_zero/batcher/batcher.h"
 #include "cloud_topics/level_zero/read_pipeline.h"
 #include "cloud_topics/level_zero/reader/fetch_request_handler.h"
-#include "cloud_topics/level_zero/reconciler/reconciler.h"
 #include "cloud_topics/level_zero/throttler/throttler.h"
 #include "cloud_topics/level_zero/write_pipeline.h"
 #include "model/fundamental.h"
-#include "storage/types.h"
+#include "storage/api.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -35,14 +34,12 @@ class impl
   , public ss::enable_shared_from_this<impl> {
 public:
     impl(
-      seastar::sharded<cluster::partition_manager>* pm,
       seastar::sharded<cloud_io::remote>* io,
       seastar::sharded<cloud_storage::cache>* cache,
       cloud_storage_clients::bucket_name bucket,
       seastar::sharded<storage::api>* storage_api,
       std::unique_ptr<cluster_services> cluster_services)
       : _cluster_services(std::move(cluster_services))
-      , _reconciler(std::make_unique<reconciler::reconciler>(pm, io, bucket))
       , _write_pipeline(std::make_unique<l0::write_pipeline<>>())
       , _throttler(std::make_unique<throttler<>>(
           10_MiB /*TODO: fixme*/,
@@ -64,8 +61,6 @@ public:
     seastar::future<> start() override {
         // Batcher
         co_await _batch_cache->start();
-        // Reconciler
-        co_await _reconciler->start();
         // Write path
         co_await _throttler->start();
         co_await _batcher->start();
@@ -80,8 +75,6 @@ public:
         co_await _write_pipeline->stop();
         co_await _batcher->stop();
         co_await _throttler->stop();
-        //  Reconciler
-        co_await _reconciler->stop();
         // Batcher
         co_await _batch_cache->stop();
     }
@@ -121,7 +114,6 @@ public:
 
 private:
     std::unique_ptr<cluster_services> _cluster_services;
-    std::unique_ptr<reconciler::reconciler> _reconciler;
     // Write path
     std::unique_ptr<l0::write_pipeline<>> _write_pipeline;
     std::unique_ptr<throttler<>> _throttler;
@@ -134,14 +126,12 @@ private:
 };
 
 ss::shared_ptr<data_plane_api> make_data_plane(
-  ss::sharded<cluster::partition_manager>* partition_manager,
   ss::sharded<cloud_io::remote>* remote,
   ss::sharded<cloud_storage::cache>* cache,
   cloud_storage_clients::bucket_name bucket,
   ss::sharded<storage::api>* log_manager,
   std::unique_ptr<cluster_services> cluster_services) {
     return ss::make_shared<impl>(
-      partition_manager,
       remote,
       cache,
       std::move(bucket),

--- a/src/v/cloud_topics/data_plane_impl.h
+++ b/src/v/cloud_topics/data_plane_impl.h
@@ -38,7 +38,6 @@ namespace experimental::cloud_topics {
 class cluster_services;
 
 ss::shared_ptr<data_plane_api> make_data_plane(
-  seastar::sharded<cluster::partition_manager>*,
   seastar::sharded<cloud_io::remote>*,
   seastar::sharded<cloud_storage::cache>*,
   cloud_storage_clients::bucket_name bucket,

--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -33,7 +33,6 @@ redpanda_cc_library(
     deps = [
         ":errc",
         "//src/v/base",
-        "//src/v/cloud_topics:app",
         "//src/v/cloud_topics:data_plane_api",
         "//src/v/cloud_topics/level_zero/common:extent_meta",
         "//src/v/cloud_topics/level_zero/reader",

--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -2,13 +2,17 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
     name = "errc",
-    srcs = [],
+    srcs = [
+        "errc.cc",
+    ],
     hdrs = [
         "errc.h",
     ],
     include_prefix = "cloud_topics/frontend",
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+        "@fmt",
+    ],
 )
 
 redpanda_cc_library(

--- a/src/v/cloud_topics/frontend/errc.cc
+++ b/src/v/cloud_topics/frontend/errc.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/frontend/errc.h"
+
+auto fmt::formatter<experimental::cloud_topics::frontend_errc>::format(
+  const experimental::cloud_topics::frontend_errc& err,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    using enum experimental::cloud_topics::frontend_errc;
+    switch (err) {
+    case offset_not_available:
+        return fmt::format_to(
+          ctx.out(), "cloud_topics::frontend_errc::offset_not_available");
+    case invalid_topic_exception:
+        return fmt::format_to(
+          ctx.out(), "cloud_topics::frontend_errc::invalid_topic_exception");
+    case not_leader_for_partition:
+        return fmt::format_to(
+          ctx.out(), "cloud_topics::frontend_errc::not_leader_for_partition");
+    case offset_out_of_range:
+        return fmt::format_to(
+          ctx.out(), "cloud_topics::frontend_errc::offset_out_of_range");
+    }
+}

--- a/src/v/cloud_topics/frontend/errc.h
+++ b/src/v/cloud_topics/frontend/errc.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include <fmt/format.h>
+
 namespace experimental::cloud_topics {
 // Frontend error codes
 enum class frontend_errc {
@@ -18,3 +20,10 @@ enum class frontend_errc {
     offset_out_of_range,
 };
 } // namespace experimental::cloud_topics
+template<>
+struct fmt::formatter<experimental::cloud_topics::frontend_errc>
+  : fmt::formatter<std::string_view> {
+    auto format(
+      const experimental::cloud_topics::frontend_errc&,
+      fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -10,7 +10,6 @@
 #include "cloud_topics/frontend/frontend.h"
 
 #include "cloud_storage/types.h"
-#include "cloud_topics/app.h"
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/errc.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
@@ -178,11 +177,6 @@ frontend::frontend(
   ss::shared_ptr<experimental::cloud_topics::data_plane_api> app) noexcept
   : _partition(std::move(p))
   , _data_plane(std::move(app)) {}
-
-frontend::frontend(
-  ss::lw_shared_ptr<cluster::partition> p,
-  ss::sharded<experimental::cloud_topics::app>& ct_app) noexcept
-  : frontend(std::move(p), ct_app.local().get_data_plane_api()) {}
 
 const model::ntp& frontend::ntp() const { return _partition->ntp(); }
 

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -177,7 +177,7 @@ frontend::frontend(
   ss::lw_shared_ptr<cluster::partition> p,
   ss::shared_ptr<experimental::cloud_topics::data_plane_api> app) noexcept
   : _partition(std::move(p))
-  , _ct_api(std::move(app)) {}
+  , _data_plane(std::move(app)) {}
 
 frontend::frontend(
   ss::lw_shared_ptr<cluster::partition> p,
@@ -274,14 +274,14 @@ model::term_id frontend::leader_epoch() const {
 ss::future<storage::translating_reader> frontend::make_reader(
   storage::log_reader_config cfg,
   std::optional<model::timeout_clock::time_point>) {
-    vassert(_ct_api != nullptr, "cloud topics api not initialized");
+    vassert(_data_plane != nullptr, "cloud topics api not initialized");
 
     auto ot_state = _partition->get_offset_translator_state();
 
     // TODO: depending on the 'cfg' construct level zero or level one
     // reader impl.
     auto impl = std::make_unique<level_zero_log_reader_impl>(
-      cfg, _partition, _ct_api);
+      cfg, _partition, _data_plane);
 
     co_return storage::translating_reader{
       model::record_batch_reader(std::move(impl)), std::move(ot_state)};
@@ -451,7 +451,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
     }
 
     // Dataplane.
-    auto res = co_await _ct_api->write_and_debounce(
+    auto res = co_await _data_plane->write_and_debounce(
       ntp(),
       std::move(batches),
       model::timeout_clock::now()
@@ -483,7 +483,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
               "Putting batch to cache: {}, term: {}",
               b.base_offset(),
               b.term());
-            _ct_api->cache_put(ntp(), b);
+            _data_plane->cache_put(ntp(), b);
         }
     }
     co_return ret_offset;
@@ -507,7 +507,7 @@ raft::replicate_stages frontend::replicate(
     out.request_enqueued = op_state->request_enqueued.get_future();
     out.replicate_finished = op_state->replicate_finished.get_future();
     ssx::background = bg_upload_and_replicate(
-      _ct_api, _partition, header, op_state, cache_enabled());
+      _data_plane, _partition, header, op_state, cache_enabled());
     return out;
 }
 

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -29,7 +29,6 @@ class partition;
 
 namespace experimental::cloud_topics {
 class data_plane_api;
-class app;
 
 struct replica_info {
     model::node_id id;
@@ -84,10 +83,6 @@ public:
     explicit frontend(
       ss::lw_shared_ptr<cluster::partition> p,
       ss::shared_ptr<experimental::cloud_topics::data_plane_api> ct) noexcept;
-
-    explicit frontend(
-      ss::lw_shared_ptr<cluster::partition> p,
-      ss::sharded<experimental::cloud_topics::app>& ct_app) noexcept;
 
     /// Get current NTP
     const model::ntp& ntp() const;

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -156,7 +156,7 @@ private:
     bool cache_enabled() const;
 
     ss::lw_shared_ptr<cluster::partition> _partition;
-    ss::shared_ptr<experimental::cloud_topics::data_plane_api> _ct_api;
+    ss::shared_ptr<experimental::cloud_topics::data_plane_api> _data_plane;
 };
 
 } // namespace experimental::cloud_topics

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -222,13 +222,13 @@ frontend::frontend(
   ss::sharded<cluster::partition_leaders_table>* leaders,
   ss::sharded<cluster::shard_table>* shards,
   ss::sharded<::rpc::connection_cache>* connections,
-  domain_supervisor* domain_supervisor)
+  ss::sharded<domain_supervisor>* domain_supervisor)
   : _self(self)
   , _metadata(metadata)
   , _leaders(leaders)
   , _shard_table(shards)
   , _connection_cache(connections)
-  , _domain_supervisor(domain_supervisor) {}
+  , _domain_supervisor(&domain_supervisor->local()) {}
 
 ss::future<> frontend::stop() { return _gate.close(); }
 

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -51,7 +51,7 @@ public:
       ss::sharded<cluster::partition_leaders_table>*,
       ss::sharded<cluster::shard_table>*,
       ss::sharded<::rpc::connection_cache>*,
-      domain_supervisor*);
+      ss::sharded<domain_supervisor>*);
 
     ss::future<> stop();
 

--- a/src/v/cloud_topics/level_zero/reader/BUILD
+++ b/src/v/cloud_topics/level_zero/reader/BUILD
@@ -108,7 +108,6 @@ redpanda_cc_library(
         "reader.h",
     ],
     implementation_deps = [
-        "//src/v/cloud_topics:app",
         "//src/v/cloud_topics:data_plane_api",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_zero/stm:placeholder",

--- a/src/v/cloud_topics/level_zero/reconciler/BUILD
+++ b/src/v/cloud_topics/level_zero/reconciler/BUILD
@@ -29,7 +29,8 @@ redpanda_cc_library(
         "reconciler.h",
     ],
     implementation_deps = [
-        "//src/v/kafka/data:partition_proxy",
+        "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics/frontend",
     ],
     include_prefix = "cloud_topics/level_zero/reconciler",
     visibility = ["//visibility:public"],

--- a/src/v/cloud_topics/level_zero/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/level_zero/reconciler/reconciler.cc
@@ -12,12 +12,12 @@
 
 #include "base/vlog.h"
 #include "cloud_storage/configuration.h"
+#include "cloud_topics/frontend/frontend.h"
 #include "cloud_topics/level_one/common/object_utils.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 #include "cloud_topics/object_utils.h"
 #include "cloud_topics/types.h"
 #include "cluster/partition.h"
-#include "kafka/data/partition_proxy.h"
 #include "kafka/utils/txn_reader.h"
 #include "model/namespace.h"
 #include "random/generators.h"
@@ -36,6 +36,27 @@ bool is_cloud_partition(
   const ss::lw_shared_ptr<cluster::partition>& partition) {
     return partition->get_ntp_config().cloud_topic_enabled();
 }
+
+class aborted_transaction_tracker_impl
+  : public kafka::aborted_transaction_tracker {
+public:
+    aborted_transaction_tracker_impl(
+      experimental::cloud_topics::frontend* fe,
+      ss::lw_shared_ptr<const storage::offset_translator_state> translator)
+      : _fe(fe)
+      , _translator(std::move(translator)) {}
+
+    ss::future<std::vector<model::tx_range>>
+    compute_aborted_transactions(model::offset base, model::offset max) final {
+        return _fe->aborted_transactions(
+          model::offset_cast(base), model::offset_cast(max), _translator);
+    }
+
+private:
+    experimental::cloud_topics::frontend* _fe;
+    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
+};
+
 } // namespace
 
 namespace experimental::cloud_topics::reconciler {
@@ -43,9 +64,11 @@ namespace experimental::cloud_topics::reconciler {
 reconciler::reconciler(
   ss::sharded<cluster::partition_manager>* pm,
   ss::sharded<cloud_io::remote>* cloud_io,
+  ss::shared_ptr<data_plane_api> data_plane,
   std::optional<cloud_storage_clients::bucket_name> bucket)
   : _partition_manager(pm)
-  , _cloud_io(cloud_io) {
+  , _cloud_io(cloud_io)
+  , _data_plane(std::move(data_plane)) {
     if (bucket.has_value()) {
         _bucket = std::move(bucket.value());
     } else {
@@ -246,50 +269,53 @@ ss::future<> reconciler::commit_object(
 
 ss::future<model::record_batch_reader>
 reconciler::make_reader(const attached_partition& partition, size_t max_bytes) {
-    auto proxy = kafka::make_partition_proxy(partition->partition);
+    auto& cluster_partition = partition->partition;
+    frontend fe(partition->partition, _data_plane);
 
-    auto effective_start = co_await proxy.sync_effective_start();
-    if (effective_start.has_error()) {
+    auto effective_start = co_await fe.sync_effective_start(5s);
+    if (!effective_start.has_value()) {
         vlog(
           lg.info,
           "Error querying partition start offset ({}): {}",
-          proxy.ntp(),
+          cluster_partition->ntp(),
           effective_start.error());
         co_return model::make_empty_record_batch_reader();
     }
 
     kafka::offset start_offset = std::max(
-      model::offset_cast(effective_start.value()), partition->lro);
+      effective_start.value(), partition->lro);
 
-    auto maybe_lso = proxy.last_stable_offset();
-    if (maybe_lso.has_error()) {
+    auto maybe_lso = fe.last_stable_offset();
+    if (!maybe_lso.has_value()) {
         vlog(
           lg.info,
           "Error querying partition LSO ({}): {}",
-          proxy.ntp(),
+          cluster_partition->ntp(),
           maybe_lso.error());
         co_return model::make_empty_record_batch_reader();
     }
 
     // It's possible for LSO to be 0, which in this case the previous offset
     // is model::offset::min(), this is the same as the kafka fetch path.
-    auto max_offset = kafka::prev_offset(model::offset_cast(maybe_lso.value()));
+    auto max_offset = kafka::prev_offset(maybe_lso.value());
 
     if (max_offset < start_offset) {
         co_return model::make_empty_record_batch_reader();
     }
 
-    auto reader = co_await proxy.make_reader(storage::log_reader_config(
-      kafka::offset_cast(start_offset),
-      kafka::offset_cast(max_offset),
-      0,
-      max_bytes,
-      std::nullopt,
-      std::nullopt,
-      _as));
+    auto reader = co_await fe.make_reader(
+      storage::log_reader_config(
+        kafka::offset_cast(start_offset),
+        kafka::offset_cast(max_offset),
+        0,
+        max_bytes,
+        std::nullopt,
+        std::nullopt,
+        _as),
+      /*debounce_deadline=*/std::nullopt);
 
-    auto tracker = kafka::aborted_transaction_tracker::create_default(
-      &proxy, std::move(reader.ot_state));
+    auto tracker = std::make_unique<aborted_transaction_tracker_impl>(
+      &fe, std::move(reader.ot_state));
 
     co_return model::make_record_batch_reader<kafka::read_committed_reader>(
       std::move(tracker), std::move(reader.reader));

--- a/src/v/cloud_topics/level_zero/reconciler/reconciler.h
+++ b/src/v/cloud_topics/level_zero/reconciler/reconciler.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "cloud_io/remote.h"
 #include "cloud_storage_clients/types.h"
+#include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/level_zero/reconciler/range_batch_consumer.h"
 #include "cluster/notification.h"
 #include "cluster/partition.h"
@@ -39,6 +40,7 @@ public:
     reconciler(
       ss::sharded<cluster::partition_manager>*,
       ss::sharded<cloud_io::remote>*,
+      ss::shared_ptr<data_plane_api>,
       std::optional<cloud_storage_clients::bucket_name> = std::nullopt);
 
     reconciler(const reconciler&) = delete;
@@ -148,6 +150,7 @@ private:
 private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<cloud_io::remote>* _cloud_io;
+    ss::shared_ptr<experimental::cloud_topics::data_plane_api> _data_plane;
     cloud_storage_clients::bucket_name _bucket;
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/cloud_topics/state_accessors.h
+++ b/src/v/cloud_topics/state_accessors.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "cloud_topics/data_plane_api.h"
+
+namespace experimental::cloud_topics {
+
+// Encapsulates the required bits to access topic state from cloud topics,
+// with minimal dependencies. This allows it to be passed around through
+// different layers without introducing circular dependencies.
+//
+// NOTE: the seastar::sharded wants to know the size of the object at compile
+// time. Simple container to use with seastar::sharded.
+class state_accessors {
+public:
+    explicit state_accessors(ss::shared_ptr<data_plane_api> data_plane)
+      : data_plane(std::move(data_plane)) {}
+    ss::future<> start() { return data_plane->start(); }
+    ss::future<> stop() { return data_plane->stop(); }
+    ss::shared_ptr<data_plane_api> get_data_plane() { return data_plane; }
+
+private:
+    ss::shared_ptr<data_plane_api> data_plane;
+};
+} // namespace experimental::cloud_topics

--- a/src/v/cluster/BUILD
+++ b/src/v/cluster/BUILD
@@ -683,6 +683,7 @@ redpanda_cc_library(
         "//src/v/cloud_storage:topic_mount_manifest_path",
         "//src/v/cloud_storage:types",
         "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster_link/model",

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -53,9 +53,9 @@ partition::partition(
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<archival::upload_housekeeping_service>& upload_hks,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
-  ss::sharded<experimental::cloud_topics::app>& ct_app)
+  ss::sharded<experimental::cloud_topics::state_accessors>* ct_state)
   : _raft(std::move(r))
-  , _cloud_topics_app(ct_app)
+  , _cloud_topics_state(ct_state)
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _feature_table(feature_table)
   , _archival_conf(std::move(archival_conf))
@@ -1856,9 +1856,9 @@ ss::future<result<ssx::rwlock_unit>> partition::hold_writes_enabled() {
     co_return *std::move(maybe_units);
 }
 
-ss::sharded<experimental::cloud_topics::app>&
-partition::get_cloud_topics_data_api() noexcept {
-    return _cloud_topics_app;
+ss::sharded<experimental::cloud_topics::state_accessors>*
+partition::get_cloud_topics_state() noexcept {
+    return _cloud_topics_state;
 }
 
 } // namespace cluster

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -32,7 +32,7 @@
 
 namespace experimental::cloud_topics {
 class ctp_stm_api;
-class app;
+class state_accessors;
 }; // namespace experimental::cloud_topics
 
 namespace cluster {
@@ -58,7 +58,7 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<archival::upload_housekeeping_service>&,
       std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
-      ss::sharded<experimental::cloud_topics::app>& ct_app);
+      ss::sharded<experimental::cloud_topics::state_accessors>* ct_state);
 
     ~partition() = default;
 
@@ -403,8 +403,8 @@ public:
 
     // Returns a pointer to the data plane api if cloud topics is enabled for
     // this partition. Otherwise, nullopt is returned
-    ss::sharded<experimental::cloud_topics::app>&
-    get_cloud_topics_data_api() noexcept;
+    ss::sharded<experimental::cloud_topics::state_accessors>*
+    get_cloud_topics_state() noexcept;
 
 private:
     ss::future<>
@@ -432,7 +432,8 @@ private:
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::shared_ptr<experimental::cloud_topics::ctp_stm_api> _ctp_stm_api;
-    ss::sharded<experimental::cloud_topics::app>& _cloud_topics_app;
+    ss::sharded<experimental::cloud_topics::state_accessors>*
+      _cloud_topics_state;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -60,7 +60,7 @@ partition_manager::partition_manager(
   ss::sharded<features::feature_table>& feature_table,
   ss::sharded<archival::upload_housekeeping_service>& upload_hks,
   config::binding<std::chrono::milliseconds> partition_shutdown_timeout,
-  ss::sharded<experimental::cloud_topics::app>& cloud_topics_app)
+  ss::sharded<experimental::cloud_topics::state_accessors>* cloud_topics_state)
   : _storage(storage.local())
   , _raft_manager(raft)
   , _partition_recovery_mgr(recovery_mgr)
@@ -70,7 +70,7 @@ partition_manager::partition_manager(
   , _feature_table(feature_table)
   , _upload_hks(upload_hks)
   , _partition_shutdown_timeout(std::move(partition_shutdown_timeout))
-  , _cloud_topics_app(cloud_topics_app) {
+  , _cloud_topics_state(cloud_topics_state) {
     _leader_notify_handle
       = _raft_manager.local().register_leadership_notification(
         [this](
@@ -302,7 +302,7 @@ ss::future<consensus_ptr> partition_manager::manage(
       _feature_table,
       _upload_hks,
       read_replica_bucket,
-      _cloud_topics_app);
+      _cloud_topics_state);
 
     _ntp_table.emplace(log->config().ntp(), p);
     _raft_table.emplace(group, p);

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -33,7 +33,7 @@
 #include <chrono>
 
 namespace experimental::cloud_topics {
-class app;
+class state_accessors;
 }
 
 namespace cluster {
@@ -53,7 +53,7 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<archival::upload_housekeeping_service>&,
       config::binding<std::chrono::milliseconds>,
-      ss::sharded<experimental::cloud_topics::app>&);
+      ss::sharded<experimental::cloud_topics::state_accessors>*);
 
     ~partition_manager();
 
@@ -308,7 +308,8 @@ private:
     state_machine_registry _stm_registry;
 
     // The sharded app may not be initialized if cloud topics isn't enabled.
-    ss::sharded<experimental::cloud_topics::app>& _cloud_topics_app;
+    ss::sharded<experimental::cloud_topics::state_accessors>*
+      _cloud_topics_state;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
     friend std::ostream& operator<<(

--- a/src/v/kafka/data/BUILD
+++ b/src/v/kafka/data/BUILD
@@ -33,8 +33,8 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/cloud_storage:types",
-        "//src/v/cloud_topics:app",
         "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/frontend:errc",
         "//src/v/cloud_topics/level_zero/reader",

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -10,7 +10,6 @@
  */
 #include "kafka/data/cloud_topic_partition.h"
 
-#include "cloud_topics/app.h"
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/errc.h"
 #include "cloud_topics/frontend/frontend.h"

--- a/src/v/kafka/data/partition_proxy.cc
+++ b/src/v/kafka/data/partition_proxy.cc
@@ -11,8 +11,8 @@
 
 #include "partition_proxy.h"
 
-#include "cloud_topics/app.h"
 #include "cloud_topics/frontend/frontend.h"
+#include "cloud_topics/state_accessors.h"
 #include "cluster/partition_manager.h"
 #include "kafka/data/cloud_topic_partition.h"
 #include "kafka/data/replicated_partition.h"
@@ -27,16 +27,15 @@ partition_proxy make_with_impl(Args&&... args) {
 partition_proxy
 make_partition_proxy(const ss::lw_shared_ptr<cluster::partition>& partition) {
     if (partition->get_ntp_config().cloud_topic_enabled()) {
-        auto& ct_data_plane = partition->get_cloud_topics_data_api();
-        if (!ct_data_plane.local_is_initialized()) {
+        auto ct_state = partition->get_cloud_topics_state();
+        if (!ct_state || !ct_state->local_is_initialized()) {
             throw std::runtime_error(
               "Cloud topic partition can't be created because the cloud-topics "
               "subsystem is not initialized");
         }
-        auto api = ct_data_plane.local().get_data_plane_api();
         auto frontend_instance
           = std::make_unique<experimental::cloud_topics::frontend>(
-            partition, api);
+            partition, ct_state->local().get_data_plane());
         return make_with_impl<cloud_topic_partition>(
           partition, std::move(frontend_instance));
     }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -384,9 +384,9 @@ void application::shutdown() {
             return mgr.invoke_on_all(&datalake::credential_manager::stop);
         });
     }
-    if (cloud_topics_api.local_is_initialized()) {
+    if (cloud_topics_app) {
         shutdown_with_watchdog(
-          cloud_topics_api, [](auto& ct) { return ct.stop(); });
+          cloud_topics_app, [](auto& app) { return app->stop(); });
     }
     // Stop all partitions before destructing the subsystems (transaction
     // coordinator, etc). This interrupts ongoing replication requests,
@@ -1725,6 +1725,17 @@ void application::wire_up_redpanda_services(
     producer_manager.invoke_on_all(&cluster::tx::producer_state_manager::start)
       .get();
 
+    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        vassert(
+          archival_storage_enabled(),
+          "cloud topics currently requires archival storage to be enabled");
+
+        // Initialize the cloud topics app to be able to pass it around to the
+        // partition manager.
+        // NOTE: this only instantiates the app; underlying services are
+        // constructed separately once more of the subsystems are available.
+        construct_single_service(cloud_topics_app);
+    }
     syschecks::systemd_message("Adding partition manager").get();
     construct_service(
       partition_manager,
@@ -1750,7 +1761,7 @@ void application::wire_up_redpanda_services(
           return config::shard_local_cfg()
             .partition_manager_shutdown_watchdog_timeout.bind();
       }),
-      std::ref(cloud_topics_api))
+      cloud_topics_app ? cloud_topics_app->get_state() : nullptr)
       .get();
     vlog(_log.info, "Partition manager started");
     construct_service(
@@ -2120,61 +2131,21 @@ void application::wire_up_redpanda_services(
       &shadow_index_cache,
       &partition_manager);
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
-        vassert(
-          archival_storage_enabled(),
-          "cloud topics currently requires archival storage to be enabled");
-
-        class real_cluster_services
-          : public experimental::cloud_topics::cluster_services {
-        public:
-            explicit real_cluster_services(
-              ss::sharded<cluster::cluster_epoch_service<>>* epoch_generator)
-              : _epoch_service(epoch_generator) {}
-
-            seastar::future<experimental::cloud_topics::cluster_epoch>
-            current_epoch(seastar::abort_source* as) override {
-                std::expected<int64_t, std::error_code> epoch
-                  = co_await _epoch_service->local().get_cached_epoch(as);
-                if (!epoch) {
-                    throw std::system_error(epoch.error());
-                }
-                co_return experimental::cloud_topics::cluster_epoch(
-                  epoch.value());
-            }
-
-        private:
-            ss::sharded<cluster::cluster_epoch_service<>>* _epoch_service;
-        };
-
-        construct_service(
-          cloud_topics_api,
-          ss::sharded_parameter([this, bucket] {
-              return experimental::cloud_topics::make_data_plane(
-                &cloud_io,
-                &shadow_index_cache,
-                bucket,
-                &storage,
-                std::make_unique<real_cluster_services>(
-                  &controller->get_cluster_epoch_generator()));
-          }),
-          ss::sharded_parameter([this, bucket] {
-              return std::make_unique<
-                experimental::cloud_topics::l1::domain_supervisor>(
-                controller.get());
-          }))
-          .get();
-
-        construct_service(
-          l1_metastore_fe,
-          node_id,
-          &metadata_cache,
-          &controller->get_partition_leaders(),
-          &controller->get_shard_table(),
-          &_connection_cache,
-          ss::sharded_parameter([this] {
-              return cloud_topics_api.local().get_l1_domain_supervisor();
-          }))
+    if (cloud_topics_app) {
+        syschecks::systemd_message("Starting cloud topics subsystems").get();
+        cloud_topics_app
+          ->construct(
+            node_id,
+            controller.get(),
+            &controller->get_partition_manager(),
+            &controller->get_partition_leaders(),
+            &controller->get_shard_table(),
+            &cloud_io,
+            &shadow_index_cache,
+            &metadata_cache,
+            &_connection_cache,
+            bucket,
+            &storage)
           .get();
     }
 
@@ -3346,12 +3317,14 @@ void application::start_runtime_services(
               sched_groups.cluster_sg(),
               smp_service_groups.cluster_smp_sg(),
               std::ref(_consumer_group_lag_metrics_frontend)));
-          if (config::shard_local_cfg().development_enable_cloud_topics()) {
+          if (
+            config::shard_local_cfg().development_enable_cloud_topics()
+            && cloud_topics_app) {
               runtime_services.push_back(
                 std::make_unique<experimental::cloud_topics::l1::rpc::service>(
                   sched_groups.datalake_sg(),
                   smp_service_groups.datalake_sg(),
-                  &l1_metastore_fe));
+                  cloud_topics_app->get_sharded_l1_metastore_fe()));
           }
 
           s.add_services(std::move(runtime_services));
@@ -3405,9 +3378,8 @@ void application::start_runtime_services(
         })
       .get();
 
-    if (cloud_storage_api.local_is_initialized()) {
-        cloud_topics_api.invoke_on_all([](auto& app) { return app.start(); })
-          .get();
+    if (cloud_topics_app) {
+        cloud_topics_app->start().get();
     }
 
     _debug_bundle_service.invoke_on_all(&debug_bundle::service::start).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2151,7 +2151,6 @@ void application::wire_up_redpanda_services(
           cloud_topics_api,
           ss::sharded_parameter([this, bucket] {
               return experimental::cloud_topics::make_data_plane(
-                &partition_manager,
                 &cloud_io,
                 &shadow_index_cache,
                 bucket,

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -203,6 +203,7 @@ public:
     kafka::server_app _kafka_server;
     ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
+    std::unique_ptr<experimental::cloud_topics::app> cloud_topics_app;
     ss::sharded<experimental::cloud_topics::app> cloud_topics_api;
     ss::sharded<experimental::cloud_topics::l1::frontend> l1_metastore_fe;
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This reorganizes cloud_topics::app so that:
1. it is a single non-sharded entity,
2. it includes all cloud_topics-related sharded services

Previously, when cloud_topics::app was sharded, 2. was difficult because
there are some cloud_topics-related services that need to be sharded,
but app itself was sharded in application.cc; having a sharded service
own another sharded service seems like a bad idea.

In doing this, I needed to wrap the data_plane_api in another class in
order to shard it, which I've done with the newly added
state_accessors. This lets us continue to use the data_plane_api instead
of the data_plane_impl, as we were before, as a sharded service.

Using the state_accessors also lets us plumb the data plane API through
to cluster::partition and to the partition_proxy without introducing a
circular dependency. Previously we plumbed down cloud_topics::app, which
made it easy to trip over dependencies.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
