### PR TITLE
Revert "dt/direct_consumer: Use progress oriented wait"

### DIFF
--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -21,7 +21,6 @@ from rptest.services.direct_consumer_verifier import (
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import wait_until_with_progress_check
 
 
 #TODO: This test must be enabled once the direct consumer verifier support
@@ -93,22 +92,14 @@ class DirectConsumerVerifierTest(RedpandaTest):
             state_request = GetConsumerStateRequest(
                 client_id=client_id, include_partition_states=True)
 
-            def get_consumption():
+            def check_consumption():
                 state = verifier.get_consumer_state(state_request)
                 self.logger.info(
                     f"Consumer state: consumed {state.total_consumed_messages} messages"
                 )
-                return state.total_consumed_messages
+                return state.total_consumed_messages >= msg_count
 
-            wait_until_with_progress_check(
-                get_consumption,
-                condition=lambda fn: fn() >= msg_count,
-                timeout_sec=60,
-                progress_sec=10,
-                backoff_sec=2,
-                err_msg=f"Stopped consuming",
-                logger=self.logger,
-            )
+            wait_until(check_consumption, timeout_sec=60, backoff_sec=2)
 
             final_state = verifier.get_consumer_state(state_request)
             assert final_state.total_consumed_messages == msg_count, \


### PR DESCRIPTION
This reverts commit f92db20b498e6f28e595f9d8a804f59bf62fab69.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
