### PR TITLE
pbgen: make protos formattable

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -150,6 +150,11 @@ func (b *codewriter) Reset() {
 
 // ----------------------------------------------------------
 
+func isDebugRedacted(f protoreflect.FieldDescriptor) bool {
+	opts := f.Options().(*descriptorpb.FieldOptions)
+	return opts.GetDebugRedact()
+}
+
 func isPtr(f protoreflect.FieldDescriptor) bool {
 	opts := f.Options().(*descriptorpb.FieldOptions)
 	if opts == nil {
@@ -322,6 +327,7 @@ func (g *headerGenerator) generateFile(w *codewriter) {
 		w.PreludePrintln()
 		w.PreludePrintln(`#pragma once`)
 		w.PreludePrintln()
+		w.PreludePrintln(`#include "base/format_to.h"`)
 		w.PreludePrintln(`#include "bytes/iobuf.h"`)
 		if g.needsChunkedHashMap {
 			w.PreludePrintln(`#include "container/chunked_hash_map.h"`)
@@ -448,6 +454,8 @@ func (g *headerGenerator) generateEnumSerde(msg protoreflect.EnumDescriptor, w *
 	w.Println("// Returns the name of the enum value")
 	w.Printf("std::string_view enum_to_string(const %s&);\n", cppName)
 	w.Printf("void enum_from_json(serde::pb::json::peekable_parser*, %s*);\n", cppName)
+	// TODO: When we've upgraded to libfmt 11 we can change this to return std::string_view
+	w.Printf("int32_t format_as(%s);\n", cppName)
 }
 
 func (g *headerGenerator) generateEnum(enum protoreflect.EnumDescriptor, w *codewriter) {
@@ -496,7 +504,8 @@ func (g *headerGenerator) generateMessage(msg protoreflect.MessageDescriptor, w 
 	w.Printf("%s& operator=(%s&&) noexcept;\n", typeName, typeName)
 	w.Printf("~%s() noexcept;\n", typeName)
 	w.Println()
-	w.Printf("bool operator==(const %s&) const;", typeName)
+	w.Printf("bool operator==(const %s&) const;\n", typeName)
+	w.Println("fmt::iterator format_to(fmt::iterator) const;")
 	w.Println()
 	w.Printf("// Serializes %s into a protocol buffer, in a way that will not cause stalls for large messages.\n", msg.FullName())
 	w.Println("seastar::future<iobuf> to_proto() const;")
@@ -607,6 +616,7 @@ func (g *implGenerator) generateFile(w *codewriter) {
 		w.PreludePrintln(`#include "serde/protobuf/json.h"`)
 		w.PreludePrintln(`#include "serde/json/writer.h"`)
 		w.PreludePrintln(`#include "serde/json/parser.h"`)
+		w.PreludePrintln(`#include "utils/to_string.h"`)
 		if g.needsRpcs {
 			w.PreludePrintln(`#include "bytes/iostream.h"`)
 			w.PreludePrintln(`#include "base/units.h"`)
@@ -638,6 +648,7 @@ func (g *implGenerator) generateFile(w *codewriter) {
 		g.generateEnumWrite(enum, w)
 		g.generateEnumToString(enum, w)
 		g.generateEnumFromJson(enum, w)
+		w.Printf("int32_t format_as(%s e) { return std::to_underlying(e); }\n", cppTypeName(enum))
 		w.Println()
 	}
 	for i := range g.file.Services().Len() {
@@ -1609,41 +1620,81 @@ func (g *implGenerator) generateMessageReadHelper(msg protoreflect.MessageDescri
 }
 
 func (g *implGenerator) generateMessage(msg protoreflect.MessageDescriptor, w *codewriter) {
-	typeName := cppTypeName(msg)
-	w.Printf("%s::%s() noexcept = default;\n", typeName, typeName)
-	w.Printf("%s::%s(%s&&) noexcept = default;\n", typeName, typeName, typeName)
-	w.Printf("%s& %s::operator=(%s&&) noexcept = default;\n", typeName, typeName, typeName)
-	w.Printf("%s::~%s() noexcept = default;\n", typeName, typeName)
-	w.Printf("bool %s::operator==(const %s&) const = default;\n", typeName, typeName)
+	parentType := cppTypeName(msg)
+	w.Printf("%s::%s() noexcept = default;\n", parentType, parentType)
+	w.Printf("%s::%s(%s&&) noexcept = default;\n", parentType, parentType, parentType)
+	w.Printf("%s& %s::operator=(%s&&) noexcept = default;\n", parentType, parentType, parentType)
+	w.Printf("%s::~%s() noexcept = default;\n", parentType, parentType)
+	w.Printf("bool %s::operator==(const %s&) const = default;\n", parentType, parentType)
+	type FmtField struct {
+		displayName string
+		argValue    string
+	}
+	fmtFields := []FmtField{}
 	oneofs := map[protoreflect.Name]bool{}
 	for i := range msg.Fields().Len() {
 		field := msg.Fields().Get(i)
-		typ, trivial := g.translateType(field)
+		fieldType, trivial := g.translateType(field)
 		if oneof := field.ContainingOneof(); oneof != nil {
 			if !oneofs[oneof.Name()] {
 				oneofs[oneof.Name()] = true
+				fmtFields = append(fmtFields, FmtField{
+					displayName: string(oneof.Name()),
+					argValue:    fmt.Sprintf("%s_", oneof.Name()),
+				})
 			}
 			idx := getOneofFieldVariantIndex(oneof, field)
-			w.Printf("bool %s::has_%s() const { return %s_.index() == %d; }\n", typeName, field.Name(), oneof.Name(), idx)
+			w.Printf("bool %s::has_%s() const { return %s_.index() == %d; }\n", parentType, field.Name(), oneof.Name(), idx)
 			if trivial {
-				w.Printf("%s %s::get_%s() const { return std::get<%d>(%s_); }\n", typ, typeName, field.Name(), idx, oneof.Name())
-				w.Printf("void %s::set_%s(%s v) { %s_.emplace<%d>(v); }\n", typeName, field.Name(), typ, oneof.Name(), idx)
+				w.Printf("%s %s::get_%s() const { return std::get<%d>(%s_); }\n", fieldType, parentType, field.Name(), idx, oneof.Name())
+				w.Printf("void %s::set_%s(%s v) { %s_.emplace<%d>(v); }\n", parentType, field.Name(), fieldType, oneof.Name(), idx)
 			} else {
-				w.Printf("%s& %s::get_%s() { return std::get<%d>(%s_); }\n", typ, typeName, field.Name(), idx, oneof.Name())
-				w.Printf("const %s& %s::get_%s() const { return std::get<%d>(%s_); }\n", typ, typeName, field.Name(), idx, oneof.Name())
-				w.Printf("void %s::set_%s(%s&& v) { %s_.emplace<%d>(std::move(v)); }\n", typeName, field.Name(), typ, oneof.Name(), idx)
+				w.Printf("%s& %s::get_%s() { return std::get<%d>(%s_); }\n", fieldType, parentType, field.Name(), idx, oneof.Name())
+				w.Printf("const %s& %s::get_%s() const { return std::get<%d>(%s_); }\n", fieldType, parentType, field.Name(), idx, oneof.Name())
+				w.Printf("void %s::set_%s(%s&& v) { %s_.emplace<%d>(std::move(v)); }\n", parentType, field.Name(), fieldType, oneof.Name(), idx)
 			}
 		} else {
+			argValue := fmt.Sprintf("%s_", field.Name())
+			if isDebugRedacted(field) {
+				argValue = `"<redacted>"`
+			}
+			fmtFields = append(fmtFields, FmtField{
+				displayName: string(field.Name()),
+				argValue:    argValue,
+			})
 			if trivial {
-				w.Printf("%s %s::get_%s() const { return %s_; }\n", typ, typeName, field.Name(), field.Name())
-				w.Printf("void %s::set_%s(%s v) { %s_ = v; }\n", typeName, field.Name(), typ, field.Name())
+				w.Printf("%s %s::get_%s() const { return %s_; }\n", fieldType, parentType, field.Name(), field.Name())
+				w.Printf("void %s::set_%s(%s v) { %s_ = v; }\n", parentType, field.Name(), fieldType, field.Name())
 			} else {
-				w.Printf("%s& %s::get_%s() { return %s_; }\n", typ, typeName, field.Name(), field.Name())
-				w.Printf("const %s& %s::get_%s() const { return %s_; }\n", typ, typeName, field.Name(), field.Name())
-				w.Printf("void %s::set_%s(%s&& v) { %s_ = std::move(v); }\n", typeName, field.Name(), typ, field.Name())
+				w.Printf("%s& %s::get_%s() { return %s_; }\n", fieldType, parentType, field.Name(), field.Name())
+				w.Printf("const %s& %s::get_%s() const { return %s_; }\n", fieldType, parentType, field.Name(), field.Name())
+				w.Printf("void %s::set_%s(%s&& v) { %s_ = std::move(v); }\n", parentType, field.Name(), fieldType, field.Name())
 			}
 		}
 	}
+	w.Printf("fmt::iterator %s::format_to(fmt::iterator it) const {\n", parentType)
+	defer w.Println("}")
+	w.Indent()
+	defer w.Dedent()
+	var fmtSpec strings.Builder
+	var fmtArgs strings.Builder
+	fmtSpec.WriteString("{{")
+	for i, f := range fmtFields {
+		if i > 0 {
+			fmtSpec.WriteString(", ")
+			fmtArgs.WriteString(", ")
+		}
+		fmtSpec.WriteString(f.displayName)
+		fmtSpec.WriteString(": {}")
+		fmtArgs.WriteString(f.argValue)
+	}
+	fmtSpec.WriteString("}}")
+	if len(fmtFields) == 0 {
+		w.Printf("return fmt::format_to(it, %q);\n", fmtSpec.String())
+	} else {
+		w.Printf("return fmt::format_to(it, %q, %s);\n", fmtSpec.String(), fmtArgs.String())
+	}
+
 }
 
 func (g *implGenerator) generateMessageRead(msg protoreflect.MessageDescriptor, w *codewriter) {

--- a/bazel/pbgen/pbgen.bzl
+++ b/bazel/pbgen/pbgen.bzl
@@ -249,11 +249,12 @@ def redpanda_proto_library(name, protos, deps = [], **kwargs):
             "//src/v/serde/json:writer",
             "//src/v/serde/json:parser",
             "//src/v/bytes:iostream",
-            "//src/v/base",
+            "//src/v/utils:to_string",
             "//src/v/bytes:iobuf_parser",
             "@fmt",
         ],
         deps = [
+            "//src/v/base",
             "//src/v/bytes:iobuf",
             "//src/v/serde/protobuf:rpc",
             "//src/v/container:chunked_hash_map",

--- a/proto/redpanda/README.md
+++ b/proto/redpanda/README.md
@@ -34,13 +34,34 @@ option (redpanda.pbgen.cpp_namespace) = "proto::your_namespace";
 // Your message and service definitions
 ```
 
+### Well-Known Protobufs
+
+There are a number of [Well Known](https://protobuf.dev/reference/protobuf/google.protobuf/) Protobuf types we support. At the moment that is:
+
+- [`google.protobuf.Duration`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/duration.proto)
+- [`google.protobuf.Timestamp`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/timestamp.proto)
+- [`google.protobuf.FieldMask`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/field_mask.proto)
+
 ### Required Imports and Options
 
 1. **Always import the options file**: `import "proto/redpanda/pbgen/options.proto";`
 
 2. **Set the C++ namespace**: Use `option (redpanda.pbgen.cpp_namespace) = "proto::your_namespace";` to control the generated C++ namespace.
 
-### Custom Field Options
+### Supported Field Options
+
+We support the following built in field options in our C++ code generator:
+
+#### `redact_debug` Option
+
+For sensitive values we don't want to be logged in our `fmt::formatter` for the protos,
+the following annotation can be added to fields:
+
+```proto
+message SuperDuperSecret {
+    string value = 1 [debug_redact = true];
+}
+```
 
 Redpanda provides several custom field options for C++ code generation:
 
@@ -70,14 +91,12 @@ When defining RPC services, you must import the RPC options and specify authenti
 
 ```proto
 import "proto/redpanda/pbgen/rpc.proto";
-import "proto/redpanda/core/version.proto";
 
 service YourService {
     rpc YourMethod(YourRequest) returns (YourResponse) {
         option (redpanda.pbgen.rpc) = {
-            version: V25_2_0,              // Required: Redpanda version when added
             authz: SUPERUSER,              // Required: Authorization level
-            http_route: "/api/v1/your-endpoint";  // Optional: Custom HTTP route
+            http_route: "/your-endpoint";  // Optional: Custom HTTP route
         };
     }
 }
@@ -91,21 +110,6 @@ service YourService {
 - `LEVEL_UNSPECIFIED`: Should not be used
 
 **Note**: APIs should default to `SUPERUSER`. Consult the Redpanda core team before using other authentication levels for admin APIs.
-
-### Version Management
-
-All RPC methods must specify the Redpanda version when they were added using the `redpanda.core.Version` enum:
-
-```proto
-import "proto/redpanda/core/version.proto";
-
-option (redpanda.pbgen.rpc) = {
-    version: V25_2_0,  // Version when this RPC was added
-    // ...
-};
-```
-
-Add new versions to `proto/redpanda/core/version.proto` as needed.
 
 ### Message Design Guidelines
 
@@ -125,7 +129,6 @@ package redpanda.example.api;
 
 import "proto/redpanda/pbgen/options.proto";
 import "proto/redpanda/pbgen/rpc.proto";
-import "proto/redpanda/core/version.proto";
 
 option (redpanda.pbgen.cpp_namespace) = "proto::example";
 
@@ -141,9 +144,8 @@ message GetConfigResponse {
 service ConfigService {
     rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {
         option (redpanda.pbgen.rpc) = {
-            version: V25_2_0,
-            authn: USER,
-            http_route: "/v2/config";
+            authn: SUPERUSER,
+            http_route: "/config";
         };
     }
 }

--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -22,6 +22,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "@fmt",
     ],
 )
 

--- a/src/v/container/chunked_hash_map.h
+++ b/src/v/container/chunked_hash_map.h
@@ -14,6 +14,7 @@
 #include "container/chunked_vector.h"
 
 #include <ankerl/unordered_dense.h>
+#include <fmt/format.h>
 
 #include <type_traits>
 
@@ -105,6 +106,30 @@ std::ostream& operator<<(std::ostream& o, const chunked_hash_map<K, V>& r) {
     o << "}";
     return o;
 }
+template<typename K, typename V>
+struct fmt::formatter<chunked_hash_map<K, V>> {
+    using type = chunked_hash_map<K, V>;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& map, FormatContext& ctx) const {
+        // Map formatting is broken until version 11:
+        // https://github.com/fmtlib/fmt/issues/3685
+        auto out = ctx.out();
+        out = fmt::format_to(out, "[");
+        auto it = map.begin();
+        if (it != map.end()) {
+            out = fmt::format_to(out, "{{{} -> {}}}", it->first, it->second);
+            for (++it; it != map.end(); ++it) {
+                out = fmt::format_to(
+                  out, ", {{{} -> {}}}", it->first, it->second);
+            }
+        }
+        return fmt::format_to(out, "]");
+    }
+};
 
 /// Returns a lower bound on the memory currently being held by `m`.
 template<

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -13,6 +13,9 @@
 #include "base/seastar_fwd.h"
 #include "base/vassert.h"
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include <bit>
 #include <cstddef>
 #include <initializer_list>
@@ -490,12 +493,9 @@ public:
         return v;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const chunked_vector& v) {
-        os << "[";
-        for (auto& e : v) {
-            os << e << ",";
-        }
-        os << "]";
+    friend std::ostream&
+    operator<<(std::ostream& os, const chunked_vector<T>& v) {
+        fmt::print(os, "[{}]", fmt::join(v, ","));
         return os;
     }
 

--- a/src/v/serde/protobuf/BUILD
+++ b/src/v/serde/protobuf/BUILD
@@ -108,12 +108,12 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "field_mask",
-    hdrs = [
-        "field_mask.h",
-    ],
+    srcs = ["field_mask.cc"],
+    hdrs = ["field_mask.h"],
     include_prefix = "serde/protobuf",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/base",
         "//src/v/container:chunked_vector",
         "@seastar",
     ],

--- a/src/v/serde/protobuf/field_mask.cc
+++ b/src/v/serde/protobuf/field_mask.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/protobuf/field_mask.h"
+
+namespace serde::pb {
+
+fmt::iterator field_mask::format_to(fmt::iterator it) const {
+    return fmt::format_to(it, "{{paths: {}}}", paths);
+}
+
+} // namespace serde::pb

--- a/src/v/serde/protobuf/field_mask.h
+++ b/src/v/serde/protobuf/field_mask.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "base/seastarx.h"
 #include "container/chunked_vector.h"
 
@@ -32,6 +33,7 @@ struct field_mask {
     chunked_vector<ss::sstring> paths;
 
     bool operator==(const field_mask& other) const = default;
+    fmt::iterator format_to(fmt::iterator it) const;
 };
 
 } // namespace serde::pb

--- a/src/v/serde/protobuf/tests/codegen_test.proto
+++ b/src/v/serde/protobuf/tests/codegen_test.proto
@@ -49,6 +49,10 @@ message B {
 
 message C {}
 
+message SuperDuperSecret {
+    string value = 1 [debug_redact = true];
+}
+
 message WellKnownProtos {
     google.protobuf.Duration single_duration = 1;
     repeated google.protobuf.Duration repeated_duration = 2;

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -10,6 +10,7 @@
 #include "serde/protobuf/json.h"
 #include "serde/json/writer.h"
 #include "serde/json/parser.h"
+#include "utils/to_string.h"
 
 #include <algorithm>
 #include <fmt/format.h>
@@ -25,6 +26,9 @@ bool a::operator==(const a&) const = default;
 c& a::get_c() { return c_; }
 const c& a::get_c() const { return c_; }
 void a::set_c(c&& v) { c_ = std::move(v); }
+fmt::iterator a::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{c: {}}}", c_);
+}
 seastar::future<> a::from_proto(serde::pb::wire_format_parser* parser, a* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -116,6 +120,9 @@ void b::set_c(c&& v) { c_ = std::move(v); }
 a& b::get_a() { return a_; }
 const a& b::get_a() const { return a_; }
 void b::set_a(a&& v) { a_ = std::move(v); }
+fmt::iterator b::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{c: {}, a: {}}}", c_, a_);
+}
 seastar::future<> b::from_proto(serde::pb::wire_format_parser* parser, b* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -228,6 +235,9 @@ c::c(c&&) noexcept = default;
 c& c::operator=(c&&) noexcept = default;
 c::~c() noexcept = default;
 bool c::operator==(const c&) const = default;
+fmt::iterator c::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{}}");
+}
 seastar::future<> c::from_proto(serde::pb::wire_format_parser* parser, c* self) {
   std::ignore = self;
   while (parser->bytes_left() > 0) {
@@ -282,6 +292,86 @@ seastar::future<c> c::from_json(iobuf data) {
   co_return self;
 }
 
+super_duper_secret::super_duper_secret() noexcept = default;
+super_duper_secret::super_duper_secret(super_duper_secret&&) noexcept = default;
+super_duper_secret& super_duper_secret::operator=(super_duper_secret&&) noexcept = default;
+super_duper_secret::~super_duper_secret() noexcept = default;
+bool super_duper_secret::operator==(const super_duper_secret&) const = default;
+ss::sstring& super_duper_secret::get_value() { return value_; }
+const ss::sstring& super_duper_secret::get_value() const { return value_; }
+void super_duper_secret::set_value(ss::sstring&& v) { value_ = std::move(v); }
+fmt::iterator super_duper_secret::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{value: {}}}", "<redacted>");
+}
+seastar::future<> super_duper_secret::from_proto(serde::pb::wire_format_parser* parser, super_duper_secret* self) {
+  while (parser->bytes_left() > 0) {
+    auto tag = parser->read_tag();
+    switch (tag.field_number) {
+    case 1: { // value
+      self->set_value(parser->read_string<"example.SuperDuperSecret.value">(tag));
+      break;
+    }
+    default:
+      parser->skip_unknown(tag);
+      break;
+    }
+  }
+  co_return;
+}
+seastar::future<super_duper_secret> super_duper_secret::from_proto(iobuf buf) {
+  super_duper_secret self;
+  serde::pb::wire_format_parser parser{std::move(buf)};
+  co_await from_proto(&parser, &self);
+  parser.check_empty();
+  co_return self;
+}
+seastar::future<iobuf> super_duper_secret::to_proto() const {
+  iobuf buf;
+  // value
+  serde::pb::tag::write({.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
+  serde::pb::write_length(static_cast<int32_t>(get_value().size()), &buf);
+  buf.append(get_value().data(), get_value().size());
+  co_return buf;
+}
+seastar::future<iobuf> super_duper_secret::to_json() const {
+  serde::json::writer w;
+  w.begin_object();
+  w.key("value");
+  w.string(get_value());
+  w.end_object();
+  co_return std::move(w).finish();
+}
+seastar::future<> super_duper_secret::from_json(serde::pb::json::peekable_parser* parser, super_duper_secret* self) {
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, int32_t>>({
+    {"value", 1},
+  });
+  auto entries = serde::pb::json::object_key_generator(parser);
+  while (auto key = co_await entries()) {
+    auto fields = std::ranges::equal_range(key_to_field_number, *key, std::less<>(), [](const auto& pair) { return pair.first; });
+    if (fields.empty()) {
+      co_await parser->skip_value();
+      continue;
+    }
+    switch (fields.front().second) {
+    case 1: { // value
+      co_await parser->next();
+      self->set_value(serde::pb::json::read_string(parser));
+      break;
+    }
+    default:
+      vassert(false, "codegen error unexpected field number: {}", fields.front().second);
+    }
+  }
+  co_return;
+}
+seastar::future<super_duper_secret> super_duper_secret::from_json(iobuf data) {
+  super_duper_secret self;
+  serde::pb::json::peekable_parser parser(std::move(data));
+  co_await from_json(&parser, &self);
+  co_await serde::pb::json::check_next_eof(&parser);
+  co_return self;
+}
+
 well_known_protos::well_known_protos() noexcept = default;
 well_known_protos::well_known_protos(well_known_protos&&) noexcept = default;
 well_known_protos& well_known_protos::operator=(well_known_protos&&) noexcept = default;
@@ -314,6 +404,9 @@ void well_known_protos::set_repeated_timestamp(chunked_vector<absl::Time>&& v) {
 chunked_hash_map<ss::sstring, absl::Time>& well_known_protos::get_timestamp_map() { return timestamp_map_; }
 const chunked_hash_map<ss::sstring, absl::Time>& well_known_protos::get_timestamp_map() const { return timestamp_map_; }
 void well_known_protos::set_timestamp_map(chunked_hash_map<ss::sstring, absl::Time>&& v) { timestamp_map_ = std::move(v); }
+fmt::iterator well_known_protos::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{single_duration: {}, repeated_duration: {}, duration_map: {}, single_field_mask: {}, repeated_field_mask: {}, field_mask_map: {}, single_timestamp: {}, repeated_timestamp: {}, timestamp_map: {}}}", single_duration_, repeated_duration_, duration_map_, single_field_mask_, repeated_field_mask_, field_mask_map_, single_timestamp_, repeated_timestamp_, timestamp_map_);
+}
 seastar::future<> well_known_protos::from_proto(serde::pb::wire_format_parser* parser, well_known_protos* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -882,6 +975,7 @@ void enum_from_json(serde::pb::json::peekable_parser* p, corpus* e) {
     throw std::runtime_error(fmt::format("unexpected json token for enum, got: {}", p->token()));
   }
 }
+int32_t format_as(corpus e) { return std::to_underlying(e); }
 
 void enum_from_proto(iobuf_parser* p, protobuf3_test* e) {
   auto v = serde::pb::read_varint<int32_t, serde::pb::zigzag::no>(p);
@@ -947,6 +1041,7 @@ void enum_from_json(serde::pb::json::peekable_parser* p, protobuf3_test* e) {
     throw std::runtime_error(fmt::format("unexpected json token for enum, got: {}", p->token()));
   }
 }
+int32_t format_as(protobuf3_test e) { return std::to_underlying(e); }
 
 void enum_from_proto(iobuf_parser* p, proto3_test* e) {
   auto v = serde::pb::read_varint<int32_t, serde::pb::zigzag::no>(p);
@@ -1011,6 +1106,7 @@ void enum_from_json(serde::pb::json::peekable_parser* p, proto3_test* e) {
     throw std::runtime_error(fmt::format("unexpected json token for enum, got: {}", p->token()));
   }
 }
+int32_t format_as(proto3_test e) { return std::to_underlying(e); }
 
 } // proto::example
 // NOLINTEND(*-avoid-magic-numbers)

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
@@ -26,6 +27,7 @@ namespace proto::example {
 class a;
 class b;
 class c;
+class super_duper_secret;
 class well_known_protos;
 
 // Test that enums that have prefixes in their values as recommended by protobuf
@@ -47,6 +49,7 @@ void enum_from_proto(iobuf_parser*, corpus*);
 // Returns the name of the enum value
 std::string_view enum_to_string(const corpus&);
 void enum_from_json(serde::pb::json::peekable_parser*, corpus*);
+int32_t format_as(corpus);
 
 enum class protobuf3_test : uint8_t {
   unspecified = 0,
@@ -59,6 +62,7 @@ void enum_from_proto(iobuf_parser*, protobuf3_test*);
 // Returns the name of the enum value
 std::string_view enum_to_string(const protobuf3_test&);
 void enum_from_json(serde::pb::json::peekable_parser*, protobuf3_test*);
+int32_t format_as(protobuf3_test);
 
 enum class proto3_test : uint8_t {
   unspecified = 0,
@@ -70,6 +74,7 @@ void enum_from_proto(iobuf_parser*, proto3_test*);
 // Returns the name of the enum value
 std::string_view enum_to_string(const proto3_test&);
 void enum_from_json(serde::pb::json::peekable_parser*, proto3_test*);
+int32_t format_as(proto3_test);
 
 class c {
 public:
@@ -80,7 +85,9 @@ public:
   c& operator=(c&&) noexcept;
   ~c() noexcept;
   
-  bool operator==(const c&) const;  
+  bool operator==(const c&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes example.C into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.C into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -109,7 +116,9 @@ public:
   a& operator=(a&&) noexcept;
   ~a() noexcept;
   
-  bool operator==(const a&) const;  
+  bool operator==(const a&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes example.A into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.A into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -142,7 +151,9 @@ public:
   b& operator=(b&&) noexcept;
   ~b() noexcept;
   
-  bool operator==(const b&) const;  
+  bool operator==(const b&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes example.B into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.B into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -170,6 +181,41 @@ private:
   a a_;
 };
 
+class super_duper_secret {
+public:
+  super_duper_secret() noexcept;
+  super_duper_secret(const super_duper_secret&) = delete;
+  super_duper_secret& operator=(const super_duper_secret&) = delete;
+  super_duper_secret(super_duper_secret&&) noexcept;
+  super_duper_secret& operator=(super_duper_secret&&) noexcept;
+  ~super_duper_secret() noexcept;
+  
+  bool operator==(const super_duper_secret&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
+  // Serializes example.SuperDuperSecret into a protocol buffer, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_proto() const;
+  // Serializes example.SuperDuperSecret into proto3 JSON, in a way that will not cause stalls for large messages.
+  seastar::future<iobuf> to_json() const;
+  // Deserializes example.SuperDuperSecret from a protocol buffer, in a way that will not cause stalls for large messages.
+  static seastar::future<super_duper_secret> from_proto(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_proto(serde::pb::wire_format_parser*, super_duper_secret*);
+  // Deserializes example.SuperDuperSecret from json, in a way that will not cause stalls for large messages.
+  static seastar::future<super_duper_secret> from_json(iobuf);
+  // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
+  // Use the iobuf version instead.
+  static seastar::future<> from_json(serde::pb::json::peekable_parser*, super_duper_secret*);
+  
+  ss::sstring& get_value();
+  const ss::sstring& get_value() const;
+  void set_value(ss::sstring&& v);
+
+private:
+  ss::sstring value_;
+};
+
 class well_known_protos {
 public:
   well_known_protos() noexcept;
@@ -179,7 +225,9 @@ public:
   well_known_protos& operator=(well_known_protos&&) noexcept;
   ~well_known_protos() noexcept;
   
-  bool operator==(const well_known_protos&) const;  
+  bool operator==(const well_known_protos&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes example.WellKnownProtos into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.WellKnownProtos into proto3 JSON, in a way that will not cause stalls for large messages.

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
@@ -10,6 +10,7 @@
 #include "serde/protobuf/json.h"
 #include "serde/json/writer.h"
 #include "serde/json/parser.h"
+#include "utils/to_string.h"
 
 #include <algorithm>
 #include <fmt/format.h>
@@ -27,6 +28,9 @@ void test_all_types_edition2023_nested_message::set_a(int32_t v) { a_ = v; }
 std::unique_ptr<test_all_types_edition2023>& test_all_types_edition2023_nested_message::get_corecursive() { return corecursive_; }
 const std::unique_ptr<test_all_types_edition2023>& test_all_types_edition2023_nested_message::get_corecursive() const { return corecursive_; }
 void test_all_types_edition2023_nested_message::set_corecursive(std::unique_ptr<test_all_types_edition2023>&& v) { corecursive_ = std::move(v); }
+fmt::iterator test_all_types_edition2023_nested_message::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{a: {}, corecursive: {}}}", a_, corecursive_);
+}
 seastar::future<> test_all_types_edition2023_nested_message::from_proto(serde::pb::wire_format_parser* parser, test_all_types_edition2023_nested_message* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -137,6 +141,9 @@ int32_t test_all_types_edition2023_group_like_type::get_group_int32() const { re
 void test_all_types_edition2023_group_like_type::set_group_int32(int32_t v) { group_int32_ = v; }
 uint32_t test_all_types_edition2023_group_like_type::get_group_uint32() const { return group_uint32_; }
 void test_all_types_edition2023_group_like_type::set_group_uint32(uint32_t v) { group_uint32_ = v; }
+fmt::iterator test_all_types_edition2023_group_like_type::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{group_int32: {}, group_uint32: {}}}", group_int32_, group_uint32_);
+}
 seastar::future<> test_all_types_edition2023_group_like_type::from_proto(serde::pb::wire_format_parser* parser, test_all_types_edition2023_group_like_type* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -518,6 +525,9 @@ void test_all_types_edition2023::set_groupliketype(test_all_types_edition2023_gr
 test_all_types_edition2023_group_like_type& test_all_types_edition2023::get_delimited_field() { return delimited_field_; }
 const test_all_types_edition2023_group_like_type& test_all_types_edition2023::get_delimited_field() const { return delimited_field_; }
 void test_all_types_edition2023::set_delimited_field(test_all_types_edition2023_group_like_type&& v) { delimited_field_ = std::move(v); }
+fmt::iterator test_all_types_edition2023::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{optional_int32: {}, optional_int64: {}, optional_uint32: {}, optional_uint64: {}, optional_sint32: {}, optional_sint64: {}, optional_fixed32: {}, optional_fixed64: {}, optional_sfixed32: {}, optional_sfixed64: {}, optional_float: {}, optional_double: {}, optional_bool: {}, optional_string: {}, optional_bytes: {}, optional_nested_message: {}, optional_foreign_message: {}, optional_nested_enum: {}, optional_foreign_enum: {}, optional_string_piece: {}, optional_cord: {}, recursive_message: {}, repeated_int32: {}, repeated_int64: {}, repeated_uint32: {}, repeated_uint64: {}, repeated_sint32: {}, repeated_sint64: {}, repeated_fixed32: {}, repeated_fixed64: {}, repeated_sfixed32: {}, repeated_sfixed64: {}, repeated_float: {}, repeated_double: {}, repeated_bool: {}, repeated_string: {}, repeated_bytes: {}, repeated_nested_message: {}, repeated_foreign_message: {}, repeated_nested_enum: {}, repeated_foreign_enum: {}, repeated_string_piece: {}, repeated_cord: {}, packed_int32: {}, packed_int64: {}, packed_uint32: {}, packed_uint64: {}, packed_sint32: {}, packed_sint64: {}, packed_fixed32: {}, packed_fixed64: {}, packed_sfixed32: {}, packed_sfixed64: {}, packed_float: {}, packed_double: {}, packed_bool: {}, packed_nested_enum: {}, unpacked_int32: {}, unpacked_int64: {}, unpacked_uint32: {}, unpacked_uint64: {}, unpacked_sint32: {}, unpacked_sint64: {}, unpacked_fixed32: {}, unpacked_fixed64: {}, unpacked_sfixed32: {}, unpacked_sfixed64: {}, unpacked_float: {}, unpacked_double: {}, unpacked_bool: {}, unpacked_nested_enum: {}, map_int32_int32: {}, map_int64_int64: {}, map_uint32_uint32: {}, map_uint64_uint64: {}, map_sint32_sint32: {}, map_sint64_sint64: {}, map_fixed32_fixed32: {}, map_fixed64_fixed64: {}, map_sfixed32_sfixed32: {}, map_sfixed64_sfixed64: {}, map_int32_float: {}, map_int32_double: {}, map_bool_bool: {}, map_string_string: {}, map_string_bytes: {}, map_string_nested_message: {}, map_string_foreign_message: {}, map_string_nested_enum: {}, map_string_foreign_enum: {}, oneof_field: {}, groupliketype: {}, delimited_field: {}}}", optional_int32_, optional_int64_, optional_uint32_, optional_uint64_, optional_sint32_, optional_sint64_, optional_fixed32_, optional_fixed64_, optional_sfixed32_, optional_sfixed64_, optional_float_, optional_double_, optional_bool_, optional_string_, optional_bytes_, optional_nested_message_, optional_foreign_message_, optional_nested_enum_, optional_foreign_enum_, optional_string_piece_, optional_cord_, recursive_message_, repeated_int32_, repeated_int64_, repeated_uint32_, repeated_uint64_, repeated_sint32_, repeated_sint64_, repeated_fixed32_, repeated_fixed64_, repeated_sfixed32_, repeated_sfixed64_, repeated_float_, repeated_double_, repeated_bool_, repeated_string_, repeated_bytes_, repeated_nested_message_, repeated_foreign_message_, repeated_nested_enum_, repeated_foreign_enum_, repeated_string_piece_, repeated_cord_, packed_int32_, packed_int64_, packed_uint32_, packed_uint64_, packed_sint32_, packed_sint64_, packed_fixed32_, packed_fixed64_, packed_sfixed32_, packed_sfixed64_, packed_float_, packed_double_, packed_bool_, packed_nested_enum_, unpacked_int32_, unpacked_int64_, unpacked_uint32_, unpacked_uint64_, unpacked_sint32_, unpacked_sint64_, unpacked_fixed32_, unpacked_fixed64_, unpacked_sfixed32_, unpacked_sfixed64_, unpacked_float_, unpacked_double_, unpacked_bool_, unpacked_nested_enum_, map_int32_int32_, map_int64_int64_, map_uint32_uint32_, map_uint64_uint64_, map_sint32_sint32_, map_sint64_sint64_, map_fixed32_fixed32_, map_fixed64_fixed64_, map_sfixed32_sfixed32_, map_sfixed64_sfixed64_, map_int32_float_, map_int32_double_, map_bool_bool_, map_string_string_, map_string_bytes_, map_string_nested_message_, map_string_foreign_message_, map_string_nested_enum_, map_string_foreign_enum_, oneof_field_, groupliketype_, delimited_field_);
+}
 seastar::future<> test_all_types_edition2023::from_proto(serde::pb::wire_format_parser* parser, test_all_types_edition2023* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -4312,6 +4322,9 @@ foreign_message_edition2023::~foreign_message_edition2023() noexcept = default;
 bool foreign_message_edition2023::operator==(const foreign_message_edition2023&) const = default;
 int32_t foreign_message_edition2023::get_c() const { return c_; }
 void foreign_message_edition2023::set_c(int32_t v) { c_ = v; }
+fmt::iterator foreign_message_edition2023::format_to(fmt::iterator it) const {
+  return fmt::format_to(it, "{{c: {}}}", c_);
+}
 seastar::future<> foreign_message_edition2023::from_proto(serde::pb::wire_format_parser* parser, foreign_message_edition2023* self) {
   while (parser->bytes_left() > 0) {
     auto tag = parser->read_tag();
@@ -4450,6 +4463,7 @@ void enum_from_json(serde::pb::json::peekable_parser* p, test_all_types_edition2
     throw std::runtime_error(fmt::format("unexpected json token for enum, got: {}", p->token()));
   }
 }
+int32_t format_as(test_all_types_edition2023_nested_enum e) { return std::to_underlying(e); }
 
 void enum_from_proto(iobuf_parser* p, foreign_enum_edition2023* e) {
   auto v = serde::pb::read_varint<int32_t, serde::pb::zigzag::no>(p);
@@ -4514,6 +4528,7 @@ void enum_from_json(serde::pb::json::peekable_parser* p, foreign_enum_edition202
     throw std::runtime_error(fmt::format("unexpected json token for enum, got: {}", p->token()));
   }
 }
+int32_t format_as(foreign_enum_edition2023 e) { return std::to_underlying(e); }
 
 } // protobuf_test_messages::editions
 // NOLINTEND(*-avoid-magic-numbers)

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "bytes/iobuf.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
@@ -38,6 +39,7 @@ void enum_from_proto(iobuf_parser*, test_all_types_edition2023_nested_enum*);
 // Returns the name of the enum value
 std::string_view enum_to_string(const test_all_types_edition2023_nested_enum&);
 void enum_from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023_nested_enum*);
+int32_t format_as(test_all_types_edition2023_nested_enum);
 
 enum class foreign_enum_edition2023 : uint8_t {
   foreign_foo = 0,
@@ -49,6 +51,7 @@ void enum_from_proto(iobuf_parser*, foreign_enum_edition2023*);
 // Returns the name of the enum value
 std::string_view enum_to_string(const foreign_enum_edition2023&);
 void enum_from_json(serde::pb::json::peekable_parser*, foreign_enum_edition2023*);
+int32_t format_as(foreign_enum_edition2023);
 
 class foreign_message_edition2023 {
 public:
@@ -59,7 +62,9 @@ public:
   foreign_message_edition2023& operator=(foreign_message_edition2023&&) noexcept;
   ~foreign_message_edition2023() noexcept;
   
-  bool operator==(const foreign_message_edition2023&) const;  
+  bool operator==(const foreign_message_edition2023&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -92,7 +97,9 @@ public:
   test_all_types_edition2023_group_like_type& operator=(test_all_types_edition2023_group_like_type&&) noexcept;
   ~test_all_types_edition2023_group_like_type() noexcept;
   
-  bool operator==(const test_all_types_edition2023_group_like_type&) const;  
+  bool operator==(const test_all_types_edition2023_group_like_type&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -127,7 +134,9 @@ public:
   test_all_types_edition2023_nested_message& operator=(test_all_types_edition2023_nested_message&&) noexcept;
   ~test_all_types_edition2023_nested_message() noexcept;
   
-  bool operator==(const test_all_types_edition2023_nested_message&) const;  
+  bool operator==(const test_all_types_edition2023_nested_message&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -163,7 +172,9 @@ public:
   test_all_types_edition2023& operator=(test_all_types_edition2023&&) noexcept;
   ~test_all_types_edition2023() noexcept;
   
-  bool operator==(const test_all_types_edition2023&) const;  
+  bool operator==(const test_all_types_edition2023&) const;
+  fmt::iterator format_to(fmt::iterator) const;
+  
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023 into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023 into proto3 JSON, in a way that will not cause stalls for large messages.

--- a/src/v/serde/protobuf/tests/round_trip_test.cc
+++ b/src/v/serde/protobuf/tests/round_trip_test.cc
@@ -325,6 +325,12 @@ TEST(ProtobufCompat, Wellknown) {
                         .get()))
       << "JSON: " << libpb_serialized;
     EXPECT_EQ(original, deserialized)
-      << "Proto: " << iobuf_to_string(original.to_json().get())
-      << "\nDeserialized: " << iobuf_to_string(deserialized.to_json().get());
+      << "Proto: " << fmt::format("{}", original)
+      << "Deserialized: " << fmt::format("{}", deserialized);
+}
+
+TEST(ProtobufCompat, DebugRedact) {
+    proto::example::super_duper_secret secret;
+    secret.set_value("12345");
+    EXPECT_EQ("{value: <redacted>}", fmt::format("{}", secret));
 }

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -189,12 +189,12 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "to_string",
-    hdrs = [
-        "to_string.h",
-    ],
+    srcs = ["to_string.cc"],
+    hdrs = ["to_string.h"],
     include_prefix = "utils",
     deps = [
         "//src/v/base",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:node_hash_map",
         "@fmt",
         "@seastar",

--- a/src/v/utils/to_string.cc
+++ b/src/v/utils/to_string.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/to_string.h"
+
+fmt::format_context::iterator fmt::formatter<std::monostate>::format(
+  const std::monostate&, format_context& ctx) {
+    return fmt::format_to(ctx.out(), "{{}}");
+}
+
+fmt::format_context::iterator fmt::formatter<absl::Duration>::format(
+  const absl::Duration& d, fmt::format_context& ctx) {
+    std::string s = absl::FormatDuration(d);
+    return fmt::format_to(ctx.out(), "{}", s);
+}
+
+fmt::format_context::iterator fmt::formatter<absl::Time>::format(
+  const absl::Time& t, fmt::format_context& ctx) {
+    std::string s = absl::FormatTime(t);
+    return fmt::format_to(ctx.out(), "{}", s);
+}

--- a/src/v/utils/to_string.h
+++ b/src/v/utils/to_string.h
@@ -54,19 +54,7 @@ struct fmt::formatter<ss::chunked_fifo<T, chunk_size>> {
     template<typename FormatContext>
     typename FormatContext::iterator
     format(const type& fifo, FormatContext& ctx) const {
-        fmt::format_to(ctx.out(), "[");
-        if (!fifo.empty()) {
-            auto it = fifo.begin();
-            fmt::format_to(ctx.out(), "{}", *(it++));
-
-            for (; it != fifo.end(); ++it) {
-                fmt::format_to(ctx.out(), ", {}", *it);
-            }
-            return ctx.out();
-        }
-
-        fmt::format_to(ctx.out(), "]");
-        return ctx.out();
+        return fmt::format_to(ctx.out(), "[{}]", fmt::join(fifo, ", "));
     }
 };
 
@@ -101,3 +89,31 @@ std::ostream& operator<<(std::ostream& o, const absl::node_hash_map<K, V>& r) {
     return o;
 }
 } // namespace absl
+
+template<>
+struct fmt::formatter<absl::Time> {
+    constexpr format_parse_context::iterator parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    format_context::iterator
+    format(const absl::Time& t, fmt::format_context& ctx);
+};
+
+template<>
+struct fmt::formatter<absl::Duration> {
+    constexpr format_parse_context::iterator parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+    format_context::iterator
+    format(const absl::Duration& d, fmt::format_context& ctx);
+};
+
+template<>
+struct fmt::formatter<std::monostate> {
+    constexpr format_parse_context::iterator parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+    format_context::iterator format(const std::monostate&, format_context& ctx);
+};


### PR DESCRIPTION
This patch series makes protobufs formattable, relying on our new `format_to` support.

Enums are currently in the sad state of printing out their numeric value. We can fix
this easily when we upgrade libfmt and instead can return a string for `format_as`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
