### PR TITLE
datalake: dlq corrupted records

### DIFF
--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -25,6 +25,8 @@
 
 #include <seastar/core/loop.hh>
 
+#include <exception>
+
 namespace datalake {
 
 namespace {
@@ -132,15 +134,43 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
             vlog(_log.debug, "Abort requested, stopping translation");
             co_return ss::stop_iteration::yes;
         }
-        auto record = it.next();
-        auto key = record.share_key_opt();
-        auto val = record.share_value_opt();
-        auto timestamp = model::timestamp{
-          first_timestamp + record.timestamp_delta()};
+
+        model::record record;
+
+        {
+            std::exception_ptr eptr;
+            try {
+                record = it.next();
+            } catch (...) {
+                eptr = std::current_exception();
+                vlog(
+                  _log.warn,
+                  "Error reading record from batch: {} at index {}. Err: {}",
+                  batch.header(),
+                  it.index(),
+                  eptr);
+            }
+
+            if (eptr) {
+                auto res = co_await handle_corrupted_batch(
+                  batch, start_offset, it.index(), as);
+                if (res.has_error()) {
+                    _error = res.error();
+                    co_return ss::stop_iteration::yes;
+                }
+                break;
+            }
+        }
+
         kafka::offset offset{batch.base_offset()() + record.offset_delta()};
         if (offset < start_offset) {
             continue;
         }
+
+        auto key = record.share_key_opt();
+        auto val = record.share_value_opt();
+        auto timestamp = model::timestamp{
+          first_timestamp + record.timestamp_delta()};
         int64_t estimated_size = (key ? key->size_bytes() : 0)
                                  + (val ? val->size_bytes() : 0);
         chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>
@@ -608,4 +638,42 @@ record_multiplexer::handle_invalid_record(
         co_return std::nullopt;
     }
 }
+
+ss::future<result<void, writer_error>>
+record_multiplexer::handle_corrupted_batch(
+  const model::record_batch& batch,
+  kafka::offset start_offset,
+  int32_t first_corrupted_record_index,
+  ss::abort_source& as) {
+    // We should use record::offset_delta() but because we weren't
+    // able to parse the header we don't have access to it. So we
+    // use a proxy for it.
+    auto first_corrupted_offset = kafka::offset{
+      batch.base_offset()() + first_corrupted_record_index};
+
+    if (first_corrupted_offset < start_offset) {
+        first_corrupted_offset = start_offset;
+    }
+
+    auto data_copy = batch.data().copy();
+
+    for (kafka::offset o = first_corrupted_offset;
+         o <= model::offset_cast(batch.last_offset());
+         ++o) {
+        auto invalid_res = co_await handle_invalid_record(
+          translation_probe::invalid_record_cause::corrupted_record,
+          o,
+          std::nullopt,
+          data_copy.share(0, data_copy.size_bytes()),
+          batch.header().first_timestamp,
+          {},
+          as);
+        if (invalid_res.has_error()) {
+            co_return invalid_res.error();
+        }
+    }
+
+    co_return outcome::success();
+}
+
 } // namespace datalake

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -129,6 +129,12 @@ private:
       chunked_vector<std::pair<std::optional<iobuf>, std::optional<iobuf>>>,
       ss::abort_source&);
 
+    ss::future<result<void, writer_error>> handle_corrupted_batch(
+      const model::record_batch& batch,
+      kafka::offset start_offset,
+      int32_t record_index,
+      ss::abort_source& as);
+
     prefix_logger _log;
     const model::ntp& _ntp;
     model::revision_id _topic_revision;

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -21,17 +21,15 @@
 #include "datalake/tests/test_data_writer.h"
 #include "datalake/tests/test_utils.h"
 #include "datalake/translation/translation_probe.h"
-#include "iceberg/filesystem_catalog.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
 #include "storage/record_batch_builder.h"
 #include "test_utils/tmp_dir.h"
 
 #include <gtest/gtest.h>
