### PR TITLE
bazel/clang_tidy: run with error checks only

### DIFF
--- a/bazel/clang_tidy/BUILD
+++ b/bazel/clang_tidy/BUILD
@@ -3,4 +3,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 py_binary(
     name = "clang_tidy",
     srcs = ["clang_tidy.py"],
+    deps = [
+        "@python_deps//pyyaml",
+    ],
 )

--- a/bazel/clang_tidy/clang_tidy.py
+++ b/bazel/clang_tidy/clang_tidy.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
-import sys
+
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
+
+import yaml
 
 
 def main():
@@ -13,25 +17,32 @@ def main():
 
     clang_tidy_bin = sys.argv[1]
     fake_output = sys.argv[2]
-    config_file = sys.argv[3]
+    user_config_file = sys.argv[3]
     remaining_args = sys.argv[4:]
 
     # Bazel requires some kind of output file must be specified
     # so always create it
     Path(fake_output).touch(exist_ok=True)
 
+    # Rewrite
+    config = yaml.safe_load(Path(user_config_file).read_text())
+    strip_warning_checks(config)
+    final_config_file = tempfile.NamedTemporaryFile("w+")
+    yaml.safe_dump(config, final_config_file.file)
+
     try:
         verify_command = [
-            clang_tidy_bin, f"--config-file={config_file}", "--quiet",
-            "--verify-config"
+            clang_tidy_bin, f"--config-file={final_config_file.name}",
+            "--quiet", "--verify-config"
         ]
         _ = subprocess.run(verify_command,
                            check=True,
                            capture_output=True,
                            text=True)
 
-        run_command = [clang_tidy_bin, f"--config-file={config_file}"
-                       ] + remaining_args
+        run_command = [
+            clang_tidy_bin, f"--config-file={final_config_file.name}"
+        ] + remaining_args
 
         _ = subprocess.run(run_command,
                            check=True,
@@ -47,6 +58,13 @@ def main():
             print("\n--- STDERR ---", file=sys.stderr)
             print(e.stderr, file=sys.stderr)
         sys.exit(1)
+
+
+def strip_warning_checks(config) -> None:
+    """
+    Strip warning checks to keep only error-generating checks for CI speed.
+    """
+    config['Checks'] = config['WarningsAsErrors']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
2x speed up.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
