### PR TITLE
archival: Make 'get_stream' reentrant

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1685,13 +1685,14 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
     std::optional<ss::input_stream<char>> stream_state = std::move(
       upload_stream);
 
-    auto get_stream = [&stream_state] {
-        // On first attempt to upload, the stream-ref passed in is used.
+    auto get_stream = [&stream_state, &strm] {
         using provider_t = std::unique_ptr<stream_provider>;
-        // Note that stream_state is known to be non-nullopt here.
+        if (!stream_state.has_value()) {
+            stream_state = strm.create_input_stream();
+        }
         auto prov = std::make_unique<one_time_stream_wrapper>(
-          std::move(stream_state.value()));
-        stream_state = std::nullopt;
+          std::move(stream_state).value());
+        stream_state.reset();
         return ss::make_ready_future<provider_t>(std::move(prov));
     };
 

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -1091,7 +1091,7 @@ segment_collector::make_upload_candidate_stream(
        final_file_offset
        = cand.final_file_offset]() mutable -> ss::input_stream<char> {
         storage::concat_segment_reader_view crv(
-          std::move(segments), file_offset, final_file_offset);
+          segments, file_offset, final_file_offset);
         return crv.take_stream();
     };
     co_return stream;


### PR DESCRIPTION
The get_stream lambda function is passed to the remote::upload_segment method. The method invokes the lambda on every retry to get a new stream (because input_stream in seastar is not seekable).

The problem is that the 'get_stream' lambda can only be called once. It consumes the generated stream and sets the variable to nullopt. Next call triggers exception. This commit returns the old behavior.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none