### PR TITLE
Ducktape: Introduce MultiClusterServices

### DIFF
--- a/tests/rptest/services/multi_cluster_services.py
+++ b/tests/rptest/services/multi_cluster_services.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from enum import Enum
+from typing import Any, Literal, Optional, Type, TypeVar
+
+import kafkatest.version
+from kafkatest.services.zookeeper import ZookeeperService
+from ducktape.utils.util import wait_until
+from rptest.clients.rpk import RpkTool, TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.kafka import KafkaServiceAdapter
+from rptest.services.redpanda import RedpandaService
+
+from kafkatest.services.kafka import KafkaService
+
+KAFKA_VERSION = kafkatest.version.KafkaVersion("3.7.0")
+
+
+class ServiceType(str, Enum):
+    REDPANDA = 'redpanda'
+    KAFKA = 'kafka'
+
+
+Service = RedpandaService | KafkaServiceAdapter
+C = TypeVar('C', bound='Cluster')
+KC = TypeVar('KC', bound='KafkaCluster')
+RC = TypeVar('RC', bound='RedpandaCluster')
+
+
+class Cluster():
+    _service: Service
+
+    def __init__(self, service: Service):
+        self._service: Service = service
+
+    @property
+    def service(self) -> Service:
+        return self._service
+
+    @property
+    def is_kafka(self) -> bool:
+        return False
+
+    @property
+    def is_redpanda(self) -> bool:
+        return False
+
+    @property
+    def admin(self) -> Admin:
+        raise NotImplementedError("Cluster.admin")
+
+    @property
+    def rpk(self) -> RpkTool:
+        return RpkTool(self._service)
+
+    def start(self):
+        self.service.start()
+
+    def stop(self):
+        self.service.stop()
+
+    def __str__(self):
+        return f"{self._service_type} cluster of {len(self._service.nodes)} nodes"
+
+
+class KafkaCluster(Cluster):
+    _zk: ZookeeperService
+
+    def __init__(self, service: KafkaServiceAdapter, zk: ZookeeperService):
+        super().__init__(service)
+        self._zk = zk
+
+    @classmethod
+    def create(cls: Type[KC], test_ctx, num_brokers) -> KC:
+        zk = ZookeeperService(test_ctx, num_nodes=1, version=KAFKA_VERSION)
+        svc = KafkaServiceAdapter(
+            test_ctx,
+            KafkaService(test_ctx,
+                         num_nodes=num_brokers,
+                         zk=zk,
+                         version=KAFKA_VERSION))
+        return cls(svc, zk)
+
+    @property
+    def is_kafka(self) -> bool:
+        return True
+
+    def start(self):
+        self._zk.start()
+        super().start()
+
+    def stop(self):
+        super().stop()
+        self._zk.stop()
+
+    def __str__(self):
+        return f"Kafka cluster of {len(self.service.nodes)} nodes"
+
+
+class RedpandaCluster(Cluster):
+    def __init__(self, service: RedpandaService):
+        super().__init__(service)
+
+    @classmethod
+    def create(cls: Type[RC], test_ctx, num_brokers) -> RC:
+        return cls(RedpandaService(test_ctx, num_brokers=num_brokers))
+
+    @property
+    def is_redpanda(self) -> bool:
+        return True
+
+    @property
+    def admin(self) -> Admin:
+        return Admin(self.service)
+
+    def __str__(self):
+        return f"Redpanda cluster of {len(self.service.nodes)} nodes"
+
+
+class MultiClusterServices():
+    def __init__(self,
+                 test_ctx,
+                 logger,
+                 redpanda: RedpandaService,
+                 secondary_type: ServiceType = ServiceType.REDPANDA,
+                 num_brokers=3):
+        self.test_ctx = test_ctx
+        self.logger = logger
+        self._clusters: list[Cluster] = [RedpandaCluster(redpanda)]
+        if secondary_type is ServiceType.REDPANDA:
+            self._clusters.append(
+                RedpandaCluster.create(self.test_ctx, num_brokers))
+        elif secondary_type is ServiceType.KAFKA:
+            self._clusters.append(
+                KafkaCluster.create(self.test_ctx, num_brokers))
+        assert len(self._clusters) == 2, \
+            f"Expected two clusters, got {self._clusters=}"
+
+    def setUp(self):
+        assert len(self.primary.service.started_nodes()) == 0, \
+            f"{str(c)}: MultiClusterServices expects to start itself"
+
+        # TODO: extra configs?
+
+        for c in self._clusters:
+            c.start()
+
+    def tearDown(self):
+        # NOTE: expect the primary service to be shut down by the test framework
+        self.secondary.stop()
+
+    @property
+    def primary(self):
+        return self._clusters[0]
+
+    @property
+    def secondary(self):
+        return self._clusters[1]
+
+    def create_topic(self,
+                     cluster: Cluster,
+                     name: str,
+                     partitions: int = 1,
+                     replicas: int = 1,
+                     config: dict[str, Any] = dict()):
+        cluster.rpk.create_topic(topic=name,
+                                 partitions=partitions,
+                                 replicas=replicas,
+                                 config=config)
+
+    def list_topics(self, cluster: Cluster, detailed: bool = False):
+        return list(cluster.rpk.list_topics(detailed))
+
+    def __enter__(self):
+        self.setUp()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.tearDown()

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -1,0 +1,107 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark import matrix
+from rptest.services.multi_cluster_services import MultiClusterServices, ServiceType
+from rptest.tests.redpanda_test import RedpandaTest
+
+from rptest.services.cluster import cluster
+from rptest.util import expect_exception
+
+
+class MultiClusterTestBase(RedpandaTest):
+    def __init__(self, test_context, *args, **kwargs):
+        super().__init__(test_context=test_context, *args, **kwargs)
+
+    def basic_ops(self, services: MultiClusterServices):
+        topic = 'test-topic'
+        services.create_topic(services.primary,
+                              topic,
+                              partitions=3,
+                              replicas=3)
+        p_topics = services.list_topics(services.primary, detailed=True)
+        services.create_topic(services.secondary,
+                              topic,
+                              partitions=3,
+                              replicas=3)
+        s_topics = services.list_topics(services.secondary, detailed=True)
+
+        assert p_topics == s_topics, \
+            f"Expected same topics on both clusters, got {p_topics=} vs {s_topics=}"
+
+        assert len(p_topics) == 1 and p_topics[0][0] == topic,\
+            f"Expected {topic=}, got {p_topics=}"
+
+        status_json = services.primary.admin.get_status_ready()
+        assert status_json['status'] == 'ready', \
+                f"Expected ready, got {status_json=}"
+
+        if services.secondary.is_redpanda:
+            status_json = services.secondary.admin.get_status_ready()
+            assert status_json['status'] == 'ready', \
+                f"Expected ready, got {status_json=}"
+        else:
+            with expect_exception(NotImplementedError, lambda e: True):
+                services.secondary.admin.get_status_ready()
+
+
+class MultiClusterRedpandaTest(MultiClusterTestBase):
+    """
+    Just verifies MultiClusterServices for now. rp + rp & rp + kafka
+    """
+    def __init__(self, test_context, *args, **kwargs):
+        super().__init__(test_context=test_context,
+                         num_brokers=3,
+                         *args,
+                         **kwargs)
+
+        self.test_context = test_context
+
+    def setUp(self):
+        # MultiClusterServices will set itself up
+        pass
+
+    @cluster(num_nodes=6)
+    def test_basic_ops(self):
+        with MultiClusterServices(self.test_context,
+                                  self.logger,
+                                  self.redpanda,
+                                  secondary_type=ServiceType.REDPANDA,
+                                  num_brokers=3) as services:
+            assert services.secondary.is_redpanda, \
+                f"Expected Redpanda service, got {services.secondary}"
+            self.basic_ops(services)
+
+
+class MultiClusterKafkaTest(MultiClusterTestBase):
+    """
+    Just verifies MultiClusterServices for now. rp + rp & rp + kafka
+    """
+    def __init__(self, test_context, *args, **kwargs):
+        super().__init__(test_context=test_context,
+                         num_brokers=3,
+                         *args,
+                         **kwargs)
+
+        self.test_context = test_context
+
+    def setUp(self):
+        # MultiClusterServices will set itself up
+        pass
+
+    @cluster(num_nodes=7)
+    def test_basic_ops(self):
+        with MultiClusterServices(self.test_context,
+                                  self.logger,
+                                  self.redpanda,
+                                  secondary_type=ServiceType.KAFKA,
+                                  num_brokers=3) as services:
+            assert services.secondary.is_kafka, \
+                f"Expected Kafka service, got {services.secondary}"
+            self.basic_ops(services)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Ducktape utilit for managing multiple cluster. Start, stop, create/list topics, grab an Rpk or an Admin, and so on. Starts Zookeeper if in Kafka mode.

Includes a basic test for the services.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
