### PR TITLE
ct/l1: add term queries to metastore

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -306,4 +306,61 @@ domain_manager::get_compaction_offsets(
     };
 }
 
+ss::future<rpc::get_term_for_offset_reply>
+domain_manager::get_term_for_offset(rpc::get_term_for_offset_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_term_for_offset_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_term_for_offset_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    auto get_res = simple_metastore::get_term_for_offset(
+      stm_state, req.tp, req.offset);
+    if (!get_res.has_value()) {
+        co_return rpc::get_term_for_offset_reply{
+          .ec = convert_metastore_errc(get_res.error()),
+        };
+    }
+    co_return rpc::get_term_for_offset_reply{
+      .ec = rpc::errc::ok,
+      .term = get_res.value(),
+    };
+}
+
+ss::future<rpc::get_end_offset_for_term_reply>
+domain_manager::get_end_offset_for_term(
+  rpc::get_end_offset_for_term_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::get_end_offset_for_term_reply{
+          .ec = rpc::errc::not_leader,
+        };
+    }
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::get_end_offset_for_term_reply{
+          .ec = convert_stm_errc(sync_res.error()),
+        };
+    }
+    auto& stm_state = stm_->state();
+    auto get_res = simple_metastore::get_end_offset_for_term(
+      stm_state, req.tp, req.term);
+    if (!get_res.has_value()) {
+        co_return rpc::get_end_offset_for_term_reply{
+          .ec = convert_metastore_errc(get_res.error()),
+        };
+    }
+    co_return rpc::get_end_offset_for_term_reply{
+      .ec = rpc::errc::ok,
+      .end_offset = get_res.value(),
+    };
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -45,6 +45,12 @@ public:
     ss::future<rpc::get_compaction_offsets_reply>
       get_compaction_offsets(rpc::get_compaction_offsets_request);
 
+    ss::future<rpc::get_term_for_offset_reply>
+      get_term_for_offset(rpc::get_term_for_offset_request);
+
+    ss::future<rpc::get_end_offset_for_term_reply>
+      get_end_offset_for_term(rpc::get_end_offset_for_term_request);
+
 private:
     std::optional<ss::gate::holder> maybe_gate();
 

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -92,6 +92,29 @@ ss::future<rpc::get_compaction_offsets_reply> do_get_compaction_offsets(
     co_return co_await domain_mgr->get_compaction_offsets(std::move(req));
 }
 
+ss::future<rpc::get_term_for_offset_reply> do_get_term_for_offset(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_term_for_offset_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_term_for_offset_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_term_for_offset(std::move(req));
+}
+
+ss::future<rpc::get_end_offset_for_term_reply> do_get_end_offset_for_term(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::get_end_offset_for_term_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::get_end_offset_for_term_reply{
+          .ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->get_end_offset_for_term(std::move(req));
+}
+
 } // namespace
 
 template<auto Func, typename req_t>
@@ -213,6 +236,22 @@ template ss::future<rpc::get_compaction_offsets_reply> frontend::process<
   &frontend::get_compaction_offsets_locally,
   &frontend::client::get_compaction_offsets>(
   rpc::get_compaction_offsets_request, bool);
