### PR TITLE
[CORE-13087] dl/coordinator: don't purge data when dropping Glue table

### DIFF
--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -856,14 +856,8 @@ ss::sstring coordinator::get_effective_default_partition_spec(
   const std::optional<ss::sstring>& partition_spec) const {
     const auto& cfg = config::shard_local_cfg();
     auto current_spec = partition_spec.value_or(default_partition_spec_());
-
-    bool is_glue = cfg.iceberg_catalog_type()
-                     == config::datalake_catalog_type::rest
-                   && cfg.iceberg_rest_catalog_authentication_mode()
-                        == config::datalake_catalog_auth_mode::aws_sigv4
-                   && cfg.iceberg_rest_catalog_aws_service_name() == "glue";
     if (
-      is_glue
+      using_glue_catalog()
       && current_spec == cfg.iceberg_default_partition_spec.default_value()) {
         // Glue can't partition on nested fields like redpanda.timestamp.
         vlog(
@@ -875,4 +869,13 @@ ss::sstring coordinator::get_effective_default_partition_spec(
 
     return current_spec;
 }
+
+bool coordinator::using_glue_catalog() const {
+    const auto& cfg = config::shard_local_cfg();
+    return cfg.iceberg_catalog_type() == config::datalake_catalog_type::rest
+           && cfg.iceberg_rest_catalog_authentication_mode()
+                == config::datalake_catalog_auth_mode::aws_sigv4
+           && cfg.iceberg_rest_catalog_aws_service_name() == "glue";
+}
+
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -747,12 +747,17 @@ coordinator::update_lifecycle_state(
           model::topic_namespace_view{model::kafka_namespace, t});
         if (tombstone_it != topic_table_.get_iceberg_tombstones().end()) {
             auto tombstone_rev = tombstone_it->second.last_deleted_revision;
+            // The Glue REST catalog doesn't support purging data; explicitly
+            // pass that down to the drop operations.
+            auto should_purge = using_glue_catalog()
+                                  ? file_committer::purge_data::no
+                                  : file_committer::purge_data::yes;
             if (tombstone_rev >= topic.revision) {
                 // Drop the main table if it exists.
                 {
                     auto table_id = table_id_provider::table_id(t);
                     auto drop_res = co_await file_committer_.drop_table(
-                      table_id);
+                      table_id, should_purge);
                     if (drop_res.has_error()) {
                         switch (drop_res.error()) {
                         case file_committer::errc::shutting_down:
@@ -771,7 +776,7 @@ coordinator::update_lifecycle_state(
                 {
                     auto dlq_table_id = table_id_provider::dlq_table_id(t);
                     auto drop_res = co_await file_committer_.drop_table(
-                      dlq_table_id);
+                      dlq_table_id, should_purge);
                     if (drop_res.has_error()) {
                         switch (drop_res.error()) {
                         case file_committer::errc::shutting_down:

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -148,6 +148,11 @@ private:
     ss::sstring get_effective_default_partition_spec(
       const std::optional<ss::sstring>& partition_spec) const;
 
+    // Return whether the underlying catalog is the Glue REST catalog.
+    // TODO: if the kludges start piling up, we should abstract some "catalog
+    // capabilities" out.
+    bool using_glue_catalog() const;
+
     ss::shared_ptr<coordinator_stm> stm_;
     cluster::topic_table& topic_table_;
     type_resolver& type_resolver_;

--- a/src/v/datalake/coordinator/file_committer.h
+++ b/src/v/datalake/coordinator/file_committer.h
@@ -28,8 +28,9 @@ public:
       checked<chunked_vector<mark_files_committed_update>, errc>>
     commit_topic_files_to_catalog(model::topic, const topics_state&) const = 0;
 
+    using purge_data = ss::bool_class<struct purge_data_tag>;
     virtual ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const = 0;
+    drop_table(const iceberg::table_identifier&, purge_data) const = 0;
 
     virtual ~file_committer() = default;
 };

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -598,7 +598,7 @@ iceberg_file_committer::commit_topic_files_to_catalog(
 
 ss::future<checked<std::nullopt_t, file_committer::errc>>
 iceberg_file_committer::drop_table(
-  const iceberg::table_identifier& table_id) const {
+  const iceberg::table_identifier& table_id, purge_data should_purge) const {
     auto load_res = co_await catalog_.load_table(table_id);
     if (load_res.has_error()) {
         if (load_res.error() == iceberg::catalog::errc::not_found) {
@@ -611,7 +611,8 @@ iceberg_file_committer::drop_table(
             "anyway",
             table_id));
     }
-    auto drop_res = co_await catalog_.drop_table(table_id, true);
+    auto drop_res = co_await catalog_.drop_table(
+      table_id, should_purge == purge_data::yes);
     if (
       drop_res.has_error()
       && drop_res.error() != iceberg::catalog::errc::not_found) {

--- a/src/v/datalake/coordinator/iceberg_file_committer.h
+++ b/src/v/datalake/coordinator/iceberg_file_committer.h
@@ -59,7 +59,7 @@ public:
       model::topic, const topics_state&) const final;
 
     ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const final;
+    drop_table(const iceberg::table_identifier&, purge_data) const final;
 
 private:
     // Must outlive this committer.

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -43,7 +43,7 @@ public:
     }
 
     ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const final {
+    drop_table(const iceberg::table_identifier&, purge_data) const final {
         co_return std::nullopt;
     }
 

--- a/src/v/datalake/coordinator/tests/state_test_utils.h
+++ b/src/v/datalake/coordinator/tests/state_test_utils.h
@@ -58,7 +58,7 @@ public:
     }
 
     ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const final {
+    drop_table(const iceberg::table_identifier&, purge_data) const final {
         co_return std::nullopt;
     }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Glue doesn's support the purgeRequested option when dropping tables, and
will reject our requests indefinitely when a tombstone exists. This ends
up blocking topic tombstone removal, and therefore blocks subsequent
Iceberg topics of the same name from translating any data.

This commit plumbs a bool to the drop_table() command that is false for
Glue.

I considered doing this in the catalog layer, but opted to be more
explicit (it's hopeflly less surprising for readers that way).

Manually tested this against Glue:
1. create an Iceberg topic
2. produce to the Iceberg topic and wait for Iceberg commits
3. drop the Iceberg topic
4. witness the drop table op eventually succeeding in Glue
5. manually delete the data in Iceberg
6. recreate the topic and produce without issues

...as well as another sequence where I didn't do step 4 and instead
immediately went on to delete data and recreate the topic. In both
cases, the Redpanda coordinator was not blocked and could produce to the
new topic without issues.

Kludge for https://redpandadata.atlassian.net/browse/CORE-13087

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Redpanda will now automatically detect when using the Glue Iceberg REST Catalog and avoid using the `purgeRequested=true` option when dropping tables. This would previously result in commits to Iceberg being blocked when an Iceberg topic was deleted and recreated.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
