### PR TITLE
[v25.2.x] schema_registry/api-doc: update schema docs

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -448,15 +448,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "schemaType": {
-                  "type": "string"
-                },
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/schema_def"
             }
           },
           "404": {
@@ -826,7 +818,7 @@
             "name": "schema_def",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/schema_def"
+              "$ref": "#/definitions/stored_schema"
             }
           }
         ],

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -79,7 +79,18 @@
       "type": "object",
       "properties": {
         "compatibilityLevel": {
-          "type": "string"
+          "type": "string",
+          "description": "Compatibility level",
+          "example": "FULL_TRANSITIVE",
+          "enum": [
+            "BACKWARD",
+            "BACKWARD_TRANSITIVE",
+            "FORWARD",
+            "FORWARD_TRANSITIVE",
+            "FULL",
+            "FULL_TRANSITIVE",
+            "NONE"
+          ]
         }
       }
     },
@@ -87,7 +98,18 @@
       "type": "object",
       "properties": {
         "compatibility": {
-          "type": "string"
+          "type": "string",
+          "description": "Compatibility level",
+          "example": "FULL_TRANSITIVE",
+          "enum": [
+            "BACKWARD",
+            "BACKWARD_TRANSITIVE",
+            "FORWARD",
+            "FORWARD_TRANSITIVE",
+            "FULL",
+            "FULL_TRANSITIVE",
+            "NONE"
+          ]
         }
       }
     },


### PR DESCRIPTION
Partial backport of https://github.com/redpanda-data/redpanda/pull/27216

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
