### PR TITLE
[v25.2.x] `storage`: advance target `segment`'s `generation_id()` during transfer (MANUAL BACKPORT)

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1160,6 +1160,8 @@ ss::future<chunked_vector<ss::rwlock::holder>> transfer_segment(
     // in the cache after the transfer.
     co_await to->reset_batch_cache_index();
 
+    // Target segment has been mutated, advance its `generation_id`.
+    to->advance_generation();
     co_return std::move(locks);
 }
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -6446,3 +6446,55 @@ TEST_F(storage_test_fixture, delete_retention_ms_without_ts) {
     ASSERT_TRUE(tx_retention_ms.has_value());
     ASSERT_EQ(tx_retention_ms.value(), delete_retention_ms);
 };
+
+TEST_F(storage_test_fixture, adjacent_merge_compaction_advances_generation_id) {
+    storage::log_manager mgr = make_log_manager();
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "a", 0);
+    using overrides_t = storage::ntp_config::default_overrides;
+    overrides_t ov;
+    ov.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+
+    auto log
+      = mgr
+          .manage(storage::ntp_config(
+            ntp, mgr.config().base_dir, std::make_unique<overrides_t>(ov)))
+          .get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(0));
+        log->force_roll().get();
+    };
+
+    add_segment_func();
+    add_segment_func();
+
+    ss::abort_source as;
+    storage::compaction_config cfg(
+      model::offset::max(), std::nullopt, std::nullopt, as);
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+
+    auto& segs = log->segments();
+    ASSERT_EQ(segs.size(), 3);
+
+    // Self compact the front segment which will be the target segment for the
+    // adjacent merge so that we already account for the generation_id
+    // advancement from that operation.
+    disk_log.segment_self_compact(cfg, segs.front()).get();
+
+    auto gen_id_before = segs.front()->get_generation_id();
+
+    disk_log.adjacent_merge_compact(segs, cfg).get();
+    ASSERT_EQ(segs.size(), 2);
+
+    auto gen_id_after = segs.front()->get_generation_id();
+
+    ASSERT_EQ(gen_id_after(), gen_id_before() + 1);
+}


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/27315. `cherry-pick` conflict due to missing tests in `storage_e2e_test.cc`.

Fixes https://github.com/redpanda-data/redpanda/issues/27317

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in which adjacent merge compaction could mutate a `segment` without advancing the `segment`'s `generation_id`, which could potentially lead to transient upload failures in tiered storage.