### PR TITLE
[v25.2.x] CORE-8504: Fix KgoVerifierProducer timeout error in CloudRetentionTest

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -696,12 +696,28 @@ class KgoVerifierProducer(KgoVerifierService):
 
         return super().wait_node(node, timeout_sec=timeout_sec)
 
-    def wait_for_acks(self, count, timeout_sec, backoff_sec):
-        self._redpanda.wait_until(
-            lambda: self._status_thread.errored or self._status.acked >= count,
-            timeout_sec=timeout_sec,
-            backoff_sec=backoff_sec,
-        )
+    def wait_for_acks(self, count, timeout_sec, backoff_sec, progress_sec=None):
+        def acks():
+            return self._status.acked
+
+        def acks_at_count():
+            return self._status_thread.errored or acks() >= count
+
+        if progress_sec is not None:
+            self._redpanda.wait_until_with_progress_check(
+                acks,
+                acks_at_count,
+                timeout_sec,
+                progress_sec,
+                backoff_sec,
+                logger=self._redpanda.logger,
+            )
+        else:
+            self._redpanda.wait_until(
+                acks_at_count,
+                timeout_sec=timeout_sec,
+                backoff_sec=backoff_sec,
+            )
         self._status_thread.raise_on_error()
 
     def _wait_for_file_on_nodes(self, file_name):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -93,7 +93,12 @@ from rptest.services.rolling_restarter import RollingRestarter
 from rptest.services.storage import ClusterStorage, NodeStorage, NodeCacheStorage
 from rptest.services.storage_failure_injection import FailureInjectionConfig
 from rptest.services.utils import NodeCrash, LogSearchLocal, LogSearchCloud, Stopwatch
-from rptest.util import inject_remote_script, ssh_output_stderr, wait_until_result
+from rptest.util import (
+    inject_remote_script,
+    ssh_output_stderr,
+    wait_until_result,
+    wait_until_with_progress_check,
+)
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
 from rptest.utils.expiring_value import ExpiringValue
 from rptest.utils.mode_checks import in_fips_environment
@@ -1271,6 +1276,49 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
 
         wait_until(
             wrapped, timeout_sec=timeout_sec, backoff_sec=backoff_sec, err_msg=err_msg
+        )
+
+    def wait_until_with_progress_check(
+        self,
+        check: Callable[[], Any],
+        condition: Callable[[], Any],
+        timeout_sec: int,
+        progress_sec: int,
+        backoff_sec: int,
+        err_msg: str | None = None,
+        logger: Logger | None = None,
+    ):
+        """
+        Cluster-aware variant of wait_until_with_progress_check, which will
+        fail out early if a node dies.
+
+        This is useful for long waits, which would otherwise not notice
+        a test failure until the end of the timeout, even if redpanda
+        already crashed.
+        """
+        t_initial = time.time()
+        # How long to delay doing redpanda liveness checks, to make short waits more efficient
+        grace_period = 15
+
+        def wrapped():
+            r = condition()
+            if not r and time.time() > t_initial + grace_period:
+                # Check the cluster is up before waiting + retrying
+                assert (
+                    self.all_up()
+                    or getattr(self, "_tolerate_crashes", False)
+                    or getattr(self, "tolerate_not_running", 0) > 0
+                )
+            return r
+
+        wait_until_with_progress_check(
+            check,
+            wrapped,
+            timeout_sec,
+            progress_sec,
+            backoff_sec,
+            err_msg=err_msg,
+            logger=logger,
         )
 
     def _check_attr(self, name: str, t: Type):

--- a/tests/rptest/tests/archive_retention_test.py
+++ b/tests/rptest/tests/archive_retention_test.py
@@ -121,9 +121,9 @@ class CloudArchiveRetentionTest(RedpandaTest):
         def produce_until_spillover():
             initial_uploaded = self.num_manifests_uploaded()
 
-            def new_manifest_spilled(get_num_spilled):
+            def new_manifest_spilled():
                 self.produce(topic, 300)
-                num_spilled = get_num_spilled()
+                num_spilled = self.num_manifests_uploaded()
                 return num_spilled > initial_uploaded + 10
 
             wait_until_with_progress_check(

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -115,7 +115,9 @@ class CloudRetentionTest(PreallocNodesTest):
 
         producer.wait_for_offset_map()
 
-        producer.wait_for_acks(msg_count, timeout_sec=600, backoff_sec=5)
+        producer.wait_for_acks(
+            msg_count, timeout_sec=1200, backoff_sec=5, progress_sec=20
+        )
         producer.wait()
         self.logger.info("finished producing")
         topics = (TopicSpec(name=self.topic_name, partition_count=num_partitions),)

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -129,7 +129,7 @@ def wait_until_result(condition: Callable[[], Any], *args: Any, **kwargs: Any) -
 
 def wait_until_with_progress_check(
     check: Callable[[], Any],
-    condition: Callable[[Callable[[], Any]], Any],
+    condition: Callable[[], Any],
     timeout_sec: int,
     progress_sec: int,
     backoff_sec: int,
@@ -149,16 +149,7 @@ def wait_until_with_progress_check(
 
     params:
       - check: the value we expect to change after each 'progress_sec'
-      - condition: the condition we are waiting for. should be written in terms
-        of the check function, e.g.
-        check:
-           def get_val():
-               return admin.stuff()['val']
-        condition:
-           def condition(check: Callable):
-               return check() > 10
-           # used like
-           condition(get_val)
+      - condition: passed to wait_until
       - timeout_sec (see above)
       - progress_sec (see above)
       - err_msg: Passed down to wait_until
@@ -168,7 +159,7 @@ def wait_until_with_progress_check(
     while timeout_sec > 0:
         try:
             wait_until(
-                lambda: condition(check),
+                condition,
                 timeout_sec=progress_sec,
                 backoff_sec=backoff_sec,
                 err_msg=err_msg,

--- a/tools/format-py
+++ b/tools/format-py
@@ -4,5 +4,5 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 root_dir=$(git -C ${script_dir} rev-parse --show-toplevel)
 
 pushd ${root_dir}
-uv tool run --with 'ruff==0.12.10' ruff format
+${script_dir}/ruff format
 popd

--- a/tools/ruff
+++ b/tools/ruff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+uv tool run --with 'ruff==0.12.10' ruff "$@"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27291 

MANUAL BACKPORT (Conflict in a test that doesn't exist on this branch & some python formatting)

Also pulled in 02a67070881316af77bcfc11068f5603cd1acef0, a minor convenience for in-editor formatting