### PR TITLE
ct/l1: introduce an io abstraction for L1

### DIFF
--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -23,6 +23,13 @@
 
 namespace cloud_storage_clients {
 
+// Corresponds to the Range HTTP header in the form <range-start>-<range-end>
+//
+// range-start: An integer in the given unit indicating the start position of
+// the request range.
+//
+// range-end: An integer in the given unit indicating the end position
+// of the requested range.
 using http_byte_range = std::pair<uint64_t, uint64_t>;
 
 class client {

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -74,3 +74,22 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "file_io",
+    srcs = ["file_io.cc"],
+    hdrs = ["file_io.h"],
+    include_prefix = "cloud_topics/level_one/common",
+    deps = [
+        ":abstract_io",
+        ":object_id",
+        ":object_utils",
+        "//src/v/cloud_io:io_result",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_storage:cache",
+        "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics:logger",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -61,3 +61,16 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "abstract_io",
+    srcs = ["abstract_io.cc"],
+    hdrs = ["abstract_io.h"],
+    include_prefix = "cloud_topics/level_one/common",
+    deps = [
+        ":object_id",
+        "//src/v/container:chunked_vector",
+        "//src/v/utils:named_type",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_library(
     ],
     include_prefix = "cloud_topics/level_one/common",
     deps = [
+        "//src/v/base",
         "//src/v/utils:named_type",
         "//src/v/utils:uuid",
     ],

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -93,3 +93,19 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "fake_io",
+    srcs = ["fake_io.cc"],
+    hdrs = ["fake_io.h"],
+    include_prefix = "cloud_topics/level_one/common",
+    deps = [
+        ":abstract_io",
+        ":object_id",
+        ":object_utils",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "@abseil-cpp//absl/container:btree",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/common/abstract_io.cc
+++ b/src/v/cloud_topics/level_one/common/abstract_io.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+
+namespace experimental::cloud_topics::l1 {
+
+ss::future<ss::input_stream<char>> io::read_file(staging_file* file) {
+    return file->input_stream();
+}
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/abstract_io.h
+++ b/src/v/cloud_topics/level_one/common/abstract_io.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/common/object_id.h"
+#include "container/chunked_vector.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
+
+#include <expected>
+#include <limits>
+
+namespace experimental::cloud_topics::l1 {
+
+// An abstraction for a local file that is used for staging uploads to object
+// storage.
+class staging_file {
+public:
+    staging_file() = default;
+    staging_file(const staging_file&) = delete;
+    staging_file(staging_file&&) = delete;
+    staging_file& operator=(const staging_file&) = delete;
+    staging_file& operator=(staging_file&&) = delete;
+    virtual ~staging_file() = default;
+
+    // Return the size of this file in bytes on disk.
+    virtual ss::future<size_t> size() = 0;
+    // Return an output stream for appending to this file.
+    virtual ss::future<ss::output_stream<char>> output_stream() = 0;
+    // Remove the file from the local filesystem.
+    //
+    // This should always be called (outside of unclean shutdown).
+    virtual ss::future<> remove() = 0;
+
+private:
+    friend class io;
+    // Return an input stream for reading from this file.
+    virtual ss::future<ss::input_stream<char>> input_stream() = 0;
+};
+
+// An abstraction for IO in level one.
+class io {
+public:
+    enum class errc : uint8_t {
+        file_io_error,
+        cloud_missing_object, // when reading something does not exist
+        cloud_op_error,
+        cloud_op_timeout,
+    };
+    io() = default;
+    io(const io&) = delete;
+    io(io&&) = delete;
+    io& operator=(const io&) = delete;
+    io& operator=(io&&) = delete;
+    virtual ~io() = default;
+
+    // Create a temporary file for staging uploads into object storage.
+    //
+    // If the operation writing to the file succeeds, then the local file should
+    // be uploaded using `io::upload_file`, then deleted using
+    // `local_file::remove()`. If there is an error than `local_file::remove()`
+    // should still be called to clean up the temporary file.
+    virtual ss::future<std::expected<std::unique_ptr<staging_file>, errc>>
+    create_tmp_file() = 0;
+
+    // Upload a local file to object storage, returning the object ID that was
+    // used to identify the object in the bucket.
+    virtual ss::future<std::expected<void, errc>>
+    put_object(object_id, staging_file*, ss::abort_source*) = 0;
+
+    // Read part of an object from object storage, returning an input stream
+    // representing the object data.
+    //
+    // Behind the scenes, there may or may not be caching going on.
+    virtual ss::future<std::expected<ss::input_stream<char>, errc>>
+    read_object(object_extent, ss::abort_source*) = 0;
+
+    // Delete the specified objects from object storage.
+    virtual ss::future<std::expected<void, errc>>
+    delete_objects(chunked_vector<object_id>, ss::abort_source*) = 0;
+
+protected:
+    // A helper to read a staging file.
+    ss::future<ss::input_stream<char>> read_file(staging_file*);
+};
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/fake_io.cc
+++ b/src/v/cloud_topics/level_one/common/fake_io.cc
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/fake_io.h"
+
+#include "bytes/iostream.h"
+#include "cloud_topics/level_one/common/object_id.h"
+
+namespace experimental::cloud_topics::l1 {
+
+class fake_file : public staging_file {
+public:
+    fake_file() = default;
+    fake_file(const fake_file&) = delete;
+    fake_file(fake_file&&) = delete;
+    fake_file& operator=(const fake_file&) = delete;
+    fake_file& operator=(fake_file&&) = delete;
+    ~fake_file() override {
+        vassert(_removed, "staging_file must be removed before destruction");
+    }
+
+    ss::future<size_t> size() override {
+        vassert(!_removed, "cannot get size of a removed file");
+        co_return _data.size_bytes();
+    }
+    ss::future<ss::output_stream<char>> output_stream() override {
+        vassert(!_removed, "cannot get output stream of a removed file");
+        co_return make_iobuf_ref_output_stream(_data);
+    }
+
+    ss::future<> remove() override {
+        _removed = true;
+        co_return;
+    }
+
+    ss::future<ss::input_stream<char>> input_stream() override {
+        vassert(!_removed, "cannot get input stream of a removed file");
+        co_return make_iobuf_input_stream(_data.share(0, _data.size_bytes()));
+    }
+
+private:
+    bool _removed = false;
+    iobuf _data;
+};
+
+ss::future<std::expected<std::unique_ptr<staging_file>, io::errc>>
+fake_io::create_tmp_file() {
+    std::unique_ptr<staging_file> file = std::make_unique<fake_file>();
+    co_return file;
+}
+
+ss::future<std::expected<void, io::errc>>
+fake_io::put_object(object_id oid, staging_file* file, ss::abort_source*) {
+    auto stream = co_await io::read_file(file);
+    auto size = co_await file->size();
+    auto data = co_await read_iobuf_exactly(stream, size);
+    put_object(oid, std::move(data));
+    co_return std::expected<void, io::errc>();
+}
+
+ss::future<std::expected<ss::input_stream<char>, io::errc>>
+fake_io::read_object(object_extent extent, ss::abort_source*) {
+    co_return get_object(extent.id)
+      .transform(
+        [&extent](
+          iobuf data) -> std::expected<ss::input_stream<char>, io::errc> {
+            return make_iobuf_input_stream(
+              data.share(extent.position, extent.size));
+        })
+      .value_or(std::unexpected(io::errc::cloud_missing_object));
+}
+
+ss::future<std::expected<void, io::errc>>
+fake_io::delete_objects(chunked_vector<object_id> oids, ss::abort_source*) {
+    for (const auto& oid : oids) {
+        remove_object(oid);
+    }
+    co_return std::expected<void, io::errc>{};
+}
+
+std::optional<iobuf> fake_io::get_object(object_id id) {
+    auto it = _storage.find(id);
+    if (it == _storage.end()) {
+        return std::nullopt;
+    }
+    return it->second.share(0, it->second.size_bytes());
+}
+
+void fake_io::put_object(object_id id, iobuf data) {
+    _storage.insert_or_assign(id, std::move(data));
+}
+
+void fake_io::remove_object(object_id id) { _storage.erase(id); }
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/fake_io.h
+++ b/src/v/cloud_topics/level_one/common/fake_io.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "absl/container/btree_map.h"
+#include "bytes/iobuf.h"
+#include "cloud_topics/level_one/common/abstract_io.h"
+
+namespace experimental::cloud_topics::l1 {
+
+// The IO implementation that is entirely in-memory, used for testing.
+class fake_io : public io {
+public:
+    fake_io();
+    ss::future<std::expected<std::unique_ptr<staging_file>, errc>>
+    create_tmp_file() override;
+
+    ss::future<std::expected<void, errc>>
+    put_object(object_id, staging_file*, ss::abort_source*) override;
+
+    ss::future<std::expected<ss::input_stream<char>, errc>>
+    read_object(object_extent, ss::abort_source*) override;
+
+    ss::future<std::expected<void, errc>>
+    delete_objects(chunked_vector<object_id>, ss::abort_source*) override;
+
+    // Get a full object that has been put directly from storage
+    std::optional<iobuf> get_object(object_id id);
+
+    // Put an object directly into storage, bypassing staging
+    void put_object(object_id id, iobuf data);
+
+    // Directly remove an object from storage
+    void remove_object(object_id id);
+
+private:
+    absl::btree_map<object_id, iobuf> _storage;
+};
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io.cc
+++ b/src/v/cloud_topics/level_one/common/file_io.cc
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/file_io.h"
+
+#include "cloud_io/io_result.h"
+#include "cloud_io/remote.h"
+#include "cloud_storage_clients/client.h"
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/common/object_utils.h"
+#include "cloud_topics/logger.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+
+#include <memory>
+
+using namespace std::chrono_literals;
+
+namespace experimental::cloud_topics::l1 {
+
+namespace {
+
+class staging_file_impl : public staging_file {
+public:
+    explicit staging_file_impl(std::filesystem::path path)
+      : _path(std::move(path)) {}
+
+    ss::future<size_t> size() override { return ss::file_size(_path.native()); }
+    ss::future<ss::output_stream<char>> output_stream() override {
+        auto file = co_await ss::open_file_dma(
+          _path.native(),
+          ss::open_flags::rw | ss::open_flags::truncate
+            | ss::open_flags::create);
+        co_return co_await ss::make_file_output_stream(std::move(file));
+    }
+    ss::future<> remove() override { return ss::remove_file(_path.native()); }
+    ss::future<ss::input_stream<char>> input_stream() override {
+        auto file = co_await ss::open_file_dma(
+          _path.native(), ss::open_flags::ro);
+        co_return ss::make_file_input_stream(std::move(file));
+    }
+
+private:
+    std::filesystem::path _path;
+};
+
+// TODO: deduplicate, expose from cloud storage
+struct one_time_stream_provider : public stream_provider {
+    explicit one_time_stream_provider(ss::input_stream<char> s)
+      : _st(std::move(s)) {}
+
+    ss::input_stream<char> take_stream() override {
+        auto tmp = std::exchange(_st, std::nullopt);
+        return std::move(tmp.value());
+    }
+    ss::future<> close() override {
+        if (_st.has_value()) {
+            return _st->close().then([this] { _st = std::nullopt; });
+        }
+        return ss::now();
+    }
+    std::optional<ss::input_stream<char>> _st;
+};
+
+} // namespace
+
+file_io::file_io(
+  std::filesystem::path staging_dir,
+  cloud_io::remote* remote,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage::cache* cache)
+  : _remote(remote)
+  , _bucket(std::move(bucket))
+  , _staging_dir(std::move(staging_dir))
+  , _cache(cache) {}
+
+ss::future<std::expected<std::unique_ptr<staging_file>, io::errc>>
+file_io::create_tmp_file() {
+    co_return std::make_unique<staging_file_impl>(
+      _staging_dir / fmt::format("{}.tmp", uuid_t::create()));
+}
+
+ss::future<std::expected<void, io::errc>>
+file_io::put_object(object_id oid, staging_file* file, ss::abort_source* as) {
+    auto file_size = co_await file->size();
+    static constexpr auto timeout = 10s;
+    static constexpr auto backoff = 100ms;
+    retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
+    lazy_abort_source las{[as] {
+        return as->abort_requested() ? std::make_optional("abort requested")
+                                     : std::nullopt;
+    }};
+    auto result_fut
+      = co_await ss::coroutine::as_future<cloud_io::upload_result>(
+        _remote->upload_stream(
+          cloud_io::transfer_details{
+            .bucket = _bucket,
+            .key = object_path_factory::level_one_path(oid),
+            .parent_rtc = root,
+          },
+          file_size,
+          [this, file]() {
+              return io::read_file(file).then(
+                [](ss::input_stream<char> stream)
+                  -> std::unique_ptr<stream_provider> {
+                    return std::make_unique<one_time_stream_provider>(
+                      std::move(stream));
+                });
+          },
+          las,
+          "l1_file_upload",
+          std::nullopt));
+    if (result_fut.failed()) {
+        vlog(
+          cd_log.warn, "Error uploading file: {}", result_fut.get_exception());
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    switch (result_fut.get()) {
+    case cloud_io::upload_result::success:
+        // TODO(cloud_topics): Consider preemptively putting the object in the
+        // cache
+        co_return std::expected<void, io::errc>{};
+    case cloud_io::upload_result::timedout:
+    case cloud_io::upload_result::cancelled:
+        co_return std::unexpected(io::errc::cloud_op_timeout);
+    case cloud_io::upload_result::failed:
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    std::unreachable();
+}
+
+ss::future<uint64_t> file_io::save_to_cache(
+  ss::input_stream<char> stream,
+  cloud_storage::space_reservation_guard* reservation,
+  std::filesystem::path cache_key,
+  uint64_t content_length) {
+    co_await _cache->put(std::move(cache_key), stream, *reservation);
+    co_return content_length;
+}
+
+ss::future<std::expected<ss::input_stream<char>, io::errc>>
+file_io::read_object(object_extent extent, ss::abort_source* as) {
+    static constexpr auto timeout = 10s;
+    static constexpr auto backoff = 100ms;
+    retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
+    lazy_abort_source las{[as] {
+        return as->abort_requested() ? std::make_optional("abort requested")
+                                     : std::nullopt;
+    }};
+    // TODO(cloud_topics): Optimize the cache such that it understands partial
+    // objects? Or we assert somehow there are no overlaps (or just live with
+    // them).
+    // TODO(cloud_topics): If reading just a footer, we should skip the cache.
+    // Maybe we need another method for that which is iobuf based?
+    std::filesystem::path cache_key = fmt::format(
+      "l1_{}_position_{}_size_{}.partial",
+      extent.id,
+      extent.position,
+      extent.size);
+    while (true) {
+        auto stream_fut = co_await ss::coroutine::as_future<
+          std::optional<cloud_io::cache_item_stream>>(
+          _cache->get_stream(cache_key));
+        if (stream_fut.failed()) {
+            vlog(
+              cd_log.warn,
+              "Error reading from cache for {}: {}",
+              extent,
+              stream_fut.get_exception());
+            co_return std::unexpected(io::errc::file_io_error);
+        }
+        auto stream = stream_fut.get();
+        if (stream) {
+            co_return std::move(stream->body);
+        }
+        // TODO(cloud_topics): reserving space should also take an abort_source
+        auto reservation_fut = co_await ss::coroutine::as_future<
+          cloud_storage::space_reservation_guard>(
+          _cache->reserve_space(extent.size, 1));
+        if (reservation_fut.failed()) {
+            vlog(
+              cd_log.warn,
+              "Error reserving cache space for download of {}: {}",
+              extent,
+              reservation_fut.get_exception());
+            co_return std::unexpected(io::errc::file_io_error);
+        }
+        cloud_io::try_consume_stream consumer =
+          [this, r = reservation_fut.get(), &cache_key](
+            uint64_t content_length, ss::input_stream<char> stream) mutable {
+              return save_to_cache(
+                std::move(stream), &r, cache_key, content_length);
+          };
+        auto result_fut
+          = co_await ss::coroutine::as_future<cloud_io::download_result>(
+            _remote->download_stream(
+              cloud_io::transfer_details{
+                .bucket = _bucket,
+                .key = object_path_factory::level_one_path(extent.id),
+                .parent_rtc = root,
+              },
+              consumer,
+              "l1_file_download",
+              /*acquire_hydration_units=*/true,
+              cloud_storage_clients::http_byte_range{
+                extent.position, extent.position + extent.size - 1}));
+        if (result_fut.failed()) {
+            vlog(
+              cd_log.warn,
+              "Error downloading object {}: {}",
+              extent,
+              result_fut.get_exception());
+            co_return std::unexpected(io::errc::cloud_op_error);
+        }
+        switch (result_fut.get()) {
+        case cloud_io::download_result::success:
+            continue; // Now that it's in the cache the lookup should succeed.
+        case cloud_io::download_result::notfound:
+            co_return std::unexpected(io::errc::cloud_missing_object);
+        case cloud_io::download_result::timedout:
+            co_return std::unexpected(io::errc::cloud_op_timeout);
+        case cloud_io::download_result::failed:
+            co_return std::unexpected(io::errc::cloud_op_error);
+        }
+        std::unreachable();
+    }
+}
+
+ss::future<std::expected<void, io::errc>>
+file_io::delete_objects(chunked_vector<object_id> ids, ss::abort_source* as) {
+    static constexpr auto timeout = 10s;
+    static constexpr auto backoff = 100ms;
+    retry_chain_node root(*as, ss::lowres_clock::now() + timeout, backoff);
+    chunked_vector<cloud_storage_clients::object_key> keys;
+    for (const auto& id : ids) {
+        keys.push_back(object_path_factory::level_one_path(id));
+    }
+    auto result_fut
+      = co_await ss::coroutine::as_future<cloud_io::upload_result>(
+        _remote->delete_objects(
+          _bucket, std::move(keys), root, [](size_t retry_count) {
+              std::ignore = retry_count;
+          }));
+    if (result_fut.failed()) {
+        vlog(
+          cd_log.warn,
+          "Error deleting objects: {}",
+          result_fut.get_exception());
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    switch (result_fut.get()) {
+    case cloud_io::upload_result::success:
+        co_return std::expected<void, io::errc>{};
+    case cloud_io::upload_result::timedout:
+    case cloud_io::upload_result::cancelled:
+        co_return std::unexpected(io::errc::cloud_op_timeout);
+    case cloud_io::upload_result::failed:
+        co_return std::unexpected(io::errc::cloud_op_error);
+    }
+    std::unreachable();
+}
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/file_io.h
+++ b/src/v/cloud_topics/level_one/common/file_io.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_io/remote.h"
+#include "cloud_storage/cache_service.h"
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/object_id.h"
+#include "model/fundamental.h"
+
+namespace experimental::cloud_topics::l1 {
+
+// The IO implementation that hides caching and other complexities of
+// interacting with persistent storage of L1 objects.
+//
+// For writing this persists the file to the local disk, then writes it
+// to object storage.
+//
+// Reads are cached locally on disk in the cloud cache before being returned.
+class file_io : public io {
+public:
+    file_io(
+      std::filesystem::path staging_dir,
+      cloud_io::remote* remote,
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage::cache* cache);
+    ss::future<std::expected<std::unique_ptr<staging_file>, errc>>
+    create_tmp_file() override;
+
+    ss::future<std::expected<void, errc>>
+    put_object(object_id, staging_file*, ss::abort_source*) override;
+
+    ss::future<std::expected<ss::input_stream<char>, errc>>
+    read_object(object_extent, ss::abort_source*) override;
+
+    ss::future<std::expected<void, errc>>
+    delete_objects(chunked_vector<object_id>, ss::abort_source*) override;
+
+private:
+    ss::future<uint64_t> save_to_cache(
+      ss::input_stream<char>,
+      cloud_storage::space_reservation_guard*,
+      std::filesystem::path,
+      uint64_t content_length);
+
+    cloud_io::remote* _remote;
+    cloud_storage_clients::bucket_name _bucket;
+    std::filesystem::path _staging_dir;
+    cloud_storage::cache* _cache;
+};
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -509,14 +509,14 @@ object_reader::create(ss::input_stream<char> input) {
 }
 
 ss::future<std::unique_ptr<object_reader>>
-object_reader::create(std::filesystem::path p, size_t offset) {
+object_reader::create(std::filesystem::path p, size_t offset, size_t length) {
     auto f = co_await ss::open_file_dma(p.native(), ss::open_flags::ro);
-    co_return create(ss::make_file_input_stream(std::move(f), offset));
+    co_return create(ss::make_file_input_stream(std::move(f), offset, length));
 }
 
 std::unique_ptr<object_reader>
-object_reader::create(ss::file f, size_t offset) {
-    return create(ss::make_file_input_stream(std::move(f), offset));
+object_reader::create(ss::file f, size_t offset, size_t length) {
+    return create(ss::make_file_input_stream(std::move(f), offset, length));
 }
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -24,6 +24,8 @@
 
 #include <fmt/format.h>
 
+#include <limits>
+
 namespace experimental::cloud_topics::l1 {
 
 // clang-format off
@@ -303,14 +305,19 @@ public:
     //
     // Offset can be used to start at a particular batch, using the file
     // position recorded in a footer
-    static std::unique_ptr<object_reader> create(ss::file, size_t offset = 0);
+    static std::unique_ptr<object_reader> create(
+      ss::file,
+      size_t offset = 0,
+      size_t length = std::numeric_limits<size_t>::max());
 
     // Create an object_reader from a file path.
     //
     // Offset can be used to start at a particular batch, using the file
     // position recorded in a footer.
-    static ss::future<std::unique_ptr<object_reader>>
-    create(std::filesystem::path, size_t offset = 0);
+    static ss::future<std::unique_ptr<object_reader>> create(
+      std::filesystem::path,
+      size_t offset = 0,
+      size_t length = std::numeric_limits<size_t>::max());
 
     // Create an object_reader from a stream.
     static std::unique_ptr<object_reader> create(ss::input_stream<char>);

--- a/src/v/cloud_topics/level_one/common/object_id.cc
+++ b/src/v/cloud_topics/level_one/common/object_id.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/object_id.h"
+
+namespace experimental::cloud_topics::l1 {
+
+fmt::iterator object_extent::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{id: {}, position: {}, size: {}}}", id, position, size);
+}
+
+} // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object_id.h
+++ b/src/v/cloud_topics/level_one/common/object_id.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "utils/named_type.h"
 #include "utils/uuid.h"
 
@@ -20,5 +21,14 @@ namespace experimental::cloud_topics::l1 {
 using object_id = named_type<uuid_t, struct l1_object_id_tag>;
 
 inline object_id create_object_id() { return object_id{uuid_t::create()}; }
+
+// An extent of a remote object, which is a pair of offset and size.
+struct object_extent {
+    object_id id;
+    size_t position = 0;
+    size_t size = 0;
+
+    fmt::iterator format_to(fmt::iterator it) const;
+};
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object_utils.cc
+++ b/src/v/cloud_topics/level_one/common/object_utils.cc
@@ -10,14 +10,13 @@
 
 #include "cloud_topics/level_one/common/object_utils.h"
 
-#include "cloud_topics/level_one/common/object_id.h"
 #include "ssx/sformat.h"
 
 namespace experimental::cloud_topics::l1 {
 
-cloud_storage_clients::object_key object_path_factory::level_one_path() {
-    return cloud_storage_clients::object_key(
-      ssx::sformat("l1_v0_{}", create_object_id()));
+cloud_storage_clients::object_key
+object_path_factory::level_one_path(object_id id) {
+    return cloud_storage_clients::object_key(ssx::sformat("l1_v0_{}", id));
 }
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object_utils.h
+++ b/src/v/cloud_topics/level_one/common/object_utils.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "cloud_storage_clients/types.h"
+#include "cloud_topics/level_one/common/object_id.h"
 
 namespace experimental::cloud_topics::l1 {
 
@@ -21,7 +22,7 @@ public:
     /*
      * Generate the path of a level-one object.
      */
-    static cloud_storage_clients::object_key level_one_path();
+    static cloud_storage_clients::object_key level_one_path(object_id);
 };
 
 } // namespace experimental::cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/object_utils_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_utils_test.cc
@@ -17,7 +17,8 @@
 
 TEST(ObjectPathFactory, LevelOnePathFormat) {
     auto path
-      = experimental::cloud_topics::l1::object_path_factory::level_one_path();
+      = experimental::cloud_topics::l1::object_path_factory::level_one_path(
+        experimental::cloud_topics::l1::create_object_id());
     EXPECT_THAT(
       path().string(), ::testing::MatchesRegex("^l1_v0_" UUID_REGEX "$"));
 }

--- a/src/v/cloud_topics/level_zero/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/level_zero/reconciler/reconciler.cc
@@ -180,7 +180,7 @@ ss::future<> reconciler::reconcile() {
     if (!object.has_value()) {
         co_return;
     }
-    auto path = l1::object_path_factory::level_one_path();
+    auto path = l1::object_path_factory::level_one_path(l1::create_object_id());
     auto result = co_await upload_object(path, std::move(object->data));
     if (result != cloud_io::upload_result::success) {
         vlog(lg.info, "Failed to upload L1 object: {}", result);


### PR DESCRIPTION
- **l1/object: support reading a limited portion of the file on disk**
- **ct/l1: add a struct for extents**
- **ct/l1: introduct io abstractions**
- **l1/object_utils: pass in object_id**
- **cloud_storage_clients: document http byte range struct**
- **ct/l1: add file_io implementation**
- **ct/l1: add a fake io impl for testing**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
