### PR TITLE
[CORE-13104] storage/parser: log parser_errc at debug level on recovery

### DIFF
--- a/src/v/storage/parser.cc
+++ b/src/v/storage/parser.cc
@@ -208,8 +208,9 @@ ss::future<result<stop_parser>> continuous_batch_parser::consume_records() {
         [this](result<iobuf, parser_errc> record)
           -> ss::future<result<stop_parser>> {
             if (unlikely(!record)) {
-                vlog(
-                  stlog.error,
+                vlogl(
+                  stlog,
+                  _recovery ? ss::log_level::debug : ss::log_level::error,
                   "parser::consume_records error: {} (record_batch_header: {}, "
                   "batch consumer: {}) ",
                   to_string(record.error()),


### PR DESCRIPTION
Elsewhere[1], short reads are logged only at debug level during recovery
(i.e. node restart) because they're somewhat expected after an unclean
shutdown. E.g. if we write the header or some parts of the batch, but
then lose power before completing the batch, reading these incomplete
batches result in a short read.

This commit follows suit w.r.t. logging, making it a debug level log
line on recovery.

I considered removing the log line entirely, given some info is logged in [1], but the additional seems like potentially useful context to have in a pinch.

[1] https://github.com/redpanda-data/redpanda/blob/b01d6272fd9722e916d69118d8d4d60dc5b31482/src/v/storage/parser.cc#L40-L68

Fixes [CORE-13104](https://redpandadata.atlassian.net/browse/CORE-13104)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13104]: https://redpandadata.atlassian.net/browse/CORE-13104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