### PR TITLE
CORE-12942 rpk/registry: create schema with id and version

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/create.go
+++ b/src/go/rpk/pkg/cli/registry/schema/create.go
@@ -24,9 +24,11 @@ import (
 
 func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		refs       string
-		schemaFile string
-		schemaType string
+		refs          string
+		schemaFile    string
+		schemaType    string
+		id            int
+		schemaVersion int
 	)
 	cmd := &cobra.Command{
 		Use:   "create SUBJECT --schema {filename}",
@@ -43,6 +45,9 @@ comma separated list of <name>:<subject>:<version> or a path to a file. The file
 must contain lines of name, subject, and version separated by a tab or space, or 
 the equivalent in json / yaml format.
 
+In import mode, you can specify a schema ID and version using the --id and
+--schema-version flags to assign specific values when creating the schema.
+
 EXAMPLES
 
 Create a protobuf schema with subject 'foo':
@@ -54,6 +59,9 @@ Create an avro schema, passing the type via flags:
 Create a protobuf schema that references the schema in subject 'my_subject', 
 version 1:
   rpk registry schema create foo --schema /path/to/file.proto --references my_name:my_subject:1
+
+Create a schema with a specific ID and version in import mode:
+  rpk registry schema create foo --schema /path/to/file.proto --id 42 --schema-version 3
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -61,6 +69,11 @@ version 1:
 			if h, ok := f.Help(subjectSchema{}); ok {
 				out.Exit(h)
 			}
+
+			if schemaVersion != -1 && id == -1 {
+				out.Die("--schema-version requires --id to be specified")
+			}
+
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
@@ -82,7 +95,8 @@ version 1:
 				Type:       t,
 				References: references,
 			}
-			s, err := cl.CreateSchema(cmd.Context(), subject, schema)
+
+			s, err := cl.CreateSchemaWithIDAndVersion(cmd.Context(), subject, schema, id, schemaVersion)
 			out.MaybeDie(err, "unable to create schema: %v", err)
 
 			err = printSubjectSchemaTable(f, true, s)
@@ -93,6 +107,8 @@ version 1:
 	cmd.Flags().StringVar(&schemaType, "type", "", fmt.Sprintf("Schema type (%v); overrides schema file extension", strings.Join(supportedTypes, ",")))
 	cmd.Flags().StringVar(&schemaFile, "schema", "", "Schema filepath to upload, must be .avro, .avsc, or .proto")
 	cmd.Flags().StringVar(&refs, "references", "", "Comma-separated list of references (name:subject:version) or path to reference file")
+	cmd.Flags().IntVar(&id, "id", -1, "Optional schema ID to use when creating the schema in import mode")
+	cmd.Flags().IntVar(&schemaVersion, "schema-version", -1, "Optional schema version to use when creating the schema in import mode (requires --id)")
 	cmd.MarkFlagRequired("schema")
 
 	cmd.RegisterFlagCompletionFunc("type", validTypes())

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1824,11 +1824,22 @@ class RpkTool:
 
         return self._run_registry(cmd)
 
-    def create_schema(self, subject, schema_path, references=None):
+    def create_schema(self,
+                      subject,
+                      schema_path,
+                      references=None,
+                      id=None,
+                      version=None):
         cmd = ["schema", "create", subject, "--schema", schema_path]
 
         if references is not None:
             cmd += ["--references", references]
+
+        if id is not None:
+            cmd += ["--id", str(id)]
+
+        if version is not None:
+            cmd += ["--schema-version", str(version)]
 
         return self._run_registry(cmd)
 

--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -120,13 +120,21 @@ class RpkRegistryTest(RedpandaTest):
                    backoff_sec=3,
                    retry_on_exc=True)
 
-    def create_schema(self, subject, schema, suffix, references=None):
+    def create_schema(self,
+                      subject,
+                      schema,
+                      suffix,
+                      references=None,
+                      id=None,
+                      version=None):
         with tempfile.NamedTemporaryFile(suffix=suffix) as tf:
             tf.write(bytes(schema, 'UTF-8'))
             tf.seek(0)
             out = self._rpk.create_schema(subject,
                                           tf.name,
-                                          references=references)
+                                          references=references,
+                                          id=id,
+                                          version=version)
             assert out["subject"] == subject
 
     def _schema_topic_created(self):
@@ -235,6 +243,34 @@ class RpkRegistryTest(RedpandaTest):
         assert out[0]["subject"] == subject_4
         assert out[0]["id"] == 4
         assert out[0]["type"] == "JSON"
+
+    @cluster(num_nodes=3)
+    def test_registry_schema_create_specific(self):
+        subject_1 = "test_subject_1"
+        subject_2 = "test_subject_2"
+
+        self._rpk.set_mode("IMPORT")
+
+        self.create_schema(subject_1,
+                           schema1_avro_def,
+                           ".avro",
+                           id=42,
+                           version=3)
+
+        out = self._rpk.get_schema(subject_1, version="3")
+        assert len(out) == 1
+        assert out[0]["subject"] == subject_1
+        assert out[0]["id"] == 42
+        assert out[0]["type"] == "AVRO"
+
+        with expect_exception(
+                RpkException, lambda e:
+                "--schema-version requires --id to be specified" in str(e)):
+            self.create_schema(subject_2,
+                               schema1_proto_def,
+                               ".proto",
+                               id=None,
+                               version=9)
 
     @cluster(num_nodes=1)
     def test_registry_compatibility_level(self):


### PR DESCRIPTION
This adds two optional flags to the `rpk registry schema create` command, which allow users to specific a version and id to register the schema with.

The id can only be set, and is required to be set, in import mode. This is validated server side.

The version may only be set if the id is set. This is not technically required server-side, but the franz-go implementation only passes on the version if the id is set, so it makes sense to validate this inside rpk.

It would be possible to specify the version without the id in readwrite mode, but in this case the server-side validates that the specified version must be exactly the version that would be projected if it would not have been specified. Therefore, there is no need to expose this "functionality" to the user, and we can just require the id to always be set if the version is specified.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes https://redpandadata.atlassian.net/browse/CORE-12942

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
