### PR TITLE
`compaction`: add `sliding_window_reducer` and `filter`

### DIFF
--- a/src/v/compaction/BUILD
+++ b/src/v/compaction/BUILD
@@ -81,3 +81,20 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "reducer",
+    srcs = [
+        "reducer.cc",
+    ],
+    hdrs = [
+        "reducer.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":types",
+        "//src/v/bytes",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/compaction/BUILD
+++ b/src/v/compaction/BUILD
@@ -98,3 +98,25 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "filter",
+    srcs = [
+        "filter.cc",
+    ],
+    hdrs = [
+        "filter.h",
+    ],
+    implementation_deps = [
+        ":utils",
+        "//src/v/model:batch_compression",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":reducer",
+        ":types",
+        "//src/v/bytes",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/compaction/filter.cc
+++ b/src/v/compaction/filter.cc
@@ -1,0 +1,146 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "filter.h"
+
+#include "compaction/utils.h"
+#include "model/batch_compression.h"
+#include "model/record.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <vector>
+
+namespace compaction {
+
+ss::future<ss::stop_iteration> filter::operator()(model::record_batch b) {
+    const auto comp = b.header().attrs.compression();
+    if (!b.compressed()) {
+        co_return co_await filter_and_rewrite_with_sink(comp, std::move(b));
+    }
+    auto batch = co_await model::decompress_batch(std::move(b));
+
+    co_return co_await filter_and_rewrite_with_sink(comp, std::move(batch));
+}
+
+ss::future<std::optional<model::record_batch>>
+filter::filter_batch(model::record_batch b) const {
+    // do not filter non-removable batch types under any circumstances
+    if (!is_filterable(b.header().type)) {
+        co_return std::move(b);
+    }
+
+    // compute which records to keep
+    std::vector<int32_t> offset_deltas = co_await compute_offset_deltas_to_keep(
+      b);
+
+    auto ret = co_await filter_batch_with_offset_deltas(
+      std::move(b), std::move(offset_deltas));
+    co_return ret;
+}
+
+ss::future<std::optional<model::record_batch>> filter::do_filter_batch(
+  model::record_batch b, std::vector<int32_t> offset_deltas) const {
+    // no records to keep
+    if (offset_deltas.empty()) {
+        co_return std::nullopt;
+    }
+
+    // keep all records
+    if (offset_deltas.size() == static_cast<size_t>(b.record_count())) {
+        co_return std::move(b);
+    }
+
+    // filter
+    iobuf ret;
+    int32_t rec_count = 0;
+    std::optional<int64_t> first_timestamp_delta;
+    int64_t last_timestamp_delta;
+    co_await b.for_each_record_async([&rec_count,
+                                      &first_timestamp_delta,
+                                      &last_timestamp_delta,
+                                      &ret,
+                                      &offset_deltas](model::record record) {
+        // contains the key
+        if (std::count(
+              offset_deltas.begin(),
+              offset_deltas.end(),
+              record.offset_delta())) {
+            /*
+             * TODO when we further optimize lazy record materialization ot
+             * make use of views we can avoid this re-encoding by copying or
+             * sharing the view. either way, we were building
+             * record batch with the uncompressed records so they were being
+             * re-encoded.
+             */
+            if (!first_timestamp_delta) {
+                first_timestamp_delta = record.timestamp_delta();
+            }
+            last_timestamp_delta = record.timestamp_delta();
+            model::append_record_to_buffer(ret, record);
+            ++rec_count;
+        }
+    });
+
+    if (rec_count == 0) {
+        co_return std::nullopt;
+    }
+
+    // There is no need to preserve the timestamp from the original
+    // batch after compaction. The FirstTimestamp field therefore always
+    // reflects the timestamp of the first record in the batch. If the batch
+    // is empty, the FirstTimestamp will be set to -1 (NO_TIMESTAMP).
+    //
+    // Similarly, the MaxTimestamp field reflects the maximum timestamp of
+    // the current records if the timestamp type is CREATE_TIME. For
+    // LOG_APPEND_TIME, on the other hand, the MaxTimestamp field reflects
+    // the timestamp set by the broker and is preserved after compaction.
+    // Additionally, the MaxTimestamp of an empty batch always retains the
+    // previous value prior to becoming empty.
+    auto& hdr = b.header();
+    const auto first_time = model::timestamp(
+      hdr.first_timestamp() + first_timestamp_delta.value());
+    auto last_time = hdr.max_timestamp;
+    if (hdr.attrs.timestamp_type() == model::timestamp_type::create_time) {
+        last_time = model::timestamp(first_time() + last_timestamp_delta);
+    }
+    auto new_hdr = hdr;
+    new_hdr.first_timestamp = first_time;
+    new_hdr.max_timestamp = last_time;
+    new_hdr.record_count = rec_count;
+    new_hdr.reset_size_checksum_metadata(ret);
+    auto new_batch = model::record_batch(
+      new_hdr, std::move(ret), model::record_batch::tag_ctor_ng{});
+    co_return new_batch;
+}
+
+ss::future<ss::stop_iteration> filter::filter_and_rewrite_with_sink(
+  model::compression original, model::record_batch b) {
+    ++_stats.batches_processed;
+    const auto record_count_before = b.record_count();
+    auto to_copy = co_await filter_batch(std::move(b));
+    if (to_copy.has_value()) {
+        const auto records_to_remove = record_count_before
+                                       - to_copy->record_count();
+        _stats.records_discarded += records_to_remove;
+        bool compactible_batch = is_compactible(_ntp, to_copy->header());
+        if (!compactible_batch) {
+            ++_stats.non_compactible_batches;
+        }
+
+        co_return co_await _sink(std::move(to_copy).value(), original);
+    } else {
+        ++_stats.batches_discarded;
+        _stats.records_discarded += record_count_before;
+    }
+
+    co_return ss::stop_iteration::no;
+}
+
+} // namespace compaction

--- a/src/v/compaction/filter.h
+++ b/src/v/compaction/filter.h
@@ -1,0 +1,82 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "compaction/reducer.h"
+#include "compaction/types.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <optional>
+#include <vector>
+
+namespace compaction {
+
+// Wrapper around a `sink&` for use with `record_batch_reader` interface.
+// This class needs to implement two functions:
+// 1. `compute_offset_deltas_to_keep(record_batch)`: This should iterate over
+// the records of the provided `record_batch` and populate a vector of offset
+// deltas of records which should be kept during compaction filtering.
+// 2. `filter_batch_with_offset_deltas(record_batch, vector<int32_t>)`: Likely a
+// pass through function to `do_filter_batch()`, but allows the `filter`
+// implementation to examine the produced `offset_deltas` before creating a new
+// `record_batch`.
+class filter {
+public:
+    filter(sliding_window_reducer::sink& sink, model::ntp ntp)
+      : _sink(sink)
+      , _ntp(std::move(ntp)) {}
+
+    ss::future<ss::stop_iteration> operator()(model::record_batch b);
+    stats end_of_stream() const { return _stats; }
+
+protected:
+    // Creates a new batch based on the provided batch and offset_deltas
+    // indicated.
+    ss::future<std::optional<model::record_batch>> do_filter_batch(
+      model::record_batch b, std::vector<int32_t> offset_deltas) const;
+
+private:
+    // For a given batch, this function should return a vector containing offset
+    // deltas from records in the batch which we intend on keeping when
+    // performing record batch filtering.
+    virtual ss::future<std::vector<int32_t>>
+    compute_offset_deltas_to_keep(const model::record_batch& b) const = 0;
+
+    // For most implementations, this should serve as a pass through function to
+    // `do_filter_batch()`. However, it provides flexibility in examining the
+    // produced `offset_deltas` before creating a new `record_batch`. This is
+    // useful for e.g. local storage in which we may need to create a
+    // placeholder batch if `offset_deltas` is empty.
+    virtual ss::future<std::optional<model::record_batch>>
+    filter_batch_with_offset_deltas(
+      model::record_batch b, std::vector<int32_t> offset_deltas) const
+      = 0;
+
+    // Computes offset deltas from the batch to keep, and then filters the
+    // provided batch.
+    ss::future<std::optional<model::record_batch>>
+    filter_batch(model::record_batch b) const;
+
+    // Performs filtering over the entire batch, and then delegates the result
+    // to `_sink` for writing.
+    ss::future<ss::stop_iteration> filter_and_rewrite_with_sink(
+      model::compression original, model::record_batch b);
+
+    sliding_window_reducer::sink& _sink;
+    model::ntp _ntp;
+
+    stats _stats;
+};
+
+} // namespace compaction

--- a/src/v/compaction/reducer.cc
+++ b/src/v/compaction/reducer.cc
@@ -1,0 +1,31 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "compaction/reducer.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace compaction {
+
+ss::future<> compaction::sliding_window_reducer::run() && {
+    // Step 0: Initialize source
+    co_await _src->initialize();
+
+    // Step 1: Perform backward pass
+    co_await ss::repeat([this]() { return _src->backward_pass_iteration(); });
+
+    // Step 2: Perform forward pass.
+    co_await ss::repeat(
+      [this]() { return _src->forward_pass_iteration(*_sink); });
+
+    // Done!
+    co_await _sink->finalize();
+}
+
+} // namespace compaction

--- a/src/v/compaction/reducer.h
+++ b/src/v/compaction/reducer.h
@@ -1,0 +1,119 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "compaction/types.h"
+#include "model/compression.h"
+#include "model/record.h"
+
+#include <seastar/core/loop.hh>
+
+#include <memory>
+#include <ostream>
+#include <utility>
+
+namespace compaction {
+
+// An implementation for the sliding window algorithm for compaction.
+// Sliding window algorithm is performed in two steps:
+// 1. A backward pass over the data source, in which the latest key-offset pair
+// is indexed in a hash map of a finite size (determined by cluster config
+// `storage_compaction_key_map_memory`) until all keys from the data source are
+// indexed OR the hash map's size has reached its allocated capacity.
+// 2. A forward pass over the data source, in which the data (i.e Kafka
+// records) is filtered and rewritten.
+// Filtering can be a removal of data due to:
+// 1. De-duplication (the removal of data due to a newer key appearing in the
+// data source).
+// 2. Deletion (the removal of data due to other logic, i.e the removal of a
+// tombstone record which has passed the time horizon set by
+// `delete.retention.ms`)
+// An example usage of this class is the following:
+// auto src  = std::make_unique<storage::segment_source>(_segs);
+// auto sink = std::make_unique<storage::segment_sink>();
+// auto reducer = compaction::sliding_window_reducer(std::move(src),
+//                std::move(sink));
+// co_await std::move(reducer).run();
+class sliding_window_reducer {
+public:
+    // The sink for the data to be written by this round of compaction.
+    // This class needs to implement two functions:
+    // 1. `operator()(record_batch)`: This operator accepts a record batch
+    // (which has already been determined to be written by a
+    // `compaction::filter`) and is responsible for writing its contents to
+    // whichever data format/store this `sink` represents.
+    // 2. `finalize()`: perform any final steps required in the `sink` layer,
+    // i.e flushing in progress writes, update final metadata, etc.
+    class sink {
+    public:
+        sink() noexcept = default;
+        sink(sink&& o) noexcept = default;
+        sink& operator=(sink&& o) noexcept = default;
+        sink(const sink& o) = delete;
+        sink& operator=(const sink& o) = delete;
+        virtual ~sink() noexcept = default;
+
+    public:
+        virtual ss::future<ss::stop_iteration>
+        operator()(model::record_batch b, model::compression c) = 0;
+        virtual ss::future<> finalize() = 0;
+    };
+
+    // The source of data for compaction.
+    // This class needs to implement three functions:
+    // 1. `initialize()`: This performs initial set-up (if required). For
+    // example, the local storage source may need to collect the set of
+    // `segment`s eligible for compaction, and perform self compaction on them
+    // before proceeding to the sliding window algorithm.
+    // 2. `backward_pass_iteration()`: This is the pass that reads from the
+    // data source from head to tail, and indexes the latest key-offset pair in
+    // the contained map within the provided `compaction_config` object.This
+    // should ideally be a light-weight read over a portion of the log that
+    // avoids de-compression or e.g. uncached reads from cloud storage.
+    // 3. `forward_pass_iteration(sink)`: This is the pass that reads from
+    // the data source from tail to head, and provides the data to be written
+    // (determined by the contents of the key-offset map and other configured
+    // parameters within `cfg`) for this round of compaction to the sink object.
+    class source {
+    public:
+        source() noexcept = default;
+        source(source&& o) noexcept = default;
+        source& operator=(source&& o) noexcept = default;
+        source(const source& o) = delete;
+        source& operator=(const source& o) = delete;
+        virtual ~source() noexcept = default;
+
+    public:
+        virtual ss::future<> initialize() = 0;
+        virtual ss::future<ss::stop_iteration> backward_pass_iteration() = 0;
+        virtual ss::future<ss::stop_iteration>
+        forward_pass_iteration(sink&) = 0;
+    };
+
+public:
+    explicit sliding_window_reducer(
+      std::unique_ptr<source> src, std::unique_ptr<sink> sink) noexcept
+      : _src(std::move(src))
+      , _sink(std::move(sink)) {}
+    sliding_window_reducer(const sliding_window_reducer&) = delete;
+    sliding_window_reducer& operator=(const sliding_window_reducer&) = delete;
+    sliding_window_reducer(sliding_window_reducer&&) noexcept = default;
+    sliding_window_reducer& operator=(sliding_window_reducer&&) noexcept
+      = default;
+    ~sliding_window_reducer() noexcept = default;
+
+    ss::future<> run() &&;
+
+private:
+    std::unique_ptr<source> _src;
+    std::unique_ptr<sink> _sink;
+};
+
+} // namespace compaction

--- a/src/v/compaction/tests/BUILD
+++ b/src/v/compaction/tests/BUILD
@@ -1,4 +1,22 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "simple_reducer",
+    hdrs = [
+        "simple_reducer.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/compaction:filter",
+        "//src/v/compaction:key",
+        "//src/v/compaction:key_offset_map",
+        "//src/v/compaction:reducer",
+        "//src/v/compaction:utils",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "key_offset_map_test",

--- a/src/v/compaction/tests/BUILD
+++ b/src/v/compaction/tests/BUILD
@@ -32,3 +32,27 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "reducer_test",
+    timeout = "short",
+    srcs = [
+        "reducer_test.cc",
+    ],
+    deps = [
+        ":simple_reducer",
+        "//src/v/bytes",
+        "//src/v/compaction:filter",
+        "//src/v/compaction:key",
+        "//src/v/compaction:key_offset_map",
+        "//src/v/compaction:reducer",
+        "//src/v/compaction:utils",
+        "//src/v/container:chunked_circular_buffer",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/storage/tests:batch_generators",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/compaction/tests/reducer_test.cc
+++ b/src/v/compaction/tests/reducer_test.cc
@@ -1,0 +1,42 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/bytes.h"
+#include "compaction/reducer.h"
+#include "compaction/tests/simple_reducer.h"
+#include "container/chunked_circular_buffer.h"
+#include "model/fundamental.h"
+#include "storage/tests/batch_generators.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <gtest/gtest.h>
+
+static const auto test_ntp = model::ntp(
+  model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
+
+TEST(CompactionReducerTest, SimpleReducer) {
+    int num_batches = 10;
+    auto gen = linear_int_kv_batch_generator();
+    auto spec = model::test::record_batch_spec{
+      .allow_compression = false, .count = 1};
+    auto input_batches = gen(spec, num_batches);
+    chunked_circular_buffer<model::record_batch> output_batches;
+
+    auto src = std::make_unique<compaction::simple_source>(
+      std::move(input_batches), test_ntp);
+    auto sink = std::make_unique<compaction::simple_sink>(output_batches);
+    auto reducer = compaction::sliding_window_reducer(
+      std::move(src), std::move(sink));
+
+    std::move(reducer).run().get();
+    ASSERT_EQ(output_batches.size(), num_batches);
+    linear_int_kv_batch_generator::validate_post_compaction(
+      std::move(output_batches));
+}

--- a/src/v/compaction/tests/simple_reducer.h
+++ b/src/v/compaction/tests/simple_reducer.h
@@ -1,0 +1,140 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/bytes.h"
+#include "compaction/filter.h"
+#include "compaction/key.h"
+#include "compaction/key_offset_map.h"
+#include "compaction/reducer.h"
+#include "compaction/utils.h"
+#include "container/chunked_circular_buffer.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace compaction {
+
+// A simple filter which persists the latest key-value pair from the built
+// key_offset_map.
+class simple_map_filter : public filter {
+public:
+    simple_map_filter(
+      sliding_window_reducer::sink& sink,
+      const key_offset_map& map,
+      model::ntp ntp)
+      : filter(sink, std::move(ntp))
+      , _map(map) {}
+
+private:
+    ss::future<> maybe_index_offset_delta(
+      const model::record_batch& b,
+      const model::record& r,
+      std::vector<int32_t>& offset_deltas) const {
+        if (co_await is_latest_record_for_key(_map, b, r)) {
+            offset_deltas.push_back(r.offset_delta());
+        }
+    }
+
+    ss::future<std::vector<int32_t>>
+    compute_offset_deltas_to_keep(const model::record_batch& b) const final {
+        std::vector<int32_t> offset_deltas;
+        offset_deltas.reserve(b.record_count());
+
+        co_await b.for_each_record_async(
+          [this, &b, &offset_deltas](const model::record& r) {
+              return maybe_index_offset_delta(b, r, offset_deltas);
+          });
+
+        co_return offset_deltas;
+    }
+
+    ss::future<std::optional<model::record_batch>>
+    filter_batch_with_offset_deltas(
+      model::record_batch b, std::vector<int32_t> offset_deltas) const final {
+        co_return co_await do_filter_batch(
+          std::move(b), std::move(offset_deltas));
+    }
+
+    const key_offset_map& _map;
+};
+
+// A simple sink which pushes filtered batches to a container.
+class simple_sink : public sliding_window_reducer::sink {
+public:
+    simple_sink(chunked_circular_buffer<model::record_batch>& output_batches)
+      : _output_batches(output_batches) {}
+
+    ss::future<ss::stop_iteration>
+    operator()(model::record_batch b, model::compression) final {
+        _output_batches.push_back(std::move(b));
+        co_return ss::stop_iteration::no;
+    }
+
+    ss::future<> finalize() final { co_return; }
+
+    chunked_circular_buffer<model::record_batch>& _output_batches;
+};
+
+// A simple source which iterates over a container of input batches, indexing
+// key-value pairs in the offset map and then uses the built key-offset map and
+// simple_map_filter in the forward pass.
+class simple_source : public sliding_window_reducer::source {
+public:
+    using container_t = chunked_circular_buffer<model::record_batch>;
+    simple_source(container_t batches, model::ntp ntp)
+      : _batches(std::move(batches))
+      , _ntp(std::move(ntp)) {}
+
+    ss::future<> initialize() final {
+        _b_it = _batches.rbegin();
+        _f_it = _batches.begin();
+        co_return;
+    }
+
+    ss::future<ss::stop_iteration> backward_pass_iteration() final {
+        if (_b_it == _batches.rend()) {
+            co_return ss::stop_iteration::yes;
+        }
+
+        auto& b = *_b_it;
+        co_await b.for_each_record_async([this, &b](const model::record& r) {
+            auto key = compaction_key{iobuf_to_bytes(r.key())};
+            auto o = b.base_offset() + model::offset_delta(r.offset_delta());
+            return _map.put(key, o);
+        });
+
+        ++_b_it;
+
+        co_return ss::stop_iteration::no;
+    }
+
+    ss::future<ss::stop_iteration>
+    forward_pass_iteration(sliding_window_reducer::sink& s) final {
+        if (_f_it == _batches.end()) {
+            co_return ss::stop_iteration::yes;
+        }
+
+        auto& b = *_f_it;
+        auto filter = simple_map_filter(s, _map, _ntp);
+        auto ret = co_await filter(std::move(b));
+        ++_f_it;
+        co_return ret;
+    }
+
+private:
+    container_t::reverse_iterator _b_it;
+    container_t::iterator _f_it;
+    container_t _batches;
+    simple_key_offset_map _map;
+    model::ntp _ntp;
+};
+
+} // namespace compaction

--- a/src/v/storage/tests/batch_generators.h
+++ b/src/v/storage/tests/batch_generators.h
@@ -77,7 +77,7 @@ struct linear_int_kv_batch_generator {
           model::timestamp(ts.value() + spec.count - 1));
         auto header = model::record_batch_header{
           .size_bytes = 0, // computed later
-          .base_offset = spec.offset,
+          .base_offset = spec.offset + model::offset_delta(idx * spec.count),
           .type = spec.bt,
           .crc = 0, // we-reassign later
           .attrs = model::record_batch_attributes(


### PR DESCRIPTION
This PR introduces several new components for a greenfield Kafka compaction implementation.

The main goals of the implementation were:
1. Flexibility via a data agnostic `source` and `sink`, allowing for future reusibility across multiple subsystems that require compaction (namely, local storage, tiered storage, and cloud topics)
2. Simplicity via a minimal interface & only a few `virtual` functions that require implementation. 
3. A massive reduction in the number of compaction related "reducers" and objects required to perform simple de-duplication of records in a Kafka `log` ([just count the number of existing reducers here](https://github.com/redpanda-data/redpanda/blob/dev/src/v/storage/compaction_reducers.h)!).

## Sliding Window Reducer 

The `sliding_window_reducer` is an abstraction that performs the two-pass "sliding window" compaction algorithm over the data provided by a `source`, and rewriting the filtered data via a provided `sink`.

 An example usage of this class is the following:

```cpp
auto src = std::make_unique<storage::segment_source>(_segs);
auto sink = std::make_unique<storage::segment_sink>(_log);
auto reducer = compaction::sliding_window_reducer(std::move(src), std::move(sink));
co_await std::move(reducer).run();
```

The `source` and `sink` require implementations that perform all the necessary steps to preparing, reading, re-writing and finalizing updates to the given `log`. Under the hood, the details of `run()` are simple:

```cpp
ss::future<> sliding_window_reducer::run() {
    // Step 0: Initialize source
    co_await _src->initialize();

    // Step 1: Perform backward pass
    co_await ss::repeat([this]() { return _src->backward_pass_iteration(); });

    // Step 2: Perform forward pass.
    co_await ss::repeat(
      [this]() { return _src->forward_pass_iteration(*_sink); });

    // Done!
    co_await _sink->finalize();
}
```

The two passes serve to perform compaction [as detailed here](https://kafka.apache.org/documentation/#design_compactiondetails):

1. The first pass iterates backwards over `log` data, indexing the latest offset for a given key in a key-offset map, until the `log` is fully indexed or a pre-defined memory limit is reached.
4. The second pass iterates forwards over `log` data, de-duplicating records containing keys below their latest offset, and performing re-writes/required metadata updates/etc to update the `log`. The commitment of new data can also be delegated to the `sink::finalize()` function depending on implementation details.

## Filter

The filter is a simple wrapper around a `sink&` for use with a `model::record_batch_reader` interface, and is responsible for filtering `record`s out of `record_batch`s before delegating the new `record_batch` to the `sink` for writing. This is ideally used within the `source::forward_pass_iteration(sink&)`, e.g

```cpp
storage::segment_source::forward_pass_iteration(sink& sink){
    auto segment = *_forward_it;
    auto rdr = internal::create_segment_full_reader(segment, ...);
    auto filter = storage_filter(std::ref(sink), compaction_placeholder_enabled, segment_last_offset, ...);
    auto stats = co_await std::move(rdr).consume(std::move(filter));
    if (stats.has_removed_data()) {
        vlog(gclog.info, "Compaction filtering removing data from {}: {}", segment->filename(), stats);
    }
    ...
}
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
