### PR TITLE
tests/ducktape: handle timeouts in dt client

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"": ["*.md"]},
     include_package_data=True,
     install_requires=[
-        "ducktape@git+https://github.com/redpanda-data/ducktape.git@c642f195d06d387348034c30f917b1a15c5d43a0",
+        "ducktape@git+https://github.com/redpanda-data/ducktape.git@b1a8012b066a823953e70b73f3659d572dd206b6",
         "prometheus-client==0.9.0",
         "kafka-python==2.0.6",
         "crc32c==2.2",


### PR DESCRIPTION
Update ducktape ref that handles ducktape timeout as a regular ducktape error (like `AssertionError`). Such failures will be reported as `TestTimeoutError`. Test timeouts used to be handled by the ducktape server by immediately raising an exception and exiting the ducktape session without triggering more tests. This leads to not producing ducktape reports, and it's not clear which part of the test was hanging until the server raises the error. The new approach treats the timeout errors like normal exceptions, so we'll be able to see it in the ducktape reports (along with the stacktrace) and pandatriage will be triaging such issues.

for more see https://github.com/redpanda-data/ducktape/pull/50

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
