### PR TITLE
chunked_vector: remove the range constructor

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
@@ -100,7 +100,8 @@ TEST_CORO(EventFilterTest, filter_triggered_once) {
     auto sub = pipeline.subscribe(flt);
     auto write = pipeline.write_and_debounce(
       model::controller_ntp,
-      chunked_vector<model::record_batch>(std::move(batches)),
+      chunked_vector<model::record_batch>(
+        std::from_range, std::move(batches) | std::views::as_rvalue),
       ss::lowres_clock::now() + 1s);
     auto event = co_await std::move(sub);
     ASSERT_EQ_CORO(event.pending_write_bytes, reader_size_bytes);
@@ -132,7 +133,8 @@ TEST_CORO(EventFilterTest, filter_has_memory) {
     auto stage = pipeline.register_write_pipeline_stage();
     auto write = pipeline.write_and_debounce(
       model::controller_ntp,
-      chunked_vector<model::record_batch>(std::move(batches)),
+      chunked_vector<model::record_batch>(
+        std::from_range, std::move(batches) | std::views::as_rvalue),
       ss::lowres_clock::now() + 1s);
     // wait until submitted
     // this is needed because 'write_and_debounce' has a scheduling point

--- a/src/v/cloud_topics/level_zero/throttler/tests/throttler_test.cc
+++ b/src/v/cloud_topics/level_zero/throttler/tests/throttler_test.cc
@@ -137,7 +137,8 @@ TEST_CORO(throttler_test, no_throttling) {
       .records = 10,
     };
     auto batches = chunked_vector<model::record_batch>(
-      co_await model::test::make_random_batches(spec));
+      std::from_range,
+      co_await model::test::make_random_batches(spec) | std::views::as_rvalue);
     size_t reader_size_bytes = get_serialized_size(batches);
 
     cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
@@ -199,7 +200,8 @@ TEST_CORO(throttler_test, tput_limit_reached) {
       .records = 10,
     };
     auto batches = chunked_vector<model::record_batch>(
-      co_await model::test::make_random_batches(spec));
+      std::from_range,
+      co_await model::test::make_random_batches(spec) | std::views::as_rvalue);
     size_t reader_size_bytes = get_serialized_size(batches);
 
     cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;
@@ -271,7 +273,8 @@ TEST_CORO(throttler_test, tput_limit_reached_req_timed_out) {
       .records = 10,
     };
     auto batches = chunked_vector<model::record_batch>(
-      co_await model::test::make_random_batches(spec));
+      std::from_range,
+      co_await model::test::make_random_batches(spec) | std::views::as_rvalue);
     size_t reader_size_bytes = get_serialized_size(batches);
 
     cloud_topics::l0::write_pipeline<ss::manual_clock> pipeline;

--- a/src/v/cluster/archival/tests/archival_service_fixture.h
+++ b/src/v/cluster/archival/tests/archival_service_fixture.h
@@ -567,7 +567,8 @@ public:
         result<raft::replicate_result> res
           = partition->raft()
               ->replicate(
-                chunked_vector<model::record_batch>(std::move(batches)),
+                chunked_vector<model::record_batch>(
+                  std::from_range, std::move(batches) | std::views::as_rvalue),
                 raft::replicate_options(acks))
               .get();
 

--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1813,10 +1813,11 @@ backend::get_topic_assignments(const model::topic_namespace& nt, const id id) {
                             const auto& assignment) {
                               return group_map.contains(assignment.id);
                           });
-        return std::move(filtered)
+        return std::move(filtered) | std::views::as_rvalue
                | std::ranges::to<chunked_vector<partition_assignment>>();
     } else {
-        return chunked_vector<partition_assignment>{std::move(assignments)};
+        return std::move(assignments) | std::views::as_rvalue
+               | std::ranges::to<chunked_vector<partition_assignment>>();
     }
 }
 

