### PR TITLE
rpk: operation parsing fix for SR ACLs

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/common v0.65.0
 	github.com/redpanda-data/common-go/proto v0.0.0-20250801174835-9eea07f1ea06
 	github.com/redpanda-data/common-go/rpadmin v0.1.14
-	github.com/redpanda-data/common-go/rpsr v0.1.1
+	github.com/redpanda-data/common-go/rpsr v0.1.2
 	github.com/rs/xid v1.6.0
 	github.com/safchain/ethtool v0.6.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -244,8 +244,8 @@ github.com/redpanda-data/common-go/proto v0.0.0-20250801174835-9eea07f1ea06 h1:i
 github.com/redpanda-data/common-go/proto v0.0.0-20250801174835-9eea07f1ea06/go.mod h1:6WXvgZCZIkbQCNsvU5zTx/+ub5eXTuCcl90i5xkhMw0=
 github.com/redpanda-data/common-go/rpadmin v0.1.14 h1:G/rlh9cHsGhTsNpkwrISdpGA8fPZ7ul57rzxbPiJhs0=
 github.com/redpanda-data/common-go/rpadmin v0.1.14/go.mod h1:zgE/M2UihQZRdivHfbm4x9Rb3Vm/crO5kiX3GQrxhG4=
-github.com/redpanda-data/common-go/rpsr v0.1.1 h1:3935qYNvAhbs8s3TrmXzXMs/Tc0+ukNjgsVxskh99kI=
-github.com/redpanda-data/common-go/rpsr v0.1.1/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
+github.com/redpanda-data/common-go/rpsr v0.1.2 h1:DThUeyfBH8fkL9WoP1sEbRhT2NVV22zmsTpcCtzfusQ=
+github.com/redpanda-data/common-go/rpsr v0.1.2/go.mod h1:2j2416onosg5FKaKz52NooRE+q/9EJqQn0kyTcTXWHc=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525 h1:vskZrV6q8W8flL0Ud23AJUYAd8ZgTadO45+loFnG2G0=
 github.com/redpanda-data/go-avro/v2 v2.0.0-20240405204525-77b1144dc525/go.mod h1:3YqAM7pgS5vW/EH7naCjFqnAajSgi0f0CfMe1HGhLxQ=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -327,22 +327,23 @@ class RpkACLTest(RedpandaTest):
         assert len(acl_list_all['matches']) == 0
 
         # ACL with SR + Kafka = 4 in total.
-        sr_kafka_acl = RPKACLInput(allow_principal=["panda"],
-                                   topic=["foo"],
-                                   registry_subject=["foo-value"],
-                                   operation=["read", "write"],
-                                   resource_pattern_type="literal")
+        sr_kafka_acl = RPKACLInput(
+            allow_principal=["panda"],
+            topic=["foo"],
+            registry_subject=["foo-value"],
+            operation=["describe_configs", "alter_configs"],
+            resource_pattern_type="literal")
         superclient.acl_create(sr_kafka_acl)
 
         acl_list_all = superclient.acl_list(format="json")
         assert len(acl_list_all['matches']
                    ) == 4, f"Expected to have 4 ACLs created: {acl_list_all}"
 
-        # List with filter (read)
-        acl_list_filter = superclient.acl_list(format="json",
-                                               flags=["--operation", "read"])
+        # List with filter (describe_configs)
+        acl_list_filter = superclient.acl_list(
+            format="json", flags=["--operation", "describe_configs"])
         assert len(acl_list_filter['matches']
-                   ) == 2, f"Expected to have 2 ACLs created: {acl_list_all}"
+                   ) == 2, f"Expected to have 2 ACLs filtered: {acl_list_all}"
 
         # Filter by subsystem
         acl_list_filter = superclient.acl_list(format="json",


### PR DESCRIPTION
This commit bumps rpsr which has a bugfix for
parsing `describe_configs` and `alter_configs`
operations in `rpk security` when used for SR ACLs

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* rpk: fixes a bug where `describe_configs` and `alter_configs` were not correctly parsed via `rpk security acl`
