### PR TITLE
direct_consumer/data_queue: fairness fix & tests

### DIFF
--- a/src/v/kafka/client/direct_consumer/data_queue.cc
+++ b/src/v/kafka/client/direct_consumer/data_queue.cc
@@ -10,60 +10,114 @@
  */
 #include "kafka/client/direct_consumer/data_queue.h"
 
+#include "base/vassert.h"
+#include "kafka/protocol/errors.h"
+
 namespace kafka::client {
 
 data_queue::data_queue(size_t max_bytes, size_t max_count)
   : _max_count(max_count)
   , _max_bytes(max_bytes) {}
 
-bool data_queue::can_insert(size_t bytes) const {
+bool data_queue::has_capacity() const {
     return _queue.empty()
-           || (_current_bytes + bytes <= _max_bytes && _queue.size() < _max_count);
+           || (_current_bytes <= _max_bytes && _queue.size() < _max_count);
+}
+
+bool data_queue::can_insert_immediately() const {
+    return has_capacity() && !_waiting_to_push.has_waiters();
 }
 
 ss::future<>
 data_queue::push(chunked_vector<fetched_topic_data> data, size_t total_bytes) {
-    // optimization, if data can be inserted immediately, do it
-    if (can_insert(total_bytes)) {
-        _current_bytes += total_bytes;
-        _queue.push_back(
-          entry{.topics = std::move(data), .total_bytes = total_bytes});
-        _updated.signal();
+    return push(entry{
+      .error_code = kafka::error_code::none,
+      .topics = std::move(data),
+      .total_bytes = total_bytes});
+}
+
+ss::future<> data_queue::push(entry e) {
+    if (can_insert_immediately()) {
+        _current_bytes += e.total_bytes;
+        _queue.push_back(std::move(e));
+
+        // we could elide the checks and call signal directly
+        update_next_pop();
+        // update_next_push(); no need there are no waiters
         return ss::now();
     }
-    return _updated
-      .wait([this, total_bytes] { return can_insert(total_bytes); })
-      .then([total_bytes, data = std::move(data), this]() mutable {
-          _current_bytes += total_bytes;
-          _queue.push_back(
-            entry{.topics = std::move(data), .total_bytes = total_bytes});
-          _updated.signal();
-      });
+    return _waiting_to_push.wait().then([this, e = std::move(e)]() mutable {
+        vassert(
+          has_capacity(),
+          "precondition: the queue must NOT be full at the point at which a "
+          "push is woken");
+        _current_bytes += e.total_bytes;
+        _queue.push_back(std::move(e));
+
+        // update waiters
+        update_next_pop();
+        update_next_push();
+    });
 }
 
 ss::future<> data_queue::push_error(kafka::error_code ec) {
-    return _updated.wait([this] { return can_insert(0); })
-      .then([ec, this]() mutable {
-          _queue.push_back(entry{.error_code = ec});
-          _updated.signal();
-      });
+    return push(entry{.error_code = ec, .topics = {}, .total_bytes = 0u});
 }
 
 ss::future<fetches> data_queue::pop(std::chrono::milliseconds timeout) {
-    co_await _updated.wait(timeout, [this] { return !_queue.empty(); });
+    if (_queue.size() == 0 || _waiting_to_pop.has_waiters()) {
+        co_await _waiting_to_pop.wait(timeout);
+    }
+    vassert(
+      _queue.size() > 0,
+      "precondition: the queue must have an entry on non-error completion of a "
+      "wait");
 
     auto entry = std::move(_queue.front());
     _current_bytes -= entry.total_bytes;
     _queue.pop_front();
-    _updated.signal();
+
+    update_next_push();
+    update_next_pop();
+
     if (entry.error_code != kafka::error_code::none) {
-        // If there is an error, we return an empty vector
+        // If there is an error, fill result with error
         co_return entry.error_code;
     }
     auto result = std::move(entry.topics);
     co_return result;
 }
 
-void data_queue::stop() { _updated.broken(); }
+void data_queue::stop() {
+    _waiting_to_pop.broken();
+    _waiting_to_push.broken();
+}
+
+void data_queue::set_max_bytes(size_t bytes) {
+    _max_bytes = bytes;
+
+    // reasonably the answer to 'can i insert now' may have changed
+    update_next_push();
+}
+
+void data_queue::set_max_count(size_t count) {
+    _max_count = count;
+
+    // reasonably the answer to 'can i insert now' may have changed
+    update_next_push();
+}
+
+void data_queue::update_next_push() {
+    if (has_capacity() && _waiting_to_push.has_waiters()) {
+        _waiting_to_push.signal();
+    }
+}
+
+// wakes the next pop if appropriate
+void data_queue::update_next_pop() {
+    if (!_queue.empty() && _waiting_to_pop.has_waiters()) {
+        _waiting_to_pop.signal();
+    }
+}
 
 } // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/data_queue.h
+++ b/src/v/kafka/client/direct_consumer/data_queue.h
@@ -17,53 +17,55 @@ namespace kafka::client {
 /**
  * Very simple blocking queue that is used in
  * the direct consumer to store data fetched from the broker. The queue is
- * bounded by the number of entries and the total size of the data in the queue.
- * The queue can store a single entry that exceeds the size limit but the
- * prerequisite for that is that the queue is empty.
+ * strictly bounded by the number of elements it may contain and loosely bounded
+ * on the maximum data size. At the point of being filled, the queue will force
+ * additional pushes to wait.
  */
 class data_queue {
 public:
     data_queue(size_t max_bytes = 10_MiB, size_t max_count = 10);
-    /*
-     * Returns true if the queue can accept more data.
-     */
-    bool can_insert(size_t bytes) const;
+
+    /** true if the queue can accept another entry without waiting */
+    bool can_insert_immediately() const;
+
     /**
-     * Pushes data into the queue. If the queue is full, it will block until
-     * there is enough space.
+     * @brief pushes fetched data onto the queue, blocks if the queue is full
+     * @param data the data to be emplaced
+     * @param total_bytes the total size of the data to be emplaced, used to
+     * limit maximum queue size
+     * @throws ss::broken_condition_variable if the queue closes before
+     * completion
      */
     ss::future<>
     push(chunked_vector<fetched_topic_data> data, size_t total_bytes);
 
-    /**
-     * Pushes an error into the queue. If the queue is full, it will block until
-     * there is enough space. The error are not accounted for the total bytes.
-     */
+    /** push operation for the queue, error case, blocks if the queue is full.
+     * Throws ss::broken_condition */
     ss::future<> push_error(kafka::error_code ec);
+
     /**
-     * Pops data from the queue. If the queue is empty, it will block until
-     * there is data available or the timeout is reached.
-     * If the timeout is reached, it will throw condition_variable_timed_out.
+     * @brief pushes fetched data onto the queue, blocks if there is no data to
+     * pop
+     * @param timeout how long to wait before throwing a ss::timed_out_error
+     * @throws ss::timed_out_error thrown if the timeout is met before data is
+     * found
+     * @throws ss::broken_condition_variable if the queue closes before
+     * completion
      */
     ss::future<fetches> pop(std::chrono::milliseconds timeout);
 
     /**
      * Stops the queue. All methods will return immediately after this
-     * method is called. If the methods is waiting it will throw an exception.
+     * method is called. If the methods is waiting it will throw an
+     * ss::broken_condition_variable exception
      */
     void stop();
 
     /**
      * Configuration setters for the queue.
      */
-    void set_max_bytes(size_t bytes) {
-        _max_bytes = bytes;
-        _updated.signal();
-    }
-    void set_max_count(size_t count) {
-        _max_count = count;
-        _updated.signal();
-    }
+    void set_max_bytes(size_t bytes);
+    void set_max_count(size_t count);
 
     size_t size() const { return _queue.size(); }
 
@@ -75,11 +77,23 @@ private:
         chunked_vector<fetched_topic_data> topics;
         size_t total_bytes{0};
     };
+
+    ss::future<> push(entry entry);
+
+    // specifically, does the queue have capacity for one more fetch
+    bool has_capacity() const;
+
+    // wake next if appropriate
+    void update_next_push();
+    void update_next_pop();
+
     size_t _max_count{10};
     size_t _max_bytes{10_MiB};
 
     size_t _current_bytes{0};
     ss::chunked_fifo<entry> _queue;
-    ss::condition_variable _updated;
+
+    ss::condition_variable _waiting_to_push;
+    ss::condition_variable _waiting_to_pop;
 };
 } // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/tests/BUILD
+++ b/src/v/kafka/client/direct_consumer/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/kafka/client/direct_consumer",
         "//src/v/model/tests:random",
+        "//src/v/random:generators",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",

--- a/src/v/kafka/client/direct_consumer/tests/data_queue_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/data_queue_test.cc
@@ -8,10 +8,15 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/client/direct_consumer/data_queue.h"
+#include "random/generators.h"
 #include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace std::literals::chrono_literals;
 
 using namespace kafka::client;
 
@@ -21,11 +26,13 @@ static constexpr size_t max_bytes = 1024;
 static constexpr size_t max_count = 10;
 static constexpr auto default_timeout = 100ms;
 
+static constexpr size_t default_payload_size = 512;
+
 chunked_vector<fetched_topic_data>
-make_data(int topic_count, int bytes_per_topic) {
+make_data(size_t topic_count, size_t bytes_per_topic) {
     chunked_vector<fetched_topic_data> data;
     data.reserve(topic_count);
-    for (auto d = 0; d < topic_count; ++d) {
+    for (auto d = 0u; d < topic_count; ++d) {
         fetched_topic_data topic_data;
         topic_data.topic = model::topic(fmt::format("topic-{}", d));
         topic_data.total_bytes = bytes_per_topic;
@@ -37,182 +44,273 @@ make_data(int topic_count, int bytes_per_topic) {
 auto insert_single_element(data_queue& queue, size_t element_size) {
     return queue.push(make_data(1, element_size), element_size);
 }
-
 } // namespace
 
+// check initial state on construction
+TEST(DataQueueTest, InitialState) {
+    data_queue queue(max_bytes, max_count);
+    ASSERT_EQ(queue.size(), 0);
+    ASSERT_EQ(queue.current_bytes(), 0);
+}
+
+// check that push succeeds with size expectations
 TEST(DataQueueTest, TestIfCanInsertWorks) {
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
-    ASSERT_TRUE(queue.can_insert(50));
-    ASSERT_TRUE(queue.can_insert(20));
-    ASSERT_TRUE(queue.can_insert(300));
-    // queue is empty, so we can insert a single entry that exceeds the size
-    // limit
-    ASSERT_TRUE(queue.can_insert(2048));
-    auto f = queue.push(make_data(1, 512), 1 * 512);
-    // future should be ready immediately
+
+    auto f = queue.push(
+      make_data(1, default_payload_size), default_payload_size);
+
+    // check on readiness optimation, not the biggest fan
     ASSERT_TRUE(f.available());
     ASSERT_EQ(queue.size(), 1);
-    ASSERT_EQ(queue.current_bytes(), 512);
-    ASSERT_TRUE(queue.can_insert(512));
-    ASSERT_FALSE(queue.can_insert(513));
-    ASSERT_FALSE(queue.can_insert(2049));
+    ASSERT_EQ(queue.current_bytes(), default_payload_size);
 }
 
-TEST(DataQueueTest, TestPushPop) {
+// push, check queue, push, check queue, pop, check fifo, pop, check fifo
+TEST_CORO(DataQueueTest, TestPushPop) {
+    static constexpr size_t fragment_size = 64;
+    static constexpr size_t num_fragments = 4;
+    static constexpr size_t fragmented_payload_size = num_fragments
+                                                      * fragment_size;
+
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
-    queue.push(make_data(1, 512), 512).get();
-    ASSERT_EQ(queue.size(), 1);
-    ASSERT_EQ(queue.current_bytes(), 512);
+    co_await insert_single_element(queue, default_payload_size);
+    ASSERT_EQ_CORO(queue.size(), 1);
+    ASSERT_EQ_CORO(queue.current_bytes(), default_payload_size);
 
-    queue.push(make_data(4, 64), 256).get();
-    ASSERT_EQ(queue.size(), 2);
-    ASSERT_EQ(queue.current_bytes(), 768);
+    co_await queue.push(
+      make_data(num_fragments, fragment_size), fragmented_payload_size);
+    ASSERT_EQ_CORO(queue.size(), 2);
+    ASSERT_EQ_CORO(
+      queue.current_bytes(), fragmented_payload_size + default_payload_size);
 
-    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(queue.size(), 1);
-    ASSERT_EQ(queue.current_bytes(), 256);
+    { // check first
+        auto fetched = co_await queue.pop(default_timeout);
+        ASSERT_EQ_CORO(queue.size(), 1);
+        ASSERT_EQ_CORO(queue.current_bytes(), fragmented_payload_size);
 
-    auto fetches_2 = queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
+        ASSERT_TRUE_CORO(fetched.has_value());
+        auto fetched_value = std::move(fetched).value();
 
-    ASSERT_EQ(fetches.value().size(), 1);
-    ASSERT_EQ(fetches.value()[0].total_bytes, 512);
-    ASSERT_EQ(fetches_2.value().size(), 4);
+        // this was the number of topics emplaced
+        ASSERT_EQ_CORO(fetched_value.size(), 1);
+        ASSERT_EQ_CORO(fetched_value[0].total_bytes, default_payload_size);
+    }
+    { // check second
+        auto fetched = co_await queue.pop(default_timeout);
+        ASSERT_EQ_CORO(queue.size(), 0);
+        ASSERT_EQ_CORO(queue.current_bytes(), 0);
+
+        ASSERT_TRUE_CORO(fetched.has_value());
+        auto fetched_value = std::move(fetched).value();
+
+        ASSERT_EQ_CORO(fetched_value.size(), num_fragments);
+        ASSERT_EQ_CORO(fetched_value[0].total_bytes, fragment_size);
+    }
 }
 
-TEST(DataQueueTest, TestPushError) {
+// check that errors come through the queue
+TEST_CORO(DataQueueTest, TestPushError) {
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
-    queue.push_error(kafka::error_code::broker_not_available).get();
-    ASSERT_EQ(queue.size(), 1);
-    ASSERT_EQ(queue.current_bytes(), 0);
+    co_await queue.push_error(kafka::error_code::broker_not_available);
 
-    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
+    auto fetches = queue.pop(default_timeout).get();
 
-    ASSERT_TRUE(fetches.has_error());
-    ASSERT_EQ(fetches.error(), kafka::error_code::broker_not_available);
+    ASSERT_TRUE_CORO(fetches.has_error());
+    ASSERT_EQ_CORO(fetches.error(), kafka::error_code::broker_not_available);
 }
 
-TEST(DataQueueTest, TestPopTimeout) {
+TEST_CORO(DataQueueTest, TestPopTimeout) {
     data_queue queue(max_bytes, max_count);
 
-    ASSERT_THROW(
-      queue.pop(std::chrono::milliseconds(10)).get(),
+    ASSERT_THROW_CORO(
+      std::ignore = co_await queue.pop(default_timeout),
       ss::condition_variable_timed_out);
 }
 
-TEST(DataQueueTest, TestMaxCountLimit) {
+TEST_CORO(DataQueueTest, TestMaxCountLimit) {
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
-    for (size_t i = 0; i < max_count; ++i) {
-        queue.push(make_data(1, 10), 10).get();
+    std::vector<ss::future<>> pushes{};
+    for (size_t i = 0; i < max_count + 1; ++i) {
+        pushes.emplace_back(queue.push(make_data(1, 10), 10));
     }
-    ASSERT_EQ(queue.size(), max_count);
-    ASSERT_EQ(queue.current_bytes(), max_count * 10);
 
-    ASSERT_FALSE(queue.can_insert(10));
+    // force the above to either complete or suspend
+    co_await tests::drain_task_queue();
 
-    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(fetches.value().size(), 1);
-    ASSERT_EQ(queue.size(), max_count - 1);
-    ASSERT_EQ(queue.current_bytes(), (max_count - 1) * 10);
+    // so we can assert that the queue respects the 'max_count' constraint
+    ASSERT_EQ_CORO(queue.size(), max_count);
+    ASSERT_EQ_CORO(queue.current_bytes(), max_count * 10);
 
-    ASSERT_TRUE(queue.can_insert(10));
+    auto fetches = queue.pop(default_timeout).get();
+
+    ASSERT_EQ_CORO(fetches.value().size(), 1);
+
+    // yield, allowing the last fiber to resume
+    co_await tests::drain_task_queue();
+
+    // which should return us to max_count
+    ASSERT_EQ_CORO(queue.size(), max_count);
+    ASSERT_EQ_CORO(queue.current_bytes(), max_count * 10);
+
+    // esure the completion of all pushes
+    for (size_t i{0}; i < pushes.size(); ++i) {
+        co_await std::move(pushes[i]);
+    }
 }
 
-TEST(DataQueueTest, TestConfigurationSetters) {
+TEST_CORO(DataQueueTest, TimeoutCVConsumption) {
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
-    queue.push(make_data(1, 500), 500).get();
-    ASSERT_EQ(queue.size(), 1);
-    ASSERT_EQ(queue.current_bytes(), 500);
-    ASSERT_TRUE(queue.can_insert(524));
-    ASSERT_FALSE(queue.can_insert(525));
+    static constexpr auto small_timeout = 100ms;
+    static constexpr auto big_timeout = 1s;
+
+    auto should_succeed_1 = queue.pop(big_timeout);
+    auto should_fail = queue.pop(small_timeout);
+    auto should_succeed_2 = queue.pop(big_timeout);
+
+    co_await ss::sleep(small_timeout);
+    // at this point should_fail should already have timed out
+
+    co_await insert_single_element(queue, default_payload_size);
+    co_await insert_single_element(queue, default_payload_size);
+
+    std::ignore = co_await std::move(should_succeed_1);
+
+    try {
+        std::ignore = co_await std::move(should_fail);
+        vassert(false, "this operation should have failed on timeout");
+    } catch (const ss::condition_variable_timed_out& e) {
+        // timeout is expected
+        std::ignore = e;
+    }
+
+    std::ignore = co_await std::move(should_succeed_2);
+}
+
+TEST_CORO(DataQueueTest, TestConfigurationSetters) {
+    static constexpr size_t big_push_size{500};
+    static constexpr size_t little_push_size{10};
+    data_queue queue(max_bytes, max_count);
+
+    auto big_push = queue.push(make_data(1, big_push_size), big_push_size);
+
+    // make sure the above actually completes
+    co_await tests::drain_task_queue();
 
     queue.set_max_bytes(2048);
-    ASSERT_EQ(queue.current_bytes(), 500);
-    ASSERT_TRUE(queue.can_insert(1548));
-    ASSERT_FALSE(queue.can_insert(1549));
-
     queue.set_max_count(5);
-    for (size_t i = 1; i < 5; ++i) {
-        queue.push(make_data(1, 10), 10).get();
-    }
-    ASSERT_EQ(queue.size(), 5);
-    ASSERT_EQ(queue.current_bytes(), 500 + 4 * 10);
-    ASSERT_FALSE(queue.can_insert(10));
 
+    // start 5 little pushes to put the queue over count capacity;
+    std::vector<ss::future<>> little_pushes{};
+    for (size_t i{0}; i < 5; ++i) {
+        little_pushes.emplace_back(
+          queue.push(make_data(1, little_push_size), little_push_size));
+    }
+
+    // ensure that the others run through to either completion or suspension
+    co_await tests::drain_task_queue();
+
+    // assert that we have 5 fetches, one big and four little
+    // one little push should be waiting on more space
+    ASSERT_EQ_CORO(queue.size(), 5);
+    ASSERT_EQ_CORO(queue.current_bytes(), big_push_size + 4 * little_push_size);
+
+    // we were previously blocked on not enough count, check that adding more
+    // count wakes next
     queue.set_max_count(20);
-    ASSERT_EQ(queue.current_bytes(), 500 + 4 * 10);
-    ASSERT_TRUE(queue.can_insert(10));
+
+    // yield the shard s.t. the waiting push can wake and execute
+    co_await tests::drain_task_queue();
+
+    ASSERT_EQ_CORO(queue.current_bytes(), 500 + 5 * 10);
+
+    // await and complete all pushes
+    co_await std::move(big_push);
+    for (auto& little_push : little_pushes) {
+        co_await std::move(little_push);
+    }
 }
 
-TEST(DataQueueTest, TestBlockingPushWhenFull) {
+TEST_CORO(DataQueueTest, TestBlockingPushWhenFull) {
+    static constexpr size_t small_payload_size = 50;
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
+    std::vector<ss::future<>> pushes{};
     for (size_t i = 0; i < max_count; ++i) {
-        queue.push(make_data(1, 50), 50).get();
+        pushes.emplace_back(insert_single_element(queue, small_payload_size));
     }
-    ASSERT_EQ(queue.size(), max_count);
-    ASSERT_EQ(queue.current_bytes(), max_count * 50);
 
-    ASSERT_FALSE(queue.can_insert(50));
+    co_await tests::drain_task_queue();
+
+    ASSERT_EQ_CORO(queue.size(), max_count);
+    ASSERT_EQ_CORO(queue.current_bytes(), max_count * 50);
 
     auto push_future = queue.push(make_data(1, 50), 50);
-    ASSERT_FALSE(push_future.available());
-    ASSERT_EQ(queue.size(), max_count);
-    ASSERT_EQ(queue.current_bytes(), max_count * 50);
+    ASSERT_FALSE_CORO(push_future.available());
+    ASSERT_EQ_CORO(queue.size(), max_count);
+    ASSERT_EQ_CORO(queue.current_bytes(), max_count * 50);
 
-    queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(queue.size(), max_count - 1);
-    ASSERT_EQ(queue.current_bytes(), (max_count - 1) * 50);
+    std::ignore = queue.pop(default_timeout);
+    ASSERT_EQ_CORO(queue.size(), max_count - 1);
+    ASSERT_EQ_CORO(queue.current_bytes(), (max_count - 1) * 50);
 
-    push_future.get();
-    ASSERT_EQ(queue.size(), max_count);
-    ASSERT_EQ(queue.current_bytes(), max_count * 50);
+    co_await std::move(push_future);
+    ASSERT_EQ_CORO(queue.size(), max_count);
+    ASSERT_EQ_CORO(queue.current_bytes(), max_count * 50);
+
+    for (auto& future : pushes) {
+        co_await std::move(future);
+    }
 }
 
-TEST(DataQueueTest, TestEdgeCases) {
+TEST_CORO(DataQueueTest, TestEdgeCases) {
+    static constexpr size_t oversized_size{2048};
+    static constexpr size_t small_size{10};
+
     data_queue queue(max_bytes, max_count);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
-    ASSERT_TRUE(queue.can_insert(2048));
-    queue.push(make_data(1, 2048), 2048).get();
-    ASSERT_EQ(queue.size(), 1);
-    ASSERT_EQ(queue.current_bytes(), 2048);
-    ASSERT_FALSE(queue.can_insert(1));
+    { // check that we can put in an element that violates the size constraint
 
-    auto fetches = queue.pop(std::chrono::milliseconds(100)).get();
-    ASSERT_EQ(fetches.value().size(), 1);
-    ASSERT_EQ(fetches.value()[0].total_bytes, 2048);
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
+        co_await insert_single_element(queue, oversized_size);
+        ASSERT_EQ_CORO(queue.size(), 1);
+        ASSERT_EQ_CORO(queue.current_bytes(), oversized_size);
 
-    ASSERT_TRUE(queue.can_insert(1024));
+        auto fetches = co_await queue.pop(default_timeout);
+        ASSERT_EQ_CORO(fetches.value().size(), 1);
+        ASSERT_EQ_CORO(fetches.value()[0].total_bytes, oversized_size);
+    }
+
+    { // check that we can put in an element that violates the size constraint
+      // even when there is an existing element
+        co_await insert_single_element(queue, small_size);
+        ASSERT_EQ_CORO(queue.size(), 1);
+        ASSERT_EQ_CORO(queue.current_bytes(), small_size);
+
+        co_await insert_single_element(queue, oversized_size);
+
+        ASSERT_EQ_CORO(queue.size(), 2);
+        ASSERT_EQ_CORO(queue.current_bytes(), oversized_size + small_size);
+
+        auto will_not_complete = insert_single_element(queue, small_size);
+
+        // show that the above is blocked
+        co_await tests::drain_task_queue();
+        ASSERT_EQ_CORO(queue.size(), 2);
+        ASSERT_EQ_CORO(queue.current_bytes(), oversized_size + small_size);
+
+        // remove enough that the push can complete for cleanup
+        std::ignore = co_await queue.pop(default_timeout);
+        std::ignore = co_await queue.pop(default_timeout);
+        co_await std::move(will_not_complete);
+    }
 }
 
 TEST(DataQueueTest, TestSizeAndCurrentBytesTracking) {
     data_queue queue(max_bytes, max_count);
-
-    ASSERT_EQ(queue.size(), 0);
-    ASSERT_EQ(queue.current_bytes(), 0);
 
     queue.push(make_data(2, 100), 200).get();
     ASSERT_EQ(queue.size(), 1);
@@ -239,6 +337,143 @@ TEST(DataQueueTest, TestSizeAndCurrentBytesTracking) {
     ASSERT_EQ(queue.current_bytes(), 0);
 }
 
+namespace {
+
+// shove a writer index & counter into a size
+size_t package(uint32_t writer_index, uint32_t counter) {
+    static_assert(sizeof(size_t) == 2 * sizeof(uint32_t));
+    return (static_cast<size_t>(writer_index) << 32u) + counter;
+}
+
+// opposite of package
+auto unpackage(size_t snuck_payload) {
+    static_assert(sizeof(size_t) == 2 * sizeof(uint32_t));
+    uint32_t counter = static_cast<uint32_t>(snuck_payload);
+    uint32_t writer_index = static_cast<uint32_t>(snuck_payload >> 32u);
+    return std::tuple<uint32_t, uint32_t>{writer_index, counter};
+}
+
+} // namespace
+
+// set up multiple writers and single reader on a single queue, check
+// monotonicity of writes
+TEST_CORO(DataQueueTest, TestChaos) {
+    // test constants
+    static constexpr size_t payload_size{128};
+    static constexpr size_t max_bytes = 1028 * 4; // intentional shadow
+    static constexpr std::chrono::duration phase_runtime = 5s;
+    static constexpr size_t number_of_writers{3};
+
+    // the writer information gets snuck into the size of the first partition,
+    // make helpers to package and unpackage
+    static constexpr auto evil_make_data =
+      [](uint32_t writer_index, uint32_t counter) {
+          auto data = make_data(1, random_generators::get_int(max_bytes));
+          data[0].total_bytes = package(writer_index, counter);
+          return data;
+      };
+    static constexpr auto evil_unpack_writer_info =
+      [](const chunked_vector<fetched_topic_data>& data) {
+          return unpackage(data[0].total_bytes);
+      };
+
+    data_queue queue(max_bytes, max_count);
+
+    // event variables for stopping bg fibers
+    bool should_push{true};
+    bool should_pop{true};
+
+    // keep track of the offset of the writers, one for writing the other for
+    // checking
+    std::vector<uint32_t> push_counters(number_of_writers, 0);
+    std::vector<uint32_t> pop_counters(number_of_writers, 0);
+
+    // tweak the delays so the proportion of pops to pushes can be tweaked
+    uint push_delay_multiplier{1};
+    uint pop_delay_multiplier{1};
+
+    // this is fine so long as the lambda itself lives longer than any spawned
+    // execution
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    auto push_fiber = [&](size_t writer_index) -> ss::future<> {
+        while (should_push) {
+            auto data = evil_make_data(
+              writer_index, push_counters[writer_index]++);
+            co_await queue.push(std::move(data), payload_size);
+            co_await ss::sleep(std::chrono::milliseconds(
+              random_generators::get_int(100) * push_delay_multiplier));
+        }
+        co_return;
+    };
+
+    // this is fine so long as the lambda itself lives longer than any spawned
+    // execution
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+    auto pop_fiber = [&] -> ss::future<> {
+        while (should_pop) {
+            std::optional<fetches> maybe_maybe_data{std::nullopt};
+            // the pop may legitimately be starved, longer timeout needed
+            try {
+                maybe_maybe_data = co_await queue.pop(
+                  std::chrono::milliseconds(1000));
+            } catch (ss::timed_out_error) {
+                // time out is fine and expected
+                continue;
+            }
+
+            // optional<result> fiddling
+            vassert(
+              maybe_maybe_data.has_value(),
+              "at this point we should have a return value");
+            auto maybe_data = std::move(maybe_maybe_data).value();
+            vassert(maybe_data.has_value(), "no errors should be written");
+            auto data = std::move(maybe_data).value();
+
+            // unpack and check
+            auto [writer_index, found_counter] = evil_unpack_writer_info(data);
+            vassert(
+              found_counter == pop_counters[writer_index]++,
+              "data from queue out of order");
+
+            // adjust sleep by the number of writers to keep the proportion even
+            // by default
+            co_await ss::sleep(std::chrono::milliseconds(
+              random_generators::get_int(100) * pop_delay_multiplier
+              / number_of_writers));
+        }
+        co_return;
+    };
+
+    // first phase, even push and pop
+    std::vector<ss::future<>> push_fibers{};
+    for (uint i{0}; i < number_of_writers; ++i) {
+        push_fibers.emplace_back(push_fiber(i));
+    }
+
+    auto pop_fiber_task = pop_fiber();
+
+    co_await ss::sleep(phase_runtime);
+
+    // second phase, pop preferenced
+    push_delay_multiplier = 2;
+    pop_delay_multiplier = 1;
+    co_await ss::sleep(phase_runtime);
+
+    // third phase, push preferenced
+    push_delay_multiplier = 1;
+    pop_delay_multiplier = 2;
+    co_await ss::sleep(phase_runtime);
+
+    // shut down
+    should_push = false;
+    for (auto& push_fiber_task : push_fibers) {
+        co_await std::move(push_fiber_task);
+    }
+
+    should_pop = false;
+    co_await std::move(pop_fiber_task);
+}
+
 // check that the queue is fair in that no writer gets starved
 TEST_CORO(DataQueueTest, QueueUnfairness) {
     static constexpr size_t small_size = 128u;
@@ -248,17 +483,18 @@ TEST_CORO(DataQueueTest, QueueUnfairness) {
 
     // drop a small record in the queue
     co_await insert_single_element(queue, small_size);
+    co_await insert_single_element(queue, big_size);
 
     // attempt to push an oversized record, and keep tabs on its successful push
     auto big_push = insert_single_element(queue, big_size);
 
-    co_await tests::drain_task_queue();
     ASSERT_FALSE_CORO(big_push.available());
 
     // start a loop that will continuously put small data on and then take small
     // data off. If the queue were fair, the small data pushes should be blocked
     // until the large data gets a chance to enter the queue
     bool should_keep_contending{true};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     auto contention_lambda = [&should_keep_contending, &queue] -> ss::future<> {
         while (should_keep_contending) {
             co_await ss::yield();

--- a/src/v/kafka/client/direct_consumer/tests/data_queue_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/data_queue_test.cc
@@ -8,14 +8,18 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/client/direct_consumer/data_queue.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <gtest/gtest.h>
 
 using namespace kafka::client;
 
+namespace {
+
 static constexpr size_t max_bytes = 1024;
 static constexpr size_t max_count = 10;
+static constexpr auto default_timeout = 100ms;
 
 chunked_vector<fetched_topic_data>
 make_data(int topic_count, int bytes_per_topic) {
@@ -29,6 +33,12 @@ make_data(int topic_count, int bytes_per_topic) {
     }
     return data;
 }
+
+auto insert_single_element(data_queue& queue, size_t element_size) {
+    return queue.push(make_data(1, element_size), element_size);
+}
+
+} // namespace
 
 TEST(DataQueueTest, TestIfCanInsertWorks) {
     data_queue queue(max_bytes, max_count);
@@ -227,4 +237,63 @@ TEST(DataQueueTest, TestSizeAndCurrentBytesTracking) {
     queue.pop(std::chrono::milliseconds(100)).get();
     ASSERT_EQ(queue.size(), 0);
     ASSERT_EQ(queue.current_bytes(), 0);
+}
+
+// check that the queue is fair in that no writer gets starved
+TEST_CORO(DataQueueTest, QueueUnfairness) {
+    static constexpr size_t small_size = 128u;
+    static constexpr size_t big_size = 2048;
+
+    data_queue queue(max_bytes, max_count);
+
+    // drop a small record in the queue
+    co_await insert_single_element(queue, small_size);
+
+    // attempt to push an oversized record, and keep tabs on its successful push
+    auto big_push = insert_single_element(queue, big_size);
+
+    co_await tests::drain_task_queue();
+    ASSERT_FALSE_CORO(big_push.available());
+
+    // start a loop that will continuously put small data on and then take small
+    // data off. If the queue were fair, the small data pushes should be blocked
+    // until the large data gets a chance to enter the queue
+    bool should_keep_contending{true};
+    auto contention_lambda = [&should_keep_contending, &queue] -> ss::future<> {
+        while (should_keep_contending) {
+            co_await ss::yield();
+            std::ignore = queue.pop(default_timeout)
+                            .discard_result()
+                            .handle_exception_type(
+                              [](ss::timed_out_error) { return ss::now(); })
+                            .handle_exception_type(
+                              [](ss::broken_condition_variable) {
+                                  return ss::now();
+                              });
+            std::ignore = insert_single_element(queue, small_size)
+                            .discard_result()
+                            .handle_exception_type(
+                              [](ss::timed_out_error) { return ss::now(); })
+                            .handle_exception_type(
+                              [](ss::broken_condition_variable) {
+                                  return ss::now();
+                              });
+        }
+        co_return;
+    };
+    auto contention_fiber = contention_lambda();
+
+    // wait to see if big_push completes within a reasonable amount of time
+    try {
+        co_await ss::with_timeout(
+          seastar::lowres_clock::now() + 10s, std::move(big_push));
+    } catch (const ss::timed_out_error& /*ignored*/) {
+        ASSERT_TRUE_CORO(false);
+    }
+
+    // stop the contention fiber, and wait for its termination
+    should_keep_contending = false;
+    co_await std::move(contention_fiber);
+
+    co_await tests::drain_task_queue();
 }


### PR DESCRIPTION
Data queue is intended to bound the memory and number of elements that
can persist in its underlying queue by blocking callers when full.

Data queue does not block fairly though. A large push may be blocked
while small pushes are allowed to bypass the waiter queue and join the
data queue immediately.

In the case of many small pushes 'cutting the line' the waiter queue
will be starved indefinitely.

This pr
1. adds a regression tests which demonstrates queue unfairness in the prior implementation
2. a mask ontop of seastar::condition_variable which disallows the problematic conditional waits
3. the fix to make the queue fair
4. test upgrades
5. a chaos test to catch any other concurrency issue

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