+
+template ss::future<rpc::get_term_for_offset_reply>
+  frontend::remote_dispatch<&frontend::client::get_term_for_offset>(
+    rpc::get_term_for_offset_request, model::node_id);
+template ss::future<rpc::get_term_for_offset_reply> frontend::process<
+  &frontend::get_term_for_offset_locally,
+  &frontend::client::get_term_for_offset>(
+  rpc::get_term_for_offset_request, bool);
+
+template ss::future<rpc::get_end_offset_for_term_reply>
+  frontend::remote_dispatch<&frontend::client::get_end_offset_for_term>(
+    rpc::get_end_offset_for_term_request, model::node_id);
+template ss::future<rpc::get_end_offset_for_term_reply> frontend::process<
+  &frontend::get_end_offset_for_term_locally,
+  &frontend::client::get_end_offset_for_term>(
+  rpc::get_end_offset_for_term_request, bool);
 
 frontend::frontend(
   model::node_id self,
@@ -365,6 +404,48 @@ ss::future<rpc::get_compaction_offsets_reply> frontend::get_compaction_offsets(
     co_return co_await process<
       &frontend::get_compaction_offsets_locally,
       &client::get_compaction_offsets>(
+      std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::get_term_for_offset_reply>
+frontend::get_term_for_offset_locally(
+  rpc::get_term_for_offset_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_get_term_for_offset(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::get_term_for_offset_reply> frontend::get_term_for_offset(
+  rpc::get_term_for_offset_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &frontend::get_term_for_offset_locally,
+      &client::get_term_for_offset>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::get_end_offset_for_term_reply>
+frontend::get_end_offset_for_term_locally(
+  rpc::get_end_offset_for_term_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_get_end_offset_for_term(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::get_end_offset_for_term_reply>
+frontend::get_end_offset_for_term(
+  rpc::get_end_offset_for_term_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &frontend::get_end_offset_for_term_locally,
+      &client::get_end_offset_for_term>(
       std::move(request), bool(local_only_exec));
 }
 

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -73,6 +73,12 @@ public:
     ss::future<rpc::get_compaction_offsets_reply> get_compaction_offsets(
       rpc::get_compaction_offsets_request, local_only = local_only::no);
 
+    ss::future<rpc::get_term_for_offset_reply> get_term_for_offset(
+      rpc::get_term_for_offset_request, local_only = local_only::no);
+
+    ss::future<rpc::get_end_offset_for_term_reply> get_end_offset_for_term(
+      rpc::get_end_offset_for_term_request, local_only = local_only::no);
+
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
@@ -127,6 +133,17 @@ private:
     ss::future<rpc::get_compaction_offsets_reply>
     get_compaction_offsets_locally(
       rpc::get_compaction_offsets_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::get_term_for_offset_reply> get_term_for_offset_locally(
+      rpc::get_term_for_offset_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::get_end_offset_for_term_reply>
+    get_end_offset_for_term_locally(
+      rpc::get_end_offset_for_term_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -174,6 +174,12 @@ public:
     virtual ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, model::timestamp) = 0;
 
+    // Returns the end (i.e. one past the last) offset at which data was added
+    // for the given partition term.
+    virtual ss::future<std::expected<kafka::offset, errc>>
+    get_end_offset_for_term(const model::topic_id_partition&, model::term_id)
+      = 0;
+
     // Compaction metadata updates per partition
     //
     // Kafka compaction works by taking "dirty" ranges of data, collecting the

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -180,6 +180,10 @@ public:
     get_end_offset_for_term(const model::topic_id_partition&, model::term_id)
       = 0;
 
+    // Returns the partition term in which the given offset was added.
+    virtual ss::future<std::expected<model::term_id, errc>>
+    get_term_for_offset(const model::topic_id_partition&, kafka::offset) = 0;
+
     // Compaction metadata updates per partition
     //
     // Kafka compaction works by taking "dirty" ranges of data, collecting the

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -395,14 +395,46 @@ replicated_metastore::get_first_ge(
 
 ss::future<std::expected<model::term_id, metastore::errc>>
 replicated_metastore::get_term_for_offset(
-  const model::topic_id_partition&, kafka::offset) {
-    co_return model::term_id{};
+  const model::topic_id_partition& tidp, kafka::offset offset) {
+    rpc::get_term_for_offset_request req;
+    req.tp = tidp;
+    req.offset = offset;
+
+    auto reply_fut = co_await ss::coroutine::as_future(
+      fe_.get_term_for_offset(std::move(req)));
+    if (reply_fut.failed()) {
+        auto ex = reply_fut.get_exception();
+        vlog(cd_log.warn, "Error while sending request: {}", ex);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+    auto reply = reply_fut.get();
+    if (reply.ec != rpc::errc::ok) {
+        co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+    }
+
+    co_return reply.term;
 }
 
 ss::future<std::expected<kafka::offset, metastore::errc>>
 replicated_metastore::get_end_offset_for_term(
-  const model::topic_id_partition&, model::term_id) {
-    co_return kafka::offset{};
+  const model::topic_id_partition& tidp, model::term_id term) {
+    rpc::get_end_offset_for_term_request req;
+    req.tp = tidp;
+    req.term = term;
+
+    auto reply_fut = co_await ss::coroutine::as_future(
+      fe_.get_end_offset_for_term(std::move(req)));
+    if (reply_fut.failed()) {
+        auto ex = reply_fut.get_exception();
+        vlog(cd_log.warn, "Error while sending request: {}", ex);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+    auto reply = reply_fut.get();
+    if (reply.ec != rpc::errc::ok) {
+        co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+    }
+
+    co_return reply.end_offset;
 }
 
 ss::future<std::expected<void, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -393,6 +393,12 @@ replicated_metastore::get_first_ge(
     co_return resp;
 }
 
+ss::future<std::expected<kafka::offset, metastore::errc>>
+replicated_metastore::get_end_offset_for_term(
+  const model::topic_id_partition&, model::term_id) {
+    co_return kafka::offset{};
+}
+
 ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::compact_objects(
   std::unique_ptr<metastore::object_metadata_builder> builder,

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -393,6 +393,12 @@ replicated_metastore::get_first_ge(
     co_return resp;
 }
 
+ss::future<std::expected<model::term_id, metastore::errc>>
+replicated_metastore::get_term_for_offset(
+  const model::topic_id_partition&, kafka::offset) {
+    co_return model::term_id{};
+}
+
 ss::future<std::expected<kafka::offset, metastore::errc>>
 replicated_metastore::get_end_offset_for_term(
   const model::topic_id_partition&, model::term_id) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -40,6 +40,9 @@ public:
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, model::timestamp) override;
 
+    ss::future<std::expected<kafka::offset, errc>> get_end_offset_for_term(
+      const model::topic_id_partition&, model::term_id) override;
+
     ss::future<std::expected<void, errc>> compact_objects(
       std::unique_ptr<object_metadata_builder>,
       const compaction_map_t&) override;

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -43,6 +43,9 @@ public:
     ss::future<std::expected<kafka::offset, errc>> get_end_offset_for_term(
       const model::topic_id_partition&, model::term_id) override;
 
+    ss::future<std::expected<model::term_id, errc>> get_term_for_offset(
+      const model::topic_id_partition&, kafka::offset) override;
+
     ss::future<std::expected<void, errc>> compact_objects(
       std::unique_ptr<object_metadata_builder>,
       const compaction_map_t&) override;

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -31,6 +31,16 @@
             "output_type": "get_offsets_reply"
         },
         {
+            "name": "get_term_for_offset",
+            "input_type": "get_term_for_offset_request",
+            "output_type": "get_term_for_offset_reply"
+        },
+        {
+            "name": "get_end_offset_for_term",
+            "input_type": "get_end_offset_for_term_request",
+            "output_type": "get_end_offset_for_term_reply"
+        },
+        {
             "name": "get_compaction_offsets",
             "input_type": "get_compaction_offsets_request",
             "output_type": "get_compaction_offsets_reply"

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -187,6 +187,50 @@ struct get_compaction_offsets_request
     model::timestamp tombstone_removal_upper_bound_ts;
 };
 
+struct get_term_for_offset_reply
+  : serde::envelope<
+      get_term_for_offset_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, term); }
+
+    errc ec;
+    model::term_id term;
+};
+struct get_term_for_offset_request
+  : serde::envelope<
+      get_term_for_offset_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = get_term_for_offset_reply;
+    auto serde_fields() { return std::tie(tp, offset); }
+
+    model::topic_id_partition tp;
+    kafka::offset offset;
+};
+
+struct get_end_offset_for_term_reply
+  : serde::envelope<
+      get_end_offset_for_term_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, end_offset); }
+
+    errc ec;
+    kafka::offset end_offset;
+};
+struct get_end_offset_for_term_request
+  : serde::envelope<
+      get_end_offset_for_term_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = get_end_offset_for_term_reply;
+    auto serde_fields() { return std::tie(tp, term); }
+
+    model::topic_id_partition tp;
+    model::term_id term;
+};
+
 } //  namespace cloud_topics::l1::rpc
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -51,6 +51,18 @@ service::get_offsets(get_offsets_request request, ::rpc::streaming_context&) {
       std::move(request), frontend::local_only::yes);
 }
 
+ss::future<get_end_offset_for_term_reply> service::get_end_offset_for_term(
+  get_end_offset_for_term_request request, ::rpc::streaming_context&) {
+    return _frontend->local().get_end_offset_for_term(
+      std::move(request), frontend::local_only::yes);
+}
+
+ss::future<get_term_for_offset_reply> service::get_term_for_offset(
+  get_term_for_offset_request request, ::rpc::streaming_context&) {
+    return _frontend->local().get_term_for_offset(
+      std::move(request), frontend::local_only::yes);
+}
+
 ss::future<get_compaction_offsets_reply> service::get_compaction_offsets(
   get_compaction_offsets_request request, ::rpc::streaming_context&) {
     return _frontend->local().get_compaction_offsets(

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -41,6 +41,12 @@ public:
     ss::future<get_offsets_reply>
     get_offsets(get_offsets_request, ::rpc::streaming_context&) override;
 
+    ss::future<get_end_offset_for_term_reply> get_end_offset_for_term(
+      get_end_offset_for_term_request, ::rpc::streaming_context&) override;
+
+    ss::future<get_term_for_offset_reply> get_term_for_offset(
+      get_term_for_offset_request, ::rpc::streaming_context&) override;
+
     ss::future<get_compaction_offsets_reply> get_compaction_offsets(
       get_compaction_offsets_request, ::rpc::streaming_context&) override;
 

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -264,6 +264,52 @@ simple_metastore::get_first_ge(
     return std::unexpected(metastore::errc::out_of_range);
 }
 
+ss::future<std::expected<kafka::offset, metastore::errc>>
+simple_metastore::get_end_offset_for_term(
+  const model::topic_id_partition& tp, model::term_id requested_term) {
+    co_return get_end_offset_for_term(state_, tp, requested_term);
+}
+std::expected<kafka::offset, metastore::errc>
+simple_metastore::get_end_offset_for_term(
+  const state& state,
+  const model::topic_id_partition& tp,
+  model::term_id requested_term) {
+    auto prt_ref = state.partition_state(tp);
+    if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
+        return std::unexpected(metastore::errc::missing_ntp);
+    }
+    auto& prt = prt_ref->get();
+    if (prt.term_starts.empty()) {
+        return std::unexpected(metastore::errc::missing_ntp);
+    }
+
+    auto first_ge_it = std::ranges::lower_bound(
+      prt.term_starts, requested_term, std::less<>{}, &term_start::term_id);
+    if (first_ge_it == prt.term_starts.end()) {
+        // All terms are below `requested_term`.
+        return std::unexpected(metastore::errc::out_of_range);
+    }
+    if (first_ge_it->term_id > requested_term) {
+        // If we've already found a higher term, return its start; that marks
+        // the end (last + 1) of the requested term.
+        return first_ge_it->start_offset;
+    }
+    vassert(
+      first_ge_it->term_id == requested_term,
+      "lower_bound() return val not >= {}: {}",
+      requested_term,
+      first_ge_it->term_id);
+    auto next_higher = std::next(first_ge_it);
+    if (next_higher == prt.term_starts.end()) {
+        // The requested term is the last term in L1. The end offset (last + 1)
+        // is equivalent to the next offset of L1.
+        return prt.next_offset;
+    }
+    // The term's end offset is equivalent to the start of the next term.
+    return next_higher->start_offset;
+}
+
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::compact_objects(
   const chunked_vector<object_metadata>& objects,

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -310,6 +310,44 @@ simple_metastore::get_end_offset_for_term(
     return next_higher->start_offset;
 }
 
+ss::future<std::expected<model::term_id, metastore::errc>>
+simple_metastore::get_term_for_offset(
+  const model::topic_id_partition& tp, kafka::offset requested_o) {
+    co_return get_term_for_offset(state_, tp, requested_o);
+}
+
+std::expected<model::term_id, metastore::errc>
+simple_metastore::get_term_for_offset(
+  const state& state,
+  const model::topic_id_partition& tp,
+  kafka::offset requested_o) {
+    auto prt_ref = state.partition_state(tp);
+    if (!prt_ref.has_value()) {
+        vlog(cd_log.debug, "Partition {} not tracked", tp);
+        return std::unexpected(metastore::errc::missing_ntp);
+    }
+    auto& prt = prt_ref->get();
+    if (prt.term_starts.empty()) {
+        return std::unexpected(metastore::errc::missing_ntp);
+    }
+    // Past the next offset return OOR, but return a valid term for the exact
+    // next offset, which may be the HWM.
+    if (requested_o > prt.next_offset) {
+        return std::unexpected(metastore::errc::out_of_range);
+    }
+
+    // Find the first > the requested, aka first >= the next.
+    auto next_o = kafka::next_offset(requested_o);
+    auto first_gt_it = std::ranges::lower_bound(
+      prt.term_starts, next_o, std::less<>{}, &term_start::start_offset);
+    if (first_gt_it == prt.term_starts.begin()) {
+        // All term starts are above `requested_o`.
+        return std::unexpected(metastore::errc::out_of_range);
+    }
+    auto last_le_it = std::prev(first_gt_it);
+    return last_le_it->term_id;
+}
+
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::compact_objects(
   const chunked_vector<object_metadata>& objects,

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -70,6 +70,9 @@ public:
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, model::timestamp) override;
 
+    ss::future<std::expected<kafka::offset, errc>> get_end_offset_for_term(
+      const model::topic_id_partition&, model::term_id) override;
+
     ss::future<std::expected<void, errc>> compact_objects(
       std::unique_ptr<object_metadata_builder>,
       const compaction_map_t&) override;
@@ -91,6 +94,8 @@ private:
     static std::expected<compaction_offsets_response, errc>
     get_compaction_offsets(
       const state&, const model::topic_id_partition&, model::timestamp);
+    static std::expected<kafka::offset, errc> get_end_offset_for_term(
+      const state&, const model::topic_id_partition&, model::term_id);
 
     state state_;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -73,6 +73,9 @@ public:
     ss::future<std::expected<kafka::offset, errc>> get_end_offset_for_term(
       const model::topic_id_partition&, model::term_id) override;
 
+    ss::future<std::expected<model::term_id, errc>> get_term_for_offset(
+      const model::topic_id_partition&, kafka::offset) override;
+
     ss::future<std::expected<void, errc>> compact_objects(
       std::unique_ptr<object_metadata_builder>,
       const compaction_map_t&) override;
@@ -96,6 +99,8 @@ private:
       const state&, const model::topic_id_partition&, model::timestamp);
     static std::expected<kafka::offset, errc> get_end_offset_for_term(
       const state&, const model::topic_id_partition&, model::term_id);
+    static std::expected<model::term_id, errc> get_term_for_offset(
+      const state&, const model::topic_id_partition&, kafka::offset);
 
     state state_;
 };

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -396,3 +396,119 @@ TEST_F(ReplicatedMetastoreTest, TestInvalidTermRequest) {
     ASSERT_FALSE(add_res.has_value());
     ASSERT_EQ(add_res.error(), metastore::errc::invalid_request);
 }
+
+TEST_F(ReplicatedMetastoreTest, TestGetTermForOffset) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+
+    auto tp = make_tp(0);
+
+    auto obj_builder = meta.object_builder();
+    auto oid1 = obj_builder->get_or_create_object_for(tp);
+    auto add_res1 = obj_builder->add(
+      oid1,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp,
+        .base_offset = o{0},
+        .last_offset = o{199},
+        .max_timestamp = ts{10000},
+        .pos = 0,
+        .size = 500,
+      });
+    ASSERT_TRUE(add_res1.has_value()) << add_res1.error();
+    auto fin_res1 = obj_builder->finish(oid1, 500);
+    ASSERT_TRUE(fin_res1.has_value()) << fin_res1.error();
+
+    // Add a couple terms.
+    metastore::term_offset_map_t terms;
+    terms[tp].emplace_back(
+      metastore::term_offset{.term = model::term_id{1}, .first_offset = o{0}});
+    terms[tp].emplace_back(
+      metastore::term_offset{
+        .term = model::term_id{2}, .first_offset = o{100}});
+
+    auto add_res = meta.add_objects(std::move(obj_builder), terms).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    const auto assert_term_eq = [&](kafka::offset o, model::term_id t) {
+        auto term_res = meta.get_term_for_offset(tp, o).get();
+        ASSERT_TRUE(term_res.has_value());
+        ASSERT_EQ(term_res.value(), t);
+    };
+
+    assert_term_eq(o{0}, model::term_id{1});
+    assert_term_eq(o{50}, model::term_id{1});
+    assert_term_eq(o{100}, model::term_id{2});
+    assert_term_eq(o{150}, model::term_id{2});
+    assert_term_eq(o{199}, model::term_id{2});
+    assert_term_eq(o{200}, model::term_id{2});
+
+    // Test offset out of range
+    auto term_res_oor = meta.get_term_for_offset(tp, o{201}).get();
+    ASSERT_FALSE(term_res_oor.has_value());
+    ASSERT_EQ(term_res_oor.error(), metastore::errc::out_of_range);
+
+    // Test missing ntp
+    auto missing_tp = make_tp(999);
+    auto term_missing = meta.get_term_for_offset(missing_tp, o{0}).get();
+    ASSERT_FALSE(term_missing.has_value());
+    ASSERT_EQ(term_missing.error(), metastore::errc::missing_ntp);
+}
+
+TEST_F(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+
+    auto tp = make_tp(0);
+
+    // Set up initial objects with multiple terms
+    auto obj_builder = meta.object_builder();
+    auto oid1 = obj_builder->get_or_create_object_for(tp);
+    auto add_res1 = obj_builder->add(
+      oid1,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp,
+        .base_offset = o{0},
+        .last_offset = o{199},
+        .max_timestamp = ts{10000},
+        .pos = 0,
+        .size = 500,
+      });
+    ASSERT_TRUE(add_res1.has_value()) << add_res1.error();
+    auto fin_res1 = obj_builder->finish(oid1, 500);
+    ASSERT_TRUE(fin_res1.has_value()) << fin_res1.error();
+
+    // Add a couple terms.
+    metastore::term_offset_map_t terms;
+    terms[tp].emplace_back(
+      metastore::term_offset{.term = model::term_id{1}, .first_offset = o{0}});
+    terms[tp].emplace_back(
+      metastore::term_offset{
+        .term = model::term_id{2}, .first_offset = o{100}});
+
+    auto add_res = meta.add_objects(std::move(obj_builder), terms).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    auto assert_end_offset_eq = [&](
+                                  model::term_id t, kafka::offset expected_o) {
+        auto end_res = meta.get_end_offset_for_term(tp, t).get();
+        ASSERT_TRUE(end_res.has_value());
+        ASSERT_EQ(expected_o, end_res.value());
+    };
+    assert_end_offset_eq(model::term_id{0}, o{0});
+    assert_end_offset_eq(model::term_id{1}, o{100});
+    assert_end_offset_eq(model::term_id{2}, o{200});
+
+    // Test non-existent term
+    auto end_res_fail
+      = meta.get_end_offset_for_term(tp, model::term_id{3}).get();
+    ASSERT_FALSE(end_res_fail.has_value());
+    ASSERT_EQ(end_res_fail.error(), metastore::errc::out_of_range);
+
+    // Test missing ntp
+    auto missing_tp = make_tp(999);
+    auto end_missing
+      = meta.get_end_offset_for_term(missing_tp, model::term_id{1}).get();
+    ASSERT_FALSE(end_missing.has_value());
+    ASSERT_EQ(end_missing.error(), metastore::errc::missing_ntp);
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1109,3 +1109,58 @@ TEST(SimpleMetastoreState, TestInvalidTermRequest) {
     ASSERT_FALSE(add_res.has_value());
     ASSERT_EQ(add_res.error(), metastore::errc::invalid_request);
 }
