### PR TITLE
tools/dev_cluster: stop post_start_configure when killed

### DIFF
--- a/tools/dev_cluster.py
+++ b/tools/dev_cluster.py
@@ -218,8 +218,8 @@ async def run_command(cmd):
     return proc.returncode == 0
 
 
-async def post_start_configure(rpk):
-    while True:
+async def post_start_configure(stop_event: asyncio.Event, rpk):
+    while not stop_event.is_set():
         if await run_command(
                 f"{rpk} cluster config set development_enable_cloud_topics true"
         ):
@@ -453,11 +453,13 @@ async def main():
         for m in node_metas
     ]
 
+    stop_event = asyncio.Event()
     redpanda_coros = [r.run() for r in nodes]
-    other_coros = [post_start_configure(args.rpk)]
+    other_coros = [post_start_configure(stop_event, args.rpk)]
     all_coros = redpanda_coros + other_coros
 
     def stop():
+        stop_event.set()
         for n in nodes:
             n.stop()
         if minio:


### PR DESCRIPTION
Currently when starting a misconfigured and crashed dev_cluster, there's an indefinite loop that keeps trying to run rpk to set the development_enable_cloud_topics config property, even after hitting ctrl-c.

This passes an asyncio Event to the coroutine so it has a stop condition when this happens.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
