### PR TITLE
Added consumer groups mirroring task

### DIFF
--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -120,6 +120,34 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "group_mirroring_task",
+    srcs = [
+        "group_mirroring_task.cc",
+    ],
+    hdrs = [
+        "group_mirroring_task.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        "//src/v/base",
+        "//src/v/cluster_link/model",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:find_coordinator",
+        "//src/v/kafka/protocol:list_offset",
+        "//src/v/kafka/server",
+        "//src/v/kafka/server:topic_config_utils",
+        "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:future_util",
+        "@fmt",
+    ],
+    visibility = ["//src/v/cluster_link:__subpackages__"],
+    deps = [
+        ":impl",
+        "//src/v/kafka/client:cluster",
+    ],
+)
+
+redpanda_cc_library(
     name = "cluster_link",
     srcs = [
         "service.cc",
@@ -128,6 +156,7 @@ redpanda_cc_library(
         "service.h",
     ],
     implementation_deps = [
+        ":group_mirroring_task",
         ":impl",
         ":logger",
         ":source_topic_syncer",
@@ -143,6 +172,7 @@ redpanda_cc_library(
         "//src/v/cluster_link/replication:deps_impl",
         "//src/v/cluster_link/replication:mux_remote_consumer",
         "//src/v/kafka/client/direct_consumer",
+        "//src/v/kafka/server",
         "//src/v/model",
         "//src/v/raft",
         "@seastar",

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -107,4 +107,24 @@ public:
     virtual std::unique_ptr<kafka::client::cluster>
     create_cluster(const model::metadata& md);
 };
+
+/**
+ * Cluster linking entry point for consumer group operations in the cluster
+ */
+class consumer_groups_router {
+public:
+    consumer_groups_router() = default;
+    consumer_groups_router(const consumer_groups_router&) = delete;
+    consumer_groups_router(consumer_groups_router&&) = delete;
+    consumer_groups_router& operator=(const consumer_groups_router&) = delete;
+    consumer_groups_router& operator=(consumer_groups_router&&) = delete;
+    virtual ~consumer_groups_router() = default;
+
+    virtual std::optional<::model::partition_id>
+    partition_for(const kafka::group_id&) const = 0;
+
+    virtual ss::future<kafka::offset_commit_response>
+      offset_commit(kafka::offset_commit_request) = 0;
+};
+
 } // namespace cluster_link

--- a/src/v/cluster_link/group_mirroring_task.cc
+++ b/src/v/cluster_link/group_mirroring_task.cc
@@ -1,0 +1,680 @@
+
+
+#include "cluster_link/group_mirroring_task.h"
+
+#include "cluster_link/link.h"
+#include "cluster_link/model/filter_utils.h"
+#include "kafka/protocol/errors.h"
+#include "ssx/async_algorithm.h"
+#include "ssx/future-util.h"
+
+namespace cluster_link {
+
+group_mirroring_task::group_mirroring_task(
+  link* link, const model::metadata& link_metadata)
+  : task(
+      link,
+      link_metadata.configuration.consumer_groups_mirroring_cfg
+        .get_task_interval(),
+      group_mirroring_task::task_name)
+
+  , _config(link_metadata.configuration.consumer_groups_mirroring_cfg.copy()) {}
+
+void group_mirroring_task::update_config(const model::metadata& link_metadata) {
+    _config = link_metadata.configuration.consumer_groups_mirroring_cfg.copy();
+    set_run_interval(_config.get_task_interval());
+}
+
+namespace {
+
+chunked_hash_set<::model::partition_id> coordinators_on_current_shard(
+  link& link, ss::shard_id current_shard, ::model::node_id self_id) {
+    auto topic_cfg = link.topic_metadata_cache().find_topic_cfg(
+      ::model::kafka_consumer_offsets_nt);
+    chunked_hash_set<::model::partition_id> ret;
+    if (!topic_cfg.has_value()) {
+        return ret;
+    }
+    for (::model::partition_id p_id{0};
+         p_id < ::model::partition_id(topic_cfg->partition_count);
+         ++p_id) {
+        ::model::ktp ktp(::model::kafka_consumer_offsets_topic, p_id);
+        const auto is_leader = link.partition_leader_cache().get_leader_node(
+                                 ktp.as_tn_view(), ktp.get_partition())
+                               == self_id;
+        const auto on_current_shard = link.partition_manager().shard_owner(ktp)
+                                      == current_shard;
+        if (is_leader && on_current_shard) {
+            ret.insert(p_id);
+        }
+    }
+
+    return ret;
+}
+} // namespace
+
+ss::future<> group_mirroring_task::run_impl() {
+    auto result = co_await list_consumer_groups();
+
+    if (!result.has_value()) {
+        make_unavailable(result.error());
+        co_return;
+    }
+
+    if (_needs_coordinator_update) {
+        auto result = co_await update_group_coordinators();
+
+        if (!result.has_value()) {
+            make_unavailable(result.error());
+            co_return;
+        }
+    }
+
+    result = co_await synchronize_consumer_groups_offsets();
+
+    if (!result.has_value()) {
+        make_unavailable(result.error());
+        co_return;
+    }
+
+    make_active();
+};
+
+bool group_mirroring_task::should_start_impl(
+  ss::shard_id current_shard, ::model::node_id node_id) const {
+    return !coordinators_on_current_shard(*get_link(), current_shard, node_id)
+              .empty();
+}
+
+bool group_mirroring_task::should_stop_impl(
+  ss::shard_id current_shard, ::model::node_id node_id) const {
+    return coordinators_on_current_shard(*get_link(), current_shard, node_id)
+      .empty();
+}
+
+ss::future<group_mirroring_task::result_t>
+group_mirroring_task::list_consumer_groups() {
+    vlog(logger().trace, "Refreshing consumer group list");
+    try {
+        auto broker_ids = get_cluster_connection().get_broker_ids();
+        if (broker_ids.empty()) {
+            vlog(
+              logger().info,
+              "No brokers available for listing consumer groups");
+            co_await get_cluster_connection().request_metadata_update();
+            co_return std::unexpected{error("No brokers available")};
+        }
+
+        size_t error_cnt = 0;
+        auto all_groups = co_await ssx::parallel_transform(
+          broker_ids, [this, &error_cnt](::model::node_id id) {
+              return list_groups_from_broker(id).then(
+                [this, id, &error_cnt](
+                  std::expected<chunked_vector<kafka::group_id>, error>
+                    result) {
+                    if (result.has_value()) {
+                        return std::move(result.value());
+                    }
+                    vlog(
+                      logger().warn,
+                      "Failed to list groups from broker {}: {}",
+                      id,
+                      result.error());
+                    // even if one broker is unavailable the mirroring should
+                    // still continue
+                    error_cnt++;
+                    return chunked_vector<kafka::group_id>{};
+                });
+          });
+        const auto current_shard_coordinators = coordinators_on_current_shard(
+          *get_link(), ss::this_shard_id(), get_link()->self());
+        chunked_hash_set<kafka::group_id> discovered_groups;
+        std::ranges::for_each(
+          all_groups | std::views::join, [&](const kafka::group_id& group) {
+              discovered_groups.insert(group);
+          });
+        // we only want to remove groups if there were no errors when listing
+        // groups
+        if (error_cnt == 0) {
+            // erase all groups that are no longer discovered
+            std::erase_if(
+              _groups_to_mirror, [this, &discovered_groups](const auto& entry) {
+                  auto remove = !discovered_groups.contains(entry.first);
+                  if (remove) {
+                      vlog(
+                        logger().debug,
+                        "Group {} is no longer present on the remote cluster, "
+                        "removing it from mirroring",
+                        entry.first,
+                        entry.second.coordinator_id.has_value());
+                  }
+                  return remove;
+              });
+        }
+
+        if (error_cnt == broker_ids.size()) {
+            vlog(
+              logger().info,
+              "All brokers returned an error when listing groups");
+            co_return std::unexpected{
+              error("All brokers returned an error when listing groups")};
+        }
+
+        co_await ssx::async_for_each(
+          std::move(discovered_groups),
+          [this, &current_shard_coordinators](kafka::group_id group_id) {
+              if (!should_group_be_mirrored(
+                    group_id, current_shard_coordinators)) {
+                  vlog(
+                    logger().trace,
+                    "Group {} is not eligible for mirroring, current shard "
+                    "coordinators: {}",
+                    group_id,
+                    fmt::join(current_shard_coordinators, ", "));
+                  _groups_to_mirror.erase(group_id);
+              } else {
+                  auto [_, inserted] = _groups_to_mirror.try_emplace(
+                    group_id, group_metadata{});
+                  _needs_coordinator_update |= inserted;
+                  vlog(
+                    logger().trace,
+                    "Group {} is eligible for mirroring, (newly discovered: "
+                    "{})",
+                    group_id,
+                    inserted);
+              }
+          });
+        co_return result_t{};
+    } catch (...) {
+        co_return std::unexpected{error(
+          ssx::sformat(
+            "Exception thrown while listing groups - {}",
+            std::current_exception()))};
+    }
+}
+
+bool group_mirroring_task::should_group_be_mirrored(
+  const kafka::group_id& group_id,
+  const chunked_hash_set<::model::partition_id>& current_shard_coordinators) {
+    if (!model::select_group(group_id, _config.filters)) {
+        return false;
+    }
+    auto maybe_partition = get_link()->get_group_router().partition_for(
+      group_id);
+
+    if (!maybe_partition.has_value()) {
+        return false;
+    }
+    return current_shard_coordinators.contains(*maybe_partition);
+}
+
+void group_mirroring_task::make_unavailable(const error& err) {
+    vlog(logger().warn, "Group mirroring task failed: {}", err);
+
+    if (get_state() != model::task_state::link_unavailable) {
+        std::ignore = change_state(
+          model::task_state::link_unavailable, fmt::format("{}", err));
+    }
+}
+
+void group_mirroring_task::make_active() {
+    vlog(logger().trace, "Group mirroring task finished successfully");
+
+    if (get_state() != model::task_state::active) {
+        std::ignore = change_state(
+          model::task_state::active, "Group mirroring finished successfully");
+    }
+}
+
+ss::future<group_mirroring_task::result_t>
+group_mirroring_task::synchronize_consumer_groups_offsets() {
+    // group by coordinator id
+    chunked_hash_map<::model::node_id, chunked_vector<kafka::group_id>>
+      groups_by_coordinator;
+    for (auto& [g_id, metadata] : _groups_to_mirror) {
+        if (!metadata.coordinator_id.has_value()) {
+            continue;
+        }
+        groups_by_coordinator[*metadata.coordinator_id].push_back(g_id);
+    }
+    // no groups, do nothing
+    if (groups_by_coordinator.empty()) {
+        co_return result_t{};
+    }
+
+    auto total_requests = groups_by_coordinator.size();
+    chunked_vector<error> errors;
+    co_await ss::max_concurrent_for_each(
+      std::move(groups_by_coordinator),
+      concurrent_requests_limit,
+      [this, &errors](auto& pair) {
+          return fetch_and_commit_offsets(std::move(pair.second), pair.first)
+            .then([&errors](result_t result) {
+                if (!result) {
+                    errors.push_back(std::move(result.error()));
+                }
+            });
+      });
+    if (errors.size() == total_requests) {
+        co_return std::unexpected{error(
+          ssx::sformat(
+            "all requests to fetch and commit offsets failed: {}",
+            fmt::join(errors, ", ")))};
+    }
+    co_return result_t{};
+}
+
+ss::future<group_mirroring_task::result_t>
+group_mirroring_task::fetch_and_commit_offsets(
+  chunked_vector<kafka::group_id> groups, ::model::node_id coordinator_id) {
+    vlog(
+      logger().trace,
+      "Fetching offsets for {} groups from: {}",
+      groups.size(),
+      coordinator_id);
+    auto result = co_await fetch_offsets(std::move(groups), coordinator_id);
+    if (!result) {
+        co_return std::unexpected{std::move(result.error())};
+    }
+    auto trimmed_offsets = co_await trim_to_partition_highwatermark(
+      std::move(result.value()));
+
+    co_await commit_group_offsets(std::move(trimmed_offsets));
+    co_return result_t{};
+}
+
+namespace {
+ss::future<kafka::offset_commit_request>
+build_offset_commit_request(group_mirroring_task::group_offsets g_offsets) {
+    ssx::async_counter cnt;
+    kafka::offset_commit_request req;
+    req.data.group_id = std::move(g_offsets.group_id);
+    req.data.topics.reserve(g_offsets.topic_offsets.size());
+
+    for (auto& topic_offsets : g_offsets.topic_offsets) {
+        kafka::offset_commit_request_topic t;
+        t.name = std::move(topic_offsets.topic);
+        t.partitions.reserve(topic_offsets.partition_offsets.size());
+        co_await ssx::async_for_each_counter(
+          cnt,
+          std::move(topic_offsets.partition_offsets),
+          [&t](auto& partition_offset) {
+              kafka::offset_commit_request_partition p;
+              p.partition_index = partition_offset.partition;
+              p.committed_offset = kafka::offset_cast(
+                partition_offset.committed_offset);
+              // do not pass leader epoch information to target cluster as the
+              // epochs are not preserved
+              p.committed_leader_epoch = kafka::leader_epoch(-1);
+              t.partitions.push_back(std::move(p));
+          });
+        req.data.topics.push_back(std::move(t));
+    }
+
+    co_return req;
+}
+template<typename ApiT>
+kafka::api_version
+get_max_supported(kafka::client::api_version_range remote_supported) {
+    return std::min(remote_supported.max, ApiT::max_valid);
+}
+
+kafka::list_groups_request make_list_groups_request() {
+    kafka::list_groups_request req;
+    req.data.states_filter.reserve(4);
+    // we want all groups, no filtering
+    req.data.states_filter.emplace_back(kafka::group_state_name_empty);
+    req.data.states_filter.emplace_back(
+      kafka::group_state_name_preparing_rebalance);
+    req.data.states_filter.emplace_back(kafka::group_state_name_stable);
+    req.data.states_filter.emplace_back(
+      kafka::group_state_name_completing_rebalance);
+
+    return req;
+}
+} // namespace
+
+ss::future<> group_mirroring_task::commit_group_offsets(
+  chunked_vector<group_offsets> offsets) {
+    co_await ss::max_concurrent_for_each(
+      std::move(offsets), concurrent_requests_limit, [this](group_offsets& go) {
+          return build_offset_commit_request(std::move(go))
+            .then([this](kafka::offset_commit_request req) {
+                auto group = req.data.group_id;
+                vlog(logger().trace, "Committing {} group offsets", group);
+                return get_link()
+                  ->get_group_router()
+                  .offset_commit(std::move(req))
+                  .then([this, group = std::move(group)](
+                          kafka::offset_commit_response resp) mutable {
+                      handle_offset_commit_response(
+                        std::move(group), std::move(resp));
+                  });
+            });
+      });
+}
+
+void group_mirroring_task::handle_offset_commit_response(
+  kafka::group_id group, kafka::offset_commit_response resp) {
+    for (const auto& tp : resp.data.topics) {
+        for (const auto& p : tp.partitions) {
+            if (p.errored()) [[unlikely]] {
+                vlog(
+                  logger().warn,
+                  "Failed to commit offset for group {}, "
+                  "partition {}/{}, error: {}",
+                  group,
+                  tp.name,
+                  p.partition_index,
+                  p.error_code);
+            }
+        }
+    }
+}
+
+ss::future<chunked_vector<group_mirroring_task::group_offsets>>
+group_mirroring_task::trim_to_partition_highwatermark(
+  chunked_vector<group_offsets> offsets) {
+    // TODO: add trimming implementation
+    co_return std::move(offsets);
+}
+
+ss::future<std::expected<
+  chunked_vector<group_mirroring_task::group_offsets>,
+  group_mirroring_task::error>>
+group_mirroring_task::fetch_offsets(
+  chunked_vector<kafka::group_id> groups, ::model::node_id coordinator) {
+    auto& c_connection = get_cluster_connection();
+
+    auto versions = co_await c_connection.supported_api_versions(
+      coordinator, kafka::offset_fetch_api::key);
+    chunked_vector<group_offsets> ret;
+    if (!versions) {
+        co_return std::unexpected<error>{ssx::sformat(
+          "Broker {} does not support offset fetch API", coordinator)};
+    }
+
+    ret.reserve(groups.size());
+    auto version = get_max_supported<kafka::offset_fetch_api>(*versions);
+    // TODO: handle new version where we can fetch offsets for multiple groups
+    // at once.
+    const auto group_count = groups.size();
+    size_t error_cnt = 0;
+    co_await ss::max_concurrent_for_each(
+      std::move(groups),
+      concurrent_requests_limit,
+      [this, &ret, version, coordinator, &c_connection, &error_cnt](
+        kafka::group_id& group_id) {
+          kafka::offset_fetch_request req;
+          req.data.group_id = group_id;
+          req.data.topics = std::nullopt; // no topics filtering
+          return c_connection.dispatch_to(coordinator, std::move(req), version)
+            .then([this, &ret, group_id, &error_cnt](
+                    kafka::offset_fetch_response resp) mutable {
+                return process_single_group_fetch_offsets_response(
+                         group_id, std::move(resp))
+                  .then([&ret, &error_cnt, group_id](
+                          std::expected<chunked_vector<topic_offsets>, error>
+                            offsets) mutable {
+                      if (!offsets) {
+                          error_cnt++;
+                      }
+                      ret.push_back(
+                        group_offsets{
+                          .group_id = std::move(group_id),
+                          .topic_offsets = std::move(offsets.value())});
+                  });
+            })
+            .handle_exception(
+              [this, group_id, &error_cnt](const std::exception_ptr& e) {
+                  vlog(
+                    logger().warn,
+                    "Failed to fetch offsets for group {} - {}",
+                    group_id,
+                    e);
+                  error_cnt++;
+              });
+      });
+
+    if (error_cnt == group_count) {
+        co_return std::unexpected<error>{
+          ssx::sformat("All requests to fetch offsets failed")};
+    }
+
+    co_return ret;
+}
+
+ss::future<std::expected<
+  chunked_vector<group_mirroring_task::topic_offsets>,
+  group_mirroring_task::error>>
+group_mirroring_task::process_single_group_fetch_offsets_response(
+  const kafka::group_id& group_id, kafka::offset_fetch_response resp) {
+    chunked_vector<topic_offsets> ret;
+    if (resp.data.error_code != kafka::error_code::none) {
+        if (kafka::is_retriable(resp.data.error_code)) {
+            _needs_coordinator_update = true;
+            vlog(
+              logger().info,
+              "Failed to fetch offsets for group {}, error_code: {}",
+              group_id,
+              resp.data.error_code);
+        } else {
+            co_return std::unexpected<error>{ssx::sformat(
+              "Failed to fetch offsets for group {}, error_code: {}",
+              group_id,
+              resp.data.error_code)};
+        }
+
+        co_return ret;
+    }
+    ret.reserve(resp.data.topics.size());
+    ssx::async_counter counter;
+    for (auto& t : resp.data.topics) {
+        topic_offsets t_offsets;
+        t_offsets.topic = std::move(t.name);
+        t_offsets.partition_offsets.reserve(t.partitions.size());
+        co_await ssx::async_for_each_counter(
+          counter,
+          std::move(t.partitions),
+          [&t_offsets, this, &group_id](
+            kafka::offset_fetch_response_partition& p) {
+              if (p.error_code != kafka::error_code::none) {
+                  if (kafka::is_retriable(p.error_code)) {
+                      _needs_coordinator_update = true;
+                  }
+                  vlogl(
+                    logger(),
+                    kafka::is_retriable(p.error_code) ? ss::log_level::info
+                                                      : ss::log_level::warn,
+                    "Failed to fetch offsets for group {}, partition {}/{}"
+                    "error_code: {}",
+                    group_id,
+                    t_offsets.topic,
+                    p.partition_index,
+                    p.error_code);
+                  return;
+              }
+              t_offsets.partition_offsets.push_back(
+                partition_committed_offset{
+                  .partition = p.partition_index,
+                  .committed_offset = ::model::offset_cast(p.committed_offset),
+                });
+          });
+        ret.push_back(std::move(t_offsets));
+    }
+
+    co_return ret;
+}
+
+ss::future<
+  std::expected<chunked_vector<kafka::group_id>, group_mirroring_task::error>>
+group_mirroring_task::list_groups_from_broker(::model::node_id broker_id) {
+    kafka::list_groups_request req;
+    auto& c_connection = get_cluster_connection();
+
+    auto versions = co_await c_connection.supported_api_versions(
+      broker_id, kafka::list_groups_api::key);
+    if (!versions) {
+        vlog(
+          logger().error,
+          "Broker {} does not support list groups API",
+          broker_id);
+        co_return std::unexpected<error>(ssx::sformat(
+          "Broker {} does not support list groups API", broker_id));
+    }
+    try {
+        auto reply = co_await c_connection.dispatch_to(
+          broker_id,
+          make_list_groups_request(),
+          get_max_supported<kafka::list_groups_api>(*versions));
+
+        if (reply.data.error_code != kafka::error_code::none) {
+            vlog(
+              logger().warn,
+              "Failed to list groups from broker {}: kafka api error: {}",
+              broker_id,
+              reply.data.error_code);
+            co_return std::unexpected<error>(ssx::sformat(
+              "Failed to list groups from {}", reply.data.error_code));
+        }
+        chunked_vector<kafka::group_id> groups;
+        groups.reserve(reply.data.groups.size());
+        for (const auto& group : reply.data.groups) {
+            groups.push_back(group.group_id);
+        }
+        co_return std::move(groups);
+    } catch (...) {
+        auto lvl = ssx::is_shutdown_exception(std::current_exception())
+                     ? ss::log_level::trace
+                     : ss::log_level::warn;
+        vlogl(
+          logger(),
+          lvl,
+          "Exception thrown while listing groups from broker {} - {}",
+          broker_id,
+          std::current_exception());
+
+        co_return std::unexpected<error>(ssx::sformat(
+          "Exception thrown while listing groups - {}",
+          std::current_exception()));
+    }
+}
+
+ss::future<group_mirroring_task::result_t>
+group_mirroring_task::update_group_coordinators() {
+    auto& c_connection = get_cluster_connection();
+
+    auto versions = co_await c_connection.supported_api_versions(
+      kafka::find_coordinator_api::key);
+    if (!versions) {
+        co_return std::unexpected<error>(
+          "Remote cluster does not support find coordinator API");
+    }
+
+    bool errored = false;
+    // TODO: add support for batched find coordinator, this will require
+    // supporting FindCoordinatorRequest v4
+    co_await ss::max_concurrent_for_each(
+      _groups_to_mirror.begin(),
+      _groups_to_mirror.end(),
+      concurrent_requests_limit,
+      [this,
+       &errored,
+       version = get_max_supported<kafka::find_coordinator_api>(*versions)](
+        auto& entry) {
+          return do_find_coordinator(entry.first, version)
+            .then([this, &entry, &errored](
+                    std::expected<::model::node_id, group_mirroring_task::error>
+                      result) {
+                if (result.has_value()) {
+                    vlog(
+                      logger().trace,
+                      "Group {} coordinator discovered: {}",
+                      entry.first,
+                      *result);
+                    entry.second.coordinator_id = *result;
+                } else {
+                    errored |= true;
+                }
+            });
+      });
+
+    if (!errored) {
+        _needs_coordinator_update = false;
+    }
+
+    co_return result_t{};
+}
+
+kafka::client::cluster& group_mirroring_task::get_cluster_connection() {
+    return get_link()->get_cluster_connection();
+}
+
+ss::future<std::expected<::model::node_id, group_mirroring_task::error>>
+group_mirroring_task::do_find_coordinator(
+  const kafka::group_id& group_id, kafka::api_version max_version) {
+    vlog(logger().trace, "Requesting find coordinator for group: {}", group_id);
+    kafka::find_coordinator_request req;
+    req.data.key_type = kafka::coordinator_type::group;
+    req.data.key = group_id;
+    // limit version to 3 as the next one use batched api
+    auto resp = co_await get_cluster_connection().dispatch_to_any(
+      std::move(req), std::min(max_version, kafka::api_version(3)));
+
+    if (resp.data.error_code != kafka::error_code::none) {
+        vlog(
+          logger().warn,
+          "Error finding coordinator for {} - {}",
+          group_id,
+          resp.data.error_code);
+        co_return std::unexpected(error(
+          ssx::sformat("Error finding coordinator for {}", group_id),
+          resp.data.error_code));
+    }
+    co_return resp.data.node_id;
+}
+
+std::string_view
+group_mirroring_task_factory::created_task_name() const noexcept {
+    return group_mirroring_task::task_name;
+}
+
+std::unique_ptr<task> group_mirroring_task_factory::create_task(link* link) {
+    return std::make_unique<group_mirroring_task>(link, link->get_config());
+}
+
+fmt::iterator group_mirroring_task::error::format_to(fmt::iterator it) const {
+    if (errc != kafka::error_code::none) {
+        return fmt::format_to(it, "{{message: {}, errc: {}}}", message, errc);
+    }
+    return fmt::format_to(it, "{{message: {}}}", message);
+}
+
+fmt::iterator group_mirroring_task::partition_committed_offset::format_to(
+  fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{partition: {}, committed_offset: {}}}",
+      partition,
+      committed_offset);
+}
+
+fmt::iterator
+group_mirroring_task::topic_offsets::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{topic: {}, partition_offsets: {}}}",
+      topic,
+      fmt::join(partition_offsets, ", "));
+}
+
+fmt::iterator
+group_mirroring_task::group_offsets::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{group_id: {}, topic_offsets: {}}}",
+      group_id,
+      fmt::join(topic_offsets, ", "));
+}
+
+} // namespace cluster_link

