### PR TITLE
`storage`: check for abort in `make_concatenated_segment()`

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -899,6 +899,13 @@ make_concatenated_segment(
     auto writer = co_await make_writer_handle(path, cfg.sanitizer_config);
     auto output = co_await ss::make_file_output_stream(std::move(writer));
     for (auto& segment : segments) {
+        if (cfg.asrc && cfg.asrc->abort_requested()) {
+            // Close the output stream and then rethrow exception for a
+            // graceful shutdown. The leftover `.staging` files that have
+            // been written will be cleanly removed by log_manager.
+            co_await output.close();
+            std::rethrow_exception(cfg.asrc->abort_requested_exception_ptr());
+        }
         auto reader_handle = co_await segment->reader().data_stream(0);
         co_await ss::copy(reader_handle.stream(), output);
         co_await reader_handle.close();


### PR DESCRIPTION
Because of the amount of IO that may now be performed while iterating over all the `segment`s being concatenated, it is important to check the attached abort source for a requested abort in order to ensure a timely shutdown.

Previously, we would eventually realize we need to abort compaction later in the adjacent merge process during self compaction of the concatenated `segment`, thereby throwing away the progress made regardless. By checking it earlier within `make_concatenated_segment()` during the heavy IO loop, we can better respect shutdowns and waste less time on IO that will ultimately be discarded anyways (see last log line in [1]).

The lack of check here manifested as a [CI failure](https://ci-artifacts.dev.vectorized.cloud/production-devprod/redpanda/70913/0198b939-27e1-444e-bf0d-84d018cf5058/vbuild/ducktape/results/2025-08-17--001/RandomNodeOperationsTest/test_node_operations/enable_failures=False.mixed_versions=False.with_iceberg=False.compaction_mode=CompactionMode.ADJACENT_MERGE.cloud_storage_type=CloudStorageType.S3/161/) due to a long `partition` shutdown [1].

[1]:

```
INFO  2025-08-17 21:04:37,651 [shard 1:lc  ] storage-gc - disk_log_impl.cc:1096 - Compacting 108 adjacent segments over range: [/var/lib/redpanda/data/kafka/tp-workload-writecaching-compact-delete/23_45/0-1-v1.log:/var/lib/redpanda/data/kafka/tp-workload-writecaching-compact-delete/23_45/102099-1-v1.log]
DEBUG 2025-08-17 21:04:39,176 [shard 1:main] cluster - partition_manager.cc:433 - removing partition {kafka/tp-workload-writecaching-compact-delete/23}
INFO  2025-08-17 21:04:39,264 [shard 1:main] storage - log_manager.cc:827 - Asked to remove: {kafka/tp-workload-writecaching-compact-delete/23}
ERROR 2025-08-17 21:05:00,570 [shard 1:main] cluster - partition_manager.cc:501 - partition {kafka/tp-workload-writecaching-compact-delete/23} shutdown takes longer than expected, current shutdown stage: removing_storage time since last update: 21 seconds
ERROR 2025-08-17 21:05:04,570 [shard 1:main] cluster - partition_manager.cc:501 - partition {kafka/tp-workload-writecaching-compact-delete/23} shutdown takes longer than expected, current shutdown stage: removing_storage time since last update: 25 seconds
ERROR 2025-08-17 21:05:08,570 [shard 1:main] cluster - partition_manager.cc:501 - partition {kafka/tp-workload-writecaching-compact-delete/23} shutdown takes longer than expected, current shutdown stage: removing_storage time since last update: 29 seconds
DEBUG 2025-08-17 21:05:09,044 [shard 1:lc  ] storage-gc - disk_log_impl.cc:1405 - Compaction of {kafka/tp-workload-writecaching-compact-delete/23} stopped because of shutdown
DEBUG 2025-08-17 21:05:09,045 [shard 1:lc  ] storage-gc - disk_log_impl.cc:1344 - Cleaning up leftover file: /var/lib/redpanda/data/kafka/tp-workload-writecaching-compact-delete/23_45/0-1-v1.log.compaction.staging
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
