### PR TITLE
gha: replace manual install of bazelisk with setup-bazel

### DIFF
--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -27,11 +27,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install Baselisk
-        run: |
-          mkdir -v -p $HOME/.local/bin
-          wget -O $HOME/.local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
-          chmod +x $HOME/.local/bin/bazel
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Share repository cache between workflows.
+          repository-cache: true
       - name: Run clang-format
         env:
           # Bazel uses this to enforce strict sandboxing - we can't do it in Github Actions,


### PR DESCRIPTION
I saw this fail with a 503 earlier today, replace it with a cached version

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
