### PR TITLE
`ct/l1/compaction`: add basic `compaction` implementations

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -1,0 +1,20 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = ["//src/v/cloud_topics/level_one:__subpackages__"])
+
+redpanda_cc_library(
+    name = "source",
+    srcs = [
+        "source.cc",
+    ],
+    hdrs = [
+        "source.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        "//src/v/compaction:reducer",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -41,3 +41,23 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "filter",
+    srcs = [
+        "filter.cc",
+    ],
+    hdrs = [
+        "filter.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        "//src/v/compaction:filter",
+        "//src/v/compaction:key_offset_map",
+        "//src/v/compaction:utils",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -18,3 +18,26 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "sink",
+    srcs = [
+        "sink.cc",
+    ],
+    hdrs = [
+        "sink.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/compaction:reducer",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/model:batch_compression",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/filter.cc
+++ b/src/v/cloud_topics/level_one/compaction/filter.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/filter.h"
+
+#include "compaction/utils.h"
+#include "model/record.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+#include <optional>
+#include <vector>
+
+namespace cloud_topics::l1 {
+
+ss::future<> compaction_filter::maybe_index_offset_delta(
+  const model::record_batch& b,
+  const model::record& r,
+  std::vector<int32_t>& offset_deltas) const {
+    if (co_await compaction::is_latest_record_for_key(_map, b, r)) {
+        offset_deltas.push_back(r.offset_delta());
+    }
+}
+
+ss::future<std::vector<int32_t>>
+compaction_filter::compute_offset_deltas_to_keep(
+  const model::record_batch& b) const {
+    std::vector<int32_t> offset_deltas;
+    offset_deltas.reserve(b.record_count());
+
+    co_await b.for_each_record_async(
+      [this, &b, &offset_deltas](const model::record& r) {
+          return maybe_index_offset_delta(b, r, offset_deltas);
+      });
+
+    co_return offset_deltas;
+}
+
+ss::future<std::optional<model::record_batch>>
+compaction_filter::filter_batch_with_offset_deltas(
+  model::record_batch b, std::vector<int32_t> offset_deltas) const {
+    co_return co_await do_filter_batch(std::move(b), std::move(offset_deltas));
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/filter.h
+++ b/src/v/cloud_topics/level_one/compaction/filter.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "compaction/filter.h"
+#include "compaction/key_offset_map.h"
+
+namespace cloud_topics::l1 {
+
+class compaction_filter : public compaction::filter {
+public:
+    compaction_filter(
+      compaction::sliding_window_reducer::sink& sink,
+      const compaction::key_offset_map& map,
+      model::ntp ntp)
+      : filter(sink, std::move(ntp))
+      , _map(map) {}
+
+private:
+    ss::future<> maybe_index_offset_delta(
+      const model::record_batch& b,
+      const model::record& r,
+      std::vector<int32_t>& offset_deltas) const;
+
+    ss::future<std::vector<int32_t>>
+    compute_offset_deltas_to_keep(const model::record_batch& b) const final;
+
+    ss::future<std::optional<model::record_batch>>
+    filter_batch_with_offset_deltas(
+      model::record_batch b, std::vector<int32_t> offset_deltas) const final;
+
+    const compaction::key_offset_map& _map;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/sink.h"
+
+#include "bytes/iostream.h"
+#include "cloud_topics/level_one/common/object.h"
+#include "compaction/reducer.h"
+#include "model/batch_compression.h"
+#include "model/compression.h"
+
+namespace cloud_topics::l1 {
+
+bool compaction_sink::needs_roll() const {
+    // TODO: This needs to consider L1 object size and what-not eventually.
+    return !_active_output_buf;
+}
+
+ss::future<> compaction_sink::maybe_flush_object_builder() {
+    if (!_builder) {
+        co_return;
+    }
+
+    auto builder = std::exchange(_builder, nullptr);
+    auto object_info = co_await builder->finish();
+    co_await builder->close();
+
+    auto active_buf = std::exchange(_active_output_buf, std::nullopt).value();
+    _closed_objs.emplace_back(std::move(object_info), std::move(active_buf));
+}
+
+ss::future<> compaction_sink::maybe_roll() {
+    if (!needs_roll()) {
+        co_return;
+    }
+
+    co_await maybe_flush_object_builder();
+
+    _active_output_buf = iobuf{};
+    _builder = object_builder::create(
+      make_iobuf_ref_output_stream(_active_output_buf.value()), _opts);
+
+    co_await _builder->start_partition(_ntp);
+
+    co_return;
+}
+
+ss::future<ss::stop_iteration>
+compaction_sink::operator()(model::record_batch b, model::compression c) {
+    co_await maybe_roll();
+    if (c != model::compression::none) {
+        b = co_await model::compress_batch(c, std::move(b));
+    }
+    co_await _builder->add_batch(std::move(b));
+    co_return ss::stop_iteration::no;
+}
+
+ss::future<> compaction_sink::finalize() {
+    // TODO: This is very temporary.
+    co_await maybe_flush_object_builder();
+    if (_obj_sink) {
+        *_obj_sink = std::move(_closed_objs);
+    }
+    co_return;
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/common/object.h"
+#include "compaction/reducer.h"
+#include "container/chunked_vector.h"
+
+namespace cloud_topics::l1 {
+
+class compaction_sink : public compaction::sliding_window_reducer::sink {
+public:
+    struct object_output_t {
+        object_builder::object_info info;
+        iobuf obj;
+    };
+
+    compaction_sink(model::ntp ntp, object_builder::options opts = {})
+      : _ntp(std::move(ntp))
+      , _opts(opts) {}
+
+    ss::future<ss::stop_iteration>
+    operator()(model::record_batch b, model::compression c) final;
+    ss::future<> finalize() final;
+
+    void set_object_sink(chunked_vector<object_output_t>* obj_sink) {
+        _obj_sink = obj_sink;
+    }
+
+private:
+    bool needs_roll() const;
+
+    ss::future<> maybe_flush_object_builder();
+
+    ss::future<> maybe_roll();
+
+    model::ntp _ntp;
+    const object_builder::options _opts;
+
+    std::optional<iobuf> _active_output_buf{std::nullopt};
+    // Guaranteed to have a value iff _output_buf.has_value().
+    std::unique_ptr<object_builder> _builder{nullptr};
+    chunked_vector<object_output_t> _closed_objs;
+
+    // TODO: This is very temporary.
+    chunked_vector<object_output_t>* _obj_sink{nullptr};
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/source.h"
+
+#include "compaction/reducer.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cloud_topics::l1 {
+
+ss::future<> compaction_source::initialize() { co_return; }
+
+ss::future<ss::stop_iteration> compaction_source::backward_pass_iteration() {
+    co_return ss::stop_iteration::yes;
+}
+
+ss::future<ss::stop_iteration> compaction_source::forward_pass_iteration(
+  compaction::sliding_window_reducer::sink&) {
+    co_return ss::stop_iteration::yes;
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/source.h
+++ b/src/v/cloud_topics/level_one/compaction/source.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "compaction/reducer.h"
+
+namespace cloud_topics::l1 {
+
+class compaction_source : public compaction::sliding_window_reducer::source {
+public:
+    ss::future<> initialize() final;
+    ss::future<ss::stop_iteration> backward_pass_iteration() final;
+    ss::future<ss::stop_iteration>
+    forward_pass_iteration(compaction::sliding_window_reducer::sink&) final;
+
+private:
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -1,0 +1,26 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "reducer_test",
+    timeout = "short",
+    srcs = [
+        "reducer_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/common:object_utils",
+        "//src/v/cloud_topics/level_one/compaction:filter",
+        "//src/v/cloud_topics/level_one/compaction:sink",
+        "//src/v/compaction:reducer",
+        "//src/v/compaction/tests:simple_reducer",
+        "//src/v/container:chunked_circular_buffer",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/storage/tests:batch_generators",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iostream.h"
+#include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/level_one/common/object_utils.h"
+#include "cloud_topics/level_one/compaction/sink.h"
+#include "compaction/reducer.h"
+#include "compaction/tests/simple_reducer.h"
+#include "container/chunked_circular_buffer.h"
+#include "container/chunked_vector.h"
+#include "model/record.h"
+#include "storage/tests/batch_generators.h"
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+static const auto test_ntp = model::ntp(
+  model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
+
+TEST(ReducerTest, Batches) {
+    namespace l1 = cloud_topics::l1;
+    int num_batches = 10;
+    auto gen = linear_int_kv_batch_generator();
+    auto spec = model::test::record_batch_spec{
+      .allow_compression = false, .count = 1};
+    auto input_batches = gen(spec, num_batches);
+
+    auto src = std::make_unique<compaction::simple_source>(
+      std::move(input_batches), test_ntp);
+    auto sink = std::make_unique<l1::compaction_sink>(test_ntp);
+
+    chunked_vector<l1::compaction_sink::object_output_t> output_objs;
+    sink->set_object_sink(&output_objs);
+    auto reducer = compaction::sliding_window_reducer(
+      std::move(src), std::move(sink));
+
+    std::move(reducer).run().get();
+
+    ASSERT_EQ(output_objs.size(), 1);
+    auto& [info, object] = output_objs.front();
+    auto rdr = l1::object_reader::create(
+      make_iobuf_input_stream(std::move(object)));
+
+    chunked_circular_buffer<model::record_batch> output_batches;
+    while (true) {
+        l1::object_reader::result res = rdr->read_next().get();
+        if (std::holds_alternative<model::record_batch>(res)) {
+            output_batches.push_back(
+              std::move(std::get<model::record_batch>(res)));
+        }
+        if (std::holds_alternative<l1::object_reader::eof>(res)) {
+            break;
+        }
+    }
+
+    ASSERT_EQ(output_batches.size(), num_batches);
+    linear_int_kv_batch_generator::validate_post_compaction(
+      std::move(output_batches));
+}


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda/pull/27255/.

Implements a very basic `compaction_filter` and `sink` with the current `l1::object_builder`, and adds a basic smoke test for these objects.

All of this stuff is in its infantile stages, but they are building blocks which shall grow over time with CT.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
