### PR TITLE
initial copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,8 @@
 
 Redpanda is a high-performance, Apache Kafka®-compatible streaming data platform. It is written primarily in C++ for the core, with Go for CLI tooling (`rpk`), and some Python for auxiliary scripts and tests. Redpanda is designed to be lightweight, fast, and simple to operate, omitting ZooKeeper and the JVM.
 
+It uses extensively the thread-per-core model and asynchronous (coroutines, futures) programming model.
+
 **Repository Characteristics:**
 - **Large multi-language codebase:** C++ (core), Go (CLI/tools), Python (testing/scripts), Bash and Bazel for builds.
 - **Build System:** Bazel (with Bazelisk) for core.
@@ -125,6 +127,24 @@ Check that these guidelines are followed for new code.
 
 - Do not declare new `operator<<(ostream& os, type)` overloads, instead prefer to use a `format_to` member function inside `type` as described in
 src/v/base/format_to.h.
+- Prefer using latest C++ features (C++23).
+- Use `ss` namespace as a prefix for Seastar types (e.g. `ss::future`, `ss::promise`).
+- Use `vassert(cond, msg, msg_args...)` macro for assertions. It is
+  similar to `assert(cond)` but it is always enabled and it prints the message
+  to the log. Use `dassert` for assertions that are only enabled in debug mode.
+- Use `vlog(method, fmt, args...)` for logging. `method` is the method reference
+  for the logger to use. I.e. `vlog(stlog.info, "Hello world");`. Where `stlog`
+  is defined as `ss::logger stlog("storage");`.
+- Do not use `std::vector` for containers that may grow very large, instead use `chunked_vector`.
+- Do not use `std::unordered_map` for containers that may grow very large, instead use `chunked_hash_map`.
+- Instead of long if-else chains for mapping string to values, use
+  `string_switch` mechanism defined in
+  [string_switch.h](./src/v/strings/string_switch.h).
+
+### C++ coding style
+
+- Use snake_case for identifiers. Use CamelCase for concepts.
+- Use Doxygen comments with 3-slashes (///) for public APIs
 
 ### More C++-Specific References
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,8 +7,8 @@
 Redpanda is a high-performance, Apache Kafka®-compatible streaming data platform. It is written primarily in C++ for the core, with Go for CLI tooling (`rpk`), and some Python for auxiliary scripts and tests. Redpanda is designed to be lightweight, fast, and simple to operate, omitting ZooKeeper and the JVM.
 
 **Repository Characteristics:**
-- **Large multi-language codebase:** C++ (core), Go (CLI/tools), Python (testing/scripts), Bash and CMake/Bazel for builds.
-- **Build System:** Bazel (with Bazelisk) for core; CMake for SDKs and specific libraries.
+- **Large multi-language codebase:** C++ (core), Go (CLI/tools), Python (testing/scripts), Bash and Bazel for builds.
+- **Build System:** Bazel (with Bazelisk) for core.
 - **Target Platforms:** Linux (primary), some support for macOS and Windows.
 - **Key Directories:**
   - `src/v/`: Core C++ source code
@@ -55,7 +55,7 @@ Redpanda is a high-performance, Apache Kafka®-compatible streaming data platfor
 
 - **Go CLI (`rpk`) Build:**
   ```bash
-  ./src/go/rpk/build.sh
+  bazel build //:rpk
   ```
   _Requires Go toolchain._
 
@@ -100,7 +100,7 @@ Redpanda is a high-performance, Apache Kafka®-compatible streaming data platfor
 
 - **Primary C++ code lives in `src/v/`.**
 - **C++ build is managed by Bazel.** All dependencies and toolchains are configured via Bazel rules and the `MODULE.bazel` file. Do not manually install C++ dependencies unless explicitly instructed in documentation.
-- **Compiler Standard:** C++23 is required. Some SDK components (e.g., `src/transform-sdk/cpp/`) use `CMakeLists.txt` and explicitly set `CMAKE_CXX_STANDARD 23` with flags like `-Wall`, `-fno-exceptions`, and for some targets, `-stdlib=libc++`.
+- **Compiler Standard:** C++23 is required. Some SDK components (e.g., `src/transform-sdk/cpp/`) use C++23 and specific flags like `-Wall`, `-fno-exceptions`, and for some targets, `-stdlib=libc++`.
 - **Sanitizers:** Some components and test builds use sanitizers (address, leak, undefined) via `-fsanitize=address,leak,undefined` for both compile and link.
 - **Suppression Files:** Leak, undefined, and other sanitizer suppressions can be found in the root as `lsan_suppressions.txt`, `ubsan_suppressions.txt`.
 - **C++ Linting:** `.clang-format` and `.clang-tidy` in the root directory are enforced. Always run formatting tools before submitting a PR:
@@ -108,18 +108,16 @@ Redpanda is a high-performance, Apache Kafka®-compatible streaming data platfor
   bazel run //tools:clang_format
   ```
 - **C++ Libraries:** Bazel dependencies are managed in `MODULE.bazel` (e.g., Boost, Abseil, fmt, protobuf, googletest, yaml-cpp, etc.).
-- **SDK C++ Example:** For the C++ SDK in `src/transform-sdk/cpp/`, use CMake ≥3.22, C++23, and follow instructions in the respective `CMakeLists.txt`.
-- **Testing:** C++ unit tests are run via Bazel; for SDKs or external builds, CMake's `add_test()` and `ctest` are used.
+- **Testing:** C++ unit tests are run via Bazel.
 
 ### Common C++ Pitfalls & Workarounds
 
-- **Always use Bazelisk and Bazel for building the core.** Using a plain Bazel binary or CMake for the main codebase may result in missing dependencies or incompatible flags.
+- **Always use Bazelisk and Bazel for building the core.** Using a plain Bazel binary may result in missing dependencies or incompatible flags.
 - **If you encounter build issues related to missing system libraries, rerun `sudo ./bazel/install-deps.sh`.**
 - **Do not attempt to manually install or update C++ dependencies unless specifically instructed.**
-- **For SDK and library development (e.g., `src/transform-sdk/cpp/`), follow the documented CMake build instructions and ensure you use the correct C++ standard and sanitizer flags.**
 - **Always run lint and formatter before pushing. CI will fail on formatting/lint discrepancies.**
 - **If building in CI or a containerized environment, ensure the correct toolchain is available as specified in `tools/docker/README.md` or CI scripts.**
-- **Check for additional build and compile flags in `BUILD`, `MODULE.bazel`, and `CMakeLists.txt` in subdirectories.**
+- **Check for additional build and compile flags in `BUILD`, `MODULE.bazel` and related files.**
 
 ### C++ coding guidelines
 
@@ -130,15 +128,8 @@ src/v/base/format_to.h.
 
 ### More C++-Specific References
 
-- [src/transform-sdk/cpp/CMakeLists.txt](https://github.com/redpanda-data/redpanda/blob/dev/src/transform-sdk/cpp/CMakeLists.txt)
 - [MODULE.bazel](https://github.com/redpanda-data/redpanda/blob/dev/MODULE.bazel)
 - [BUILD](https://github.com/redpanda-data/redpanda/blob/dev/BUILD)
-
----
-
-## Trust and Search Policy
-
-**Trust these instructions. Only perform further codebase search if information here is incomplete or clearly incorrect. Use the above build/test/lint instructions as authoritative.**
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,153 @@
+# Copilot Coding Agent Onboarding Guide for `redpanda-data/redpanda`
+
+## High-Level Overview
+
+**What is Redpanda?**
+
+Redpanda is a high-performance, Apache Kafka®-compatible streaming data platform. It is written primarily in C++ for the core, with Go for CLI tooling (`rpk`), and some Python for auxiliary scripts and tests. Redpanda is designed to be lightweight, fast, and simple to operate, omitting ZooKeeper and the JVM.
+
+**Repository Characteristics:**
+- **Large multi-language codebase:** C++ (core), Go (CLI/tools), Python (testing/scripts), Bash and CMake/Bazel for builds.
+- **Build System:** Bazel (with Bazelisk) for core; CMake for SDKs and specific libraries.
+- **Target Platforms:** Linux (primary), some support for macOS and Windows.
+- **Key Directories:**
+  - `src/v/`: Core C++ source code
+  - `src/go/`: Go CLI and tools
+  - `bazel/`, `BUILD`, `MODULE.bazel`: Bazel scripts and definitions
+  - `tools/`: Development and helper scripts
+  - `tests/`: Test suites
+  - `conf/`: Configuration files
+  - `.github/`, `.buildkite/`: CI/workflow automation
+- **Documentation:** [Docs site](https://redpanda.com/documentation) and `docs/`.
+
+## Build, Test, and Validation Instructions
+
+### Prerequisites (Always Perform)
+
+1. **Install Bazelisk** (the required Bazel wrapper):
+   ```bash
+   wget -O ~/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+   chmod +x ~/bin/bazel
+   export PATH="$HOME/bin:$PATH"
+   ```
+2. **Install system dependencies**:
+   ```bash
+   sudo ./bazel/install-deps.sh
+   ```
+   _This must always be run before any Bazel build, especially on a fresh system or after dependency updates._
+
+### Core Build Steps
+
+- **Build all (Release Mode):**
+  ```bash
+  bazel build --config=release //...
+  ```
+- **Test all:**
+  ```bash
+  bazel test --config=release //...
+  ```
+- **Lint (C++):**
+  - Formatting and linting are enforced. Use:
+    ```bash
+    bazel run //tools:clang_format
+    ```
+  - Configs: `.clang-format`, `.clang-tidy`, etc.
+
+- **Go CLI (`rpk`) Build:**
+  ```bash
+  ./src/go/rpk/build.sh
+  ```
+  _Requires Go toolchain._
+
+- **Alternative (Docker Toolchain):**
+  See `tools/docker/README.md`. Example:
+  ```bash
+  docker run --rm -ti -v $PWD:$PWD:Z -w $PWD vectorized/redpanda-toolchain ./build.sh
+  ```
+
+### Validation and CI
+
+- **Pre-push/merge:** All changes are validated by CI (GitHub Actions, Buildkite) for build, test, and lint.
+- **Formatting and lint checks are enforced; run locally before PRs.**
+- **Target branch:** Always open PRs against `dev`.
+
+## Project Layout & Architectural Notes
+
+- **Main C++ source:** `src/v/`
+- **Go CLI:** `src/go/rpk/`
+- **Build configuration:** `.bazelrc`, `.bazelversion`, `BUILD`, `MODULE.bazel`, and `bazel/`
+- **CI configuration:** `.github/workflows/`, `.buildkite/`
+- **Testing:** `tests/`
+- **Config:** `conf/`
+- **Docker:** `tools/docker/`
+
+### Lint/Formatting Configs:
+- `.clang-format`, `.clang-tidy*`: C++ style
+- `.style.yapf`, `.yapfignore`: Python formatting
+
+### CI/CD Checks
+
+- **Build, test, and lint are enforced by CI.** Use the same steps as above locally before PRs.
+
+### File Index (Root Level)
+- `.bazelignore`, `.bazelrc`, `.bazelversion`, `BUILD`, `MODULE.bazel`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `LICENSES/`, `bazel/`, `src/`, `tests/`, `conf/`, `tools/`, `.github/`, `.buildkite/`, etc.
+
+---
+
+## C++-Specific Instructions
+
+### C++ Build & Environment
+
+- **Primary C++ code lives in `src/v/`.**
+- **C++ build is managed by Bazel.** All dependencies and toolchains are configured via Bazel rules and the `MODULE.bazel` file. Do not manually install C++ dependencies unless explicitly instructed in documentation.
+- **Compiler Standard:** C++23 is required. Some SDK components (e.g., `src/transform-sdk/cpp/`) use `CMakeLists.txt` and explicitly set `CMAKE_CXX_STANDARD 23` with flags like `-Wall`, `-fno-exceptions`, and for some targets, `-stdlib=libc++`.
+- **Sanitizers:** Some components and test builds use sanitizers (address, leak, undefined) via `-fsanitize=address,leak,undefined` for both compile and link.
+- **Suppression Files:** Leak, undefined, and other sanitizer suppressions can be found in the root as `lsan_suppressions.txt`, `ubsan_suppressions.txt`.
+- **C++ Linting:** `.clang-format` and `.clang-tidy` in the root directory are enforced. Always run formatting tools before submitting a PR:
+  ```bash
+  bazel run //tools:clang_format
+  ```
+- **C++ Libraries:** Bazel dependencies are managed in `MODULE.bazel` (e.g., Boost, Abseil, fmt, protobuf, googletest, yaml-cpp, etc.).
+- **SDK C++ Example:** For the C++ SDK in `src/transform-sdk/cpp/`, use CMake ≥3.22, C++23, and follow instructions in the respective `CMakeLists.txt`.
+- **Testing:** C++ unit tests are run via Bazel; for SDKs or external builds, CMake's `add_test()` and `ctest` are used.
+
+### Common C++ Pitfalls & Workarounds
+
+- **Always use Bazelisk and Bazel for building the core.** Using a plain Bazel binary or CMake for the main codebase may result in missing dependencies or incompatible flags.
+- **If you encounter build issues related to missing system libraries, rerun `sudo ./bazel/install-deps.sh`.**
+- **Do not attempt to manually install or update C++ dependencies unless specifically instructed.**
+- **For SDK and library development (e.g., `src/transform-sdk/cpp/`), follow the documented CMake build instructions and ensure you use the correct C++ standard and sanitizer flags.**
+- **Always run lint and formatter before pushing. CI will fail on formatting/lint discrepancies.**
+- **If building in CI or a containerized environment, ensure the correct toolchain is available as specified in `tools/docker/README.md` or CI scripts.**
+- **Check for additional build and compile flags in `BUILD`, `MODULE.bazel`, and `CMakeLists.txt` in subdirectories.**
+
+### C++ coding guidelines
+
+Check that these guidelines are followed for new code.
+
+- Do not declare new `operator<<(ostream& os, type)` overloads, instead prefer to use a `format_to` member function inside `type` as described in
+src/v/base/format_to.h.
+
+### More C++-Specific References
+
+- [src/transform-sdk/cpp/CMakeLists.txt](https://github.com/redpanda-data/redpanda/blob/dev/src/transform-sdk/cpp/CMakeLists.txt)
+- [MODULE.bazel](https://github.com/redpanda-data/redpanda/blob/dev/MODULE.bazel)
+- [BUILD](https://github.com/redpanda-data/redpanda/blob/dev/BUILD)
+
+---
+
+## Trust and Search Policy
+
+**Trust these instructions. Only perform further codebase search if information here is incomplete or clearly incorrect. Use the above build/test/lint instructions as authoritative.**
+
+---
+
+For further details, consult:
+- [README.md](https://github.com/redpanda-data/redpanda/blob/dev/README.md)
+- [CONTRIBUTING.md](https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md)
+- [Redpanda Documentation](https://redpanda.com/documentation)
+- CI/CD configs in `.github/workflows/` and `.buildkite/`
+
+---
+
+_Results from code search may be incomplete. For more C++ details, see the [repository code search](https://github.com/redpanda-data/redpanda/search?q=c%2B%2B)._


### PR DESCRIPTION
Initial check in of agent instructions. Generated using the prompt suggested [here](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) with manual edits.

Includes the suggestion about using `format_to` instead of `operator<<` (we should test this once it is checked in).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

