### PR TITLE
k/write_at_offset_stm: make stm accept vector<record_batch>

### DIFF
--- a/src/v/kafka/server/tests/write_at_offset_stm_test.cc
+++ b/src/v/kafka/server/tests/write_at_offset_stm_test.cc
@@ -13,6 +13,18 @@
 
 #include <gmock/gmock.h>
 
+namespace {
+chunked_vector<model::record_batch>
+copy_batches(const chunked_vector<model::record_batch>& batches) {
+    chunked_vector<model::record_batch> copy;
+    for (auto& batch : batches) {
+        copy.push_back(batch.copy());
+    }
+    return copy;
+};
+
+} // namespace
+
 static ss::logger t_log{"test_log"};
 using namespace testing;
 struct WriteAtOffsetStmFixture
@@ -26,11 +38,24 @@ struct WriteAtOffsetStmFixture
           model::offset_translator_batch_types());
     }
 
-    chunked_vector<model::record_batch> generate_batches(
-      kafka::offset starting_at, size_t batch_count, size_t records_per_batch) {
-        chunked_vector<model::record_batch> batches;
+    chunked_vector<kafka::offset>
+    start_offsets(const chunked_vector<model::record_batch>& batches) {
+        chunked_vector<kafka::offset> offsets;
+        for (const auto& batch : batches) {
+            offsets.push_back(kafka::offset{batch.base_offset()()});
+        }
+        return offsets;
+    }
 
+    chunked_vector<chunked_vector<model::record_batch>> generate_data(
+      kafka::offset starting_at, size_t batch_count, size_t records_per_batch) {
+        chunked_vector<chunked_vector<model::record_batch>> batches;
+
+        // randomly split batches into multiple batch groups
         for (auto _ : boost::irange(batch_count)) {
+            if (batches.empty() || tests::random_bool()) {
+                batches.emplace_back();
+            }
             storage::record_batch_builder builder(
               model::record_batch_type::raft_data, model::offset(starting_at));
 
@@ -40,7 +65,7 @@ struct WriteAtOffsetStmFixture
                   serde::to_iobuf(starting_at()));
                 starting_at++;
             }
-            batches.push_back(std::move(builder).build());
+            batches.back().push_back(std::move(builder).build());
         }
         return batches;
     }
@@ -105,22 +130,33 @@ struct WriteAtOffsetStmFixture
         return count;
     }
 
