### PR TITLE
CORE-13040 schema_registry: return max id on post schema endpoints

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -533,9 +533,10 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
       sub,
       norm);
 
+    auto& wr = rq.service().writer();
     auto& st = rq.service().schema_store();
 
-    co_await rq.service().writer().read_sync();
+    co_await wr.read_sync();
 
     auto unparsed = co_await rjson_parse(
       *rq.req, post_subject_versions_request_handler<>{sub});
@@ -563,19 +564,8 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     // Determine if the definition already exists
     auto s_id = co_await st.get_schema_id(schema.schema.def().share());
 
-    // Determine if a provided schema id is appropriate
-    const auto mode = co_await st.get_mode(sub, default_to_global::yes);
-    if (mode == mode::import) {
-        if (
-          schema.id != invalid_schema_id && s_id != schema.id
-          && co_await st.has_schema(schema.id)) {
-            // The supplied id already exists, but the schema is different
-            co_return ss::coroutine::return_exception(
-              as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
-        }
-    }
-
-    vlog(srlog.debug, "get_schema_version: ID for schema definition: {}", s_id);
+    vlog(
+      srlog.debug, "post_subject_versions: ID for schema definition: {}", s_id);
 
     // Determine if the subject already has a version that references this
     // schema, deleted versions are seen.
@@ -584,26 +574,10 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 
     std::optional<schema_version> v_id;
     if (s_id.has_value()) {
-        auto v_it = absl::c_find_if(versions, [id = *s_id](const auto& s_id_v) {
-            return s_id_v.id == id;
-        });
+        auto v_it = std::ranges::find(
+          versions, *s_id, &subject_version_entry::id);
         if (v_it != versions.end()) {
             v_id.emplace(v_it->version);
-        }
-    }
-
-    // Check compatibility of the schema
-    if (!v_id.has_value() && !versions.empty() && mode != mode::import) {
-        auto compat = co_await st.is_compatible(
-          versions.back().version, schema.schema.share(), verbose::yes);
-        if (!compat.is_compat) {
-            throw exception(
-              error_code::schema_incompatible,
-              fmt::format(
-                "Schema being registered is incompatible with an earlier "
-                "schema for subject \"{}\", details: [{}]",
-                sub,
-                fmt::join(compat.messages, ", ")));
         }
     }
 
@@ -621,16 +595,47 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
 
     schema_id schema_id{s_id.value_or(invalid_schema_id)};
     if (!matched) {
+        // Check if the request is appropriate for the mode
+        const auto mode = co_await st.get_mode(sub, default_to_global::yes);
+        if (mode == mode::read_only) {
+            throw as_exception(mode_is_readonly(sub));
+        }
         if (schema.id >= 0 && mode != mode::import) {
             throw as_exception(mode_not_import(schema.schema.sub()));
+        }
+        if (schema.id < 0 && mode != mode::read_write) {
+            throw as_exception(mode_not_readwrite(sub));
+        }
+
+        // Determine if a provided schema id is appropriate
+        if (
+          schema.id != invalid_schema_id && s_id != schema.id
+          && co_await st.has_schema(schema.id)) {
+            // The supplied id already exists, but the schema is different
+            co_return ss::coroutine::return_exception(
+              as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
+        }
+
+        // Check compatibility of the schema
+        if (!versions.empty() && mode != mode::import) {
+            auto compat = co_await st.is_compatible(
+              versions.back().version, schema.schema.share(), verbose::yes);
+            if (!compat.is_compat) {
+                throw exception(
+                  error_code::schema_incompatible,
+                  fmt::format(
+                    "Schema being registered is incompatible with an earlier "
+                    "schema for subject \"{}\", details: [{}]",
+                    sub,
+                    fmt::join(compat.messages, ", ")));
+            }
         }
 
         schema.id = (schema.id == invalid_schema_id)
                       ? s_id.value_or(invalid_schema_id)
                       : schema.id;
 
-        schema_id = co_await rq.service().writer().write_subject_version(
-          std::move(schema));
+        schema_id = co_await wr.write_subject_version(std::move(schema));
     }
 
     auto resp = ppj::rjson_serialize_iobuf(

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -568,15 +568,15 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
       srlog.debug, "post_subject_versions: ID for schema definition: {}", s_id);
 
     // Determine if the subject already has a version that references this
-    // schema, deleted versions are seen.
-    const auto versions = co_await st.get_subject_versions(
+    // schema, deleted versions are not seen.
+    const auto undeleted_versions = co_await st.get_subject_versions(
       sub, include_deleted::no);
 
     std::optional<schema_version> v_id;
     if (s_id.has_value()) {
         auto v_it = std::ranges::find(
-          versions, *s_id, &subject_version_entry::id);
-        if (v_it != versions.end()) {
+          undeleted_versions, *s_id, &subject_version_entry::id);
+        if (v_it != undeleted_versions.end()) {
             v_id.emplace(v_it->version);
         }
     }
@@ -617,9 +617,11 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
         }
 
         // Check compatibility of the schema
-        if (!versions.empty() && mode != mode::import) {
+        if (!undeleted_versions.empty() && mode != mode::import) {
             auto compat = co_await st.is_compatible(
-              versions.back().version, schema.schema.share(), verbose::yes);
+              undeleted_versions.back().version,
+              schema.schema.share(),
+              verbose::yes);
             if (!compat.is_compat) {
                 throw exception(
                   error_code::schema_incompatible,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -523,14 +523,17 @@ ss::future<server::reply_t>
 post_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_content_type_header(rq);
     parse_accept_header(rq, rp);
-    auto sub = parse::request_param<subject>(*rq.req, "subject");
-    auto norm{parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
-                .value_or(normalize::no)};
+    const auto sub = parse::request_param<subject>(*rq.req, "subject");
+    const auto norm{
+      parse::query_param<std::optional<normalize>>(*rq.req, "normalize")
+        .value_or(normalize::no)};
     vlog(
       srlog.debug,
       "post_subject_versions subject='{}', normalize='{}'",
       sub,
       norm);
+
+    auto& st = rq.service().schema_store();
 
     co_await rq.service().writer().read_sync();
 
@@ -549,38 +552,81 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     }
 
     stored_schema schema{
-      co_await rq.service().schema_store().make_canonical_schema(
-        std::move(unparsed.def), norm),
+      co_await st.make_canonical_schema(std::move(unparsed.def), norm),
       unparsed.version.value_or(invalid_schema_version),
       unparsed.id.value_or(invalid_schema_id),
       is_deleted::no};
 
-    auto ids = co_await rq.service().schema_store().get_schema_version(
-      schema.share());
+    // Validate the schema (may throw)
+    co_await st.validate_schema(schema.schema.share());
+
+    // Determine if the definition already exists
+    auto s_id = co_await st.get_schema_id(schema.schema.def().share());
+
+    // Determine if a provided schema id is appropriate
+    const auto mode = co_await st.get_mode(sub, default_to_global::yes);
+    if (mode == mode::import) {
+        if (
+          schema.id != invalid_schema_id && s_id != schema.id
+          && co_await st.has_schema(schema.id)) {
+            // The supplied id already exists, but the schema is different
+            co_return ss::coroutine::return_exception(
+              as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
+        }
+    }
+
+    vlog(srlog.debug, "get_schema_version: ID for schema definition: {}", s_id);
+
+    // Determine if the subject already has a version that references this
+    // schema, deleted versions are seen.
+    const auto versions = co_await st.get_subject_versions(
+      sub, include_deleted::no);
+
+    std::optional<schema_version> v_id;
+    if (s_id.has_value()) {
+        auto v_it = absl::c_find_if(versions, [id = *s_id](const auto& s_id_v) {
+            return s_id_v.id == id;
+        });
+        if (v_it != versions.end()) {
+            v_id.emplace(v_it->version);
+        }
+    }
+
+    // Check compatibility of the schema
+    if (!v_id.has_value() && !versions.empty() && mode != mode::import) {
+        auto compat = co_await st.is_compatible(
+          versions.back().version, schema.schema.share(), verbose::yes);
+        if (!compat.is_compat) {
+            throw exception(
+              error_code::schema_incompatible,
+              fmt::format(
+                "Schema being registered is incompatible with an earlier "
+                "schema for subject \"{}\", details: [{}]",
+                sub,
+                fmt::join(compat.messages, ", ")));
+        }
+    }
 
     // Check if a match was found for the given request
     // Return the id if a match was found, register the schema if not
     const auto any_id_allowed = schema.id == invalid_schema_id;
-    const auto id_matches = (any_id_allowed && ids.id.has_value())
-                            || schema.id == ids.id;
+    const auto id_matches = (any_id_allowed && s_id.has_value())
+                            || schema.id == s_id;
 
     const auto any_version_allowed = schema.version == invalid_schema_version;
-    const auto version_matches = (any_version_allowed
-                                  && ids.version.has_value())
-                                 || schema.version == ids.version;
+    const auto version_matches = (any_version_allowed && v_id.has_value())
+                                 || schema.version == v_id;
 
     const auto matched = id_matches && version_matches;
 
-    schema_id schema_id{ids.id.value_or(invalid_schema_id)};
+    schema_id schema_id{s_id.value_or(invalid_schema_id)};
     if (!matched) {
-        const auto mode = co_await rq.service().schema_store().get_mode(
-          schema.schema.sub(), default_to_global::yes);
         if (schema.id >= 0 && mode != mode::import) {
             throw as_exception(mode_not_import(schema.schema.sub()));
         }
 
         schema.id = (schema.id == invalid_schema_id)
-                      ? ids.id.value_or(invalid_schema_id)
+                      ? s_id.value_or(invalid_schema_id)
                       : schema.id;
 
         schema_id = co_await rq.service().writer().write_subject_version(

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -227,11 +227,6 @@ ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
     const auto& sub = schema.schema.sub();
     co_await check_mutable(sub);
 
-    const auto mode = co_await _store.get_mode(sub, default_to_global::yes);
-    if (schema.id < 0 && mode != mode::read_write) {
-        throw as_exception(mode_not_readwrite(sub));
-    }
-
     // Check if store already contains this data: if
     // so, we do no I/O and return the schema ID.
     auto projected

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -159,14 +159,7 @@ sharded_store::get_schema_version(stored_schema schema) {
     co_await validate_schema(schema.schema.share());
 
     // Determine if the definition already exists
-    auto map = [&schema](store& s) {
-        return s.get_schema_id(schema.schema.def());
-    };
-    auto reduce = [](
-                    std::optional<schema_id> acc,
-                    std::optional<schema_id> s_id) { return acc ? acc : s_id; };
-    auto s_id = co_await _store.map_reduce0(
-      map, std::optional<schema_id>{}, reduce);
+    auto s_id = co_await get_schema_id(schema.schema.def().share());
 
     // Determine if a provided schema id is appropriate
     const auto& sub = schema.schema.sub();
@@ -185,18 +178,8 @@ sharded_store::get_schema_version(stored_schema schema) {
 
     // Determine if the subject already has a version that references this
     // schema, deleted versions are seen.
-    const auto versions = co_await _store.invoke_on(
-      shard_for(sub),
-      _smp_opts,
-      [sub](auto& s) -> std::vector<subject_version_entry> {
-          auto res = s.get_version_ids(sub, include_deleted::no);
-          if (
-            res.has_error()
-            && res.assume_error().code() == error_code::subject_not_found) {
-              return {};
-          }
-          return res.value();
-      });
+    const auto versions = co_await get_subject_versions(
+      sub, include_deleted::no);
 
     std::optional<schema_version> v_id;
     if (s_id.has_value()) {
@@ -404,6 +387,22 @@ sharded_store::get_schema_subject_versions(schema_id id) {
         return acc;
     };
     co_return co_await _store.map_reduce0(map, subject_versions{}, reduce);
+}
+
+ss::future<std::vector<subject_version_entry>>
+sharded_store::get_subject_versions(subject sub, include_deleted inc_del) {
+    co_return co_await _store.invoke_on(
+      shard_for(sub),
+      _smp_opts,
+      [sub, inc_del](store& s) -> std::vector<subject_version_entry> {
+          auto res = s.get_version_ids(sub, inc_del);
+          if (
+            res.has_error()
+            && res.assume_error().code() == error_code::subject_not_found) {
+              return {};
+          }
+          return res.value();
+      });
 }
 
 ss::future<chunked_vector<subject>>
@@ -938,6 +937,16 @@ ss::future<bool> sharded_store::has_version(
           return s.has_version(sub, id, i);
       });
     co_return has_id.has_value() && has_id.assume_value();
+}
+
+ss::future<std::optional<schema_id>>
+sharded_store::get_schema_id(schema_definition def) const {
+    auto map = [&def](const store& s) { return s.get_schema_id(def); };
+    auto reduce = [](
+                    std::optional<schema_id> acc,
+                    std::optional<schema_id> s_id) { return acc ? acc : s_id; };
+    co_return co_await _store.map_reduce0(
+      map, std::optional<schema_id>{}, reduce);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -153,61 +153,6 @@ sharded_store::make_valid_schema(subject_schema schema) {
     throw as_exception(invalid_schema_type(schema.type()));
 }
 
-ss::future<sharded_store::has_schema_result>
-sharded_store::get_schema_version(stored_schema schema) {
-    // Validate the schema (may throw)
-    co_await validate_schema(schema.schema.share());
-
-    // Determine if the definition already exists
-    auto s_id = co_await get_schema_id(schema.schema.def().share());
-
-    // Determine if a provided schema id is appropriate
-    const auto& sub = schema.schema.sub();
-    const auto mode = co_await get_mode(sub, default_to_global::yes);
-    if (mode == mode::import) {
-        if (
-          schema.id != invalid_schema_id && s_id != schema.id
-          && co_await has_schema(schema.id)) {
-            // The supplied id already exists, but the schema is different
-            co_return ss::coroutine::return_exception(
-              as_exception(overwrite_schema_with_id_not_permitted(schema.id)));
-        }
-    }
-
-    vlog(srlog.debug, "get_schema_version: ID for schema definition: {}", s_id);
-
-    // Determine if the subject already has a version that references this
-    // schema, deleted versions are seen.
-    const auto versions = co_await get_subject_versions(
-      sub, include_deleted::no);
-
-    std::optional<schema_version> v_id;
-    if (s_id.has_value()) {
-        auto v_it = absl::c_find_if(versions, [id = *s_id](const auto& s_id_v) {
-            return s_id_v.id == id;
-        });
-        if (v_it != versions.end()) {
-            v_id.emplace(v_it->version);
-        }
-    }
-
-    // Check compatibility of the schema
-    if (!v_id.has_value() && !versions.empty() && mode != mode::import) {
-        auto compat = co_await is_compatible(
-          versions.back().version, schema.schema.share(), verbose::yes);
-        if (!compat.is_compat) {
-            throw exception(
-              error_code::schema_incompatible,
-              fmt::format(
-                "Schema being registered is incompatible with an earlier "
-                "schema for subject \"{}\", details: [{}]",
-                sub,
-                fmt::join(compat.messages, ", ")));
-        }
-    }
-    co_return has_schema_result{s_id, v_id};
-}
-
 ss::future<sharded_store::insert_result>
 sharded_store::project_ids(stored_schema schema) {
     const auto& sub = schema.schema.sub();

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -260,13 +260,20 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
         throw as_exception(invalid_subject_schema(schema.sub()));
     }
 
-    std::optional<stored_schema> sub_schema;
-    for (auto ver : versions) {
+    // Find the maximal id schema with the given definition
+    struct match {
+        stored_schema sub_schema;
+        schema_id id;
+    };
+    std::optional<match> found;
+    for (auto ver : std::views::reverse(versions)) {
         try {
             auto res = co_await get_subject_schema(schema.sub(), ver, inc_del);
-            if (schema.def() == res.schema.def()) {
-                sub_schema.emplace(std::move(res));
-                break;
+            if (
+              (!found || res.id > found->id)
+              && schema.def() == res.schema.def()) {
+                auto id = res.id;
+                found.emplace(match{.sub_schema = std::move(res), .id = id});
             }
         } catch (const exception& e) {
             if (failed_subject_schema_lookup(e.code())) {
@@ -284,11 +291,11 @@ sharded_store::has_schema(subject_schema schema, include_deleted inc_del) {
                 throw;
             }
         }
-    };
-    if (!sub_schema.has_value()) {
+    }
+    if (!found.has_value()) {
         throw as_exception(schema_not_found());
     }
-    co_return std::move(sub_schema).value();
+    co_return std::move(found->sub_schema);
 }
 
 ss::future<std::optional<schema_definition>>

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -887,9 +887,7 @@ ss::future<bool> sharded_store::has_version(
 ss::future<std::optional<schema_id>>
 sharded_store::get_schema_id(schema_definition def) const {
     auto map = [&def](const store& s) { return s.get_schema_id(def); };
-    auto reduce = [](
-                    std::optional<schema_id> acc,
-                    std::optional<schema_id> s_id) { return acc ? acc : s_id; };
+    auto reduce = [](auto acc, auto s_id) { return std::max(acc, s_id); };
     co_return co_await _store.map_reduce0(
       map, std::optional<schema_id>{}, reduce);
 }

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -89,6 +89,11 @@ public:
     ss::future<chunked_vector<subject_version>>
     get_schema_subject_versions(schema_id id);
 
+    ///\brief Return a list of subject-versions for the subject. Returns an
+    /// empty vector if the subject does not exist.
+    ss::future<std::vector<subject_version_entry>>
+    get_subject_versions(subject sub, include_deleted inc_del);
+
     ///\brief Return a list of subjects for the schema id.
     ss::future<chunked_vector<subject>>
     get_schema_subjects(schema_id id, include_deleted inc_del);
@@ -209,6 +214,10 @@ public:
 
     //// \brief Throw if the store is not mutable
     void check_mode_mutability(force f) const;
+
+    ///\brief Look up the id of a schema by definition
+    ss::future<std::optional<schema_id>>
+    get_schema_id(schema_definition def) const;
 
 private:
     ss::future<compatibility_result> do_is_compatible(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -46,12 +46,6 @@ public:
     ///\brief Construct a schema in the native format
     ss::future<valid_schema> make_valid_schema(subject_schema schema);
 
-    struct has_schema_result {
-        std::optional<schema_id> id;
-        std::optional<schema_version> version;
-    };
-    ss::future<has_schema_result> get_schema_version(stored_schema schema);
-
     struct insert_result {
         schema_version version;
         schema_id id;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -31,21 +31,6 @@
 
 namespace pandaproxy::schema_registry {
 
-///\brief A mapping of version and schema id for a subject.
-struct subject_version_entry {
-    subject_version_entry(
-      schema_version version, schema_id id, is_deleted deleted)
-      : version{version}
-      , id{id}
-      , deleted(deleted) {}
-
-    schema_version version;
-    schema_id id;
-    is_deleted deleted{is_deleted::no};
-
-    std::vector<seq_marker> written_at;
-};
-
 namespace detail {
 
 template<typename T>

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -90,13 +90,11 @@ public:
 
     ///\brief Return the id of the schema, if it already exists.
     std::optional<schema_id> get_schema_id(const schema_definition& def) const {
-        const auto s_it = std::find_if(
-          _schemas.begin(), _schemas.end(), [&](const auto& s) {
-              const auto& entry = s.second;
-              return def == entry.definition;
-          });
-        return s_it == _schemas.end() ? std::optional<schema_id>{}
-                                      : s_it->first;
+        // Iterate in decreasing order to return the maximal matching id
+        auto rev = std::views::reverse(_schemas);
+        const auto s_it = std::ranges::find_if(
+          rev, [&](const auto& s) { return def == s.second.definition; });
+        return s_it == rev.end() ? std::optional<schema_id>{} : s_it->first;
     }
 
     ///\brief Return a list of subject-versions for the shema id.

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -480,6 +480,21 @@ struct stored_schema {
     }
 };
 
+///\brief A mapping of version and schema id for a subject.
+struct subject_version_entry {
+    subject_version_entry(
+      schema_version version, schema_id id, is_deleted deleted)
+      : version{version}
+      , id{id}
+      , deleted(deleted) {}
+
+    schema_version version;
+    schema_id id;
+    is_deleted deleted{is_deleted::no};
+
+    std::vector<seq_marker> written_at;
+};
+
 enum class compatibility_level {
     none = 0,
     backward,

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4654,9 +4654,20 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         self.assert_equal(result_raw.status_code, 200)
         self.assert_equal(result_raw.json()["mode"], "READWRITE")
 
+        # POST /subjects/{subject}/versions/{version}
         self.logger.debug(
-            "Post the schema definition again - should return id 2")
+            "Post the schema definition again to post_subjects_subject_versions - should return id 2"
+        )
         result_raw = self.sr_client.post_subjects_subject_versions(
+            sub, data=json.dumps({"schema": schema1_def}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 2)
+
+        # POST /subjects/{subject}
+        self.logger.debug(
+            "Post the schema definition again to post_subjects_subject - should return id 2"
+        )
+        result_raw = self.sr_client.post_subjects_subject(
             sub, data=json.dumps({"schema": schema1_def}))
         self.assert_equal(result_raw.status_code, 200)
         self.assert_equal(result_raw.json()["id"], 2)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -4615,6 +4615,52 @@ class SchemaRegistryModeMutableTest(SchemaRegistryEndpoints):
         got_ver_to_id = {int(elem["version"]): elem["id"] for elem in resp}
         self.assert_equal(expected_ver_to_id, got_ver_to_id)
 
+    @cluster(num_nodes=3)
+    def test_id_lookup_multiple_matches(self):
+        """
+        Test the behaviour of the schema lookup/registration endpoint when
+        there are multiple existing schemas with different ids but identical
+        schema definition.
+        """
+        sub = "test-subject-1"
+
+        self.logger.debug("Enable IMPORT mode to allow posting specific ids")
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "IMPORT"}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["mode"], "IMPORT")
+
+        self.logger.debug("Post the schema first with id 1")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            sub, data=json.dumps({
+                "id": 1,
+                "schema": schema1_def
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 1)
+
+        self.logger.debug("Post the same schema again now with id 2")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            sub, data=json.dumps({
+                "id": 2,
+                "schema": schema1_def
+            }))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 2)
+
+        self.logger.debug("Enable READWRITE mode to post without id")
+        result_raw = self.sr_client.set_mode(
+            data=json.dumps({"mode": "READWRITE"}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["mode"], "READWRITE")
+
+        self.logger.debug(
+            "Post the schema definition again - should return id 2")
+        result_raw = self.sr_client.post_subjects_subject_versions(
+            sub, data=json.dumps({"schema": schema1_def}))
+        self.assert_equal(result_raw.status_code, 200)
+        self.assert_equal(result_raw.json()["id"], 2)
+
 
 class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
     """


### PR DESCRIPTION
This PR:
1. Includes a refactoring of the schema registration logic, which is a follow up from https://github.com/redpanda-data/redpanda/pull/27079#discussion_r2259529075
2. Implements [CORE-13040](https://redpandadata.atlassian.net/browse/CORE-13040), which is to deterministically return the schema with the maximal schema id when looking up a schema by schema definition where there are multiple matches. This is necessary now that in import mode we allow posting schemas with identical definition at multiple schema ids. This is done for the two endpoints that perform lookups by schema definition: `POST /subjects/{subject}/versions/{version}` and `POST /subjects/{subject}`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13040]: https://redpandadata.atlassian.net/browse/CORE-13040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