+
+TEST(SimpleMetastoreTest, TestEndOffsetForEpoch) {
+    simple_metastore m;
+    auto ometa
+      = om_builder(oid1, 200).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder()
+                        .add(tid_a, 1_tm, 0_o)
+                        .add(tid_a, 2_tm, 5_o)
+                        .add(tid_a, 5_tm, 10_o)
+                        .add(tid_a, 6_tm, 15_o)
+                        .add(tid_a, 7_tm, 20_o)
+                        .build())
+                     .get();
+    ASSERT_TRUE(add_res.has_value());
+    ASSERT_EQ(0, add_res->corrected_next_offsets.size());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+    const auto assert_end_term_eq = [&](model::term_id t, kafka::offset o) {
+        auto res = m.get_end_offset_for_term(tp, t).get();
+        EXPECT_TRUE(res.has_value()) << "term: " << t;
+        EXPECT_EQ(res.value(), o) << "term: " << t;
+    };
+    // Below the earliest term.
+    assert_end_term_eq(0_tm, 0_o);
+
+    // Exact match of term.
+    assert_end_term_eq(1_tm, 5_o);
+    assert_end_term_eq(2_tm, 10_o);
+
+    // Terms that are in between term entries get bumped up to the next highest
+    // end offset.
+    assert_end_term_eq(3_tm, 10_o);
+    assert_end_term_eq(4_tm, 10_o);
+
+    // Exact match of term.
+    assert_end_term_eq(5_tm, 15_o);
+    assert_end_term_eq(6_tm, 20_o);
+
+    // The last term.
+    assert_end_term_eq(7_tm, 21_o);
+
+    // Out of range.
+    auto res = m.get_end_offset_for_term(tp, 8_tm).get();
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(metastore::errc::out_of_range, res.error());
+
+    // Missing NTP.
+    res = m.get_end_offset_for_term(
+             model::topic_id_partition::from(tid_b), 0_tm)
+            .get();
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(metastore::errc::missing_ntp, res.error());
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1164,3 +1164,57 @@ TEST(SimpleMetastoreTest, TestEndOffsetForEpoch) {
     EXPECT_FALSE(res.has_value());
     EXPECT_EQ(metastore::errc::missing_ntp, res.error());
 }
