### PR TITLE
ct/l1: add set_start_offset to metastore

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -363,4 +363,50 @@ domain_manager::get_end_offset_for_term(
     };
 }
 
+ss::future<rpc::set_start_offset_reply>
+domain_manager::set_start_offset(rpc::set_start_offset_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::set_start_offset_reply{.ec = rpc::errc::not_leader};
+    }
+
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::set_start_offset_reply{
+          .ec = convert_stm_errc(sync_res.error())};
+    }
+    auto update_res = set_start_offset_update::build(
+      stm_->state(), req.tp, req.start_offset);
+    if (!update_res.has_value()) {
+        vlog(
+          cd_log.debug,
+          "Rejecting request to set start offset: {}",
+          update_res.error());
+        co_return rpc::set_start_offset_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+    storage::record_batch_builder builder(
+      model::record_batch_type::l1_stm, model::offset{0});
+    builder.add_raw_kv(
+      serde::to_iobuf(set_start_offset_update::key),
+      serde::to_iobuf(std::move(update_res.value())));
+    auto repl_res = co_await stm_->replicate_and_wait(
+      sync_res.value(), std::move(builder).build(), as_);
+    if (!repl_res.has_value()) {
+        co_return rpc::set_start_offset_reply{
+          .ec = convert_stm_errc(repl_res.error()),
+        };
+    }
+    auto prt_ref = stm_->state().partition_state(req.tp);
+    if (
+      !prt_ref.has_value() || prt_ref->get().start_offset != req.start_offset) {
+        co_return rpc::set_start_offset_reply{
+          .ec = rpc::errc::concurrent_requests,
+        };
+    }
+
+    co_return rpc::set_start_offset_reply{.ec = rpc::errc::ok};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -51,6 +51,9 @@ public:
     ss::future<rpc::get_end_offset_for_term_reply>
       get_end_offset_for_term(rpc::get_end_offset_for_term_request);
 
+    ss::future<rpc::set_start_offset_reply>
+      set_start_offset(rpc::set_start_offset_request);
+
 private:
     std::optional<ss::gate::holder> maybe_gate();
 

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -115,6 +115,17 @@ ss::future<rpc::get_end_offset_for_term_reply> do_get_end_offset_for_term(
     co_return co_await domain_mgr->get_end_offset_for_term(std::move(req));
 }
 
+ss::future<rpc::set_start_offset_reply> do_set_start_offset(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::set_start_offset_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::set_start_offset_reply{.ec = rpc::errc::not_leader};
+    }
+    co_return co_await domain_mgr->set_start_offset(std::move(req));
+}
+
 } // namespace
 
 template<auto Func, typename req_t>
@@ -252,6 +263,13 @@ template ss::future<rpc::get_end_offset_for_term_reply> frontend::process<
   &frontend::get_end_offset_for_term_locally,
   &frontend::client::get_end_offset_for_term>(
   rpc::get_end_offset_for_term_request, bool);
