### PR TITLE
chunked_vector: fix move semantics of the range constructor

### DIFF
--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -115,17 +115,6 @@ public:
     explicit chunked_vector(Range range)
       : chunked_vector(std::ranges::begin(range), std::ranges::end(range)) {}
 
-    /**
-     * @brief Construct a new vector by copying from a const range
-     */
-    template<typename Range>
-    requires(std::ranges::sized_range<Range>)
-    chunked_vector(std::from_range_t, const Range& range)
-      : chunked_vector() {
-        reserve(std::ranges::size(range));
-        std::copy(range.begin(), range.end(), std::back_inserter(*this));
-    }
-
     chunked_vector& operator=(chunked_vector&& other) noexcept {
         if (this != &other) {
             this->_size = other._size;

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -113,10 +113,7 @@ public:
     template<typename Range>
     requires std::ranges::sized_range<Range>
     explicit chunked_vector(Range range)
-      : chunked_vector() {
-        reserve(std::ranges::size(range));
-        std::move(range.begin(), range.end(), std::back_inserter(*this));
-    }
+      : chunked_vector(std::ranges::begin(range), std::ranges::end(range)) {}
 
     /**
      * @brief Construct a new vector by copying from a const range

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <limits>
 #include <numeric>
+#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -556,6 +557,95 @@ TEST(ChunkedVector, FromRange) {
 
     auto vec = chunked_vector<int32_t>(buffer);
     EXPECT_THAT(vec, ElementsAreArray(buffer));
+}
+
+TEST(ChunkedVector, FromRVRefView) {
+    // Test for a regression in which chunked vector would steal/move
+    // the underlying data instead of copying it if given an RV
+    // std::ranges::ref_view.
+
+    struct v { // NOLINT
+        int32_t data;
+
+        v(int32_t v) // NOLINT
+          : data(v) {}
+
+        v(const v& other) = default;
+
+        // Move constructor available but it must not be called.
+        v(v&& other) noexcept
+          : data(other.data) {
+            other.data = -1;
+        }
+
+        bool operator==(const v& other) const = default;
+    };
+
+    std::vector<v> buffer;
+    buffer.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        buffer.emplace_back(i);
+    }
+
+    auto vec = chunked_vector<v>(buffer | std::views::all);
+    EXPECT_THAT(vec, ElementsAreArray(buffer));
+
+    for (const auto& elem : buffer) {
+        EXPECT_NE(elem.data, -1) << "Element should not have been moved";
+    }
+}
+
+TEST(ChunkedVector, FromOwningView) {
+    // Test that moving from an owning view works as expected.
+
+    struct v { // NOLINT
+        int32_t data;
+
+        v(int32_t v) // NOLINT
+          : data(v) {}
+
+        v(v&& other) noexcept
+          : data(other.data) {
+            other.data = -1;
+        }
+
+        // Not deleting to avoid missing the case when implementation does
+        // something surprising based on the presence of the copy-constructor.
+        v(const v&) { // NOLINT
+            throw std::runtime_error("Copying is not allowed");
+        };
+        v& operator=(const v&) { // NOLINT
+            throw std::runtime_error("Copying is not allowed");
+        }
+
+        bool operator==(const v& other) const = default;
+    };
+
+    std::vector<v> source;
+    std::vector<v> ref;
+
+    for (int i = 0; i < 10; ++i) {
+        // Create a source and a reference to which we'll compare the
+        // destination.
+        source.emplace_back(i);
+        ref.emplace_back(i);
+    }
+
+    auto vec = chunked_vector<v>(
+      source | std::views::as_rvalue | std::views::all);
+    EXPECT_EQ(vec.size(), ref.size());
+    EXPECT_EQ(source.size(), vec.size())
+      << "Only the values should have been moved but not the container itself.";
+
+    // Values should match.
+    for (auto i = 0; i < 10; ++i) {
+        EXPECT_EQ(ref[i].data, vec[i].data);
+    }
+
+    // Source values are set to 0.
+    for (auto i = 0; i < 10; ++i) {
+        EXPECT_EQ(source[i].data, -1);
+    }
 }
 
 TEST(ChunkedVector, InPlaceSingleElement) {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1817,7 +1817,6 @@ ss::future<std::error_code> group_manager::empty_and_delete_groups(
     });
 
     chunked_vector<std::pair<model::ntp, group_id>> groups_with_ntps{
-      std::from_range,
       groups | std::views::transform([&ntp](const group_id& group_id) {
           return std::make_pair(ntp, group_id);
       })};

--- a/src/v/kafka/server/group_tx_tracker_stm.cc
+++ b/src/v/kafka/server/group_tx_tracker_stm.cc
@@ -151,7 +151,7 @@ group_tx_tracker_stm::take_local_snapshot(ssx::semaphore_units apply_units) {
     auto offset = last_applied_offset();
     snapshot snap{
       .transactions{_all_txs},
-      .blocked_groups{std::from_range, _blocked_groups},
+      .blocked_groups{_blocked_groups},
     };
     apply_units.return_all();
     iobuf snap_buf;


### PR DESCRIPTION
This PR introduces two main changes to the `chunked_vector` container and its overloads.

The first commit addresses an issue with the range-based constructor for `chunked_vector`. Previously, the constructor was implemented by moving from the range's iterators, which led to incorrect behavior with rvalue `ref_view`s where the underlying data was moved instead of copied. This has been fixed by refactoring the range constructor to delegate to the iterator-pair constructor, which correctly handles the value category of the elements. Two new tests have been added to verify this fix and ensure that constructing from an owning view correctly moves the elements.

The second commit removes a tautological overload for the range constructor. There is no need to have multiple range constructors, as the value category of the source is encoded in the type of the constructor argument rather than in the tagged dispatch.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
