### PR TITLE
CORE-13076 admin: require controller leadership before license idempotence check

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2366,11 +2366,18 @@ admin_server::put_license_handler(std::unique_ptr<ss::http::request> req) {
             throw ss::httpd::bad_request_exception(
               fmt::format("License is expired: {}", license));
         }
+
+        if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+            // In order that we can do a reliable idempotence check, run on the
+            // controller leader
+            throw co_await redirect_to_leader(*req, model::controller_ntp);
+        }
+
         const auto& ft = _controller->get_feature_table().local();
         const auto& loaded_license = ft.get_license();
         if (loaded_license && (*loaded_license == license)) {
             /// Loaded license is idential to license in request, do
-            /// nothing and return 200(OK)
+            /// nothing and return 200(OK) for idempotence
             vlog(
               adminlog.info,
               "Attempted to load identical license, doing nothing: {}",

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -229,13 +229,22 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
 
         assert self.admin.put_license(license).status_code == 200
 
-        def obtain_configured_license():
-            lic = self.admin.get_license()
-            return (self.admin.is_sample_license(lic), lic)
+        def check_license(is_matching_license):
+            # Wait for all of the nodes to see the next license to ensure that
+            # we don't get idempotent 200's when updating the license on a
+            # stale node in the face of leadership changes
+            licenses = [
+                self.admin.get_license(node=node)
+                for node in self.redpanda.started_nodes()
+            ]
+            if any(not is_matching_license(lic) for lic in licenses):
+                return False, None
+            return (True, licenses[0])
 
-        resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=20,
-                                 backoff_sec=1)
+        resp = wait_until_result(
+            lambda: check_license(self.admin.is_sample_license),
+            timeout_sec=20,
+            backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
 
@@ -261,13 +270,12 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
 
         assert self.admin.put_license(license_v1).status_code == 200
 
-        def obtain_configured_license_v1():
-            lic = self.admin.get_license()
+        def is_v1_license(lic):
             if lic is None or 'license' not in lic:
                 return False
-            return (lic['license']['format_version'] == 1, lic)
+            return lic['license']['format_version'] == 1
 
-        resp = wait_until_result(obtain_configured_license_v1,
+        resp = wait_until_result(lambda: check_license(is_v1_license),
                                  timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
@@ -276,9 +284,10 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         # Set back to v0 for sanity check
         assert self.admin.put_license(license).status_code == 200
 
-        resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=20,
-                                 backoff_sec=1)
+        resp = wait_until_result(
+            lambda: check_license(self.admin.is_sample_license),
+            timeout_sec=20,
+            backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
 


### PR DESCRIPTION
This PR makes two changes:
1. [admin: require controller leadership before license idempotence check](https://github.com/redpanda-data/redpanda/commit/1144acd3a496f97d763f23c184de54ea8044b18f) in the put license handler to avoid flakiness when a license update request races with the controller command to stale nodes.
2. [dt: check for license on all nodes](https://github.com/redpanda-data/redpanda/commit/a3998fcadbd32699bdfd058d0311e0e001034a7b) in the test_license_upload_and_query test to make it robust against unstable leadership.

See the commit messages for details. 

Fixes https://redpandadata.atlassian.net/browse/CORE-13076

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
