### PR TITLE
k/groups: do not return ntp from the coordinator mapper

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1370,10 +1370,10 @@ ss::future<> backend::reconcile_migration(
           metadata.migration);
 
         for (const auto& group : groups) {
-            auto ntp = _group_proxy.ntp_for(group);
-            vassert(ntp, "cannot get ntp for group {}", group);
-            auto pid = ntp->tp.partition;
-            auto [it, ins] = mrstate.partition_group_map->try_emplace(pid);
+            auto partition = _group_proxy.partition_for(group);
+            vassert(partition, "cannot get ntp for group {}", group);
+            auto [it, ins] = mrstate.partition_group_map->try_emplace(
+              *partition);
             it->second.push_back(group);
         }
     }

--- a/src/v/cluster/data_migration_group_proxy.h
+++ b/src/v/cluster/data_migration_group_proxy.h
@@ -27,7 +27,8 @@ class group_proxy {
 public:
     virtual ~group_proxy() = default;
 
-    virtual std::optional<model::ntp> ntp_for(const kafka::group_id& group) = 0;
+    virtual std::optional<model::partition_id>
+    partition_for(const kafka::group_id& group) = 0;
 
     virtual ss::future<result<model::offset>> set_blocked_for_groups(
       const model::ntp& co_ntp,

--- a/src/v/kafka/server/coordinator_ntp_mapper.h
+++ b/src/v/kafka/server/coordinator_ntp_mapper.h
@@ -47,16 +47,16 @@ public:
       : _md(md)
       , _tp_ns(std::move(group_topic)) {}
 
-    std::optional<model::ntp> ntp_for(const kafka::group_id& group) const {
+    std::optional<model::partition_id>
+    partition_for(const kafka::group_id& group) const {
         auto cfg = _md.local().get_topic_cfg(_tp_ns);
         if (!cfg) {
             return std::nullopt;
         }
         incremental_xxhash64 inc;
         inc.update(group);
-        auto p = static_cast<model::partition_id::type>(
-          jump_consistent_hash(inc.digest(), cfg->partition_count));
-        return model::ntp(_tp_ns.ns, _tp_ns.tp, model::partition_id{p});
+        return model::partition_id(static_cast<model::partition_id::type>(
+          jump_consistent_hash(inc.digest(), cfg->partition_count)));
     }
 
     bool topic_exists() const {

--- a/src/v/kafka/server/data_migration_group_proxy_impl.cc
+++ b/src/v/kafka/server/data_migration_group_proxy_impl.cc
@@ -27,9 +27,9 @@ data_migration_group_proxy_impl::data_migration_group_proxy_impl(
   , _group_manager(group_manager)
   , _group_initializer(group_initializer) {}
 
-std::optional<model::ntp>
-data_migration_group_proxy_impl::ntp_for(const kafka::group_id& group) {
-    return _coordinator_ntp_mapper.ntp_for(group);
+std::optional<model::partition_id>
+data_migration_group_proxy_impl::partition_for(const kafka::group_id& group) {
+    return _coordinator_ntp_mapper.partition_for(group);
 }
 
 ss::future<result<model::offset>>

--- a/src/v/kafka/server/data_migration_group_proxy_impl.h
+++ b/src/v/kafka/server/data_migration_group_proxy_impl.h
@@ -31,7 +31,8 @@ public:
       group_manager& group_manager,
       group_initializer& group_initializer);
 
-    std::optional<model::ntp> ntp_for(const kafka::group_id& group) override;
+    std::optional<model::partition_id>
+    partition_for(const kafka::group_id& group) override;
 
     ss::future<result<model::offset>> set_blocked_for_groups(
       const model::ntp& co_ntp,

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -119,9 +119,14 @@ private:
 
     std::optional<std::pair<model::ntp, ss::shard_id>>
     shard_for(const group_id& group) {
-        if (auto ntp = coordinator_mapper().local().ntp_for(group); ntp) {
-            if (auto shard_id = _shards.local().shard_for(*ntp); shard_id) {
-                return std::make_pair(std::move(*ntp), *shard_id);
+        if (auto p_id = coordinator_mapper().local().partition_for(group);
+            p_id) {
+            model::ntp ntp(
+              model::kafka_namespace,
+              model::kafka_consumer_offsets_topic,
+              *p_id);
+            if (auto shard_id = _shards.local().shard_for(ntp); shard_id) {
+                return std::make_pair(std::move(ntp), *shard_id);
             }
         }
         return std::nullopt;

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -49,9 +49,9 @@ handle_leader(request_context& ctx, model::node_id leader) {
  * leader to be elected if it isn't yet available immediately, like in the case
  * of creating the internal metadata topic on-demand.
  */
-static ss::future<response_ptr>
-handle_ntp(request_context& ctx, std::optional<model::ntp> ntp) {
-    if (!ntp) {
+static ss::future<response_ptr> handle_partition(
+  request_context& ctx, std::optional<model::partition_id> partition) {
+    if (!partition) {
         return ctx.respond(
           find_coordinator_response(error_code::coordinator_not_available));
     }
@@ -60,7 +60,12 @@ handle_ntp(request_context& ctx, std::optional<model::ntp> ntp) {
                    + config::shard_local_cfg().wait_for_leader_timeout_ms();
 
     return ctx.metadata_cache()
-      .get_leader(*ntp, timeout)
+      .get_leader(
+        model::ntp(
+          model::kafka_namespace,
+          model::kafka_consumer_offsets_topic,
+          *partition),
+        timeout)
       .then(
         [&ctx](model::node_id leader) { return handle_leader(ctx, leader); })
       .handle_exception([&ctx](const std::exception_ptr&) {
@@ -139,10 +144,10 @@ ss::future<response_ptr> find_coordinator_handler::handle(
            * metadata topic doesn't exist. in this case fall through and create
            * the topic on-demand.
            */
-          if (auto ntp = ctx.coordinator_mapper().ntp_for(
+          if (auto partition_id = ctx.coordinator_mapper().partition_for(
                 kafka::group_id(request.data.key));
-              ntp) {
-              return handle_ntp(ctx, std::move(ntp));
+              partition_id) {
+              return handle_partition(ctx, partition_id);
           }
 
           return ctx.group_initializer().assure_topic_exists().then(
@@ -152,9 +157,9 @@ ss::future<response_ptr> find_coordinator_handler::handle(
                  * will be updated and we can retry the group-ntp mapping.
                  */
                 if (created) {
-                    auto ntp = ctx.coordinator_mapper().ntp_for(
+                    auto partition_id = ctx.coordinator_mapper().partition_for(
                       kafka::group_id(request.data.key));
-                    return handle_ntp(ctx, std::move(ntp));
+                    return handle_partition(ctx, partition_id);
                 }
                 return ctx.respond(find_coordinator_response(
                   error_code::coordinator_not_available));

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -69,10 +69,10 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
     std::optional<model::node_id> leader_opt;
     cluster::tx::errc ec;
     while (!leader_opt && 0 < retries--) {
-        auto ntp_opt
-          = _group_router.local().coordinator_mapper().local().ntp_for(
+        auto partition_opt
+          = _group_router.local().coordinator_mapper().local().partition_for(
             group_id);
-        if (!ntp_opt) {
+        if (!partition_opt) {
             vlog(
               cluster::txlog.trace,
               "can't find ntp for {}, retrying",
@@ -81,22 +81,24 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
             co_await ss::sleep(delay_ms);
             continue;
         }
-
-        auto ntp = std::move(ntp_opt.value());
-        auto nt = model::topic_namespace_view(ntp.ns, ntp.tp.topic);
-        if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
+        auto& tp = model::kafka_consumer_offsets_nt;
+        if (!_metadata_cache.local().contains(tp, *partition_opt)) {
             vlog(
               cluster::txlog.trace,
-              "can't find meta info for {}, retrying",
-              ntp);
+              "can't find meta info for {}/{}, retrying",
+              *partition_opt);
             ec = cluster::tx::errc::partition_not_exists;
             co_await ss::sleep(delay_ms);
             continue;
         }
 
-        leader_opt = _leaders.local().get_leader(ntp);
+        leader_opt = _leaders.local().get_leader(tp, *partition_opt);
         if (!leader_opt) {
-            vlog(cluster::txlog.trace, "can't find a leader for {}", ntp);
+            vlog(
+              cluster::txlog.trace,
+              "can't find a leader for {}/{}",
+              tp,
+              *partition_opt);
             ec = cluster::tx::errc::leader_not_found;
             co_await ss::sleep(delay_ms);
         }
@@ -201,26 +203,28 @@ ss::future<cluster::commit_group_tx_reply> rm_group_frontend::commit_group_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    auto ntp_opt = _group_router.local().coordinator_mapper().local().ntp_for(
-      group_id);
-    if (!ntp_opt) {
+    auto p_id_opt
+      = _group_router.local().coordinator_mapper().local().partition_for(
+        group_id);
+    if (!p_id_opt) {
         vlog(cluster::txlog.warn, "can't find ntp for {}", group_id);
         co_return cluster::commit_group_tx_reply{
           cluster::tx::errc::partition_not_exists};
     }
 
-    auto ntp = std::move(ntp_opt.value());
+    auto& nt = model::kafka_consumer_offsets_nt;
 
-    auto nt = model::topic_namespace(ntp.ns, ntp.tp.topic);
-    if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
-        vlog(cluster::txlog.warn, "can' find meta info for {}", ntp);
+    if (!_metadata_cache.local().contains(nt, *p_id_opt)) {
+        vlog(
+          cluster::txlog.warn, "can' find meta info for {}/{}", nt, *p_id_opt);
         co_return cluster::commit_group_tx_reply{
           cluster::tx::errc::partition_not_exists};
     }
 
-    auto leader_opt = _leaders.local().get_leader(ntp);
+    auto leader_opt = _leaders.local().get_leader(nt, *p_id_opt);
     if (!leader_opt) {
-        vlog(cluster::txlog.warn, "can't find a leader for {}", ntp);
+        vlog(
+          cluster::txlog.warn, "can't find a leader for {}/{}", nt, *p_id_opt);
         co_return cluster::commit_group_tx_reply{
           cluster::tx::errc::leader_not_found};
     }
@@ -314,25 +318,27 @@ ss::future<cluster::abort_group_tx_reply> rm_group_frontend::abort_group_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    auto ntp_opt = _group_router.local().coordinator_mapper().local().ntp_for(
-      group_id);
-    if (!ntp_opt) {
+    auto p_id_opt
+      = _group_router.local().coordinator_mapper().local().partition_for(
+        group_id);
+    if (!p_id_opt) {
         vlog(cluster::txlog.warn, "can't find ntp for {} ", group_id);
         co_return cluster::abort_group_tx_reply{
           cluster::tx::errc::partition_not_exists};
     }
-    auto ntp = std::move(ntp_opt.value());
+    auto& nt = model::kafka_consumer_offsets_nt;
 
-    auto nt = model::topic_namespace(ntp.ns, ntp.tp.topic);
-    if (!_metadata_cache.local().contains(nt, ntp.tp.partition)) {
-        vlog(cluster::txlog.warn, "can't find meta info for {}", ntp);
+    if (!_metadata_cache.local().contains(nt, *p_id_opt)) {
+        vlog(
+          cluster::txlog.warn, "can't find meta info for {}/{}", nt, *p_id_opt);
         co_return cluster::abort_group_tx_reply{
           cluster::tx::errc::partition_not_exists};
     }
 
-    auto leader_opt = _leaders.local().get_leader(ntp);
+    auto leader_opt = _leaders.local().get_leader(nt, *p_id_opt);
     if (!leader_opt) {
-        vlog(cluster::txlog.warn, "can't find a leader for {}", ntp);
+        vlog(
+          cluster::txlog.warn, "can't find a leader for  {}/{}", nt, *p_id_opt);
         co_return cluster::abort_group_tx_reply{
           cluster::tx::errc::leader_not_found};
     }

--- a/src/v/kafka/server/tests/consumer_groups_test.cc
+++ b/src/v/kafka/server/tests/consumer_groups_test.cc
@@ -163,8 +163,12 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
     auto deferred = ss::defer(decltype(client_stop)(client_stop));
     client->connect().get();
 
-    auto gntp = app.coordinator_ntp_mapper.local().ntp_for(g);
-    BOOST_REQUIRE(gntp);
+    auto g_partition = app.coordinator_ntp_mapper.local().partition_for(g);
+    BOOST_REQUIRE(g_partition);
+    model::ntp gntp(
+      model::kafka_namespace,
+      model::kafka_consumer_offsets_topic,
+      *g_partition);
 
     auto can_commit_offset = [&] {
         for (int _ : std::views::iota(0, 5)) {
@@ -195,7 +199,7 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
 
     auto set_blocked = [&](bool blocked) {
         auto res = app._group_manager.local()
-                     .set_blocked_for_groups(*gntp, {g}, blocked)
+                     .set_blocked_for_groups(gntp, {g}, blocked)
                      .get();
         BOOST_REQUIRE(res.has_value());
     };
@@ -204,7 +208,7 @@ FIXTURE_TEST(block_test, consumer_offsets_fixture) {
         client_stop();
         consumer_offsets_fixture::restart(should_wipe::no);
         wait_for_consumer_offsets_topic(gi);
-        wait_for_leader(*gntp).get();
+        wait_for_leader(gntp).get();
         client = std::make_unique<kafka::client::transport>(
           make_kafka_client().get());
         client->connect().get();

--- a/src/v/redpanda/admin/transaction.cc
+++ b/src/v/redpanda/admin/transaction.cc
@@ -240,7 +240,8 @@ admin_server::unsafe_abort_group_transaction(
 
     if (pid_str.empty() || epoch_str.empty() || sequence_str.empty()) {
         throw ss::httpd::bad_param_exception(fmt::format(
-          "invalid producer_id({})/epoch({})/sequence({}), should be integers "
+          "invalid producer_id({})/epoch({})/sequence({}), should be "
+          "integers "
           ">= 0",
           pid_str,
           epoch_str,
@@ -279,8 +280,8 @@ admin_server::unsafe_abort_group_transaction(
 
     auto& mapper = _kafka_server.local().coordinator_mapper();
     auto kafka_gid = kafka::group_id{group_id};
-    auto group_ntp = mapper.ntp_for(kafka::group_id{group_id});
-    if (!group_ntp) {
+    auto group_partition = mapper.partition_for(kafka::group_id{group_id});
+    if (!group_partition) {
         throw ss::httpd::server_error_exception(
           "consumer_offsets topic not found");
     }
@@ -292,6 +293,12 @@ admin_server::unsafe_abort_group_transaction(
         seq.value(),
         5s);
 
-    co_await throw_on_error(*request, result, group_ntp.value());
+    co_await throw_on_error(
+      *request,
+      result,
+      model::ntp(
+        model::kafka_namespace,
+        model::kafka_consumer_offsets_topic,
+        *group_partition));
     co_return ss::json::json_return_type(ss::json::json_void());
 }


### PR DESCRIPTION
When looking for the `__consumer_topics` partition that host the groups it is always clear to the caller what namespace and topic that host the group is. Returning the whole `ntp` from the coordinator mapper doesn't make any sense and requires additional copy.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none