### PR TITLE
rptest: fix skip_in_debug/fips decorator args

### DIFF
--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -63,7 +63,7 @@ def skip_debug_mode(*args, **kwargs):
             ...
     """
     if is_debug_mode():
-        return ignore(args, kwargs)
+        return ignore(*args, **kwargs)
     else:
         return args[0]
 
@@ -120,6 +120,6 @@ def skip_fips_mode(*args, **kwargs):
             ...
     """
     if in_fips_environment():
-        return ignore(args, kwargs)
+        return ignore(*args, **kwargs)
     else:
         return args[0]


### PR DESCRIPTION
These decorators were incorrectly passing args/kwargs as positional arguments to the ignore() decorator, which caused the tests to just disapear rather than being ignored.

args and kwargs need to be unpacked when passing them along.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

