### PR TITLE
ct: Add write_balancer component

### DIFF
--- a/src/v/cloud_topics/level_zero/common/BUILD
+++ b/src/v/cloud_topics/level_zero/common/BUILD
@@ -14,6 +14,8 @@ package(
         "//src/v/cloud_topics/level_zero/reader:__pkg__",
         "//src/v/cloud_topics/level_zero/reader/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/throttler/tests:__pkg__",
+        "//src/v/cloud_topics/level_zero/write_request_scheduler:__pkg__",
+        "//src/v/cloud_topics/level_zero/write_request_scheduler/tests:__pkg__",
     ],
 )
 

--- a/src/v/cloud_topics/level_zero/pipeline/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/BUILD
@@ -148,6 +148,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":serializer",
         "//src/v/cloud_topics:logger",
+        "//src/v/resource_mgmt:memory_groups",
         "//src/v/ssx:sformat",
         "//src/v/utils:human",
     ],
@@ -183,6 +184,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":serializer",
         "//src/v/cloud_topics:logger",
+        "//src/v/resource_mgmt:memory_groups",
         "//src/v/ssx:sformat",
         "//src/v/utils:human",
     ],

--- a/src/v/cloud_topics/level_zero/pipeline/BUILD
+++ b/src/v/cloud_topics/level_zero/pipeline/BUILD
@@ -9,6 +9,8 @@ package(default_visibility = [
     "//src/v/cloud_topics/level_zero/reader/tests:__pkg__",
     "//src/v/cloud_topics/level_zero/throttler:__pkg__",
     "//src/v/cloud_topics/level_zero/throttler/tests:__pkg__",
+    "//src/v/cloud_topics/level_zero/write_request_scheduler:__pkg__",
+    "//src/v/cloud_topics/level_zero/write_request_scheduler/tests:__pkg__",
 ])
 
 redpanda_cc_library(

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_zero/pipeline/event_filter.h"
 #include "cloud_topics/level_zero/pipeline/read_request.h"
 #include "cloud_topics/logger.h"
+#include "resource_mgmt/memory_groups.h"
 #include "utils/human.h"
 
 #include <seastar/core/abort_source.hh>
@@ -30,10 +31,21 @@
 
 namespace cloud_topics::l0 {
 
+// Memory limit used in tests (when cluster config is disabled)
+static constexpr size_t max_memory_when_disabled = 100 * 1024 * 1024;
+
+namespace {
+size_t get_cloud_topics_l0_read_path_memory() {
+    return memory_groups().cloud_topics_memory() > 0
+             // TODO: take L1 into account.
+             ? memory_groups().cloud_topics_memory() / 2
+             : max_memory_when_disabled;
+}
+} // namespace
+
 template<class Clock>
 read_pipeline<Clock>::read_pipeline()
-  // TODO: use config parameter
-  : _mem_quota(100_MiB, "read-pipeline")
+  : _mem_quota(get_cloud_topics_l0_read_path_memory(), "read-pipeline")
   // TODO: use config parameter
   , _breaker(10, std::chrono::seconds(1)) {}
 

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_zero/pipeline/pipeline_stage.h"
 #include "cloud_topics/level_zero/pipeline/write_request.h"
 #include "cloud_topics/logger.h"
+#include "resource_mgmt/memory_groups.h"
 #include "utils/human.h"
 
 #include <seastar/core/abort_source.hh>
@@ -29,10 +30,30 @@
 
 namespace cloud_topics::l0 {
 
+// The max value is used in unit-tests only. Normally, the memory_groups
+// function is used to set up the limit. If the cloud_topics are disabled
+// but the pipeline is still created (which is something we do in tests)
+// then this constant will be used.
+static constexpr size_t max_memory_when_disabled = 100 * 1024 * 1024;
+
+namespace {
+size_t get_cloud_topics_l0_write_path_memory() {
+    return memory_groups().cloud_topics_memory() > 0
+             // Split memory in half between read and write path.
+             // TODO: take L1 into account.
+             ? memory_groups().cloud_topics_memory() / 2
+             : max_memory_when_disabled;
+}
+} // namespace
+
 template<class Clock>
 write_pipeline<Clock>::write_pipeline()
-  // TODO: use configuration parameter and binding
-  : _mem_budget(10_MiB, "write-pipeline") {}
+  : _mem_budget(get_cloud_topics_l0_write_path_memory(), "write-pipeline") {
+    vlog(
+      cd_log.trace,
+      "write_pipeline created, memory budget: {}",
+      _mem_budget.current());
+}
 
 template<class Clock>
 write_pipeline<Clock>::~write_pipeline() = default;

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -132,7 +132,7 @@ write_pipeline<Clock>::stage::stage(write_pipeline<Clock>* p, pipeline_stage s)
 template<class Clock>
 typename write_pipeline<Clock>::write_requests_list
 write_pipeline<Clock>::get_write_requests(
-  size_t max_bytes, pipeline_stage stage) {
+  size_t max_bytes, pipeline_stage stage, size_t max_requests) {
     // First remove timed out write request to avoid returning them
     this->remove_timed_out_requests();
 
@@ -144,6 +144,7 @@ write_pipeline<Clock>::get_write_requests(
     write_requests_list result(this, stage, {});
 
     size_t acc_size = 0;
+    size_t acc_req = 0;
 
     // The elements in the list are in the insertion order.
     auto it = pending.begin();
@@ -153,7 +154,8 @@ write_pipeline<Clock>::get_write_requests(
         }
         auto sz = it->data_chunk.payload.size_bytes();
         acc_size += sz;
-        if (acc_size >= max_bytes) {
+        acc_req++;
+        if (acc_size >= max_bytes || acc_req >= max_requests) {
             // Include last element
             it++;
             break;
@@ -204,8 +206,9 @@ void write_pipeline<Clock>::stage::push_next_stage(write_request<Clock>& req) {
 
 template<class Clock>
 write_pipeline<Clock>::write_requests_list
-write_pipeline<Clock>::stage::pull_write_requests(size_t max_bytes) {
-    return _parent->get_write_requests(max_bytes, _ps);
+write_pipeline<Clock>::stage::pull_write_requests(
+  size_t max_bytes, size_t max_requests) {
+    return _parent->get_write_requests(max_bytes, _ps, max_requests);
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -73,7 +73,12 @@ public:
         /// The caller is responsible for handling each write request.
         /// The request could be either returned using 'push_next_stage'
         /// method.
-        write_requests_list pull_write_requests(size_t max_bytes);
+        /// \param max_bytes Maximum number of bytes to extract
+        /// \param max_requests Maximum number of requests to extract
+        /// \return List of write requests that were extracted
+        write_requests_list pull_write_requests(
+          size_t max_bytes,
+          size_t max_requests = std::numeric_limits<size_t>::max());
 
         /// Wait until either the 'deadline' is reached or the pipeline
         /// accumulated 'max_bytes' bytes
@@ -162,8 +167,14 @@ private:
     /// Get write requests atomically.
     /// The total size of returned write requests and the stage to which they
     /// belong to should be specified.
-    write_requests_list
-    get_write_requests(size_t max_bytes, pipeline_stage stage);
+    /// \param max_bytes Maximum number of bytes to extract
+    /// \param stage Pipeline stage to get write requests from
+    /// \param max_requests Maximum number of requests to extract
+    /// \return List of write requests that were extracted
+    write_requests_list get_write_requests(
+      size_t max_bytes,
+      pipeline_stage stage,
+      size_t max_requests = std::numeric_limits<size_t>::max());
 
     /// Return write request which was already been in the pipeline
     /// before back into the pipeline.

--- a/src/v/cloud_topics/level_zero/pipeline/write_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_request.h
@@ -21,6 +21,7 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/weak_ptr.hh>
 
 namespace cloud_topics::l0 {

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/BUILD
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/BUILD
@@ -1,0 +1,32 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+package(default_visibility = [
+    ":__subpackages__",
+    "//src/v/cloud_topics:__pkg__",
+    "//src/v/cloud_topics/level_zero/write_request_scheduler/tests:__pkg__",
+])
+
+redpanda_cc_library(
+    name = "write_request_scheduler",
+    srcs = [
+        "write_request_scheduler.cc",
+    ],
+    hdrs = [
+        "write_request_scheduler.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes",
+        "//src/v/bytes:iobuf",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/level_zero/common:extent_meta",
+        "//src/v/cloud_topics/level_zero/pipeline:base_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:event_filter",
+        "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:write_request",
+        "//src/v/config",
+        "//src/v/ssx:future_util",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
     name = "write_request_scheduler_test",
@@ -19,5 +19,28 @@ redpanda_cc_gtest(
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
         "@seastar",
+    ],
+)
+
+redpanda_cc_bench(
+    name = "write_request_scheduler_rpbench",
+    timeout = "short",
+    srcs = [
+        "write_request_scheduler_bench.cc",
+    ],
+    cpu = 2,
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_topics/level_zero/pipeline:event_filter",
+        "//src/v/cloud_topics/level_zero/pipeline:pipeline_stage",
+        "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:write_request",
+        "//src/v/cloud_topics/level_zero/write_request_scheduler",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:scoped_config",
+        "@seastar",
+        "@seastar//:benchmark",
     ],
 )

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/BUILD
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/BUILD
@@ -1,0 +1,23 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "write_request_scheduler_test",
+    timeout = "short",
+    srcs = [
+        "write_request_scheduler_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/cloud_topics/level_zero/pipeline:event_filter",
+        "//src/v/cloud_topics/level_zero/pipeline:pipeline_stage",
+        "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
+        "//src/v/cloud_topics/level_zero/pipeline:write_request",
+        "//src/v/cloud_topics/level_zero/write_request_scheduler",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_bench.cc
@@ -1,0 +1,217 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_topics/level_zero/pipeline/event_filter.h"
+#include "cloud_topics/level_zero/pipeline/pipeline_stage.h"
+#include "cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/scoped_config.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <chrono>
+#include <cstddef>
+#include <exception>
+#include <limits>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics {
+namespace l0 {
+struct write_request_balancer_accessor {
+    static void disable_data_threshold_uploads(write_request_scheduler* s) {
+        s->_test_only_disable_data_threshold = true;
+    }
+    static void disable_time_based_fallback(write_request_scheduler* s) {
+        s->_test_only_disable_time_based_fallback = true;
+    }
+    static ss::future<> apply_time_based_fallback(write_request_scheduler* s) {
+        return s->apply_time_based_fallback();
+    }
+};
+} // namespace l0
+
+struct pipeline_sink {
+    explicit pipeline_sink(l0::write_pipeline<>& p)
+      : stage(p.register_write_pipeline_stage()) {}
+
+    ss::future<> start() {
+        ssx::background = bg_run();
+        co_return;
+    }
+
+    ss::future<> stop() {
+        _as.request_abort();
+        co_await _gate.close();
+    }
+
+    ss::future<> bg_run() {
+        auto h = _gate.hold();
+        while (!_as.abort_requested()) {
+            auto res = co_await stage.wait_next(&_as);
+            if (res.has_error()) {
+                co_return;
+            }
+            auto event = res.value();
+            if (event.type == l0::event_type::shutting_down) {
+                co_return;
+            }
+            vassert(
+              event.type == l0::event_type::new_write_request,
+              "unexpected event type");
+            auto result = stage.pull_write_requests(
+              std::numeric_limits<size_t>::max());
+            for (auto& r : result.requests) {
+                r.set_value(chunked_vector<extent_meta>{});
+            }
+        }
+    }
+    l0::write_pipeline<>::stage stage;
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+} // namespace cloud_topics
+
+class write_request_scheduler_bench {
+public:
+    ss::future<>
+    start(bool disable_data_threshold, bool disable_time_based_fallback) {
+        co_await pipeline.start();
+
+        co_await scheduler.start(ss::sharded_parameter([this] {
+            return pipeline.local().register_write_pipeline_stage();
+        }));
+
+        co_await scheduler.invoke_on_all(
+          [disable_data_threshold, disable_time_based_fallback](
+            cloud_topics::l0::write_request_scheduler& s) {
+              if (disable_data_threshold) {
+                  cloud_topics::l0::write_request_balancer_accessor::
+                    disable_data_threshold_uploads(&s);
+              }
+              if (disable_time_based_fallback) {
+                  cloud_topics::l0::write_request_balancer_accessor::
+                    disable_time_based_fallback(&s);
+              }
+          });
+
+        co_await scheduler.invoke_on_all(
+          [](auto& sched) { return sched.start(); });
+
+        co_await request_sink.start(
+          ss::sharded_parameter([this] { return std::ref(pipeline.local()); }));
+        co_await request_sink.invoke_on_all(
+          [](cloud_topics::pipeline_sink& sink) { return sink.start(); });
+    }
+
+    ss::future<> stop() {
+        co_await request_sink.stop();
+        co_await scheduler.stop();
+        co_await pipeline.stop();
+    }
+
+    ss::sharded<cloud_topics::l0::write_pipeline<>> pipeline;
+    ss::sharded<cloud_topics::l0::write_request_scheduler> scheduler;
+    ss::sharded<cloud_topics::pipeline_sink> request_sink;
+};
+
+PERF_TEST_C(write_request_scheduler_bench, data_threshold) {
+    // Boring case, data is just propagated to the next stage once
+    // the threshold is reached. To reach the threshold we need to
+    // generate right amount of data.
+    constexpr size_t size_threshold = 0x1000;
+    scoped_config cfg{};
+    cfg.get("cloud_topics_produce_batching_size_threshold")
+      .set_value(size_threshold);
+
+    co_await start(false, true);
+
+    chunked_vector<model::record_batch> batches;
+    auto batch = model::test::make_random_batch(
+      model::test::record_batch_spec{
+        .offset = model::offset(0),
+        .allow_compression = false,
+        .count = 1,
+        .records = 1,
+        .record_sizes = std::vector<size_t>{size_threshold},
+      });
+    if (batch.size_bytes() < (int32_t)size_threshold) {
+        throw std::runtime_error(
+          fmt::format(
+            "Batch size {} does not match threshold {}",
+            batch.size_bytes(),
+            size_threshold));
+    }
+    batches.push_back(std::move(batch));
+
+    perf_tests::start_measuring_time();
+    perf_tests::do_not_optimize(
+      co_await pipeline.local().write_and_debounce(
+        model::controller_ntp,
+        std::move(batches),
+        ss::lowres_clock::now() + std::chrono::milliseconds(10)));
+    perf_tests::stop_measuring_time();
+
+    co_await stop();
+}
+
+PERF_TEST_C(write_request_scheduler_bench, time_fallback) {
+    // This test measures the time needed to propagate write requests
+    // from all shards.
+
+    static constexpr size_t batch_size = 1000;
+
+    // Disable all background activity and invoke time based fallback
+    // manually.
+    co_await start(true, true);
+
+    auto invoke_fut = pipeline.invoke_on_all(
+      [](cloud_topics::l0::write_pipeline<>& p) -> ss::future<> {
+          chunked_vector<model::record_batch> batches;
+          // Make shard 1 have more data so the uploads are moved to shard 1.
+          size_t size = ss::this_shard_id() == ss::shard_id(1) ? batch_size * 2
+                                                               : batch_size;
+          auto batch = model::test::make_random_batch(
+            model::test::record_batch_spec{
+              .offset = model::offset(0),
+              .allow_compression = false,
+              .count = 1,
+              .records = 1,
+              .record_sizes = std::vector<size_t>{size},
+            });
+          batches.push_back(std::move(batch));
+          return p
+            .write_and_debounce(
+              model::controller_ntp,
+              std::move(batches),
+              ss::lowres_clock::now() + std::chrono::milliseconds(10))
+            .discard_result();
+      });
+
+    // Make sure requests are enqueued on all shards
+    co_await ss::sleep(100ms);
+
+    perf_tests::start_measuring_time();
+    co_await cloud_topics::l0::write_request_balancer_accessor::
+      apply_time_based_fallback(&scheduler.local());
+    perf_tests::stop_measuring_time();
+
+    co_await std::move(invoke_fut);
+    co_await stop();
+}

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -106,7 +106,7 @@ struct pipeline_sink {
 };
 
 namespace l0 {
-struct resource_balancer_accessor {
+struct write_request_balancer_accessor {
     static void disable_data_threshold_uploads(write_request_scheduler* s) {
         s->_test_only_disable_data_threshold = true;
     }
@@ -133,17 +133,18 @@ public:
             return pipeline.local().register_write_pipeline_stage();
         }));
 
-        co_await scheduler.invoke_on_all([disable_data_threshold,
-                                          disable_time_based_fallback](
-                                           l0::write_request_scheduler& s) {
-            if (disable_data_threshold) {
-                l0::resource_balancer_accessor::disable_data_threshold_uploads(
-                  &s);
-            }
-            if (disable_time_based_fallback) {
-                l0::resource_balancer_accessor::disable_time_based_fallback(&s);
-            }
-        });
+        co_await scheduler.invoke_on_all(
+          [disable_data_threshold,
+           disable_time_based_fallback](l0::write_request_scheduler& s) {
+              if (disable_data_threshold) {
+                  l0::write_request_balancer_accessor::
+                    disable_data_threshold_uploads(&s);
+              }
+              if (disable_time_based_fallback) {
+                  l0::write_request_balancer_accessor::
+                    disable_time_based_fallback(&s);
+              }
+          });
 
         vlog(test_log.info, "Starting scheduler");
         co_await scheduler.invoke_on_all(
@@ -255,7 +256,7 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
     ASSERT_TRUE_CORO(ss::smp::count > 1);
 
     co_await scheduler.invoke_on_all([](l0::write_request_scheduler& s) {
-        l0::resource_balancer_accessor::disable_data_threshold_uploads(&s);
+        l0::write_request_balancer_accessor::disable_data_threshold_uploads(&s);
     });
 
     co_await start(

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -1,0 +1,479 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_topics/level_zero/pipeline/event_filter.h"
+#include "cloud_topics/level_zero/pipeline/pipeline_stage.h"
+#include "cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <chrono>
+#include <exception>
+#include <limits>
+
+inline ss::logger test_log("balancer_gtest");
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics {
+
+// Sink consumes and acknowledges all write requests
+// in the pipeline.
+struct pipeline_sink {
+    explicit pipeline_sink(l0::write_pipeline<>& p)
+      : stage(p.register_write_pipeline_stage()) {
+        vlog(test_log.info, "pipeline_sink stage: {}", stage.id());
+    }
+
+    ss::future<> start() {
+        ssx::background = bg_run();
+        co_return;
+    }
+
+    ss::future<> stop() {
+        _as.request_abort();
+        co_await _gate.close();
+    }
+
+    ss::future<> bg_run() {
+        auto h = _gate.hold();
+        while (!_as.abort_requested()) {
+            vlog(
+              test_log.debug,
+              "pipeline_sink subscribe, stage id {}",
+              stage.id());
+            auto res = co_await stage.wait_next(&_as);
+            vlog(test_log.debug, "pipeline_sink event");
+            if (res.has_error()) {
+                vlog(
+                  test_log.error, "Event subscription failed: {}", res.error());
+                continue;
+            }
+            auto event = res.value();
+            if (event.type != l0::event_type::new_write_request) {
+                co_return;
+            }
+            // Vacuum all write requests
+            auto result = stage.pull_write_requests(
+              std::numeric_limits<size_t>::max());
+            for (auto& r : result.requests) {
+                if (error_generator) {
+                    auto errc = error_generator(r);
+                    if (errc != errc::success) {
+                        r.set_value(errc);
+                        write_requests_acked++;
+                        vlog(
+                          test_log.debug,
+                          "Write request NACK({}), total ack: {}",
+                          errc,
+                          write_requests_acked);
+                        continue;
+                    }
+                }
+                r.set_value(chunked_vector<extent_meta>{});
+                write_requests_acked++;
+                vlog(
+                  test_log.debug,
+                  "Write request ACK, total ack: {}",
+                  write_requests_acked);
+            }
+        }
+    }
+
+    l0::write_pipeline<>::stage stage;
+    ss::gate _gate;
+    ss::abort_source _as;
+    size_t write_requests_acked{0};
+    // This function is used to simulate upload failures
+    std::function<errc(l0::write_request<>&)> error_generator;
+};
+
+namespace l0 {
+struct resource_balancer_accessor {
+    static void disable_data_threshold_uploads(write_request_scheduler* s) {
+        s->_test_only_disable_data_threshold = true;
+    }
+    static void disable_time_based_fallback(write_request_scheduler* s) {
+        s->_test_only_disable_time_based_fallback = true;
+    }
+};
+} // namespace l0
+
+} // namespace cloud_topics
+
+using namespace cloud_topics;
+
+class write_request_balancer_fixture : public seastar_test {
+public:
+    ss::future<>
+    start(bool disable_data_threshold, bool disable_time_based_fallback) {
+        vlog(test_log.info, "Creating pipeline");
+        co_await pipeline.start();
+
+        // Start the scheduler
+        vlog(test_log.info, "Creating scheduler");
+        co_await scheduler.start(ss::sharded_parameter([this] {
+            return pipeline.local().register_write_pipeline_stage();
+        }));
+
+        co_await scheduler.invoke_on_all([disable_data_threshold,
+                                          disable_time_based_fallback](
+                                           l0::write_request_scheduler& s) {
+            if (disable_data_threshold) {
+                l0::resource_balancer_accessor::disable_data_threshold_uploads(
+                  &s);
+            }
+            if (disable_time_based_fallback) {
+                l0::resource_balancer_accessor::disable_time_based_fallback(&s);
+            }
+        });
+
+        vlog(test_log.info, "Starting scheduler");
+        co_await scheduler.invoke_on_all(
+          [](l0::write_request_scheduler& sched) { return sched.start(); });
+
+        // Start the sink
+        vlog(test_log.info, "Creating request_sink");
+        co_await request_sink.start(
+          ss::sharded_parameter([this] { return std::ref(pipeline.local()); }));
+        vlog(test_log.info, "Starting request_sink");
+        co_await request_sink.invoke_on_all(
+          [](pipeline_sink& sink) { return sink.start(); });
+    }
+
+    ss::future<> stop() {
+        vlog(test_log.info, "Stopping request_sink");
+        co_await request_sink.stop();
+        vlog(test_log.info, "Stopping scheduler");
+        co_await scheduler.stop();
+        vlog(test_log.info, "Stopping pipeline");
+        co_await pipeline.stop();
+    }
+
+    ss::sharded<l0::write_pipeline<>> pipeline;
+    ss::sharded<l0::write_request_scheduler> scheduler;
+    ss::sharded<pipeline_sink> request_sink;
+};
+
+static const model::topic_namespace
+  test_topic(model::kafka_namespace, model::topic("tapioca"));
+
+static const model::ntp
+  test_ntp0(test_topic.ns, test_topic.tp, model::partition_id(0));
+
+static const model::ntp
+  test_ntp1(test_topic.ns, test_topic.tp, model::partition_id(1));
+
+/// Returns expected number of requests
+static ss::future<size_t> write_until_threshold(
+  write_request_balancer_fixture& fix, size_t size_threshold) {
+    size_t num_requests_sent = 0;
+    size_t total_size = 0;
+    std::vector<ss::future<result<chunked_vector<extent_meta>>>> wd;
+    while (total_size < size_threshold) {
+        auto buf = co_await model::test::make_random_batches();
+        chunked_vector<model::record_batch> batches;
+        for (auto& b : buf) {
+            total_size += b.size_bytes();
+            batches.push_back(std::move(b));
+        }
+
+        num_requests_sent++;
+        wd.push_back(fix.pipeline.local().write_and_debounce(
+          test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s));
+
+        vlog(
+          test_log.info,
+          "Produced {} requests and {} bytes",
+          num_requests_sent,
+          total_size);
+    }
+    auto results = co_await ss::when_all(wd.begin(), wd.end());
+    // no errors expected
+    bool failure = false;
+    for (auto& r : results) {
+        if (r.failed()) {
+            vlog(
+              test_log.error,
+              "Unexpected write failure: {}",
+              r.get_exception());
+            failure = true;
+        }
+    }
+    if (failure) {
+        throw std::runtime_error("Unexpected failure");
+    }
+    co_return num_requests_sent;
+}
+
+TEST_F_CORO(write_request_balancer_fixture, time_based_fallback_test) {
+    // This test produces some batches and expects time based threshold
+    // mechanism to trigger the upload.
+    ASSERT_TRUE_CORO(ss::smp::count > 1);
+
+    co_await start(
+      /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
+
+    auto buf = co_await model::test::make_random_batches();
+    chunked_vector<model::record_batch> batches;
+    for (auto& b : buf) {
+        batches.push_back(std::move(b));
+    }
+
+    auto placeholders = co_await pipeline.local().write_and_debounce(
+      test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+
+    // Check that number of upload requests matches expectation.
+    // The current shard should receive the write request.
+    ASSERT_EQ_CORO(request_sink.local().write_requests_acked, 1);
+
+    co_await stop();
+}
+
+TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
+    // This test generates batches on two different shards and expects
+    // time-based-fallback mechanism to trigger the upload. It expects
+    // that write requests to land on one shard. The shard that receives
+    // requests is expected to be the one that produced the most data.
+    ASSERT_TRUE_CORO(ss::smp::count > 1);
+
+    co_await scheduler.invoke_on_all([](l0::write_request_scheduler& s) {
+        l0::resource_balancer_accessor::disable_data_threshold_uploads(&s);
+    });
+
+    co_await start(
+      /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
+
+    std::atomic<size_t> shard1_data_size = 0;
+    auto fut = ss::smp::submit_to(ss::shard_id(1), [this, &shard1_data_size] {
+        return model::test::make_random_batches().then(
+          [this, &shard1_data_size](auto buf) {
+              for (const model::record_batch& b : buf) {
+                  shard1_data_size += b.size_bytes();
+              }
+              chunked_vector<model::record_batch> batches;
+              std::move(buf.begin(), buf.end(), std::back_inserter(batches));
+              vlog(test_log.info, "Calling write_and_debounce on shard 1");
+              return pipeline.local().write_and_debounce(
+                test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+          });
+    });
+
+    size_t shard0_data_size = 0;
+    auto buf = co_await model::test::make_random_batches();
+    chunked_vector<model::record_batch> batches;
+    for (auto& b : buf) {
+        shard0_data_size += b.size_bytes();
+        batches.push_back(std::move(b));
+    }
+
+    vlog(test_log.info, "Calling write_and_debounce on shard 0");
+    auto s0_placeholders = co_await pipeline.local().write_and_debounce(
+      test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+
+    auto s1_placeholders = co_await std::move(fut);
+
+    // Check that number of upload requests matches expectation.
+    // The shard that has the most data should handle the request.
+    auto expected_shard = shard0_data_size > shard1_data_size ? 0 : 1;
+    auto num_requests = co_await request_sink.invoke_on(
+      expected_shard, [](auto& s) { return s.write_requests_acked; });
+    ASSERT_EQ_CORO(num_requests, 2);
+
+    co_await stop();
+}
+
+TEST_F_CORO(write_request_balancer_fixture, data_threshold_test) {
+    ASSERT_TRUE_CORO(ss::smp::count > 1);
+    auto size_threshold
+      = config::shard_local_cfg()
+          .cloud_topics_produce_batching_size_threshold.value();
+
+    co_await start(
+      /*disable_data_threshold=*/false, /*disable_time_based_fallback=*/true);
+
+    auto num_requests_sent = co_await write_until_threshold(
+      *this, size_threshold);
+
+    // Check that number of upload requests matches expectation.
+    ASSERT_EQ_CORO(
+      request_sink.local().write_requests_acked, num_requests_sent);
+
+    co_await stop();
+}
+
+TEST_F_CORO(write_request_balancer_fixture, test_data_threshold_with_failover) {
+    // On shard zero produce little data on shard 0 and in parallel produce a
+    // lot of data on shard 1. Expect data threshold to be reached on shard 1
+    // and time based threshold to be reached on shard 0.
+
+    ASSERT_TRUE_CORO(ss::smp::count > 1);
+    auto size_threshold
+      = config::shard_local_cfg()
+          .cloud_topics_produce_batching_size_threshold.value();
+
+    co_await start(false, false);
+
+    // Produce on shard 0
+    auto buf = co_await model::test::make_random_batches();
+    chunked_vector<model::record_batch> batches;
+    for (auto& b : buf) {
+        batches.push_back(std::move(b));
+    }
+    auto placeholders = co_await pipeline.local().write_and_debounce(
+      test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
+
+    // Produce on shard 1
+    auto expected_num_requests1 = co_await ss::smp::submit_to(
+      1, [this, size_threshold] {
+          return write_until_threshold(*this, size_threshold);
+      });
+
+    ASSERT_EQ_CORO(request_sink.local().write_requests_acked, 1);
+    auto actual_num_requests1 = co_await request_sink.invoke_on(
+      1, [](auto& s) { return s.write_requests_acked; });
+    ASSERT_EQ_CORO(expected_num_requests1, actual_num_requests1);
+
+    co_await stop();
+}
+
+TEST_F_CORO(
+  write_request_balancer_fixture, test_time_based_fallback_with_failures) {
+    // This test checks different combinations of failures.
+    ASSERT_TRUE_CORO(ss::smp::count > 1);
+    static constexpr size_t batch_size = 0x1000;
+
+    co_await scheduler.invoke_on_all([](l0::write_request_scheduler& s) {
+        l0::write_request_balancer_accessor::disable_data_threshold_uploads(&s);
+    });
+
+    co_await start(
+      /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
+
+    co_await request_sink.invoke_on_all([](pipeline_sink& s) {
+        // Inject failure on test_ntp1
+        s.error_generator = [](l0::write_request<>& r) {
+            if (r.ntp == test_ntp1) {
+                return cloud_topics::errc::upload_failure;
+            }
+            return cloud_topics::errc::success;
+        };
+    });
+
+    auto write_on_shard = [&](ss::shard_id shard, model::ntp ntp, size_t size) {
+        return pipeline.invoke_on(
+          shard, [ntp, size](l0::write_pipeline<>& pipeline) {
+              // Produce small batch on shard 1 so shard 0 will be
+              // uploading the data.
+              chunked_vector<model::record_batch> batches;
+              auto batch = model::test::make_random_batch(
+                model::test::record_batch_spec{
+                  .offset = model::offset(0),
+                  .allow_compression = false,
+                  .count = 1,
+                  .records = 1,
+                  .record_sizes = std::vector<size_t>{size},
+                });
+              batches.push_back(std::move(batch));
+              vlog(test_log.info, "Calling write_and_debounce");
+              // The failure is injected based on ntp
+              return pipeline.write_and_debounce(
+                ntp, std::move(batches), ss::lowres_clock::now() + 10s);
+          });
+    };
+
+    // This case generates batches on two different shards and expects
+    // time-based-fallback mechanism to trigger the upload. The test
+    // case injects failure on shard 1 and expects the fallback mechanism
+    // to propagate them back to the caller. The target shard in this case
+    // is shard 0 (the shard that makes the upload).
+    {
+        // Produce on shard 1
+        auto fut11 = write_on_shard(ss::shard_id(1), test_ntp1, batch_size);
+        auto fut10 = write_on_shard(ss::shard_id(1), test_ntp0, batch_size);
+
+        // Produce on shard 0
+        auto fut00 = write_on_shard(ss::shard_id(0), test_ntp0, batch_size * 4);
+
+        auto ph00 = co_await std::move(fut00);
+        auto ph10 = co_await std::move(fut10);
+        auto ph11 = co_await std::move(fut11);
+
+        // Check that number of upload requests matches expectation.
+        // The shard that has the most data should handle the request.
+        auto num_requests = request_sink.local().write_requests_acked;
+        ASSERT_EQ_CORO(num_requests, 3);
+
+        ASSERT_FALSE_CORO(ph00.has_error());
+        ASSERT_TRUE_CORO(ph11.has_error());
+        ASSERT_TRUE_CORO(ph11.error() == cloud_topics::errc::upload_failure);
+        ASSERT_FALSE_CORO(ph10.has_error());
+    }
+    // This test case is about the same as the previous one with the only
+    // difference that the failure is injected on shard 0 (the uploading shard).
+    {
+        // Produce on shard 1
+        auto fut10 = write_on_shard(ss::shard_id(1), test_ntp0, batch_size);
+
+        // Produce on shard 0
+        auto fut01 = write_on_shard(
+          ss::shard_id(0), test_ntp1, batch_size * 2); // will fail
+        auto fut00 = write_on_shard(ss::shard_id(0), test_ntp0, batch_size * 2);
+
+        auto ph00 = co_await std::move(fut00);
+        auto ph01 = co_await std::move(fut01);
+        auto ph10 = co_await std::move(fut10);
+
+        auto num_requests = request_sink.local().write_requests_acked;
+        ASSERT_EQ_CORO(num_requests, 6);
+
+        ASSERT_FALSE_CORO(ph00.has_error());
+        ASSERT_TRUE_CORO(ph01.has_error());
+        ASSERT_TRUE_CORO(ph01.error() == cloud_topics::errc::upload_failure);
+        ASSERT_FALSE_CORO(ph10.has_error());
+    }
+    // The data is uploaded on shard 1 and the failure is injected on shard 0.
+    {
+        // Produce on shard 0
+        auto fut00 = write_on_shard(ss::shard_id(0), test_ntp0, batch_size);
+        auto fut01 = write_on_shard(
+          ss::shard_id(0), test_ntp1, batch_size); // will fail
+        // Produce on shard 1
+        auto fut10 = write_on_shard(ss::shard_id(1), test_ntp0, batch_size * 4);
+
+        auto ph00 = co_await std::move(fut00);
+        auto ph01 = co_await std::move(fut01);
+        auto ph10 = co_await std::move(fut10);
+
+        auto num_requests0 = request_sink.local().write_requests_acked;
+        // Nothing is uploaded on this shard
+        ASSERT_EQ_CORO(num_requests0, 6);
+        auto num_requests1 = co_await request_sink.invoke_on(
+          ss::shard_id(1), [](auto& s) { return s.write_requests_acked; });
+        ASSERT_EQ_CORO(num_requests1, 3);
+
+        ASSERT_FALSE_CORO(ph00.has_error());
+        ASSERT_TRUE_CORO(ph01.has_error());
+        ASSERT_TRUE_CORO(ph01.error() == cloud_topics::errc::upload_failure);
+        ASSERT_FALSE_CORO(ph10.has_error());
+    }
+
+    co_await stop();
+}

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h"
+
+#include "cloud_topics/level_zero/common/extent_meta.h"
+#include "cloud_topics/level_zero/pipeline/base_pipeline.h"
+#include "cloud_topics/level_zero/pipeline/write_pipeline.h"
+#include "cloud_topics/level_zero/pipeline/write_request.h"
+#include "cloud_topics/logger.h"
+#include "config/configuration.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shard_id.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <limits>
+
+namespace cloud_topics::l0 {
+
+namespace {
+// Copy extents and share the payload to use on another shard
+static inline serialized_chunk shallow_copy(serialized_chunk& chunk) {
+    serialized_chunk copy;
+    copy.extents = chunk.extents.copy();
+    copy.payload = chunk.payload.share(0, chunk.payload.size_bytes());
+    return copy;
+}
+} // namespace
+
+write_request_scheduler::write_request_scheduler(write_pipeline<>::stage s)
+  : _stage(s)
+  , _max_buffer_size(
+      config::shard_local_cfg()
+        .cloud_topics_produce_batching_size_threshold.bind())
+  , _max_cardinality(
+      config::shard_local_cfg()
+        .cloud_topics_produce_cardinality_threshold.bind())
+  , _scheduling_interval(
+      config::shard_local_cfg().cloud_topics_produce_upload_interval.bind()) {}
+
+ss::future<> write_request_scheduler::start() {
+    // Start the background time based fallback loop on shard 0
+    if (
+      ss::this_shard_id() == ss::shard_id(0)
+      && !_test_only_disable_time_based_fallback) {
+        ssx::spawn_with_gate(
+          _gate, [this] { return bg_time_based_fallback(); });
+    }
+    if (!_test_only_disable_data_threshold) {
+        ssx::spawn_with_gate(_gate, [this] { return bg_data_threshold(); });
+    }
+    co_return;
+}
+
+ss::future<> write_request_scheduler::stop() {
+    _as.request_abort();
+    co_await _gate.close();
+}
+
+struct shard_info {
+    ss::shard_id shard;
+    size_t bytes;
+};
+
+size_t write_request_scheduler::shard_bytes() noexcept {
+    // Count bytes but take limits into account.
+    size_t total_bytes = 0;
+    size_t total_requests = 0;
+    _stage.process(
+      [&total_bytes, &total_requests, this](
+        const l0::write_request<>& req) noexcept
+        -> checked<l0::request_processing_result, errc> {
+          total_bytes += req.size_bytes();
+          total_requests++;
+          return total_requests < _max_cardinality()
+                     && total_bytes < _max_buffer_size()
+                   ? request_processing_result::ignore_and_continue
+                   : request_processing_result::ignore_and_stop;
+      });
+    return total_bytes;
+}
+
+ss::future<> write_request_scheduler::bg_data_threshold() {
+    vassert(
+      !_test_only_disable_data_threshold, "Data threshold is not disabled");
+    while (!_as.abort_requested()) {
+        auto req = co_await _stage.wait_until(
+          _max_buffer_size(), ss::lowres_clock::time_point::max(), &_as);
+        if (req.has_error()) {
+            if (req.error() == errc::shutting_down) {
+                vlog(cd_log.debug, "bg_data_threshold: shutting down");
+                co_return;
+            } else {
+                vlog(
+                  cd_log.error,
+                  "bg_data_threshold: error waiting for write requests: {}",
+                  req.error());
+            }
+            co_return;
+        }
+        vlog(
+          cd_log.debug,
+          "bg_data_threshold: pending bytes: {}, total bytes: "
+          "{}",
+          req.value().pending_write_bytes,
+          req.value().total_write_bytes);
+
+        // Propagate to the next stage
+        _stage.process(
+          [](const l0::write_request<>&) noexcept
+            -> checked<l0::request_processing_result, errc> {
+              return l0::request_processing_result::advance_and_continue;
+          });
+    }
+}
+
+ss::future<> write_request_scheduler::apply_time_based_fallback() {
+    // The time based fallback works in three stages:
+    // 1. Collect information about the requests from every shard.
+    // 2. Decide which shard should handle the requests.
+    // 3. Tell every shard to forward its requests to the target shard.
+    // The whole process is triggered on shard 0. The end to end latency
+    // of the process is relatively high (up to 1ms) but it's fine. The
+    // method is invoked periodically (e.g. every 500ms) so the
+    // additional latency is not significant. If we have very high tput
+    // on some shards they will be excluded from the time based fallback
+    // because they will trigger the data threshold based uploads.
+    auto shard_bytes = co_await container().map([](write_request_scheduler& s) {
+        return shard_info{
+          .shard = ss::this_shard_id(), .bytes = s.shard_bytes()};
+    });
+
+    // NOTE: the heuristic is based on cache behavior. The shard that
+    // uploads the data has to read it. If the write request originates
+    // from the same shard it will be hot in the CPU cache. Otherwise
+    // it will be cold. So the main heuristic is to use the shard
+    // that has the most write requests in the pipeline (by size).
+    // In the future more complex partitioning can be used. E.g. we can
+    // select more than one shard as a target and take NUMA mapping into
+    // account. We can also take into account the load and resources
+    // available for upload. For now it's assumed that the client pool
+    // will always be able to handle the addition L0 upload (e.g. it has
+    // borrowing mechanism to do this).
+
+    for (auto& req : shard_bytes) {
+        vlog(
+          cd_log.trace,
+          "map result: {} requests, {} bytes",
+          req.shard,
+          req.bytes);
+    }
+
+    // Find the shard with the most bytes to write
+    auto target_shard = ss::shard_id(0);
+    auto max_shard_bytes = std::numeric_limits<size_t>::min();
+    for (auto& info : shard_bytes) {
+        if (info.bytes > max_shard_bytes) {
+            max_shard_bytes = info.bytes;
+            target_shard = info.shard;
+        }
+    }
+    vlog(
+      cd_log.debug,
+      "bg_time_based_fallback: target shard for write requests: {}, "
+      "bytes: {}",
+      target_shard,
+      max_shard_bytes);
+
+    // We can forward write requests to the target shard now
+    // Every shards forwards its own requests. This shard sends
+    // the requests accumulated in the previous step to the
+    // original shard first. There is a fast path for the
+    // requests that are already on the target shard.
+
+    if (max_shard_bytes > 0) {
+        co_await container().invoke_on_all(
+          [target_shard](write_request_scheduler& scheduler) {
+              if (ss::this_shard_id() == target_shard) {
+                  // Fast path: process requests locally
+                  // This shard is the one that has the most data.
+                  scheduler._stage.process([](write_request<>&) noexcept {
+                      return request_processing_result::advance_and_continue;
+                  });
+              } else {
+                  // Forward requests to target shard by proxying
+                  // write requests
+                  return scheduler.forward_to(target_shard);
+              }
+              return ss::now();
+          });
+    }
+}
+
+ss::future<> write_request_scheduler::bg_time_based_fallback() {
+    // This is the background fiber that runs only on shard 0
+    // It is waking up every N ms and forces uploads on all shards
+    // to be aggregated and uploaded to the cloud storage on a single
+    // "target" shard.
+    //
+    // It handles the case when there is not enough updates on every
+    // shards to trigger the upload within N ms.
+    try {
+        vassert(
+          ss::this_shard_id() == ss::shard_id(0),
+          "bg_time_based_fallback: should only run on shard 0");
+        vassert(
+          !_test_only_disable_time_based_fallback,
+          "time based fallback is not disabled");
+        vlog(
+          cd_log.debug,
+          "Starting write_request_scheduler time based fallback background "
+          "loop");
+        while (!_as.abort_requested() && !_stage.stopped()) {
+            // Sleep before next iteration
+            co_await ss::sleep_abortable(_scheduling_interval(), _as);
+            co_await apply_time_based_fallback();
+        }
+    } catch (...) {
+        if (ssx::is_shutdown_exception(std::current_exception())) {
+            vlog(cd_log.debug, "bg_time_based_fallback: shutting down");
+        } else {
+            vlog(
+              cd_log.error,
+              "bg_time_based_fallback: failed: {}",
+              std::current_exception());
+        }
+    }
+}
+
+/// Get a single write request which was created on another shard
+/// then copy it and enqueue it to the pipeline on this shard.
+/// Then await the response and return it.
+ss::future<std::expected<write_request_scheduler::foreign_ptr_t, errc>>
+write_request_scheduler::proxy_write_request(write_request<>* req) noexcept {
+    auto h = _gate.hold();
+    write_request<> proxy(
+      req->ntp,
+      shallow_copy(req->data_chunk),
+      req->expiration_time,
+      _stage.id());
+    auto fut = proxy.response.get_future();
+    _stage.push_next_stage(proxy);
+    auto extents_fut = co_await ss::coroutine::as_future(std::move(fut));
+    if (extents_fut.failed()) {
+        vlog(
+          cd_log.error,
+          "Proxy write request failed: {}",
+          extents_fut.get_exception());
+        co_return std::unexpected(errc::upload_failure);
+    }
+    auto extents = extents_fut.get();
+    if (extents.has_error()) {
+        // Normal errors (S3 upload failure or timeout)
+        // are handled here
+        errc e = extents.error();
+        vlog(cd_log.error, "Proxy write request failed: {}", e);
+        co_return std::unexpected(e);
+    }
+    auto ptr = ss::make_lw_shared<chunked_vector<extent_meta>>();
+    *ptr = std::move(extents.value());
+    foreign_ptr_t fp(ss::make_foreign(std::move(ptr)));
+    co_return std::move(fp);
+}
+
+void write_request_scheduler::ack_write_response(
+  write_request<>* req,
+  std::expected<write_request_scheduler::foreign_ptr_t, errc> resp) {
+    // The response was created on another shard.
+    // The req was created on this shard.
+    // The response contains only extent_meta struct so cheap
+    // to copy between shards.
+    if (!resp.has_value()) {
+        req->set_value(resp.error());
+    } else {
+        req->set_value(std::move(*resp.value()));
+    }
+}
+
+ss::future<> write_request_scheduler::roundtrip(
+  ss::shard_id shard, write_pipeline<>::write_requests_list list) {
+    auto h = _gate.hold();
+    // Temporary storage for x-shard request and response correlation.
+    using response_t
+      = std::expected<write_request_scheduler::foreign_ptr_t, errc>;
+    struct result_t {
+        std::optional<response_t> response{std::nullopt};
+        write_request<>* request{nullptr};
+    };
+    chunked_vector<result_t> results;
+    for (auto& req : list.requests) {
+        results.push_back(result_t{.request = &req});
+    }
+    co_await container().invoke_on(
+      shard, [&results](write_request_scheduler& balancer) mutable {
+          chunked_vector<ss::future<response_t>> futures;
+          for (auto& r : results) {
+              vassert(
+                r.response.has_value() == false,
+                "Should not have response yet");
+              futures.emplace_back(balancer.proxy_write_request(r.request));
+          }
+          return ss::when_all(futures.begin(), futures.end())
+            .then([&results](auto fut) {
+                for (size_t i = 0; i < results.size(); i++) {
+                    // This propagate the response or the error code.
+                    // 'proxy_write_request' can't throw and the write_request
+                    // can only be acknowledged using error code and not
+                    // exception.
+                    results[i].response = fut[i].get();
+                }
+            });
+      });
+    for (auto& r : results) {
+        vassert(r.response.has_value(), "Should have response after invoke_on");
+        ack_write_response(r.request, std::move(*r.response));
+    }
+}
+
+ss::future<> write_request_scheduler::forward_to(ss::shard_id target_shard) {
+    auto req = _stage.pull_write_requests(
+      _max_buffer_size(), _max_cardinality());
+    co_await roundtrip(target_shard, std::move(req));
+}
+
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "cloud_topics/level_zero/pipeline/write_pipeline.h"
+#include "cloud_topics/level_zero/pipeline/write_request.h"
+#include "config/property.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shard_id.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/weak_ptr.hh>
+
+#include <chrono>
+#include <expected>
+#include <future>
+
+namespace cloud_topics::l0 {
+
+/// The scheduler decides the which shard to use to handle write
+/// requests. It also batches requests.
+///
+/// The write_request_scheduler is a pipeline component that implements the
+/// "parallel batcher" design. It is placed before the batcher in the pipeline
+/// and acts as a peering_sharded_service, redirecting write requests to
+/// batchers for upload. It can move write requests between shards to maximize
+/// the size of the uploaded objects while keeping the latency bounded.
+///
+/// The scheduler uses two policies to decide when to trigger uploads:
+///
+/// - **Data threshold policy** — Forces a shard to upload immediately once its
+/// local data reaches a set threshold. This operates per shard and does not
+/// cross shard boundaries.
+///
+/// - **Time-based fallback policy** — Runs only on shard 0. After N ms, it
+/// forces all shards to send write requests to a single target shard for
+/// upload. The target shard is chosen based on having the most data in the
+/// pipeline to minimize CPU cache invalidation.
+class write_request_scheduler
+  : public ss::peering_sharded_service<write_request_scheduler> {
+    friend struct write_request_balancer_accessor;
+
+public:
+    explicit write_request_scheduler(write_pipeline<>::stage s);
+
+    ss::future<> start();
+
+    ss::future<> stop();
+
+private:
+    /// The fiber that runs on a shard 0 and schedules
+    /// write requests based on timeout. It works
+    /// across all shards at the same time. When it wakes up
+    /// it collects write requests and triggers
+    /// uploads.
+    ss::future<> bg_time_based_fallback();
+    /// This method implements the actual fallback mechanism.
+    /// It is invoked by the 'bg_time_based_fallback' method.
+    ss::future<> apply_time_based_fallback();
+
+    /// This fiber runs on every shard and is triggered by
+    /// the data accumulation threshold. If enough data is accumulated
+    /// on a shard this shard will trigger the upload without going
+    /// cross shard.
+    ss::future<> bg_data_threshold();
+
+    /// Run the load balancing for all available write requests
+    ss::future<checked<bool, errc>> run_once() noexcept;
+
+    /// Simply count number of bytes in the queue
+    size_t shard_bytes() noexcept;
+
+    using foreign_ptr_t
+      = ss::foreign_ptr<ss::lw_shared_ptr<chunked_vector<extent_meta>>>;
+
+    /// Make a copy of the write request and enqueue it
+    ss::future<std::expected<foreign_ptr_t, errc>>
+    proxy_write_request(write_request<>* req) noexcept;
+
+    ss::future<>
+    roundtrip(ss::shard_id shard, write_pipeline<>::write_requests_list list);
+
+    void ack_write_response(
+      write_request<>* req, std::expected<foreign_ptr_t, errc> resp);
+
+    /// Forward all write requests to the target shard
+    ss::future<> forward_to(ss::shard_id shard);
+
+    write_pipeline<>::stage _stage;
+    ss::abort_source _as;
+    ss::gate _gate;
+
+    // This field is used in tests to limit the uploads to time based fallback
+    bool _test_only_disable_data_threshold{false};
+    // This field is used in tests to limit the uploads to data threshold
+    bool _test_only_disable_time_based_fallback{false};
+
+    config::binding<size_t> _max_buffer_size;
+    config::binding<size_t> _max_cardinality;
+    config::binding<std::chrono::milliseconds> _scheduling_interval;
+};
+
+} // namespace cloud_topics::l0

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4453,6 +4453,27 @@ configuration::configuration()
       "Enable cloud topics.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , cloud_topics_produce_batching_size_threshold(
+      *this,
+      "cloud_topics_produce_batching_size_threshold",
+      "The size limit for the object size in cloud topics. When the "
+      "amount of data on a shard reaches this limit, an upload is triggered.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      4_MiB)
+  , cloud_topics_produce_upload_interval(
+      *this,
+      "cloud_topics_produce_upload_interval",
+      "Time interval after which the upload is triggered.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      250ms)
+  , cloud_topics_produce_cardinality_threshold(
+      *this,
+      "cloud_topics_produce_cardinality_threshold",
+      "Threshold for the object cardinality in cloud topics. When the "
+      "number of partitions in waiting for the upload reach this limit, an "
+      "upload is triggered.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1000)
   , development_feature_property_testing_only(
       *this,
       "development_feature_property_testing_only",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -805,6 +805,9 @@ struct configuration final : public config_store {
 
 public:
     development_feature_property<bool> development_enable_cloud_topics;
+    property<size_t> cloud_topics_produce_batching_size_threshold;
+    property<std::chrono::milliseconds> cloud_topics_produce_upload_interval;
+    property<size_t> cloud_topics_produce_cardinality_threshold;
 
     development_feature_property<int> development_feature_property_testing_only;
 

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -32,6 +32,10 @@ bool datalake_enabled() {
     return config::shard_local_cfg().iceberg_enabled.value();
 }
 
+bool cloud_topics_enabled() {
+    return config::shard_local_cfg().development_enable_cloud_topics();
+}
+
 struct memory_shares {
     constexpr static size_t chunk_cache = 15;
     constexpr static size_t kafka = 30;
@@ -40,14 +44,19 @@ struct memory_shares {
     constexpr static size_t tiered_storage = 10;
     constexpr static size_t data_transforms = 10;
     constexpr static size_t datalake = 10;
+    constexpr static size_t cloud_topics = 10;
 
-    static size_t total_shares(bool with_wasm, bool with_datalake) {
+    static size_t
+    total_shares(bool with_wasm, bool with_datalake, bool with_cloud_topics) {
         size_t total = chunk_cache + kafka + rpc + recovery + tiered_storage;
         if (with_wasm) {
             total += data_transforms;
         }
         if (with_datalake) {
             total += datalake;
+        }
+        if (with_cloud_topics) {
+            total += cloud_topics;
         }
         return total;
     }
@@ -71,6 +80,7 @@ system_memory_groups::system_memory_groups(
   compaction_memory_reservation compaction,
   bool wasm_enabled,
   bool datalake_enabled,
+  bool cloud_topics_enabled,
   partitions_memory_reservation partitions)
   : _compaction_reserved_memory(
       compaction.reserved_bytes(total_available_memory))
@@ -80,7 +90,8 @@ system_memory_groups::system_memory_groups(
       total_available_memory - _compaction_reserved_memory
       - _partitions_reserved_memory)
   , _wasm_enabled(wasm_enabled)
-  , _datalake_enabled(datalake_enabled) {}
+  , _datalake_enabled(datalake_enabled)
+  , _cloud_topics_enabled(cloud_topics_enabled) {}
 
 size_t system_memory_groups::chunk_cache_min_memory() const {
     return chunk_cache_max_memory() / 3;
@@ -120,6 +131,13 @@ size_t system_memory_groups::datalake_max_memory() const {
     return subsystem_memory<memory_shares::datalake>();
 }
 
+size_t system_memory_groups::cloud_topics_memory() const {
+    if (!_cloud_topics_enabled) {
+        return 0;
+    }
+    return subsystem_memory<memory_shares::cloud_topics>();
+}
+
 size_t system_memory_groups::partitions_max_memory() const {
     return _partitions_reserved_memory;
 }
@@ -133,7 +151,9 @@ template<size_t shares>
 size_t system_memory_groups::subsystem_memory() const {
     size_t per_share_amount = total_memory()
                               / memory_shares::total_shares(
-                                _wasm_enabled, _datalake_enabled);
+                                _wasm_enabled,
+                                _datalake_enabled,
+                                _cloud_topics_enabled);
     return per_share_amount * shares;
 }
 
@@ -187,6 +207,12 @@ system_memory_groups& memory_groups() {
     }
     partitions_memory_reservation partitions{
       .max_limit_pct = cfg.topic_partitions_memory_allocation_percent()};
-    groups.emplace(total, compaction, wasm, datalake_enabled(), partitions);
+    groups.emplace(
+      total,
+      compaction,
+      wasm,
+      datalake_enabled(),
+      cloud_topics_enabled(),
+      partitions);
     return *groups;
 }

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -57,6 +57,7 @@ public:
       compaction_memory_reservation compaction,
       bool wasm_enabled,
       bool datalake_enabled,
+      bool cloud_topics_enabled,
       partitions_memory_reservation partitions);
 
     size_t kafka_total_memory() const;
@@ -92,6 +93,8 @@ public:
 
     size_t datalake_max_memory() const;
 
+    size_t cloud_topics_memory() const;
+
     // Absolute memory in bytes reserved for partitions
     size_t partitions_max_memory() const;
 
@@ -118,6 +121,7 @@ private:
     size_t _total_system_memory;
     bool _wasm_enabled;
     bool _datalake_enabled;
+    bool _cloud_topics_enabled;
 
     friend class testing::system_memory_groups_accessor;
 };

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -19,6 +19,7 @@
 static constexpr size_t total_shares_without_optionals = 85;
 static constexpr size_t total_wasm_shares = 10;
 static constexpr size_t total_datalake_shares = 10;
+static constexpr size_t total_cloud_topic_shares = 10;
 
 // It's not really useful to know the exact byte values for each of these
 // numbers so we just make sure we're within a MB
@@ -32,7 +33,7 @@ MATCHER_P(IsApprox, n, "") {
 
 class MemoryGroupSharesTest
   : public ::testing::Test
-  , public ::testing::WithParamInterface<std::tuple<bool, bool, bool>> {
+  , public ::testing::WithParamInterface<std::tuple<bool, bool, bool, bool>> {
 public:
     static constexpr size_t total_memory = 2_GiB;
     static constexpr size_t user_wasm_reservation = 20_MiB;
@@ -41,6 +42,7 @@ public:
     bool compaction_enabled() const { return std::get<0>(GetParam()); }
     bool wasm_enabled() const { return std::get<1>(GetParam()); }
     bool datalake_enabled() const { return std::get<2>(GetParam()); }
+    bool cloud_topics_enabled() const { return std::get<3>(GetParam()); }
 };
 
 TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
@@ -64,6 +66,7 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
       reservation,
       wasm_enabled(),
       datalake_enabled(),
+      cloud_topics_enabled(),
       partitions);
     auto total_shares = total_shares_without_optionals;
     if (wasm_enabled()) {
@@ -71,6 +74,9 @@ TEST_P(MemoryGroupSharesTest, DividesSharesCorrectly) {
     }
     if (datalake_enabled()) {
         total_shares += total_datalake_shares;
+    }
+    if (cloud_topics_enabled()) {
+        total_shares += total_cloud_topic_shares;
     }
     EXPECT_THAT(
       groups.chunk_cache_min_memory(),
@@ -134,6 +140,7 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
           },
           /*wasm_enabled=*/false,
           /*datalake_enabled=*/false,
+          /*cloud_topics_enabled=*/false,
           {
             .max_limit_pct = 20,
           });
@@ -150,6 +157,7 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
           },
           /*wasm_enabled=*/false,
           /*datalake_enabled=*/false,
+          /*cloud_topics_enabled=*/false,
           {
             .max_limit_pct = 20,
           });
@@ -161,4 +169,8 @@ TEST(MemoryGroups, CompactionMemoryBytes) {
 INSTANTIATE_TEST_SUITE_P(
   MemoryGroupShares,
   MemoryGroupSharesTest,
-  ::testing::Combine(::testing::Bool(), ::testing::Bool(), ::testing::Bool()));
+  ::testing::Combine(
+    ::testing::Bool(),
+    ::testing::Bool(),
+    ::testing::Bool(),
+    ::testing::Bool()));


### PR DESCRIPTION
Introduce write_request_scheduler for cross-shard write scheduling

The write_request_scheduler is a new pipeline component implementing the "parallel batcher" design. It is placed before the batcher in the pipeline and acts as a peering_sharded_service, redirecting write requests to batchers for upload.

Currently, the batcher handles uploads, aggregation, and scheduling. It decides when enough data has accumulated (N ms or M bytes) to trigger an upload. This design forces the batcher to manage multiple concerns at once. With upcoming cross-shard operations, this complexity would grow further.

In the new setup, the batcher no longer schedules writes. Instead, it simply aggregates all write requests it receives and uploads them to cloud storage. Scheduling is now handled by the write_request_scheduler across shards, using two asynchronous background fibers that implement two policies:

- **Data threshold policy** — Forces a shard to upload immediately once its local data reaches a set threshold. This operates per shard and does not cross shard boundaries.

- **Time-based fallback policy** — Runs only on shard 0. After N ms, it forces all shards to send write requests to a single target shard for upload. The target shard is chosen based on having the most data in the pipeline to minimize cross-shard data copying and improve CPU cache usage.

This separation of scheduling from batching reduces complexity, supports cross-shard coordination, and optimizes resource usage.

The batcher will be updated in the next commits. It has to be simplified. The scheduling aspect should be removed out of it.
Also, some additional notification mechanism should be implemented to avoid a situation when batcher uploads L0 object without waiting for all data sent by the scheduler. This is a simple change local to the even subscription mechanism of the pipeline.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none