### PR TITLE
`storage`: move location of `mark_segment_as_finished_self_compaction()`

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -657,6 +657,7 @@ ss::future<compaction_result> do_self_compact_segment(
     s->index().swap_index_state(std::move(idx));
     s->force_set_commit_offset_from_index();
     co_await s->reset_batch_cache_index();
+    co_await mark_segment_as_finished_self_compaction(s, pb);
     co_await s->index().flush();
     s->advance_generation();
     co_return compaction_result(size_before, s->size_bytes(), cmp_idx_size);
@@ -850,7 +851,6 @@ ss::future<compaction_result> self_compact_segment(
     if (res.did_compact()) {
         pb.add_compaction_removed_bytes(
           ssize_t(res.size_before) - ssize_t(res.size_after));
-        co_await internal::mark_segment_as_finished_self_compaction(s, pb);
     }
 
     co_return res;


### PR DESCRIPTION
This will forcefully flush the `segment_index`. Before, due to the location of this call, we would end up flushing the index twice.

Make this codepath a bit more optimal by marking the `segment` as self compacted before making another call to flush the `segment_index` in `do_self_compact_segment()` (now a no-op in the general case)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
