### PR TITLE
model: simplify semantics of compression + decompression of batches

### DIFF
--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -110,7 +110,7 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
     const auto raw_size_bytes = batch.size_bytes();
     _translation_probe.increment_raw_bytes_processed(raw_size_bytes);
     if (batch.compressed()) {
-        batch = co_await model::decompress_batch(std::move(batch));
+        batch = co_await model::decompress_batch(batch);
     }
     const auto decompressed_size_bytes = batch.size_bytes();
     _translation_probe.increment_decompressed_bytes_processed(

--- a/src/v/model/batch_compression.cc
+++ b/src/v/model/batch_compression.cc
@@ -14,6 +14,8 @@
 
 #include <seastar/core/coroutine.hh>
 
+#include <stdexcept>
+
 namespace model {
 
 namespace {
@@ -32,7 +34,8 @@ namespace {
     case model::compression::producer:
         break;
     }
-    throw std::runtime_error(fmt::format("Unknown compression type: {}", c));
+    throw std::runtime_error(
+      fmt::format("Unconvertable compression type: {}", c));
 }
 } // namespace
 
@@ -48,12 +51,11 @@ model::record_batch decompress_batch_sync(model::record_batch&& b) {
     if (!b.compressed()) {
         return std::move(b);
     }
-
     return maybe_decompress_batch_sync(b);
 }
 
 model::record_batch maybe_decompress_batch_sync(const model::record_batch& b) {
-    if (unlikely(!b.compressed())) {
+    if (!b.compressed()) [[unlikely]] {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "Asked to decompressed a non-compressed batch:{}",
@@ -72,14 +74,16 @@ model::record_batch maybe_decompress_batch_sync(const model::record_batch& b) {
 
 ss::future<model::record_batch>
 compress_batch(model::compression c, model::record_batch b) {
-    if (c == model::compression::none) {
-        vassert(
-          b.header().attrs.compression() == model::compression::none,
-          "Asked to compress a batch with `none` compression, but header "
-          "metadata is incorrect: {}",
-          b.header());
-        b.header().reset_size_checksum_metadata(b.data());
-        co_return b;
+    if (b.compressed()) [[unlikely]] {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Asked to compress a batch that is already compressed: {}",
+          b.header()));
+    }
+    if (c == model::compression::none) [[unlikely]] {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Asked to compress a batch using compression type none"));
     }
     model::record_batch_header h = b.header();
     auto payload = co_await ::compression::stream_compressor::compress(
@@ -94,14 +98,16 @@ compress_batch(model::compression c, model::record_batch b) {
 
 model::record_batch
 compress_batch_sync(model::compression c, model::record_batch b) {
-    if (c == model::compression::none) {
-        vassert(
-          b.header().attrs.compression() == model::compression::none,
-          "Asked to compress a batch with `none` compression, but header "
-          "metadata is incorrect: {}",
-          b.header());
-        b.header().reset_size_checksum_metadata(b.data());
-        return b;
+    if (b.compressed()) [[unlikely]] {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Asked to compress a batch that is already compressed: {}",
+          b.header()));
+    }
+    if (c == model::compression::none) [[unlikely]] {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Asked to compress a batch using compression type none"));
     }
     model::record_batch_header h = b.header();
     auto payload = ::compression::compressor::compress(

--- a/src/v/model/batch_compression.cc
+++ b/src/v/model/batch_compression.cc
@@ -39,22 +39,31 @@ namespace {
 }
 } // namespace
 
-ss::future<model::record_batch> decompress_batch(model::record_batch&& b) {
-    return ss::futurize_invoke(decompress_batch_sync, std::move(b));
-}
-
 ss::future<model::record_batch> decompress_batch(const model::record_batch& b) {
-    return ss::futurize_invoke(maybe_decompress_batch_sync, b);
-}
-
-model::record_batch decompress_batch_sync(model::record_batch&& b) {
-    if (!b.compressed()) {
-        return std::move(b);
+    if (!b.compressed()) [[unlikely]] {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Asked to decompressed a non-compressed batch:{}",
+          b.header()));
     }
-    return maybe_decompress_batch_sync(b);
+    // TODO: For zstd we have a non-reactor-stall version of uncompress that is
+    // async, but currently the API requires ownership of the iobuf, but at
+    // least one consumer of this API uses a const model::record_batch&
+    //
+    // We should consider a version of async uncompress that takes a const
+    // iobuf& where the caller owns the lifetime of the iobuf.
+    iobuf body_buf = ::compression::compressor::uncompress(
+      b.data(), to_compression_type(b.header().attrs.compression()));
+    // must remove compression first!
+    auto h = b.header();
+    h.attrs.remove_compression();
+    h.reset_size_checksum_metadata(body_buf);
+    auto batch = model::record_batch(
+      h, std::move(body_buf), model::record_batch::tag_ctor_ng{});
+    co_return batch;
 }
 
-model::record_batch maybe_decompress_batch_sync(const model::record_batch& b) {
+model::record_batch decompress_batch_sync(const model::record_batch& b) {
     if (!b.compressed()) [[unlikely]] {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,

--- a/src/v/model/batch_compression.h
+++ b/src/v/model/batch_compression.h
@@ -31,8 +31,14 @@ model::record_batch maybe_decompress_batch_sync(const model::record_batch&);
 
 // Compress the batch according to the specified compression type.
 //
-// *Always* recomputes the batch CRC and metadata, even if the batch
-// is not compressed.
+// This method may only be called if the compression type passed in is a valid
+// compression (snappy, gzip, lz4, zstd).
+//
+// The batch passed in must be uncompressed and *not* have the compression flags
+// set in the header.
+//
+// The CRC and size metadata of the batch header are updated to reflect the
+// compressed batch.
 ss::future<model::record_batch>
   compress_batch(model::compression, model::record_batch);
 

--- a/src/v/model/batch_compression.h
+++ b/src/v/model/batch_compression.h
@@ -17,17 +17,12 @@
 namespace model {
 
 /// \brief batch decompression
-ss::future<model::record_batch> decompress_batch(model::record_batch&&);
-
-/// \brief batch decompression
+///
+/// Throws if the batch is not compressed.
 ss::future<model::record_batch> decompress_batch(const model::record_batch&);
 
 /// \brief synchronous batch decompression
-model::record_batch decompress_batch_sync(model::record_batch&&);
-
-/// \brief synchronous batch decompression
-/// \throw std::runtime_error If provided batch is not compressed
-model::record_batch maybe_decompress_batch_sync(const model::record_batch&);
+model::record_batch decompress_batch_sync(const model::record_batch&);
 
 // Compress the batch according to the specified compression type.
 //

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -133,6 +133,7 @@ redpanda_cc_gtest(
     deps = [
         ":random",
         "//src/v/model",
+        "//src/v/model:batch_compression",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -123,7 +123,7 @@ redpanda_cc_btest(
     ],
 )
 
-redpanda_cc_btest(
+redpanda_cc_gtest(
     name = "record_batch_test",
     timeout = "short",
     srcs = [
@@ -133,9 +133,8 @@ redpanda_cc_btest(
     deps = [
         ":random",
         "//src/v/model",
-        "//src/v/test_utils:seastar_boost",
-        "@boost//:test",
-        "@seastar//:testing",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
     ],
 )
 

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -131,8 +131,7 @@ model::record_batch make_random_batch(record_batch_spec spec) {
       .base_offset = spec.offset,
       .type = spec.bt,
       .crc = 0, // we-reassign later
-      .attrs = model::record_batch_attributes(
-        get_int<int16_t>(0, spec.allow_compression ? 4 : 0)),
+      .attrs = {},
       .last_offset_delta = spec.count - 1,
       .first_timestamp = ts,
       .max_timestamp = max_ts,
@@ -177,10 +176,13 @@ model::record_batch make_random_batch(record_batch_spec spec) {
       model::packed_record_batch_header_size + body.size_bytes());
     auto batch = model::record_batch(
       header, std::move(body), model::record_batch::tag_ctor_ng{});
-    batch.header().crc = model::crc_record_batch(batch);
-    batch.header().header_crc = model::internal_header_only_crc(batch.header());
-    return model::compress_batch_sync(
-      header.attrs.compression(), std::move(batch));
+    auto compression = static_cast<model::compression>(
+      get_int<uint8_t>(0, spec.allow_compression ? 4 : 0));
+    if (compression == model::compression::none) {
+        batch.header().reset_size_checksum_metadata(batch.data());
+        return batch;
+    }
+    return model::compress_batch_sync(compression, std::move(batch));
 }
 
 model::record_batch make_random_batch(

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/batch_compression.h"
 #include "model/record.h"
 #include "model/record_utils.h"
 #include "model/tests/random_batch.h"
@@ -109,3 +110,40 @@ TEST_F(RecordBatchTest, TestCorruptedRecordBytes) {
       b, [](model::record& r) { EXPECT_GE(r.offset_delta(), 0); });
     EXPECT_THROW(f.get(), std::out_of_range);
 }
+
+class RecordBatchCompressionTest
+  : public ::testing::TestWithParam<model::compression> {};
+
+TEST_P(RecordBatchCompressionTest, CompressionTest) {
+    auto b = model::test::make_random_batch({
+      .offset = model::offset(0),
+      .allow_compression = false,
+      .count = 10,
+    });
+    if (GetParam() == model::compression::none) {
+        // TODO: Reconsider the difference between throwing and not throwing
+        // based on the kind of reference used.
+        EXPECT_NO_THROW(model::decompress_batch(b.copy()).get());
+        EXPECT_ANY_THROW(model::decompress_batch(b).get());
+        EXPECT_ANY_THROW(model::compress_batch(GetParam(), std::move(b)).get());
+    } else {
+        auto c = model::compress_batch(GetParam(), std::move(b)).get();
+        EXPECT_TRUE(c.compressed());
+        EXPECT_EQ(c.header().attrs.compression(), GetParam());
+        auto u_copy = model::decompress_batch(c).get();
+        auto u = model::decompress_batch(std::move(c)).get();
+        EXPECT_FALSE(u.compressed());
+        EXPECT_EQ(u.header().attrs.compression(), model::compression::none);
+        EXPECT_EQ(u_copy, u);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  CompressionTypes,
+  RecordBatchCompressionTest,
+  ::testing::Values(
+    model::compression::none,
+    model::compression::gzip,
+    model::compression::snappy,
+    model::compression::zstd,
+    model::compression::lz4));

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -114,18 +114,16 @@ TEST_F(RecordBatchTest, TestCorruptedRecordBytes) {
 class RecordBatchCompressionTest
   : public ::testing::TestWithParam<model::compression> {};
 
-TEST_P(RecordBatchCompressionTest, CompressionTest) {
+TEST_P(RecordBatchCompressionTest, Compression) {
     auto b = model::test::make_random_batch({
       .offset = model::offset(0),
       .allow_compression = false,
       .count = 10,
     });
     if (GetParam() == model::compression::none) {
-        // TODO: Reconsider the difference between throwing and not throwing
-        // based on the kind of reference used.
-        EXPECT_NO_THROW(model::decompress_batch(b.copy()).get());
         EXPECT_ANY_THROW(model::decompress_batch(b).get());
-        EXPECT_ANY_THROW(model::compress_batch(GetParam(), std::move(b)).get());
+        EXPECT_ANY_THROW(
+          model::compress_batch(model::compression::none, std::move(b)).get());
     } else {
         auto c = model::compress_batch(GetParam(), std::move(b)).get();
         EXPECT_TRUE(c.compressed());

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -12,48 +12,38 @@
 #include "model/tests/random_batch.h"
 #include "model/timestamp.h"
 
-#include <seastar/testing/thread_test_case.hh>
+#include <gtest/gtest.h>
 
-#include <boost/test/data/monomorphic.hpp>
-#include <boost/test/data/test_case.hpp>
-#include <boost/test/unit_test.hpp>
+class RecordBatchTest : public ::testing::Test {};
 
-namespace bdata = boost::unit_test::data;
+class RecordBatchAttributesTest
+  : public ::testing::TestWithParam<
+      std::tuple<model::compression, model::timestamp_type>> {};
 
-std::array<model::compression, 5> compressions{
-  model::compression::none,
-  model::compression::gzip,
-  model::compression::snappy,
-  model::compression::zstd,
-  model::compression::lz4};
-
-BOOST_DATA_TEST_CASE(
-  test_with_append_time,
-  bdata::make(compressions) ^ bdata::make(model::timestamp_type::append_time),
-  c,
-  ts_tp) {
+TEST_P(RecordBatchAttributesTest, TestAttributes) {
+    auto [c, ts_tp] = GetParam();
     model::record_batch_attributes attrs;
     attrs |= c;
     attrs |= ts_tp;
 
-    BOOST_REQUIRE_EQUAL(attrs.compression(), c);
-    BOOST_REQUIRE_EQUAL(attrs.timestamp_type(), ts_tp);
+    EXPECT_EQ(attrs.compression(), c);
+    EXPECT_EQ(attrs.timestamp_type(), ts_tp);
 }
 
-BOOST_DATA_TEST_CASE(
-  test_with_create_time,
-  bdata::make(compressions) ^ bdata::make(model::timestamp_type::create_time),
-  c,
-  ts_tp) {
-    model::record_batch_attributes attrs;
-    attrs |= c;
-    attrs |= ts_tp;
+INSTANTIATE_TEST_SUITE_P(
+  CompressionAndTimestampTypes,
+  RecordBatchAttributesTest,
+  ::testing::Combine(
+    ::testing::Values(
+      model::compression::none,
+      model::compression::gzip,
+      model::compression::snappy,
+      model::compression::zstd,
+      model::compression::lz4),
+    ::testing::Values(
+      model::timestamp_type::append_time, model::timestamp_type::create_time)));
 
-    BOOST_REQUIRE_EQUAL(attrs.compression(), c);
-    BOOST_REQUIRE_EQUAL(attrs.timestamp_type(), ts_tp);
-}
-
-SEASTAR_THREAD_TEST_CASE(set_max_timestamp) {
+TEST_F(RecordBatchTest, SetMaxTimestamp) {
     auto batch = model::test::make_random_batch(model::offset(0), 10, true);
 
     // nothing changes if set to same values
@@ -61,37 +51,37 @@ SEASTAR_THREAD_TEST_CASE(set_max_timestamp) {
     auto hdr_crc = batch.header().header_crc;
     batch.set_max_timestamp(
       batch.header().attrs.timestamp_type(), batch.header().max_timestamp);
-    BOOST_TEST(crc == batch.header().crc);
-    BOOST_TEST(hdr_crc == batch.header().header_crc);
+    EXPECT_EQ(crc, batch.header().crc);
+    EXPECT_EQ(hdr_crc, batch.header().header_crc);
 
     // ts change updates crcs
     batch.set_max_timestamp(
       model::timestamp_type::append_time,
       model::timestamp(batch.header().max_timestamp() + 1));
-    BOOST_TEST(crc != batch.header().crc);
-    BOOST_TEST(hdr_crc != batch.header().header_crc);
+    EXPECT_NE(crc, batch.header().crc);
+    EXPECT_NE(hdr_crc, batch.header().header_crc);
 
     // same ts produces orig crcs
     batch.set_max_timestamp(
       model::timestamp_type::create_time,
       model::timestamp(batch.header().max_timestamp() - 1));
-    BOOST_TEST(crc == batch.header().crc);
-    BOOST_TEST(hdr_crc == batch.header().header_crc);
+    EXPECT_EQ(crc, batch.header().crc);
+    EXPECT_EQ(hdr_crc, batch.header().header_crc);
 }
 
-SEASTAR_THREAD_TEST_CASE(iterator) {
+TEST_F(RecordBatchTest, Iterator) {
     auto b = model::test::make_random_batch(model::offset(0), 10, false);
 
     auto it = model::record_batch_iterator::create(b);
     for (int i = 0; i < b.record_count(); ++i) {
-        BOOST_TEST(it.has_next());
+        EXPECT_TRUE(it.has_next());
         model::record r = it.next();
-        BOOST_TEST(r.offset_delta() == i);
+        EXPECT_EQ(r.offset_delta(), i);
     }
-    BOOST_TEST(!it.has_next());
+    EXPECT_FALSE(it.has_next());
 }
 
-SEASTAR_THREAD_TEST_CASE(extra_bytes_iterator) {
+TEST_F(RecordBatchTest, ExtraBytesIterator) {
     auto b = model::test::make_random_batch(model::offset(0), 1, false);
     auto buf = b.data().copy();
     // If there are extra bytes at the end of the batch we should throw.
@@ -103,11 +93,11 @@ SEASTAR_THREAD_TEST_CASE(extra_bytes_iterator) {
     b = model::record_batch(
       header, std::move(buf), model::record_batch::tag_ctor_ng{});
     auto it = model::record_batch_iterator::create(b);
-    BOOST_TEST(it.has_next());
-    BOOST_REQUIRE_THROW(it.next(), std::out_of_range);
+    EXPECT_TRUE(it.has_next());
+    EXPECT_THROW(it.next(), std::out_of_range);
 }
 
-SEASTAR_THREAD_TEST_CASE(test_corrupted_record_bytes) {
+TEST_F(RecordBatchTest, TestCorruptedRecordBytes) {
     auto b = model::test::make_random_batch(model::offset(0), 10, false);
     // use the trick to get mutable access to the records
     auto fields = b.serde_fields();
@@ -116,6 +106,6 @@ SEASTAR_THREAD_TEST_CASE(test_corrupted_record_bytes) {
         std::fill_n(f.get_write(), f.size(), 0xFF);
     }
     auto f = model::for_each_record(
-      b, [](model::record& r) { BOOST_CHECK(r.offset_delta() >= 0); });
-    BOOST_REQUIRE_THROW(f.get(), std::out_of_range);
+      b, [](model::record& r) { EXPECT_GE(r.offset_delta(), 0); });
+    EXPECT_THROW(f.get(), std::out_of_range);
 }

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -121,7 +121,7 @@ public:
                 auto batch = std::move(*adapter.batch);
 
                 if (batch.compressed()) {
-                    batch = model::maybe_decompress_batch_sync(batch);
+                    batch = model::decompress_batch_sync(batch);
                 }
 
                 batch.for_each_record([&rjs, &w](model::record record) {

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1360,7 +1360,9 @@ struct consume_to_store {
 
     ss::future<ss::stop_iteration> operator()(model::record_batch b) {
         if (!b.header().attrs.is_control()) {
-            b = co_await model::decompress_batch(std::move(b));
+            if (b.compressed()) {
+                b = co_await model::decompress_batch(b);
+            }
             auto base_offset = b.base_offset();
             co_await model::for_each_record(
               b, [this, base_offset](model::record& rec) {

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -333,7 +333,7 @@ public:
         std::optional<const model::record_batch> u;
         bool compressed = batch.compressed();
         if (compressed) {
-            u.emplace(co_await model::decompress_batch(batch.copy()));
+            u.emplace(co_await model::decompress_batch(batch));
             _api->_schema_id_validation_probe.local().decompressed();
         }
 

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -271,6 +271,9 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     new_hdr.first_timestamp = first_time;
     new_hdr.max_timestamp = last_time;
     new_hdr.record_count = rec_count;
+    // Remove compression bit, as this batch isn't compressed. If the original
+    // batch is compressed, the caller will re-compress.
+    new_hdr.attrs.remove_compression();
     new_hdr.reset_size_checksum_metadata(ret);
     auto new_batch = model::record_batch(
       new_hdr, std::move(ret), model::record_batch::tag_ctor_ng{});

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -354,24 +354,18 @@ copy_data_segment_reducer::operator()(model::record_batch b) {
     if (!b.compressed()) {
         co_return co_await filter_and_append(comp, std::move(b));
     }
-    auto batch = co_await model::decompress_batch(std::move(b));
-
-    co_return co_await filter_and_append(comp, std::move(batch));
+    b = co_await model::decompress_batch(b);
+    co_return co_await filter_and_append(comp, std::move(b));
 }
 
 ss::future<ss::stop_iteration>
-index_rebuilder_reducer::operator()(model::record_batch&& b) {
+index_rebuilder_reducer::operator()(model::record_batch b) {
     using stop_t = ss::stop_iteration;
-    auto f = ss::now();
-    if (!b.compressed()) {
-        f = do_index(std::move(b));
-    } else {
-        f = model::decompress_batch(std::move(b))
-              .then([this](model::record_batch&& b) {
-                  return do_index(std::move(b));
-              });
+    if (b.compressed()) {
+        b = co_await model::decompress_batch(b);
     }
-    return f.then([] { return ss::make_ready_future<stop_t>(stop_t::no); });
+    co_await do_index(std::move(b));
+    co_return stop_t::no;
 }
 
 ss::future<> index_rebuilder_reducer::do_index(model::record_batch&& b) {
@@ -483,11 +477,13 @@ map_building_reducer::operator()(model::record_batch batch) {
         // map state (see copy_data_segment_reducer::filter()).
         co_return ss::stop_iteration::no;
     }
-    auto b = co_await model::decompress_batch(std::move(batch));
-    co_await b.for_each_record_async(
+    if (batch.compressed()) {
+        batch = co_await model::decompress_batch(batch);
+    }
+    co_await batch.for_each_record_async(
       [this,
        &fully_indexed_batch,
-       base_offset = b.base_offset(),
+       base_offset = batch.base_offset(),
        type = header.type,
        is_control = header.attrs.is_control()](
         const model::record& r) -> ss::future<ss::stop_iteration> {

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -209,7 +209,7 @@ class index_rebuilder_reducer : public compaction_reducer {
 public:
     explicit index_rebuilder_reducer(compacted_index_writer* w) noexcept
       : _w(w) {}
-    ss::future<ss::stop_iteration> operator()(model::record_batch&&);
+    ss::future<ss::stop_iteration> operator()(model::record_batch);
     void end_of_stream() {}
 
 private:

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -570,7 +570,9 @@ ss::future<timequery_result> batch_timequery(
     // records in the batch have different timestamps.
     model::offset result_o = batch.base_offset();
     model::timestamp result_t = batch.header().first_timestamp;
-    batch = co_await model::decompress_batch(std::move(batch));
+    if (batch.compressed()) {
+        batch = co_await model::decompress_batch(batch);
+    }
     co_await batch.for_each_record_async(
       [&result_o, &result_t, &batch, query_interval, t](
         const model::record& r) -> ss::future<ss::stop_iteration> {

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -60,25 +60,26 @@ model::record_batch record_batch_builder::build() && {
     if (!_timestamp) {
         _timestamp = model::timestamp::now();
     }
-    return model::compress_batch_sync(
-      _compression,
-      model::record_batch(
-        build_header(),
-        std::move(_records),
-        model::record_batch::tag_ctor_ng{}));
+    auto batch = model::record_batch(
+      build_header(), std::move(_records), model::record_batch::tag_ctor_ng{});
+    if (_compression == model::compression::none) {
+        batch.header().reset_size_checksum_metadata(batch.data());
+        return batch;
+    }
+    return model::compress_batch_sync(_compression, std::move(batch));
 }
 
 ss::future<model::record_batch> record_batch_builder::build_async() && {
     if (!_timestamp) {
         _timestamp = model::timestamp::now();
     }
-
-    co_return co_await model::compress_batch(
-      _compression,
-      model::record_batch(
-        build_header(),
-        std::move(_records),
-        model::record_batch::tag_ctor_ng{}));
+    auto batch = model::record_batch(
+      build_header(), std::move(_records), model::record_batch::tag_ctor_ng{});
+    if (_compression == model::compression::none) {
+        batch.header().reset_size_checksum_metadata(batch.data());
+        co_return batch;
+    }
+    co_return co_await model::compress_batch(_compression, std::move(batch));
 }
 
 model::record_batch_header record_batch_builder::build_header() const {

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -548,10 +548,8 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
         return ss::make_exception_future<append_result>(std::runtime_error(
           fmt::format(
             "Invalid state. Attempted to append a batch with base_offset:{}, "
-            "but "
-            "would invalidate our initial state base offset of:{}. Actual "
-            "batch "
-            "header:{}, self:{}",
+            "but would invalidate our initial state base offset of:{}. Actual "
+            "batch header:{}, self:{}",
             b.base_offset(),
             _tracker.get_base_offset(),
             b.header(),

--- a/src/v/storage/tests/batch_generators.h
+++ b/src/v/storage/tests/batch_generators.h
@@ -80,9 +80,7 @@ struct linear_int_kv_batch_generator {
           .base_offset = spec.offset,
           .type = spec.bt,
           .crc = 0, // we-reassign later
-          .attrs = model::record_batch_attributes(
-            random_generators::get_int<int16_t>(
-              0, spec.allow_compression ? 4 : 0)),
+          .attrs = {},
           .last_offset_delta = spec.count - 1,
           .first_timestamp = ts,
           .max_timestamp = max_ts,
@@ -119,11 +117,14 @@ struct linear_int_kv_batch_generator {
           model::packed_record_batch_header_size + body.size_bytes());
         auto batch = model::record_batch(
           header, std::move(body), model::record_batch::tag_ctor_ng{});
-        batch.header().crc = model::crc_record_batch(batch);
-        batch.header().header_crc = model::internal_header_only_crc(
-          batch.header());
-        return model::compress_batch_sync(
-          header.attrs.compression(), std::move(batch));
+        auto compression = static_cast<model::compression>(
+          random_generators::get_int<uint8_t>(
+            0, spec.allow_compression ? 4 : 0));
+        if (compression == model::compression::none) {
+            batch.header().reset_size_checksum_metadata(batch.data());
+            return batch;
+        }
+        return model::compress_batch_sync(compression, std::move(batch));
     }
 
     chunked_circular_buffer<model::record_batch>

--- a/src/v/storage/tests/utils/log_gap_analysis.cc
+++ b/src/v/storage/tests/utils/log_gap_analysis.cc
@@ -65,7 +65,9 @@ log_gap_analysis make_log_gap_analysis(
     };
 
     for (auto&& rb : mem_log) {
-        rb = model::decompress_batch(std::move(rb)).get();
+        if (rb.compressed()) {
+            rb = model::decompress_batch(rb).get();
+        }
         batch_consumer(rb);
     }
     return ga;

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -531,7 +531,7 @@ public:
             co_return;
         }
         if (batch.compressed()) {
-            batch = co_await model::decompress_batch(std::move(batch));
+            batch = co_await model::decompress_batch(batch);
         }
         ss::future<> fut = co_await ss::coroutine::as_future(
           invoke_transform(std::move(batch), probe, std::move(cb)));


### PR DESCRIPTION
It sort of doesn't make sense TBH to support this, and now there is a
duality with the decompress methods, which throw if trying to decompress
something that is uncompressed

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
