### PR TITLE
`rptest`: assert `!_stopped` in `KgoVerifierServices::wait()` implementations 

### DIFF
--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -7,17 +7,19 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from typing import Any
+
 import random
 import threading
 from enum import Enum
-from typing import Any, Callable
+from typing import Callable
 
 from ducktape.tests.test import TestContext
 from ducktape.mark import matrix
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
 
 from rptest.clients.types import TopicSpec
-from rptest.services.admin import Admin
-from rptest.services.cluster import cluster
 from rptest.services.direct_consumer_verifier import (
     AssignPartitionsRequest,
     BrokerAddress,
@@ -35,9 +37,6 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_with_progress_check
 from rptest.utils.node_operations import (
     FailureInjectorBackgroundThread,
-    NodeOpsExecutor,
-    generate_random_workload,
-    verify_offset_translator_state_consistent,
 )
 
 
@@ -216,7 +215,7 @@ class DirectConsumerVerifierTest(RedpandaTest):
                 timeout_sec=600,
                 progress_sec=10,
                 backoff_sec=2,
-                err_msg=f"Stopped consuming",
+                err_msg="Stopped consuming",
                 logger=self.logger,
             )
 
@@ -237,6 +236,6 @@ class DirectConsumerVerifierTest(RedpandaTest):
 
         finally:
             troublemaker.stop()
-            producer.stop()
             verifier.stop()
             producer.wait(timeout_sec=600)
+            producer.stop()

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -413,7 +413,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 backoff_sec=5,
                 err_msg="Waiting for elections to complete after restart",
             )
-            self.logger.info(f"Post-restart elections done.")
+            self.logger.info("Post-restart elections done.")
 
             inter_restart_check()
 
@@ -484,7 +484,6 @@ class ManyPartitionsTest(PreallocNodesTest):
                 )
             finally:
                 producer.stop()
-                producer.wait(timeout_sec=expect_runtime)
                 self.free_preallocated_nodes()
         finally:
             self.logger.info(
@@ -629,7 +628,6 @@ class ManyPartitionsTest(PreallocNodesTest):
         rand_consumer.wait()
 
         fast_producer.stop()
-        fast_producer.wait()
         self.logger.info("Write+randread stress test complete, verifying sequentially")
 
         max_msgs = None
@@ -943,14 +941,14 @@ class ManyPartitionsTest(PreallocNodesTest):
                 tn, partitions=n_partitions, replicas=replication_factor, config=config
             )
 
-        self.logger.info(f"Awaiting elections...")
+        self.logger.info("Awaiting elections...")
         wait_until(
             lambda: self._all_elections_done(topic_names, n_partitions),
             timeout_sec=60,
             backoff_sec=5,
             err_msg="Waiting for initial elections",
         )
-        self.logger.info(f"Initial elections done.")
+        self.logger.info("Initial elections done.")
 
         for node_name, file_count in self._get_fd_counts():
             self.logger.info(
@@ -1008,7 +1006,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # Explicit wait for consumer group, because we might have e.g.
                 # just restarted the cluster, and don't want to include that
                 # delay in our throughput-driven timeout expectations
-                self.logger.info(f"Checking repeater group is ready...")
+                self.logger.info("Checking repeater group is ready...")
                 repeater.await_group_ready()
 
                 t = repeater_await_bytes / scale.expect_bandwidth
@@ -1017,7 +1015,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 )
                 t1 = time.time()
                 repeater.await_progress(
-                    repeater_await_msgs, t, err_msg=f"Waiting for repeater messages"
+                    repeater_await_msgs, t, err_msg="Waiting for repeater messages"
                 )
                 t2 = time.time()
 
@@ -1029,18 +1027,18 @@ class ManyPartitionsTest(PreallocNodesTest):
 
             progress_check()
 
-            self.logger.info(f"Entering single node restart phase")
+            self.logger.info("Entering single node restart phase")
             self._single_node_restart(scale, topic_names, n_partitions)
             progress_check()
 
-            self.logger.info(f"Entering restart stress test phase")
+            self.logger.info("Entering restart stress test phase")
             self._restart_stress(scale, topic_names, n_partitions, progress_check)
 
-            self.logger.info(f"Post-restarts: checking repeater group is ready...")
+            self.logger.info("Post-restarts: checking repeater group is ready...")
             repeater.await_group_ready()
 
             # Done with restarts, now do a longer traffic soak
