### PR TITLE
dt: Update kcl 0.16.0

### DIFF
--- a/tests/docker/ducktape-deps/kcl
+++ b/tests/docker/ducktape-deps/kcl
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-go install github.com/twmb/kcl@v0.8.0
+go install github.com/twmb/kcl@v0.16.0
 mv /root/go/bin/kcl /usr/local/bin/

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -423,6 +423,9 @@ class RawKCL(KCL):
 
     Callers should expect raw kafka responses json encoded with franz-go key naming scheme
     """
+    def _controller_id(self):
+        return self._redpanda.node_id(self._redpanda.controller())
+
     def create_topics(self,
                       version,
                       topics: list[dict] = [],
@@ -467,8 +470,10 @@ class RawKCL(KCL):
                 'ReplicationFactor': t.replication_factor
             } for t in topics]
         }
-        return self._cmd(['misc', 'raw-req', '-k', '19'],
-                         input=json.dumps(create_topics_request))
+        return self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(self._controller_id()), '-k', '19'],
+            input=json.dumps(create_topics_request))
 
     def raw_delete_topics(self, version, topics):
         assert version >= 0 and version <= 5, "version out of supported redpanda range for this API"
@@ -477,8 +482,10 @@ class RawKCL(KCL):
             'TimeoutMillis': 15000,
             'TopicNames': topics
         }
-        return self._cmd(['misc', 'raw-req', '-k', '20'],
-                         input=json.dumps(delete_topics_request))
+        return self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(self._controller_id()), '-k', '20'],
+            input=json.dumps(delete_topics_request))
 
     def raw_create_partitions(self, version, topics):
         assert version >= 0 and version <= 3, "version out of supported redpanda range for this API"
@@ -491,20 +498,20 @@ class RawKCL(KCL):
                 'Count': t.count
             } for t in topics]
         }
-        return self._cmd(['misc', 'raw-req', '-k', '37'],
-                         input=json.dumps(create_partitions_request))
+        return self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(self._controller_id()), '-k', '37'],
+            input=json.dumps(create_partitions_request))
 
     def raw_alter_topic_config(self, version, topic, configs):
         assert version >= 0 and version <= 1, "version out of supported redpanda range for this API"
         alter_configs_request = {
             'Version':
             version,
-            'ValidateOnly':
-            False,
             'TimeoutMillis':
             15000,
             'Resources': [{
-                'ResourceType': 2,
+                'ResourceType': 'TOPIC',
                 'ResourceName': topic,
                 'Configs': []
             }],
@@ -512,29 +519,45 @@ class RawKCL(KCL):
             False
         }
 
-        for k, v in configs.items():
+        alter_configs_request['Resources'][0]['Configs'] = [{
+            "Name": k,
+            "Value": str(v)
+        } for k, v in configs.items()]
 
-            alter_configs_request['Resources'][0]['Configs'].append({
-                "Name":
-                k,
-                "Value":
-                str(v)
-            })
         self._redpanda.logger.info(f"DBG: {json.dumps(alter_configs_request)}")
-        return self._cmd(['misc', 'raw-req', '-k', '33'],
-                         input=json.dumps(alter_configs_request))
+        return self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(self._controller_id()), '-k', '33'],
+            input=json.dumps(alter_configs_request))
 
     def raw_alter_quotas(self, body):
-        res = self._cmd(['misc', 'raw-req', '-k', '49'],
-                        input=json.dumps(body))
+        res = self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(self._controller_id()), '-k', '49'],
+            input=json.dumps(body))
         return json.loads(res)
 
     def raw_describe_quotas(self, body):
-        res = self._cmd(['misc', 'raw-req', '-k', '48'],
+        res = self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(self._controller_id()), '-k', '48'],
+            input=json.dumps(body))
+        return json.loads(res)
+
+    def raw_find_coordinator(self, body):
+        res = self._cmd(['misc', 'raw-req', '-k', '10'],
                         input=json.dumps(body))
         return json.loads(res)
 
     def raw_join_group(self, body):
-        res = self._cmd(['misc', 'raw-req', '-k', '11'],
-                        input=json.dumps(body))
+        res = self.raw_find_coordinator({
+            "Version": 3,
+            "CoordinatorKey": body["Group"],
+            "CoordinatorType": 0
+        })
+
+        res = self._cmd(
+            ['misc', 'raw-req', '-b',
+             str(res["NodeID"]), '-k', '11'],
+            input=json.dumps(body))
         return json.loads(res)

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -696,6 +696,7 @@ class ConsumerGroupTest(RedpandaTest):
         group = 'test-gr-1'
 
         self.redpanda._admin.set_log_level("kafka", "trace")
+        self.redpanda._admin.set_log_level("kafka-cg", "trace")
 
         self.redpanda.logger.info("Starting my-consumer-1")
         consumer1 = self.create_consumer(topic=self.topic_spec.name,

--- a/tests/rptest/tests/quota_management_test.py
+++ b/tests/rptest/tests/quota_management_test.py
@@ -449,7 +449,7 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
         describe_body = {
             "Components": [{
                 "EntityType": "client-id-prefix",
-                "MatchType": 1,  # default
+                "MatchType": "DEFAULT",
             }],
         }
         res = self.kcl.raw_describe_quotas(describe_body)
@@ -464,7 +464,7 @@ Quota configs for client-id 'custom-producer' are producer_byte_rate=20480.0"""
         describe_body = {
             "Components": [{
                 "EntityType": "client-id",
-                "MatchType": 0,  # exact match
+                "MatchType": "EXACT",
                 # "Match": "missing"
             }],
         }

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -511,9 +511,9 @@ class CreateTopicsResponseTest(RedpandaTest):
         np = self.get_np(topic)
         assert np == expected_np, f"Expected partition count {expected_np}, got {np}"
         rf = self.get_rf(topic)
-        assert rf == expected_rf, f"Expected partition count {expected_rf}, got {rf}"
+        assert rf == expected_rf, f"Expected replication factor {expected_rf}, got {rf}"
         ec = self.get_ec(topic)
-        assert ec == expected_ec, f"Expected partition count {expected_ec}, got {ec}"
+        assert ec == expected_ec, f"Expected error code {expected_ec}, got {ec}"
 
     @cluster(num_nodes=3)
     @matrix(


### PR DESCRIPTION
Update kcl to 0.16.0

* This includes a bugfix to respect `Version` (introduced in 0.15.0)
* Unfortunately that bugfix introduced another bug https://github.com/twmb/kcl/issues/49
  * Workaround that bug by dispatching to the correct broker manually
* Added a fix for enabling a logger
* Improved logging in another test (drive-by fix)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
