### PR TITLE
kafka/write_at_offset_stm: do not pass the timeout to replicate call

### DIFF
--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -178,8 +178,7 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
      * Thanks to that assumption we can simply reset all inflight state instead
      * of reverting to the previous last offset.
      */
-    auto stages = try_replicate_in_stages(
-      std::move(batches), timeout, std::move(as));
+    auto stages = try_replicate_in_stages(std::move(batches), as);
 
     auto enq = std::move(stages.request_enqueued).finally([u = std::move(u)] {
     });
@@ -241,16 +240,12 @@ kafka::offset write_at_offset_stm::expected_last_offset() const {
 
 raft::replicate_stages write_at_offset_stm::try_replicate_in_stages(
   chunked_vector<model::record_batch> batches,
-  model::timeout_clock::duration timeout,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
     try {
         return _raft->replicate_in_stages(
           _insync_term,
           std::move(batches),
-          raft::replicate_options(
-            raft::consistency_level::quorum_ack,
-            std::chrono::duration_cast<std::chrono::milliseconds>(timeout),
-            std::move(as)));
+          raft::replicate_options(raft::consistency_level::quorum_ack, as));
     } catch (...) {
         vlog(
           _log.warn,

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -142,7 +142,6 @@ private:
 
     raft::replicate_stages try_replicate_in_stages(
       chunked_vector<model::record_batch>,
-      model::timeout_clock::duration timeout,
       std::optional<std::reference_wrapper<ss::abort_source>> as);
 
     kafka::offset expected_last_offset() const;


### PR DESCRIPTION
For the `persisted_stm` to work correctly it must be guaranteed that if replicate fails in a raft term then all subsequent replicate calls in the same term will fail. Using timeout passed in into `raft::replicate` violates this invariant.

Removed the timeout passed into `raft::replicate` method.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none