-            self.logger.info(f"Entering traffic soak phase")
+            self.logger.info("Entering traffic soak phase")
 
             # soak for two minutes
             soak_time_seconds = 120

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -279,13 +279,9 @@ class KgoVerifierService(Service):
         Wrapper to catch timeouts on wait, and send a `/print_stack` to the remote
         process in case it is experiencing a hang bug.
         """
-
-        if self._stopped:
-            raise RuntimeError(
-                f"Can't wait {self.who_am_i()}. It was already stopped."
-                f" You can either stop() a service or wait() and then stop() it"
-                f" but not the other way around."
-            )
+        assert not self._stopped, (
+            f"Can't wait {self.who_am_i()}. It was already stopped. You can either stop() a service or wait() and then stop() it but not the other way around."
+        )
 
         try:
             return self._do_wait_node(node, timeout_sec)
@@ -675,6 +671,10 @@ class KgoVerifierProducer(KgoVerifierService):
         return self._status
 
     def wait_node(self, node, timeout_sec: int | None):
+        assert not self._stopped, (
+            f"Can't wait {self.who_am_i()}. It was already stopped. You can either stop() a service or wait() and then stop() it but not the other way around."
+        )
+
         if not self._status_thread:
             return True
 
@@ -771,7 +771,7 @@ class KgoVerifierProducer(KgoVerifierService):
             cmd = cmd + f" --password {self._password}"
 
         if self._enable_tls:
-            cmd = cmd + f" --enable-tls"
+            cmd = cmd + " --enable-tls"
 
         if self._batch_max_bytes is not None:
             cmd = cmd + f" --batch_max_bytes {self._batch_max_bytes}"
@@ -783,7 +783,7 @@ class KgoVerifierProducer(KgoVerifierService):
             cmd = cmd + f" --fake-timestamp-step-ms {self._fake_timestamp_step_ms}"
 
         if self._use_transactions:
-            cmd = cmd + f" --use-transactions"
+            cmd = cmd + " --use-transactions"
 
             if self._msgs_per_transaction is not None:
                 cmd = cmd + f" --msgs-per-transaction {self._msgs_per_transaction}"
@@ -898,7 +898,7 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
         if self._password is not None:
             cmd = cmd + f" --password {self._password}"
         if self._enable_tls:
-            cmd = cmd + f" --enable-tls"
+            cmd = cmd + " --enable-tls"
         if self._max_msgs is not None:
             cmd += f" --seq_read_msgs {self._max_msgs}"
         if self._max_throughput_mb is not None:
@@ -920,6 +920,10 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
         self._status_thread.start()
 
     def wait_node(self, node, timeout_sec=None):
+        assert not self._stopped, (
+            f"Can't wait {self.who_am_i()}. It was already stopped. You can either stop() a service or wait() and then stop() it but not the other way around."
+        )
+
         if self._producer:
             producer: KgoVerifierProducer = self._producer
 
@@ -993,7 +997,7 @@ class KgoVerifierRandomConsumer(AbstractConsumer):
         if self._password is not None:
             cmd = cmd + f" --password {self._password}"
         if self._enable_tls:
-            cmd = cmd + f" --enable-tls"
+            cmd = cmd + " --enable-tls"
         if self._use_transactions:
             cmd += " --use-transactions"
 
@@ -1069,7 +1073,7 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
         if self._password is not None:
             cmd = cmd + f" --password {self._password}"
         if self._enable_tls:
-            cmd = cmd + f" --enable-tls"
+            cmd = cmd + " --enable-tls"
         if self._loop:
             cmd += " --loop"
         if self._max_msgs is not None:

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -129,19 +129,20 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
             msg_count=msg_count,
             custom_node=self.preallocated_nodes,
         )
-        producer.start()
-        produce_until_segments(
-            redpanda=self.redpanda,
-            topic=self.topic,
-            partition_idx=0,
-            count=n_segments,
-        )
+        try:
+            producer.start()
+            produce_until_segments(
+                redpanda=self.redpanda,
+                topic=self.topic,
+                partition_idx=0,
+                count=n_segments,
+            )
+        finally:
+            producer.stop()
+
         snapshot = self.redpanda.storage(all_nodes=True).segments_by_node(
             "kafka", self.topic, 0
         )
-
-        producer.stop()
-        producer.wait()
 
         wait_until(
             lambda: nodes_report_cloud_segments(
@@ -167,8 +168,6 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
             n=n_remove,
             original_snapshot=snapshot,
         )
-
-        return producer
 
     def _remove_indices_from_cloud(self):
         for obj in self.cloud_storage_client.list_objects(

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1109,18 +1109,20 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
             )
         finally:
             producer.stop()
-            producer.wait()
 
-        seq_consumer = KgoVerifierSeqConsumer(
-            self.test_context,
-            self.redpanda,
-            self.topic,
-            0,
-            nodes=self.preallocated_nodes,
-        )
-        seq_consumer.start(clean=False)
-        seq_consumer.wait()
-        self.redpanda.stop_node(self.redpanda.nodes[0])
+        try:
+            seq_consumer = KgoVerifierSeqConsumer(
+                self.test_context,
+                self.redpanda,
+                self.topic,
+                0,
+                nodes=self.preallocated_nodes,
+            )
+            seq_consumer.start(clean=False)
+            seq_consumer.wait()
+            self.redpanda.stop_node(self.redpanda.nodes[0])
+        finally:
+            seq_consumer.stop()
 
     @skip_debug_mode
     @cluster(num_nodes=2)
@@ -1147,7 +1149,6 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
             )
         finally:
             producer.stop()
-            producer.wait()
 
         node = self.redpanda.nodes[0]
         self.redpanda.stop()
@@ -1718,7 +1719,6 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
                 )
             finally:
                 producer.stop()
-                producer.wait()
 
         self.logger.debug(
             "Now check that the things return to normal after traffic shaping is switched off"
@@ -1732,7 +1732,6 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
             )
         finally:
             producer.stop()
-            producer.wait()
 
         node = self.redpanda.nodes[0]
         self.redpanda.stop()

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -505,7 +505,6 @@ class NodesDecommissioningTest(PreallocNodesTest):
             f"decommissioning node: {to_decommission_id}",
         )
         self._decommission(to_decommission_id)
-        self.producer.wait()
 
         def learner_gap_reported(decommissioned_node_id: int):
             total_gap = calculate_total_learners_gap()

--- a/tests/rptest/tests/workload_producer_consumer.py
+++ b/tests/rptest/tests/workload_producer_consumer.py
@@ -83,9 +83,10 @@ class ProducerConsumerWorkload(PWorkload):
         self._seq_consumer.start(clean=False)
 
     def end(self):
-        self._producer.stop()
         self._producer.wait()
+        self._producer.stop()
         self._seq_consumer.wait()
+        self._seq_consumer.stop()
         wrote_at_least = self._producer.produce_status.acked
         assert (
             self._seq_consumer.consumer_status.validator.valid_reads >= wrote_at_least


### PR DESCRIPTION
`KgoVerifierService` objects should be waited upon and then stopped, not the other way around.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
