### PR TITLE
ct/l1: add terms to metastore::add_objects

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -76,7 +76,10 @@ domain_manager::add_objects(rpc::add_objects_request req) {
     }
     chunked_hash_map<model::topic_id_partition, kafka::offset> corrections;
     auto update_res = add_objects_update::build(
-      stm_state, std::move(req.new_objects), &corrections);
+      stm_state,
+      std::move(req.new_objects),
+      std::move(req.new_terms),
+      &corrections);
     if (!update_res.has_value()) {
         vlog(
           cd_log.debug,

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -111,6 +111,22 @@ public:
     };
     virtual std::unique_ptr<object_metadata_builder> object_builder() = 0;
 
+    struct term_offset {
+        model::term_id term;
+
+        // The first offset that the given term was seen in a given offset
+        // range. Note, this doesn't necessarily indicate the start offset for
+        // the term in the entire log, just within a specific range (e.g. the
+        // range covered by a newly added object)
+        kafka::offset first_offset;
+    };
+    // Mapping per partition of the first offset seen for each term for a given
+    // set of extents. Both the terms and the offsets must be strictly
+    // monotonically increasing.
+    using term_offset_map_t = chunked_hash_map<
+      model::topic_id_partition,
+      chunked_vector<term_offset>>;
+
     // Returns offsets (e.g. start, next) for the given partition.
     virtual ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) = 0;
@@ -131,8 +147,9 @@ public:
     // it does not imply that all extents were accepted by the metastore. The
     // response should be examined to determine if subsequent add_objects()
     // requests need to be re-aligned to a different offset.
