### PR TITLE
Fix ASAN and UBSAN backtrace decoding in ducktape

### DIFF
--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -809,6 +809,36 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/debug/trigger_crash",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Trigger various internal failure scenarios.",
+                    "type": "void",
+                    "nickname": "trigger_crash",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "in": "query",
+                            "required": true,
+                            "allowMultiple": false,
+                            "type": "string",
+                            "enum": [
+                                "segfault",
+                                "abort",
+                                "assert",
+                                "asan_crash",
+                                "ubsan_crash"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -129,6 +129,37 @@ void fill_raft_state(
         vlog(adminlog.info, "Backtrace:\n{}", ss::current_backtrace());
     }
 }
+// Trigger a variety of different crash types, used in ducktape testing.
+void trigger_crash(std::unique_ptr<ss::http::request> req) {
+    auto crash_type = req->get_query_param("type");
+
+    if (crash_type == "segfault") {
+        vlog(adminlog.info, "Triggering segfault from /trigger_crash API");
+        // This will cause a segmentation fault
+        volatile int* p = nullptr;
+        *p = 42;
+    } else if (crash_type == "abort") {
+        vlog(adminlog.info, "Triggering abort from /trigger_crash API");
+        std::abort();
+    } else if (crash_type == "assert") {
+        vlog(adminlog.info, "Triggering assert from /trigger_crash API");
+        vassert(false, "Intentional assert triggered by admin request");
+    } else if (crash_type == "asan_crash") {
+        volatile char* p = new char[1];
+        p[1] = 42; // deliberate out-of-bounds write
+        delete[] p;
+    } else if (crash_type == "ubsan_crash") {
+        // triggers integer overflow
+        volatile int max_int = std::numeric_limits<int>::max(), one = 1, sink{};
+        sink = max_int + one + sink;
+    } else {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("invalid crash type: {}", crash_type));
+    }
+
+    // if we get here, the crash failed, we will just return an empty json
+    // object
+}
 
 } // namespace
 
@@ -533,6 +564,18 @@ void admin_server::register_debug_routes() {
           log_backtrace(std::move(req));
           co_return ss::json::json_void{};
       });
