### PR TITLE
gha: rename slash command

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -7,7 +7,7 @@ on:
       - ci-repeat-command
       - dt-command
       - microbench-command
-      - publish-to-install-pack-command
+      - install-pack-command
       - rp-unit-test-command
       - test-arm64-command
       - test-codecov-command

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -30,7 +30,7 @@ jobs:
             ci-repeat
             dt
             microbench
-            publish-to-install-pack
+            install-pack
             rp-unit-test
             test-arm64
             test-codecov


### PR DESCRIPTION
From `publish-to-install-pack` to just `install-pack`

part of https://redpandadata.atlassian.net/browse/DEVPROD-1798

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