-    virtual ss::future<std::expected<add_response, errc>>
-      add_objects(std::unique_ptr<object_metadata_builder>) = 0;
+    virtual ss::future<std::expected<add_response, errc>> add_objects(
+      std::unique_ptr<object_metadata_builder>, const term_offset_map_t&)
+      = 0;
 
     // Adds the given objects to the metastore, expecting that the new extents
     // replace an extent or set of extents covering the same range.

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -232,7 +232,8 @@ replicated_metastore::get_offsets(const model::topic_id_partition& tidp) {
 
 ss::future<std::expected<metastore::add_response, metastore::errc>>
 replicated_metastore::add_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder) {
+  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const metastore::term_offset_map_t& terms) {
     auto replicated_builder = std::unique_ptr<replicated_object_builder>(
       static_cast<replicated_object_builder*>(builder.release()));
 
@@ -244,10 +245,34 @@ replicated_metastore::add_objects(
           objects_result.error());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
+    chunked_hash_map<model::partition_id, term_state_update_t>
+      partitioned_terms;
+    for (const auto& [tp, tp_terms] : terms) {
+        auto metastore_partition = fe_.metastore_partition(tp);
+        if (!metastore_partition) {
+            vlog(cd_log.error, "Unable to get metastore partition for {}", tp);
+            co_return std::unexpected(errc::transport_error);
+        }
+        auto& prt_terms = partitioned_terms[*metastore_partition][tp];
+        for (const auto& t : tp_terms) {
+            prt_terms.emplace_back(
+              term_start{.term_id = t.term, .start_offset = t.first_offset});
+        }
+    }
     add_response resp;
     for (auto& [partition_id, partition_objects] : objects_result.value()) {
+        auto terms_it = partitioned_terms.find(partition_id);
+        if (terms_it == partitioned_terms.end()) {
+            // TODO: consider making this less strict, down to the STM layer?
+            vlog(
+              cd_log.error,
+              "No term metadata routed to partition {}",
+              partition_id);
+            co_return std::unexpected(errc::invalid_request);
+        }
         rpc::add_objects_request req;
         req.metastore_partition = partition_id;
+        req.new_terms = std::move(terms_it->second);
         chunked_vector<new_object> new_objects;
         for (auto& obj : partition_objects) {
             new_objects.emplace_back(meta_to_rpc_obj(obj));

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -262,10 +262,7 @@ replicated_metastore::add_objects(
         }
         auto reply = reply_fut.get();
         if (reply.ec != rpc::errc::ok) {
-            vlog(
-              cd_log.debug,
-              "Error code received for request {}",
-              int(reply.ec));
+            vlog(cd_log.debug, "Error code received for request {}", reply.ec);
             co_return std::unexpected(rpc_to_meta_errc(reply.ec));
         }
         for (const auto& [tp, o] : reply.corrected_next_offsets) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -27,8 +27,9 @@ public:
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;
 
-    ss::future<std::expected<add_response, errc>>
-      add_objects(std::unique_ptr<object_metadata_builder>) override;
+    ss::future<std::expected<add_response, errc>> add_objects(
+      std::unique_ptr<object_metadata_builder>,
+      const term_offset_map_t&) override;
 
     ss::future<std::expected<void, errc>>
       replace_objects(std::unique_ptr<object_metadata_builder>) override;

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -49,10 +49,13 @@ struct add_objects_request
       serde::version<0>,
       serde::compat_version<0>> {
     using resp_t = add_objects_reply;
-    auto serde_fields() { return std::tie(metastore_partition, new_objects); }
+    auto serde_fields() {
+        return std::tie(metastore_partition, new_objects, new_terms);
+    }
 
     model::partition_id metastore_partition;
     chunked_vector<new_object> new_objects;
+    term_state_update_t new_terms;
 };
 
 struct replace_objects_reply

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -17,6 +17,8 @@
 #include "serde/rw/enum.h"
 #include "serde/rw/envelope.h"
 
+#include <fmt/format.h>
+
 namespace experimental::cloud_topics::l1::rpc {
 
 enum class errc : int16_t {
@@ -183,3 +185,30 @@ struct get_compaction_offsets_request
 };
 
 } //  namespace experimental::cloud_topics::l1::rpc
+
+template<>
+struct fmt::formatter<experimental::cloud_topics::l1::rpc::errc> final
+  : fmt::formatter<std::string_view> {
+    using errc = experimental::cloud_topics::l1::rpc::errc;
+    template<typename FormatContext>
+    auto format(const errc& ec, FormatContext& ctx) const {
+        switch (ec) {
+        case errc::ok:
+            return fmt::format_to(ctx.out(), "rpc::errc::ok");
+        case errc::incorrect_partition:
+            return fmt::format_to(ctx.out(), "rpc::errc::incorrect_partition");
+        case errc::timed_out:
+            return fmt::format_to(ctx.out(), "rpc::errc::timed_out");
+        case errc::not_leader:
+            return fmt::format_to(ctx.out(), "rpc::errc::not_leader");
+        case errc::concurrent_requests:
+            return fmt::format_to(ctx.out(), "rpc::errc::concurrent_requests");
+        case errc::missing_ntp:
+            return fmt::format_to(ctx.out(), "rpc::errc::missing_ntp");
+        case errc::out_of_range:
+            return fmt::format_to(ctx.out(), "rpc::errc::out_of_range");
+        }
+        return fmt::format_to(
+          ctx.out(), "rpc::errc::unknown({})", static_cast<int>(ec));
+    }
+};

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -133,9 +133,13 @@ simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
     for (const auto& o : objects) {
         new_objects.emplace_back(make_new_object(o));
     }
+    auto terms_update = term_state_update_t{};
     add_response resp;
     auto update_res = add_objects_update::build(
-      state_, std::move(new_objects), &resp.corrected_next_offsets);
+      state_,
+      std::move(new_objects),
+      std::move(terms_update),
+      &resp.corrected_next_offsets);
     if (!update_res.has_value()) {
         vlog(cd_log.debug, "Object add failed: {}", update_res.error());
         co_return std::unexpected(metastore::errc::invalid_request);

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -18,6 +18,21 @@
 
 namespace experimental::cloud_topics::l1 {
 
+namespace {
+term_state_update_t make_terms_update(const metastore::term_offset_map_t& m) {
+    term_state_update_t ret;
+    for (const auto& [tp, tp_terms] : m) {
+        chunked_vector<term_start> term_updates;
+        for (const auto& ts : tp_terms) {
+            term_updates.emplace_back(
+              term_start{.term_id = ts.term, .start_offset = ts.first_offset});
+        }
+        ret[tp] = std::move(term_updates);
+    }
+    return ret;
+}
+} // namespace
+
 object_id simple_object_builder::get_or_create_object_for(
   const model::topic_id_partition&) {
     // The simple metastore isn't partitioned at all, so have all partitions
@@ -117,23 +132,26 @@ simple_metastore::get_offsets(
 
 ss::future<std::expected<metastore::add_response, metastore::errc>>
 simple_metastore::add_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder) {
+  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const term_offset_map_t& terms) {
     auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
     auto objects_res = simple_builder->release();
     if (!objects_res.has_value()) {
         vlog(cd_log.error, "Failed to add: {}", objects_res.error());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
-    co_return co_await add_objects(objects_res.value());
+    co_return co_await add_objects(objects_res.value(), terms);
 }
 
 ss::future<std::expected<metastore::add_response, metastore::errc>>
-simple_metastore::add_objects(const chunked_vector<object_metadata>& objects) {
+simple_metastore::add_objects(
+  const chunked_vector<object_metadata>& objects,
+  const term_offset_map_t& terms) {
     chunked_vector<new_object> new_objects;
     for (const auto& o : objects) {
         new_objects.emplace_back(make_new_object(o));
     }
-    auto terms_update = term_state_update_t{};
+    auto terms_update = make_terms_update(terms);
     add_response resp;
     auto update_res = add_objects_update::build(
       state_,

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -53,10 +53,11 @@ public:
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;
 
-    ss::future<std::expected<add_response, errc>>
-      add_objects(std::unique_ptr<object_metadata_builder>) override;
-    ss::future<std::expected<add_response, errc>>
-    add_objects(const chunked_vector<object_metadata>&);
+    ss::future<std::expected<add_response, errc>> add_objects(
+      std::unique_ptr<object_metadata_builder>,
+      const term_offset_map_t&) override;
+    ss::future<std::expected<add_response, errc>> add_objects(
+      const chunked_vector<object_metadata>&, const term_offset_map_t&);
 
     ss::future<std::expected<void, errc>>
       replace_objects(std::unique_ptr<object_metadata_builder>) override;

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -51,6 +51,17 @@ struct extent
     object_id oid;
 };
 
+// Offset that corresponds to the start of a given term.
+struct term_start
+  : public serde::
+      envelope<term_start, serde::version<0>, serde::compat_version<0>> {
+    friend bool operator==(const term_start&, const term_start&) = default;
+    auto serde_fields() { return std::tie(term_id, start_offset); }
+
+    model::term_id term_id;
+    kafka::offset start_offset;
+};
+
 struct compaction_state
   : public serde::
       envelope<compaction_state, serde::version<0>, serde::compat_version<0>> {
@@ -189,6 +200,16 @@ struct partition_state
     // Empty iff compaction has not been run for this partition.
     // TODO: should we remove this if cleanup policy is switched?
     std::optional<compaction_state> compaction_state;
+
+    // A mapping of terms (used instead of Kafka epochs) to the starting Kafka
+    // offset for that term. Both the term and offsets are maintained to be
+    // monotonically strictly increasing.
+    //
+    // TODO: when we implement set_start_offset(), we should retain enough
+    // information to return a value for the start_offset, even when the log
+    // has been prefix truncated to be empty. I.e. this list should never be
+    // empty once there has been data in the log.
+    chunked_vector<term_start> term_starts;
 };
 
 // Tracks the state managed for each partition of a Kafka topic.

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -60,9 +60,11 @@ void new_object::collect_extents_by_tidp(sorted_extents_by_tidp_t* ret) const {
 std::expected<add_objects_update, stm_update_error> add_objects_update::build(
   const state& state,
   chunked_vector<new_object> objects,
+  term_state_update_t terms,
   chunked_hash_map<model::topic_id_partition, kafka::offset>* corrections) {
     add_objects_update update{
       .new_objects = std::move(objects),
+      .new_terms = std::move(terms),
     };
     auto allowed = update.can_apply(state, corrections);
     if (!allowed.has_value()) {

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -79,6 +79,10 @@ std::expected<std::monostate, stm_update_error> add_objects_update::can_apply(
     if (new_objects.empty()) {
         return std::unexpected(stm_update_error{"No objects requested"});
     }
+    if (new_terms.empty()) {
+        return std::unexpected(
+          stm_update_error{"Missing term info in request"});
+    }
     new_object::sorted_extents_by_tidp_t new_extents;
     for (const auto& o : new_objects) {
         if (state.objects.contains(o.oid)) {
@@ -115,6 +119,97 @@ std::expected<std::monostate, stm_update_error> add_objects_update::can_apply(
                     extent.base_offset())));
             }
             expected_next = kafka::next_offset(extent.last_offset);
+        }
+        if (!new_terms.contains(tidp)) {
+            return std::unexpected(
+              stm_update_error{fmt::format("Missing term info for {}", tidp)});
+        }
+    }
+    // Now that we've validated the offsets of our extents, validate the terms
+    // for the accepted extents.
+    for (const auto& [tp, req_entries] : new_terms) {
+        if (req_entries.empty()) {
+            return std::unexpected(
+              stm_update_error{
+                fmt::format("Empty terms requested for {}", tp)});
+        }
+        if (corrected_next_offsets.contains(tp)) {
+            continue;
+        }
+        auto extents_it = new_extents.find(tp);
+        if (extents_it == new_extents.end() || extents_it->second.empty()) {
+            return std::unexpected(
+              stm_update_error{fmt::format(
+                "Terms provided for a partition that has no extents", tp)});
+        }
+        auto new_extents_start_offset
+          = extents_it->second.begin()->base_offset();
+        auto new_terms_start_offset = req_entries.begin()->start_offset;
+        if (new_extents_start_offset != new_terms_start_offset) {
+            return std::unexpected(
+              stm_update_error{fmt::format(
+                "Extent start and term start do not match for {}: {} != {}",
+                tp,
+                new_extents_start_offset,
+                new_terms_start_offset)});
+        }
+        auto new_extents_last_offset = extents_it->second.rbegin()->last_offset;
+        auto new_terms_last_start_offset = req_entries.back().start_offset;
+        if (new_extents_last_offset < new_terms_last_start_offset) {
+            return std::unexpected(
+              stm_update_error{fmt::format(
+                "Extents end below a requested new term for {}: {} < {}",
+                tp,
+                new_extents_last_offset,
+                new_terms_last_start_offset)});
+        }
+        auto p_state = state.partition_state(tp);
+        // First do a basic check that the incoming term entries can be
+        // appended to our state without violating ordering requirements.
+        if (p_state.has_value() && !p_state->get().term_starts.empty()) {
+            auto p_last_entry = p_state->get().term_starts.back();
+            auto req_first_entry = req_entries.begin();
+
+            // NOTE: it's valid for the first requested term to be equal to the
+            // last term (e.g. if leadership has not changed). The same cannot
+            // be said about offsets, hence the difference in comparator.
+            if (req_first_entry->term_id < p_last_entry.term_id) {
+                return std::unexpected(
+                  stm_update_error{fmt::format(
+                    "New term for {} must be >= last term: {} < {}",
+                    tp,
+                    req_first_entry->term_id,
+                    p_last_entry.term_id)});
+            }
+            if (req_first_entry->start_offset <= p_last_entry.start_offset) {
+                return std::unexpected(
+                  stm_update_error{fmt::format(
+                    "New term for {} must start after last term: {} <= {}",
+                    tp,
+                    req_first_entry->start_offset,
+                    p_last_entry.start_offset)});
+            }
+        }
+        // Now check that the the term entries themselves (both terms and
+        // offsets) are in increasing order.
+        auto max_term_so_far = model::term_id{-1};
+        auto max_offset_so_far = kafka::offset{-1};
+        for (const auto& entry : req_entries) {
+            if (
+              entry.term_id <= max_term_so_far
+              || entry.start_offset <= max_offset_so_far) {
+                return std::unexpected(
+                  stm_update_error{fmt::format(
+                    "Invalid term for {}: term={}, offset={}, "
+                    "max_term_so_far={}, max_offset_so_far={}",
+                    tp,
+                    entry.term_id,
+                    entry.start_offset,
+                    max_term_so_far,
+                    max_offset_so_far)});
+            }
+            max_term_so_far = entry.term_id;
+            max_offset_so_far = entry.start_offset;
         }
     }
     if (corrections) {
@@ -157,6 +252,30 @@ add_objects_update::apply(state& state) {
             for (const auto& extent : extents) {
                 state.objects[extent.oid].total_data_size += extent.len;
             }
+
+            // Also append the terms.
+            auto req_terms_it = new_terms.find(tidp);
+            if (req_terms_it == new_terms.end()) {
+                // Conservative error -- this should have been validated in
+                // can_apply().
+                return std::unexpected(
+                  stm_update_error{fmt::format(
+                    "Expected term updates for applied extents: {}", tidp)});
+            }
+            const auto& req_terms = req_terms_it->second;
+            auto new_term_it = req_terms.begin();
+            if (
+              !p_state.term_starts.empty()
+              && req_terms.begin()->term_id
+                   <= p_state.term_starts.back().term_id) {
+                // If the first added term matches the back of the latest
+                // tracked term, it isn't a new term.
+                ++new_term_it;
+            }
+            std::copy(
+              new_term_it,
+              req_terms.end(),
+              std::back_inserter(p_state.term_starts));
         } else {
             // The incoming extents don't align with the next position. "Drop"
             // them all.

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -62,6 +62,9 @@ struct new_object
     void collect_extents_by_tidp(sorted_extents_by_tidp_t*) const;
 };
 
+using term_state_update_t
+  = chunked_hash_map<model::topic_id_partition, chunked_vector<term_start>>;
+
 struct add_objects_update
   : public serde::envelope<
       add_objects_update,
@@ -69,12 +72,13 @@ struct add_objects_update
       serde::compat_version<0>> {
     friend bool operator==(const add_objects_update&, const add_objects_update&)
       = default;
-    auto serde_fields() { return std::tie(new_objects); }
+    auto serde_fields() { return std::tie(new_objects, new_terms); }
 
     static constexpr auto key{update_key::add_objects};
     static std::expected<add_objects_update, stm_update_error> build(
       const state&,
       chunked_vector<new_object>,
+      term_state_update_t,
       chunked_hash_map<model::topic_id_partition, kafka::offset>* = nullptr);
 
     std::expected<std::monostate, stm_update_error> can_apply(
@@ -83,6 +87,7 @@ struct add_objects_update
     std::expected<std::monostate, stm_update_error> apply(state&);
 
     chunked_vector<new_object> new_objects;
+    term_state_update_t new_terms;
 };
 
 struct compaction_state_update

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -373,3 +373,26 @@ TEST_F(ReplicatedMetastoreTest, TestNotLeader) {
         expected_next = kafka::next_offset(e.last_offset);
     }
 }
+
+TEST_F(ReplicatedMetastoreTest, TestInvalidTermRequest) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+
+    std::unique_ptr<metastore::object_metadata_builder> objs;
+    ASSERT_NO_FATAL_FAILURE(create_initial_objects(meta, 100, o{99}, &objs));
+    metastore::term_offset_map_t terms;
+    for (int i = 0; i < 100; ++i) {
+        if (i == 0) {
+            // Omit the term of one partition.
+            continue;
+        }
+        terms[make_tp(i)].emplace_back(
+          metastore::term_offset{
+            .term = model::term_id{0}, .first_offset = o{0}});
+    }
+    // This constitutes an incorrectly formed request, and is not expected
+    // ever, hence overall failure.
+    auto add_res = meta.add_objects(std::move(objs), terms).get();
+    ASSERT_FALSE(add_res.has_value());
+    ASSERT_EQ(add_res.error(), metastore::errc::invalid_request);
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -75,7 +75,13 @@ public:
         std::unique_ptr<metastore::object_metadata_builder> objs;
         ASSERT_NO_FATAL_FAILURE_CORO(
           create_initial_objects(meta, partitions_count, last_offset, &objs));
-        auto add_res = meta.add_objects(std::move(objs)).get();
+        metastore::term_offset_map_t terms;
+        for (int i = 0; i < partitions_count; ++i) {
+            terms[make_tp(i)].emplace_back(
+              metastore::term_offset{
+                .term = model::term_id{0}, .first_offset = o{0}});
+        }
+        auto add_res = meta.add_objects(std::move(objs), terms).get();
         ASSERT_TRUE_CORO(add_res.has_value());
     }
 };
@@ -97,7 +103,7 @@ TEST_F(ReplicatedMetastoreTest, TestAddNotFinished) {
         .size = 500,
       });
     ASSERT_TRUE(add_res.has_value()) << add_res.error();
-    auto commit_res = meta.add_objects(std::move(obj_builder)).get();
+    auto commit_res = meta.add_objects(std::move(obj_builder), {}).get();
     ASSERT_FALSE(commit_res.has_value());
     ASSERT_EQ(commit_res.error(), metastore::errc::invalid_request);
 }
@@ -317,9 +323,17 @@ TEST_F(ReplicatedMetastoreTest, TestNotLeader) {
         auto fin_res = obj_builder->finish(oid, 500);
         ASSERT_TRUE(fin_res.has_value()) << fin_res.error();
 
-        auto commit_res = meta.add_objects(std::move(obj_builder)).get();
+        metastore::term_offset_map_t terms;
+        terms[tp].emplace_back(
+          metastore::term_offset{
+            .term = model::term_id{0}, .first_offset = next_to_send});
+        auto commit_res = meta.add_objects(std::move(obj_builder), terms).get();
         if (!commit_res.has_value()) {
             while (true) {
+                if (ss::lowres_clock::now() > deadline) {
+                    timed_out = true;
+                    break;
+                }
                 // If there's an error, reset our expected next offset with
                 // whatever is actually in L1.
                 auto get_res = meta.get_offsets(tp).get();

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -35,9 +35,30 @@ model::timestamp operator""_t(unsigned long long t) {
     return model::timestamp{static_cast<int64_t>(t)};
 }
 
+model::term_id operator""_tm(unsigned long long t) {
+    return model::term_id{static_cast<int64_t>(t)};
+}
+
 MATCHER_P2(MatchesRange, base, last, "") {
     return arg.base_offset == base && arg.last_offset == last;
 }
+
+using term_list_t = chunked_vector<metastore::term_offset>;
+using term_map_t = metastore::term_offset_map_t;
+class terms_builder {
+public:
+    terms_builder&
+    add(std::string_view tp_str, model::term_id t, kafka::offset o) {
+        auto tp = model::topic_id_partition::from(tp_str);
+        out[tp].emplace_back(
+          metastore::term_offset{.term = t, .first_offset = o});
+        return *this;
+    }
+    term_map_t build() { return std::move(out); }
+
+private:
+    term_map_t out;
+};
 
 using om_list_t = chunked_vector<metastore::object_metadata>;
 using cmap_t = metastore::compaction_map_t;
@@ -123,7 +144,11 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .add(tid_b, 0_o, 10_o, 2000_t, 100, 199)
                    .build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res
+      = m.add_objects(
+           om_list_t::single(std::move(ometa)),
+           terms_builder().add(tid_a, 0_tm, 0_o).add(tid_b, 0_tm, 0_o).build())
+          .get();
     ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -157,7 +182,10 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
     {
         auto ometa
           = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-        auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+        auto add_res = m.add_objects(
+                          om_list_t::single(std::move(ometa)),
+                          terms_builder().add(tid_a, 0_tm, 0_o).build())
+                         .get();
         ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
         ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -172,7 +200,10 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
         // Add another object just past where we expect it.
         auto ometa
           = om_builder(oid2, 100).add(tid_a, 12_o, 20_o, 2000_t, 0, 99).build();
-        auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+        auto add_res = m.add_objects(
+                          om_list_t::single(std::move(ometa)),
+                          terms_builder().add(tid_a, 0_tm, 12_o).build())
+                         .get();
         ASSERT_TRUE(add_res.has_value());
         ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
 
@@ -187,7 +218,10 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
     // Now add the object right at the end, where it should be.
     auto ometa
       = om_builder(oid3, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 11_o).build())
+                     .get();
     ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -205,7 +239,8 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
           = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(
                           chunked_vector<metastore::object_metadata>::single(
-                            std::move(ometa)))
+                            std::move(ometa)),
+                          terms_builder().add(tid_a, 0_tm, 0_o).build())
                          .get();
         ASSERT_TRUE(add_res.has_value()) << int(add_res.error());
         ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
@@ -217,7 +252,8 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
           = om_builder(oid2, 100).add(tid_a, 10_o, 20_o, 2000_t, 0, 99).build();
         auto add_res = m.add_objects(
                           chunked_vector<metastore::object_metadata>::single(
-                            std::move(ometa)))
+                            std::move(ometa)),
+                          terms_builder().add(tid_a, 0_tm, 10_o).build())
                          .get();
         ASSERT_TRUE(add_res.has_value());
         ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
@@ -226,7 +262,10 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
         // Add another object that fully overlaps with what exists.
         auto ometa
           = om_builder(oid3, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-        auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+        auto add_res = m.add_objects(
+                          om_list_t::single(std::move(ometa)),
+                          terms_builder().add(tid_a, 0_tm, 0_o).build())
+                         .get();
         ASSERT_TRUE(add_res.has_value());
         ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
     }
@@ -237,7 +276,10 @@ TEST(SimpleMetastoreTest, TestAddPastBeginning) {
     // Add the first object so it doesn't start at 0.
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 1_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_EQ(1, add_res.value().corrected_next_offsets.size());
 }
@@ -251,7 +293,8 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
       om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -280,7 +323,10 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -296,7 +342,10 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetOutOfRange) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -316,7 +365,8 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
       om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2999_t, 0, 99).build());
     os.emplace_back(
       om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 3999_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -345,7 +395,10 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBelowStart) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -359,7 +412,10 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampOutOfRange) {
     simple_metastore m;
     auto ometa
       = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
-    auto add_res = m.add_objects(om_list_t::single(std::move(ometa))).get();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder().add(tid_a, 0_tm, 0_o).build())
+                     .get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -374,7 +430,8 @@ TEST(StateUpdateTest, TestReplaceBasic) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -403,7 +460,11 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(
+           os,
+           terms_builder().add(tid_a, 0_tm, 0_o).add(tid_b, 0_tm, 0_o).build())
+          .get();
     ASSERT_TRUE(add_res.has_value());
 
     om_list_t new_os;
@@ -455,7 +516,11 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(
+           os,
+           terms_builder().add(tid_a, 0_tm, 0_o).add(tid_b, 0_tm, 0_o).build())
+          .get();
     ASSERT_TRUE(add_res.has_value());
     ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
 
@@ -506,7 +571,8 @@ TEST(StateUpdateTest, TestReplaceEmptyRequest) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Add a replacement object that has no objects.
@@ -541,7 +607,8 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
 
     for (const auto& [base_o, last_o] :
@@ -562,7 +629,8 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
 
     {
@@ -601,7 +669,11 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(
+           os,
+           terms_builder().add(tid_a, 0_tm, 0_o).add(tid_b, 0_tm, 0_o).build())
+          .get();
     ASSERT_TRUE(add_res.has_value());
 
     {
@@ -630,7 +702,8 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsMissingPartition) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_b, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_b, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Look for a different partition.
@@ -648,7 +721,11 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsAllDirty) {
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(
+           os,
+           terms_builder().add(tid_a, 0_tm, 0_o).add(tid_b, 0_tm, 0_o).build())
+          .get();
     ASSERT_TRUE(add_res.has_value());
 
     // Without having anything compacted, the whole log is dirty.
@@ -666,7 +743,8 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Simple compaction to clean offsets [3, 5].
@@ -761,7 +839,8 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     om_list_t os;
     os.emplace_back(
       om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    auto add_res = m.add_objects(os).get();
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
 
     // Simple compaction to clean offsets [3, 5].
@@ -922,7 +1001,10 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_TRUE(add_res.has_value());
         auto fin_res = ob->finish(o_a, 0);
         ASSERT_TRUE(fin_res.has_value());
-        auto add_obj_res = m.add_objects(std::move(ob)).get();
+        auto add_obj_res = m.add_objects(
+                              std::move(ob),
+                              terms_builder().add(tid_a, 0_tm, 0_o).build())
+                             .get();
         ASSERT_TRUE(add_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();
@@ -946,7 +1028,10 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_TRUE(add_res.has_value());
         auto fin_res = ob->finish(o_a, 0);
         ASSERT_TRUE(fin_res.has_value());
-        auto add_obj_res = m.add_objects(std::move(ob)).get();
+        auto add_obj_res = m.add_objects(
+                              std::move(ob),
+                              terms_builder().add(tid_a, 0_tm, 10_o).build())
+                             .get();
         ASSERT_TRUE(add_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1096,3 +1096,16 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         EXPECT_THAT(dirty, testing::ElementsAre(MatchesRange(0_o, 9_o)));
     }
 }
+
+TEST(SimpleMetastoreState, TestInvalidTermRequest) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    // Make the term misaligned with the extent.
+    auto add_res = m.add_objects(
+                      os, terms_builder().add(tid_a, 0_tm, 1337_o).build())
+                     .get();
+    ASSERT_FALSE(add_res.has_value());
+    ASSERT_EQ(add_res.error(), metastore::errc::invalid_request);
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -114,7 +114,7 @@ private:
 
 TEST(StateUpdateTest, TestEmptyAdd) {
     state s;
-    auto empty_update = add_objects_update::build(s, {});
+    auto empty_update = add_objects_update::build(s, {}, {});
     EXPECT_FALSE(empty_update.has_value());
     EXPECT_EQ(empty_update.error(), "No objects requested");
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -37,6 +37,9 @@ kafka::offset operator""_o(unsigned long long o) {
 model::timestamp operator""_t(unsigned long long t) {
     return model::timestamp{static_cast<int64_t>(t)};
 }
+model::term_id operator""_tm(unsigned long long t) {
+    return model::term_id{static_cast<int64_t>(t)};
+}
 
 class new_obj_builder {
 public:
@@ -74,6 +77,13 @@ struct add_objects_builder {
 public:
     add_objects_builder& add(new_object o) {
         out.new_objects.emplace_back(std::move(o));
+        return *this;
+    }
+    add_objects_builder&
+    add_term_start(std::string_view tp_str, model::term_id t, kafka::offset o) {
+        auto tp = model::topic_id_partition::from(tp_str);
+        out.new_terms[tp].emplace_back(
+          term_start{.term_id = t, .start_offset = o});
         return *this;
     }
     add_objects_update build() { return std::move(out); }
@@ -127,6 +137,8 @@ TEST(StateUpdateTest, TestAddBasic) {
                                .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                                .build())
+                        .add_term_start(tidp_a, 0_tm, 0_o)
+                        .add_term_start(tidp_b, 0_tm, 0_o)
                         .build();
         ASSERT_FALSE(update.new_objects.empty());
         auto res = update.apply(s);
@@ -139,6 +151,8 @@ TEST(StateUpdateTest, TestAddBasic) {
                                .add(tidp_c, 0_o, 10_o, 1999_t, 0, 99)
                                .add(tidp_b, 11_o, 20_o, 1999_t, 100, 199)
                                .build())
+                        .add_term_start(tidp_c, 0_tm, 0_o)
+                        .add_term_start(tidp_b, 0_tm, 11_o)
                         .build();
         ASSERT_FALSE(update.new_objects.empty());
         auto res = update.apply(s);
@@ -156,6 +170,8 @@ TEST(StateUpdateTest, TestDuplicateAddSingleUpdate) {
                     .add(new_obj_builder(oid2, 100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
+                    .add_term_start(tidp_a, 0_tm, 0_o)
+                    .add_term_start(tidp_b, 0_tm, 0_o)
                     .build();
     ASSERT_FALSE(update.new_objects.empty());
     auto res = update.can_apply(s);
@@ -169,6 +185,7 @@ TEST(StateUpdateTest, TestStartAfterZero) {
                     .add(new_obj_builder(oid1, 100)
                            .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                            .build())
+                    .add_term_start(tidp_a, 0_tm, 11_o)
                     .build();
     state s;
     auto res = update.apply(s);
@@ -188,6 +205,9 @@ TEST(StateUpdateTest, TestDuplicateObject) {
                            .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                            .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
                            .build())
+                    .add_term_start(tidp_a, 0_tm, 0_o)
+                    .add_term_start(tidp_b, 0_tm, 0_o)
+                    .add_term_start(tidp_c, 0_tm, 0_o)
                     .build();
     state s;
     ASSERT_FALSE(update.new_objects.empty());
@@ -211,6 +231,9 @@ TEST(StateUpdateTest, TestDuplicateAddMultipleUpdates) {
                            .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                            .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
                            .build())
+                    .add_term_start(tidp_a, 0_tm, 0_o)
+                    .add_term_start(tidp_b, 0_tm, 0_o)
+                    .add_term_start(tidp_c, 0_tm, 0_o)
                     .build();
     state s;
     auto res = update.apply(s);
@@ -246,6 +269,8 @@ TEST(StateUpdateTest, TestOverlapSomePartitions) {
                                .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                                .build())
+                        .add_term_start(tidp_a, 0_tm, 0_o)
+                        .add_term_start(tidp_b, 0_tm, 0_o)
                         .build();
         auto res = update.apply(s);
         EXPECT_TRUE(res.has_value());
@@ -264,6 +289,8 @@ TEST(StateUpdateTest, TestOverlapSomePartitions) {
                            .add(tidp_a, 1337_o, 1337_o, 1999_t, 0, 5)
                            .add(tidp_b, 11_o, 20_o, 1999_t, 100, 199)
                            .build())
+                    .add_term_start(tidp_a, 0_tm, 1337_o)
+                    .add_term_start(tidp_b, 0_tm, 11_o)
                     .build();
     auto misaligned_res = update.apply(s);
     EXPECT_TRUE(misaligned_res.has_value());
@@ -294,6 +321,9 @@ MATCHER_P3(MatchesRange, oid, base, last, "") {
 MATCHER_P2(MatchesRange, base, last, "") {
     return arg.base_offset == base && arg.last_offset == last;
 }
+MATCHER_P2(MatchesTermStart, term, offset, "") {
+    return arg.term_id == term && arg.start_offset == offset;
+}
 
 } // namespace
 
@@ -309,6 +339,9 @@ TEST(StateUpdateTest, TestReplaceBasic) {
                         .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                         .add(tidp_c, 11_o, 20_o, 1999_t, 0, 99)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
+                 .add_term_start(tidp_c, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -369,6 +402,7 @@ TEST(StateUpdateTest, TestReplaceDuplicate) {
                  .add(new_obj_builder(oid1, 100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -393,6 +427,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
                  .add(new_obj_builder(oid1, 100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -418,6 +453,7 @@ TEST(StateUpdateTest, TestReplaceBadOrdering) {
                  .add(new_obj_builder(oid1, 100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -446,6 +482,7 @@ TEST(StateUpdateTest, TestEmptyReplace) {
                  .add(new_obj_builder(oid1, 100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -469,6 +506,9 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
+                 .add_term_start(tidp_c, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -552,6 +592,8 @@ TEST(StateUpdateTest, TestCompactionMissingExtent) {
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -585,6 +627,8 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtents) {
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -618,6 +662,8 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtentsStart) {
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -626,6 +672,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtentsStart) {
             .add(new_obj_builder(oid2, 300)
                    .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                    .build())
+            .add_term_start(tidp_a, 0_tm, 11_o)
             .build();
     add_res = add.apply(s);
     ASSERT_TRUE(add_res.has_value());
@@ -658,6 +705,8 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceLogStart) {
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -666,6 +715,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceLogStart) {
             .add(new_obj_builder(oid2, 300)
                    .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                    .build())
+            .add_term_start(tidp_a, 0_tm, 11_o)
             .build();
     add_res = add.apply(s);
     ASSERT_TRUE(add_res.has_value());
@@ -698,6 +748,8 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -744,6 +796,8 @@ TEST(StateUpdateTest, TestRemoveNonExistingTombstones) {
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
                  .build();
     state s;
     auto add_res = add.apply(s);
@@ -762,4 +816,247 @@ TEST(StateUpdateTest, TestRemoveNonExistingTombstones) {
       testing::ContainsRegex(
         "Tombstone-removed range .+ for .+ is not tracked "
         "as having tombstones"));
+}
+
+TEST(StateUpdateTest, TestAddIncreasingTerms) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 1_tm, 0_o)
+                    .add_term_start(tidp_a, 2_tm, 1_o)
+                    .build();
+    auto res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(1, s.topic_to_state.size());
+
+    update = add_objects_builder()
+               .add(new_obj_builder(oid2, 100)
+                      .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                      .build())
+               .add_term_start(tidp_a, 3_tm, 11_o)
+               .add_term_start(tidp_a, 4_tm, 12_o)
+               .build();
+    res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+
+    auto p_state = s.partition_state(model::topic_id_partition::from(tidp_a));
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(2, p_state->get().extents.size());
+    EXPECT_EQ(4, p_state->get().term_starts.size());
+    EXPECT_THAT(
+      p_state->get().term_starts,
+      testing::ElementsAre(
+        MatchesTermStart(1_tm, 0_o),
+        MatchesTermStart(2_tm, 1_o),
+        MatchesTermStart(3_tm, 11_o),
+        MatchesTermStart(4_tm, 12_o)));
+}
+
+TEST(StateUpdateTest, TestAddSameSubsequentTerm) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 1_tm, 0_o)
+                    .add_term_start(tidp_a, 2_tm, 1_o)
+                    .build();
+    auto res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(1, s.topic_to_state.size());
+    auto p_state = s.partition_state(model::topic_id_partition::from(tidp_a));
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(1, p_state->get().extents.size());
+    EXPECT_EQ(2, p_state->get().term_starts.size());
+    EXPECT_THAT(
+      p_state->get().term_starts,
+      testing::ElementsAre(
+        MatchesTermStart(1_tm, 0_o), MatchesTermStart(2_tm, 1_o)));
+
+    // The start of term 2 shouldn't be changed, but term 3 should be added.
+    update = add_objects_builder()
+               .add(new_obj_builder(oid2, 100)
+                      .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                      .build())
+               .add_term_start(tidp_a, 2_tm, 11_o)
+               .add_term_start(tidp_a, 3_tm, 12_o)
+               .build();
+    res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(2, p_state->get().extents.size());
+    EXPECT_EQ(3, p_state->get().term_starts.size());
+    EXPECT_THAT(
+      p_state->get().term_starts,
+      testing::ElementsAre(
+        MatchesTermStart(1_tm, 0_o),
+        MatchesTermStart(2_tm, 1_o),
+        MatchesTermStart(3_tm, 12_o)));
+}
+
+TEST(StateUpdateTest, TestAddNoTerms) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .build();
+
+    auto res = update.can_apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(
+      res.error()().c_str(),
+      testing::HasSubstr("Missing term info in request"));
+}
+
+TEST(StateUpdateTest, TestAddMissingTermsForPartition) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
+                           .build())
+                    .add_term_start(tidp_a, 0_tm, 0_o)
+                    .build();
+
+    auto res = update.can_apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(
+      res.error()().c_str(), testing::HasSubstr("Missing term info for"));
+}
+
+TEST(StateUpdateTest, TestAddDecreasingTermInUpdate) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 2_tm, 0_o)
+                    .add_term_start(tidp_a, 1_tm, 1_o)
+                    .build();
+    auto res = update.apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(res.error()().c_str(), testing::HasSubstr("Invalid term for"));
+}
+
+TEST(StateUpdateTest, TestAddDecreasingTerm) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 2_tm, 0_o)
+                    .build();
+    auto res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+
+    update = add_objects_builder()
+               .add(new_obj_builder(oid2, 100)
+                      .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                      .build())
+               .add_term_start(tidp_a, 1_tm, 11_o)
+               .build();
+    res = update.can_apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(
+      res.error()().c_str(), testing::HasSubstr("must be >= last term"));
+}
+
+TEST(StateUpdateTest, TestAllowBogusTermWithBogusExtent) {
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 10_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 2_tm, 10_o)
+                    .add_term_start(tidp_a, 1_tm, 10_o)
+                    .build();
+    // If there's a misaligned extent, we won't expect that its terms are valid
+    // either, but we should expect the corrections to be populated.
+    state s;
+    chunked_hash_map<model::topic_id_partition, kafka::offset> corrections;
+    auto res = update.can_apply(s, &corrections);
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(1, corrections.size());
+
+    // When applying, the operation should succeed, but we should be left with
+    // a dead object and no extents.
+    res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+    EXPECT_TRUE(s.topic_to_state.empty());
+    EXPECT_EQ(1, s.objects.size());
+    auto& dead_obj = s.objects.begin()->second;
+    EXPECT_EQ(dead_obj.removed_data_size, dead_obj.total_data_size);
+}
+
+TEST(StateUpdateTest, TestTermsWithNoExtent) {
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 0_tm, 0_o)
+                    // Add some terms for a missing partition.
+                    .add_term_start(tidp_b, 0_tm, 0_o)
+                    .build();
+    state s;
+    auto res = update.can_apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(
+      res.error()().c_str(),
+      testing::HasSubstr("Terms provided for a partition that has no extents"));
+}
+
+TEST(StateUpdateTest, TestAddMismatchedStartOffset) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 1_tm, 0_o)
+                    .build();
+    auto res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+
+    // Add an update where the term's start offset doesn't match the extent.
+    update = add_objects_builder()
+               .add(new_obj_builder(oid2, 100)
+                      .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                      .build())
+               .add_term_start(tidp_a, 2_tm, 0_o)
+               .build();
+    res = update.can_apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(
+      res.error()().c_str(),
+      testing::HasSubstr("Extent start and term start do not match"));
+}
+
+TEST(StateUpdateTest, TestAddExtentEndsBelowLastTermStart) {
+    state s;
+    auto update = add_objects_builder()
+                    .add(new_obj_builder(oid1, 100)
+                           .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                           .build())
+                    .add_term_start(tidp_a, 1_tm, 0_o)
+                    // We can add at the last offset.
+                    .add_term_start(tidp_a, 2_tm, 10_o)
+                    .build();
+    auto res = update.apply(s);
+    EXPECT_TRUE(res.has_value());
+
+    update = add_objects_builder()
+               .add(new_obj_builder(oid2, 100)
+                      .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                      .build())
+               .add_term_start(tidp_a, 3_tm, 11_o)
+               // We cannot past the last offset.
+               .add_term_start(tidp_a, 4_tm, 21_o)
+               .build();
+    res = update.apply(s);
+    EXPECT_FALSE(res.has_value());
+    EXPECT_THAT(
+      res.error()().c_str(),
+      testing::HasSubstr("Extents end below a requested new term for"));
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds term metadata to the metastore::add_objects() interface, with the expectation that the reconciler will collect term starts as L1 objects are built, and send that metadata to the metastore with each batch of objects.

The added STM state itself is simple enough -- a list of monotonically increasing term-offset pairs. These are validated to be monotonically increasing and add_objects updates are rejected if the requested terms are invalid.

Subsequent work will add the read interfaces (to get the end offsets per term, and to get the term for a given offset). This focuses just on the interface for accepting terms into the system.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
