### PR TITLE
iceberg: a couple fixes found working with Glue + Redshift

### DIFF
--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -597,6 +597,18 @@ iceberg_file_committer::commit_topic_files_to_catalog(
 ss::future<checked<std::nullopt_t, file_committer::errc>>
 iceberg_file_committer::drop_table(
   const iceberg::table_identifier& table_id) const {
+    auto load_res = co_await catalog_.load_table(table_id);
+    if (load_res.has_error()) {
+        if (load_res.error() == iceberg::catalog::errc::not_found) {
+            co_return std::nullopt;
+        }
+        log_and_convert_catalog_errc(
+          load_res.error(),
+          fmt::format(
+            "Failed to load {} before dropping, proceeding to attempt drop "
+            "anyway",
+            table_id));
+    }
     auto drop_res = co_await catalog_.drop_table(table_id, true);
     if (
       drop_res.has_error()

--- a/src/v/iceberg/manifest_list_avro.cc
+++ b/src/v/iceberg/manifest_list_avro.cc
@@ -105,16 +105,14 @@ avrogen::manifest_file file_to_avro(const manifest_file& f) {
     ret.existing_rows_count = static_cast<int32_t>(f.existing_rows_count);
     ret.deleted_rows_count = static_cast<int32_t>(f.deleted_rows_count);
 
-    if (f.partitions.empty()) {
-        ret.partitions.set_null();
-    } else {
-        std::vector<avrogen::r508> partitions;
+    std::vector<avrogen::r508> partitions;
+    if (!f.partitions.empty()) {
         partitions.reserve(f.partitions.size());
         for (const auto& s : f.partitions) {
             partitions.emplace_back(summary_to_avro(s));
         }
-        ret.partitions.set_array(partitions);
     }
+    ret.partitions.set_array(partitions);
     return ret;
 }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
See individual commits.

We will need follow-up work to allow for topic deletion to not require manual intervention. This at least allows a cluster to become functional after the Iceberg topic has already been deleted.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Redpanda now serializes Iceberg manifest lists differently, to allow certain engines (e.g. AWS Redshift) to query the Iceberg tables when using the empty partition spec.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
