### PR TITLE
`rptest`: add `log_allow_list` to `test_tx_compaction_with_recovery`

### DIFF
--- a/tests/rptest/transactions/compaction_e2e_test.py
+++ b/tests/rptest/transactions/compaction_e2e_test.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import re
+
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.clients.rpk import RpkTool
@@ -194,7 +196,8 @@ class CompactionWithRecoveryTest(RedpandaTest, PartitionMovementMixin):
                              extra_rp_conf=extra_rp_conf)
 
     @skip_debug_mode
-    @cluster(num_nodes=4)
+    @cluster(num_nodes=4,
+             log_allow_list=[re.compile("tx - .*partition_not_found")])
     def test_tx_compaction_with_recovery(self):
         """Ensures correctness of tx + compaction with partition moves"""
 


### PR DESCRIPTION
The use of partition moves in this test can cause a race condition in which a transaction in flight can be rejected due to a concurrent removal of a partition on a given shard, leading to a log line like:

```
rptest.services.utils.BadLogLines: <BadLogLines nodes=docker-rp-10(2) example="ERROR 2025-08-18 20:37:46,518 [shard 1:kafk] tx - tx_gateway_frontend.cc:1471 - [tx_id=f686ce8c-b0f3-4593-b6f6-652fa0ca59b3] begin_tx request for pid: {producer_identity: id=1, epoch=0} at ntp: {kafka/topic-rddqwlsrwh/0} result: tx::errc::partition_not_found">
```

Add a regex for this line to the `log_allow_list` for the test, as it is a transient error and should be treated as one.


## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
