### PR TITLE
[CORE-12919] `cloud_storage`: check for closed `_gate` at start of `run_hydrate_bg()`

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -764,6 +764,25 @@ bool remote_segment::is_state_materialized() const {
 }
 
 ss::future<> remote_segment::run_hydrate_bg() {
+    // The gate could potentially be closed before the background loop even has
+    // the chance to start.
+    if (_gate.is_closed()) {
+        // If any new download requests got queued up while we were downloading
+        // chunks before the gate closed, cancel them so that the gate close
+        // does not get stuck during segment stop.
+        if (!_chunk_waiters.empty()) {
+            vlog(
+              _ctxlog.debug,
+              "Cancelling {} pending chunk downloads during segment stop",
+              _chunk_waiters.size());
+            for (auto& w : _chunk_waiters) {
+                w.promise.set_exception(ss::gate_closed_exception{});
+            }
+        }
+        _hydration_loop_running = false;
+        co_return;
+    }
+
     ss::gate::holder guard(_gate);
 
     // Track whether we have seen our objects in the cache during the loop


### PR DESCRIPTION
From a CI failure [1] , it seems that a `remote_segment` can be created, and then stopped before the background loop kicked off from the `remote_segment`'s constructor even has the chance to obtain a holder, leading to an `WARN - Exceptional future ignored` log from seastar.

To avoid this, add a check for `_gate.is_closed()` before trying to obtain the holder. If there exists any chunk waiters when taking this early return path, cancel them to ensure a graceful `remote_segment` shutdown.

JIRA link: https://redpandadata.atlassian.net/browse/CORE-12919

### [1]

```
DEBUG 2025-07-25 14:52:54,414 [shard 1:kafk] cloud_storage - [fiber142~52 kafka/reader-stress/0 [7182:7833]] - remote_segment.cc:170 - total 10 chunks in segment of size 10621011, max hydrated chunks at a time: 7, chunk size: 1048576
DEBUG 2025-07-25 14:52:54,416 [shard 1:main] cloud_storage - [fiber142~52 kafka/reader-stress/0 [7182:7833]] - remote_segment.cc:219 - remote segment stop: gate closing
DEBUG 2025-07-25 14:52:54,416 [shard 1:main] cloud_storage - [fiber142~52 kafka/reader-stress/0 [7182:7833]] - remote_segment.cc:222 - remote segment stop: gate closed
WARN  2025-07-25 14:52:54,417 [shard 1:tr  ] seastar - Exceptional future ignored: seastar::gate_closed_exception (gate closed), backtrace: 0x9a9be9a 0x9773525 0x8101608 0x98499a2 0x98b88c4 0x97d75e2 /opt/redpanda/lib/libc.so.6+0x94ac2 /opt/redpanda/lib/libc.so.6+0x12684f
   --------
   seastar::lambda_task<auto seastar::with_scheduling_group<cloud_storage::remote_segment::remote_segment(cloud_storage::remote&, cloud_storage::cache&, detail::base_named_type<seastar::basic_sstring<char, unsigned int, 15u, true>, cloud_storage_clients::s3_bucket_name, std::__1::integral_constant<bool, false>>, detail::base_named_type<std::__1::__fs::filesystem::path, cloud_storage::archival_remote_segment_path_t, std::__1::integral_constant<bool, false>> const&, model::ntp const&, cloud_storage::segment_meta const&, basic_retry_chain_node<seastar::lowres_clock>&, cloud_storage::partition_probe&, cloud_storage::ts_read_path_probe&)::$_0>(seastar::scheduling_group, T)::'lambda'()>
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
