### PR TITLE
rpk.py: trim exception string

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -50,8 +50,16 @@ class RpkException(Exception):
         self.parsed_output: list[RpkOffsetDeleteResponsePartition] | None = None
 
     def __str__(self):
+        def last_two(input: str):
+            lines = input.splitlines()
+            if len(lines) > 2:
+                return f"... ({len(lines)-2} lines skipped)\n" + "\n".join(
+                    lines[-2:])
+            else:
+                return input
+
         if self.stderr:
-            err = f"; stderr: {self.stderr}"
+            err = f"; stderr: {last_two(self.stderr)}"
         else:
             err = ""
         if self.returncode:
@@ -59,7 +67,7 @@ class RpkException(Exception):
         else:
             retcode = ""
         if self.stdout:
-            stdout = f"; stdout: {self.stdout}"
+            stdout = f"; stdout: {last_two(self.stdout)}"
         else:
             stdout = ""
         return f"RpkException<{self.msg}{err}{stdout}{retcode}>"
@@ -1258,18 +1266,24 @@ class RpkTool:
                              stderr=subprocess.PIPE,
                              env=env,
                              text=True)
+
+        def _log_rpk_output(stdout, stderr):
+            self._redpanda.logger.debug(f'rpk stdout: \n{stdout}')
+            self._redpanda.logger.debug(f'rpk stderr: \n{stderr}')
+
         try:
             output, stderror = p.communicate(input=stdin, timeout=timeout)
         except subprocess.TimeoutExpired:
             p.kill()
-            output, stderr = p.communicate()
-            raise RpkException(f"command `{' '.join(cmd)}' timed out",
-                               stdout=output,
-                               stderr=stderr)
+            output, stderror = p.communicate()
+            msg = f"command `{' '.join(cmd)}' timed out"
+            _log_rpk_output(output, stderror)
+            raise RpkException(msg, stdout=output, stderr=stderror)
 
         self._redpanda.logger.debug(f'\n{output}')
 
         if p.returncode:
+            _log_rpk_output(output, stderror)
             raise RpkException(
                 'command %s returned %d, output: %s' %
                 (' '.join(cmd) if log_cmd else '[redacted]', p.returncode,

--- a/tests/rptest/tests/rbac_test.py
+++ b/tests/rptest/tests/rbac_test.py
@@ -827,7 +827,7 @@ class RBACEndToEndTest(RBACTestBase):
             "Since No permissions have been added to either role, expect authZ failed"
         )
         with expect_exception(RpkException,
-                              lambda e: 'AUTHORIZATION_FAILED' in str(e)):
+                              lambda e: 'AUTHORIZATION_FAILED' in e.stderr):
             self.alice_rpk.produce(self.topic0, 'foo', 'bar')
 
         self.logger.debug("Now add topic access rights for user")
@@ -884,7 +884,7 @@ class RBACEndToEndTest(RBACTestBase):
                    retry_on_exc=True)
 
         with expect_exception(RpkException,
-                              lambda e: 'AUTHORIZATION_FAILED' in str(e)):
+                              lambda e: 'AUTHORIZATION_FAILED' in e.stderr):
             self.alice_rpk.consume(self.topic1, n=1)
 
         self.logger.debug(


### PR DESCRIPTION
The RPK exception sometimes embeds the entire stdout/stderr of the command that was run, which can be very large, especially the stderr since we turn on RPK debugging so there is verbose output about every request.

These exceptions may casually be logged to the console, or end up in a report, where this amount of info isn't useful and causes other issues.

Instead, include only the last two lines of stdout/stderr in the exception __str__, but keep the full text in the exception object for those who want to dig into it (i.e., don't change the contract of RpkException, except its __str__).

Futhermore, in failure cases, log the full stdout/stderr to the test log at debug level, which is probably where folks would want it.

Fixes CORE-13195.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
