### PR TITLE
Do not remove force reconfigured replica if it a learner

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -282,6 +282,12 @@ inline bool contains_node(
            != replicas.end();
 }
 
+inline bool
+contains_node(const std::vector<raft::vnode>& replicas, model::node_id id) {
+    return std::ranges::any_of(
+      replicas, [id](const raft::vnode& vn) { return vn.id() == id; });
+}
+
 inline std::optional<ss::shard_id>
 find_shard_on_node(const replicas_t& replicas, model::node_id node) {
     for (const auto& bs : replicas) {

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -725,6 +725,8 @@ controller_backend::force_replica_set_update(
         // will be cleaned up as a part of update_finished command.
         co_return ss::stop_iteration::yes;
     }
+    auto [voters, learners] = split_voters_learners_for_force_reconfiguration(
+      previous_replicas, new_replicas, initial_replicas_revisions, cmd_rev);
     if (partition->cloud_data_available()) {
         auto last_cloud_offset
           = co_await partition->fetch_latest_cloud_offset_from_manifest(
@@ -740,7 +742,45 @@ controller_backend::force_replica_set_update(
               last_cloud_offset.error());
             co_return last_cloud_offset.error();
         }
-        if (last_cloud_offset.value() > partition->dirty_offset()) {
+
+        vlog(
+          clusterlog.info,
+          "[{}] force-update replica set - last cloud offset {}, dirty offset: "
+          "{}",
+          partition->ntp(),
+          last_cloud_offset.value(),
+          partition->dirty_offset());
+
+        /**
+         * This variable indicates whether the partition can be recovered
+         * by the leader.
+         *
+         * When force reconfiguring partition controller backend decides which
+         * of the new replicas should be added to the partition configuration as
+         * learners. The logic here is relatively simple: if a replica is
+         * already in the replica set (it is the disaster survivor), it is
+         * added to the replica set as a voter serving as a source of truth.
+         * Nodes that join the replica set are added to the configuration as
+         * learners in order to prevent them from reaching a majority and
+         * overcoming the current minority (the survivors).
+         *
+         * After establishing which replicas are learners vs voters the
+         * condition below decides if the survivor should be treated as a
+         * source of truth or if cloud data contains more up to date state.
+         *
+         * If replica dirty offset is greater than last cloud offset it means
+         * that the replica is more up to date, otherwise data in the bucket are
+         * newer and they should be used. This condition should only be verified
+         * if a node is not a learner and can not be recovered from the cloud.
+         * Otherwise all learners would face multiple deletions while being
+         * recovered by the leader as their dirty offset may be smaller than
+         * last cloud offset for a very long time.
+         *
+         */
+        const auto can_be_recovered_by_leader = contains_node(learners, _self);
+        if (
+          !can_be_recovered_by_leader
+          && last_cloud_offset.value() > partition->dirty_offset()) {
             vlog(
               clusterlog.info,
               "[{}] force-update replica set - last cloud offset {} is greater "
@@ -762,8 +802,6 @@ controller_backend::force_replica_set_update(
         }
     }
 
-    auto [voters, learners] = split_voters_learners_for_force_reconfiguration(
-      previous_replicas, new_replicas, initial_replicas_revisions, cmd_rev);
     vlog(
       clusterlog.debug,
       "[{}] force updating replica set with: [voters: {}, learners: {}]",

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -772,19 +772,20 @@ class NodeWiseRecoveryTest(RedpandaTest):
                         f"partition {t.name}/{partition_id}: {initial_hw=} vs {final_hw=}"
 
     @cluster(num_nodes=6)
-    def test_recovery_local_data_missing(self):
+    @matrix(wait_for_final_manifest_uploads=[False, True])
+    def test_recovery_local_data_missing(self,
+                                         wait_for_final_manifest_uploads):
         self.redpanda._disable_cloud_storage_diagnostics = True
 
-        topic = TopicSpec(name=f"topic-0",
-                          replication_factor=3,
+        topic = TopicSpec(replication_factor=3,
                           partition_count=1,
                           redpanda_remote_read=True,
                           redpanda_remote_write=True)
-
+        local_retention = 50 * 1024 * 1024  # 50 MiB
         self.client().create_topic(topic)
         self.client().alter_topic_config(
             topic.name, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
-            2 * 1024 * 1024)
+            local_retention)
 
         admin = self.redpanda._admin
         rpk = RpkTool(self.redpanda)
@@ -796,7 +797,11 @@ class NodeWiseRecoveryTest(RedpandaTest):
 
         # produce initial data
         self.produce_until_log_eviction(topic.name)
-        self.wait_for_final_manifest_uploads(topic.name)
+        if wait_for_final_manifest_uploads:
+            self.wait_for_final_manifest_uploads(topic.name)
+        else:
+            self.client().alter_topic_config(topic.name,
+                                             "redpanda.remote.write", False)
 
         # collect topic partition high watermarks before recovery
         initial_status = self.get_topic_partition_status(topic.name, 1)
@@ -807,15 +812,15 @@ class NodeWiseRecoveryTest(RedpandaTest):
         node_to_stop = self.redpanda.get_node_by_id(node_to_stop_id)
         self.logger.debug(f"Stopping node: {node_to_stop_id}")
         self.redpanda.stop_node(node_to_stop)
-
+        msg_size = 512
+        total_bytes = 75 * 1024 * 1024  # 75 MiB
+        msg_cnt = total_bytes // msg_size
         # produce more data while node 0 is stopped
-        producer = KgoVerifierProducer(self.test_context, self.redpanda,
-                                       topic.name, 512, 5000)
-        producer.start(clean=False)
-        producer.wait()
-        producer.clean()
-        producer.free()
-        self.wait_for_final_manifest_uploads(topic.name)
+        KgoVerifierProducer.oneshot(self.test_context, self.redpanda,
+                                    topic.name, msg_size, msg_cnt)
+
+        if wait_for_final_manifest_uploads:
+            self.wait_for_final_manifest_uploads(topic.name)
 
         status_2nd_step = self.get_topic_partition_status(topic.name, 1)
 
@@ -851,13 +856,12 @@ class NodeWiseRecoveryTest(RedpandaTest):
         rpk.force_partition_recovery(from_nodes=to_kill_node_ids)
         self.wait_for_no_reconfigurations()
         # wait for quiescence
-        for part in range(0, topic.partition_count):
-            self.redpanda._admin.await_stable_leader(
-                topic=topic.name,
-                partition=part,
-                timeout_s=self.default_timeout_sec,
-                backoff_s=2,
-                hosts=self._alive_nodes())
+        self.redpanda._admin.await_stable_leader(
+            topic=topic.name,
+            partition=0,
+            timeout_s=self.default_timeout_sec,
+            backoff_s=2,
+            hosts=self._alive_nodes())
 
         status_after = self.get_topic_partition_status(topic.name,
                                                        topic.partition_count)


### PR DESCRIPTION
When force reconfiguring partition controller backed decides which of the new replicas should be added to the partition configuration as learners. The logic here is relatively simple: if a replica is not already in the replica set i.e. it is the disaster survivor it is added to the replica set as a voter serving as a source of truth. Nodes that joins the replica set are added to the configuration as learners in order to prevent them from reaching a majority and overcoming the current minority (the survivors).  After establishing which replicas are learners vs voters the condition in controller backend decides if the survivor should be treated as a source of truth or if cloud data contains more up to date state.  If replica dirty offset is greater than last cloud offset it means that the replica is more up to date, otherwise data in the bucket are newer and they should be used. This condition should only be verified if a node is not a learner and can not be recovered from the cloud. Otherwise all learners would face multiple deletions while being recovered by the leader as their dirty offset may smaller than last cloud offset for a very long time. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes
- Fixes node wise recovery issue leading to stuck reconfiguration when local data on the replicas is more up to date than data in tiered storage
