### PR TITLE
`cloud_storage`: reduce calls to `segment_meta_cstore::end()`

### DIFF
--- a/src/v/cloud_storage/anomalies_detector.cc
+++ b/src/v/cloud_storage/anomalies_detector.cc
@@ -64,7 +64,9 @@ ss::future<anomalies_detector::result> anomalies_detector::run(
 
     std::deque<ss::sstring> spill_manifest_paths;
     const auto& spillovers = manifest.get_spillover_map();
-    for (auto iter = spillovers.begin(); iter != spillovers.end(); ++iter) {
+    for (auto iter = spillovers.begin(), end_it = spillovers.end();
+         iter != end_it;
+         ++iter) {
         spillover_manifest_path_components comp{
           .base = iter->base_offset,
           .last = iter->committed_offset,
@@ -242,15 +244,16 @@ anomalies_detector::check_manifest(
         co_return stop_detector::no;
     }
     std::optional<segment_meta> previous_seg_meta;
+    auto manifest_end = manifest.end();
     if (scrub_from && manifest.get_last_offset() > scrub_from) {
         if (auto iter = manifest.segment_containing(*scrub_from);
-            iter != manifest.end()) {
+            iter != manifest_end) {
             previous_seg_meta = *iter;
             seg_iter = std::move(++iter);
         }
     }
 
-    for (; seg_iter != manifest.end(); ++seg_iter) {
+    for (; seg_iter != manifest_end; ++seg_iter) {
         if (should_stop()) {
             _result.status = scrub_status::partial;
             co_return stop_detector::yes;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -269,7 +269,8 @@ std::optional<kafka::offset>
 partition_manifest::compute_start_kafka_offset_local() const {
     std::optional<kafka::offset> local_start_offset;
     auto iter = _segments.find(_start_offset);
-    if (iter != _segments.end()) {
+    auto segments_end = _segments.end();
+    if (iter != segments_end) {
         auto delta = iter->delta_offset;
         local_start_offset = _start_offset - delta;
     } else {
@@ -277,7 +278,7 @@ partition_manifest::compute_start_kafka_offset_local() const {
         // translate it.  If there are any segments ahead of it, then
         // those may be considered the start of the remote log.
         if (auto front_it = _segments.begin();
-            front_it != _segments.end()
+            front_it != segments_end
             && front_it->base_offset >= _start_offset) {
             local_start_offset = front_it->base_offset - front_it->delta_offset;
         }
@@ -851,6 +852,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
       .last_segment = last_segment(),
     };
 
+    auto segments_end = _segments.end();
     for (const auto& m : meta_list) {
         if (_segments.empty() && !subst.last_segment.has_value()) {
             // The empty manifest can be started from any offset. If we deleted
@@ -896,7 +898,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
               };
 
             auto it = _segments.find(m.base_offset);
-            if (it == _segments.end()) {
+            if (it == segments_end) {
                 // Segment added to tip of the log
                 const auto last_seg = subst.last_segment;
                 vassert(
@@ -968,7 +970,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
                 // *not valid*.
                 ++it;
                 bool boundary_found = false;
-                while (it != _segments.end()) {
+                while (it != segments_end) {
                     if (it->committed_offset == m.committed_offset) {
                         boundary_found = true;
                         break;
@@ -2323,7 +2325,8 @@ void partition_manifest::serialize_segments(
     }
     if (!_segments.empty()) {
         auto it = _segments.lower_bound(cursor->next_offset);
-        for (; it != _segments.end(); ++it) {
+        auto end_it = _segments.end();
+        for (; it != end_it; ++it) {
             serialize_segment_meta(*it, cursor);
             cursor->segments_serialized++;
             if (cursor->segments_serialized >= cursor->max_segments_per_call) {
@@ -2332,7 +2335,7 @@ void partition_manifest::serialize_segments(
                 break;
             }
         }
-        if (it == _segments.end()) {
+        if (it == end_it) {
             cursor->next_offset = _last_offset;
         } else {
             // We hit the limit on number of serialized segment
@@ -2384,7 +2387,8 @@ void partition_manifest::serialize_spillover(
 
     if (!_spillover_manifests.empty()) {
         auto it = _spillover_manifests.lower_bound(cursor->next_spill_offset);
-        for (; it != _spillover_manifests.end(); ++it) {
+        auto end_it = _spillover_manifests.end();
+        for (; it != end_it; ++it) {
             serialize_spillover_manifest_meta(*it, cursor);
             cursor->spills_serialized++;
             if (cursor->spills_serialized >= cursor->max_segments_per_call) {
@@ -2393,7 +2397,7 @@ void partition_manifest::serialize_spillover(
                 break;
             }
         }
-        if (it == _spillover_manifests.end()) {
+        if (it == end_it) {
             cursor->next_spill_offset = _last_offset;
         } else {
             cursor->next_spill_offset = it->base_offset;
@@ -2706,13 +2710,14 @@ void partition_manifest::process_anomalies(
 
     const auto archive_start_offset = get_archive_start_offset();
     absl::erase_if(
-      missing_spills, [this, &archive_start_offset](const auto& spill_comp) {
+      missing_spills,
+      [this, &archive_start_offset, end_it = _spillover_manifests.end()](
+        const auto& spill_comp) {
           // Remove the missing spill if lies below the start offset of the
           // archive or if it doesn't match with any of the entries in the
           // manifest.
           return spill_comp.last < archive_start_offset
-                 || _spillover_manifests.find(spill_comp.base)
-                      == _spillover_manifests.end();
+                 || _spillover_manifests.find(spill_comp.base) == end_it;
       });
 
     auto first_kafka_offset = full_log_start_kafka_offset();

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -123,6 +123,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
     //   doesn't have any data. The 'segment_containing' method of the
     //   manifest takes this into account.
     // - find materialized segment or materialize the new one
+    const auto manifest_end = manifest.end();
     auto mit = manifest.end();
     if (hint == model::offset{}) {
         // This code path is only used for the first lookup. It
@@ -139,7 +140,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
             // skip segments without data batches (the logic is implemented
             // inside the partition_manifest).
             mit = manifest.segment_containing(ko);
-            if (mit == manifest.end()) {
+            if (mit == manifest_end) {
                 // Segment that matches exactly can't be found in the manifest.
                 // In this case we want to start scanning from the beginning of
                 // the partition if the start of the manifest is contained by
@@ -153,7 +154,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
         }
     } else {
         mit = manifest.segment_containing(hint);
-        while (mit != manifest.end()) {
+        while (mit != manifest_end) {
             // The segment 'mit' points to might not have any
             // data batches. In this case we need to move iterator forward.
             // The check can only be done if we have 'delta_offset_end'.
@@ -173,7 +174,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
     }
     const auto partition_start_offset
       = _manifest_view->stm_manifest().full_log_start_offset();
-    while (mit != manifest.end()
+    while (mit != manifest_end
            && mit->committed_offset < partition_start_offset) {
         // Make sure to skip segments that have been removed via archival GC,
         // which wouldn't be reflected in a spillover manifest's segment list.
@@ -182,7 +183,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
         // before getting here, but that isn't the case for timequeries.
         ++mit;
     }
-    if (mit == manifest.end()) {
+    if (mit == manifest_end) {
         // No such segment
         return borrow_result_t{};
     }
@@ -206,7 +207,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
     }
     auto mit_committed_offset = mit->committed_offset;
     auto next_it = std::next(std::move(mit));
-    while (next_it != manifest.end()) {
+    while (next_it != manifest_end) {
         // Normally, the segments in the manifest do not overlap.
         // But in some cases we may see them overlapping, for instance
         // if they were produced by older version of redpanda.
@@ -217,9 +218,8 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
         }
         ++next_it;
     }
-    model::offset next_offset = next_it == manifest.end()
-                                  ? model::offset{}
-                                  : next_it->base_offset;
+    model::offset next_offset = next_it == manifest_end ? model::offset{}
+                                                        : next_it->base_offset;
     return borrow_result_t{
       .reader = iter->second->borrow_reader(
         config, _ctxlog, _probe, _ts_probe, std::move(segment_reader_unit)),
@@ -1056,8 +1056,9 @@ remote_partition::aborted_transactions(offset_range offsets) {
         // redpanda offsets to extract aborted transactions metadata because
         // tx-manifests contains redpanda offsets.
         std::deque<ss::lw_shared_ptr<remote_segment>> remote_segs;
-        for (auto it = stm_manifest.segment_containing(offsets.begin);
-             it != stm_manifest.end();
+        for (auto it = stm_manifest.segment_containing(offsets.begin),
+                  end_it = stm_manifest.end();
+             it != end_it;
              ++it) {
             if (it->base_offset > offsets.end_rp) {
                 break;
@@ -1105,8 +1106,9 @@ remote_partition::aborted_transactions(offset_range offsets) {
           std::move(cursor),
           [&offsets, &meta_to_materialize, this](
             ssx::task_local_ptr<const partition_manifest> manifest) {
-              for (auto it = manifest->segment_containing(offsets.begin);
-                   it != manifest->end();
+              for (auto it = manifest->segment_containing(offsets.begin),
+                        end_it = manifest->end();
+                   it != end_it;
                    ++it) {
                   if (it->base_offset > offsets.end_rp) {
                       return ss::stop_iteration::yes;

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -1120,7 +1120,8 @@ bool segment_meta_cstore::operator==(const segment_meta_cstore& oth) const {
     if (size() != oth.size()) {
         return false;
     }
-    for (auto lhs = begin(), rhs = oth.begin(); lhs != end(); ++lhs, ++rhs) {
+    for (auto lhs = begin(), rhs = oth.begin(), e = end(); lhs != e;
+         ++lhs, ++rhs) {
         if (*lhs != *rhs) {
             return false;
         }

--- a/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
+++ b/src/v/cloud_storage/tests/segment_meta_cstore_bench.cc
@@ -285,6 +285,33 @@ void cs_deserialize_test(auto& store, size_t sz) {
     store.from_iobuf(std::move(buf));
     perf_tests::stop_measuring_time();
 }
+
+void cs_iteration_recompute_end_test(auto& store, size_t sz) {
+    for (auto manifest = generate_metadata(sz); auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    for (auto it = store.begin(); it != store.end(); ++it) {
+        auto v = it->size_bytes;
+        perf_tests::do_not_optimize(v);
+    }
+    perf_tests::stop_measuring_time();
+}
+
+void cs_iteration_precompute_end_test(auto& store, size_t sz) {
+    for (auto manifest = generate_metadata(sz); auto& s : manifest) {
+        store.insert(s);
+    }
+
+    perf_tests::start_measuring_time();
+    for (auto it = store.begin(), e_it = store.end(); it != e_it; ++it) {
+        auto v = it->size_bytes;
+        perf_tests::do_not_optimize(v);
+    }
+    perf_tests::stop_measuring_time();
+}
+
 PERF_TEST(cstore_bench, column_store_append_baseline) {
     baseline_column_store store;
     cs_append_test(store, 10000);
@@ -372,4 +399,24 @@ PERF_TEST(cstore_bench, column_store_deserialize_baseline) {
 PERF_TEST(cstore_bench, column_store_deserialize_result) {
     segment_meta_cstore store;
     cs_deserialize_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, cs_iteration_recompute_end_test_1000) {
+    segment_meta_cstore store;
+    cs_iteration_recompute_end_test(store, 1000);
+}
+
+PERF_TEST(cstore_bench, cs_iteration_recompute_end_test_10000) {
+    segment_meta_cstore store;
+    cs_iteration_recompute_end_test(store, 10000);
+}
+
+PERF_TEST(cstore_bench, cs_iteration_precompute_end_test_1000) {
+    segment_meta_cstore store;
+    cs_iteration_precompute_end_test(store, 1000);
+}
+
+PERF_TEST(cstore_bench, cs_iteration_precompute_end_test_10000) {
+    segment_meta_cstore store;
+    cs_iteration_precompute_end_test(store, 10000);
 }

--- a/src/v/cluster/archival/adjacent_segment_merger.cc
+++ b/src/v/cluster/archival/adjacent_segment_merger.cc
@@ -105,7 +105,8 @@ std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
 
     adjacent_segment_run run(_archiver.get_ntp());
 
-    for (auto it = manifest.segment_containing(so); it != manifest.end();
+    for (auto it = manifest.segment_containing(so), end_it = manifest.end();
+         it != end_it;
          ++it) {
         if (!_is_local && it->committed_offset >= local_start_offset) {
             // We're looking for the remote segment

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -1611,9 +1611,9 @@ archival_metadata_stm::get_segments_to_cleanup() const {
       source_backlog.begin(),
       source_backlog.end(),
       std::back_inserter(backlog),
-      [this](const lw_segment_meta& m) {
+      [this, end_it = _manifest->end()](const lw_segment_meta& m) {
           auto it = _manifest->find(m.base_offset);
-          if (it == _manifest->end()) {
+          if (it == end_it) {
               return true;
           }
           auto m_name = _manifest->generate_remote_segment_name(

--- a/src/v/cluster/archival/retention_calculator.cc
+++ b/src/v/cluster/archival/retention_calculator.cc
@@ -127,7 +127,7 @@ std::optional<retention_calculator> retention_calculator::factory(
               overshot_by);
         }
     }
-
+    auto manifest_end = manifest.end();
     if (ntp_config.retention_duration()) {
         model::timestamp oldest_allowed_timestamp{
           model::timestamp::now().value()
@@ -136,7 +136,7 @@ std::optional<retention_calculator> retention_calculator::factory(
         if (manifest.size() > 0) {
             auto first_seg = manifest.first_addressable_segment();
             if (
-              first_seg != manifest.end()
+              first_seg != manifest_end
               && first_seg->max_timestamp < oldest_allowed_timestamp) {
                 strats.push_back(
                   std::make_unique<time_based_strategy>(
@@ -156,7 +156,7 @@ std::optional<retention_calculator> retention_calculator::factory(
     if (start_kafka_override > kafka::offset(0)) {
         auto first_seg = manifest.first_addressable_segment();
         if (
-          first_seg != manifest.end()
+          first_seg != manifest_end
           && start_kafka_override > first_seg->last_kafka_offset()) {
             // The user has passed in a start override via DeleteRecords, and
             // there exists at least one segment below this offset. Remove up
@@ -191,7 +191,8 @@ retention_calculator::retention_calculator(
 
 std::optional<model::offset> retention_calculator::next_start_offset() {
     auto it = _manifest.first_addressable_segment();
-    for (; it != _manifest.end(); ++it) {
+    auto end_it = _manifest.end();
+    for (; it != end_it; ++it) {
         const auto& entry = *it;
         if (_pinned_offset && entry.last_kafka_offset() >= *_pinned_offset) {
             // The pin is blocking us from removing this segment and beyond.
@@ -219,7 +220,7 @@ std::optional<model::offset> retention_calculator::next_start_offset() {
 
     // We made it to the end of our strategies and our policies are still not
     // satisfied. Return just past the end -- we will truncate all segments.
-    if (it == _manifest.end()) {
+    if (it == end_it) {
         return model::next_offset(_manifest.get_last_offset());
     }
 

--- a/src/v/cluster/archival/segment_reupload.cc
+++ b/src/v/cluster/archival/segment_reupload.cc
@@ -489,17 +489,17 @@ model::offset segment_collector::find_replacement_boundary(
 
         // manifest: 10-19, 25-29
         // _begin_inclusive (in gap): 22.
-        if (it == _manifest.end()) {
+        auto manifest_end = _manifest.end();
+        if (it == manifest_end) {
             // first segment after gap: 25-29
-            for (it = _manifest.begin(); it != _manifest.end(); ++it) {
+            for (it = _manifest.begin(); it != manifest_end; ++it) {
                 const auto& entry = *it;
                 if (entry.base_offset > _begin_inclusive) {
                     break;
                 }
             }
             // The collection is valid if it can reach the end of the gap: 24
-            vassert(
-              it != _manifest.end(), "Trying to dereference end iterator");
+            vassert(it != manifest_end, "Trying to dereference end iterator");
             replace_boundary = it->base_offset - model::offset{1};
         } else {
             replace_boundary = it->committed_offset;
@@ -797,16 +797,16 @@ void segment_collector::align_begin_offset_to_manifest() {
     }
 
     auto it = _manifest.find(_begin_inclusive);
-
+    auto end_it = _manifest.end();
     // If iterator points to a segment, it means that _begin_inclusive is
     // aligned on manifest segment boundary, so do nothing. Otherwise, skip
     // _begin_inclusive to the start of the next manifest segment.
-    if (it == _manifest.end()) {
+    if (it == end_it) {
         it = _manifest.segment_containing(_begin_inclusive);
 
         // manifest: 10-19, 25-29
         // _begin_inclusive (in gap): before: 22, after: 22
-        if (it == _manifest.end()) {
+        if (it == end_it) {
             vlog(
               archival_log.debug,
               "_begin_inclusive lies in manifest gap for ntp: {} "


### PR DESCRIPTION
This PR demonstrates the difference between a simple `for` loop over a `segment_meta_cstore` from `.begin()` to `.end()`, showing that precomputing `.end()` boasts a valuable performance improvement, or rather, that the naive

```cpp
for (auto it = store.begin(); it != store.end(); ++it) {
    ...
}
```

is a potential performance footgun, and would be better written as e.g.

```cpp
for (auto it = store.begin(), e_it = store.end(); it != e_it; ++it) {
    ...
}
```

if possible.

Results from the benchmark on my machine:

```
test                                                 iterations      median         mad         min         max      allocs       tasks        inst      cycles
cstore_bench.cs_iteration_recompute_end_test_1000           108     4.354ms   837.139ns     4.354ms     4.362ms    1530.000       0.000  59711228.3  22991621.4
cstore_bench.cs_iteration_recompute_end_test_10000            9    41.775ms    15.943us    41.710ms    41.816ms   14833.000       0.000 573555849.7 220456245.3
cstore_bench.cs_iteration_precompute_end_test_1000          160     1.293ms   507.575ns     1.293ms     1.295ms     530.000       0.000  18506437.3   6820267.5
cstore_bench.cs_iteration_precompute_end_test_10000          11    11.178ms    28.978us    11.126ms    11.207ms    4833.000       0.000 161778399.1  58919071.7
```

And with a test bumped up to `100000` entries:

```
test                                                 iterations      median         mad         min         max      allocs       tasks         inst       cycles
cstore_bench.cs_iteration_recompute_end_test_100000           1   399.905ms   234.335us   398.822ms   400.803ms  147819.000       0.000 5717966516.0 2109965829.4
cstore_bench.cs_iteration_precompute_end_test_100000          1   101.535ms   359.658us   101.176ms   101.966ms   47819.000       0.000 1594675168.8  536228334.2
```

The added benchmark should serve as motivation for finding sub-optimal loops over `segment_meta_cstore` objects in the code and altering them to be closer to the precomputed case.

For a summary as to why `segment_meta_cstore::end()` is not a cheap operation, check the following definitions:

### `segment_meta_cstore::impl::end()`:

https://github.com/redpanda-data/redpanda/blob/083e363fe0425ccc941e35f32487c34522543d5f/src/v/cloud_storage/segment_meta_cstore.cc#L938-L942

### `column_store::end()`:

https://github.com/redpanda-data/redpanda/blob/083e363fe0425ccc941e35f32487c34522543d5f/src/v/cloud_storage/segment_meta_cstore.cc#L531-L535

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements
* Improve performance in the `cloud_storage` layer in a commonly used data type.