### PR TITLE
rptest: add a script to create a local venv

### DIFF
--- a/tests/local_venv.sh
+++ b/tests/local_venv.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Make a local ducktape venv. This installs ducktape and rptest packages to ease
+# local development in an IDE (which will now be able to find the packages it
+# expects) but does _not_ let you run tests locally outside of docker: for that
+# you should still use the rp:run-ducktape-tests targets to run them inside docker.
+
+set -euo pipefail
+
+# script expects cwd to be the parent dir of the script
+# CC BY-SA 4.0 https://creativecommons.org/licenses/by-sa/4.0/ https://stackoverflow.com/a/246128
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null
+
+echo "Setting up the venv for local ducktape in ${VENV:=.venv}"
+
+python3 -m venv $VENV
+. $VENV/bin/activate
+
+# this should be closely aligned with the install step in ./docker/Dockerfile
+python3 -m pip install -e .
+
+echo "Everything installed, now activate the venv in your shell by running:"
+echo "source $VENV/bin/activate"


### PR DESCRIPTION
For rptest, so this can be set up in a standard way.

Local venv is important so that LSP functions like autocomplete, type checking work properly in your IDE or emacs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

