### PR TITLE
`compaction`: remove unused variable in `compaction_config` & test

### DIFF
--- a/src/v/compaction/types.h
+++ b/src/v/compaction/types.h
@@ -89,8 +89,6 @@ struct compaction_config {
     // abort source for compaction task
     ss::abort_source* asrc;
 
-    mutable std::optional<model::offset> min_offset_fully_indexed;
-
     friend std::ostream& operator<<(std::ostream&, const compaction_config&);
 };
 

--- a/src/v/storage/tests/compaction_fuzz_test.cc
+++ b/src/v/storage/tests/compaction_fuzz_test.cc
@@ -159,7 +159,6 @@ ss::future<ot_state> arrange_and_compact(
                 co_await b1.get_disk_log_impl().force_roll();
             }
         }
-        ss::abort_source as;
         auto compact_cfg = compaction::compaction_config(
           batches.back().last_offset(), std::nullopt, std::nullopt, as);
         std::ignore = co_await b1.apply_sliding_window_compaction(compact_cfg);


### PR DESCRIPTION
Commit 1:
- This accidentally snuck into `dev` from a working branch change. Revert its addition.
Commit 2:
- Unnecessary `ss::abort_source`. Remove it.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