--- a/src/v/cluster/tests/partition_properties_stm_test.cc
+++ b/src/v/cluster/tests/partition_properties_stm_test.cc
@@ -119,7 +119,9 @@ struct partition_properties_stm_fixture : raft::raft_fixture {
                         chunked_circular_buffer<model::record_batch> batches) {
                     return leader_node.raft()
                       ->replicate(
-                        chunked_vector<model::record_batch>(std::move(batches)),
+                        chunked_vector<model::record_batch>(
+                          std::from_range,
+                          std::move(batches) | std::views::as_rvalue),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack))
                       .then([](result<raft::replicate_result> res) {

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -135,7 +135,9 @@ public:
               .then([&pm, ntp](auto batches) {
                   // replicate
                   auto f = pm.get(ntp)->raft()->replicate(
-                    chunked_vector<model::record_batch>(std::move(batches)),
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack));
 

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -531,7 +531,8 @@ compat_copy(raft::append_entries_request r) {
       source_node,
       target_node,
       metadata,
-      chunked_vector<model::record_batch>(std::move(a_batches)),
+      chunked_vector<model::record_batch>(
+        std::from_range, std::move(a_batches) | std::views::as_rvalue),
       sz,
       flush);
 
@@ -579,7 +580,8 @@ struct compat_check<raft::append_entries_request> {
           node,
           target,
           meta,
-          chunked_vector<model::record_batch>(std::move(batches)),
+          chunked_vector<model::record_batch>(
+            std::from_range, std::move(batches) | std::views::as_rvalue),
           0,
           flush};
     }

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -18,6 +18,8 @@
 #include "test_utils/random_bytes.h"
 #include "test_utils/randoms.h"
 
+#include <ranges>
+
 namespace compat {
 
 template<>
@@ -325,7 +327,9 @@ struct instance_generator<raft::append_entries_request> {
           instance_generator<raft::vnode>::random(),
           instance_generator<raft::protocol_metadata>::random(),
           chunked_vector<model::record_batch>(
-            model::test::make_random_batches(model::offset(0), 3, false).get()),
+            std::from_range,
+            model::test::make_random_batches(model::offset(0), 3, false).get()
+              | std::views::as_rvalue),
           0,
           raft::flush_after_append(tests::random_bool()),
         };

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -135,7 +135,8 @@ public:
      */
     template<typename Range>
     requires(std::ranges::sized_range<Range>)
-    chunked_vector(std::from_range_t, const Range& range)
+    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+    chunked_vector(std::from_range_t, Range&& range)
       : chunked_vector() {
         reserve(std::ranges::size(range));
         std::copy(range.begin(), range.end(), std::back_inserter(*this));

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -128,7 +128,10 @@ public:
     chunked_vector(std::from_range_t, Range&& range)
       : chunked_vector() {
         reserve(std::ranges::size(range));
-        std::copy(range.begin(), range.end(), std::back_inserter(*this));
+        std::copy(
+          std::ranges::begin(range),
+          std::ranges::end(range),
+          std::back_inserter(*this));
     }
 
     chunked_vector& operator=(chunked_vector&& other) noexcept {

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -108,17 +108,6 @@ public:
       : chunked_vector(elems.begin(), elems.end()) {}
 
     /**
-     * @brief Construct a new vector by moving from a given range
-     */
-    template<typename Range>
-    requires std::ranges::sized_range<Range>
-    explicit chunked_vector(Range range)
-      : chunked_vector() {
-        reserve(std::ranges::size(range));
-        std::move(range.begin(), range.end(), std::back_inserter(*this));
-    }
-
-    /**
      * @brief Construct a new vector from a range
      *
      * This constructor will copy or move from the range depending on the value

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -119,7 +119,19 @@ public:
     }
 
     /**
-     * @brief Construct a new vector by copying from a const range
+     * @brief Construct a new vector from a range
+     *
+     * This constructor will copy or move from the range depending on the value
+     * category of the elements NOT the one of the range. I.e.
+     * `chunked_vector(std::move(src))` will not necessarily invoke move
+     * constructor on the elements of `src`. For example, an rvalue `std::span`
+     * is a non-owning view, and moving from its elements would be a bug.
+     * Similar for most of the standard library views.
+     *
+     * To ensure move semantics from the range elements, use
+     * `std::views::as_rvalue`.
+     *
+     * https://en.cppreference.com/w/cpp/ranges/as_rvalue_view.html
      */
     template<typename Range>
     requires(std::ranges::sized_range<Range>)

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -575,8 +575,19 @@ TEST(ChunkedVector, FromRangeMove) {
 
     auto src = chunked_vector<move_only_t>();
 
+    // From ref.
     auto vec = chunked_vector<move_only_t>(
       std::from_range, src | std::views::as_rvalue);
+
+    // From temporary.
+    auto vec2 = chunked_vector<move_only_t>(
+      std::from_range, chunked_vector<move_only_t>() | std::views::as_rvalue);
+}
+
+TEST(ChunkedVector, FromRangeCopy) {
+    chunked_vector<int> src;
+    static_assert(!std::is_copy_constructible_v<decltype(src)>);
+    auto vec = chunked_vector<int>(std::from_range, src);
 }
 
 TEST(ChunkedVector, InPlaceSingleElement) {

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -590,6 +590,18 @@ TEST(ChunkedVector, FromRangeCopy) {
     auto vec = chunked_vector<int>(std::from_range, src);
 }
 
+struct adl_range_t {
+    std::vector<int> data{1, 2, 3};
+};
+auto begin(const adl_range_t& r) { return r.data.begin(); }
+auto end(const adl_range_t& r) { return r.data.end(); }
+
+TEST(ChunkedVector, FromRangeADL) {
+    adl_range_t r;
+    auto vec = chunked_vector<int>(std::from_range, r);
+    EXPECT_THAT(vec, ElementsAreArray(r.data));
+}
+
 TEST(ChunkedVector, InPlaceSingleElement) {
     auto v = chunked_vector<std::pair<ss::sstring, int32_t>>::single("a2", 3);
     ASSERT_THAT(v, ElementsAre(std::make_pair("a2", 3)));

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -555,7 +555,7 @@ TEST(ChunkedVector, FromRange) {
         buffer.push_back(i);
     }
 
-    auto vec = chunked_vector<int32_t>(buffer);
+    auto vec = chunked_vector<int32_t>(std::from_range, buffer);
     EXPECT_THAT(vec, ElementsAreArray(buffer));
 }
 

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -23,6 +23,7 @@
 #include <initializer_list>
 #include <limits>
 #include <numeric>
+#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -556,6 +557,26 @@ TEST(ChunkedVector, FromRange) {
 
     auto vec = chunked_vector<int32_t>(buffer);
     EXPECT_THAT(vec, ElementsAreArray(buffer));
+}
+
+struct move_only_t {
+    move_only_t() = default;
+    move_only_t(move_only_t&) = delete;
+    move_only_t& operator=(move_only_t&) = delete;
+    move_only_t(move_only_t&&) = default;
+    move_only_t& operator=(move_only_t&&) = default;
+    ~move_only_t() = default;
+};
+
+TEST(ChunkedVector, FromRangeMove) {
+    static_assert(
+      !(std::is_copy_constructible_v<move_only_t>
+        || std::is_copy_assignable_v<move_only_t>));
+
+    auto src = chunked_vector<move_only_t>();
+
+    auto vec = chunked_vector<move_only_t>(
+      std::from_range, src | std::views::as_rvalue);
 }
 
 TEST(ChunkedVector, InPlaceSingleElement) {

--- a/src/v/datalake/datalake_usage_aggregator.cc
+++ b/src/v/datalake/datalake_usage_aggregator.cc
@@ -18,7 +18,10 @@
 
 #include <seastar/coroutine/as_future.hh>
 
+#include <ranges>
+
 namespace {
+
 ss::future<chunked_vector<datalake::coordinator::usage_stats_reply>>
 dispatch_requests(
   datalake::coordinator::frontend& frontend, int partition_count) {
@@ -29,7 +32,10 @@ dispatch_requests(
           model::partition_id(i)};
         replies.push_back(frontend.get_usage_stats(request));
     }
-    co_return co_await ss::when_all_succeed(replies.begin(), replies.end());
+    co_return co_await ss::when_all_succeed(replies.begin(), replies.end())
+      | std::views::as_rvalue
+      | std::ranges::to<
+        chunked_vector<datalake::coordinator::usage_stats_reply>>();
 }
 } // namespace
 

--- a/src/v/kafka/data/rpc/service.cc
+++ b/src/v/kafka/data/rpc/service.cc
@@ -188,7 +188,8 @@ ss::future<result<model::offset, cluster::errc>> local_service::produce(
       *shard,
       ntp,
       [timeout,
-       batches = chunked_vector<model::record_batch>(std::move(batches))](
+       batches = chunked_vector<model::record_batch>(
+         std::from_range, std::move(batches) | std::views::as_rvalue)](
         kafka::partition_proxy* partition) mutable {
           return partition
             ->replicate(std::move(batches), make_replicate_options(timeout))

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -436,7 +436,9 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
 
                 partition->raft()
                   ->replicate(
-                    chunked_vector<model::record_batch>(std::move(batches)),
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack))
                   .discard_result()
@@ -446,7 +448,9 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
             wait_for_leader(ntp, 10s).get();
             {
                 auto batches = chunked_vector<model::record_batch>(
-                  model::test::make_random_batches(model::offset(0), 5).get());
+                  std::from_range,
+                  model::test::make_random_batches(model::offset(0), 5).get()
+                    | std::views::as_rvalue);
 
                 partition->raft()
                   ->replicate(
@@ -530,7 +534,9 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
                   .then([ntp, &mgr](auto batches) {
                       auto partition = mgr.get(ntp);
                       return partition->raft()->replicate(
-                        chunked_vector<model::record_batch>(std::move(batches)),
+                        chunked_vector<model::record_batch>(
+                          std::from_range,
+                          std::move(batches) | std::views::as_rvalue),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack));
                   });
@@ -598,7 +604,9 @@ FIXTURE_TEST(fetch_leader_ack, redpanda_thread_fixture) {
               .then([ntp, &mgr](auto batches) {
                   auto partition = mgr.get(ntp);
                   return partition->raft()->replicate(
-                    chunked_vector<model::record_batch>(std::move(batches)),
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
                     raft::replicate_options(
                       raft::consistency_level::leader_ack));
               });
@@ -657,7 +665,9 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
               .then([ntp, &mgr](auto batches) {
                   auto partition = mgr.get(ntp);
                   return partition->raft()->replicate(
-                    chunked_vector<model::record_batch>(std::move(batches)),
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack));
               });
@@ -738,7 +748,9 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
                   .then([ntp, &mgr](auto batches) {
                       auto partition = mgr.get(ntp);
                       return partition->raft()->replicate(
-                        chunked_vector<model::record_batch>(std::move(batches)),
+                        chunked_vector<model::record_batch>(
+                          std::from_range,
+                          std::move(batches) | std::views::as_rvalue),
                         raft::replicate_options(
                           raft::consistency_level::quorum_ack));
                   });
@@ -790,7 +802,9 @@ FIXTURE_TEST(fetch_request_max_bytes, redpanda_thread_fixture) {
               .then([ntp, &mgr](auto batches) {
                   auto partition = mgr.get(ntp);
                   return partition->raft()->replicate(
-                    chunked_vector<model::record_batch>(std::move(batches)),
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack));
               });
@@ -855,7 +869,9 @@ FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
               .then([ntp, &mgr](auto batches) {
                   auto partition = mgr.get(ntp);
                   return partition->raft()->replicate(
-                    chunked_vector<model::record_batch>(std::move(batches)),
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
                     raft::replicate_options(
                       raft::consistency_level::quorum_ack));
               });

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -276,7 +276,8 @@ FIXTURE_TEST(test_recreated_topic_does_not_lose_data, recreate_test_fixture) {
                       return p->raft()
                         ->replicate(
                           chunked_vector<model::record_batch>(
-                            std::move(batches)),
+                            std::from_range,
+                            std::move(batches) | std::views::as_rvalue),
                           raft::replicate_options(
                             raft::consistency_level::quorum_ack))
                         .then([p](auto) { return p->committed_offset(); });

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -63,7 +63,9 @@ void verify_batches(
 
 SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
     chunked_vector<model::record_batch> batches{
-      model::test::make_random_batches(model::offset(1), 3, false).get()};
+      std::from_range,
+      model::test::make_random_batches(model::offset(1), 3, false).get()
+        | std::views::as_rvalue};
 
     chunked_vector<model::record_batch> reference_batches;
 
@@ -552,7 +554,9 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_backward_compatibility) {
 
 SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
     chunked_vector<model::record_batch> batches{
-      model::test::make_random_batches(model::offset(1), 3, false).get()};
+      std::from_range,
+      model::test::make_random_batches(model::offset(1), 3, false).get()
+        | std::views::as_rvalue};
     chunked_vector<model::record_batch> reference_batches;
     for (auto& b : batches) {
         b.set_term(model::term_id(123));

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -159,7 +159,8 @@ ss::future<result<model::offset, cluster::errc>> local_service::produce(
       *shard,
       ntp,
       [timeout,
-       batches = chunked_vector<model::record_batch>(std::move(batches))](
+       batches = chunked_vector<model::record_batch>(
+         std::from_range, std::move(batches) | std::views::as_rvalue)](
         kafka::partition_proxy* partition) mutable {
           return partition
             ->replicate(std::move(batches), make_replicate_options(timeout))


### PR DESCRIPTION
chunked_vector: remove the range constructor

The constructor in its current form is dangerous. In particular, it
always moves values from source container even when it shouldn't.

For example, prior to this commit, running the following code

```cpp
auto npts = std::views::all(src)
    | std::ranges::to<chunked_vector<my_type>>();
```

move out of the values of `src`. Similar for other views like `take(n)`
and others.

I have tried to fix that constructor in
https://github.com/redpanda-data/redpanda/pull/27184 and I think I got
close but in the end I didn't like it because it is very easy for a
programmer to try to initialize a chunked_vector with
`std::move(unrelated_container_type)` thinking that they will get move
semantics when in fact not only they get O(n) operations for moving
values they also get copies of underlying values rather than moves
unless they also pipe to `std::views::as_rvalue`.

Why it is impossible to do anything more sensible with the range value
is described better than I could in the linked SO answer referenced
below.

I still want to remove the footgun so I'm implementing the next sensible
thing that can be done. This now also behaves similar to std::vector.

1. We retain the chunked_vector(chunked_vector&&) move constructor.
2. To construct from an unrelated container, we ask the programmer to
    explicitly call the std::from_range tagged constructor (we remove the
    single argument range constructor). This way I hope to prompt the
    programmer to think twice about what will happen. After a bit of
    experience working with ranges everyone should know that range
    constructors are O(n), by default they copy the values unless piped
    to `std::views::as_rvalue`.

PS. Are you surprised how many hidden O(n) the previous commit in
uncovered? https://github.com/redpanda-data/redpanda/pull/27192

Ref: https://stackoverflow.com/a/77877816

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