-
-#include <filesystem>
 
 using namespace datalake;
 namespace {
@@ -203,6 +201,222 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
     EXPECT_EQ(
       result.value().last_offset(),
       start_offset + record_count * batch_count - 1);
+}
+
+TEST(DatalakeMultiplexerTest, CorruptedBatchRecordHeader) {
+    constexpr int record_count = 10;
+    constexpr int batch_count = 10;
+    constexpr int start_offset = 1005;
+
+    constexpr auto corrupted_offsets = std::to_array(
+      {// Make sure we have a batch with first record corrupted.
+       1005,
+       // Corrupt the middle of the second batch.
+       1005 + record_count + record_count / 2,
+       // Corrupt the last record in the last batch.
+       1005 + (batch_count - 1) * (record_count + 1)});
+
+    auto writer_factory = std::make_unique<datalake::test_data_writer_factory>(
+      false);
+    translation_probe probe(ntp);
+    datalake::record_multiplexer multiplexer(
+      ntp,
+      rev,
+      std::move(writer_factory),
+      simple_schema_mgr,
+      bin_resolver,
+      translator,
+      t_creator,
+      model::iceberg_invalid_record_action::dlq_table,
+      location_provider(
+        cloud_io::s3_compat_provider{"s3"},
+        cloud_storage_clients::bucket_name{"bucket"}),
+      probe);
+
+    model::test::record_batch_spec batch_spec;
+    batch_spec.allow_compression = false;
+    batch_spec.records = record_count;
+    batch_spec.count = batch_count;
+    batch_spec.offset = model::offset{start_offset};
+    chunked_circular_buffer<model::record_batch> batches = {};
+
+    for (auto& batch : model::test::make_random_batches(batch_spec).get()) {
+        iobuf mutated_record_buf = {};
+        batch.for_each_record([&](const model::record& r) {
+            auto record_offset = batch.base_offset()
+                                 + model::offset(r.offset_delta());
+            auto should_corrupt = std::ranges::find(
+                                    corrupted_offsets, record_offset())
+                                  != corrupted_offsets.end();
+
+            if (should_corrupt) {
+                iobuf record_buf;
+                model::append_record_to_buffer(record_buf, r);
+                std::string s(record_buf.size_bytes(), static_cast<char>(0xFF));
+                mutated_record_buf.append(s.data(), s.size());
+            } else {
+                model::append_record_to_buffer(mutated_record_buf, r);
+            }
+        });
+
+        batches.emplace_back(
+          batch.header(),
+          std::move(mutated_record_buf),
+          model::record_batch::tag_ctor_ng{});
+
+        batches.back().header().reset_size_checksum_metadata(
+          batches.back().data());
+    }
+
+    auto reader = model::make_generating_record_batch_reader(
+      [batches = std::move(batches)]() mutable {
+          return ss::make_ready_future<model::record_batch_reader::data_t>(
+            std::move(batches));
+      });
+
+    multiplexer
+      .multiplex(
+        std::move(reader), kafka::offset{start_offset}, model::no_timeout, as)
+      .get();
+    auto result = std::move(multiplexer).finish().get();
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().start_offset(), start_offset);
+
+    // Subtract one since offsets end at 0, and this is an inclusive range.
+    EXPECT_EQ(
+      result.value().last_offset(),
+      start_offset + record_count * batch_count - 1);
+
+    // Valid records
+    ASSERT_EQ(result.value().data_files.size(), 1);
+    EXPECT_EQ(result.value().data_files[0].local_file.row_count, 84) << "";
+
+    // DLQ records
+    ASSERT_EQ(result.value().dlq_files.size(), 1);
+    EXPECT_EQ(result.value().dlq_files[0].local_file.row_count, 16) << "";
+
+    // Result must add up to total.
+    EXPECT_EQ(
+      result.value().data_files[0].local_file.row_count
+        + result.value().dlq_files[0].local_file.row_count,
+      record_count * batch_count);
+
+    EXPECT_EQ(
+      probe.counter_ref(
+        translation_probe::invalid_record_cause::corrupted_record),
+      16);
+}
+
+TEST(DatalakeMultiplexerTest, CorruptedBatchRecordHeaderStartOffset) {
+    constexpr int record_count = 10;
+    constexpr int batch_count = 10;
+    constexpr int start_offset = 1005;
+
+    constexpr auto corrupted_offsets = std::to_array(
+      {// Make sure we have a batch with first record corrupted.
+       1005,
+       // Corrupt the middle of the second batch.
+       1005 + record_count + record_count / 2,
+       // Corrupt the last record in the last batch.
+       1005 + (batch_count - 1) * (record_count + 1)});
+
+    auto writer_factory = std::make_unique<datalake::test_data_writer_factory>(
+      false);
+    translation_probe probe(ntp);
+    datalake::record_multiplexer multiplexer(
+      ntp,
+      rev,
+      std::move(writer_factory),
+      simple_schema_mgr,
+      bin_resolver,
+      translator,
+      t_creator,
+      model::iceberg_invalid_record_action::dlq_table,
+      location_provider(
+        cloud_io::s3_compat_provider{"s3"},
+        cloud_storage_clients::bucket_name{"bucket"}),
+      probe);
+
+    model::test::record_batch_spec batch_spec;
+    batch_spec.allow_compression = false;
+    batch_spec.records = record_count;
+    batch_spec.count = batch_count;
+    batch_spec.offset = model::offset{start_offset};
+    chunked_circular_buffer<model::record_batch> batches = {};
+
+    for (auto& batch : model::test::make_random_batches(batch_spec).get()) {
+        iobuf mutated_record_buf = {};
+        batch.for_each_record([&](const model::record& r) {
+            auto record_offset = batch.base_offset()
+                                 + model::offset(r.offset_delta());
+            auto should_corrupt = std::ranges::find(
+                                    corrupted_offsets, record_offset())
+                                  != corrupted_offsets.end();
+
+            if (should_corrupt) {
+                iobuf record_buf;
+                model::append_record_to_buffer(record_buf, r);
+                std::string s(record_buf.size_bytes(), static_cast<char>(0xFF));
+                mutated_record_buf.append(s.data(), s.size());
+            } else {
+                model::append_record_to_buffer(mutated_record_buf, r);
+            }
+        });
+
+        batches.emplace_back(
+          batch.header(),
+          std::move(mutated_record_buf),
+          model::record_batch::tag_ctor_ng{});
+
+        batches.back().header().reset_size_checksum_metadata(
+          batches.back().data());
+    }
+
+    auto reader = model::make_generating_record_batch_reader(
+      [batches = std::move(batches)]() mutable {
+          return ss::make_ready_future<model::record_batch_reader::data_t>(
+            std::move(batches));
+      });
+
+    // Multiplex with start offset past the first corrupted record but within
+    // the same batch.
+    ASSERT_EQ(corrupted_offsets[0], start_offset);
+    multiplexer
+      .multiplex(
+        std::move(reader),
+        kafka::offset{start_offset + 1},
+        model::no_timeout,
+        as)
+      .get();
+    auto result = std::move(multiplexer).finish().get();
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().start_offset(), start_offset + 1);
+
+    // Subtract one since offsets end at 0, and this is an inclusive range.
+    EXPECT_EQ(
+      result.value().last_offset(),
+      start_offset + record_count * batch_count - 1);
+
+    // Valid records
+    ASSERT_EQ(result.value().data_files.size(), 1);
+    EXPECT_EQ(result.value().data_files[0].local_file.row_count, 84) << "";
+
+    // DLQ records
+    ASSERT_EQ(result.value().dlq_files.size(), 1);
+    EXPECT_EQ(result.value().dlq_files[0].local_file.row_count, 15) << "";
+
+    // Result must add up to total.
+    EXPECT_EQ(
+      result.value().data_files[0].local_file.row_count
+        + result.value().dlq_files[0].local_file.row_count,
+      record_count * batch_count - 1);
+
+    EXPECT_EQ(
+      probe.counter_ref(
+        translation_probe::invalid_record_cause::corrupted_record),
+      15);
 }
 
 namespace {

--- a/src/v/datalake/translation/translation_probe.cc
+++ b/src/v/datalake/translation/translation_probe.cc
@@ -183,6 +183,8 @@ operator<<(std::ostream& os, translation_probe::invalid_record_cause cause) {
         return os << "failed_data_translation";
     case failed_iceberg_schema_resolution:
         return os << "failed_iceberg_schema_resolution";
+    case corrupted_record:
+        return os << "corrupted_record";
     }
 }
 }; // namespace datalake

