### PR TITLE
copilot: Use shortlink for scalable ref

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -144,7 +144,7 @@ src/v/base/format_to.h.
   partitions, topics or segments. Instead prefer `ss::max_concurrent_for_each` to
   limit concurrency. Think about how much concurrency is needed to adequately hide
   latency. See our
-  [docs](https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1331232769/Writing+scalable+and+high+performance+code#Managing-Concurrency-in-the-system)
+  [docs](https://redpandadata.atlassian.net/wiki/x/AQBZTw#Managing-Concurrency-in-the-system)
   for more background.
 
 


### PR DESCRIPTION
Occurred to me the moment I hit merge.

Generally better to use those as they are more stable and shorter.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

