### PR TITLE
CORE-13116 rpk/sr: add force flag when setting sr mode

### DIFF
--- a/src/go/rpk/pkg/cli/registry/mode/set.go
+++ b/src/go/rpk/pkg/cli/registry/mode/set.go
@@ -28,6 +28,7 @@ var supportedModes = []string{"READONLY", "READWRITE", "IMPORT"}
 func setCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var modeFlag string
 	var global bool
+	var force bool
 	cmd := &cobra.Command{
 		Use:   "set [SUBJECT...]",
 		Short: "Set schema registry mode",
@@ -41,6 +42,12 @@ Acceptable mode values:
   - READONLY
   - READWRITE
   - IMPORT
+
+You can only enable IMPORT mode on an empty schema registry (if setting mode
+globally) or an empty subject (if setting at the subject level). Empty means no
+schemas have ever been registered. Soft deletions are not sufficient — you must
+hard-delete any existing schemas before enabling IMPORT mode. To override this
+emptiness check, use the --force flag.
 `,
 		Example: `
 Set the global schema registry mode to READONLY
@@ -48,6 +55,9 @@ Set the global schema registry mode to READONLY
 
 Set the schema registry mode to READWRITE in subjects foo and bar
   rpk registry mode set foo bar --mode READWRITE
+
+Set the schema registry mode to IMPORT, overriding the emptiness check
+  rpk registry mode set --mode IMPORT --global --force
 `,
 		Run: func(cmd *cobra.Command, subjects []string) {
 			f := p.Formatter
@@ -70,10 +80,15 @@ Set the schema registry mode to READWRITE in subjects foo and bar
 			err = mode.UnmarshalText([]byte(modeFlag))
 			out.MaybeDie(err, "unable to parse mode flag: %v", err)
 
+			ctx := cmd.Context()
+			if force {
+				ctx = sr.WithParams(ctx, sr.Force)
+			}
+
 			if len(subjects) > 0 && global {
 				subjects = append(subjects, sr.GlobalSubject)
 			}
-			setModeResult := cl.SetMode(cmd.Context(), *mode, subjects...)
+			setModeResult := cl.SetMode(ctx, *mode, subjects...)
 
 			exit1, err := printModeResult(f, setModeResult)
 			out.MaybeDieErr(err)
@@ -84,6 +99,7 @@ Set the schema registry mode to READWRITE in subjects foo and bar
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "Set the global schema registry mode in addition to subject modes")
+	cmd.Flags().BoolVar(&force, "force", false, "Whether to force setting mode to IMPORT when there are existing schemas")
 	cmd.Flags().StringVar(&modeFlag, "mode", "", fmt.Sprintf("Schema registry mode to set. Supported values: %v (case insensitive)", strings.Join(supportedModes, ", ")))
 	cmd.MarkFlagRequired("mode")
 	cmd.RegisterFlagCompletionFunc("mode", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
This flag can be set to force setting mode to IMPORT when there are existing schemas.

Fixes https://redpandadata.atlassian.net/browse/CORE-13116

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
