### PR TITLE
[CORE-12892] [v24.3.x] `storage`: raise failed to build offset map log level to `ERROR`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -668,7 +668,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             std::rethrow_exception(eptr);
         }
         vlog(
-          gclog.warn,
+          gclog.error,
           "[{}] failed to build offset map. Stopping compaction: {}",
           config().ntp(),
           std::current_exception());

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -125,6 +125,9 @@ DEFAULT_LOG_ALLOW_LIST = [
     # which is not present in typical CI runs, which results in the following
     # error message from the debug bundle service
     re.compile(r"Current specified RPK location"),
+
+    # Ignore this log line, which is more like a compaction warning.
+    re.compile(r"failed to build offset map"),
 ]
 
 # Log errors that are expected in tests that restart nodes mid-test


### PR DESCRIPTION
This was specifically requested by a user, and is a fair request, as the presence of this log line can indicate blocked compaction for a given partition and may require operator intervention.

JIRA: https://redpandadata.atlassian.net/browse/CORE-12892

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
