### PR TITLE
cloud_topics: add level zero data object path utils

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -146,6 +146,9 @@ redpanda_cc_library(
     hdrs = [
         "object_utils.h",
     ],
+    implementation_deps = [
+        "//src/v/base",
+    ],
     visibility = [
         ":__subpackages__",
         "//src/v/cloud_topics/reconciler:__pkg__",

--- a/src/v/cloud_topics/object_utils.cc
+++ b/src/v/cloud_topics/object_utils.cc
@@ -10,13 +10,66 @@
 
 #include "cloud_topics/object_utils.h"
 
+#include "base/vassert.h"
 #include "ssx/sformat.h"
+
+#include <charconv>
+
+constexpr auto level_zero_data_dir_str = "level_zero/data/";
+
+/*
+ * We are using full-width int64 padding here. Using that many digits means
+ * we don't need to think at all about the choice in terms of future growth.
+ * We can revisit the width if for some reason we want a lower limit.
+ */
+constexpr size_t epoch_digits = 18;
+static_assert(std::numeric_limits<int64_t>::digits10 == epoch_digits);
 
 namespace cloud_topics {
 
 cloud_storage_clients::object_key
 object_path_factory::level_zero_path(object_id id) {
-    return cloud_storage_clients::object_key(ssx::sformat("{}", id));
+    vassert(id.epoch() >= 0, "level zero object has negative epoch: {}", id);
+    return cloud_storage_clients::object_key(
+      ssx::sformat(
+        "{0}{2:0{1}}/{3}",
+        level_zero_data_dir_str,
+        epoch_digits,
+        id.epoch(),
+        id.name));
+}
+
+cloud_storage_clients::object_key object_path_factory::level_zero_data_dir() {
+    return cloud_storage_clients::object_key(level_zero_data_dir_str);
+}
+
+std::expected<cluster_epoch, std::string>
+object_path_factory::level_zero_path_to_epoch(std::string_view key) {
+    // find the level zero prefix and chop it off
+    auto name = key;
+    auto it = name.find(level_zero_data_dir_str);
+    if (it == std::string_view::npos) {
+        return std::unexpected(
+          fmt::format("L0 object name missing prefix: {}", key));
+    }
+    name.remove_prefix(it + std::strlen(level_zero_data_dir_str));
+    if (name.size() < epoch_digits) {
+        return std::unexpected(
+          fmt::format("L0 object name is too short: {}", key));
+    }
+
+    // remove the tail so that all should be left is the epoch
+    name.remove_suffix(name.size() - epoch_digits);
+
+    // parse the epoch into an integer
+    int64_t epoch{0};
+    auto res = std::from_chars(name.data(), name.data() + name.size(), epoch);
+    if (res.ptr != name.data() + name.size() || res.ec != std::errc{}) {
+        return std::unexpected(
+          fmt::format("L0 object name has invalid epoch: {}", key));
+    }
+
+    return cluster_epoch(epoch);
 }
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/object_utils.h
+++ b/src/v/cloud_topics/object_utils.h
@@ -12,6 +12,8 @@
 #include "cloud_storage_clients/types.h"
 #include "cloud_topics/types.h"
 
+#include <expected>
+
 namespace cloud_topics {
 
 /*
@@ -23,6 +25,17 @@ public:
      * Generate the path of a level-zero object.
      */
     static cloud_storage_clients::object_key level_zero_path(object_id id);
+
+    /*
+     * Level-zero object data root directory. Contains a trailing "/".
+     */
+    static cloud_storage_clients::object_key level_zero_data_dir();
+
+    /*
+     * Extract the epoch from an L0 object key.
+     */
+    static std::expected<cluster_epoch, std::string>
+      level_zero_path_to_epoch(std::string_view);
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/tests/object_utils_test.cc
+++ b/src/v/cloud_topics/tests/object_utils_test.cc
@@ -19,5 +19,45 @@ TEST(ObjectPathFactory, LevelZeroPathFormat) {
     auto path = cloud_topics::object_path_factory::level_zero_path(
       cloud_topics::object_id::create(cloud_topics::cluster_epoch{42}));
     EXPECT_THAT(
-      path().string(), ::testing::MatchesRegex("^42/" UUID_REGEX "$"));
+      path().string(),
+      ::testing::MatchesRegex(
+        "^level_zero/data/000000000000000042/" UUID_REGEX "$"));
+}
+
+TEST(ObjectPathFactory, LevelZeroDataDir) {
+    EXPECT_EQ(
+      cloud_topics::object_path_factory::level_zero_data_dir(),
+      cloud_storage_clients::object_key("level_zero/data/"));
+}
+
+TEST(ObjectPathFactory, LevelZeroParseEpoch) {
+    EXPECT_EQ(
+      cloud_topics::object_path_factory::level_zero_path_to_epoch(
+        "level_zero/data/000000000000010042/"),
+      cloud_topics::cluster_epoch(10042));
+
+    EXPECT_EQ(
+      cloud_topics::object_path_factory::level_zero_path_to_epoch(
+        "level_zero/data/000000000000010042/asdfalksjdflkjsdflkj"),
+      cloud_topics::cluster_epoch(10042));
+
+    EXPECT_EQ(
+      cloud_topics::object_path_factory::level_zero_path_to_epoch(
+        "level_asdf_zero/data/000000000000010042/asdfasdf")
+        .error(),
+      "L0 object name missing prefix: "
+      "level_asdf_zero/data/000000000000010042/asdfasdf");
+
+    EXPECT_EQ(
+      cloud_topics::object_path_factory::level_zero_path_to_epoch(
+        "level_zero/data/0000000000010042/")
+        .error(),
+      "L0 object name is too short: level_zero/data/0000000000010042/");
+
+    EXPECT_EQ(
+      cloud_topics::object_path_factory::level_zero_path_to_epoch(
+        "level_zero/data/00000X0000000010042/asdfasdf")
+        .error(),
+      "L0 object name has invalid epoch: "
+      "level_zero/data/00000X0000000010042/asdfasdf");
 }


### PR DESCRIPTION
Changes made to L0 object naming to support GC:

- A dedicated prefix for L0 data objects because GC will depend on object listing by prefix. We also need some structure because we'll have several different categories of objects all in the same bucket.

     L0 Data: <...> / level_zero / data / epoch / uuid

- Parsing of epoch from object name. This is necessary because we do not trust object storage listing APIs and want to verify before deletion even if the expectation is that everything works exactly as specified. We may very well have a bug on our side, or encounter an object storage provider that isn't quite up to spec.

- We need to zero-pad epochs in the name in order to take advantage of the lexiographic ordering provided by object storage systems.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

