### PR TITLE
raft/c: avoid exceptional futures in linearizable barrier

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -666,6 +666,8 @@ void consensus::dispatch_recovery(follower_index_metadata& idx) {
 
 ss::future<result<model::offset>>
 consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
+    auto holder = _bg.hold();
+
     using ret_t = result<model::offset>;
     ssx::semaphore_units u;
     try {
@@ -702,13 +704,10 @@ consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
      * Dispatch round of heartbeats
      */
 
+    _bg.check();
     absl::flat_hash_map<vnode, follower_req_seq> sequences;
-    std::vector<ss::future<>> send_futures;
-    send_futures.reserve(cfg.unique_voter_count());
-    cfg.for_each_voter([this,
-                        dirty_offset = offsets.dirty_offset,
-                        &sequences,
-                        &send_futures](vnode target) {
+    cfg.for_each_voter([this, dirty_offset = offsets.dirty_offset, &sequences](
+                         vnode target) {
         // do not send request to self
         if (target == _self) {
             return;
@@ -722,29 +721,37 @@ consensus::linearizable_barrier(model::timeout_clock::time_point deadline) {
         update_node_append_timestamp(target);
         vlog(
           _ctxlog.trace, "Sending empty append entries request to {}", target);
-        auto f = _client_protocol
-                   .append_entries(
-                     target.id(),
-                     std::move(req),
-                     rpc::client_opts(_replicate_append_timeout))
-                   .then([this, id = target.id(), seq, dirty_offset](
-                           result<append_entries_reply> reply) {
-                       process_append_entries_reply(
-                         id, reply, seq, dirty_offset);
-                   });
 
-        send_futures.push_back(std::move(f));
+        ssx::spawn_with_gate(
+          _bg,
+          [this,
+           id = target.id(),
+           req = std::move(req),
+           seq,
+           dirty_offset]() mutable {
+              return _client_protocol
+                .append_entries(
+                  id,
+                  std::move(req),
+                  rpc::client_opts(_replicate_append_timeout))
+                .then([this, id, seq, dirty_offset](
+                        result<append_entries_reply> reply) {
+                    process_append_entries_reply(id, reply, seq, dirty_offset);
+                })
+                .handle_exception([this, id](const std::exception_ptr& e) {
+                    vlog(
+                      _ctxlog.warn,
+                      "append entries dispatch to node {} failed: {}",
+                      id,
+                      e);
+                });
+          });
     });
     // release semaphore
     // term snapshot taken under the semaphore
     auto term = _term;
 
     u.return_all();
-
-    // wait for responses in background
-    ssx::spawn_with_gate(_bg, [futures = std::move(send_futures)]() mutable {
-        return ss::when_all_succeed(futures.begin(), futures.end());
-    });
 
     auto majority_sequences_updated = [&cfg, &sequences, this] {
         return cfg.majority([this, &sequences](vnode id) {


### PR DESCRIPTION
Two problems

1. linearizable_barrier() does not operate under a gate.
2. If the gate closes midway through the method, send_futures are created but awaiting on them in the bg fails, so the futures are dangling

Tightens the future handling by dispatching each append entries request under the gate.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
