### PR TITLE
ct/l1: return corrected next offsets from bad add_objects()

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -74,8 +74,9 @@ domain_manager::add_objects(rpc::add_objects_request req) {
     for (const auto& obj : req.new_objects) {
         added_oids.emplace(obj.oid);
     }
+    chunked_hash_map<model::topic_id_partition, kafka::offset> corrections;
     auto update_res = add_objects_update::build(
-      stm_state, std::move(req.new_objects));
+      stm_state, std::move(req.new_objects), &corrections);
     if (!update_res.has_value()) {
         vlog(
           cd_log.debug,
@@ -114,6 +115,7 @@ domain_manager::add_objects(rpc::add_objects_request req) {
     }
     co_return rpc::add_objects_reply{
       .ec = rpc::errc::ok,
+      .corrected_next_offsets = std::move(corrections),
     };
 }
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -115,10 +115,23 @@ public:
     virtual ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) = 0;
 
-    // Adds the given objects to the metastore. If any are invalid, e.g.
-    // because they break an invariant of a partition's offset ranges, all
-    // objects are rejected.
-    virtual ss::future<std::expected<void, errc>>
+    struct add_response {
+        // The actual next offsets for any topic partitions whose input objects
+        // were not properly aligned in a given add request.
+        //
+        // Callers should treat this as the new source of truth for subsequent
+        // attempts to add objects for these partitions.
+        chunked_hash_map<model::topic_id_partition, kafka::offset>
+          corrected_next_offsets;
+    };
+    // If the input is invalid (e.g. unordered, empty, contains an object that
+    // already exists) an error is returned.
+    //
+    // If no error is returned, this means that the request was valid, though
+    // it does not imply that all extents were accepted by the metastore. The
+    // response should be examined to determine if subsequent add_objects()
+    // requests need to be re-aligned to a different offset.
+    virtual ss::future<std::expected<add_response, errc>>
       add_objects(std::unique_ptr<object_metadata_builder>) = 0;
 
     // Adds the given objects to the metastore, expecting that the new extents

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -229,7 +229,7 @@ replicated_metastore::get_offsets(const model::topic_id_partition& tidp) {
     co_return resp;
 }
 
-ss::future<std::expected<void, metastore::errc>>
+ss::future<std::expected<metastore::add_response, metastore::errc>>
 replicated_metastore::add_objects(
   std::unique_ptr<metastore::object_metadata_builder> builder) {
     auto replicated_builder = std::unique_ptr<replicated_object_builder>(
@@ -243,6 +243,7 @@ replicated_metastore::add_objects(
           objects_result.error());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
+    add_response resp;
     for (auto& [partition_id, partition_objects] : objects_result.value()) {
         rpc::add_objects_request req;
         req.metastore_partition = partition_id;
@@ -266,8 +267,11 @@ replicated_metastore::add_objects(
               int(reply.ec));
             co_return std::unexpected(rpc_to_meta_errc(reply.ec));
         }
+        for (const auto& [tp, o] : reply.corrected_next_offsets) {
+            resp.corrected_next_offsets[tp] = o;
+        }
     }
-    co_return std::expected<void, errc>{};
+    co_return resp;
 }
 
 ss::future<std::expected<void, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -27,7 +27,7 @@ public:
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;
 
-    ss::future<std::expected<void, errc>>
+    ss::future<std::expected<add_response, errc>>
       add_objects(std::unique_ptr<object_metadata_builder>) override;
 
     ss::future<std::expected<void, errc>>

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -32,9 +32,14 @@ enum class errc : int16_t {
 struct add_objects_reply
   : serde::
       envelope<add_objects_reply, serde::version<0>, serde::compat_version<0>> {
-    auto serde_fields() { return std::tie(ec); }
+    auto serde_fields() { return std::tie(ec, corrected_next_offsets); }
 
     errc ec;
+
+    // Corrected next offsets for subsequent add_objects_requests to try.
+    // Expected to only be set on success.
+    chunked_hash_map<model::topic_id_partition, kafka::offset>
+      corrected_next_offsets;
 };
 struct add_objects_request
   : serde::envelope<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -113,7 +113,8 @@ simple_metastore::get_offsets(
     };
 }
 