+
+template ss::future<rpc::set_start_offset_reply>
+  frontend::remote_dispatch<&frontend::client::set_start_offset>(
+    rpc::set_start_offset_request, model::node_id);
+template ss::future<rpc::set_start_offset_reply> frontend::process<
+  &frontend::set_start_offset_locally,
+  &frontend::client::set_start_offset>(rpc::set_start_offset_request, bool);
 
 frontend::frontend(
   model::node_id self,
@@ -447,6 +465,25 @@ frontend::get_end_offset_for_term(
       &frontend::get_end_offset_for_term_locally,
       &client::get_end_offset_for_term>(
       std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::set_start_offset_reply> frontend::set_start_offset_locally(
+  rpc::set_start_offset_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_set_start_offset(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::set_start_offset_reply> frontend::set_start_offset(
+  rpc::set_start_offset_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &frontend::set_start_offset_locally,
+      &client::set_start_offset>(std::move(request), bool(local_only_exec));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -79,6 +79,9 @@ public:
     ss::future<rpc::get_end_offset_for_term_reply> get_end_offset_for_term(
       rpc::get_end_offset_for_term_request, local_only = local_only::no);
 
+    ss::future<rpc::set_start_offset_reply> set_start_offset(
+      rpc::set_start_offset_request, local_only = local_only::no);
+
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
@@ -144,6 +147,11 @@ private:
     ss::future<rpc::get_end_offset_for_term_reply>
     get_end_offset_for_term_locally(
       rpc::get_end_offset_for_term_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::set_start_offset_reply> set_start_offset_locally(
+      rpc::set_start_offset_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -162,6 +162,10 @@ public:
     virtual ss::future<std::expected<void, errc>>
       replace_objects(std::unique_ptr<object_metadata_builder>) = 0;
 
+    // Moves the start offset of the given partition's log to the given offset.
+    virtual ss::future<std::expected<void, errc>>
+    set_start_offset(const model::topic_id_partition&, kafka::offset) = 0;
+
     // Finds the first object of a given partition with data greater than or
     // equal to the given offset. If no such offset exists, returns
     // `out_of_range`.

--- a/src/v/cloud_topics/level_one/metastore/offset_interval_set.cc
+++ b/src/v/cloud_topics/level_one/metastore/offset_interval_set.cc
@@ -60,4 +60,34 @@ offset_interval_set::to_vec() const {
     return ret;
 }
 
+void offset_interval_set::truncate_with_new_start_offset(
+  kafka::offset new_start_offset) {
+    // First, remove all intervals that are fully below the new start.
+    while (!iset_.empty()) {
+        auto begin_it = iset_.begin();
+        auto begin_last_offset = kafka::offset{iset_.to_end(begin_it) - 1};
+        if (begin_last_offset >= new_start_offset) {
+            // This interval is partially or entirely above the new start.
+            // Handle below.
+            break;
+        }
+        // This interval is entirely below the new start.
+        iset_.erase(begin_it);
+    }
+    if (iset_.empty()) {
+        return;
+    }
+    auto begin_it = iset_.begin();
+    auto begin_base_offset = kafka::offset{iset_.to_start(begin_it)};
+    if (begin_base_offset >= new_start_offset) {
+        // This interval starts above or is aligned exactly with the new start.
+        return;
+    }
+    // This interval is partially below the new start. Replace it with an
+    // interval that is aligned with the new start.
+    auto begin_last_offset = kafka::offset{iset_.to_end(begin_it) - 1};
+    iset_.erase(begin_it);
+    insert(new_start_offset, begin_last_offset);
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/offset_interval_set.h
+++ b/src/v/cloud_topics/level_one/metastore/offset_interval_set.h
@@ -53,6 +53,7 @@ public:
     bool contains(kafka::offset offset) const;
     stream make_stream() const;
     chunked_vector<interval> to_vec() const;
+    void truncate_with_new_start_offset(kafka::offset);
 
 private:
     interval_set<kafka::offset::type> iset_;

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -343,8 +343,24 @@ replicated_metastore::replace_objects(
 
 ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::set_start_offset(
-  const model::topic_id_partition&, kafka::offset) {
-    co_return std::expected<void, errc>{};
+  const model::topic_id_partition& tidp, kafka::offset offset) {
+    rpc::set_start_offset_request req;
+    req.tp = tidp;
+    req.start_offset = offset;
+
+    auto reply_fut = co_await ss::coroutine::as_future(
+      fe_.set_start_offset(std::move(req)));
+    if (reply_fut.failed()) {
+        auto ex = reply_fut.get_exception();
+        vlog(cd_log.warn, "Error while sending request: {}", ex);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+    auto reply = reply_fut.get();
+    if (reply.ec != rpc::errc::ok) {
+        co_return std::unexpected(rpc_to_meta_errc(reply.ec));
+    }
+
+    co_return std::expected<void, metastore::errc>{};
 }
 
 ss::future<std::expected<metastore::object_response, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -341,6 +341,12 @@ replicated_metastore::replace_objects(
     co_return std::expected<void, errc>{};
 }
 
+ss::future<std::expected<void, metastore::errc>>
+replicated_metastore::set_start_offset(
+  const model::topic_id_partition&, kafka::offset) {
+    co_return std::expected<void, errc>{};
+}
+
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 replicated_metastore::get_first_ge(
   const model::topic_id_partition& tidp, kafka::offset offset) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -34,6 +34,9 @@ public:
     ss::future<std::expected<void, errc>>
       replace_objects(std::unique_ptr<object_metadata_builder>) override;
 
+    ss::future<std::expected<void, errc>>
+    set_start_offset(const model::topic_id_partition&, kafka::offset) override;
+
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;
 

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -44,6 +44,11 @@
             "name": "get_compaction_offsets",
             "input_type": "get_compaction_offsets_request",
             "output_type": "get_compaction_offsets_reply"
+        },
+        {
+            "name": "set_start_offset",
+            "input_type": "set_start_offset_request",
+            "output_type": "set_start_offset_reply"
         }
     ]
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -231,6 +231,27 @@ struct get_end_offset_for_term_request
     model::term_id term;
 };
 
+struct set_start_offset_reply
+  : serde::envelope<
+      set_start_offset_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec); }
+
+    errc ec;
+};
+struct set_start_offset_request
+  : serde::envelope<
+      set_start_offset_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = set_start_offset_reply;
+    auto serde_fields() { return std::tie(tp, start_offset); }
+
+    model::topic_id_partition tp;
+    kafka::offset start_offset;
+};
+
 } //  namespace cloud_topics::l1::rpc
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -33,6 +33,12 @@ ss::future<replace_objects_reply> service::replace_objects(
       std::move(request), frontend::local_only::yes);
 }
 
+ss::future<set_start_offset_reply> service::set_start_offset(
+  set_start_offset_request request, ::rpc::streaming_context&) {
+    return _frontend->local().set_start_offset(
+      std::move(request), frontend::local_only::yes);
+}
+
 ss::future<get_first_offset_ge_reply> service::get_first_offset_ge(
   get_first_offset_ge_request request, ::rpc::streaming_context&) {
     return _frontend->local().get_first_offset_ge(

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -32,6 +32,9 @@ public:
     ss::future<replace_objects_reply> replace_objects(
       replace_objects_request, ::rpc::streaming_context&) override;
 
+    ss::future<set_start_offset_reply> set_start_offset(
+      set_start_offset_request, ::rpc::streaming_context&) override;
+
     ss::future<get_first_offset_ge_reply> get_first_offset_ge(
       get_first_offset_ge_request, ::rpc::streaming_context&) override;
 

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -200,6 +200,22 @@ simple_metastore::replace_objects(
     co_return std::expected<void, metastore::errc>{};
 }
 
+ss::future<std::expected<void, metastore::errc>>
+simple_metastore::set_start_offset(
+  const model::topic_id_partition& tp, kafka::offset requested_o) {
+    auto update_res = set_start_offset_update::build(state_, tp, requested_o);
+    if (!update_res.has_value()) {
+        vlog(cd_log.debug, "Set start offset failed: {}", update_res.error());
+        co_return std::unexpected(metastore::errc::invalid_request);
+    }
+    auto apply_res = update_res->apply(state_);
+    vassert(
+      apply_res.has_value(),
+      "Apply must succeed if can_apply() is true: {}",
+      apply_res.error());
+    co_return std::expected<void, metastore::errc>{};
+}
+
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 simple_metastore::get_first_ge(
   const model::topic_id_partition& tpr, kafka::offset o) {

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -64,6 +64,9 @@ public:
     ss::future<std::expected<void, errc>>
     replace_objects(const chunked_vector<object_metadata>&);
 
+    ss::future<std::expected<void, errc>>
+    set_start_offset(const model::topic_id_partition&, kafka::offset) override;
+
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;
 

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -128,6 +128,11 @@ ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
             maybe_log_update_error(_log, key, o, result);
             break;
         }
+        case update_key::set_start_offset: {
+            auto update = serde::read<set_start_offset_update>(value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+        }
         }
     }
 

--- a/src/v/cloud_topics/level_one/metastore/state.cc
+++ b/src/v/cloud_topics/level_one/metastore/state.cc
@@ -72,6 +72,40 @@ bool compaction_state::erase_contiguous_range_with_tombstones(
     return true;
 }
 
+void compaction_state::truncate_with_new_start_offset(
+  kafka::offset new_start_offset) {
+    cleaned_ranges.truncate_with_new_start_offset(new_start_offset);
+
+    // TODO: below is basically identical to offset_interval_set's
+    // truncate_with_new_start_offset impl. Figure out a way to unify the code.
+
+    // First, remove all intervals that are fully below the new start.
+    while (!cleaned_ranges_with_tombstones.empty()) {
+        auto begin_it = cleaned_ranges_with_tombstones.begin();
+        if (begin_it->last_offset >= new_start_offset) {
+            // This interval is partially or entirely above the new start.
+            // Handle below.
+            break;
+        }
+        // This interval is entirely below the new start.
+        cleaned_ranges_with_tombstones.erase(begin_it);
+    }
+    if (cleaned_ranges_with_tombstones.empty()) {
+        return;
+    }
+    auto begin_it = cleaned_ranges_with_tombstones.begin();
+    if (begin_it->base_offset >= new_start_offset) {
+        // This interval starts above or is aligned exactly with the new start.
+        return;
+    }
+    // This interval is partially below the new start. Replace it with an
+    // interval that is aligned with the new start.
+    auto truncated_begin = *begin_it;
+    truncated_begin.base_offset = new_start_offset;
+    cleaned_ranges_with_tombstones.erase(begin_it);
+    cleaned_ranges_with_tombstones.insert(truncated_begin);
+}
+
 bool compaction_state::may_add(
   const cleaned_range_with_tombstones& new_range) const {
     if (cleaned_ranges_with_tombstones.empty()) {

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -57,6 +57,7 @@ struct term_start
       envelope<term_start, serde::version<0>, serde::compat_version<0>> {
     friend bool operator==(const term_start&, const term_start&) = default;
     auto serde_fields() { return std::tie(term_id, start_offset); }
+    auto operator<=>(const term_start&) const = default;
 
     model::term_id term_id;
     kafka::offset start_offset;
@@ -209,7 +210,7 @@ struct partition_state
     // information to return a value for the start_offset, even when the log
     // has been prefix truncated to be empty. I.e. this list should never be
     // empty once there has been data in the log.
-    chunked_vector<term_start> term_starts;
+    absl::btree_set<term_start> term_starts;
 };
 
 // Tracks the state managed for each partition of a Kafka topic.

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -133,6 +133,11 @@ struct compaction_state
     // We are not able to erase [0, 79], because [0, 9] are not covered.
     bool erase_contiguous_range_with_tombstones(kafka::offset, kafka::offset);
 
+    // Prefix truncates the cleaned_ranges and cleaned_ranges_with_tombstones
+    // such that all ranges below the new start are removed and any range that
+    // overlaps with the new start is truncated to start at the given offset.
+    void truncate_with_new_start_offset(kafka::offset);
+
 private:
     struct tombstone_range_iters {
         tombstone_range_set_t::const_iterator begin;

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -167,7 +167,7 @@ std::expected<std::monostate, stm_update_error> add_objects_update::can_apply(
         // First do a basic check that the incoming term entries can be
         // appended to our state without violating ordering requirements.
         if (p_state.has_value() && !p_state->get().term_starts.empty()) {
-            auto p_last_entry = p_state->get().term_starts.back();
+            auto p_last_entry = *p_state->get().term_starts.rbegin();
             auto req_first_entry = req_entries.begin();
 
             // NOTE: it's valid for the first requested term to be equal to the
@@ -267,15 +267,12 @@ add_objects_update::apply(state& state) {
             if (
               !p_state.term_starts.empty()
               && req_terms.begin()->term_id
-                   <= p_state.term_starts.back().term_id) {
+                   <= p_state.term_starts.rbegin()->term_id) {
                 // If the first added term matches the back of the latest
                 // tracked term, it isn't a new term.
                 ++new_term_it;
             }
-            std::copy(
-              new_term_it,
-              req_terms.end(),
-              std::back_inserter(p_state.term_starts));
+            p_state.term_starts.insert(new_term_it, req_terms.end());
         } else {
             // The incoming extents don't align with the next position. "Drop"
             // them all.

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -571,4 +571,88 @@ replace_objects_update::build(
     return update;
 }
 
+std::expected<set_start_offset_update, stm_update_error>
+set_start_offset_update::build(
+  const state& state, const model::topic_id_partition& tp, kafka::offset o) {
+    set_start_offset_update update{
+      .tp = tp,
+      .new_start_offset = o,
+    };
+    auto allowed = update.can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    return update;
+}
+
+std::expected<std::monostate, stm_update_error>
+set_start_offset_update::can_apply(const state& state) {
+    auto prt_ref = state.partition_state(tp);
+    if (!prt_ref.has_value()) {
+        return std::unexpected(stm_update_error(
+          fmt::format("Partition {} not tracked by state", tp)));
+    }
+    auto& prt = prt_ref->get();
+    if (new_start_offset < prt.start_offset) {
+        return std::unexpected(stm_update_error(
+          fmt::format(
+            "Requested start offset for {} is below the current start: {} < {}",
+            tp,
+            new_start_offset,
+            prt.start_offset)));
+    }
+    if (new_start_offset > prt.next_offset) {
+        return std::unexpected(stm_update_error(
+          fmt::format(
+            "Requested start offset for {} is above the next start: {} < {}",
+            tp,
+            new_start_offset,
+            prt.next_offset)));
+    }
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+set_start_offset_update::apply(state& state) {
+    auto allowed = can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    auto& p_state
+      = state.topic_to_state[tp.topic_id].pid_to_state[tp.partition];
+    if (p_state.start_offset == new_start_offset) {
+        return std::monostate{};
+    }
+    p_state.start_offset = new_start_offset;
+    while (!p_state.extents.empty()) {
+        if (p_state.extents.begin()->last_offset >= new_start_offset) {
+            break;
+        }
+        // The front extent falls entirely below the new start offset, meaning
+        // it's can be removed.
+        auto begin_it = p_state.extents.begin();
+        auto oid = begin_it->oid;
+        auto obj_it = state.objects.find(oid);
+        if (obj_it == state.objects.end()) {
+            // Unexpected, but benign.
+            continue;
+        }
+        obj_it->second.removed_data_size += begin_it->len;
+        p_state.extents.erase(begin_it);
+    }
+    // Now remove terms. Note that the removal should always leave at least one
+    // term start, enough to cover `next_offset`, even if the log is empty.
+    while (p_state.term_starts.size() > 1) {
+        if (p_state.term_starts.begin()->start_offset < new_start_offset) {
+            p_state.term_starts.erase(p_state.term_starts.begin());
+        }
+    }
+    // Finally, remove any compaction state that falls below the start offset.
+    if (p_state.compaction_state.has_value()) {
+        auto& c_state = *p_state.compaction_state;
+        c_state.truncate_with_new_start_offset(new_start_offset);
+    }
+    return std::monostate{};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -23,6 +23,7 @@ namespace cloud_topics::l1 {
 enum class update_key : uint8_t {
     add_objects = 0,
     replace_objects = 1,
+    set_start_offset = 2,
 };
 
 using stm_update_error = named_type<ss::sstring, struct update_error_tag>;
@@ -159,6 +160,27 @@ struct replace_objects_update
       compaction_updates;
 };
 
+struct set_start_offset_update
+  : public serde::envelope<
+      set_start_offset_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool
+    operator==(const set_start_offset_update&, const set_start_offset_update&)
+      = default;
+    auto serde_fields() { return std::tie(tp, new_start_offset); }
+
+    static constexpr auto key{update_key::set_start_offset};
+    static std::expected<set_start_offset_update, stm_update_error>
+    build(const state&, const model::topic_id_partition&, kafka::offset);
+
+    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> apply(state&);
+
+    model::topic_id_partition tp;
+    kafka::offset new_start_offset;
+};
+
 } // namespace cloud_topics::l1
 
 template<>
@@ -172,6 +194,8 @@ struct fmt::formatter<cloud_topics::l1::update_key> final
             return formatter<string_view>::format("add_objects", ctx);
         case cloud_topics::l1::update_key::replace_objects:
             return formatter<string_view>::format("replace_objects", ctx);
+        case cloud_topics::l1::update_key::set_start_offset:
+            return formatter<string_view>::format("set_start_offset", ctx);
         }
     }
 };

--- a/src/v/cloud_topics/level_one/metastore/tests/offset_interval_set_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/offset_interval_set_test.cc
@@ -76,3 +76,44 @@ TEST(OffsetIntervalSetTest, TestSerde) {
     auto roundtrip_s = serde::from_iobuf<offset_interval_set>(std::move(b));
     ASSERT_TRUE(s == roundtrip_s);
 }
+
+TEST(OffsetIntervalSetTest, TestTruncate) {
+    offset_interval_set s;
+    ASSERT_TRUE(s.insert(o{0}, o{0}));
+    ASSERT_TRUE(s.insert(o{2}, o{3}));
+    ASSERT_TRUE(s.insert(o{5}, o{5}));
+
+    // Below the start.
+    s.truncate_with_new_start_offset(o{-1});
+    EXPECT_THAT(
+      s.to_vec(),
+      testing::ElementsAre(
+        MatchesRange(o{0}, o{0}),
+        MatchesRange(o{2}, o{3}),
+        MatchesRange(o{5}, o{5})));
+
+    // At the start.
+    s.truncate_with_new_start_offset(o{0});
+    EXPECT_THAT(
+      s.to_vec(),
+      testing::ElementsAre(
+        MatchesRange(o{0}, o{0}),
+        MatchesRange(o{2}, o{3}),
+        MatchesRange(o{5}, o{5})));
+
+    // Between intervals.
+    s.truncate_with_new_start_offset(o{1});
+    EXPECT_THAT(
+      s.to_vec(),
+      testing::ElementsAre(MatchesRange(o{2}, o{3}), MatchesRange(o{5}, o{5})));
+
+    // At the edge of an interval.
+    s.truncate_with_new_start_offset(o{3});
+    EXPECT_THAT(
+      s.to_vec(),
+      testing::ElementsAre(MatchesRange(o{3}, o{3}), MatchesRange(o{5}, o{5})));
+
+    // Beyond the end.
+    s.truncate_with_new_start_offset(o{6});
+    EXPECT_THAT(s.to_vec(), testing::ElementsAre());
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -512,3 +512,51 @@ TEST_F(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
     ASSERT_FALSE(end_missing.has_value());
     ASSERT_EQ(end_missing.error(), metastore::errc::missing_ntp);
 }
+
+TEST_F(ReplicatedMetastoreTest, TestSetStartOffset) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+
+    // Create initial objects for testing
+    ASSERT_NO_FATAL_FAILURE(add_initial_objects(meta, 3, 99).get());
+
+    auto tp = make_tp(0);
+    auto assert_get_offsets =
+      [&](kafka::offset expected_start, kafka::offset expected_next) {
+          auto offsets = meta.get_offsets(tp).get();
+          ASSERT_TRUE(offsets.has_value());
+          ASSERT_EQ(expected_start, offsets->start_offset);
+          ASSERT_EQ(expected_next, offsets->next_offset);
+      };
+
+    // Get initial offsets
+    ASSERT_NO_FATAL_FAILURE(assert_get_offsets(o{0}, o{100}));
+
+    // Set start offset to a value within the extent
+    auto set_start_res = meta.set_start_offset(tp, o{50}).get();
+    ASSERT_TRUE(set_start_res.has_value());
+    ASSERT_NO_FATAL_FAILURE(assert_get_offsets(o{50}, o{100}));
+
+    // Test setting below the start.
+    auto set_start_invalid = meta.set_start_offset(tp, o{0}).get();
+    ASSERT_FALSE(set_start_invalid.has_value());
+    ASSERT_EQ(set_start_invalid.error(), metastore::errc::invalid_request);
+    ASSERT_NO_FATAL_FAILURE(assert_get_offsets(o{50}, o{100}));
+
+    // Test setting start offset for missing ntp
+    auto missing_tp = make_tp(999);
+    auto set_start_missing = meta.set_start_offset(missing_tp, o{10}).get();
+    ASSERT_FALSE(set_start_missing.has_value());
+    ASSERT_EQ(set_start_missing.error(), metastore::errc::invalid_request);
+    ASSERT_NO_FATAL_FAILURE(assert_get_offsets(o{50}, o{100}));
+
+    // Set start so it's totally empty
+    set_start_res = meta.set_start_offset(tp, o{100}).get();
+    ASSERT_TRUE(set_start_res.has_value());
+    ASSERT_NO_FATAL_FAILURE(assert_get_offsets(o{100}, o{100}));
+
+    // Sanity check that getting the term for the next offset is still valid.
+    auto term_res = meta.get_term_for_offset(tp, o{100}).get();
+    ASSERT_TRUE(term_res.has_value());
+    ASSERT_EQ(term_res.value(), model::term_id{0});
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1218,3 +1218,182 @@ TEST(SimpleMetastoreTest, TestEpochForOffset) {
     EXPECT_FALSE(res.has_value());
     EXPECT_EQ(metastore::errc::missing_ntp, res.error());
 }
+
+TEST(SimpleMetastoreTest, TestSetStartAlignedWithExtent) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Set start offset to be aligned with the second extent.
+    auto set_start_res = m.set_start_offset(tp, 11_o).get();
+    ASSERT_TRUE(set_start_res.has_value());
+
+    auto offsets_res = m.get_offsets(tp).get();
+    ASSERT_TRUE(offsets_res.has_value());
+    ASSERT_EQ(11_o, offsets_res->start_offset);
+    ASSERT_EQ(31_o, offsets_res->next_offset);
+
+    // Getting objects below the new start (11) should return the earliest
+    // object, as should extents that actually point to that object.
+    for (const auto& o : {0_o, 5_o, 10_o, 11_o, 15_o, 20_o}) {
+        auto get_res = m.get_first_ge(tp, o).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid2);
+    }
+
+    // Sanity check getting the object after.
+    for (const auto& o : {21_o, 25_o, 30_o}) {
+        auto get_res = m.get_first_ge(tp, o).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid3);
+    }
+}
+
+TEST(SimpleMetastoreTest, TestSetStartNotAlignedWithExtent) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Set start offset to be not aligned with any extent (offset 15 is in the
+    // middle of second extent)
+    auto set_start_res = m.set_start_offset(tp, 15_o).get();
+    ASSERT_TRUE(set_start_res.has_value());
+
+    auto offsets_res = m.get_offsets(tp).get();
+    ASSERT_TRUE(offsets_res.has_value());
+    ASSERT_EQ(15_o, offsets_res->start_offset);
+    ASSERT_EQ(31_o, offsets_res->next_offset);
+
+    // Getting objects below the start (15) should return the earliest object,
+    // as should extents that actually point to that object.
+    for (const auto& o : {0_o, 5_o, 10_o, 14_o, 15_o, 16_o, 20_o}) {
+        auto get_res = m.get_first_ge(tp, o).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid2);
+    }
+
+    // Sanity check getting the object after.
+    for (const auto& o : {21_o, 25_o, 30_o}) {
+        auto get_res = m.get_first_ge(tp, o).get();
+        ASSERT_TRUE(get_res.has_value());
+        ASSERT_EQ(get_res->oid, oid3);
+    }
+}
+
+TEST(SimpleMetastoreTest, TestSetStartEmptyWithTerms) {
+    simple_metastore m;
+    auto ometa
+      = om_builder(oid1, 100).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
+    auto add_res = m.add_objects(
+                      om_list_t::single(std::move(ometa)),
+                      terms_builder()
+                        .add(tid_a, 1_tm, 0_o)
+                        .add(tid_a, 2_tm, 3_o)
+                        .add(tid_a, 5_tm, 7_o)
+                        .build())
+                     .get();
+    ASSERT_TRUE(add_res.has_value());
+    ASSERT_TRUE(add_res.value().corrected_next_offsets.empty());
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Set start offset beyond the end of all extents to make log effectively
+    // empty
+    auto set_start_res = m.set_start_offset(tp, 10_o).get();
+    ASSERT_TRUE(set_start_res.has_value());
+
+    auto offsets_res = m.get_offsets(tp).get();
+    ASSERT_TRUE(offsets_res.has_value());
+    ASSERT_EQ(10_o, offsets_res->start_offset);
+    ASSERT_EQ(10_o, offsets_res->next_offset);
+
+    // Getting objects should return out_of_range since log is effectively empty
+    auto get_res = m.get_first_ge(tp, 10_o).get();
+    ASSERT_FALSE(get_res.has_value());
+    ASSERT_EQ(metastore::errc::out_of_range, get_res.error());
+
+    // We should still be able to get the term for the next offset The term at
+    // next offset should be the last term from the extent
+    auto term_res = m.get_term_for_offset(tp, 10_o).get();
+    ASSERT_TRUE(term_res.has_value());
+    ASSERT_EQ(5_tm, term_res.value());
+}
+
+TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
+    simple_metastore m;
+    om_list_t os;
+    os.emplace_back(
+      om_builder(oid1, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Clean range is [5, 15].
+    {
+        om_list_t new_os;
+        new_os.emplace_back(
+          om_builder(oid2, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 5_o, 15_o, 3000_t);
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    auto tp = model::topic_id_partition::from(tid_a);
+
+    // Verify initial compaction state and dirty ranges: [0, 4] and [16, 20].
+    auto cmp_before = m.get_compaction_offsets(tp, 3000_t).get();
+    ASSERT_TRUE(cmp_before.has_value());
+    EXPECT_THAT(
+      cmp_before->dirty_ranges.to_vec(),
+      testing::ElementsAre(MatchesRange(0_o, 4_o), MatchesRange(16_o, 20_o)));
+    EXPECT_THAT(
+      cmp_before->removable_tombstone_ranges.to_vec(),
+      testing::ElementsAre(MatchesRange(5_o, 15_o)));
+
+    // Set start offset to fall within the cleaned range.
+    auto set_start_res = m.set_start_offset(tp, 10_o).get();
+    ASSERT_TRUE(set_start_res.has_value());
+
+    // Check that offsets are updated.
+    auto offsets_res = m.get_offsets(tp).get();
+    ASSERT_TRUE(offsets_res.has_value());
+    ASSERT_EQ(10_o, offsets_res->start_offset);
+    ASSERT_EQ(21_o, offsets_res->next_offset);
+
+    // Only the [16, 20] should remain dirty.
+    auto cmp_after = m.get_compaction_offsets(tp, 3000_t).get();
+    ASSERT_TRUE(cmp_after.has_value());
+    EXPECT_THAT(
+      cmp_after->dirty_ranges.to_vec(),
+      testing::ElementsAre(MatchesRange(16_o, 20_o)));
+
+    // Removable tombstone ranges should also be adjusted to reflect the new
+    // start.
+    EXPECT_THAT(
+      cmp_after->removable_tombstone_ranges.to_vec(),
+      testing::ElementsAre(MatchesRange(10_o, 15_o)));
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/state_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_test.cc
@@ -17,6 +17,17 @@ using namespace cloud_topics::l1;
 using o = kafka::offset;
 using ts = model::timestamp;
 
+namespace {
+compaction_state::cleaned_range_with_tombstones
+tombstone_range(int base, int last, int t) {
+    return {
+      .base_offset = o{base},
+      .last_offset = o{last},
+      .cleaned_with_tombstones_at = ts{t},
+    };
+}
+} // namespace
+
 // Simple test that makes sure we can build serde serialization.
 TEST(StateTest, TestSerde) {
     state s;
@@ -263,4 +274,96 @@ TEST(CompactionStateTest, TestAddContiguousTombstoneRanges) {
             ASSERT_FALSE(s.may_add(range(base, last)));
         }
     }
+}
+
+TEST(CompactionStateTest, TestTruncateWithNewStartOffsetEmpty) {
+    compaction_state s;
+    s.truncate_with_new_start_offset(o{50});
+    EXPECT_TRUE(s.cleaned_ranges_with_tombstones.empty());
+}
+
+TEST(CompactionStateTest, TestTruncateWithNewStartOffsetRemovesAll) {
+    compaction_state s;
+    s.cleaned_ranges_with_tombstones = {
+      tombstone_range(10, 20, 1000),
+      tombstone_range(30, 40, 2000),
+    };
+
+    s.truncate_with_new_start_offset(o{50});
+    EXPECT_TRUE(s.cleaned_ranges_with_tombstones.empty());
+}
+
+TEST(CompactionStateTest, TestTruncateWithNewStartOffsetNoOp) {
+    compaction_state s;
+    s.cleaned_ranges_with_tombstones = {
+      tombstone_range(10, 20, 1000),
+      tombstone_range(30, 40, 2000),
+    };
+    auto expected = s.cleaned_ranges_with_tombstones;
+
+    s.truncate_with_new_start_offset(o{10});
+    EXPECT_EQ(s.cleaned_ranges_with_tombstones, expected);
+}
+
+TEST(CompactionStateTest, TestTruncateRemovePartialRange) {
+    compaction_state s;
+    s.cleaned_ranges_with_tombstones = {
+      tombstone_range(10, 20, 1000),
+      tombstone_range(25, 30, 1500),
+      tombstone_range(35, 45, 2000),
+    };
+
+    // Cut somewhere in the middle of a range.
+    s.truncate_with_new_start_offset(o{26});
+
+    compaction_state::tombstone_range_set_t expected = {
+      tombstone_range(26, 30, 1500),
+      tombstone_range(35, 45, 2000),
+    };
+    EXPECT_EQ(s.cleaned_ranges_with_tombstones, expected);
+}
+
+TEST(CompactionStateTest, TestTruncateRemoveExactBoundary) {
+    compaction_state s;
+    s.cleaned_ranges_with_tombstones = {
+      tombstone_range(10, 20, 1000),
+      tombstone_range(30, 40, 2000),
+    };
+
+    // Cut exactly at the start of a range.
+    s.truncate_with_new_start_offset(o{30});
+
+    compaction_state::tombstone_range_set_t expected = {
+      tombstone_range(30, 40, 2000),
+    };
+    EXPECT_EQ(s.cleaned_ranges_with_tombstones, expected);
+}
+
+TEST(CompactionStateTest, TestTruncateCleanedRanges) {
+    compaction_state s;
+
+    // Add some intervals to cleaned_ranges along with the tombstone ranges.
+    s.cleaned_ranges.insert(o{10}, o{20});
+    s.cleaned_ranges.insert(o{25}, o{35});
+    s.cleaned_ranges.insert(o{40}, o{50});
+    s.cleaned_ranges_with_tombstones = {
+      tombstone_range(10, 20, 1000),
+      tombstone_range(25, 35, 1500),
+      tombstone_range(40, 50, 2000),
+    };
+
+    // They should both be truncated following set_start_offset().
+    s.truncate_with_new_start_offset(o{27});
+    auto vec = s.cleaned_ranges.to_vec();
+    EXPECT_EQ(vec.size(), 2);
+    EXPECT_EQ(vec[0].base_offset, o{27});
+    EXPECT_EQ(vec[0].last_offset, o{35});
+    EXPECT_EQ(vec[1].base_offset, o{40});
+    EXPECT_EQ(vec[1].last_offset, o{50});
+
+    compaction_state::tombstone_range_set_t expected = {
+      tombstone_range(27, 35, 1500),
+      tombstone_range(40, 50, 2000),
+    };
+    EXPECT_EQ(s.cleaned_ranges_with_tombstones, expected);
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -1060,3 +1060,193 @@ TEST(StateUpdateTest, TestAddExtentEndsBelowLastTermStart) {
       res.error()().c_str(),
       testing::HasSubstr("Extents end below a requested new term for"));
 }
+
+TEST(StateUpdateTest, TestSetStartOffsetAlignedWithExtent) {
+    state s;
+    // Add some extents
+    auto add_update = add_objects_builder()
+                        .add(new_obj_builder(oid1, 100)
+                               .add(tidp_a, 0_o, 10_o, 2000_t, 0, 99)
+                               .build())
+                        .add(new_obj_builder(oid2, 100)
+                               .add(tidp_a, 11_o, 20_o, 2000_t, 0, 99)
+                               .build())
+                        .add(new_obj_builder(oid3, 100)
+                               .add(tidp_a, 21_o, 30_o, 2000_t, 0, 99)
+                               .build())
+                        .add_term_start(tidp_a, 0_tm, 0_o)
+                        .build();
+    auto res = add_update.apply(s);
+    ASSERT_TRUE(res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(3, p_state->get().extents.size());
+
+    // Set start offset to be aligned with the second extent (starts at 11)
+    auto set_start_update = set_start_offset_update::build(s, tp, 11_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Verify that the state has been updated correctly
+    p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(11_o, p_state->get().start_offset);
+    EXPECT_EQ(31_o, p_state->get().next_offset);
+
+    // The first extent should be fully removed from accounting
+    // Only extents 2 and 3 should remain
+    EXPECT_EQ(2, p_state->get().extents.size());
+}
+
+TEST(StateUpdateTest, TestSetStartOffsetNotAlignedWithExtent) {
+    state s;
+    // Add some extents
+    auto add_update = add_objects_builder()
+                        .add(new_obj_builder(oid1, 100)
+                               .add(tidp_a, 0_o, 10_o, 2000_t, 0, 99)
+                               .build())
+                        .add(new_obj_builder(oid2, 100)
+                               .add(tidp_a, 11_o, 20_o, 2000_t, 0, 99)
+                               .build())
+                        .add(new_obj_builder(oid3, 100)
+                               .add(tidp_a, 21_o, 30_o, 2000_t, 0, 99)
+                               .build())
+                        .add_term_start(tidp_a, 0_tm, 0_o)
+                        .build();
+    auto res = add_update.apply(s);
+    ASSERT_TRUE(res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(3, p_state->get().extents.size());
+
+    // Set start offset to be not aligned with any extent (offset 15 is in the
+    // middle of second extent)
+    auto set_start_update = set_start_offset_update::build(s, tp, 15_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Verify that the state has been updated correctly
+    p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(15_o, p_state->get().start_offset);
+    EXPECT_EQ(31_o, p_state->get().next_offset);
+
+    // The first extent should be fully removed, but the second and third should
+    // remain even though start is not aligned with the second extent's boundary
+    EXPECT_EQ(2, p_state->get().extents.size());
+}
+
+TEST(StateUpdateTest, TestSetStartOffsetEmptyWithTerms) {
+    state s;
+    // Add extents with various terms
+    auto add_update = add_objects_builder()
+                        .add(new_obj_builder(oid1, 100)
+                               .add(tidp_a, 0_o, 9_o, 2000_t, 0, 99)
+                               .build())
+                        .add_term_start(tidp_a, 1_tm, 0_o)
+                        .add_term_start(tidp_a, 2_tm, 3_o)
+                        .add_term_start(tidp_a, 5_tm, 7_o)
+                        .build();
+    auto res = add_update.apply(s);
+    ASSERT_TRUE(res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(1, p_state->get().extents.size());
+    EXPECT_EQ(3, p_state->get().term_starts.size());
+
+    // Set start offset beyond the end of all extents to make log empty.
+    auto set_start_update = set_start_offset_update::build(s, tp, 10_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(10_o, p_state->get().start_offset);
+    EXPECT_EQ(10_o, p_state->get().next_offset);
+
+    // All extents should be removed since start is beyond them.
+    EXPECT_EQ(0, p_state->get().extents.size());
+
+    // One term information should still be preserved to be able to serve term
+    // queries at the next offset.
+    EXPECT_EQ(1, p_state->get().term_starts.size());
+}
+
+TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
+    using testing::ElementsAre;
+    using range = struct compaction_state_update::cleaned_range;
+
+    state s;
+    // Add an extent and then compact it
+    auto add_update = add_objects_builder()
+                        .add(new_obj_builder(oid1, 100)
+                               .add(tidp_a, 0_o, 20_o, 2000_t, 0, 99)
+                               .build())
+                        .add_term_start(tidp_a, 0_tm, 0_o)
+                        .build();
+    auto res = add_update.apply(s);
+    ASSERT_TRUE(res.has_value());
+
+    // Compact part of the extent (clean offsets [5, 15])
+    auto replace_update
+      = replace_objects_builder()
+          .add(new_obj_builder(oid2, 100)
+                 .add(tidp_a, 0_o, 20_o, 2000_t, 0, 99)
+                 .build())
+          .clean(
+            tidp_a,
+            range{
+              .base_offset = 5_o, .last_offset = 15_o, .has_tombstones = true},
+            3000_t)
+          .build();
+    auto replace_res = replace_update.apply(s);
+    ASSERT_TRUE(replace_res.has_value());
+
+    auto tp = model::topic_id_partition::from(tidp_a);
+    auto p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    ASSERT_TRUE(p_state->get().compaction_state.has_value());
+
+    // Verify initial compaction state
+    EXPECT_THAT(
+      p_state->get().compaction_state->cleaned_ranges.to_vec(),
+      ElementsAre(MatchesRange(5_o, 15_o)));
+    EXPECT_THAT(
+      p_state->get().compaction_state->cleaned_ranges_with_tombstones,
+      ElementsAre(MatchesRange(5_o, 15_o)));
+
+    // Set start offset to fall within the cleaned range (offset 10)
+    auto set_start_update = set_start_offset_update::build(s, tp, 10_o);
+    ASSERT_TRUE(set_start_update.has_value());
+
+    auto apply_res = set_start_update->apply(s);
+    ASSERT_TRUE(apply_res.has_value());
+
+    // Verify that the state has been updated correctly
+    p_state = s.partition_state(tp);
+    ASSERT_TRUE(p_state.has_value());
+    EXPECT_EQ(10_o, p_state->get().start_offset);
+    EXPECT_EQ(21_o, p_state->get().next_offset);
+
+    // Check that compaction state reflects the new start
+    // The cleaned ranges should be adjusted to reflect the new start
+    ASSERT_TRUE(p_state->get().compaction_state.has_value());
+    EXPECT_THAT(
+      p_state->get().compaction_state->cleaned_ranges.to_vec(),
+      ElementsAre(MatchesRange(10_o, 15_o)));
+    EXPECT_THAT(
+      p_state->get().compaction_state->cleaned_ranges_with_tombstones,
+      ElementsAre(MatchesRange(10_o, 15_o)));
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Adds set_start_offset to the metastore, which prefix truncates the extents, terms, and compaction state. Some caveats for each:
- extents: if the new start offset splits up an extent, that entire extent is kept
- terms: when the log is made empty via set_start_offset, we preserve the last term so that queries for the next offset are still able to work (e.g. likely important for RRR and topic recovery scenarios)
- compaction state: the data structures used to back compaction state are updated in this PR to allow for truncation

This PR is structured as:
- the data structure updates to support set_start_offset
- the state updates to be used in the STM
- the simple metastore impl that uses just the state updates
- the replicated metastore impl that plugs the state updates into the STM and has calls them via RPC

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
