### PR TITLE
github: Add copilot guideline about ss::parallel_for_each

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -140,6 +140,13 @@ src/v/base/format_to.h.
 - Instead of long if-else chains for mapping string to values, use
   `string_switch` mechanism defined in
   [string_switch.h](./src/v/strings/string_switch.h).
+- Don't use `ss::parallel_for_each` with ranges that can grow large such as
+  partitions, topics or segments. Instead prefer `ss::max_concurrent_for_each` to
+  limit concurrency. Think about how much concurrency is needed to adequately hide
+  latency. See our
+  [docs](https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1331232769/Writing+scalable+and+high+performance+code#Managing-Concurrency-in-the-system)
+  for more background.
+
 
 ### C++ coding style
 


### PR DESCRIPTION
Make copilot recommend against using `ss::parallel_for_each`.

Inducing too much concurrency into the system by using unlimited
`ss::parallel_for_each` is bad as it can lead to OOMs amongst other
issues.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