+
+TEST(SimpleMetastoreTest, TestEpochForOffset) {
+    simple_metastore m;
+    auto ometa
+      = om_builder(oid1, 200).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder()
+                        .add(tid_a, 1_tm, 0_o)
+                        .add(tid_a, 2_tm, 3_o)
+                        .add(tid_a, 5_tm, 5_o)
+                        .add(tid_a, 6_tm, 7_o)
+                        .add(tid_a, 7_tm, 9_o)
+                        .build())
+                     .get();
+    ASSERT_TRUE(add_res.has_value());
+    ASSERT_EQ(0, add_res->corrected_next_offsets.size());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+    const auto assert_term_eq = [&](kafka::offset o, model::term_id t) {
+        auto res = m.get_term_for_offset(tp, o).get();
+        EXPECT_TRUE(res.has_value()) << "offset: " << o;
+        EXPECT_EQ(res.value(), t) << "offset: " << o;
+    };
+    assert_term_eq(0_o, 1_tm);
+    assert_term_eq(1_o, 1_tm);
+    assert_term_eq(2_o, 1_tm);
+    assert_term_eq(3_o, 2_tm);
+    assert_term_eq(4_o, 2_tm);
+    assert_term_eq(5_o, 5_tm);
+    assert_term_eq(6_o, 5_tm);
+    assert_term_eq(7_o, 6_tm);
+    assert_term_eq(8_o, 6_tm);
+    assert_term_eq(9_o, 7_tm);
+
+    // At next.
+    assert_term_eq(10_o, 7_tm);
+
+    // Below start.
+    auto res = m.get_term_for_offset(tp, kafka::offset{-1}).get();
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(metastore::errc::out_of_range, res.error());
+
+    // Above next.
+    res = m.get_term_for_offset(tp, 11_o).get();
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(metastore::errc::out_of_range, res.error());
+
+    // Missing NTP.
+    res = m.get_term_for_offset(model::topic_id_partition::from(tid_b), 1_o)
+            .get();
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(metastore::errc::missing_ntp, res.error());
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Uses the newly introduced term state in the metastore from https://github.com/redpanda-data/redpanda/pull/27272 to expose the calls that will be relevant to Kafka API (though s/term/epoch in Kafka land):
- get_end_offset_for_term: returns the end offset (last + 1) in a given term, or the next highest term if the term doesn't exist
- get_term_for_offset: returns the term of a given offset

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
