### PR TITLE
[v25.2.x] archival: Make 'get_stream' reentrant

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1540,13 +1540,14 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
     std::optional<ss::input_stream<char>> stream_state = std::move(
       upload_stream);
 
-    auto get_stream = [&stream_state] {
-        // On first attempt to upload, the stream-ref passed in is used.
+    auto get_stream = [&stream_state, &strm] {
         using provider_t = std::unique_ptr<stream_provider>;
-        // Note that stream_state is known to be non-nullopt here.
+        if (!stream_state.has_value()) {
+            stream_state = strm.create_input_stream();
+        }
         auto prov = std::make_unique<one_time_stream_wrapper>(
-          std::move(stream_state.value()));
-        stream_state = std::nullopt;
+          std::move(stream_state).value());
+        stream_state.reset();
         return ss::make_ready_future<provider_t>(std::move(prov));
     };
 

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -1091,7 +1091,7 @@ segment_collector::make_upload_candidate_stream(
        final_file_offset
        = cand.final_file_offset]() mutable -> ss::input_stream<char> {
         storage::concat_segment_reader_view crv(
-          std::move(segments), file_offset, final_file_offset);
+          segments, file_offset, final_file_offset);
         return crv.take_stream();
     };
     co_return stream;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27169
