### PR TITLE
rpk: fix cluster config status in dedicated cluster

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/set.go
+++ b/src/go/rpk/pkg/cli/cluster/config/set.go
@@ -91,7 +91,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.`,
 
 			if vp.FromCloud {
 				if vp.CloudCluster.IsServerless() {
-					out.Die("rpk cluster config set is not supported for serverless clusters.")
+					out.Die("rpk cluster config set is not supported on Redpanda serverless clusters")
 				}
 				out.MaybeDie(err, "rpk unable to load config: %v", err)
 				operation, err := setCloudConfig(cmd.Context(), cfg, vp, configs)

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -50,8 +50,8 @@ is offline.`,
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
 			if vp.FromCloud {
-				if !vp.CloudCluster.IsBYOC() {
-					out.Die("rpk cluster config set is not supported for serverless and dedicated clusters.")
+				if vp.CloudCluster.IsServerless() {
+					out.Die("rpk cluster config status is not supported on Redpanda serverless clusters")
 				}
 				cfg, err := p.Load(fs)
 				out.MaybeDie(err, "rpk unable to load config: %v", err)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes

*  rpk: Allow using `rpk config status` in dedicated clusters.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
