### PR TITLE
Added `kafka::offset` high watermark to partition status in health report.

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -832,7 +832,7 @@ TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
                         model::kafka_namespace, topic_name)) {
                         continue;
                     }
-                    for (auto partition : partitions) {
+                    for (auto& [id, partition] : partitions) {
                         sizes.push_back(
                           partition.reclaimable_size_bytes.value_or(0));
                     }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -938,70 +938,85 @@ health_monitor_backend::get_current_node_health() {
 
 namespace {
 
-struct ntp_report {
-    model::topic_namespace tp_ns;
+partition_status build_partition_status(const partition& p) {
     partition_status status;
+    status.id = p.ntp().tp.partition;
+    status.term = p.term();
+    status.leader_id = p.get_leader_id();
+    status.revision_id = p.get_revision_id();
+    status.size_bytes = p.size_bytes() + p.non_log_disk_size_bytes();
+    status.reclaimable_size_bytes = p.reclaimable_size_bytes();
+    status.shard = ss::this_shard_id();
 
-    explicit ntp_report(const partition& p)
-      : tp_ns(model::topic_namespace(p.ntp().ns, p.ntp().tp.topic)) {
-        status.id = p.ntp().tp.partition;
-        status.term = p.term();
-        status.leader_id = p.get_leader_id();
-        status.revision_id = p.get_revision_id();
-        status.size_bytes = p.size_bytes() + p.non_log_disk_size_bytes();
-        status.reclaimable_size_bytes = p.reclaimable_size_bytes();
-        status.shard = ss::this_shard_id();
+    if (p.ntp().ns == model::kafka_namespace) {
+        status.high_watermark = model::offset_cast(
+          p.log()->from_log_offset(p.high_watermark()));
+    }
 
-        if (p.ntp().ns == model::kafka_namespace) {
-            status.high_watermark = model::offset_cast(
-              p.log()->from_log_offset(p.high_watermark()));
-        }
+    if (p.raft()->is_elected_leader()) {
+        const auto fms = p.raft()->get_follower_metrics();
 
-        if (p.raft()->is_elected_leader()) {
-            const auto fms = p.raft()->get_follower_metrics();
-
-            status.followers_stats.emplace();
-            status.under_replicated_replicas = 0;
-            for (const auto& fm : fms) {
-                if (fm.is_learner) {
-                    continue;
-                }
-                if (fm.is_live) {
-                    if (fm.under_replicated) {
-                        status.followers_stats->out_of_sync.push_back(fm.id);
-                        ++*status.under_replicated_replicas;
-                    } else {
-                        ++status.followers_stats->in_sync;
-                    }
+        status.followers_stats.emplace();
+        status.under_replicated_replicas = 0;
+        for (const auto& fm : fms) {
+            if (fm.is_learner) {
+                continue;
+            }
+            if (fm.is_live) {
+                if (fm.under_replicated) {
+                    status.followers_stats->out_of_sync.push_back(fm.id);
+                    ++*status.under_replicated_replicas;
                 } else {
-                    status.followers_stats->down.push_back(fm.id);
-                    if (fm.under_replicated) {
-                        ++*status.under_replicated_replicas;
-                    }
+                    ++status.followers_stats->in_sync;
+                }
+            } else {
+                status.followers_stats->down.push_back(fm.id);
+                if (fm.under_replicated) {
+                    ++*status.under_replicated_replicas;
                 }
             }
         }
     }
+    return status;
+}
+
+struct shard_report {
+    chunked_hash_map<
+      model::topic_namespace,
+      chunked_vector<partition_status>,
+      model::topic_namespace_hash,
+      model::topic_namespace_eq>
+      topics;
 };
 
-chunked_vector<ntp_report> collect_shard_local_reports(partition_manager& pm) {
+shard_report collect_shard_local_reports(partition_manager& pm) {
     auto partitions = pm.partitions() | std::views::values;
 
-    chunked_vector<ntp_report> reports;
-    reports.reserve(partitions.size());
+    shard_report report;
+
     for (const auto& p : partitions) {
-        reports.emplace_back(*p);
+        const auto& ntp = p->ntp();
+        auto it = report.topics.find(model::topic_namespace_view{ntp});
+        if (it == report.topics.end()) {
+            it = report.topics
+                   .emplace(
+                     model::topic_namespace{ntp.ns, ntp.tp.topic},
+                     chunked_vector<partition_status>{})
+                   .first;
+        }
+        it->second.push_back(build_partition_status(*p));
     }
-    return reports;
+    return report;
 }
 
 using reports_acc_t
-  = absl::node_hash_map<model::topic_namespace, partition_statuses_t>;
+  = chunked_hash_map<model::topic_namespace, partition_statuses_t>;
 
-reports_acc_t reduce_reports_map(
-  reports_acc_t acc, chunked_vector<cluster::ntp_report> current_reports) {
-    for (auto& ntpr : current_reports) {
-        acc[ntpr.tp_ns].push_back(ntpr.status);
+reports_acc_t reduce_reports_map(reports_acc_t acc, shard_report shard_report) {
+    for (auto& [tp_ns, statuses] : shard_report.topics) {
+        auto& reduced_topic = acc[tp_ns];
+        reduced_topic.reserve(reduced_topic.size() + statuses.size());
+        std::ranges::move(statuses, std::back_inserter(reduced_topic));
     }
     return acc;
 }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -166,7 +166,7 @@ node_health_report::topics_t filter_topic_status(
         node_health_report::topics_t ret;
         ret.reserve(topics.bucket_count());
         for (const auto& [tp_ns, partitions] : topics) {
-            ret.emplace(tp_ns, partitions.copy());
+            ret.emplace(tp_ns, copy_partition_statuses(partitions));
         }
         return ret;
     }
@@ -174,10 +174,10 @@ node_health_report::topics_t filter_topic_status(
     node_health_report::topics_t filtered;
 
     for (auto& [tp_ns, partitions] : topics) {
-        partition_statuses_t filtered_partitions;
-        for (auto& pl : partitions) {
-            if (filter.matches(tp_ns, pl.id)) {
-                filtered_partitions.push_back(pl);
+        partition_statuses_map_t filtered_partitions;
+        for (auto& [p_id, status] : partitions) {
+            if (filter.matches(tp_ns, p_id)) {
+                filtered_partitions.emplace(p_id, status);
             }
         }
         if (!filtered_partitions.empty()) {
@@ -454,7 +454,8 @@ ss::future<errc> health_monitor_backend::walk_local_and_remote_reports(
           counter,
           partitions,
           [&unclaimed_partitions, nt, &local_leader_handler](
-            const auto& partition_status) {
+            const auto& partition_status_pair) {
+              const auto& partition_status = partition_status_pair.second;
               if (const auto& fs = partition_status.followers_stats) {
                   vlog(
                     clusterlog.trace,
@@ -486,7 +487,8 @@ ss::future<errc> health_monitor_backend::walk_local_and_remote_reports(
               counter,
               partitions,
               [&unclaimed_partitions, nt, node_id, &remote_leader_handler](
-                const auto& partition_status) {
+                const auto& partition_status_pair) {
+                  const auto& partition_status = partition_status_pair.second;
                   auto nt_it = unclaimed_partitions.find(nt);
                   if (nt_it == unclaimed_partitions.end()) {
                       return;
@@ -1132,12 +1134,12 @@ health_monitor_backend::aggregate_reports(const report_cache_t& reports) {
             auto& leaderless_this_topic = leaderless.t_to_p[tp_ns];
             auto& urp_this_topic = urp.t_to_p[tp_ns];
 
-            for (const auto& partition : partitions) {
-                if (!partition.leader_id.has_value()) {
-                    leaderless_this_topic.emplace(partition.id);
+            for (const auto& [partition_id, status] : partitions) {
+                if (!status.leader_id.has_value()) {
+                    leaderless_this_topic.emplace(partition_id);
                 }
-                if (partition.under_replicated_replicas.value_or(0) > 0) {
-                    urp_this_topic.emplace(partition.id);
+                if (status.under_replicated_replicas.value_or(0) > 0) {
+                    urp_this_topic.emplace(partition_id);
                 }
             }
         }

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -952,6 +952,11 @@ struct ntp_report {
         status.reclaimable_size_bytes = p.reclaimable_size_bytes();
         status.shard = ss::this_shard_id();
 
+        if (p.ntp().ns == model::kafka_namespace) {
+            status.high_watermark = model::offset_cast(
+              p.log()->from_log_offset(p.high_watermark()));
+        }
+
         if (p.raft()->is_elected_leader()) {
             const auto fms = p.raft()->get_follower_metrics();
 

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -213,7 +213,7 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
       o,
       "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
       "reclaimable_size_bytes: {}, under_replicated: {}, shard: {}, "
-      "followers_stats: {}}}",
+      "followers_stats: {}, kafka_highwatermark: {}}}",
       ps.id,
       ps.term,
       ps.leader_id,
@@ -222,7 +222,8 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
       ps.reclaimable_size_bytes,
       ps.under_replicated_replicas,
       ps.shard,
-      ps.followers_stats);
+      ps.followers_stats,
+      ps.high_watermark);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -85,7 +85,8 @@ node_health_report::node_health_report(
   , drain_status(drain_status) {
     topics.reserve(topics_vec.size());
     for (auto& topic : topics_vec) {
-        topics.emplace(std::move(topic.tp_ns), std::move(topic.partitions));
+        topics.emplace(
+          std::move(topic.tp_ns), move_to_map(std::move(topic.partitions)));
     }
 }
 
@@ -93,7 +94,7 @@ node_health_report node_health_report::copy() const {
     node_health_report ret{id, local_state, {}, drain_status};
     ret.topics.reserve(topics.bucket_count());
     for (const auto& [tp_ns, partitions] : topics) {
-        ret.topics.emplace(tp_ns, partitions.copy());
+        ret.topics.emplace(tp_ns, copy_partition_statuses(partitions));
     }
     return ret;
 }
@@ -106,8 +107,48 @@ node_health_report_serde::node_health_report_serde(const node_health_report& hr)
   : node_health_report_serde(hr.id, hr.local_state, {}, hr.drain_status) {
     topics.reserve(hr.topics.size());
     for (const auto& [tp_ns, partitions] : hr.topics) {
-        topics.emplace_back(tp_ns, partitions.copy());
+        topics.emplace_back(tp_ns, copy_to_vector(partitions));
     }
+}
+
+partition_statuses_map_t
+copy_partition_statuses(const partition_statuses_map_t& ps) {
+    partition_statuses_map_t ret;
+    ret.reserve(ps.size());
+    for (const auto& [p_id, status] : ps) {
+        ret.emplace(p_id, status);
+    }
+    return ret;
+}
+
+partition_statuses_t copy_to_vector(const partition_statuses_map_t& ps) {
+    partition_statuses_t vec;
+    vec.reserve(ps.size());
+    std::ranges::copy(ps | std::views::values, std::back_inserter(vec));
+    return vec;
+}
+partition_statuses_t move_to_vector(partition_statuses_map_t&& ps) {
+    partition_statuses_t vec;
+    vec.reserve(ps.size());
+    std::ranges::move(ps | std::views::values, std::back_inserter(vec));
+    return vec;
+}
+partition_statuses_map_t move_to_map(partition_statuses_t&& ps_vec) {
+    partition_statuses_map_t ret;
+    ret.reserve(ps_vec.size());
+    for (auto& status : ps_vec) {
+        ret.emplace(status.id, std::move(status));
+    }
+    return ret;
+}
+
+partition_statuses_map_t copy_to_map(const partition_statuses_t& ps_vec) {
+    partition_statuses_map_t ret;
+    ret.reserve(ps_vec.size());
+    for (const auto& status : ps_vec) {
+        ret.emplace(status.id, status);
+    }
+    return ret;
 }
 
 std::ostream& operator<<(std::ostream& o, const node_health_report_serde& r) {

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -155,6 +155,8 @@ struct partition_status
 };
 
 using partition_statuses_t = chunked_vector<partition_status>;
+using partition_statuses_map_t
+  = chunked_hash_map<model::partition_id, partition_status>;
 
 struct topic_status
   : serde::envelope<topic_status, serde::version<0>, serde::compat_version<0>> {
@@ -183,7 +185,7 @@ struct topic_status
 struct node_health_report {
     using topics_t = chunked_hash_map<
       model::topic_namespace,
-      partition_statuses_t,
+      partition_statuses_map_t,
       model::topic_namespace_hash,
       model::topic_namespace_eq>;
 
@@ -608,5 +610,12 @@ struct get_cluster_health_reply
 
     auto serde_fields() { return std::tie(error, report); }
 };
+
+partition_statuses_map_t
+copy_partition_statuses(const partition_statuses_map_t& ps);
+partition_statuses_t copy_to_vector(const partition_statuses_map_t&);
+partition_statuses_t move_to_vector(partition_statuses_map_t&&);
+partition_statuses_map_t move_to_map(partition_statuses_t&&);
+partition_statuses_map_t copy_to_map(const partition_statuses_t&);
 
 } // namespace cluster

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -104,7 +104,7 @@ struct followers_stats
 };
 struct partition_status
   : serde::
-      envelope<partition_status, serde::version<4>, serde::compat_version<0>> {
+      envelope<partition_status, serde::version<5>, serde::compat_version<0>> {
     static constexpr size_t invalid_size_bytes = size_t(-1);
     static constexpr uint32_t invalid_shard_id = uint32_t(-1);
 
@@ -136,6 +136,13 @@ struct partition_status
     // present on leaders only
     std::optional<followers_stats> followers_stats;
 
+    /**
+     * Kafka high watermark of partition replica, this offset is only populated
+     * for Kafka partitions. For other partitions the offset stays not
+     * initialized.
+     */
+    kafka::offset high_watermark;
+
     auto serde_fields() {
         return std::tie(
           id,
@@ -146,7 +153,8 @@ struct partition_status
           under_replicated_replicas,
           reclaimable_size_bytes,
           shard,
-          followers_stats);
+          followers_stats,
+          high_watermark);
     }
 
     friend std::ostream& operator<<(std::ostream&, const partition_status&);

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -432,7 +432,7 @@ ss::future<> partition_balancer_planner::init_ntp_sizes_from_health_report(
   const cluster_health_report& health_report, request_context& ctx) {
     for (const auto& node_report : health_report.node_reports) {
         for (const auto& [tp_ns, partitions] : node_report->topics) {
-            for (const auto& partition : partitions) {
+            for (const auto& [_, partition] : partitions) {
                 model::ntp ntp{tp_ns.ns, tp_ns.tp, partition.id};
                 size_t reclaimable = partition.reclaimable_size_bytes.value_or(
                   0);

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -102,8 +102,7 @@ ss::future<> partition_leaders_table::update_with_node_report(
           = _topic_table.local().last_applied_revision();
         co_await ssx::async_for_each_counter(
           counter,
-          partitions.begin(),
-          partitions.end(),
+          partitions | std::views::values,
           [&](const partition_status& p) {
               if (!p.leader_id.has_value()) {
                   return;

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -933,8 +933,7 @@ leader_balancer::collect_group_replicas_from_health_report(
 
             co_await ssx::async_for_each_counter(
               counter,
-              partitions.begin(),
-              partitions.end(),
+              partitions | std::views::values,
               [&](const partition_status& partition) {
                   auto as_it = meta.get_assignments().find(partition.id);
                   if (as_it != meta.get_assignments().end()) {

--- a/src/v/cluster/tests/health_bench.cc
+++ b/src/v/cluster/tests/health_bench.cc
@@ -38,7 +38,7 @@ struct health_bench : health_report_accessor {
 
         for (const auto& [_, report] : reports) {
             for (const auto& [tp_ns, partitions] : report->topics) {
-                for (const auto& partition : partitions) {
+                for (const auto& [_, partition] : partitions) {
                     if (
                       !partition.leader_id.has_value()
                       && ret.leaderless.size() < max_partitions_report) {

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -59,9 +59,8 @@ void check_reports_the_same(
             BOOST_REQUIRE_MESSAGE(r_it != rr->topics.end(), "tp_ns: " << tp_ns);
             auto& r_partitions = r_it->second;
             BOOST_REQUIRE_EQUAL(l_partitions.size(), r_partitions.size());
-            for (size_t p = 0; p < l_partitions.size(); ++p) {
-                auto& l_p = l_partitions[p];
-                auto& r_p = r_partitions[p];
+            for (auto [p_id, l_p] : l_partitions) {
+                auto& r_p = r_partitions.at(p_id);
                 BOOST_REQUIRE_EQUAL(l_p.id, r_p.id);
                 BOOST_REQUIRE_EQUAL(l_p.leader_id, r_p.leader_id);
                 BOOST_REQUIRE_EQUAL(l_p.term, r_p.term);
@@ -176,7 +175,7 @@ bool contains_exactly_ntp_leaders(
   const cluster::node_health_report::topics_t& topics) {
     auto left = expected;
     for (const auto& [tp_ns, partitions] : topics) {
-        for (const auto& p_l : partitions) {
+        for (const auto& [_, p_l] : partitions) {
             model::ntp ntp(tp_ns.ns, tp_ns.tp, p_l.id);
             if (left.erase(ntp) == 0) {
                 vlog(

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -530,7 +530,7 @@ FIXTURE_TEST(
     // Set partition sizes
     for (auto& [tp_ns, partitions] : nr_0.topics) {
         if (tp_ns.tp == "topic-1") {
-            for (auto& partition : partitions) {
+            for (auto& [_, partition] : partitions) {
                 if (partition.id == 1) {
                     partition.size_bytes = default_partition_size - 1_KiB;
                 }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1959,7 +1959,7 @@ ss::future<topics_frontend::capacity_info> topics_frontend::get_health_info(
           32,
           [&info](const node_health_report::topics_t::value_type& status) {
               for (const auto& partition : status.second) {
-                  info.ntp_sizes[partition.id] = partition.size_bytes;
+                  info.ntp_sizes[partition.first] = partition.second.size_bytes;
               }
               return ss::now();
           });

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3802,7 +3802,7 @@ void collect_shards_from_health_report(
         }
 
         for (const auto& replica : topic_it->second) {
-            auto partition_it = partitions.find(replica.id);
+            auto partition_it = partitions.find(replica.first);
             if (partition_it == partitions.end()) {
                 continue;
             }
@@ -3815,7 +3815,7 @@ void collect_shards_from_health_report(
                   return bs.node_id == node_id;
               });
             if (bs_it != part.replicas.end()) {
-                bs_it->shard = replica.shard;
+                bs_it->shard = replica.second.shard;
             }
         }
     }


### PR DESCRIPTION
Added `kafka::offset high_watermark` to node health report `partition_status`. The high watermark will be used for consumer offset lag calculation and disaster recovery. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none