### PR TITLE
compression: remove model dependency

### DIFF
--- a/src/v/compression/BUILD
+++ b/src/v/compression/BUILD
@@ -31,7 +31,6 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
-        "//src/v/model",
         "//src/v/utils:object_pool",
         "//src/v/utils:static_deleter_fn",
         "@fmt",

--- a/src/v/compression/compression.cc
+++ b/src/v/compression/compression.cc
@@ -19,6 +19,8 @@
 
 #include <seastar/util/log.hh>
 
+#include <utility>
+
 namespace compression {
 
 /*
@@ -36,20 +38,16 @@ ss::logger complog{"compression"};
 
 iobuf compressor::compress(const iobuf& io, type t) {
     switch (t) {
-    case type::none:
-        throw std::runtime_error("compressor: nothing to compress for 'none'");
     case type::gzip:
         return internal::gzip_compressor::compress(io);
-    case type::snappy:
+    case type::java_snappy:
         return internal::snappy_java_compressor::compress(io);
     case type::lz4:
         return internal::lz4_frame_compressor::compress(io);
     case type::zstd:
         return internal::zstd_compressor::compress(io);
-    default:
-        vlog(complog.error, "Cannot compress type {}", t);
-        vassert(false, "Cannot compress type {}", t);
     }
+    vassert(false, "Unknown compression type {}", t);
 }
 iobuf compressor::uncompress(const iobuf& io, type t) {
     if (io.empty()) {
@@ -57,27 +55,20 @@ iobuf compressor::uncompress(const iobuf& io, type t) {
           fmt::format("Asked to decompress:{} an empty buffer:{}", (int)t, io));
     }
     switch (t) {
-    case type::none:
-        throw std::runtime_error(
-          "compressor: nothing to uncompress for 'none'");
     case type::gzip:
         return internal::gzip_compressor::uncompress(io);
-    case type::snappy:
+    case type::java_snappy:
         return internal::snappy_java_compressor::uncompress(io);
     case type::lz4:
         return internal::lz4_frame_compressor::uncompress(io);
     case type::zstd:
         return internal::zstd_compressor::uncompress(io);
-    default:
-        vassert(false, "Cannot uncompress type {}", t);
     }
+    vassert(false, "Unknown uncompression type {}", t);
 }
 
 ss::future<iobuf> stream_compressor::compress(iobuf io, type t) {
     switch (t) {
-    case type::none:
-        return ss::make_exception_future<iobuf>(
-          std::runtime_error("compressor: nothing to compress for 'none'"));
     case type::zstd:
         return compression::async_stream_zstd_instance().compress(
           std::move(io));
@@ -97,6 +88,20 @@ ss::future<iobuf> stream_compressor::uncompress(iobuf io, type t) {
     default:
         return ss::make_ready_future<iobuf>(compressor::uncompress(io, t));
     }
+}
+
+std::ostream& operator<<(std::ostream& os, const type& c) {
+    switch (c) {
+    case type::gzip:
+        return os << "gzip";
+    case type::java_snappy:
+        return os << "java_snappy";
+    case type::lz4:
+        return os << "lz4";
+    case type::zstd:
+        return os << "zstd";
+    }
+    return os << "compression::type::unknown(" << std::to_underlying(c) << ")";
 }
 
 } // namespace compression

--- a/src/v/compression/compression.h
+++ b/src/v/compression/compression.h
@@ -11,10 +11,20 @@
 
 #pragma once
 #include "bytes/iobuf.h"
-#include "model/compression.h"
+
 namespace compression {
 
-using type = model::compression;
+enum class type : uint8_t {
+    gzip,
+    // NOTE: This is *NOT* standard snappy compression. It uses the java-snappy
+    // framing compression which is fundamentally not compatible with upstream
+    // google snappy
+    java_snappy,
+    lz4,
+    zstd,
+};
+std::ostream& operator<<(std::ostream& os, const type& c);
+
 // a very simple compressor. Exposes virtually no knobs and uses
 // the defaults for all compressors. In the future, we can make these
 // a virtual interface so we can instantiate them

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -204,6 +204,26 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
     return remainder;
 }
 
+namespace {
+::compression::type to_compression_type(model::compression c) {
+    switch (c) {
+    case model::compression::gzip:
+        return ::compression::type::gzip;
+    case model::compression::snappy:
+        return ::compression::type::java_snappy;
+    case model::compression::lz4:
+        return ::compression::type::lz4;
+    case model::compression::zstd:
+        return ::compression::type::zstd;
+    case model::compression::none:
+    case model::compression::count:
+    case model::compression::producer:
+        break;
+    }
+    throw std::runtime_error(fmt::format("Unknown compression type: {}", c));
+}
+} // namespace
+
 /*
  * Handle a MessageSet. For each uncompressed message the message data is
  * accumulated in the new-style redpanda batch format. Compressed messages
@@ -274,7 +294,7 @@ void kafka_batch_adapter::convert_message_set(
         }
 
         auto batch_data = compression::compressor::uncompress(
-          *batch->value, batch->compression());
+          *batch->value, to_compression_type(batch->compression()));
 
         convert_message_set(builder, std::move(batch_data), true);
     }

--- a/src/v/model/batch_compression.cc
+++ b/src/v/model/batch_compression.cc
@@ -16,6 +16,26 @@
 
 namespace model {
 
+namespace {
+::compression::type to_compression_type(model::compression c) {
+    switch (c) {
+    case model::compression::gzip:
+        return ::compression::type::gzip;
+    case model::compression::snappy:
+        return ::compression::type::java_snappy;
+    case model::compression::lz4:
+        return ::compression::type::lz4;
+    case model::compression::zstd:
+        return ::compression::type::zstd;
+    case model::compression::none:
+    case model::compression::count:
+    case model::compression::producer:
+        break;
+    }
+    throw std::runtime_error(fmt::format("Unknown compression type: {}", c));
+}
+} // namespace
+
 ss::future<model::record_batch> decompress_batch(model::record_batch&& b) {
     return ss::futurize_invoke(decompress_batch_sync, std::move(b));
 }
@@ -40,7 +60,7 @@ model::record_batch maybe_decompress_batch_sync(const model::record_batch& b) {
           b.header()));
     }
     iobuf body_buf = ::compression::compressor::uncompress(
-      b.data(), b.header().attrs.compression());
+      b.data(), to_compression_type(b.header().attrs.compression()));
     // must remove compression first!
     auto h = b.header();
     h.attrs.remove_compression();
@@ -58,17 +78,40 @@ compress_batch(model::compression c, model::record_batch b) {
           "Asked to compress a batch with `none` compression, but header "
           "metadata is incorrect: {}",
           b.header());
+        b.header().reset_size_checksum_metadata(b.data());
         co_return b;
     }
-    auto h = b.header();
+    model::record_batch_header h = b.header();
     auto payload = co_await ::compression::stream_compressor::compress(
-      std::move(b).release_data(), c);
+      std::move(b).release_data(), to_compression_type(c));
     // compression bit must be set first!
     h.attrs |= c;
     h.reset_size_checksum_metadata(payload);
     auto batch = model::record_batch(
       h, std::move(payload), model::record_batch::tag_ctor_ng{});
     co_return batch;
+}
+
+model::record_batch
+compress_batch_sync(model::compression c, model::record_batch b) {
+    if (c == model::compression::none) {
+        vassert(
+          b.header().attrs.compression() == model::compression::none,
+          "Asked to compress a batch with `none` compression, but header "
+          "metadata is incorrect: {}",
+          b.header());
+        b.header().reset_size_checksum_metadata(b.data());
+        return b;
+    }
+    model::record_batch_header h = b.header();
+    auto payload = ::compression::compressor::compress(
+      std::move(b).release_data(), to_compression_type(c));
+    // compression bit must be set first!
+    h.attrs |= c;
+    h.reset_size_checksum_metadata(payload);
+    auto batch = model::record_batch(
+      h, std::move(payload), model::record_batch::tag_ctor_ng{});
+    return batch;
 }
 
 } // namespace model

--- a/src/v/model/batch_compression.h
+++ b/src/v/model/batch_compression.h
@@ -29,8 +29,17 @@ model::record_batch decompress_batch_sync(model::record_batch&&);
 /// \throw std::runtime_error If provided batch is not compressed
 model::record_batch maybe_decompress_batch_sync(const model::record_batch&);
 
-/// \brief batch compression
+// Compress the batch according to the specified compression type.
+//
+// *Always* recomputes the batch CRC and metadata, even if the batch
+// is not compressed.
 ss::future<model::record_batch>
   compress_batch(model::compression, model::record_batch);
+
+// The same as above, but synchronous.
+//
+// Only use in test code.
+model::record_batch
+  compress_batch_sync(model::compression, model::record_batch);
 
 } // namespace model

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -19,6 +19,7 @@ redpanda_test_cc_library(
         "//src/v/compression",
         "//src/v/container:chunked_circular_buffer",
         "//src/v/model",
+        "//src/v/model:batch_compression",
         "//src/v/random:generators",
         "//src/v/test_utils:random",
         "//src/v/test_utils:random_bytes",

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -11,7 +11,7 @@
 
 #include "base/vassert.h"
 #include "bytes/iobuf.h"
-#include "compression/compression.h"
+#include "model/batch_compression.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
@@ -147,7 +147,6 @@ model::record_batch make_random_batch(record_batch_spec spec) {
         header.base_sequence = spec.base_sequence;
     }
 
-    auto size = model::packed_record_batch_header_size;
     model::record_batch::records_type records;
     auto rs = model::record_batch::uncompressed_records();
     rs.reserve(spec.count);
@@ -164,30 +163,22 @@ model::record_batch make_random_batch(record_batch_spec spec) {
             rs.emplace_back(make_random_record(i, sz));
         }
     }
-    if (header.attrs.compression() != model::compression::none) {
-        iobuf body;
-        for (auto& r : rs) {
-            model::append_record_to_buffer(body, r);
-        }
-        rs.clear();
-        records = ::compression::compressor::compress(
-          body, header.attrs.compression());
-        size += std::get<iobuf>(records).size_bytes();
-    } else {
-        for (auto& r : rs) {
-            size += r.size_bytes();
-            size += vint::vint_size(r.size_bytes());
-        }
-        records = std::move(rs);
+    iobuf body;
+    for (auto& r : rs) {
+        model::append_record_to_buffer(body, r);
     }
+    rs.clear();
     // TODO: expose term setting
     header.ctx = model::record_batch_header::context(
       model::term_id(0), ss::this_shard_id());
-    header.size_bytes = size;
-    auto batch = model::record_batch(header, std::move(records));
+    header.size_bytes = static_cast<int32_t>(
+      model::packed_record_batch_header_size + body.size_bytes());
+    auto batch = model::record_batch(
+      header, std::move(body), model::record_batch::tag_ctor_ng{});
     batch.header().crc = model::crc_record_batch(batch);
     batch.header().header_crc = model::internal_header_only_crc(batch.header());
-    return batch;
+    return model::compress_batch_sync(
+      header.attrs.compression(), std::move(batch));
 }
 
 model::record_batch make_random_batch(

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -356,19 +356,11 @@ model::record_batch transformed_data::make_batch(
 
     header.last_offset_delta = i - 1;
     header.record_count = i;
-    header.size_bytes = int32_t(
-      model::packed_record_batch_header_size + serialized_records.size_bytes());
-
-    auto batch = model::record_batch(
+    header.reset_size_checksum_metadata(serialized_records);
+    return model::record_batch(
       header,
       std::move(serialized_records),
       model::record_batch::tag_ctor_ng{});
-
-    // Recompute the crc
-    batch.header().crc = model::crc_record_batch(batch);
-    batch.header().header_crc = model::internal_header_only_crc(batch.header());
-
-    return batch;
 }
 
 transformed_data transformed_data::from_record(record r) {

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -47,6 +47,7 @@ redpanda_cc_library(
         "//src/v/bytes:iobuf",
         "//src/v/compression",
         "//src/v/model",
+        "//src/v/model:batch_compression",
         "//src/v/utils:vint",
         "@seastar",
     ],

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -282,24 +282,22 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
     ++_stats.batches_processed;
     using stop_t = ss::stop_iteration;
     const auto record_count_before = b.record_count();
-    auto to_copy = co_await filter(std::move(b));
-    if (to_copy == std::nullopt) {
+    auto maybe_batch = co_await filter(std::move(b));
+    if (maybe_batch == std::nullopt) {
         ++_stats.batches_discarded;
         _stats.records_discarded += record_count_before;
         co_return stop_t::no;
     }
-    const auto records_to_remove = record_count_before
-                                   - to_copy->record_count();
+    auto batch = std::move(maybe_batch.value());
+    const auto records_to_remove = record_count_before - batch.record_count();
     _stats.records_discarded += records_to_remove;
-    bool compactible_batch = compaction::is_compactible(
-      _ntp, to_copy.value().header());
+    bool compactible_batch = compaction::is_compactible(_ntp, batch.header());
     if (!compactible_batch) {
         ++_stats.non_compactible_batches;
     }
     if (_compacted_idx && compactible_batch) {
         co_await model::for_each_record(
-          to_copy.value(),
-          [&batch = to_copy.value(), this](const model::record& r) {
+          batch, [&batch, this](const model::record& r) {
               auto& hdr = batch.header();
               return _compacted_idx->index(
                 hdr.type,
@@ -309,8 +307,9 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
                 r.offset_delta());
           });
     }
-    auto batch = co_await model::compress_batch(
-      original, std::move(to_copy.value()));
+    if (original != model::compression::none) {
+        batch = co_await model::compress_batch(original, std::move(batch));
+    }
     const auto start_pos = _appender->file_byte_offset();
     const auto header_size = batch.header().size_bytes;
     _acc += header_size;

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -9,7 +9,7 @@
 
 #include "storage/record_batch_builder.h"
 
-#include "compression/compression.h"
+#include "model/batch_compression.h"
 #include "model/record.h"
 #include "model/record_utils.h"
 #include "model/timeout_clock.h"
@@ -60,16 +60,12 @@ model::record_batch record_batch_builder::build() && {
     if (!_timestamp) {
         _timestamp = model::timestamp::now();
     }
-
-    auto header = build_header();
-
-    if (_compression != model::compression::none) {
-        _records = compression::compressor::compress(_records, _compression);
-    }
-
-    header.reset_size_checksum_metadata(_records);
-    return model::record_batch(
-      header, std::move(_records), model::record_batch::tag_ctor_ng{});
+    return model::compress_batch_sync(
+      _compression,
+      model::record_batch(
+        build_header(),
+        std::move(_records),
+        model::record_batch::tag_ctor_ng{}));
 }
 
 ss::future<model::record_batch> record_batch_builder::build_async() && {
@@ -77,26 +73,22 @@ ss::future<model::record_batch> record_batch_builder::build_async() && {
         _timestamp = model::timestamp::now();
     }
 
-    auto header = build_header();
-
-    if (_compression != model::compression::none) {
-        _records = co_await compression::stream_compressor::compress(
-          std::move(_records), _compression);
-    }
-
-    header.reset_size_checksum_metadata(_records);
-
-    co_return model::record_batch(
-      header, std::move(_records), model::record_batch::tag_ctor_ng{});
+    co_return co_await model::compress_batch(
+      _compression,
+      model::record_batch(
+        build_header(),
+        std::move(_records),
+        model::record_batch::tag_ctor_ng{}));
 }
 
 model::record_batch_header record_batch_builder::build_header() const {
     model::record_batch_header header = {
-      .size_bytes = 0,
+      .size_bytes = static_cast<int32_t>(
+        model::packed_record_batch_header_size + _records.size_bytes()),
       .base_offset = _base_offset,
       .type = _batch_type,
       .crc = 0, // crc computed later
-      .attrs = model::record_batch_attributes{} |= _compression,
+      .attrs = model::record_batch_attributes{},
       .last_offset_delta = _offset_delta - 1,
       .first_timestamp = *_timestamp,
       .max_timestamp = *_timestamp,
@@ -106,15 +98,12 @@ model::record_batch_header record_batch_builder::build_header() const {
       .record_count = _offset_delta,
       .ctx = model::record_batch_header::context(
         model::term_id(0), ss::this_shard_id())};
-
     if (_is_control_type) {
         header.attrs.set_control_type();
     }
-
     if (_transactional_type) {
         header.attrs.set_transactional_type();
     }
-
     return header;
 }
 

--- a/src/v/storage/tests/batch_generators.h
+++ b/src/v/storage/tests/batch_generators.h
@@ -15,6 +15,7 @@
 #include "compression/compression.h"
 #include "container/chunked_circular_buffer.h"
 #include "hashing/crc32c.h"
+#include "model/batch_compression.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_utils.h"
@@ -98,8 +99,6 @@ struct linear_int_kv_batch_generator {
             header.base_sequence = spec.base_sequence;
         }
 
-        auto size = model::packed_record_batch_header_size;
-        model::record_batch::records_type records;
         auto rs = model::record_batch::uncompressed_records();
         rs.reserve(spec.count);
 
@@ -108,31 +107,23 @@ struct linear_int_kv_batch_generator {
               model::test::make_random_record(i, reflection::to_iobuf(idx)));
         }
 
-        if (header.attrs.compression() != model::compression::none) {
-            iobuf body;
-            for (auto& r : rs) {
-                model::append_record_to_buffer(body, r);
-            }
-            rs.clear();
-            records = ::compression::compressor::compress(
-              body, header.attrs.compression());
-            size += std::get<iobuf>(records).size_bytes();
-        } else {
-            for (auto& r : rs) {
-                size += r.size_bytes();
-                size += vint::vint_size(r.size_bytes());
-            }
-            records = std::move(rs);
+        iobuf body;
+        for (auto& r : rs) {
+            model::append_record_to_buffer(body, r);
         }
+        rs.clear();
         // TODO: expose term setting
         header.ctx = model::record_batch_header::context(
           model::term_id(0), ss::this_shard_id());
-        header.size_bytes = size;
-        auto batch = model::record_batch(header, std::move(records));
+        header.size_bytes = static_cast<int32_t>(
+          model::packed_record_batch_header_size + body.size_bytes());
+        auto batch = model::record_batch(
+          header, std::move(body), model::record_batch::tag_ctor_ng{});
         batch.header().crc = model::crc_record_batch(batch);
         batch.header().header_crc = model::internal_header_only_crc(
           batch.header());
-        return batch;
+        return model::compress_batch_sync(
+          header.attrs.compression(), std::move(batch));
     }
 
     chunked_circular_buffer<model::record_batch>


### PR DESCRIPTION
In reality, our models are a higher level primative than compression,
which is really a low level operation and quite independent from our
models in the kafka/redpanda world. Make the build graph reflect this
reality.

Followup from https://github.com/redpanda-data/redpanda/pull/27235


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
