### PR TITLE
Update libxml2 2.14.5

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -244,7 +244,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "fTIzrNQ1j1wBnG6aCoX8uzFvUHPP+SXufsvJ2MoGndI=",
+        "bzlTransitiveDigest": "AUxTxAiNCGRb6ZttpNB80tjb4a12aB61jgZ8vBpeh8g=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -361,9 +361,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:libxml2.BUILD",
-              "sha256": "e9aa61639c3e764622e20511a8bf8e223c658b4c54b6d2f9ded1db03f141842c",
-              "strip_prefix": "libxml2-2491c632a44d8bbfa58ce84bc0c18a40cd1121be",
-              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-2491c632a44d8bbfa58ce84bc0c18a40cd1121be.tar.gz"
+              "sha256": "f52638e4d67135c49f676d1c8fcc4f9f35afb7ec9bfb4aee743e2e86d56e006b",
+              "strip_prefix": "libxml2-2.14.5",
+              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.14.5.tar.gz"
             }
           },
           "lksctp": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -100,9 +100,9 @@ def data_dependency():
     http_archive(
         name = "libxml2",
         build_file = "//bazel/thirdparty:libxml2.BUILD",
-        sha256 = "e9aa61639c3e764622e20511a8bf8e223c658b4c54b6d2f9ded1db03f141842c",
-        strip_prefix = "libxml2-2491c632a44d8bbfa58ce84bc0c18a40cd1121be",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-2491c632a44d8bbfa58ce84bc0c18a40cd1121be.tar.gz",
+        sha256 = "f52638e4d67135c49f676d1c8fcc4f9f35afb7ec9bfb4aee743e2e86d56e006b",
+        strip_prefix = "libxml2-2.14.5",
+        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/libxml2-v2.14.5.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Fixes a high sev vuln: https://security.snyk.io/vuln/SNYK-UNMANAGED-LIBXML2-10674189

NOTE: This PR contains the update to seastar in #27115 , or it'll just collide anyway.

I'll do backports manually.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