-ss::future<std::expected<void, metastore::errc>> simple_metastore::add_objects(
+ss::future<std::expected<metastore::add_response, metastore::errc>>
+simple_metastore::add_objects(
   std::unique_ptr<metastore::object_metadata_builder> builder) {
     auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
     auto objects_res = simple_builder->release();
@@ -124,20 +125,25 @@ ss::future<std::expected<void, metastore::errc>> simple_metastore::add_objects(
     co_return co_await add_objects(objects_res.value());
 }
 
-ss::future<std::expected<void, metastore::errc>>
+ss::future<std::expected<metastore::add_response, metastore::errc>>
 simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
     chunked_vector<new_object> new_objects;
     for (const auto& o : objects) {
         new_objects.emplace_back(make_new_object(o));
     }
-    auto update_res = add_objects_update::build(state_, std::move(new_objects));
+    add_response resp;
+    auto update_res = add_objects_update::build(
+      state_, std::move(new_objects), &resp.corrected_next_offsets);
     if (!update_res.has_value()) {
         vlog(cd_log.debug, "Object add failed: {}", update_res.error());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
     auto apply_res = update_res->apply(state_);
-    vassert(apply_res.has_value(), "Apply must succeed if can_apply() is true");
-    co_return std::expected<void, metastore::errc>{};
+    vassert(
+      apply_res.has_value(),
+      "Apply must succeed if can_apply() is true: {}",
+      apply_res.error());
+    co_return resp;
 }
 
 ss::future<std::expected<void, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -53,9 +53,9 @@ public:
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;
 
-    ss::future<std::expected<void, errc>>
+    ss::future<std::expected<add_response, errc>>
       add_objects(std::unique_ptr<object_metadata_builder>) override;
-    ss::future<std::expected<void, errc>>
+    ss::future<std::expected<add_response, errc>>
     add_objects(const chunked_vector<object_metadata>&);
 
     ss::future<std::expected<void, errc>>

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -57,19 +57,22 @@ void new_object::collect_extents_by_tidp(sorted_extents_by_tidp_t* ret) const {
 }
 
 std::expected<add_objects_update, stm_update_error> add_objects_update::build(
-  const state& state, chunked_vector<new_object> objects) {
+  const state& state,
+  chunked_vector<new_object> objects,
+  chunked_hash_map<model::topic_id_partition, kafka::offset>* corrections) {
     add_objects_update update{
       .new_objects = std::move(objects),
     };
-    auto allowed = update.can_apply(state);
+    auto allowed = update.can_apply(state, corrections);
     if (!allowed.has_value()) {
         return std::unexpected(allowed.error());
     }
     return update;
 }
 
-std::expected<std::monostate, stm_update_error>
-add_objects_update::can_apply(const state& state) {
+std::expected<std::monostate, stm_update_error> add_objects_update::can_apply(
+  const state& state,
+  chunked_hash_map<model::topic_id_partition, kafka::offset>* corrections) {
     if (new_objects.empty()) {
         return std::unexpected(stm_update_error{"No objects requested"});
     }
@@ -82,6 +85,8 @@ add_objects_update::can_apply(const state& state) {
         o.collect_extents_by_tidp(&new_extents);
     }
 
+    chunked_hash_map<model::topic_id_partition, kafka::offset>
+      corrected_next_offsets;
     for (const auto& [tidp, extents] : new_extents) {
         // TODO: maybe we need some mount operation that adopts a partition log
         // and allows it to start a specific offset.
@@ -89,6 +94,13 @@ add_objects_update::can_apply(const state& state) {
         auto expected_next = p_state ? p_state->get().next_offset
                                      : kafka::offset{0};
 
+        if (extents.begin()->base_offset != expected_next) {
+            // If the start of the new extents for this partition aren't
+            // aligned, allow the operation to succeed, but the expectation is
+            // when applying, we'll "drop" these extents.
+            corrected_next_offsets[tidp] = expected_next;
+            continue;
+        }
         for (const auto& extent : extents) {
             if (extent.base_offset != expected_next) {
                 return std::unexpected(stm_update_error(fmt::format(
@@ -96,10 +108,13 @@ add_objects_update::can_apply(const state& state) {
                   "expected next: {}, actual: {}",
                   tidp,
                   expected_next,
-                  extent.base_offset)));
+                  extent.base_offset())));
             }
             expected_next = kafka::next_offset(extent.last_offset);
         }
+    }
+    if (corrections) {
+        *corrections = std::move(corrected_next_offsets);
     }
     return std::monostate{};
 }
@@ -110,9 +125,9 @@ add_objects_update::apply(state& state) {
     if (!allowed.has_value()) {
         return std::unexpected(allowed.error());
     }
-    new_object::sorted_extents_by_tidp_t extents_by_tpr;
+    new_object::sorted_extents_by_tidp_t extents_by_tp;
     for (const auto& o : new_objects) {
-        o.collect_extents_by_tidp(&extents_by_tpr);
+        o.collect_extents_by_tidp(&extents_by_tp);
         state.objects.emplace(
           o.oid,
           object_entry{
@@ -121,17 +136,31 @@ add_objects_update::apply(state& state) {
             .footer_pos = o.footer_pos,
           });
     }
-    for (const auto& [tidp, extents] : extents_by_tpr) {
-        auto& t_state = state.topic_to_state[tidp.topic_id];
-        auto& p_state = t_state.pid_to_state[tidp.partition];
-        for (const auto& e : extents) {
-            p_state.extents.emplace(e);
-        }
-        p_state.next_offset = kafka::next_offset(
-          p_state.extents.rbegin()->last_offset);
-
-        for (const auto& extent : extents) {
-            state.objects[extent.oid].total_data_size += extent.len;
+    for (const auto& [tidp, extents] : extents_by_tp) {
+        auto p_state = state.partition_state(tidp);
+        auto expected_next = p_state ? p_state->get().next_offset
+                                     : kafka::offset{0};
+        if (extents.begin()->base_offset == expected_next) {
+            auto& t_state = state.topic_to_state[tidp.topic_id];
+            auto& p_state = t_state.pid_to_state[tidp.partition];
+            // We've validated that all extents form a contiguous offset space.
+            // Accept them all.
+            for (const auto& e : extents) {
+                p_state.extents.emplace(e);
+            }
+            p_state.next_offset = kafka::next_offset(
+              p_state.extents.rbegin()->last_offset);
+            for (const auto& extent : extents) {
+                state.objects[extent.oid].total_data_size += extent.len;
+            }
+        } else {
+            // The incoming extents don't align with the next position. "Drop"
+            // them all.
+            for (const auto& extent : extents) {
+                auto& obj_entry = state.objects[extent.oid];
+                obj_entry.removed_data_size += extent.len;
+                obj_entry.total_data_size += extent.len;
+            }
         }
     }
     return std::monostate{};

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -72,10 +72,14 @@ struct add_objects_update
     auto serde_fields() { return std::tie(new_objects); }
 
     static constexpr auto key{update_key::add_objects};
-    static std::expected<add_objects_update, stm_update_error>
-    build(const state&, chunked_vector<new_object>);
+    static std::expected<add_objects_update, stm_update_error> build(
+      const state&,
+      chunked_vector<new_object>,
+      chunked_hash_map<model::topic_id_partition, kafka::offset>* = nullptr);
 
-    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> can_apply(
+      const state&,
+      chunked_hash_map<model::topic_id_partition, kafka::offset>* = nullptr);
     std::expected<std::monostate, stm_update_error> apply(state&);
 
     chunked_vector<new_object> new_objects;

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -124,6 +124,7 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
                    .build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     // We didn't add tid_c, so we should still get an error.
     get_res = m.get_first_ge(
@@ -157,6 +158,7 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
           = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
         ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+        ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
         auto offsets_res
           = m.get_offsets(model::topic_id_partition::from(tid_a)).get();
@@ -170,8 +172,8 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
         auto ometa
           = om_builder(oid2, 100).add(tid_a, 12_o, 20_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
-        ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
-        ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
+        ASSERT_TRUE(add_res.has_value());
+        ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
 
         // The offsets should not be affected.
         auto offsets_res
@@ -183,9 +185,10 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
 
     // Now add the object right at the end, where it should be.
     auto ometa
-      = om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build();
+      = om_builder(oid3, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto offsets_res
       = m.get_offsets(model::topic_id_partition::from(tid_a)).get();
@@ -204,6 +207,7 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
                             std::move(ometa)))
                          .get();
         ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
+        ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
     }
 
     {
@@ -214,16 +218,16 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)))
                          .get();
-        ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
-        ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
+        ASSERT_TRUE(add_res.has_value());
+        ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
     }
     {
         // Add another object that fully overlaps with what exists.
         auto ometa
-          = om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+          = om_builder(oid3, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
-        ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
-        ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
+        ASSERT_TRUE(add_res.has_value());
+        ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
     }
 }
 
@@ -233,8 +237,8 @@ TEST(SimpleMetastoreTest, TestAddPastBeginning) {
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 1_o, 10_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
-    ASSERT_FALSE(add_res.has_value()) << int(add_res.error());
-    ASSERT_EQ(metastore::errc::invalid_request, add_res.error());
+    ASSERT_TRUE(add_res.has_value());
+    ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
 }
 
 TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
@@ -248,6 +252,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
       om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
     auto add_res = m.add_objects(os).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto tpr = model::topic_id_partition::from(tid_a);
     for (const auto& o : std::views::iota(0, 11)) {
@@ -276,6 +281,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto get_res = m.get_first_ge(
                       model::topic_id_partition::from(tid_a), kafka::offset{-1})
@@ -291,6 +297,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetOutOfRange) {
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto get_res = m.get_first_ge(
                       model::topic_id_partition::from(tid_a), kafka::offset{11})
@@ -310,6 +317,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
       om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 3999_t, 0, 99).build());
     auto add_res = m.add_objects(os).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto tpr = model::topic_id_partition::from(tid_a);
     for (const auto& t : {1000_t, 1999_t}) {
@@ -338,6 +346,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBelowStart) {
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto get_res
       = m.get_first_ge(model::topic_id_partition::from(tid_a), 999_t).get();
@@ -351,6 +360,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampOutOfRange) {
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     auto get_res
       = m.get_first_ge(model::topic_id_partition::from(tid_a), 3000_t).get();
@@ -365,6 +375,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res = m.add_objects(os).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     om_list_t new_os;
     new_os.emplace_back(
@@ -445,6 +456,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                       .build());
     auto add_res = m.add_objects(os).get();
     ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
     // For one partition, replace the entire range. For another, replace part
     // of the range. As long as they're both aligned this should succeed.

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -172,11 +172,13 @@ TEST(StateUpdateTest, TestStartAfterZero) {
                     .build();
     state s;
     auto res = update.apply(s);
-    EXPECT_FALSE(res.has_value());
-    EXPECT_THAT(
-      res.error()(), testing::HasSubstr("Input object breaks partition"))
-      << res.error();
-    EXPECT_EQ(0, s.objects.size());
+    EXPECT_TRUE(res.has_value());
+
+    // The added object should be tracked as removed.
+    EXPECT_EQ(0, s.topic_to_state.size());
+    EXPECT_EQ(1, s.objects.size());
+    auto& added_obj = s.objects.at(oid1);
+    EXPECT_EQ(added_obj.removed_data_size, added_obj.total_data_size);
 }
 
 TEST(StateUpdateTest, TestDuplicateObject) {
@@ -214,17 +216,74 @@ TEST(StateUpdateTest, TestDuplicateAddMultipleUpdates) {
     auto res = update.apply(s);
     EXPECT_TRUE(res.has_value());
     EXPECT_EQ(3, s.topic_to_state.size());
+    for (const auto& [t, p_states] : s.topic_to_state) {
+        EXPECT_EQ(
+          1, p_states.pid_to_state.at(model::partition_id{0}).extents.size());
+    }
     EXPECT_EQ(1, s.objects.size());
 
     // Tweak the update to overlap with the one we just applied but with a
     // different object.
     update.new_objects[0].oid = oid2;
-    auto dupe_res = update.can_apply(s);
-    EXPECT_FALSE(dupe_res.has_value());
-    EXPECT_THAT(
-      dupe_res.error()(), testing::HasSubstr("Input object breaks partition"))
-      << dupe_res.error();
+    auto dupe_res = update.apply(s);
+    EXPECT_TRUE(dupe_res.has_value());
+    EXPECT_EQ(3, s.topic_to_state.size());
+    for (const auto& [t, p_states] : s.topic_to_state) {
+        // The tracked extents shouldn't change.
+        EXPECT_EQ(
+          1, p_states.pid_to_state.at(model::partition_id{0}).extents.size());
+    }
+    EXPECT_EQ(2, s.objects.size());
+    auto& dupe_obj = s.objects.at(oid2);
+    EXPECT_EQ(dupe_obj.removed_data_size, dupe_obj.total_data_size);
+}
+
+TEST(StateUpdateTest, TestOverlapSomePartitions) {
+    state s;
+    {
+        auto update = add_objects_builder()
+                        .add(new_obj_builder(oid1, 100)
+                               .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                               .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
+                               .build())
+                        .build();
+        auto res = update.apply(s);
+        EXPECT_TRUE(res.has_value());
+    }
+    EXPECT_EQ(2, s.topic_to_state.size());
+    for (const auto& [t, p_states] : s.topic_to_state) {
+        EXPECT_EQ(
+          1, p_states.pid_to_state.at(model::partition_id{0}).extents.size());
+    }
     EXPECT_EQ(1, s.objects.size());
+
+    // Now send a bogus range for one of the partitions, but a correct extent
+    // for another.
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid2, 100)
+                           .add(tidp_a, 1337_o, 1337_o, 1999_t, 0, 5)
+                           .add(tidp_b, 11_o, 20_o, 1999_t, 100, 199)
+                           .build())
+                    .build();
+    auto misaligned_res = update.apply(s);
+    EXPECT_TRUE(misaligned_res.has_value());
+    EXPECT_EQ(2, s.topic_to_state.size());
+
+    // The bad update shouldn't be applied.
+    auto p_a = s.partition_state(model::topic_id_partition::from(tidp_a));
+    ASSERT_TRUE(p_a.has_value());
+    EXPECT_EQ(1, p_a->get().extents.size());
+
+    // But the good update should be there.
+    auto p_b = s.partition_state(model::topic_id_partition::from(tidp_b));
+    ASSERT_TRUE(p_b.has_value());
+    EXPECT_EQ(2, p_b->get().extents.size());
+
+    // The accounting for the object should reflect this.
+    EXPECT_EQ(2, s.objects.size());
+    auto& dupe_obj = s.objects.at(oid2);
+    EXPECT_EQ(dupe_obj.removed_data_size, 5);
+    EXPECT_EQ(dupe_obj.total_data_size, 104);
 }
 
 namespace {


### PR DESCRIPTION
There's general concern that a single partition's bad update can fail a shared object's commit to the metastore. This case may end up being quite common, especially if there are leadership changes while reconciling, as in this case, we end up not being able to replicate LRO, which may cause subsequent reconciliation attempts to be misaligned.

So, this commit changes the behavior of the metastore to return success on add_objects() even if some or all of the objects extent ranges are misaligned with their expected next. Now, a corrected map of partition to offset is returned, with the expectation that the caller will use the corrected offsets next time.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