--- a/src/v/cluster_link/group_mirroring_task.h
+++ b/src/v/cluster_link/group_mirroring_task.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "base/format_to.h"
+#include "cluster_link/deps.h"
+#include "cluster_link/task.h"
+#include "kafka/protocol/types.h"
+
+#include <fmt/format.h>
+
+#include <expected>
+namespace cluster_link {
+
+/**
+ * @brief Task responsible for mirroring consumer group offsets across cluster
+ * links
+ *
+ * This task manages the synchronization of consumer group committed offsets
+ * from a source cluster to a target cluster. It performs the following
+ * operations:
+ *
+ * 1. Periodically discovers consumer groups in the source cluster by querying
+ * all brokers
+ * 2. Identifies which groups should be mirrored based on configuration filters
+ * 3. Tracks group coordinators to optimize offset fetch operations
+ * 4. Fetches committed offsets for each consumer group from the source cluster
+ * 5. Commits those offsets to the corresponding consumer groups in the target
+ * cluster
+ *
+ * The task runs on shards that own partitions of the __consumer_offsets topic
+ * and are leaders for those partitions. It supports concurrent requests with a
+ * configurable limit to optimize throughput while avoiding overwhelming the
+ * clusters.
+ *
+ * Configuration is provided through consumer_groups_mirroring_config which
+ * includes:
+ * - Group sync interval: How often to synchronize offsets for known groups
+ * - Consumer group filters: Which groups to include/exclude from mirroring
+ *
+ * Task handles terminal error by marking the state of link as unavailable. The
+ * task is made unavailable only if the operations for each
+ * broker/partition/group failed. Otherwise it is assumed that the task can
+ * still make progress.
+ */
+class group_mirroring_task : public task {
+public:
+    struct group_metadata {
+        std::optional<::model::node_id> coordinator_id;
+    };
+
+    struct partition_committed_offset {
+        ::model::partition_id partition;
+        ::kafka::offset committed_offset;
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    struct topic_offsets {
+        ::model::topic topic;
+        ::chunked_vector<partition_committed_offset> partition_offsets;
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    struct group_offsets {
+        using topics_t = chunked_vector<topic_offsets>;
+        kafka::group_id group_id;
+        topics_t topic_offsets;
+
+        fmt::iterator format_to(fmt::iterator) const;
+    };
+
+    static constexpr auto task_name = "Consumer Group Mirroring";
+    static constexpr auto concurrent_requests_limit = 32;
+
+    group_mirroring_task(link* link, const model::metadata& link_metadata);
+    group_mirroring_task(const group_mirroring_task&) = delete;
+    group_mirroring_task(group_mirroring_task&&) = delete;
+    group_mirroring_task& operator=(const group_mirroring_task&) = delete;
+    group_mirroring_task& operator=(group_mirroring_task&&) = delete;
+    ~group_mirroring_task() override = default;
+
+    void update_config(const model::metadata& link_metadata) override;
+
+protected:
+    ss::future<> run_impl() override;
+
+    bool should_start_impl(ss::shard_id, ::model::node_id) const final;
+
+    bool should_stop_impl(ss::shard_id, ::model::node_id) const final;
+
+private:
+    struct error {
+        error(ss::sstring msg, kafka::error_code errc)
+          : message(std::move(msg))
+          , errc(errc) {}
+
+        explicit error(ss::sstring msg)
+          : message(std::move(msg))
+          , errc(kafka::error_code::none) {}
+
+        ss::sstring message;
+        kafka::error_code errc;
+        fmt::iterator format_to(fmt::iterator it) const;
+    };
+    using result_t = std::expected<void, error>;
+
+    ss::future<result_t> list_consumer_groups();
+
+    ss::future<std::expected<chunked_vector<kafka::group_id>, error>>
+    list_groups_from_broker(::model::node_id broker_id);
+
+    ss::future<std::expected<::model::node_id, error>> do_find_coordinator(
+      const kafka::group_id& group_id, kafka::api_version max_version);
+
+    inline bool should_group_be_mirrored(
+      const kafka::group_id& group_id,
+      const chunked_hash_set<::model::partition_id>&
+        current_shard_coordinators);
+
+    ss::future<result_t> update_group_coordinators();
+
+    ss::future<result_t> synchronize_consumer_groups_offsets();
+
+    ss::future<
+      std::expected<chunked_vector<group_mirroring_task::group_offsets>, error>>
+    fetch_offsets(
+      chunked_vector<kafka::group_id> groups, ::model::node_id coordinator_id);
+
+    ss::future<std::expected<chunked_vector<topic_offsets>, error>>
+    process_single_group_fetch_offsets_response(
+      const kafka::group_id& group_id, kafka::offset_fetch_response resp);
+
+    ss::future<std::expected<void, group_mirroring_task::error>>
+    fetch_and_commit_offsets(
+      chunked_vector<kafka::group_id> groups, ::model::node_id coordinator_id);
+
+    ss::future<>
+    commit_group_offsets(chunked_vector<group_offsets> group_offsets);
+
+    ss::future<chunked_vector<group_offsets>>
+      trim_to_partition_highwatermark(chunked_vector<group_offsets>);
+
+    kafka::client::cluster& get_cluster_connection();
+
+    void handle_offset_commit_response(
+      kafka::group_id, kafka::offset_commit_response);
+
+    void make_unavailable(const error& err);
+    void make_active();
+
+    model::consumer_groups_mirroring_config _config;
+    chunked_hash_map<kafka::group_id, group_metadata> _groups_to_mirror;
+
+    bool _needs_coordinator_update = false;
+};
+
+/**
+ * @brief Factory used to create the consumer offsets mirroring task
+ */
+class group_mirroring_task_factory : public task_factory {
+public:
+    /// Returns the name of the task that this factory creates
+    std::string_view created_task_name() const noexcept override;
+
+    /// Creates a new task through the factory.  Provides the owning link
+    std::unique_ptr<task> create_task(link* link) override;
+};
+} // namespace cluster_link

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -269,6 +269,10 @@ kafka::client::cluster& link::get_cluster_connection() noexcept {
     return *_cluster_connection;
 }
 
+consumer_groups_router& link::get_group_router() {
+    return _manager->get_group_router();
+}
+
 std::optional<chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
 link::get_mirror_topics_for_link() const {
     return _manager->get_mirror_topics_for_link(_link_id);

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster_link/deps.h"
 #include "cluster_link/model/types.h"
 #include "cluster_link/replication/deps.h"
 #include "cluster_link/replication/link_replication_mgr.h"
@@ -99,6 +100,8 @@ public:
     kafka::data::rpc::topic_creator& topic_creator() noexcept;
 
     kafka::client::cluster& get_cluster_connection() noexcept;
+
+    consumer_groups_router& get_group_router();
 
     std::optional<
       chunked_hash_map<::model::topic, model::mirror_topic_metadata>>

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -104,6 +104,8 @@ public:
       chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
     get_mirror_topics_for_link() const;
 
+    ::model::node_id self() const { return _self; }
+
 private:
     bool should_start_task(task* t) const;
     bool should_stop_task(task* t) const;

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -80,6 +80,7 @@ manager::manager(
   std::unique_ptr<link_registry> registry,
   std::unique_ptr<link_factory> link_factory,
   std::unique_ptr<cluster_factory> cluster_factory,
+  std::unique_ptr<consumer_groups_router> group_router,
   ss::lowres_clock::duration task_reconciler_interval)
   : _self(self)
   , _partition_leader_cache(std::move(partition_leader_cache))
@@ -89,6 +90,7 @@ manager::manager(
   , _registry(std::move(registry))
   , _link_factory(std::move(link_factory))
   , _cluster_factory(std::move(cluster_factory))
+  , _group_router(std::move(group_router))
   , _queue(
       [](const std::exception_ptr& ex) {
           vlog(cllog.warn, "unexpected cluster link manager error: {}", ex);
@@ -510,5 +512,9 @@ ss::future<> manager::stop_topic_reconciler() {
               10s, [this] { return stop_topic_reconciler(); });
         }
     }
+}
+
+consumer_groups_router& manager::get_group_router() noexcept {
+    return *_group_router;
 }
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -46,6 +46,7 @@ public:
       std::unique_ptr<link_registry> registry,
       std::unique_ptr<link_factory> link_factory,
       std::unique_ptr<cluster_factory> cluster_factory,
+      std::unique_ptr<consumer_groups_router> group_router,
       ss::lowres_clock::duration task_reconciler_interval);
     manager(const manager&) = delete;
     manager(manager&&) = delete;
@@ -131,6 +132,8 @@ public:
     const kafka::data::rpc::partition_manager&
     partition_manager() const noexcept;
 
+    consumer_groups_router& get_group_router() noexcept;
+
     kafka::data::rpc::topic_creator& topic_creator() noexcept;
 
 private:
@@ -151,6 +154,7 @@ private:
     std::unique_ptr<link_factory> _link_factory;
     std::unique_ptr<cluster_factory> _cluster_factory;
     std::unique_ptr<topic_reconciler> _topic_reconciler;
+    std::unique_ptr<consumer_groups_router> _group_router;
     ssx::work_queue _queue;
 
     chunked_vector<std::unique_ptr<task_factory>> _task_factories;

--- a/src/v/cluster_link/model/BUILD
+++ b/src/v/cluster_link/model/BUILD
@@ -16,6 +16,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/container:chunked_hash_map",
+        "//src/v/kafka/protocol",
         "//src/v/model",
         "//src/v/serde",
         "//src/v/serde:variant",

--- a/src/v/cluster_link/model/filter_utils.cc
+++ b/src/v/cluster_link/model/filter_utils.cc
@@ -12,8 +12,10 @@
 #include "cluster_link/model/filter_utils.h"
 
 namespace cluster_link::model {
-bool select_topic(
-  ::model::topic_view topic,
+namespace {
+template<typename T>
+bool select_using_filter(
+  const T& resource,
   const chunked_vector<resource_name_filter_pattern>& patterns) {
     bool matched = false;
     for (const auto& pattern : patterns) {
@@ -22,11 +24,11 @@ bool select_topic(
         case filter_pattern_type::literal:
             filter_selected = (pattern.pattern
                                == resource_name_filter_pattern::wildcard)
-                              || (topic == pattern.pattern);
+                              || (resource == pattern.pattern);
             break;
         case filter_pattern_type::prefix:
             if (!pattern.pattern.empty()) {
-                filter_selected = topic().starts_with(pattern.pattern);
+                filter_selected = resource().starts_with(pattern.pattern);
             }
             break;
         }
@@ -44,4 +46,18 @@ bool select_topic(
 
     return matched;
 }
+
+} // namespace
+bool select_topic(
+  ::model::topic_view topic,
+  const chunked_vector<resource_name_filter_pattern>& patterns) {
+    return select_using_filter(topic, patterns);
+}
+
+bool select_group(
+  const kafka::group_id& group_id,
+  const chunked_vector<resource_name_filter_pattern>& patterns) {
+    return select_using_filter(group_id, patterns);
+}
+
 } // namespace cluster_link::model

--- a/src/v/cluster_link/model/filter_utils.h
+++ b/src/v/cluster_link/model/filter_utils.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster_link/model/types.h"
+#include "kafka/protocol/types.h"
 
 namespace cluster_link::model {
 /**
@@ -28,4 +29,9 @@ namespace cluster_link::model {
 bool select_topic(
   ::model::topic_view topic,
   const chunked_vector<resource_name_filter_pattern>& patterns);
+
+bool select_group(
+  const kafka::group_id& group_id,
+  const chunked_vector<resource_name_filter_pattern>& patterns);
+
 } // namespace cluster_link::model

--- a/src/v/cluster_link/model/types.cc
+++ b/src/v/cluster_link/model/types.cc
@@ -62,6 +62,7 @@ consumer_groups_mirroring_config::copy() const {
 link_configuration link_configuration::copy() const {
     link_configuration copy;
     copy.topic_metadata_mirroring_cfg = topic_metadata_mirroring_cfg.copy();
+    copy.consumer_groups_mirroring_cfg = consumer_groups_mirroring_cfg.copy();
     return copy;
 }
 
@@ -274,6 +275,18 @@ auto fmt::formatter<cluster_link::model::topic_metadata_mirroring_config>::
       m.topic_properties_to_mirror);
 }
 
+auto fmt::formatter<cluster_link::model::consumer_groups_mirroring_config>::
+  format(
+    const cluster_link::model::consumer_groups_mirroring_config& m,
+    format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(
+      ctx.out(),
+      "{{is_enabled: {}, task_interval: {}, filters: {}}}",
+      m.is_enabled,
+      m.task_interval,
+      m.filters);
+}
+
 auto fmt::formatter<cluster_link::model::link_state>::format(
   const cluster_link::model::link_state& s, format_context& ctx) const
   -> decltype(ctx.out()) {
@@ -385,6 +398,7 @@ auto fmt::formatter<cluster_link::model::link_configuration>::format(
   -> decltype(ctx.out()) {
     return fmt::format_to(
       ctx.out(),
-      "{{topic_metadata_mirroring_cfg: {}}}",
-      cfg.topic_metadata_mirroring_cfg);
+      "{{topic_metadata_mirroring_cfg: {}, consumer_groups_mirroring_cfg: {}}}",
+      cfg.topic_metadata_mirroring_cfg,
+      cfg.consumer_groups_mirroring_cfg);
 }

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -347,7 +347,6 @@ struct consumer_groups_mirroring_config
     enabled_t is_enabled{enabled_t::yes};
     // Task interval for consumer group mirroring
     std::optional<ss::lowres_clock::duration> task_interval;
-    // Default interval for task (30s)
     static constexpr auto default_task_interval = std::chrono::seconds(30);
 
     /// Filters
@@ -378,11 +377,16 @@ struct link_configuration
       serde::compat_version<0>> {
     /// Configuration for the auto mirror topic creation task
     topic_metadata_mirroring_config topic_metadata_mirroring_cfg;
+    /// Configuration for the consumer groups mirroring task
+    consumer_groups_mirroring_config consumer_groups_mirroring_cfg;
 
     friend bool operator==(const link_configuration&, const link_configuration&)
       = default;
 
-    auto serde_fields() { return std::tie(topic_metadata_mirroring_cfg); }
+    auto serde_fields() {
+        return std::tie(
+          topic_metadata_mirroring_cfg, consumer_groups_mirroring_cfg);
+    }
 
     link_configuration copy() const;
 };
@@ -701,6 +705,14 @@ struct fmt::formatter<cluster_link::model::topic_metadata_mirroring_config>
   : fmt::formatter<string_view> {
     auto format(
       const cluster_link::model::topic_metadata_mirroring_config& m,
+      format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<cluster_link::model::consumer_groups_mirroring_config>
+  : fmt::formatter<string_view> {
+    auto format(
+      const cluster_link::model::consumer_groups_mirroring_config& m,
       format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -13,6 +13,7 @@
 
 #include "cluster/cluster_link/frontend.h"
 #include "cluster/partition_manager.h"
+#include "cluster_link/group_mirroring_task.h"
 #include "cluster_link/link.h"
 #include "cluster_link/logger.h"
 #include "cluster_link/manager.h"
@@ -21,6 +22,7 @@
 #include "cluster_link/replication/mux_remote_consumer.h"
 #include "cluster_link/source_topic_syncer.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
+#include "kafka/server/group_router.h"
 
 namespace cluster_link {
 
@@ -143,6 +145,48 @@ private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
 };
 
+class kafka_consumer_groups_router : public consumer_groups_router {
+public:
+    explicit kafka_consumer_groups_router(
+      ss::sharded<kafka::group_router>* router)
+      : _router(router) {}
+    std::optional<::model::partition_id>
+    partition_for(const kafka::group_id& group) const final {
+        return _router->local().coordinator_mapper().local().partition_for(
+          group);
+    }
+
+    ss::future<kafka::offset_commit_response>
+    offset_commit(kafka::offset_commit_request req) final {
+        auto stages = _router->local().offset_commit(std::move(req));
+
+        auto dispatched = co_await ss::coroutine::as_future(
+          std::move(stages.dispatched));
+        auto result = co_await ss::coroutine::as_future(
+          std::move(stages.result));
+        std::exception_ptr error = nullptr;
+        if (dispatched.failed()) {
+            error = dispatched.get_exception();
+        }
+
+        if (result.failed()) {
+            auto r_err = result.get_exception();
+            if (error == nullptr) {
+                error = r_err;
+            }
+        }
+
+        if (error) {
+            std::rethrow_exception(error);
+        }
+
+        co_return result.get();
+    }
+
+private:
+    ss::sharded<kafka::group_router>* _router;
+};
+
 service::service(
   ::model::node_id self,
   ss::sharded<frontend>* plf,
@@ -152,6 +196,7 @@ service::service(
   ss::sharded<cluster::shard_table>* shard_table,
   ss::sharded<cluster::metadata_cache>* metadata_cache,
   cluster::controller* controller,
+  ss::sharded<kafka::group_router>* group_router,
   ss::smp_service_group smp_group)
   : _self(self)
   , _plf(plf)
@@ -161,6 +206,7 @@ service::service(
   , _shard_table(shard_table)
   , _metadata_cache(metadata_cache)
   , _controller(controller)
+  , _group_router(group_router)
   , _smp_group(smp_group) {}
 
 service::~service() = default;
@@ -177,6 +223,7 @@ ss::future<> service::start() {
       std::make_unique<link_registry_adapter>(&_plf->local()),
       std::make_unique<default_link_factory>(_partition_manager),
       std::make_unique<cluster_factory>(),
+      std::make_unique<kafka_consumer_groups_router>(_group_router),
       30s); // Temporary until we have a proper configuration for this
 
     co_await _manager->register_task_factory<source_topic_syncer_factory>();

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -227,6 +227,7 @@ ss::future<> service::start() {
       30s); // Temporary until we have a proper configuration for this
 
     co_await _manager->register_task_factory<source_topic_syncer_factory>();
+    co_await _manager->register_task_factory<group_mirroring_task_factory>();
 
     // Register notifications before the manager starts.  The manager will have
     // a constructed the underlying workqueue to start in a paused state and

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -18,8 +18,8 @@
 #include "cluster_link/errc.h"
 #include "cluster_link/fwd.h"
 #include "cluster_link/model/types.h"
+#include "kafka/server/fwd.h"
 #include "model/fundamental.h"
-#include "raft/fundamental.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
@@ -40,6 +40,7 @@ public:
       ss::sharded<cluster::shard_table>* shard_table,
       ss::sharded<cluster::metadata_cache>* metadata_cache,
       cluster::controller* controller,
+      ss::sharded<kafka::group_router>* group_router,
       ss::smp_service_group smp_group);
 
     service(const service&) = delete;
@@ -87,6 +88,7 @@ private:
     ss::sharded<cluster::shard_table>* _shard_table;
     ss::sharded<cluster::metadata_cache>* _metadata_cache;
     cluster::controller* _controller;
+    ss::sharded<kafka::group_router>* _group_router;
     ss::smp_service_group _smp_group;
     std::unique_ptr<manager> _manager;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -130,3 +130,17 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "group_mirroring_task",
+    timeout = "short",
+    srcs = [
+        "group_mirroring_task_test.cc",
+    ],
+    deps = [
+        ":test_deps",
+        "//src/v/cluster_link:group_mirroring_task",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -75,6 +75,11 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
       ss::sharded_parameter([this]() {
           return std::make_unique<cluster_mock_factory>(&_cluster_mock);
       }),
+      ss::sharded_parameter([this]() {
+          auto router = std::make_unique<test_consumer_group_router>();
+          _consumer_group_router = router.get();
+          return router;
+      }),
       1s);
 
     auto notif_id = _table.local().register_for_updates(
@@ -201,5 +206,26 @@ void cluster_link_manager_test_fixture::setup_cluster_mock() {
       ::model::node_id(1), net::unresolved_address{"localhost", 9093});
     _cluster_mock.add_broker(
       ::model::node_id(2), net::unresolved_address{"localhost", 9094});
+}
+
+std::optional<::model::partition_id>
+test_consumer_group_router::partition_for(const kafka::group_id& group) const {
+    auto hash = std::hash<kafka::group_id>{}(group);
+    return ::model::partition_id(
+      static_cast<::model::partition_id::type>(hash % partition_count));
+}
+
+ss::future<kafka::offset_commit_response>
+test_consumer_group_router::offset_commit(kafka::offset_commit_request req) {
+    auto& g_state = groups[req.data.group_id];
+    for (auto& tp : req.data.topics) {
+        auto& topic = g_state.offsets[tp.name];
+        for (auto& p : tp.partitions) {
+            topic[p.partition_index] = ::model::offset_cast(p.committed_offset);
+        }
+    }
+    kafka::offset_commit_response resp;
+
+    co_return resp;
 }
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -193,6 +193,17 @@ cluster_link_manager_test_fixture::await_status_report(
     co_return std::nullopt;
 }
 
+ss::future<bool> cluster_link_manager_test_fixture::wait_for_report_to_match(
+  ss::lowres_clock::duration timeout,
+  ss::lowres_clock::duration backoff,
+  std::function<bool(const model::cluster_link_task_status_report&)>
+    predicate) {
+    return await_status_report(timeout, backoff, std::move(predicate))
+      .then([](std::optional<model::cluster_link_task_status_report> report) {
+          return report.has_value();
+      });
+}
+
 void cluster_link_manager_test_fixture::set_topic_config(
   cluster::topic_configuration cfg) {
     _tmc->set_topic_config(std::move(cfg));

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -384,6 +384,25 @@ private:
       _topic_cfgs;
 };
 
+struct test_consumer_group_router : public consumer_groups_router {
+    struct group_state {
+        chunked_hash_map<
+          ::model::topic,
+          chunked_hash_map<::model::partition_id, kafka::offset>>
+          offsets;
+    };
+
+    std::optional<::model::partition_id>
+    partition_for(const kafka::group_id&) const override;
+
+    ss::future<kafka::offset_commit_response>
+      offset_commit(kafka::offset_commit_request) override;
+
+    chunked_hash_map<kafka::group_id, group_state> groups;
+
+    int partition_count = 1;
+};
+
 class cluster_link_manager_test_fixture {
 public:
     explicit cluster_link_manager_test_fixture(::model::node_id self);
@@ -448,6 +467,10 @@ public:
 
     void set_topic_config(cluster::topic_configuration cfg);
 
+    test_consumer_group_router* consumer_group_router() {
+        return _consumer_group_router;
+    }
+
 private:
     void setup_cluster_mock();
 
@@ -463,6 +486,7 @@ private:
     fake_topic_metadata_cache* _tmc{nullptr};
     kafka::data::rpc::test::fake_topic_creator* _ftpc{nullptr};
     link_factory* _lf{nullptr};
+    test_consumer_group_router* _consumer_group_router{nullptr};
     ss::sharded<manager> _manager;
 
     ::model::node_id _self;

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -471,6 +471,12 @@ public:
         return _consumer_group_router;
     }
 
+    ss::future<bool> wait_for_report_to_match(
+      ss::lowres_clock::duration timeout,
+      ss::lowres_clock::duration backoff,
+      std::function<bool(const model::cluster_link_task_status_report&)>
+        predicate);
+
 private:
     void setup_cluster_mock();
 

--- a/src/v/cluster_link/tests/group_mirroring_task_test.cc
+++ b/src/v/cluster_link/tests/group_mirroring_task_test.cc
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster_link/group_mirroring_task.h"
+#include "cluster_link/tests/deps.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+
+#include <gmock/gmock.h>
+
+using namespace std::chrono_literals;
+
+namespace cluster_link::tests {
+
+using model::filter_pattern_type;
+using model::filter_type;
+using model::resource_name_filter_pattern;
+
+namespace {
+static const model::name_t link_name{"test_cluster_link"};
+constexpr auto task_interval = 1s;
+constexpr auto wait_interval = 2 * task_interval;
+
+model::metadata get_default_metadata() {
+    model::link_state link_state;
+    model::metadata metadata{
+      .name = link_name,
+      .uuid = model::uuid_t(::uuid_t::create()),
+      .connection = model::
+        connection_config{.bootstrap_servers = {net::unresolved_address("localhost", 9092)}},
+      .state = std::move(link_state)};
+    metadata.configuration.consumer_groups_mirroring_cfg.task_interval
+      = task_interval;
+
+    metadata.configuration.consumer_groups_mirroring_cfg.filters.emplace_back(
+      resource_name_filter_pattern{
+        .pattern_type = filter_pattern_type::literal,
+        .filter = filter_type::include,
+        .pattern = resource_name_filter_pattern::wildcard});
+    return metadata;
+}
+
+/**
+ * Consumer groups metadata
+ */
+struct partition_offset_metadata {
+    kafka::offset committed_offset;
+};
+
+struct consumer_group_metadata {
+    kafka::group_id group_id;
+    ::model::node_id coordinator_id;
+    ss::sstring state = "stable";
+    chunked_hash_map<
+      ::model::topic,
+      chunked_hash_map<::model::partition_id, partition_offset_metadata>>
+      offsets;
+};
+
+} // namespace
+
+/**
+ * The test setup has the following assumptions:
+ *
+ *  - 4 consumer offsets topic partitions
+ */
+class group_mirroring_task_test : public seastar_test {
+public:
+    static constexpr auto task_reconciler_interval = 1s;
+    template<typename Api>
+    void set_supported_version(::model::node_id id) {
+        fixture()->get_cluster_mock().set_supported_versions(
+          id, Api::key, {.min = Api::min_valid, .max = Api::max_valid});
+    }
+    ss::future<> SetUpAsync() override {
+        _clmtf = std::make_unique<cluster_link_manager_test_fixture>(self());
+        co_await _clmtf->wire_up_and_start(
+          std::make_unique<test_link_factory>(task_reconciler_interval));
+
+        co_await _clmtf->get_manager().invoke_on_all([](manager& m) {
+            return m.register_task_factory<group_mirroring_task_factory>();
+        });
+
+        fixture()->elect_leader(::model::controller_ntp, self(), std::nullopt);
+
+        // Set up __consumer_offsets topic
+        auto consumer_offsets_cfg = cluster::topic_configuration(
+          ::model::kafka_namespace,
+          ::model::kafka_consumer_offsets_topic,
+          4,  // partition count
+          1); // replication factor
+        fixture()->set_topic_config(consumer_offsets_cfg);
+        fixture()->consumer_group_router()->partition_count = 4;
+        fixture()->get_cluster_mock().register_handler(
+          kafka::list_groups_api::key,
+          [this](
+            ::model::node_id id,
+            kafka::client::request_t req,
+            kafka::api_version version) {
+              return handle_list_groups_request(id, std::move(req), version);
+          });
+        fixture()->get_cluster_mock().register_handler(
+          kafka::find_coordinator_api::key,
+          [this](
+            ::model::node_id id,
+            kafka::client::request_t req,
+            kafka::api_version version) {
+              return handle_find_coordinator_request(
+                id, std::move(req), version);
+          });
+        fixture()->get_cluster_mock().register_handler(
+          kafka::offset_fetch_api::key,
+          [this](
+            ::model::node_id id,
+            kafka::client::request_t req,
+            kafka::api_version version) {
+              return handle_offset_fetch_request(id, std::move(req), version);
+          });
+
+        for (int i = 0; i < 3; ++i) {
+            ::model::node_id id{i};
+            set_supported_version<kafka::find_coordinator_api>(id);
+            set_supported_version<kafka::list_groups_api>(id);
+            set_supported_version<kafka::offset_fetch_api>(id);
+        }
+    }
+
+    void make_current_node_leader_for(const std::vector<int>& partition_ids) {
+        for (const auto& p_id : partition_ids) {
+            ::model::ntp ntp(
+              ::model::kafka_namespace,
+              ::model::kafka_consumer_offsets_topic,
+              p_id);
+            fixture()->elect_leader(ntp, self(), ss::this_shard_id());
+        }
+    }
+
+    void make_other_node_leader_for(const std::vector<int>& partition_ids) {
+        for (const auto& p_id : partition_ids) {
+            ::model::ntp ntp(
+              ::model::kafka_namespace,
+              ::model::kafka_consumer_offsets_topic,
+              p_id);
+            fixture()->elect_leader(ntp, ::model::node_id(1), std::nullopt);
+        }
+    }
+
+    ss::future<> TearDownAsync() override {
+        co_await _clmtf->reset();
+        _clmtf.reset();
+    }
+
+    cluster_link_manager_test_fixture* fixture() { return _clmtf.get(); }
+
+    ::model::node_id self() { return ::model::node_id(0); }
+
+    ss::future<bool> wait_for_task_state(model::task_state state) {
+        return fixture()->wait_for_report_to_match(
+          wait_interval,
+          100ms,
+          [state](const model::cluster_link_task_status_report& report) {
+              auto link_it = report.link_reports.find(link_name);
+              if (link_it == report.link_reports.end()) {
+                  return false;
+              }
+              auto task_it = link_it->second.task_status_reports.find(
+                group_mirroring_task::task_name);
+              if (task_it == link_it->second.task_status_reports.end()) {
+                  return false;
+              }
+
+              return task_it->second.task_state == state;
+          });
+    }
+    template<typename Predicate>
+    ss::future<>
+    wait_for_group_state(const kafka::group_id& group, Predicate&& pred) {
+        return ::tests::cooperative_spin_wait_with_timeout(
+          3 * wait_interval,
+          [this, pred = std::forward<Predicate>(pred), &group]() {
+              auto& groups = fixture()->consumer_group_router()->groups;
+              auto it = groups.find(group);
+              if (it != groups.end()) {
+                  return pred(it->second);
+              }
+              return false;
+          });
+    }
+
+    ss::future<> wait_for_mirrored_offsets(
+      const kafka::group_id& group,
+      std::unordered_map<ss::sstring, std::unordered_map<int, int64_t>>
+        offsets) {
+        return wait_for_group_state(
+          group,
+          [offsets = std::move(offsets)](
+            const test_consumer_group_router::group_state& g_state) {
+              if (g_state.offsets.size() != offsets.size()) {
+                  return false;
+              }
+              for (auto& [tp, partitions] : offsets) {
+                  ::model::topic m_tp(tp);
+                  auto it = g_state.offsets.find(m_tp);
+
+                  if (it == g_state.offsets.end()) {
+                      return false;
+                  }
+                  if (partitions.size() != it->second.size()) {
+                      return false;
+                  }
+                  for (auto& [p, offset] : partitions) {
+                      auto pit = it->second.find(::model::partition_id(p));
+                      if (
+                        pit == it->second.end()
+                        || pit->second != kafka::offset(offset)) {
+                          return false;
+                      }
+                  }
+              }
+              return true;
+          });
+    }
+
+    void set_source_cluster_group_offsets(
+      const kafka::group_id& group,
+      std::unordered_map<ss::sstring, std::unordered_map<int, int64_t>>
+        offsets) {
+        auto& metadata = source_cluster_group[group];
+        metadata.offsets.clear();
+
+        for (auto& [topic, partitions] : offsets) {
+            for (auto& [p, offset] : partitions) {
+                metadata
+                  .offsets[::model::topic(topic)][::model::partition_id(p)]
+                  .committed_offset
+                  = kafka::offset(offset);
+            }
+        }
+    }
+
+    ss::future<kafka::client::response_t> handle_list_groups_request(
+      ::model::node_id id, kafka::client::request_t, kafka::api_version) {
+        kafka::list_groups_response resp{};
+        if (id == self()) {
+            for (auto& [g, md] : source_cluster_group) {
+                resp.data.groups.push_back(
+                  kafka::listed_group{
+                    .group_id = g,
+                    .group_state = md.state,
+                  });
+            }
+        }
+        resp.data.error_code = kafka::error_code::none;
+        co_return resp;
+    }
+
+    ss::future<kafka::client::response_t> handle_find_coordinator_request(
+      ::model::node_id, kafka::client::request_t req, kafka::api_version) {
+        auto fc_req = std::get<kafka::find_coordinator_request>(std::move(req));
+        if (fc_req.data.key_type != kafka::coordinator_type::group) {
+            co_return kafka::find_coordinator_response{
+              kafka::error_code::unsupported_version,
+              ssx::sformat(
+                "Unsupported coordinator type: {}", fc_req.data.key_type)};
+        }
+
+        kafka::group_id gr{std::move(fc_req.data.key)};
+        auto it = source_cluster_group.find(gr);
+        if (it == source_cluster_group.end()) {
+            co_return kafka::find_coordinator_response{
+              kafka::error_code::coordinator_not_available,
+              ssx::sformat("Unknown group: {}", gr)};
+        }
+
+        co_return kafka::find_coordinator_response{
+          kafka::error_code::none,
+          std::nullopt,
+          it->second.coordinator_id,
+          "localhost",
+          9092};
+    }
+
+    ss::future<kafka::client::response_t> handle_offset_fetch_request(
+      ::model::node_id id, kafka::client::request_t req, kafka::api_version) {
+        auto of_req = std::get<kafka::offset_fetch_request>(std::move(req));
+
+        auto it = source_cluster_group.find(of_req.data.group_id);
+        if (it == source_cluster_group.end()) {
+            co_return kafka::offset_fetch_response(of_req.data.topics);
+        }
+
+        if (it->second.coordinator_id != id) {
+            co_return kafka::offset_fetch_response(
+              kafka::error_code::not_coordinator);
+        }
+
+        kafka::offset_fetch_response resp;
+        for (auto& [topic, partitions] : it->second.offsets) {
+            kafka::offset_fetch_response_topic r_topic;
+            r_topic.name = topic;
+            for (auto& [p_id, offset_meta] : partitions) {
+                r_topic.partitions.push_back(
+                  kafka::offset_fetch_response_partition{
+                    .partition_index = p_id,
+                    .committed_offset = kafka::offset_cast(
+                      offset_meta.committed_offset),
+                    .error_code = kafka::error_code::none});
+            }
+            resp.data.topics.push_back(std::move(r_topic));
+        }
+        co_return resp;
+    }
+
+    chunked_hash_map<kafka::group_id, consumer_group_metadata>
+      source_cluster_group;
+
+    std::unique_ptr<cluster_link_manager_test_fixture> _clmtf;
+};
+
+TEST_F(group_mirroring_task_test, check_if_task_follows_the_leader) {
+    // Clear the consumer offsets leadership
+    make_other_node_leader_for({0, 1, 2, 3});
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    ss::sleep(wait_interval).get();
+
+    bool is_stopped = wait_for_task_state(model::task_state::stopped).get();
+
+    ASSERT_TRUE(is_stopped);
+
+    // make current node a leader
+    make_current_node_leader_for({0, 4});
+    bool is_active = wait_for_task_state(model::task_state::active).get();
+    ASSERT_TRUE(is_active);
+
+    // make other node a leader
+    make_other_node_leader_for({4});
+    // wait for some time
+    ss::sleep(wait_interval).get();
+    // task should still be active as current node is still leader for one
+    // of the cg partitions
+    bool still_active = wait_for_task_state(model::task_state::active).get();
+    ASSERT_TRUE(still_active);
+
+    make_other_node_leader_for({0});
+    // no leaders on current node, task should be stopped
+    bool stopped = wait_for_task_state(model::task_state::stopped).get();
+    ASSERT_TRUE(stopped);
+}
+
+/**
+ * Simplest test validating consumer groups mirroring. This test mirrors
+ * state of consumer group from `kafka::client::cluster_mock` representing
+ * connection to the source cluster to the fixture `test_group_router` which
+ * maintains the state of target cluster consumer groups.
+ */
+TEST_F(group_mirroring_task_test, test_happy_path_offsets_mirroring) {
+    make_current_node_leader_for({0, 1, 2, 3});
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    bool is_active = wait_for_task_state(model::task_state::active).get();
+    ASSERT_TRUE(is_active);
+
+    // set consumer group offsets
+
+    kafka::group_id test_group("t-group");
+
+    consumer_group_metadata metadata;
+    metadata.group_id = test_group;
+    metadata.coordinator_id = ::model::node_id(0);
+    source_cluster_group[test_group] = std::move(metadata);
+
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 100}, {4, 312}}}});
+    /**
+     * Verify if offset is mirrored
+     */
+    wait_for_mirrored_offsets(test_group, {{"t-topic", {{0, 100}, {4, 312}}}})
+      .get();
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 0}, {4, 312}, {1, 10}}}});
+
+    wait_for_mirrored_offsets(
+      test_group, {{"t-topic", {{0, 0}, {4, 312}, {1, 10}}}})
+      .get();
+}
+
+TEST_F(group_mirroring_task_test, test_updating_source_cluster_coordinator) {
+    make_current_node_leader_for({0, 1, 2, 3});
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    bool is_active = wait_for_task_state(model::task_state::active).get();
+    ASSERT_TRUE(is_active);
+
+    kafka::group_id test_group("t-group");
+
+    consumer_group_metadata metadata;
+    metadata.group_id = test_group;
+    metadata.coordinator_id = ::model::node_id(0);
+    source_cluster_group[test_group] = std::move(metadata);
+
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 100}, {4, 312}}}});
+    /**
+     * Verify if offset is mirrored
+     */
+    wait_for_mirrored_offsets(test_group, {{"t-topic", {{0, 100}, {4, 312}}}})
+      .get();
+    // change coordinator
+    source_cluster_group[test_group].coordinator_id = ::model::node_id(1);
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 100}, {4, 1024}, {12, 10}}}});
+    /**
+     * Verify if offset is mirrored
+     */
+    wait_for_mirrored_offsets(
+      test_group, {{"t-topic", {{0, 100}, {4, 1024}, {12, 10}}}})
+      .get();
+}
+
+} // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -182,6 +182,7 @@ public:
           std::make_unique<test_link_registry>(&_table.local()),
           std::make_unique<link_test_factory>(this, 1s),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
