### PR TITLE
tests/utils/data_migrations: increase tolerance to clock drift

### DIFF
--- a/tests/rptest/utils/data_migrations.py
+++ b/tests/rptest/utils/data_migrations.py
@@ -122,7 +122,7 @@ class DataMigrationTestMixin:
     def validate_timing(self, time_before, happened_at):
         time_now = now()
         self.logger.debug(f"{time_before=}, {happened_at=}, {time_now=}")
-        err_ms = 5  # allow for ntp error across nodes
+        err_ms = 25  # allow for ntp error across nodes
         assert time_before - err_ms <= happened_at <= time_now + err_ms
 
     def wait_migration_appear(self,


### PR DESCRIPTION
Setting it to 25ms to make the test less flaky when clocks are not precicely in sync.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
* 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
