### PR TITLE
[CORE-9880]: Preperation for Topic Identifiers

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -169,6 +169,10 @@ bool metadata_cache::contains(
     return _topics_state.local().contains(tp, pid);
 }
 
+bool metadata_cache::contains(const model::kitp& kitp) const {
+    return _topics_state.local().contains(kitp);
+}
+
 bool metadata_cache::contains(model::topic_namespace_view tp) const {
     return _topics_state.local().contains(tp);
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "absl/container/flat_hash_map.h"
 #include "base/seastarx.h"
 #include "cluster/fwd.h"
 #include "cluster/members_table.h"
@@ -19,6 +18,7 @@
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
+#include "model/kitp.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
@@ -127,6 +127,7 @@ public:
     bool should_reject_reads(model::topic_namespace_view) const;
     bool should_reject_writes(model::topic_namespace_view) const;
 
+    bool contains(const model::kitp& kitp) const;
     bool contains(model::topic_namespace_view, model::partition_id) const;
     bool contains(model::topic_namespace_view) const;
     topic_table::topic_state

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -101,6 +101,11 @@ public:
 
     const topic_table::underlying_t& all_topics_metadata() const;
 
+    std::optional<model::topic_namespace>
+    get_name_by_id(model::topic_id tp_id) const {
+        return _topics_state.local().get_name_by_id(tp_id);
+    }
+
     /// Returns all brokers, returns copy as the content of broker can change
     const members_table::cache_t& nodes() const;
 

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -35,7 +35,7 @@ requires std::predicate<Pred>
 void wait_for(model::timeout_clock::duration timeout, Pred&& p) {
     with_timeout(
       model::timeout_clock::now() + timeout,
-      do_until(
+      ss::do_until(
         [p = std::forward<Pred>(p)] { return p(); },
         [] { return ss::sleep(std::chrono::milliseconds(400)); }))
       .get();

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1845,6 +1845,18 @@ bool topic_table::contains(
     return false;
 }
 
+bool topic_table::contains(const model::kitp& kitp) const {
+    if (kitp.get_topic_id() != model::topic_id{}) {
+        auto it = _topics.by_id().find(kitp.get_topic_id());
+        if (it == _topics.by_id().end()) {
+            return false;
+        }
+        vassert(
+          it->second == kitp.as_tn_view(), "An inconsistency was detected");
+    }
+    return contains(kitp.as_tn_view(), kitp.get_partition());
+}
+
 topic_table::topic_state topic_table::get_topic_state(
   model::topic_namespace_view tp, model::revision_id id) const {
     if (id > _last_applied_revision_id) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -20,6 +20,7 @@
 #include "container/contiguous_range_map.h"
 #include "logger.h"
 #include "model/fundamental.h"
+#include "model/kitp.h"
 #include "model/metadata.h"
 #include "utils/stable_iterator_adaptor.h"
 
@@ -654,6 +655,8 @@ public:
     bool contains(model::topic_namespace_view tp) const {
         return _topics.contains(tp);
     }
+    /// Checks if it has given partition
+    bool contains(const model::kitp& kitp) const;
     /// contains() check with stronger validation on the topic revision/offset.
     /// Just looking up in the cache can yield false negatives if the cache is
     /// not warmed up because controller replay can be in progress. This variant

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2496,6 +2496,7 @@ struct leader_term {
 
     std::optional<model::node_id> leader;
     model::term_id term;
+    friend auto operator<=>(const leader_term&, const leader_term&) = default;
     friend std::ostream& operator<<(std::ostream&, const leader_term&);
 };
 

--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -222,6 +222,9 @@ redpanda_cc_library(
     hdrs = [
         "partitioners.h",
     ],
+    implementation_deps = [
+        "//src/v/kafka/client:utils",
+    ],
     deps = [
         ":exceptions",
         ":types",
@@ -243,6 +246,9 @@ redpanda_cc_library(
     ],
     hdrs = [
         "topic_cache.h",
+    ],
+    implementation_deps = [
+        "//src/v/kafka/client:utils",
     ],
     deps = [
         ":exceptions",

--- a/src/v/kafka/client/assignment_plans.cc
+++ b/src/v/kafka/client/assignment_plans.cc
@@ -9,6 +9,8 @@
 
 #include "kafka/client/assignment_plans.h"
 
+#include "kafka/client/utils.h"
+#include "kafka/protocol/metadata.h"
 #include "kafka/protocol/wire.h"
 
 namespace kafka::client {
@@ -73,7 +75,11 @@ assignments assignment_range::plan(
                 ++p_end;
                 --rem;
             }
-            auto& rtm = assignments[*mem_it][t.name];
+            static_assert(
+              api_version_for(metadata_request::api_type::key)
+                < api_version(12),
+              "topic::name is nullable in v12+");
+            auto& rtm = assignments[*mem_it][*t.name];
             rtm.reserve(std::distance(p_begin, p_end));
             std::transform(
               p_begin, p_end, std::back_inserter(rtm), [](auto& p) {

--- a/src/v/kafka/client/errors.h
+++ b/src/v/kafka/client/errors.h
@@ -40,6 +40,7 @@ inline bool is_retriable_error(kafka::error_code ec) {
     case error_code::preferred_leader_not_available:
     case error_code::unstable_offset_commit:
     case error_code::throttling_quota_exceeded:
+    case error_code::unknown_topic_id:
         return true;
     case error_code::unknown_server_error:
     case error_code::invalid_fetch_size:

--- a/src/v/kafka/client/partitioners.cc
+++ b/src/v/kafka/client/partitioners.cc
@@ -13,6 +13,7 @@
 
 #include "hashing/murmur.h"
 #include "kafka/client/exceptions.h"
+#include "kafka/client/utils.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/metadata.h"
 #include "random/generators.h"
@@ -113,8 +114,12 @@ partitioner default_partitioner(model::partition_id initial) {
 void partitioners_cache::apply_metadata(const metadata_response_data& data) {
     chunked_hash_set<model::topic> metadata_topics;
     for (const auto& t : data.topics) {
-        metadata_topics.emplace(t.name);
-        auto it = _partitioners.find(t.name);
+        static_assert(
+          api_version_for(metadata_request::api_type::key) < api_version(12),
+          "topic::name is nullable in v12+");
+        const auto& t_name = *t.name;
+        metadata_topics.emplace(t_name);
+        auto it = _partitioners.find(t_name);
         if (
           it != _partitioners.end()
           && it->second.partition_count == t.partitions.size()) {
@@ -127,7 +132,7 @@ void partitioners_cache::apply_metadata(const metadata_response_data& data) {
           random_generators::get_int<model::partition_id::type>(
             t.partitions.size())};
 
-        _partitioners[t.name] = entry{
+        _partitioners[t_name] = entry{
           .partition_count = t.partitions.size(),
           .partitioner = default_partitioner(initial_partition_id)};
     }

--- a/src/v/kafka/client/test/BUILD
+++ b/src/v/kafka/client/test/BUILD
@@ -219,6 +219,7 @@ redpanda_cc_btest(
     deps = [
         "//src/v/kafka/client",
         "//src/v/kafka/client:configuration",
+        "//src/v/kafka/client:utils",
         "//src/v/kafka/client/test:fixture",
         "//src/v/kafka/client/test:utils",
         "//src/v/kafka/protocol",
@@ -243,6 +244,7 @@ redpanda_cc_btest(
         "//src/v/http",
         "//src/v/kafka/client",
         "//src/v/kafka/client:configuration",
+        "//src/v/kafka/client:utils",
         "//src/v/kafka/client/test:fixture",
         "//src/v/kafka/client/test:utils",
         "//src/v/kafka/protocol",

--- a/src/v/kafka/client/test/produce.cc
+++ b/src/v/kafka/client/test/produce.cc
@@ -13,6 +13,7 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/test/fixture.h"
 #include "kafka/client/test/utils.h"
+#include "kafka/client/utils.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/metadata.h"
 #include "model/fundamental.h"
@@ -51,7 +52,11 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
     info("Client.dispatch metadata");
     auto res = client.dispatch(make_list_topics_req()).get();
     BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+    static_assert(
+      kafka::client::api_version_for(kafka::metadata_request::api_type::key)
+        < kafka::api_version(12),
+      "topic::name is nullable in v12+");
+    BOOST_REQUIRE_EQUAL((*res.data.topics[0].name)(), "t");
 
     client.set_batch_record_count(3);
     client.set_batch_size_bytes(1024);

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -12,6 +12,7 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/test/fixture.h"
 #include "kafka/client/test/utils.h"
+#include "kafka/client/utils.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/metadata.h"
 #include "kafka/protocol/produce.h"
@@ -53,7 +54,11 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
         info("Checking for known topic");
         auto res = client.dispatch(make_list_topics_req()).get();
         BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
-        BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+        static_assert(
+          kc::api_version_for(kafka::metadata_request::api_type::key)
+            < kafka::api_version(12),
+          "topic::name is nullable in v12+");
+        BOOST_REQUIRE_EQUAL((*res.data.topics[0].name)(), "t");
     }
 
     {
@@ -66,7 +71,11 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
         info("Checking for known topic - controller ready");
         auto res = client.dispatch(make_list_topics_req()).get();
         BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
-        BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+        static_assert(
+          kc::api_version_for(kafka::metadata_request::api_type::key)
+            < kafka::api_version(12),
+          "topic::name is nullable in v12+");
+        BOOST_REQUIRE_EQUAL((*res.data.topics[0].name)(), "t");
     }
 
     info("Stopping client");
@@ -128,7 +137,11 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
         info("Checking for known topic");
         auto res = kafka_client.dispatch(make_list_topics_req()).get();
         BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
-        BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+        static_assert(
+          kc::api_version_for(kafka::metadata_request::api_type::key)
+            < kafka::api_version(12),
+          "topic::name is nullable in v12+");
+        BOOST_REQUIRE_EQUAL((*res.data.topics[0].name)(), "t");
     }
 
     {
@@ -146,7 +159,11 @@ FIXTURE_TEST(password_change_live_client, kafka_client_fixture) {
         info("Recheck for known topic");
         auto res = kafka_client.dispatch(make_list_topics_req()).get();
         BOOST_REQUIRE_EQUAL(res.data.topics.size(), 1);
-        BOOST_REQUIRE_EQUAL(res.data.topics[0].name(), "t");
+        static_assert(
+          kc::api_version_for(kafka::metadata_request::api_type::key)
+            < kafka::api_version(12),
+          "topic::name is nullable in v12+");
+        BOOST_REQUIRE_EQUAL((*res.data.topics[0].name)(), "t");
     }
 
     info("Stopping kafka client");

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -10,8 +10,8 @@
 #include "kafka/client/topic_cache.h"
 
 #include "container/chunked_vector.h"
-#include "kafka/client/exceptions.h"
 #include "kafka/client/types.h"
+#include "kafka/client/utils.h"
 #include "kafka/protocol/metadata.h"
 
 #include <seastar/core/future.hh>
@@ -23,7 +23,10 @@ void topic_cache::apply(
     topics_t new_cache;
     new_cache.reserve(topics.size());
     for (const auto& t : topics) {
-        auto& cache_t = new_cache.emplace(t.name, topic_data{}).first->second;
+        static_assert(
+          api_version_for(metadata_request::api_type::key) < api_version(12),
+          "topic::name is nullable in v12+");
+        auto& cache_t = new_cache.emplace(*t.name, topic_data{}).first->second;
         cache_t.authorized_operations = t.topic_authorized_operations;
         if (!t.partitions.empty()) {
             cache_t.replication_factor = t.partitions[0].replica_nodes.size();

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -22,7 +22,7 @@ namespace kafka::client {
 /**
  * Default API versions for Kafka APIs used by the client.
  */
-inline api_version api_version_for(api_key key) {
+constexpr api_version api_version_for(api_key key) {
     switch (key) {
     case offset_fetch_api::key:
         return api_version(4);

--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -199,6 +199,8 @@ std::string_view error_code_to_str(error_code error) {
         return "duplicate_resource";
     case error_code::unacceptable_credential:
         return "unacceptable_credential";
+    case error_code::unknown_topic_id:
+        return "unknown_topic_id";
     case error_code::transactional_id_not_found:
         return "transactional_id_not_found";
     default:
@@ -244,6 +246,7 @@ bool is_retriable(error_code error) {
     case error_code::kafka_storage_error:
     case error_code::fetch_session_id_not_found:
     case error_code::invalid_fetch_session_epoch:
+    case error_code::unknown_topic_id:
         return true;
     case error_code::unknown_server_error:
     case error_code::none:

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -235,6 +235,8 @@ enum class error_code : int16_t {
     duplicate_resource = 92,
     // Requested credential would not meet criteria for acceptability
     unacceptable_credential = 93,
+    // This server does not host this topic ID.
+    unknown_topic_id = 100,
     // The transactional_id could not be found for describe tx request.
     transactional_id_not_found = 105,
 };

--- a/src/v/kafka/protocol/metadata.h
+++ b/src/v/kafka/protocol/metadata.h
@@ -50,7 +50,7 @@ struct metadata_request {
 
     metadata_request copy() const {
         static_assert(
-          api_type::max_valid == api_version(11),
+          api_type::max_valid == api_version(12),
           "Please update the metadata_request::copy method when updating the "
           "Metadata API");
         return {

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -170,6 +170,14 @@ path_type_map = {
     },
     "DeleteTopicsRequestData": {
         "TimeoutMs": ("std::chrono::milliseconds", "int32"),
+        "Topics": {
+            "TopicId": ("model::topic_id", "uuid"),
+        },
+    },
+    "DeleteTopicsResponseData": {
+        "Responses": {
+            "TopicId": ("model::topic_id", "uuid"),
+        },
     },
     "CreateTopicsRequestData": {
         "timeoutMs": ("std::chrono::milliseconds", "int32"),
@@ -181,6 +189,7 @@ path_type_map = {
     },
     "CreateTopicsResponseData": {
         "Topics": {
+            "TopicId": ("model::topic_id", "uuid"),
             "Configs": {
                 "ConfigSource": ("kafka::describe_configs_source", "int8"),
             },
@@ -251,8 +260,14 @@ path_type_map = {
             },
         },
     },
+    "MetadataRequestData": {
+        "Topics": {
+            "TopicId": ("model::topic_id", "uuid"),
+        }
+    },
     "MetadataResponseData": {
         "Topics": {
+            "TopicId": ("model::topic_id", "uuid"),
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "IsrNodes": ("model::node_id", "int32"),
@@ -270,15 +285,20 @@ path_type_map = {
         "ReplicaId": ("model::node_id", "int32"),
         "RackId": ("model::rack_id", "string"),
         "Topics": {
+            "TopicId": ("model::topic_id", "uuid"),
             "Partitions": {
                 "Partition": ("model::partition_id", "int32"),
                 "FetchOffset": ("model::offset", "int64"),
                 "CurrentLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
+        "ForgottenTopicsData": {
+            "TopicId": ("model::topic_id", "uuid"),
+        },
     },
     "FetchResponseData": {
         "Responses": {
+            "TopicId": ("model::topic_id", "uuid"),
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "HighWatermark": ("model::offset", "int64"),

--- a/src/v/kafka/protocol/schemata/metadata_request.json
+++ b/src/v/kafka/protocol/schemata/metadata_request.json
@@ -18,12 +18,12 @@
   "type": "request",
   "listeners": ["zkBroker", "broker"],
   "name": "MetadataRequest",
-  "validVersions": "0-11",
+  "validVersions": "0-12",
   "flexibleVersions": "9+",
   "fields": [
     // In version 0, an empty array indicates "request metadata for all topics."  In version 1 and
     // higher, an empty array indicates "request metadata for no topics," and a null array is used to
-    // indiate "request metadata for all topics."
+    // indicate "request metadata for all topics."
     //
     // Version 2 and 3 are the same as version 1.
     //
@@ -38,6 +38,7 @@
     //
     // Version 11 deprecates IncludeClusterAuthorizedOperations field. This is now exposed
     // by the DescribeCluster API (KIP-700).
+    // Version 12 supports topic Id.
     { "name": "Topics", "type": "[]MetadataRequestTopic", "versions": "0+", "nullableVersions": "1+",
       "about": "The topics to fetch metadata for.", "fields": [
       { "name": "TopicId", "type": "uuid", "versions": "10+", "ignorable": true, "about": "The topic id." },

--- a/src/v/kafka/protocol/schemata/metadata_response.json
+++ b/src/v/kafka/protocol/schemata/metadata_response.json
@@ -41,13 +41,14 @@
   //
   // Version 11 deprecates ClusterAuthorizedOperations. This is now exposed
   // by the DescribeCluster API (KIP-700).
-  "validVersions": "0-11",
+  // Version 12 supports topicId.
+  "validVersions": "0-12",
   "flexibleVersions": "9+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "Brokers", "type": "[]MetadataResponseBroker", "versions": "0+",
-      "about": "Each broker in the response.", "fields": [
+      "about": "A list of brokers present in the cluster.", "fields": [
       { "name": "NodeId", "type": "int32", "versions": "0+", "mapKey": true, "entityType": "brokerId",
         "about": "The broker ID." },
       { "name": "Host", "type": "string", "versions": "0+",
@@ -65,9 +66,10 @@
       "about": "Each topic in the response.", "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The topic error, or 0 if there was no error." },
-      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
-        "about": "The topic name." },
-      { "name": "TopicId", "type": "uuid", "versions": "10+", "ignorable": true, "about": "The topic id." },
+      { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName", "nullableVersions": "12+",
+        "about": "The topic name. Null for non-existing topics queried by ID. This is never null when ErrorCode is zero. One of Name and TopicId is always populated." },
+      { "name": "TopicId", "type": "uuid", "versions": "10+", "ignorable": true,
+        "about": "The topic id. Zero for non-existing topics queried by name. This is never zero when ErrorCode is zero. One of Name and TopicId is always populated." },
       { "name": "IsInternal", "type": "bool", "versions": "1+", "default": "false", "ignorable": true,
         "about": "True if the topic is internal." },
       { "name": "Partitions", "type": "[]MetadataResponsePartition", "versions": "0+",

--- a/src/v/kafka/protocol/tests/field_parser_test.cc
+++ b/src/v/kafka/protocol/tests/field_parser_test.cc
@@ -107,7 +107,7 @@ void write_flex(T& type, iobuf& buf) {
               writer.write_tags(kafka::tagged_fields{});
           });
     } else if constexpr (
-      std::is_same_v<T, kafka::uuid> || std::is_same_v<T, kafka::float64_t>) {
+      std::is_same_v<T, uuid_t> || std::is_same_v<T, kafka::float64_t>) {
         writer.write(type);
     } else {
         writer.write_flex(type);
@@ -119,7 +119,7 @@ T read_flex(iobuf buf) {
     kafka::protocol::decoder reader(std::move(buf));
     if constexpr (std::is_same_v<T, ss::sstring>) {
         return reader.read_flex_string();
-    } else if constexpr (std::is_same_v<T, kafka::uuid>) {
+    } else if constexpr (std::is_same_v<T, uuid_t>) {
         return reader.read_uuid();
     } else if constexpr (std::is_same_v<T, kafka::float64_t>) {
         return reader.read_float64();
@@ -162,13 +162,10 @@ SEASTAR_THREAD_TEST_CASE(serde_flex_types) {
         return random_generators::gen_alphanum_string(str_len);
     };
     {
-        /// uuid
-        auto bytes = tests::random_bytes(16);
-        auto encoded = bytes_to_base64(bytes);
-        auto uuid = kafka::uuid::from_string(encoded);
+        /// uuid_t
+        auto uuid = uuid_t::create();
         auto rt = serde_flex(uuid);
-        BOOST_CHECK_EQUAL(uuid.view(), rt.view());
-        BOOST_CHECK_EQUAL(encoded, rt.to_string());
+        BOOST_CHECK_EQUAL(uuid, rt);
     }
     {
         /// flex strings

--- a/src/v/kafka/protocol/types.cc
+++ b/src/v/kafka/protocol/types.cc
@@ -10,35 +10,7 @@
  */
 #include "kafka/protocol/types.h"
 
-#include "utils/base64.h"
-
 namespace kafka {
-
-uuid uuid::from_string(std::string_view encoded) {
-    if (encoded.size() > 24) {
-        details::throw_out_of_range(
-          "Input size of {} too long to be decoded as b64-UUID, expected "
-          "{} bytes or less",
-          encoded.size(),
-          24);
-    }
-    auto decoded = base64_to_bytes(encoded);
-    if (decoded.size() != length) {
-        details::throw_out_of_range(
-          "Expected {} byte value post b64decoding the input: {} bytes",
-          length,
-          decoded.size());
-    }
-    underlying_t ul;
-    std::copy_n(decoded.begin(), length, ul.begin());
-    return uuid(ul);
-}
-
-ss::sstring uuid::to_string() const { return bytes_to_base64(view()); }
-
-std::ostream& operator<<(std::ostream& os, const uuid& u) {
-    return os << u.to_string();
-}
 
 std::ostream& operator<<(std::ostream& os, describe_configs_type t) {
     switch (t) {

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -91,35 +91,6 @@ enum class describe_configs_source : int8_t {
     // DYNAMIC_BROKER_LOGGER_CONFIG((byte) 6);
 };
 
-/**
- * Immutable UUID, represents a 128 bit value of the variant 2 (Leach-Salz)
- * version 4 UUID type. Conversions to/from string will expect or perform a b64
- * encoding/decoding
- */
-class uuid {
-public:
-    static constexpr auto length = 16;
-    using underlying_t = std::array<uint8_t, length>;
-
-    uuid() = default;
-
-    static uuid from_string(std::string_view encoded);
-
-    explicit uuid(const underlying_t& uuid)
-      : _uuid(uuid) {}
-
-    bytes_view view() const { return {_uuid.data(), _uuid.size()}; }
-
-    ss::sstring to_string() const;
-
-    friend bool operator==(const uuid&, const uuid&) = default;
-
-    friend std::ostream& operator<<(std::ostream& os, const uuid& u);
-
-private:
-    underlying_t _uuid{};
-};
-
 /// Types for tags and tagged fields
 /// These structures are used for encoding / decoding flexible requests
 /// Additional metadata is allowed to be stored in this dynamic structure

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -17,6 +17,7 @@
 #include "bytes/iobuf_parser.h"
 #include "kafka/protocol/batch_reader.h"
 #include "kafka/protocol/types.h"
+#include "model/fundamental.h"
 #include "strings/utf8.h"
 #include "utils/vint.h"
 
@@ -140,9 +141,7 @@ public:
         return {apply_control_validation(do_read_flex_string(n))};
     }
 
-    uuid read_uuid() {
-        return uuid(_parser.consume_type<uuid::underlying_t>());
-    }
+    uuid_t read_uuid() { return _parser.consume_type<uuid_t>(); }
 
     bytes read_bytes() { return _parser.read_bytes(read_int32()); }
 
@@ -452,10 +451,10 @@ public:
         return write(std::string_view(*v));
     }
 
-    uint32_t write(uuid uuid) {
+    uint32_t write(uuid_t id) {
         /// This type is not prepended with its size
-        _out->append(uuid.view().data(), uuid::length);
-        return uuid::length;
+        _out->append(id.uuid().begin(), uuid_t::length);
+        return uuid_t::length;
     }
 
     uint32_t write(float64_t v) {

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -564,7 +564,7 @@ ss::future<typename T::api::response_type> handle_metadata(
                       "Topic name can not be null for version {}",
                       version);
                     break;
-                } else if (topic.topic_id != uuid{}) {
+                } else if (topic.topic_id != model::topic_id{}) {
                     err = kafka::error_code::invalid_request;
                     vlog(
                       klog.info,

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -8,8 +8,10 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/security_frontend.h"
+#include "cluster/topic_configuration.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/errors.h"
 #include "kafka/protocol/metadata.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/details/security.h"
@@ -80,6 +82,30 @@ protected:
                        user, credential, model::timeout_clock::now() + 5s)
                      .get();
         BOOST_REQUIRE_EQUAL(err, cluster::errc::success);
+    }
+
+    std::optional<model::topic_id>
+    get_topic_id(const model::topic& topic_name) {
+        return app.controller->get_topics_state()
+          .local()
+          .get_topic_cfg({model::kafka_namespace, topic_name})
+          .and_then(&cluster::topic_configuration::tp_id);
+    }
+
+    [[nodiscard]] auto set_auto_create_topics(bool value) {
+        auto current = config::shard_local_cfg().auto_create_topics_enabled();
+        auto apply = [this](bool value) {
+            cluster::config_update_request r{
+              .upsert = {
+                {"auto_create_topics_enabled", ssx::sformat("{}", value)}}};
+            auto res = app.controller->get_config_frontend()
+                         .local()
+                         .patch(r, model::timeout_clock::now() + 1s)
+                         .get();
+            BOOST_REQUIRE(!res.errc);
+        };
+        apply(value);
+        return ss::defer([current, apply] { apply(current); });
     }
 };
 
@@ -358,5 +384,48 @@ FIXTURE_TEST(metadata_cluster_auth, metadata_fixture) {
               ? cluster_ops
               : default_response.cluster_authorized_operations;
         BOOST_REQUIRE_EQUAL(resp.data.cluster_authorized_operations, expected);
+    }
+}
+
+FIXTURE_TEST(metadata_autocreate, metadata_fixture) {
+    using kafka::api_version;
+    constexpr auto max_supported = kafka::metadata_handler::max_supported;
+    const model::topic test_topic_query{"metadata_autocreate_query"};
+    const model::topic test_topic_create{"metadata_autocreate_create"};
+
+    auto undo = set_auto_create_topics(true);
+
+    auto client = make_kafka_client().get();
+    client.connect().get();
+    auto close = ss::defer([&client] { client.stop().get(); });
+
+    auto create_resp = client
+                         .dispatch(
+                           kafka::create_topics_request{.data{
+                             .topics{
+                               {.name{test_topic_query},
+                                .num_partitions = 1,
+                                .replication_factor = 1}},
+                             .timeout_ms = 10s,
+                             .validate_only = false}},
+                           kafka::api_version{2})
+                         .get();
+    BOOST_REQUIRE(!create_resp.data.errored());
+
+    const kafka::metadata_response_data default_response;
+    for (api_version ver{8}; ver < max_supported; ++ver) {
+        auto req = kafka::metadata_request{.data{
+          .topics
+          = {{{.name{ssx::sformat("{}_{}_{}", test_topic_create, "by_name", ver)}}, {.name{test_topic_query}}}},
+          .allow_auto_topic_creation = true,
+          .include_cluster_authorized_operations = false,
+          .include_topic_authorized_operations = false}};
+        auto resp = client.dispatch(std::move(req), ver).get();
+
+        BOOST_REQUIRE(!resp.data.errored());
+        const auto& topics = resp.data.topics;
+        BOOST_REQUIRE_EQUAL(topics.size(), 2);
+        BOOST_REQUIRE_EQUAL(topics[0].error_code, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(topics[1].error_code, kafka::error_code::none);
     }
 }

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -306,11 +306,9 @@ FIXTURE_TEST(metadata_non_empty_topic_id, metadata_fixture) {
     client.connect().get();
 
     const auto make_request = [&]() {
-        auto uuid = kafka::uuid::from_string(
-          bytes_to_base64(tests::random_bytes(16)));
         return kafka::metadata_request{.data{
           .topics = {{{
-            .topic_id{uuid},
+            .topic_id{uuid_t::create()},
             .name{test_topic_name},
           }}},
           .allow_auto_topic_creation = false,

--- a/src/v/model/BUILD
+++ b/src/v/model/BUILD
@@ -30,6 +30,7 @@ redpanda_cc_library(
         "compression.h",
         "errc.h",
         "fundamental.h",
+        "kitp.h",
         "ktp.h",
         "limits.h",
         "metadata.h",

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -293,6 +293,9 @@ struct topic_partition_view {
     model::topic_view topic;
     model::partition_id partition;
     friend std::ostream& operator<<(std::ostream&, const topic_partition_view&);
+    friend auto
+    operator<=>(const topic_partition_view&, const topic_partition_view&)
+      = default;
     template<typename H>
     friend H AbslHashValue(H h, const topic_partition_view& tp) {
         return H::combine(std::move(h), tp.topic, tp.partition);

--- a/src/v/model/kitp.h
+++ b/src/v/model/kitp.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/ktp.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+
+namespace model {
+
+/*
+ * @brief A kitp_view is a view of a topic partition with an optional topic_id,
+ * in the kafka namespace.
+ *
+ * It hashes the same as a topic_partition_view, that is, without the topic id.
+ *
+ * It compares equal when:
+ * - Both have a topic_id, and all fields are equal, otherwise
+ * - Both have the same topic_partition_view
+ */
+class kitp_view {
+public:
+    kitp_view(topic_id id, topic_partition_view tp_view)
+      : _id(id)
+      , _tp_view{tp_view} {}
+
+    kitp_view(topic_id id, const topic& tp, partition_id pid)
+      : _id(id)
+      , _tp_view{tp, pid} {}
+
+    topic_id get_topic_id() const { return _id; }
+    topic_view get_topic() const { return _tp_view.topic; }
+    partition_id get_partition() const { return _tp_view.partition; }
+    topic_namespace_view as_tn_view() const {
+        return {kafka_namespace, _tp_view.topic};
+    }
+    topic_partition_view as_tp_view() const { return _tp_view; }
+    ktp as_ktp() const { return {_tp_view.topic, _tp_view.partition}; }
+
+private:
+    // Note: the id is not hashed, as it's only available if the request
+    // specified a non-default topic_id
+    template<typename H>
+    friend inline H AbslHashValue(H h, const kitp_view& kitp) {
+        return H::combine(std::move(h), kitp._tp_view);
+    }
+
+    // Note: the id is compared iff both have an id, otherwise the tp_view is
+    // compared.
+    friend inline bool operator==(const kitp_view& lhs, const kitp_view& rhs) {
+        const auto no_id = topic_id{};
+        if (lhs._id == no_id || rhs._id == no_id) {
+            return lhs._tp_view == rhs._tp_view;
+        }
+        return std::tie(lhs._id, lhs._tp_view)
+               == std::tie(rhs._id, rhs._tp_view);
+    };
+
+    friend inline std::ostream&
+    operator<<(std::ostream& os, const kitp_view& v) {
+        fmt::print(os, "{}, topic_id: {}", v._tp_view, v._id);
+        return os;
+    }
+
+    topic_id _id;
+    topic_partition_view _tp_view;
+};
+
+/*
+ * Represents an ntp kafka namespace, with an optional topic_id.
+ */
+class kitp : private model::ktp {
+public:
+    kitp(topic_id id, topic t, partition_id pid)
+      : ktp{std::move(t), pid}
+      , _id(id) {}
+
+    kitp_view as_kitp_view() const { return {_id, as_tp_view()}; }
+
+    /**
+     * @brief Returns a the kitp's topic_id.
+     *
+     * The kitp must not be in a moved-from state and this is checked via assert
+     * in non-release builds.
+     */
+    topic_id get_topic_id() const {
+        check();
+        return _id;
+    }
+
+    /**
+     * @brief Returns a reference to the kitp's topic.
+     *
+     * The kitp must not be in a moved-from state and this is checked via assert
+     * in non-release builds.
+     */
+    const topic& get_topic() const { return ktp().get_topic(); }
+
+    /**
+     * @brief Returns the kitp's partition id.
+     *
+     * The kitp must not be in a moved-from state and this is checked via assert
+     * in non-release builds.
+     */
+    partition_id get_partition() const { return ktp().get_partition(); }
+
+    topic_namespace_view as_tn_view() const {
+        return {kafka_namespace, get_topic()};
+    }
+
+    const ktp& as_ktp() const { return *this; }
+
+private:
+    template<typename H>
+    friend inline H AbslHashValue(H h, const kitp& kitp) {
+        return H::combine(std::move(h), kitp.as_kitp_view());
+    }
+
+    friend inline bool operator==(const kitp& lhs, const kitp& rhs) {
+        return lhs.as_kitp_view() == rhs.as_kitp_view();
+    }
+
+    friend inline std::ostream& operator<<(std::ostream& os, const kitp& v) {
+        return os << v.as_kitp_view();
+    }
+
+    topic_id _id;
+};
+
+/*
+ * @brief A kitp that remembers its hash code.
+ */
+struct kitp_with_hash : public kitp {
+    kitp_with_hash(topic_id id, class topic t, partition_id pid)
+      : kitp{id, std::move(t), pid}
+      , _hash_code(hash_code()) {}
+
+private:
+    template<typename T>
+    friend class std::hash; // std::hash needs _hash_code
+
+    template<typename H>
+    friend inline H AbslHashValue(H h, const kitp_with_hash& kitp) {
+        return H::combine(std::move(h), kitp._hash_code);
+    }
+
+    /**
+     * Return the hash code for this object.
+     */
+    inline size_t hash_code() const {
+        return absl::Hash<kitp>{}(static_cast<const kitp&>(*this));
+    }
+
+    size_t _hash_code;
+};
+
+} // namespace model
+
+namespace std {
+
+template<>
+struct hash<model::kitp_view> {
+    size_t operator()(const model::kitp_view& kitp) const {
+        return absl::Hash<model::kitp_view>{}(kitp);
+    }
+};
+
+template<>
+struct hash<model::kitp> {
+    size_t operator()(const model::kitp& kitp) const {
+        return absl::Hash<model::kitp>{}(kitp);
+    }
+};
+
+template<>
+struct hash<model::kitp_with_hash> {
+    size_t operator()(const model::kitp_with_hash& kitp) const {
+        return kitp._hash_code;
+    }
+};
+
+} // namespace std

--- a/src/v/model/ktp.h
+++ b/src/v/model/ktp.h
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/node_hash_map.h"
 #include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -94,6 +94,20 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_gtest(
+    name = "kitp_test",
+    timeout = "short",
+    srcs = [
+        "kitp_test.cc",
+    ],
+    deps = [
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/hash",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "topic_id_partition_test",
     timeout = "short",
     srcs = [

--- a/src/v/model/tests/kitp_test.cc
+++ b/src/v/model/tests/kitp_test.cc
@@ -1,0 +1,80 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "absl/hash/hash.h"
+#include "model/kitp.h"
+
+#include <gtest/gtest.h>
+
+using namespace model;
+
+namespace {
+
+const topic_id topic_id_none{};
+const topic_id topic_id_1{uuid_t::create()};
+const topic_id topic_id_2{uuid_t::create()};
+const topic topic_1{"topic_1"};
+const topic topic_2{"topic_2"};
+const partition_id part_id{42};
+
+template<typename T>
+void test_hash() {
+    const T without_id_1{topic_id_none, topic_1, part_id};
+    const T without_id_1_copy{topic_id_none, topic_1, part_id};
+    const T without_id_2{topic_id_none, topic_2, part_id};
+    const T with_id_1{topic_id_1, topic_1, part_id};
+    const T with_id_1_copy{topic_id_1, topic_1, part_id};
+    const T with_id_2{topic_id_2, topic_2, part_id};
+
+    auto hasher = absl::Hash<T>{};
+    auto expected = hasher(without_id_1);
+    ASSERT_EQ(expected, hasher(without_id_1_copy));
+    ASSERT_EQ(expected, hasher(with_id_1));
+    ASSERT_EQ(expected, hasher(with_id_1_copy));
+
+    ASSERT_NE(expected, hasher(without_id_2));
+    ASSERT_NE(expected, hasher(with_id_2));
+}
+
+template<typename T>
+void test_equality() {
+    const T without_id_1{topic_id_none, topic_1, part_id};
+    const T without_id_1_copy{topic_id_none, topic_1, part_id};
+    const T without_id_2{topic_id_none, topic_2, part_id};
+    const T with_id_1{topic_id_1, topic_1, part_id};
+    const T with_id_1_copy{topic_id_1, topic_1, part_id};
+    const T with_id_2{topic_id_2, topic_2, part_id};
+
+    // Test equal
+    ASSERT_EQ(without_id_1, without_id_1_copy);
+    ASSERT_EQ(with_id_1, with_id_1_copy);
+
+    // Test equivalence (id is not compared if either is default)
+    ASSERT_EQ(without_id_1, with_id_1);
+    ASSERT_EQ(with_id_1, without_id_1);
+    ASSERT_EQ(with_id_2, without_id_2);
+    ASSERT_EQ(without_id_1_copy, with_id_1);
+    ASSERT_EQ(without_id_1_copy, with_id_1_copy);
+    ASSERT_EQ(without_id_1, with_id_1_copy);
+
+    // Test inequality
+    ASSERT_NE(without_id_2, without_id_1);
+    ASSERT_NE(without_id_1, with_id_2);
+    ASSERT_NE(with_id_2, without_id_1);
+}
+
+} // namespace
+
+TEST(KitpViewTest, TestHash) { test_hash<kitp_view>(); }
+TEST(KitpTest, TestHash) { test_hash<kitp>(); }
+TEST(KitpWithHashViewTest, TestHash) { test_hash<kitp_with_hash>(); }
+
+TEST(KitpViewTest, TestEquality) { test_equality<kitp_view>(); }
+TEST(KitpTest, TestEquality) { test_equality<kitp>(); }
+TEST(KitpWithHashViewTest, TestEquality) { test_equality<kitp_with_hash>(); }

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -280,6 +280,7 @@ std::error_condition make_error_condition(std::error_code ec) {
         case kec::reassignment_in_progress:
             return rec::kafka_retriable_error;
         case kec::unknown_topic_or_partition:
+        case kec::unknown_topic_id:
             return rec::partition_not_found;
         case kec::unknown_member_id:
             return rec::consumer_instance_not_found;

--- a/src/v/pandaproxy/rest/BUILD
+++ b/src/v/pandaproxy/rest/BUILD
@@ -15,6 +15,9 @@ redpanda_cc_library(
         "handlers.h",
         "proxy.h",
     ],
+    implementation_deps = [
+        "//src/v/kafka/client:utils",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -12,6 +12,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "base/vlog.h"
 #include "kafka/client/exceptions.h"
+#include "kafka/client/utils.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/schemata/offset_commit_request.h"
 #include "model/fundamental.h"
@@ -110,7 +111,12 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
           names.reserve(res.data.topics.size());
           for (auto& topic : res.data.topics) {
               if (!topic.is_internal) {
-                  names.emplace_back(topic.name);
+                  static_assert(
+                    kafka::client::api_version_for(
+                      kafka::metadata_request::api_type::key)
+                      < kafka::api_version(12),
+                    "topic::name is nullable in v12+");
+                  names.emplace_back(*topic.name);
               }
           }
 


### PR DESCRIPTION
Updates and rebase of some of the commits in: https://github.com/redpanda-data/redpanda/pull/26968

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
