### PR TITLE
dt: Deflake MultiClusterKafkaTest.test_basic_ops

### DIFF
--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -8,11 +8,11 @@
 # by the Apache License, Version 2.0
 
 from ducktape.mark import matrix
-from rptest.services.multi_cluster_services import MultiClusterServices, ServiceType
+from rptest.services.multi_cluster_services import Cluster, MultiClusterServices, ServiceType
 from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.services.cluster import cluster
-from rptest.util import expect_exception
+from rptest.util import expect_exception, wait_until_result
 
 
 class MultiClusterTestBase(RedpandaTest):
@@ -20,17 +20,29 @@ class MultiClusterTestBase(RedpandaTest):
         super().__init__(test_context=test_context, *args, **kwargs)
 
     def basic_ops(self, services: MultiClusterServices):
+        def at_least_one_topic_exists(services: MultiClusterServices,
+                                      node: Cluster):
+            topics = services.list_topics(node, detailed=True)
+            return len(topics) > 0, topics
+
         topic = 'test-topic'
         services.create_topic(services.primary,
                               topic,
                               partitions=3,
                               replicas=3)
-        p_topics = services.list_topics(services.primary, detailed=True)
+        p_topics = wait_until_result(
+            lambda: at_least_one_topic_exists(services, services.primary),
+            timeout_sec=30,
+            err_msg="Failed to create a single topic on the primary cluster")
+
         services.create_topic(services.secondary,
                               topic,
                               partitions=3,
                               replicas=3)
-        s_topics = services.list_topics(services.secondary, detailed=True)
+        s_topics = wait_until_result(
+            lambda: at_least_one_topic_exists(services, services.secondary),
+            timeout_sec=30,
+            err_msg="Failed to create a single topic on the secondary cluster")
 
         assert p_topics == s_topics, \
             f"Expected same topics on both clusters, got {p_topics=} vs {s_topics=}"


### PR DESCRIPTION
Added a wait_until to await at least one topic being created on both clusters before comparing the list of topics between the two.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
