### PR TITLE
[v25.2.x] CORE-13076 admin: require controller leadership before license idempotence check

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2320,11 +2320,18 @@ admin_server::put_license_handler(std::unique_ptr<ss::http::request> req) {
             throw ss::httpd::bad_request_exception(
               fmt::format("License is expired: {}", license));
         }
+
+        if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+            // In order that we can do a reliable idempotence check, run on the
+            // controller leader
+            throw co_await redirect_to_leader(*req, model::controller_ntp);
+        }
+
         const auto& ft = _controller->get_feature_table().local();
         const auto& loaded_license = ft.get_license();
         if (loaded_license && (*loaded_license == license)) {
             /// Loaded license is idential to license in request, do
-            /// nothing and return 200(OK)
+            /// nothing and return 200(OK) for idempotence
             vlog(
               adminlog.info,
               "Attempted to load identical license, doing nothing: {}",

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -234,7 +234,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
             return (self.admin.is_sample_license(lic), lic)
 
         resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=5,
+                                 timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
@@ -268,7 +268,7 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
             return (lic['license']['format_version'] == 1, lic)
 
         resp = wait_until_result(obtain_configured_license_v1,
-                                 timeout_sec=5,
+                                 timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents_v1 == resp['license'], resp['license']
@@ -276,12 +276,8 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         # Set back to v0 for sanity check
         assert self.admin.put_license(license).status_code == 200
 
-        def obtain_configured_license():
-            lic = self.admin.get_license()
-            return (self.admin.is_sample_license(lic), lic)
-
         resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=5,
+                                 timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -229,13 +229,22 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
 
         assert self.admin.put_license(license).status_code == 200
 
-        def obtain_configured_license():
-            lic = self.admin.get_license()
-            return (self.admin.is_sample_license(lic), lic)
+        def check_license(is_matching_license):
+            # Wait for all of the nodes to see the next license to ensure that
+            # we don't get idempotent 200's when updating the license on a
+            # stale node in the face of leadership changes
+            licenses = [
+                self.admin.get_license(node=node)
+                for node in self.redpanda.started_nodes()
+            ]
+            if any(not is_matching_license(lic) for lic in licenses):
+                return False, None
+            return (True, licenses[0])
 
-        resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=20,
-                                 backoff_sec=1)
+        resp = wait_until_result(
+            lambda: check_license(self.admin.is_sample_license),
+            timeout_sec=20,
+            backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
 
@@ -261,13 +270,12 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
 
         assert self.admin.put_license(license_v1).status_code == 200
 
-        def obtain_configured_license_v1():
-            lic = self.admin.get_license()
+        def is_v1_license(lic):
             if lic is None or 'license' not in lic:
                 return False
-            return (lic['license']['format_version'] == 1, lic)
+            return lic['license']['format_version'] == 1
 
-        resp = wait_until_result(obtain_configured_license_v1,
+        resp = wait_until_result(lambda: check_license(is_v1_license),
                                  timeout_sec=20,
                                  backoff_sec=1)
         assert resp['license'] is not None
@@ -276,9 +284,10 @@ class FeaturesMultiNodeTest(FeaturesTestBase):
         # Set back to v0 for sanity check
         assert self.admin.put_license(license).status_code == 200
 
-        resp = wait_until_result(obtain_configured_license,
-                                 timeout_sec=20,
-                                 backoff_sec=1)
+        resp = wait_until_result(
+            lambda: check_license(self.admin.is_sample_license),
+            timeout_sec=20,
+            backoff_sec=1)
         assert resp['license'] is not None
         assert expected_license_contents == resp['license'], resp['license']
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27288 and https://github.com/redpanda-data/redpanda/pull/27168

Backported https://github.com/redpanda-data/redpanda/pull/27168 since otherwise there would be a merge conflict and it is also beneficial to backport that PR as well. The cherry picks were conflict-free now that both PRs are backported.

Fixes https://redpandadata.atlassian.net/browse/CORE-13169