### PR TITLE
[CORE-13170] - Support SR ACLs in DescribeACLs

### DIFF
--- a/src/v/kafka/protocol/schemata/describe_acls_request.json
+++ b/src/v/kafka/protocol/schemata/describe_acls_request.json
@@ -37,6 +37,8 @@
     { "name": "Operation", "type": "int8", "versions": "0+",
       "about": "The operation to match." },
     { "name": "PermissionType", "type": "int8", "versions": "0+",
-      "about": "The permission type to match." }
+      "about": "The permission type to match." },
+    { "name": "DescribeRegistryAcls", "type": "bool", "versions": "2+", "tag": 1000, "taggedVersions": "2+", "ignorable": true,
+      "about": "Request is to describe Schema Registry ACLs." }
   ]
 }

--- a/src/v/kafka/protocol/schemata/describe_acls_response.json
+++ b/src/v/kafka/protocol/schemata/describe_acls_response.json
@@ -38,6 +38,8 @@
         "about": "The resource name." },
       { "name": "PatternType", "type": "int8", "versions": "1+", "default": "3", "ignorable": false,
         "about": "The resource pattern type." },
+      { "name": "RegistryResource", "type": "bool", "versions": "2+", "tag": 1000, "taggedVersions": "2+", "ignorable": true,
+        "about": "Response contains only Schema Registry resources."},
       { "name": "Acls", "type": "[]AclDescription", "versions": "0+",
         "about": "The ACLs.", "fields": [
         { "name": "Principal", "type": "string", "versions": "0+",

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -28,7 +28,8 @@ namespace kafka {
 static void fill_response(
   request_context& ctx,
   security::acl_binding_filter& filter,
-  describe_acls_response_data& response) {
+  describe_acls_response_data& response,
+  bool describing_registry_resource) {
     /*
      * collapse common acls by pattern
      */
@@ -47,10 +48,14 @@ static void fill_response(
         describe_acls_resource resource;
 
         // resource pattern
-        resource.type = details::to_kafka_resource_type(entry.first.resource());
+        resource.type
+          = describing_registry_resource
+              ? details::to_kafka_registry_resource_type(entry.first.resource())
+              : details::to_kafka_resource_type(entry.first.resource());
         resource.name = entry.first.name();
         resource.pattern_type = details::to_kafka_pattern_type(
           entry.first.pattern());
+        resource.registry_resource = describing_registry_resource;
 
         // acl entries
         for (auto& acl : entry.second) {
@@ -113,7 +118,7 @@ ss::future<response_ptr> describe_acls_handler::handle(
 
     try {
         auto filter = details::to_acl_binding_filter(request.data);
-        fill_response(ctx, filter, data);
+        fill_response(ctx, filter, data, request.data.describe_registry_acls);
     } catch (const details::acl_conversion_error& e) {
         vlog(klog.debug, "Error describing ACLs: {}", e.what());
         data.error_code = error_code::invalid_request;

--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -18,6 +18,9 @@
 #include "security/scram_credential.h"
 namespace kafka::details {
 
+constexpr auto sr_subject_wire_value = 100;
+constexpr auto sr_registry_wire_value = 101;
+
 using acl_conversion_error = security::acl_conversion_error;
 
 inline security::acl_principal to_acl_principal(const ss::sstring& principal) {
@@ -49,6 +52,18 @@ inline security::resource_type to_resource_type(int8_t type) {
     default:
         throw acl_conversion_error(
           fmt::format("Invalid resource type: {}", type));
+    }
+}
+
+inline security::resource_type to_registry_resource_type(int8_t type) {
+    switch (type) {
+    case sr_subject_wire_value:
+        return security::resource_type::sr_subject;
+    case sr_registry_wire_value:
+        return security::resource_type::sr_registry;
+    default:
+        throw acl_conversion_error(
+          fmt::format("Invalid registry resource type: {}", type));
     }
 }
 
@@ -156,7 +171,9 @@ to_resource_pattern_filter(const describe_acls_request_data& request) {
         // wildcard
         break;
     default:
-        resource_type = to_resource_type(request.resource_type);
+        resource_type = request.describe_registry_acls
+                          ? to_registry_resource_type(request.resource_type)
+                          : to_resource_type(request.resource_type);
     }
 
     std::optional<security::resource_pattern_filter::pattern_filter_type>
@@ -174,7 +191,12 @@ to_resource_pattern_filter(const describe_acls_request_data& request) {
     }
 
     return security::resource_pattern_filter(
-      resource_type, request.resource_name_filter, pattern_filter);
+      resource_type,
+      request.resource_name_filter,
+      pattern_filter,
+      request.describe_registry_acls
+        ? security::resource_pattern_filter::resource_subsystem::schema_registry
+        : security::resource_pattern_filter::resource_subsystem::kafka);
 }
 
 /*
@@ -238,7 +260,20 @@ inline int8_t to_kafka_resource_type(security::resource_type type) {
         vassert(
           false, "Schema Registry resources are not supported in kafka ACLs");
     }
-    __builtin_unreachable();
+}
+
+inline int8_t to_kafka_registry_resource_type(security::resource_type type) {
+    switch (type) {
+    case security::resource_type::sr_subject:
+        return sr_subject_wire_value;
+    case security::resource_type::sr_registry:
+        return sr_registry_wire_value;
+    case security::resource_type::topic:
+    case security::resource_type::group:
+    case security::resource_type::cluster:
+    case security::resource_type::transactional_id:
+        vassert(false, "Request only for Schema Registry resources");
+    }
 }
 
 inline int8_t to_kafka_pattern_type(security::pattern_type type) {

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -934,3 +934,25 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "describe_acls_test",
+    timeout = "short",
+    srcs = [
+        "describe_acls_test.cc",
+    ],
+    env = {"RP_FIXTURE_ENV": "1"},
+    tags = ["exclusive"],
+    deps = [
+        "//src/v/cluster",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:describe_acls",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/security",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/kafka/server/tests/describe_acls_test.cc
+++ b/src/v/kafka/server/tests/describe_acls_test.cc
@@ -1,0 +1,168 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/security_frontend.h"
+#include "kafka/protocol/describe_acls.h"
+#include "redpanda/tests/fixture.h"
+#include "security/acl.h"
+
+using namespace std::chrono_literals;
+
+class describe_acls_fixture : public redpanda_thread_fixture {
+protected:
+    void create_acl(security::acl_binding binding) {
+        app.controller->get_security_frontend()
+          .local()
+          .create_acls({std::move(binding)}, 5s)
+          .get();
+    }
+};
+
+FIXTURE_TEST(describe_acls_any_kafka, describe_acls_fixture) {
+    // This test verifies that when requesting any ACL and
+    // "describe_registry_acls" is false, only receive back Kafka resource ACLs
+    wait_for_controller_leadership().get();
+
+    create_acl(
+      security::acl_binding{
+        security::resource_pattern{
+          security::resource_type::topic,
+          "test-topic",
+          security::pattern_type::literal},
+        security::acl_entry{
+          security::acl_principal{
+            security::principal_type::user, "User:test-user"},
+          security::acl_host::wildcard_host(),
+          security::acl_operation::read,
+          security::acl_permission::allow}});
+
+    create_acl(
+      security::acl_binding{
+        security::resource_pattern{
+          security::resource_type::sr_subject,
+          "test-topic-value",
+          security::pattern_type::literal},
+        security::acl_entry{
+          security::acl_principal{
+            security::principal_type::user, "User:test-user"},
+          security::acl_host::wildcard_host(),
+          security::acl_operation::read,
+          security::acl_permission::allow}});
+
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+    client.connect().get();
+
+    kafka::describe_acls_request req;
+    req.data.describe_registry_acls = false;
+    req.data.resource_type = 1;
+    req.data.resource_pattern_type = 1;
+    req.data.operation = 1;
+    req.data.permission_type = 1;
+
+    auto resp = client.dispatch(std::move(req), kafka::api_version(2)).get();
+    BOOST_REQUIRE(!resp.data.errored());
+    BOOST_REQUIRE_EQUAL(resp.data.error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.resources.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.resources[0].type, 2);
+    BOOST_REQUIRE_EQUAL(resp.data.resources[0].name, "test-topic");
+    BOOST_REQUIRE(!resp.data.resources[0].registry_resource);
+}
+
+FIXTURE_TEST(describe_acls_any_sr, describe_acls_fixture) {
+    // This test verifies that when requesting any ACL and
+    // "describe_registry_acls" is true, only receive back Schema Registry
+    // resource ACLs
+    wait_for_controller_leadership().get();
+
+    create_acl(
+      security::acl_binding{
+        security::resource_pattern{
+          security::resource_type::topic,
+          "test-topic",
+          security::pattern_type::literal},
+        security::acl_entry{
+          security::acl_principal{
+            security::principal_type::user, "User:test-user"},
+          security::acl_host::wildcard_host(),
+          security::acl_operation::read,
+          security::acl_permission::allow}});
+
+    create_acl(
+      security::acl_binding{
+        security::resource_pattern{
+          security::resource_type::sr_subject,
+          "test-topic-value",
+          security::pattern_type::literal},
+        security::acl_entry{
+          security::acl_principal{
+            security::principal_type::user, "User:test-user"},
+          security::acl_host::wildcard_host(),
+          security::acl_operation::read,
+          security::acl_permission::allow}});
+
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+    client.connect().get();
+
+    kafka::describe_acls_request req;
+    req.data.describe_registry_acls = true;
+    req.data.resource_type = 1;
+    req.data.resource_pattern_type = 1;
+    req.data.operation = 1;
+    req.data.permission_type = 1;
+
+    auto resp = client.dispatch(std::move(req), kafka::api_version(2)).get();
+    BOOST_REQUIRE(!resp.data.errored());
+    BOOST_REQUIRE_EQUAL(resp.data.error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.resources.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.resources[0].type, 100); // 100 is SR_SUBJECT
+    BOOST_REQUIRE_EQUAL(resp.data.resources[0].name, "test-topic-value");
+    BOOST_REQUIRE(resp.data.resources[0].registry_resource);
+}
+
+FIXTURE_TEST(describe_acls_invalid_for_kafka, describe_acls_fixture) {
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+    client.connect().get();
+
+    kafka::describe_acls_request req;
+    req.data.describe_registry_acls = false;
+    // Request SR_SUBJECT resource type, which is invalid if
+    // describe_registry_acls is false
+    req.data.resource_type = 100;
+    req.data.resource_pattern_type = 1;
+    req.data.operation = 1;
+    req.data.permission_type = 1;
+
+    auto resp = client.dispatch(std::move(req), kafka::api_version(2)).get();
+    BOOST_REQUIRE(resp.data.errored());
+    BOOST_REQUIRE_EQUAL(
+      resp.data.error_code, kafka::error_code::invalid_request);
+}
+
+FIXTURE_TEST(describe_acls_invalid_for_sr, describe_acls_fixture) {
+    auto client = make_kafka_client().get();
+    auto deferred_close = ss::defer([&client] { client.stop().get(); });
+    client.connect().get();
+
+    kafka::describe_acls_request req;
+    req.data.describe_registry_acls = true;
+    // Request TOPIC resource type, which is invalid if describe_registry_acls
+    // is true
+    req.data.resource_type = 2;
+    req.data.resource_pattern_type = 1;
+    req.data.operation = 1;
+    req.data.permission_type = 1;
+
+    auto resp = client.dispatch(std::move(req), kafka::api_version(2)).get();
+    BOOST_REQUIRE(resp.data.errored());
+    BOOST_REQUIRE_EQUAL(
+      resp.data.error_code, kafka::error_code::invalid_request);
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds support for describe SR resource based ACLs via the DescribeACLs API.  This adds a new tagged field to the `describe_acls_request` and `describe_acls_response` messages that is used to indicate whether or not the request is for describing SR ACLs or Kafka ACLs.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
