### PR TITLE
dt: increase timeout in license check

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -234,7 +234,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
             return (self.admin.is_sample_license(lic), lic)
 
         resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=5,
+                                 timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
@@ -268,7 +268,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
             return (lic['license']['format_version'] == 1, lic)
 
         resp = wait_until_result(obtain_configured_license_v1,
-                                 timeout_sec=5,
+                                 timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents_v1 == resp['license'], resp['license']
@@ -276,12 +276,8 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         # Set back to v0 for sanity check
         assert self.admin.put_license(license).status_code == 200
 
-        def obtain_configured_license():
-            lic = self.admin.get_license()
-            return (self.admin.is_sample_license(lic), lic)
-
         resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=5,
+                                 timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']


### PR DESCRIPTION
Increase timeout cause nightly tests seems to be hitting the timeout limit.
Also remove unnecessary re-definition of the wait-logic.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
