### PR TITLE
[CORE-13139] `storage`: advance target `segment`'s `generation_id()` during transfer

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1177,6 +1177,8 @@ ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
     // in the cache after the transfer.
     co_await to->reset_batch_cache_index();
 
+    // Target segment has been mutated, advance its `generation_id`.
+    to->advance_generation();
     co_return std::move(locks);
 }
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -7046,3 +7046,56 @@ TEST_F(storage_test_fixture, test_eligible_for_compacted_reupload) {
     ASSERT_FALSE(efcr(
       seg1.offsets().get_base_offset(), seg2.offsets().get_committed_offset()));
 }
+
+TEST_F(storage_test_fixture, adjacent_merge_compaction_advances_generation_id) {
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "a", 0);
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    auto log
+      = mgr
+          .manage(
+            storage::ntp_config(
+              ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(0));
+        log->force_roll().get();
+    };
+
+    add_segment_func();
+    add_segment_func();
+
+    ss::abort_source as;
+    compaction::compaction_config cfg(
+      model::offset::max(), std::nullopt, std::nullopt, as);
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+
+    auto& segs = log->segments();
+    ASSERT_EQ(segs.size(), 3);
+
+    // Self compact the front segment which will be the target segment for the
+    // adjacent merge so that we already account for the generation_id
+    // advancement from that operation.
+    disk_log.segment_self_compact(cfg, segs.front()).get();
+
+    auto gen_id_before = segs.front()->get_generation_id();
+
+    disk_log.adjacent_merge_compact(segs, cfg).get();
+    ASSERT_EQ(segs.size(), 2);
+
+    auto gen_id_after = segs.front()->get_generation_id();
+
+    ASSERT_EQ(gen_id_after(), gen_id_before() + 1);
+}


### PR DESCRIPTION
During adjacent merge compaction, we properly advance the `generation_id` of the `replacement` segment. However, when `transfer_segment()` is called for transferring the state of the `replacement` segment to the `target` segment, erroneously, the `generation_id` of `target` is currently not altered.

Indicate the `target` segment was indeed mutated by this operation by calling `to->advance_generation()` within `transfer_segment()`.

This bug manifested as a CI failure due to a failed archival upload. Because we only check the `generation_id` under read lock in the `segment_collector` and the upload size is computed outside the locking, this mutation would go undetected and the upload request for the upload would fail [1].

[1]:

```
INFO  2025-08-20 17:47:20,191 [shard 0:lc  ] storage-gc - segment_utils.cc:1237 - Final compacted segment {offset_tracker:{term:1, base_offset:0, committed_offset:8704, stable_offset:8704, dirty_offset:8704}, compacted_segment=1, finished_self_compaction=1, finished_windowed_compaction=0, generation=7002, reader={/var/lib/redpanda/data/kafka/tp-workload-compaction/16_45/0-1-v1.log.compaction.staging, (125911 bytes)}, writer=nullptr, cache=nullptr, compaction_index:nullopt, closed=0, tombstone=0, index={file:/var/lib/redpanda/data/kafka/tp-workload-compaction/16_45/0-1-v1.log.compaction.base_index, offsets:0, index:{header_bitflags:0, base_offset:0, max_offset:8704, base_timestamp:{timestamp: 1755712014271}, max_timestamp:{timestamp: 1755712036879}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{{timestamp: 1755712036879}}, num_compactible_records_appended:{500}, clean_compact_timestamp:{nullopt}, may_have_tombstone_records:0, self_compact_timestamp:{{timestamp: 1755712040165}}, has_transaction_batches:0, index(4, 4, 4)}, step:32768, needs_persistence:0}}
DEBUG 2025-08-20 17:47:20,198 [shard 0:au  ] cloud_io - [fiber362~16~1|1|15000ms] - remote.cc:252 - Uploading segment to path "c68eb0c5-8fa0-48df-9610-41a1d644935b/kafka/tp-workload-compaction/16_45/1456-7848-148987-1-v1.log.1", length 148987
ERROR 2025-08-20 17:47:20,202 [shard 0:au  ] abs - abs_client.cc:544 - Received [Bad Request] Unknown unexpected error response from ABS:
WARN  2025-08-20 17:47:20,202 [shard 0:au  ] cloud_io - remote.cc:347 - Uploading segment "c68eb0c5-8fa0-48df-9610-41a1d644935b/kafka/tp-workload-compaction/16_45/1456-7848-148987-1-v1.log.1" to panda-container-51926b12-7ded-11f0-a8c6-0242c0a8d71c, {failed}, segment not uploaded
```

Fixes https://redpandadata.atlassian.net/issues/CORE-13139.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which adjacent merge compaction could mutate a `segment` without advancing the `segment`'s `generation_id`, which could potentially lead to transient upload failures in tiered storage.