### PR TITLE
rpk: update console version to v3.2.0

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -34,7 +34,7 @@ import (
 var (
 	tag               = "latest"
 	redpandaImageBase = "redpandadata/redpanda:" + tag
-	consoleImageBase  = "redpandadata/console:v3.1.2"
+	consoleImageBase  = "redpandadata/console:v3.2.0"
 )
 
 const (


### PR DESCRIPTION
 Updates the default console image version in rpk from the current version to v3.2.0.

  This change ensures that `rpk container start` uses the latest console release, providing users with the most recent features and bug fixes when running the console locally.

  ## Backports Required

  - [x] none - not a bug fix
  - [ ] none - this is a backport
  - [ ] none - issue does not exist in previous branches
  - [ ] none - papercut/not impactful enough to backport
  - [ ] v25.2.x
  - [ ] v25.1.x
  - [ ] v24.3.x

  ## Release Notes

  ### Improvements

  * Updated default console image version in rpk container commands to v3.2.0