-    chunked_vector<model::record_batch>
-    make_gaps(chunked_vector<model::record_batch> batches) {
-        chunked_vector<model::record_batch> filtered_batches;
+    chunked_vector<chunked_vector<model::record_batch>>
+    make_gaps(chunked_vector<chunked_vector<model::record_batch>> data) {
+        chunked_vector<chunked_vector<model::record_batch>> filtered_data;
 
         /**
-         * Drop some batches
+         * Drop some batches randomly. Sometimes the entire vector of batches
+         * are dropped and sometimes individual batches from within the vector
+         * are dropped.
          */
-        for (auto& batch : batches) {
+        for (auto& batches : data) {
             if (random_generators::get_int(0, 100) < 50) {
-                filtered_batches.push_back(std::move(batch));
+                chunked_vector<model::record_batch> inner_filtered;
+                for (auto& batch : batches) {
+                    if (random_generators::get_int(0, 100) < 70) {
+                        inner_filtered.push_back(std::move(batch));
+                    }
+                }
+                if (inner_filtered.empty()) {
+                    inner_filtered.push_back(std::move(batches[0]));
+                }
+                filtered_data.push_back(std::move(inner_filtered));
             }
         }
-        if (filtered_batches.empty()) {
-            filtered_batches.push_back(std::move(batches[0]));
+        if (filtered_data.empty()) {
+            filtered_data.push_back(std::move(data[0]));
         }
-        return filtered_batches;
+        return filtered_data;
     }
 
     std::optional<ss::shared_ptr<kafka::write_at_offset_stm>> get_leader_stm() {
@@ -140,22 +176,24 @@ TEST_F(WriteAtOffsetStmFixture, test_write_at_offset_happy_path) {
     initialize_state_machines(3).get();
     wait_for_leader(10s).get();
     auto stm = get_leader_stm();
-    kafka::offset expected_offset{0};
+    kafka::offset gen_offset{0};
 
     for (int i = 0; i < 10; ++i) {
-        auto batches = generate_batches(
-          expected_offset,
-          random_generators::get_int(1, 10),
-          random_generators::get_int(1, 10));
-
-        for (auto& batch : batches) {
-            auto bsz = batch.record_count();
+        auto num_batches = random_generators::get_int(1, 10);
+        auto records_per_batch = random_generators::get_int(1, 10);
+        auto data = generate_data(gen_offset, num_batches, records_per_batch);
+        gen_offset = model::offset_cast(
+          model::next_offset(data.back().back().last_offset()));
+        for (auto& batches : data) {
+            auto expected_offsets = start_offsets(batches);
             auto stages = stm->get()->replicate(
-              std::move(batch), expected_offset, std::nullopt, 10s);
+              std::move(batches),
+              std::move(expected_offsets),
+              std::nullopt,
+              10s);
             stages.request_enqueued.get();
             auto result = stages.replicate_finished.get();
-            ASSERT_FALSE(result.has_error());
-            expected_offset += bsz;
+            ASSERT_FALSE(result.has_error()) << result.error();
         }
     }
 
@@ -168,16 +206,18 @@ TEST_F(WriteAtOffsetStmFixture, test_write_at_offset_gaps) {
     wait_for_leader(10s).get();
     auto stm = get_leader_stm();
 
-    auto batches = make_gaps(generate_batches(
-      kafka::offset{0}, 200, random_generators::get_int(1, 10)));
+    auto data = make_gaps(
+      generate_data(kafka::offset{0}, 200, random_generators::get_int(1, 10)));
 
     kafka::offset expected_prev_offset{};
-    for (auto& batch : batches) {
-        auto o = model::offset_cast(batch.last_offset());
-        auto expected_offset = model::offset_cast(batch.base_offset());
-
+    for (auto& batches : data) {
+        auto o = model::offset_cast(batches.back().last_offset());
+        auto expected_offsets = start_offsets(batches);
         auto stages = (*stm)->replicate(
-          std::move(batch), expected_offset, expected_prev_offset, 10s);
+          std::move(batches),
+          std::move(expected_offsets),
+          expected_prev_offset,
+          10s);
         expected_prev_offset = o;
         stages.request_enqueued.get();
         auto result = stages.replicate_finished.get();
@@ -193,16 +233,18 @@ TEST_F(WriteAtOffsetStmFixture, test_start_offset_advancement) {
     wait_for_leader(10s).get();
     auto stm = get_leader_stm();
     // generate a batch that stars at non zero offset
-    auto batches = generate_batches(
+    auto data = generate_data(
       kafka::offset{1000123}, 10, random_generators::get_int(1, 10));
 
     kafka::offset expected_prev_offset{};
-    for (auto& batch : batches) {
-        auto o = model::offset_cast(batch.last_offset());
-        auto expected_offset = model::offset_cast(batch.base_offset());
-
+    for (auto& batches : data) {
+        auto o = model::offset_cast(batches.back().last_offset());
+        auto expected_offsets = start_offsets(batches);
         auto stages = (*stm)->replicate(
-          std::move(batch), expected_offset, expected_prev_offset, 10s);
+          std::move(batches),
+          std::move(expected_offsets),
+          expected_prev_offset,
+          10s);
         expected_prev_offset = o;
         stages.request_enqueued.get();
         auto result = stages.replicate_finished.get();
@@ -218,16 +260,18 @@ TEST_F(WriteAtOffsetStmFixture, test_concurrent_writes) {
     wait_for_leader(10s).get();
     auto stm = get_leader_stm();
 
-    auto batches = make_gaps(generate_batches(
-      kafka::offset{0}, 200, random_generators::get_int(1, 10)));
+    auto data = make_gaps(
+      generate_data(kafka::offset{0}, 200, random_generators::get_int(1, 10)));
     chunked_vector<raft::replicate_stages> all_stages;
     kafka::offset expected_prev_offset{};
-    for (auto& batch : batches) {
-        auto o = model::offset_cast(batch.last_offset());
-        auto expected_offset = model::offset_cast(batch.base_offset());
-
+    for (auto& batches : data) {
+        auto o = model::offset_cast(batches.back().last_offset());
+        auto expected_offsets = start_offsets(batches);
         auto stages = (*stm)->replicate(
-          std::move(batch), expected_offset, expected_prev_offset, 10s);
+          std::move(batches),
+          std::move(expected_offsets),
+          expected_prev_offset,
+          10s);
         expected_prev_offset = o;
         all_stages.push_back(std::move(stages));
     }
@@ -249,28 +293,34 @@ TEST_F(WriteAtOffsetStmFixture, test_writes_out_of_order) {
                  ->stm_manager()
                  ->get<kafka::write_at_offset_stm>();
 
-    auto batches = make_gaps(generate_batches(
-      kafka::offset{0}, 30, random_generators::get_int(1, 10)));
+    auto num_records_per_batch = random_generators::get_int(1, 10);
+    constexpr auto num_batches = 30;
+    auto total_records = num_batches * num_records_per_batch;
+
+    auto data = make_gaps(
+      generate_data(kafka::offset{0}, num_batches, num_records_per_batch));
 
     std::vector<size_t> indicies;
-    indicies.reserve(batches.size());
-    for (size_t i = 0; i < batches.size(); ++i) {
+    indicies.reserve(total_records);
+    for (size_t i = 0; i < data.size(); ++i) {
         indicies.push_back(i);
     }
     // randomize the order of batches, finally we should replicate all of them,
     // this simulate gaps & duplicates
     while (!indicies.empty()) {
         auto idx = random_generators::random_choice(indicies);
-        auto b_cp = batches[idx].copy();
-        auto o = model::offset_cast(b_cp.last_offset());
-        auto expected_offset = model::offset_cast(b_cp.base_offset());
+        auto b_cp = copy_batches(data[idx]);
+        auto o = model::offset_cast(b_cp.back().last_offset());
         auto expected_prev_offset = idx == 0
                                       ? kafka::offset{}
                                       : model::offset_cast(
-                                          batches[idx - 1].last_offset());
-
+                                          data[idx - 1].back().last_offset());
+        auto expected_offsets = start_offsets(b_cp);
         auto stages = stm->replicate(
-          std::move(b_cp), expected_offset, expected_prev_offset, 10s);
+          std::move(b_cp),
+          std::move(expected_offsets),
+          expected_prev_offset,
+          10s);
         expected_prev_offset = o;
         stages.request_enqueued.get();
         auto result = stages.replicate_finished.get();
@@ -305,12 +355,12 @@ TEST_P(WriteAtOffsetConcurrentWritesTest, TestConcurrentWrites) {
     initialize_state_machines(replication_factor).get();
     wait_for_leader(10s).get();
 
-    auto batches = make_gaps(generate_batches(
-      kafka::offset{0}, 1000, random_generators::get_int(1, 10)));
+    auto data = make_gaps(
+      generate_data(kafka::offset{0}, 1000, random_generators::get_int(1, 10)));
 
     std::vector<size_t> indicies;
-    indicies.reserve(batches.size());
-    for (size_t i = 0; i < batches.size(); ++i) {
+    indicies.reserve(data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
         indicies.push_back(i);
     }
 
@@ -321,13 +371,13 @@ TEST_P(WriteAtOffsetConcurrentWritesTest, TestConcurrentWrites) {
           [&] { return indicies.empty(); },
           [&] {
               auto idx = random_generators::random_choice(indicies);
-              auto b_cp = batches[idx].copy();
-              auto o = model::offset_cast(b_cp.last_offset());
-              auto expected_offset = model::offset_cast(b_cp.base_offset());
-              auto expected_prev_offset = idx == 0
-                                            ? kafka::offset{}
-                                            : model::offset_cast(
-                                                batches[idx - 1].last_offset());
+              auto b_cp = copy_batches(data[idx]);
+              auto o = model::offset_cast(b_cp.back().last_offset());
+              auto expected_offsets = start_offsets(b_cp);
+              auto expected_prev_offset
+                = idx == 0
+                    ? kafka::offset{}
+                    : model::offset_cast(data[idx - 1].back().last_offset());
               auto maybe_stm = get_leader_stm();
               if (!maybe_stm) {
                   return ss::sleep(50ms);
@@ -335,7 +385,7 @@ TEST_P(WriteAtOffsetConcurrentWritesTest, TestConcurrentWrites) {
               auto stages = (*maybe_stm)
                               ->replicate(
                                 std::move(b_cp),
-                                expected_offset,
+                                std::move(expected_offsets),
                                 expected_prev_offset,
                                 10s);
               expected_prev_offset = o;
@@ -380,7 +430,7 @@ TEST_P(WriteAtOffsetConcurrentWritesTest, TestConcurrentWrites) {
 
     ASSERT_EQ(
       node(leader_id).raft()->log()->from_log_offset(dirty_offset),
-      batches.back().last_offset());
+      data.back().back().last_offset());
     ASSERT_TRUE(logs_content_is_valid().get());
 }
 
@@ -394,24 +444,27 @@ TEST_F(WriteAtOffsetStmFixture, test_recovery_from_snapshot) {
     initialize_state_machines(3).get();
     auto leader_id = wait_for_leader(10s).get();
     auto stm = get_leader_stm();
-    kafka::offset expected_offset{0};
+    kafka::offset gen_offset{0};
     // store the truncation point, it is the base offset of second replicated
     // batch.
     model::offset snapshot_offset{};
     for (int i = 0; i < 10; ++i) {
-        auto batches = generate_batches(
-          expected_offset,
+        auto data = generate_data(
+          gen_offset,
           random_generators::get_int(1, 10),
           random_generators::get_int(1, 10));
-
-        for (auto& batch : batches) {
-            auto bsz = batch.record_count();
+        gen_offset = model::offset_cast(
+          model::next_offset(data.back().back().last_offset()));
+        for (auto& batches : data) {
+            auto expected_offsets = start_offsets(batches);
             auto stages = stm->get()->replicate(
-              std::move(batch), expected_offset, std::nullopt, 10s);
+              std::move(batches),
+              std::move(expected_offsets),
+              std::nullopt,
+              10s);
             stages.request_enqueued.get();
             auto result = stages.replicate_finished.get();
             ASSERT_FALSE(result.has_error());
-            expected_offset += bsz;
         }
         if (snapshot_offset == model::offset{}) {
             snapshot_offset = node(leader_id).raft()->dirty_offset();
@@ -450,22 +503,25 @@ TEST_F(WriteAtOffsetStmFixture, test_failed_replication) {
     initialize_state_machines(3).get();
     wait_for_leader(10s).get();
     auto stm = get_leader_stm();
-    kafka::offset expected_offset{0};
+    kafka::offset gen_offset{0};
     // replicate some batches
     for (int i = 0; i < 10; ++i) {
-        auto batches = generate_batches(
-          expected_offset,
+        auto data = generate_data(
+          gen_offset,
           random_generators::get_int(1, 10),
           random_generators::get_int(1, 10));
-
-        for (auto& batch : batches) {
-            auto bsz = batch.record_count();
+        gen_offset = model::offset_cast(
+          model::next_offset(data.back().back().last_offset()));
+        for (auto& batches : data) {
+            auto expected_offsets = start_offsets(batches);
             auto stages = stm->get()->replicate(
-              std::move(batch), expected_offset, std::nullopt, 10s);
+              std::move(batches),
+              std::move(expected_offsets),
+              std::nullopt,
+              10s);
             stages.request_enqueued.get();
             auto result = stages.replicate_finished.get();
             ASSERT_FALSE(result.has_error());
-            expected_offset += bsz;
         }
     }
     auto leader_id = wait_for_leader(10s).get();
@@ -480,18 +536,17 @@ TEST_F(WriteAtOffsetStmFixture, test_failed_replication) {
         return ss::now();
     });
     stm = get_leader_stm();
-    auto err_expected_offset = expected_offset;
-    auto batches = generate_batches(
+    auto err_expected_offset = gen_offset;
+    auto data = generate_data(
       err_expected_offset, 10, random_generators::get_int(1, 10));
 
     std::vector<ss::future<result<raft::replicate_result>>> results;
-    for (auto& batch : batches) {
-        auto bsz = batch.record_count();
+    for (auto& batches : data) {
+        auto expected_offsets = start_offsets(batches);
         auto stages = stm->get()->replicate(
-          std::move(batch), err_expected_offset, std::nullopt, 10s);
+          std::move(batches), std::move(expected_offsets), std::nullopt, 10s);
         stages.request_enqueued.get();
         results.push_back(std::move(stages.replicate_finished));
-        err_expected_offset += bsz;
     }
 
     leader.raft()->block_new_leadership();
@@ -511,19 +566,18 @@ TEST_F(WriteAtOffsetStmFixture, test_failed_replication) {
           .group = leader.raft()->group(), .target = leader_id, .timeout = 10s})
       .get();
     // Go back to batches with previous expected offsets
-    auto new_batches = generate_batches(
-      expected_offset, 10, random_generators::get_int(1, 10));
+    auto new_data = generate_data(
+      gen_offset, 10, random_generators::get_int(1, 10));
     leader_id = wait_for_leader(10s).get();
     stm = get_leader_stm();
 
-    for (auto& batch : new_batches) {
-        auto bsz = batch.record_count();
+    for (auto& batches : new_data) {
+        auto expected_offsets = start_offsets(batches);
         auto stages = stm->get()->replicate(
-          std::move(batch), expected_offset, std::nullopt, 10s);
+          std::move(batches), std::move(expected_offsets), std::nullopt, 10s);
         stages.request_enqueued.get();
         auto res = stages.replicate_finished.get();
         ASSERT_FALSE(res.has_error());
-        expected_offset += bsz;
     }
     ASSERT_TRUE(logs_content_is_valid().get());
 }

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -47,6 +47,8 @@ std::string write_at_offset_stm::errc_category::message(int c) const {
     case errc::invalid_batch_type:
         return "Invalid batch type. Offset translated batches are not "
                "supported by write at offset state machine";
+    case errc::invalid_input:
+        return "Invalid input provided to write at offset state machine";
     }
     __builtin_unreachable();
 }
@@ -71,8 +73,8 @@ write_at_offset_stm::write_at_offset_stm(
   , _sync_lock("w-at-offset") {}
 
 raft::replicate_stages write_at_offset_stm::replicate(
-  model::record_batch batch,
-  kafka::offset expected_base_offset,
+  chunked_vector<model::record_batch> batches,
+  chunked_vector<kafka::offset> expected_base_offsets,
   std::optional<kafka::offset> prev_log_offset,
   model::timeout_clock::duration timeout,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
@@ -81,8 +83,8 @@ raft::replicate_stages write_at_offset_stm::replicate(
     return raft::replicate_stages{
       std::move(f),
       do_replicate(
-        std::move(batch),
-        expected_base_offset,
+        std::move(batches),
+        std::move(expected_base_offsets),
         prev_log_offset,
         timeout,
         std::move(as),
@@ -90,15 +92,24 @@ raft::replicate_stages write_at_offset_stm::replicate(
 }
 
 ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
-  model::record_batch batch,
-  kafka::offset expected_base_offset,
+  chunked_vector<model::record_batch> batches,
+  chunked_vector<kafka::offset> expected_base_offsets,
   std::optional<kafka::offset> prev_log_offset,
   model::timeout_clock::duration timeout,
   std::optional<std::reference_wrapper<ss::abort_source>> as,
   ss::promise<> enqueued_promise) {
+    if (batches.empty() || expected_base_offsets.size() != batches.size())
+      [[unlikely]] {
+        enqueued_promise.set_value();
+        co_return make_error_code(errc::invalid_input);
+    }
     // offset translated batches are not supported by write at offset state
     // machine
-    if (is_offset_translated_batch(batch)) [[unlikely]] {
+    auto any_offset_translated = std::ranges::any_of(
+      batches, [this](const model::record_batch& batch) {
+          return is_offset_translated_batch(batch);
+      });
+    if (any_offset_translated) [[unlikely]] {
         enqueued_promise.set_value();
         co_return make_error_code(errc::invalid_batch_type);
     }
@@ -128,12 +139,12 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
       _log.trace,
       "Requested replicate at offset: {} with previous log offset: {}. "
       "stm last offset: {} [inflight_last_offset: {}, last_offset: {}]",
-      expected_base_offset,
+      expected_base_offsets,
       prev_log_offset,
       stm_last_offset,
       _inflight_last_offset,
       _last_offset);
-
+    auto expected_base_offset = expected_base_offsets.front();
     const auto effective_prev_log_offset = prev_log_offset.value_or(
       kafka::prev_offset(expected_base_offset));
     /*
@@ -151,24 +162,50 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
         co_return make_error_code(errc::invalid_offset);
     }
 
-    chunked_vector<model::record_batch> batches;
-    // fill the gap with ghost batches if required
-    if (effective_prev_log_offset != kafka::prev_offset(expected_base_offset)) {
-        // the term argument is not important here, it will be
-        // overriden in Raft layer
-        auto ghost_batches = model::make_ghost_batches(
-          kafka::offset_cast(kafka::next_offset(stm_last_offset)),
-          model::prev_offset(kafka::offset_cast(expected_base_offset)),
-          model::term_id{0});
-        batches.reserve(ghost_batches.size() + 1);
-        std::ranges::move(ghost_batches, std::back_inserter(batches));
+    chunked_vector<model::record_batch> effective_batches;
+    effective_batches.reserve(batches.size());
+    auto effective_last_offset = effective_prev_log_offset;
+    // Fill in any gaps in the input batch offset space.
+    kafka::offset last_seen_offset{};
+    for (auto&& [expected_offset, batch] :
+         std::ranges::zip_view(expected_base_offsets, batches)) {
+        if (expected_offset < last_seen_offset) [[unlikely]] {
+            enqueued_promise.set_value();
+            vlog(
+              _log.warn,
+              "Expected batch offsets are not monotonically increasing: {} "
+              "followed by {}",
+              last_seen_offset,
+              expected_offset);
+            co_return make_error_code(errc::invalid_input);
+        }
+        last_seen_offset = expected_offset;
+        auto expected_prev_offset = kafka::prev_offset(expected_offset);
+        if (effective_last_offset != expected_prev_offset) {
+            // fill with ghost batch.
+            // The term argument is not important here, it will be
+            // overriden in Raft layer
+            auto ghost_batches = model::make_ghost_batches(
+              kafka::offset_cast(kafka::next_offset(effective_last_offset)),
+              kafka::offset_cast(expected_prev_offset),
+              model::term_id{0});
+            std::ranges::move(
+              ghost_batches, std::back_inserter(effective_batches));
+        }
+        effective_batches.push_back(std::move(batch));
+        effective_last_offset = kafka::offset(
+          expected_offset()
+          + effective_batches.back().header().last_offset_delta);
     }
 
+    vassert(
+      effective_batches.size() >= expected_base_offsets.size(),
+      "Effective batches {} are fewer than input batches {}",
+      effective_batches.size(),
+      expected_base_offsets.size());
+
     _inflight_last_offset = term_offset{
-      .offset = kafka::offset(
-        expected_base_offset() + batch.header().last_offset_delta),
-      .in_sync_term = _insync_term};
-    batches.push_back(std::move(batch));
+      .offset = effective_last_offset, .in_sync_term = _insync_term};
     /**
      * Write at offset state machine error handling is based on the assumption
      * that if one of the replicate calls fails all the subsequent replicate
@@ -178,7 +215,7 @@ ss::future<result<raft::replicate_result>> write_at_offset_stm::do_replicate(
      * Thanks to that assumption we can simply reset all inflight state instead
      * of reverting to the previous last offset.
      */
-    auto stages = try_replicate_in_stages(std::move(batches), as);
+    auto stages = try_replicate_in_stages(std::move(effective_batches), as);
 
     auto enq = std::move(stages.request_enqueued).finally([u = std::move(u)] {
     });

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -56,20 +56,21 @@ public:
       storage::kvstore& kvstore,
       std::vector<model::record_batch_type> offset_translated_batches);
     /**
-     * Method that replicates a vector of record batches only if its
-     * kafka::offset of the first batch is going to be exactly the expected
+     * Method that replicates a vector of record batches only if the
+     * kafka::offset of each batch is going to be exactly the expected
      * offset.
      *
      * The method supports replicating gaps in the logs, in this case the
      * prev_log_offset parameter must be present. If the `prev_log_offset` is
-     * not present it is equivalent for it to be equal to (expected_base_offset
+     * not present it is equivalent for it to be equal to (first
+     * expected_base_offset
      * - 1).
      *
      * If prev_log_offset is present the state machine will match the expected
-     * prev_log_offset with the tracked offset and fill the gap between
-     * (prev_log_offset, expected_base_offset) - both offsets are exclusive.
-     * i.e. gap first offset will be prev_log_offset + 1 and the gap last offset
-     * will be expected_base_offset - 1.
+     * prev_log_offset with the tracked offset and fill any gaps between
+     * consecutive batches and within the provided batch sequence.
+     * Gaps are filled between (prev_log_offset, first_expected_base_offset)
+     * and between any non-consecutive expected offsets in the batch vector.
      *
      * Example:
      *
@@ -77,22 +78,33 @@ public:
      * (denoted as [base_offset, end_offset])
      *
      *
-     * [0,0][1,3][4,4][gap][10,13]
+     * [0,4][gap][10,13][gap][20,22]
      *
-     * In order to replicate the sequence the following set of replicate calls
+     * In order to replicate the sequence the following replicate call
      * is required:
      *
-     * - batch [0,0]
-     *   replicate(batch, expected_base_offset=0,  prev_log_offset=std::nullopt)
+     * replicate(
+     *   batches=[[0, 4], [10, 13], [20, 22]],
+     *   expected_base_offsets=[0, 10, 20],
+     *   prev_log_offset=std::nullopt
+     * )
      *
-     * - batch [1,3]
-     *   replicate(batch, expected_base_offset=1,  prev_log_offset=std::nullopt)
+     * This will replicate:
+     * - [0, 4] at offset 0
+     * - fill gap from 5-9
+     * - [10, 13] at offset 10
+     * - fill gap from 14-19
+     * - [20, 22] at offset 20
      *
-     * - batch [4,4]
-     *   replicate(batch, expected_base_offset=4, prev_log_offset=std::nullopt);
+     * Alternatively, to replicate with a gap from a previous log position:
      *
-     * - gap & batch [10,13]
-     *   replicate(batch, expected_base_offset=10, prev_log_offset=4);
+     * replicate(
+     *   batches=[[10, 13]],
+     *   expected_base_offsets=[10],
+     *   prev_log_offset=4
+     * )
+     *
+     * This fills the gap [5, 9]  and replicates [10, 13] at offset 10.
      *
      * The method guarantees the replication in the call order. There can be
      * more than one replicate request in flight at the same time.

--- a/src/v/kafka/server/write_at_offset_stm.h
+++ b/src/v/kafka/server/write_at_offset_stm.h
@@ -36,6 +36,7 @@ public:
         invalid_offset,
         replicate_exception,
         invalid_batch_type,
+        invalid_input,
     };
     struct errc_category final : public std::error_category {
         const char* name() const noexcept final;
@@ -55,8 +56,9 @@ public:
       storage::kvstore& kvstore,
       std::vector<model::record_batch_type> offset_translated_batches);
     /**
-     * Method that replicates a record batch only if its kafka::offset is going
-     * to be exactly the expected offset.
+     * Method that replicates a vector of record batches only if its
+     * kafka::offset of the first batch is going to be exactly the expected
+     * offset.
      *
      * The method supports replicating gaps in the logs, in this case the
      * prev_log_offset parameter must be present. If the `prev_log_offset` is
@@ -96,8 +98,8 @@ public:
      * more than one replicate request in flight at the same time.
      */
     raft::replicate_stages replicate(
-      model::record_batch,
-      kafka::offset expected_base_offset,
+      chunked_vector<model::record_batch>,
+      chunked_vector<kafka::offset> expected_base_offsets,
       std::optional<kafka::offset> prev_log_offset,
       model::timeout_clock::duration timeout,
       std::optional<std::reference_wrapper<ss::abort_source>> as
@@ -133,8 +135,8 @@ private:
     bool is_offset_translated_batch(const model::record_batch& batch) const;
 
     ss::future<result<raft::replicate_result>> do_replicate(
-      model::record_batch,
-      kafka::offset expected_base_offset,
+      chunked_vector<model::record_batch>,
+      chunked_vector<kafka::offset> expected_base_offsets,
       std::optional<kafka::offset> prev_log_offset,
       model::timeout_clock::duration timeout,
       std::optional<std::reference_wrapper<ss::abort_source>> as,


### PR DESCRIPTION
..instead of replicating per batch. Helps do batched replication calls. The idea is to consume a bunch of batches from the client and replicate them together in a single call.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