+          std::make_unique<test_consumer_group_router>(),
           task_reconciler_interval);
     }
 
@@ -414,6 +415,7 @@ public:
           std::make_unique<test_link_registry>(&_table.local()),
           std::move(elf),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
+          std::make_unique<test_consumer_group_router>(),
           task_reconciler_interval);
         co_await _manager->start();
     }

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -87,6 +87,9 @@ public:
       api_key key,
       std::optional<std::reference_wrapper<ss::abort_source>>);
 
+    // Returns a view of a all broker ids
+    auto get_broker_ids() const { return std::views::keys(_brokers); }
+
 private:
     ss::future<> do_erase(model::node_id id);
     /// \brief Brokers map a model::node_id to a client.

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -158,6 +158,8 @@ public:
      */
     prefix_logger& logger() { return _logger; }
 
+    auto get_broker_ids() const { return _brokers.get_broker_ids(); }
+
 private:
     ss::future<> update_metadata();
     ss::future<> dispatch_metadata_request();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1530,6 +1530,7 @@ void application::wire_up_runtime_services(
       &controller->get_shard_table(),
       &metadata_cache,
       controller.get(),
+      &group_router,
       smp_service_groups.cluster_link_smp_sg())
       .get();
 


### PR DESCRIPTION
This task manages the synchronization of consumer group committed offsets
from a source cluster to a target cluster. It performs the following
operations:

1. Periodically discovers consumer groups in the source cluster by queryingall brokers
2. Identifies which groups should be mirrored based on configuration filters
3. Tracks group coordinators to optimize offset fetch operations
4. Fetches committed offsets for each consumer group from the source cluster
5. Commits those offsets to the corresponding consumer groups in the target cluster
 
 The task runs on shards that own partitions of the __consumer_offsets topic
 and are leaders for those partitions. It supports concurrent requests with a
 configurable limit to optimize throughput while avoiding overwhelming the
 clusters.
 
Configuration is provided through consumer_groups_mirroring_config which
includes:
- Group sync interval: How often to synchronize offsets for groups
- Consumer group filters: Which groups to include/exclude from mirroring
 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none