### PR TITLE
datalake: Allow replacing dots in table names

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4236,6 +4236,18 @@ configuration::configuration()
       "its own.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , iceberg_topic_name_dot_replacement(
+      *this,
+      "iceberg_topic_name_dot_replacement",
+      "Optional replacement string for dots in topic names when deriving "
+      "Iceberg table names, useful when downstream systems do not permit "
+      "dots in table names. The replacement string cannot contain dots. "
+      "Be careful to avoid table name collisions caused by the replacement."
+      "If an Iceberg topic with dots in the name exists in the cluster, the "
+      "value of this property should not be changed.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      &validate_iceberg_topic_name_dot_replacement)
   , enable_host_metrics(
       *this,
       "enable_host_metrics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -767,6 +767,7 @@ struct configuration final : public config_store {
     bounded_property<std::chrono::milliseconds> iceberg_target_lag_ms;
     property<bool> iceberg_disable_snapshot_tagging;
     property<bool> iceberg_disable_automatic_snapshot_expiry;
+    property<std::optional<ss::sstring>> iceberg_topic_name_dot_replacement;
 
     property<bool> enable_host_metrics;
 

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -257,6 +257,14 @@ validate_iceberg_partition_spec(const ss::sstring& value) {
     return std::nullopt;
 }
 
+std::optional<ss::sstring> validate_iceberg_topic_name_dot_replacement(
+  const std::optional<ss::sstring>& value) {
+    if (value.has_value() && value->find('.') != ss::sstring::npos) {
+        return "iceberg_topic_name_dot_replacement cannot contain dots";
+    }
+    return std::nullopt;
+}
+
 std::optional<ss::sstring>
 validate_iceberg_rest_catalog_auth_mode(const config::configuration& config) {
     auto auth_mode = config.iceberg_rest_catalog_authentication_mode();

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -60,6 +60,9 @@ std::optional<ss::sstring> validate_tombstone_retention_ms(
 std::optional<ss::sstring>
 validate_iceberg_partition_spec(const ss::sstring& spec);
 
+std::optional<ss::sstring> validate_iceberg_topic_name_dot_replacement(
+  const std::optional<ss::sstring>& value);
+
 std::optional<ss::sstring>
 validate_iceberg_rest_catalog_auth_mode(const configuration& config);
 

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -465,8 +465,15 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "table_id_provider",
+    srcs = [
+        "table_id_provider.cc",
+    ],
     hdrs = [
         "table_id_provider.h",
+    ],
+    implementation_deps = [
+        "//src/v/config",
+        "@boost//:algorithm",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/datalake/table_id_provider.cc
+++ b/src/v/datalake/table_id_provider.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/table_id_provider.h"
+
+#include "config/configuration.h"
+
+#include <boost/algorithm/string/replace.hpp>
+
+namespace datalake {
+
+model::topic table_id_provider::sanitize_topic_name(const model::topic& topic) {
+    const auto& dot_replacement
+      = config::shard_local_cfg().iceberg_topic_name_dot_replacement();
+    if (!dot_replacement.has_value()) {
+        return topic;
+    }
+    return model::topic(
+      boost::replace_all_copy(topic(), ".", *dot_replacement));
+}
+
+iceberg::table_identifier table_id_provider::table_id(const model::topic& t) {
+    return {
+      // TODO: namespace as a topic property? Keep it in the table metadata?
+      .ns = {"redpanda"},
+      .table = sanitize_topic_name(t),
+    };
+}
+
+iceberg::table_identifier
+table_id_provider::dlq_table_id(const model::topic& t) {
+    return {
+      // TODO: namespace as a topic property? Keep it in the table metadata?
+      .ns = {"redpanda"},
+      .table = fmt::format("{}~dlq", sanitize_topic_name(t)),
+    };
+}
+
+} // namespace datalake

--- a/src/v/datalake/table_id_provider.h
+++ b/src/v/datalake/table_id_provider.h
@@ -17,21 +17,12 @@ namespace datalake {
 
 class table_id_provider {
 public:
-    static iceberg::table_identifier table_id(model::topic t) {
-        return {
-          // TODO: namespace as a topic property? Keep it in the table metadata?
-          .ns = {"redpanda"},
-          .table = std::move(t),
-        };
-    }
+    static iceberg::table_identifier table_id(const model::topic& t);
 
-    static iceberg::table_identifier dlq_table_id(const model::topic& t) {
-        return {
-          // TODO: namespace as a topic property? Keep it in the table metadata?
-          .ns = {"redpanda"},
-          .table = fmt::format("{}~dlq", t()),
-        };
-    }
+    static iceberg::table_identifier dlq_table_id(const model::topic& t);
+
+private:
+    static model::topic sanitize_topic_name(const model::topic& topic);
 };
 
 } // namespace datalake

--- a/tests/rptest/tests/datalake/datalake_services.py
+++ b/tests/rptest/tests/datalake/datalake_services.py
@@ -266,7 +266,7 @@ class DatalakeServices():
             timeout_sec=timeout,
             backoff_sec=backoff_sec,
             err_msg=
-            f"Timed out waiting {namespace}.{table} to be created in the catalog"
+            f"Timed out waiting for {namespace}.{table} to be created in the catalog"
         )
 
     def wait_for_translation_until_offset(self,

--- a/tests/rptest/tests/datalake/datalake_table_name_test.py
+++ b/tests/rptest/tests/datalake/datalake_table_name_test.py
@@ -1,0 +1,102 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings, CloudStorageType
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.datalake.catalog_service_factory import filesystem_catalog_type
+from rptest.util import expect_http_error
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+
+class DatalakeTableNameTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(DatalakeTableNameTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=1,
+                             si_settings=SISettings(test_context=test_context),
+                             extra_rp_conf={
+                                 "iceberg_enabled": "true",
+                                 "iceberg_catalog_commit_interval_ms": 5000
+                             })
+
+    def setUp(self):
+        # redpanda will be started by DatalakeServices
+        pass
+
+    # For iceberg, should it be an icecube test?
+    def _iceberg_dot_replacement_smoke(self, dl, topic, replacement):
+        rpk = RpkTool(self.redpanda)
+        admin = Admin(self.redpanda)
+
+        if replacement is not None:
+            admin.patch_cluster_config(
+                upsert={"iceberg_topic_name_dot_replacement": replacement})
+
+        expected_table = topic.replace(
+            ".", replacement) if replacement is not None else topic
+        dl.create_iceberg_enabled_topic(topic)
+
+        rpk.produce(topic, "key", "value")
+        dl.wait_for_translation(topic,
+                                table_override=expected_table,
+                                msg_count=1)
+
+        spark = dl.spark()
+        tables = spark.run_query_fetch_all("SHOW TABLES IN redpanda")
+        table_names = [row[1] for row in tables]
+        assert expected_table in table_names, f"Table {expected_table} not found. Tables: {table_names}"
+        assert replacement is None or topic not in table_names, f"Table should not have dots: {table_names}"
+
+        result = spark.run_query_fetch_all(
+            f"SELECT COUNT(*) FROM redpanda.`{expected_table}`")
+        assert result[0][0] == 1, f"Expected 1 row, got {result}"
+
+        rpk.delete_topic(topic)
+        wait_until(lambda: topic not in rpk.list_topics(),
+                   timeout_sec=30,
+                   err_msg=f"Topic {topic} was not deleted")
+        wait_until(lambda: expected_table not in spark.run_query_fetch_all(
+            "SHOW TABLES IN redpanda"),
+                   timeout_sec=30,
+                   err_msg=f"Table {expected_table} was not deleted")
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types(),
+            catalog_type=[filesystem_catalog_type()])
+    def test_topic_name_dot_replacement(self, cloud_storage_type,
+                                        catalog_type):
+        """Test that dots in topic names are replaced in Iceberg table names"""
+
+        with DatalakeServices(self.test_context,
+                              redpanda=self.redpanda,
+                              include_query_engines=[QueryEngineType.SPARK],
+                              catalog_type=catalog_type) as dl:
+
+            self._iceberg_dot_replacement_smoke(dl, "test.zero", None)
+            self._iceberg_dot_replacement_smoke(dl, "test.one", "")
+            self._iceberg_dot_replacement_smoke(dl, "test.two", "_")
+
+
+class DatalakeTableNameInvalidReplacementTest(RedpandaTest):
+    @cluster(num_nodes=1)
+    def test_invalid_replacement_validation(self):
+        """Test that replacement strings containing dots are rejected"""
+
+        admin = Admin(self.redpanda)
+
+        with expect_http_error(400):
+            admin.patch_cluster_config(
+                upsert={"iceberg_topic_name_dot_replacement": "dot.dot"})


### PR DESCRIPTION
This defines a configuration property `iceberg_topic_name_dot_replacement` that, when set, will replace .'s in table names when a Kafka topic name is translated into the corresponding Iceberg table name (or DLQ table name).

The replacement is done using the current value of the setting, so to preserve the link between topic and table, the setting should not be changed once there is an Iceberg topic whose name contains dots. It'd be nice to copy the cluster configuration into topic configuration when an Iceberg topic is created or when Iceberg mode is set for a topic, so the link is preserved even if the cluster configuration is changed, but that's a far more invasive change. This workaround may suffice.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* A new configuration option `iceberg_topic_name_dot_replacement` specifies a string that will replace dots in Iceberg topic names when those names are converted into Iceberg table names. This allows working around downstream systems which do not allow table names with dots in them. Be careful to avoid table name collisions by picking a proper replacement string, and do not change the replacement string if there exists an Iceberg topic with dots in the name.