+
+#ifndef NDEBUG
+    register_route<superuser>(
+      ss::httpd::debug_json::trigger_crash,
+      [](std::unique_ptr<ss::http::request> req)
+        -> ss::future<ss::json::json_return_type> {
+          trigger_crash(std::move(req));
+          co_return ss::json::json_void{};
+      });
+#else
+    std::ignore = trigger_crash; // silence unused function warning
+#endif
 
     if constexpr (admin_server::is_store_message_enabled()) {
         register_route_raw_async<superuser>(

--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -43,3 +43,7 @@ chmod +x llvm.sh
 mkdir -p /opt/llvm
 # make it available in a version-independent way
 ln -s /usr/bin/llvm-addr2line-$LLVM_VERSION /opt/llvm/llvm-addr2line
+
+# Make llvm-symbolizer available in the PATH, this allows ASAN, UBSAN, etc
+# symbolization to work out of the box.
+ln -s /usr/bin/llvm-symbolizer-$LLVM_VERSION /usr/local/bin/llvm-symbolizer

--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -44,6 +44,16 @@ mkdir -p /opt/llvm
 # make it available in a version-independent way
 ln -s /usr/bin/llvm-addr2line-$LLVM_VERSION /opt/llvm/llvm-addr2line
 
-# Make llvm-symbolizer available in the PATH, this allows ASAN, UBSAN, etc
+# Install an llvm-symbolizer shim in the PATH, this allows ASAN, UBSAN, etc
 # symbolization to work out of the box.
-ln -s /usr/bin/llvm-symbolizer-$LLVM_VERSION /usr/local/bin/llvm-symbolizer
+cat <<EOF >/usr/local/bin/llvm-symbolizer
+#!/bin/bash
+
+# This shim unsets LD_LIBRARY_PATH to avoid the issue that
+# redpanda libraries are loaded into the symbolizer, causing
+# it to crash.
+echo "exec llvm-symbolizer shim, cmd: '\$*', ASAN_OPTIONS=\$ASAN_OPTIONS, UBSAN_OPTIONS=\$UBSAN_OPTIONS" >&2
+unset LD_LIBRARY_PATH
+exec /usr/bin/llvm-symbolizer-$LLVM_VERSION "\$@"
+EOF
+chmod +x /usr/local/bin/llvm-symbolizer

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -27,6 +27,7 @@ from requests.exceptions import HTTPError, RequestException
 from urllib3.util.retry import Retry
 from rptest.util import wait_until_result
 from rptest.services.redpanda_types import SaslCredentials
+from rptest.utils.mode_checks import is_debug_mode
 
 DEFAULT_TIMEOUT = 30
 
@@ -453,6 +454,14 @@ class DebugBundleStartConfigParams(NamedTuple):
 class DebugBundleStartConfig(NamedTuple):
     job_id: UUID
     config: Optional[DebugBundleStartConfigParams] = None
+
+
+class CrashType(Enum):
+    SEGFAULT = "segfault"
+    ABORT = "abort"
+    ASSERT = "assert"
+    ASAN_CRASH = "asan_crash"
+    UBSAN_CRASH = "ubsan_crash"
 
 
 class Admin:
@@ -1994,3 +2003,21 @@ class Admin:
         """
         path = f"debug/log_backtrace?simple={str(simple_backtrace).lower()}"
         return self._request('post', path, node=node)
+
+    def trigger_crash(self, node: ClusterNode, crash_type: CrashType):
+        """
+        Trigger an immediate crash of the given type on the specified node.
+
+        This admin API is only available in debug mode, this function throws if
+        called in non-debug mode.
+        """
+        assert is_debug_mode(), \
+            "trigger_crash is only available in debug mode"
+        path = f"debug/trigger_crash?type={crash_type.value}"
+        try:
+            self._request('post', path, node=node)
+            raise RuntimeError("trigger_crash did not crash the node")
+        except requests.exceptions.ConnectionError:
+            # this is the expected error as the node will go down,
+            # requests will retry and throw connection error
+            return

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4249,33 +4249,32 @@ class RedpandaService(RedpandaServiceBase):
             return
 
         def _metrics_sum(name: str) -> int:
-            try:
-                samples = self.metrics_sample(name, [node])
-                if samples is None:
-                    return 0
-                return sum(s.value for s in samples.samples)
-            except Exception as e:
-                self.logger.warning(f"Cannot check metrics - {e}")
+            samples = self.metrics_sample(name, [node])
+            if samples is None:
                 return 0
+            return sum(s.value for s in samples.samples)
 
-        self._usage_stats.disk_bytes_read += _metrics_sum(
-            "vectorized_io_queue_total_read_bytes_total")
+        try:
+            self._usage_stats.disk_bytes_read += _metrics_sum(
+                "vectorized_io_queue_total_read_bytes_total")
 
-        self._usage_stats.disk_bytes_written += _metrics_sum(
-            "vectorized_io_queue_total_write_bytes_total")
-        self._usage_stats.batches_read += _metrics_sum(
-            "vectorized_storage_log_batches_read")
+            self._usage_stats.disk_bytes_written += _metrics_sum(
+                "vectorized_io_queue_total_write_bytes_total")
+            self._usage_stats.batches_read += _metrics_sum(
+                "vectorized_storage_log_batches_read")
 
-        self._usage_stats.batches_written += _metrics_sum(
-            "vectorized_storage_log_batches_written")
-        self._usage_stats.internal_rpc_bytes_sent += _metrics_sum(
-            "vectorized_internal_rpc_sent_bytes")
-        self._usage_stats.internal_rpc_bytes_recv += _metrics_sum(
-            "vectorized_internal_rpc_received_bytes")
-        self._usage_stats.cloud_storage_puts += _metrics_sum(
-            "vectorized_cloud_client_total_uploads")
-        self._usage_stats.cloud_storage_gets += _metrics_sum(
-            "vectorized_cloud_client_total_downloads")
+            self._usage_stats.batches_written += _metrics_sum(
+                "vectorized_storage_log_batches_written")
+            self._usage_stats.internal_rpc_bytes_sent += _metrics_sum(
+                "vectorized_internal_rpc_sent_bytes")
+            self._usage_stats.internal_rpc_bytes_recv += _metrics_sum(
+                "vectorized_internal_rpc_received_bytes")
+            self._usage_stats.cloud_storage_puts += _metrics_sum(
+                "vectorized_cloud_client_total_uploads")
+            self._usage_stats.cloud_storage_gets += _metrics_sum(
+                "vectorized_cloud_client_total_downloads")
+        except Exception as e:
+            self.logger.warning(f"Cannot check metrics - {e}")
 
     def stop_node(self, node, timeout=None, forced=False):
         # collect usage stats before the node is stopped, the usage stats

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -9,6 +9,7 @@
 
 import signal
 from subprocess import CalledProcessError
+from ducktape.cluster.cluster import ClusterNode
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.mark import matrix
 from ducktape.mark.resource import cluster as dt_cluster
@@ -23,11 +24,12 @@ from rptest.services.failure_injector import FailureSpec, make_failure_injector
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.kgo_repeater_service import repeater_traffic
 from rptest.services.kgo_verifier_services import KgoVerifierRandomConsumer, KgoVerifierSeqConsumer, KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
-from rptest.services.redpanda import RedpandaService, RedpandaServiceCloud, SISettings, CloudStorageType, get_cloud_storage_type, make_redpanda_service, make_redpanda_mixed_service
+from rptest.services.redpanda import LogSearchLocal, RedpandaService, RedpandaServiceCloud, SISettings, CloudStorageType, get_cloud_storage_type, make_redpanda_service, make_redpanda_mixed_service
+from rptest.services.admin import CrashType
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.si_utils import BucketView
 from rptest.util import expect_exception
-from rptest.utils.mode_checks import skip_debug_mode
+from rptest.utils.mode_checks import ignore_if_not_asan, ignore_if_not_ubsan, skip_debug_mode
 from rptest.services.producer_swarm import ProducerSwarm
 
 
@@ -504,6 +506,45 @@ class RedpandaServiceSelfTest(RedpandaTest):
             # expected when the inner test passed, as if the inner test passed,
             # the backtrace capture file should not exist
             assert not fail_test
+
+    @cluster(num_nodes=1, check_allowed_error_logs=False)
+    @ignore_if_not_asan
+    def test_asan_backtrace(self):
+        """This test checks that we correctly backtrace from an ASAN crash. This
+        backtrace is the one done by ASAN itself, not the decode_backtrace() one
+        we do in ducktape in test teardown."""
+        self._crash_test_impl(CrashType.ASAN_CRASH)
+
+    @cluster(num_nodes=1, check_allowed_error_logs=False)
+    @ignore_if_not_ubsan
+    def test_ubsan_backtrace(self):
+        """This test checks that we correctly backtrace from a UBSAN crash. This
+        backtrace is the one done by UBSAN itself, not the decode_backtrace() one
+        we do in ducktape in test teardown."""
+        self._crash_test_impl(CrashType.UBSAN_CRASH)
+
+    def _crash_test_impl(self, crash_type: CrashType):
+        """This test checks that we correctly capture a backtrace from a crash
+        of the given type."""
+        rp = self.redpanda
+        node = rp.nodes[0]
+        rp._admin.trigger_crash(node, crash_type)
+        # look for this snipptet which will appear at the top of the backtrace
+        # if it was properly decoded
+        self._assert_log_content(node,
+                                 "in (anonymous namespace)::trigger_crash")
+
+    def _assert_log_content(self, node: ClusterNode, needle: str):
+        """
+        Assert that the redpanda log contains the expected content.
+        """
+        log_searcher = LogSearchLocal(self.test_context, [],
+                                      self.redpanda.logger,
+                                      self.redpanda.STDOUT_STDERR_CAPTURE)
+
+        lines = list(log_searcher._capture_log(node, f"'{needle}'"))
+        assert lines, f"Did not find expected string '{needle}' in redpanda log"
+        self.logger.debug(f"Found matching log line: {lines[0]}")
 
     def _assert_expected_backtrace_contents(self):
         """

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -38,6 +38,22 @@ def is_debug_mode():
     return os.environ.get('BUILD_TYPE', None) in ['debug', 'sanitizer']
 
 
+def is_ubsan():
+    """
+    Returns True if redpanda is built with UBSAN enabled.
+    """
+    # For now, we just assume ubsan is only in debug mode
+    return is_debug_mode()
+
+
+def is_asan():
+    """
+    Returns True if redpanda is built with ASAN enabled.
+    """
+    # For now, we just assume asan is only in debug mode
+    return is_debug_mode()
+
+
 def skip_debug_mode(*args, **kwargs):
     """
     Test method decorator which signals to the test runner to ignore a given test.
@@ -63,6 +79,28 @@ def skip_debug_mode(*args, **kwargs):
             ...
     """
     if is_debug_mode():
+        return ignore(*args, **kwargs)
+    else:
+        return args[0]
+
+
+def ignore_if_not_ubsan(*args, **kwargs):
+    """
+    Test method decorator which ignores (skips) a test if redpanda is not built
+    with UBSAN enabled.
+    """
+    if not is_ubsan():
+        return ignore(*args, **kwargs)
+    else:
+        return args[0]
+
+
+def ignore_if_not_asan(*args, **kwargs):
+    """
+    Test method decorator which ignores (skips) a test if redpanda is not built
+    with ASAN enabled.
+    """
+    if not is_asan():
         return ignore(*args, **kwargs)
     else:
         return args[0]


### PR DESCRIPTION
This series fixes decoding for UBSAN and ASAN failures in ducktape. Primarily it involves making llvm-symbolizer available to the sanitizers, and ensuring that LD_LIBRARY_PATH does not interfere with symbolizer operation when launched as a child of Redpanda.

Fixes [CORE-13191].

AI's take: pull request introduces a new admin API endpoint to trigger various internal crash scenarios for testing, and adds corresponding test infrastructure to validate crash handling and backtrace capture. It also includes improvements to test utilities and error handling in metrics collection.

**Debug API and Crash Testing Enhancements:**

* Added a new admin API endpoint `/v1/debug/trigger_crash` (debug mode only) to trigger different crash types (`segfault`, `abort`, `assert`, `asan_crash`, `ubsan_crash`) for use in ducktape-based testing. The implementation is in `src/v/redpanda/admin/debug.cc` and documented in `src/v/redpanda/admin/api-doc/debug.json`. [[1]](diffhunk://#diff-5b3d53553c16b9473bd9b7cc48bdfc6a846bb77498d3e83c75b6a988c5d3e45eR812-R841) [[2]](diffhunk://#diff-83a56125cfc0e59053dded5e8e1ef8c88b31c974017ccd2a02d5f5fd2a6a4ab1R132-R162) [[3]](diffhunk://#diff-83a56125cfc0e59053dded5e8e1ef8c88b31c974017ccd2a02d5f5fd2a6a4ab1R568-R579)
* Added a `CrashType` enum and `trigger_crash` method to the Python admin API wrapper, enabling tests to programmatically trigger crashes and assert expected node failures. [[1]](diffhunk://#diff-e021a5879b3f89d7ca4dc0901d14abec295fcb62668426b505ec56c1ef948951R459-R466) [[2]](diffhunk://#diff-e021a5879b3f89d7ca4dc0901d14abec295fcb62668426b505ec56c1ef948951R2006-R2023)
* Added new self-test cases for ASAN and UBSAN crash scenarios, including decorators to conditionally skip tests if the build is not configured with the relevant sanitizer. Tests assert that the expected backtrace appears in logs. [[1]](diffhunk://#diff-0e489db926b1ee56c943324415f61c4ae1aa048ee0a5e0682e5b9a8c02a922b0L26-R32) [[2]](diffhunk://#diff-0e489db926b1ee56c943324415f61c4ae1aa048ee0a5e0682e5b9a8c02a922b0R510-R548) [[3]](diffhunk://#diff-5541fd7f55462e778e4d7c27296ba0073924b1ca770b9c26f1a04ffe5b0f70dbR41-R56) [[4]](diffhunk://#diff-5541fd7f55462e778e4d7c27296ba0073924b1ca770b9c26f1a04ffe5b0f70dbR87-R108)

**Test Environment Improvements:**

* Ensured `llvm-symbolizer` is available in the test environment for proper symbolization of ASAN/UBSAN backtraces by adding a symlink in the Docker setup.

**Error Handling and Logging:**

* Refactored metrics collection in `RedpandaService` to improve error handling: exceptions in metrics sampling now result in a warning log and a zero value, rather than interrupting the stats update. [[1]](diffhunk://#diff-3f567de33923dec6fa4ca0462aa968416b58c956c824dd007cff23498c342785L4214-R4219) [[2]](diffhunk://#diff-3f567de33923dec6fa4ca0462aa968416b58c956c824dd007cff23498c342785R4238-R4240)

(no, the real change is that we bail out when metrics aren't available instead of trying to get each family)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not backporting for now
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none



[CORE-13191]: https://redpandadata.atlassian.net/browse/CORE-13191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