--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -30,6 +30,8 @@ public:
         /// Failed to ensure the table schema matches the inferred Iceberg
         /// schema.
         failed_iceberg_schema_resolution,
+        /// Successfully parsed the batch header but the record is corrupted.
+        corrupted_record,
     };
 
 public:
@@ -62,6 +64,8 @@ public:
             return _num_failed_data_translation;
         case invalid_record_cause::failed_iceberg_schema_resolution:
             return _num_failed_iceberg_schema_resolution;
+        case invalid_record_cause::corrupted_record:
+            return _num_corrupted_records;
         }
     }
 
@@ -83,6 +87,7 @@ private:
     size_t _num_failed_kafka_schema_resolution = 0;
     size_t _num_failed_data_translation = 0;
     size_t _num_failed_iceberg_schema_resolution = 0;
+    size_t _num_corrupted_records = 0;
 
     // NOTE: the accounting for bytes here is not strictly accurate and should
     // only be used to get a rough sense for translation throughput.

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -691,6 +691,8 @@ public:
 
     model::record next();
 
+    int32_t index() const noexcept { return _index; }
+
     static record_batch_iterator create(const model::record_batch& b);
 
 private:


### PR DESCRIPTION
ref https://redpandadata.atlassian.net/browse/INC-923


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes

* datalake: handle corrupted records by writing them to DLQ table.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
