### PR TITLE
git: mark generated files as generated for github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Mark generated files as so. This allows Github to flag them as generated in PR reviews.
+src/v/serde/protobuf/goldens/* linguist-generated=true
+tests/rptest/clients/admin/google/** linguist-generated=true
+tests/rptest/clients/admin/proto/** linguist-generated=true

--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -128,7 +128,12 @@ func (b *codewriter) Printf(msg string, args ...any) {
 }
 
 func (b *codewriter) Println(args ...any) {
-	_, _ = b.content.WriteString(b.indent + fmt.Sprintln(args...))
+	if len(args) == 0 {
+		// Don't add indentation for blank lines.
+		b.content.WriteString("\n")
+	} else {
+		_, _ = b.content.WriteString(b.indent + fmt.Sprintln(args...))
+	}
 }
 
 func (b *codewriter) PreludePrintf(msg string, args ...any) {

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -89,10 +89,10 @@ public:
   c(c&&) noexcept;
   c& operator=(c&&) noexcept;
   ~c() noexcept;
-  
+
   bool operator==(const c&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.C into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.C into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -107,13 +107,13 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, c*);
-  
-  
+
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, c* update);
-  
+
 private:
 };
 
@@ -125,10 +125,10 @@ public:
   a(a&&) noexcept;
   a& operator=(a&&) noexcept;
   ~a() noexcept;
-  
+
   bool operator==(const a&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.A into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.A into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -143,16 +143,16 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, a*);
-  
+
   c& get_c();
   const c& get_c() const;
   void set_c(c&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, a* update);
-  
+
 private:
   c c_;
 };
@@ -165,10 +165,10 @@ public:
   b(b&&) noexcept;
   b& operator=(b&&) noexcept;
   ~b() noexcept;
-  
+
   bool operator==(const b&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.B into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.B into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -183,19 +183,19 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, b*);
-  
+
   c& get_c();
   const c& get_c() const;
   void set_c(c&& v);
   a& get_a();
   const a& get_a() const;
   void set_a(a&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, b* update);
-  
+
 private:
   c c_;
   a a_;
@@ -209,10 +209,10 @@ public:
   super_duper_secret(super_duper_secret&&) noexcept;
   super_duper_secret& operator=(super_duper_secret&&) noexcept;
   ~super_duper_secret() noexcept;
-  
+
   bool operator==(const super_duper_secret&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.SuperDuperSecret into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.SuperDuperSecret into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -227,16 +227,16 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, super_duper_secret*);
-  
+
   ss::sstring& get_value();
   const ss::sstring& get_value() const;
   void set_value(ss::sstring&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, super_duper_secret* update);
-  
+
 private:
   ss::sstring value_;
 };
@@ -249,10 +249,10 @@ public:
   mask_wrapper(mask_wrapper&&) noexcept;
   mask_wrapper& operator=(mask_wrapper&&) noexcept;
   ~mask_wrapper() noexcept;
-  
+
   bool operator==(const mask_wrapper&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.MaskWrapper into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.MaskWrapper into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -267,16 +267,16 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, mask_wrapper*);
-  
+
   serde::pb::field_mask& get_mask();
   const serde::pb::field_mask& get_mask() const;
   void set_mask(serde::pb::field_mask&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, mask_wrapper* update);
-  
+
 private:
   serde::pb::field_mask mask_;
 };
@@ -289,10 +289,10 @@ public:
   well_known_protos(well_known_protos&&) noexcept;
   well_known_protos& operator=(well_known_protos&&) noexcept;
   ~well_known_protos() noexcept;
-  
+
   bool operator==(const well_known_protos&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.WellKnownProtos into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.WellKnownProtos into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -307,7 +307,7 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, well_known_protos*);
-  
+
   absl::Duration& get_single_duration();
   const absl::Duration& get_single_duration() const;
   void set_single_duration(absl::Duration&& v);
@@ -335,12 +335,12 @@ public:
   chunked_hash_map<ss::sstring, absl::Time>& get_timestamp_map();
   const chunked_hash_map<ss::sstring, absl::Time>& get_timestamp_map() const;
   void set_timestamp_map(chunked_hash_map<ss::sstring, absl::Time>&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, well_known_protos* update);
-  
+
 private:
   absl::Duration single_duration_;
   chunked_vector<absl::Duration> repeated_duration_;
@@ -361,10 +361,10 @@ public:
   say_greeting_request(say_greeting_request&&) noexcept;
   say_greeting_request& operator=(say_greeting_request&&) noexcept;
   ~say_greeting_request() noexcept;
-  
+
   bool operator==(const say_greeting_request&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.SayGreetingRequest into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.SayGreetingRequest into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -379,16 +379,16 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, say_greeting_request*);
-  
+
   ss::sstring& get_greeting();
   const ss::sstring& get_greeting() const;
   void set_greeting(ss::sstring&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, say_greeting_request* update);
-  
+
 private:
   ss::sstring greeting_;
 };
@@ -401,10 +401,10 @@ public:
   say_greeting_response(say_greeting_response&&) noexcept;
   say_greeting_response& operator=(say_greeting_response&&) noexcept;
   ~say_greeting_response() noexcept;
-  
+
   bool operator==(const say_greeting_response&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes example.SayGreetingResponse into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes example.SayGreetingResponse into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -419,16 +419,16 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, say_greeting_response*);
-  
+
   ss::sstring& get_response();
   const ss::sstring& get_response() const;
   void set_response(ss::sstring&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, say_greeting_response* update);
-  
+
 private:
   ss::sstring response_;
 };
@@ -441,14 +441,14 @@ public:
   test_service& operator=(test_service&&) noexcept = delete;
   test_service(test_service&&) noexcept = delete;
   virtual ~test_service() noexcept = default;
-  
+
   // Return the name of this RPC service
   std::string_view name() const override { return "example.TestService"; }
   // Call this to get all the routes defined for this service.
   //
   // NOTE: The service must outlive anything returned from this method.
   std::vector<serde::pb::rpc::route_descriptor> all_routes() override;
-  
+
   virtual seastar::future<say_greeting_response> say_greeting(serde::pb::rpc::context, say_greeting_request) = 0;
 
 private:
@@ -462,17 +462,17 @@ public:
   // It should only throw subclasses of serde::pb::rpc::base_exception.
   // NOTE: This RPC client only uses protobuf serialization at the moment.
   using send_rpc_fn_t = std::function<seastar::future<iobuf>(serde::pb::rpc::context, iobuf)>;
-  
+
   test_service_client(send_rpc_fn_t fn) : send_rpc_fn_(std::move(fn)) {}
   test_service_client& operator=(const test_service_client&) noexcept = delete;
   test_service_client(const test_service_client&) noexcept = delete;
   test_service_client& operator=(test_service_client&&) noexcept = default;
   test_service_client(test_service_client&&) noexcept = default;
   virtual ~test_service_client() noexcept = default;
-  
+
   // Return the name of this RPC service
   std::string_view name() const { return "example.TestService"; }
-  
+
   seastar::future<say_greeting_response> say_greeting(serde::pb::rpc::context, say_greeting_request);
 
 private:

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
@@ -62,10 +62,10 @@ public:
   foreign_message_edition2023(foreign_message_edition2023&&) noexcept;
   foreign_message_edition2023& operator=(foreign_message_edition2023&&) noexcept;
   ~foreign_message_edition2023() noexcept;
-  
+
   bool operator==(const foreign_message_edition2023&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.ForeignMessageEdition2023 into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -80,15 +80,15 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, foreign_message_edition2023*);
-  
+
   int32_t get_c() const;
   void set_c(int32_t v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, foreign_message_edition2023* update);
-  
+
 private:
   int32_t c_{};
 };
@@ -102,10 +102,10 @@ public:
   test_all_types_edition2023_group_like_type(test_all_types_edition2023_group_like_type&&) noexcept;
   test_all_types_edition2023_group_like_type& operator=(test_all_types_edition2023_group_like_type&&) noexcept;
   ~test_all_types_edition2023_group_like_type() noexcept;
-  
+
   bool operator==(const test_all_types_edition2023_group_like_type&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -120,17 +120,17 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023_group_like_type*);
-  
+
   int32_t get_group_int32() const;
   void set_group_int32(int32_t v);
   uint32_t get_group_uint32() const;
   void set_group_uint32(uint32_t v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, test_all_types_edition2023_group_like_type* update);
-  
+
 private:
   int32_t group_int32_{};
   uint32_t group_uint32_{};
@@ -144,10 +144,10 @@ public:
   test_all_types_edition2023_nested_message(test_all_types_edition2023_nested_message&&) noexcept;
   test_all_types_edition2023_nested_message& operator=(test_all_types_edition2023_nested_message&&) noexcept;
   ~test_all_types_edition2023_nested_message() noexcept;
-  
+
   bool operator==(const test_all_types_edition2023_nested_message&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -162,18 +162,18 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023_nested_message*);
-  
+
   int32_t get_a() const;
   void set_a(int32_t v);
   std::unique_ptr<test_all_types_edition2023>& get_corecursive();
   const std::unique_ptr<test_all_types_edition2023>& get_corecursive() const;
   void set_corecursive(std::unique_ptr<test_all_types_edition2023>&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, test_all_types_edition2023_nested_message* update);
-  
+
 private:
   int32_t a_{};
   std::unique_ptr<test_all_types_edition2023> corecursive_;
@@ -187,10 +187,10 @@ public:
   test_all_types_edition2023(test_all_types_edition2023&&) noexcept;
   test_all_types_edition2023& operator=(test_all_types_edition2023&&) noexcept;
   ~test_all_types_edition2023() noexcept;
-  
+
   bool operator==(const test_all_types_edition2023&) const;
   fmt::iterator format_to(fmt::iterator) const;
-  
+
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023 into a protocol buffer, in a way that will not cause stalls for large messages.
   seastar::future<iobuf> to_proto() const;
   // Serializes protobuf_test_messages.editions.TestAllTypesEdition2023 into proto3 JSON, in a way that will not cause stalls for large messages.
@@ -205,7 +205,7 @@ public:
   // Note: This factory function should not be used directly, it's exposed for other protobuf parsers to use.
   // Use the iobuf version instead.
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023*);
-  
+
   // Singular
   int32_t get_optional_int32() const;
   void set_optional_int32(int32_t v);
@@ -504,12 +504,12 @@ public:
   test_all_types_edition2023_group_like_type& get_delimited_field();
   const test_all_types_edition2023_group_like_type& get_delimited_field() const;
   void set_delimited_field(test_all_types_edition2023_group_like_type&& v);
-  
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   void apply_field_path_from(std::span<const ss::sstring> path, test_all_types_edition2023* update);
-  
+
 private:
   int32_t optional_int32_{};
   int64_t optional_int64_{};


### PR DESCRIPTION
- **gh: add .gitattributes to mark certain files as generated**
- **pbgen: don't add indents for empty lines**

Followup from another PR

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
