### PR TITLE
`cloud_io`: return proper `upload_result` iff `result.has_value()`

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -331,22 +331,23 @@ ss::future<upload_result> remote::upload_stream(
     if (!result) {
         vlog(
           log.warn,
-          "Uploading {} {} to {}, backoff quota exceded, {} not "
-          "uploaded",
+          "Uploading {} {} to {}, backoff quota exceded, {} not uploaded",
           stream_label,
           path,
           bucket,
           stream_label);
+        result = upload_result::timedout;
     } else {
         vlog(
           log.warn,
-          "Uploading {} {} to {}, {}, segment not uploaded",
+          "Uploading {} {} to {}, {}, {} not uploaded",
           stream_label,
           path,
           bucket,
-          *result);
+          *result,
+          stream_label);
     }
-    co_return upload_result::timedout;
+    co_return *result;
 }
 
 ss::future<download_result> remote::download_stream(
@@ -1208,6 +1209,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           path,
           transfer_details.bucket,
           upload_type);
+        result = upload_result::timedout;
     } else {
         vlog(
           ctxlog.warn,
@@ -1218,7 +1220,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           *result,
           upload_type);
     }
-    co_return upload_result::timedout;
+    co_return *result;
 }
 
 ss::future<>


### PR DESCRIPTION
Previously these functions would fall through to returning `upload_result::timeout` even if, for example, we hit the `error_outcome::fail` branch in the upload retry loop and broke out after setting `result = upload_result::failed`. See log lines in [1] for an example of the return value not matching the error seen in `cloud_io/remote`.

Return the proper `result` instead of a catch-all `timedout` if `result.has_value()`.

Also, fix the `vlog()` line which hardcoded the `stream_label` as `"segment"` in its output.


### [1]

```
DEBUG 2025-08-20 17:47:20,198 [shard 0:au  ] cloud_io - [fiber362~16~1|1|15000ms] - remote.cc:252 - Uploading segment to path "c68eb0c5-8fa0-48df-9610-41a1d644935b/kafka/tp-workload-compaction/16_45/1456-7848-148987-1-v1.log.1", length 148987
ERROR 2025-08-20 17:47:20,202 [shard 0:au  ] abs - abs_client.cc:544 - Received [Bad Request] Unknown unexpected error response from ABS: 
WARN  2025-08-20 17:47:20,202 [shard 0:au  ] cloud_io - remote.cc:347 - Uploading segment "c68eb0c5-8fa0-48df-9610-41a1d644935b/kafka/tp-workload-compaction/16_45/1456-7848-148987-1-v1.log.1" to panda-container-51926b12-7ded-11f0-a8c6-0242c0a8d71c, {failed}, segment not uploaded
INFO  2025-08-20 17:47:20,202 [shard 0:au  ] archival - [fiber362~16|0|14995ms kafka/tp-workload-compaction/16] - ntp_archiver_service.cc:1783 - Segment upload failed: "c68eb0c5-8fa0-48df-9610-41a1d644935b/kafka/tp-workload-compaction/16_45/1456-7848-148987-1-v1.log.1", error: {timed_out}
```

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
