### PR TITLE
packaging: use a fixed install_path

### DIFF
--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -35,11 +35,12 @@ redpanda_package(
     rpk_binary = "//:rpk",
 )
 
+# This is "bazel-dir" packaging mode used for local DT tests.
 redpanda_package(
     name = "ducktape",
     out = "redpanda_ducktape",
     include_sysroot_libs = True,
-    install_path = ":install_path",
+    install_path = "/opt/redpanda_installs/redpanda",
     redpanda_binary = "//:redpanda",
     rpath_override = "$ORIGIN/../lib",
     rpk_binary = "//:rpk",
@@ -64,9 +65,7 @@ native_package(
     cc_binaries = [
         "//src/v/kafka/client/direct_consumer/verifier:direct_consumer_verifier",
     ],
-    include_sysroot_libs = True,
-    install_path = ":install_path",
-    rpath_override = "$ORIGIN/../lib",
+    install_path = "/opt/redpanda_installs/direct_consumer_verifier",
 )
 
 native_package(
@@ -75,9 +74,7 @@ native_package(
     cc_binaries = [
         "//src/v/kafka/client/direct_consumer/verifier:direct_consumer_verifier",
     ],
-    include_sysroot_libs = True,
-    install_path = ":install_path",
-    rpath_override = "$ORIGIN/../lib",
+    install_path = "/opt/redpanda_installs/direct_consumer_verifier",
 )
 
 # NOTE: this image is currently experimental, don't use this for production.

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -3,7 +3,6 @@ A rule to create a redpanda tarball given inputs from the build system.
 """
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _is_versioned(file, starts_with):
@@ -52,7 +51,7 @@ def _set_dynamic_loader(ctx, binary, loader, interpreter_path):
     )
     return patched_binary
 
-def _prepare_package_binaries(ctx, binaries, dynamic_loader_path = "/opt/redpanda/lib"):
+def _prepare_package_binaries(ctx, binaries, dynamic_loader_path):
     """
     Prepares binaries for packaging, collecting shared libraries setting rpath and dynamic loader.
 
@@ -103,7 +102,7 @@ def _prepare_package_binaries(ctx, binaries, dynamic_loader_path = "/opt/redpand
 
     return struct(binary_files = ret_binaries, shared_libraries = collections.uniq(shared_libraries))
 
-def _prepare_redpanda_package_content(ctx, dynamic_loader_path = "/opt/redpanda/lib"):
+def _prepare_redpanda_package_content(ctx, dynamic_loader_path):
     # Collect all the shared libraries that we built as part of each binary.
     # NOTE: We don't need to do this for `rpk` because it's a static binary,
     # this is only needed for binaries with shared libraries.
@@ -245,10 +244,7 @@ def _tarball_package_configuration(ctx, package_content, fips_enabled):
 def _impl(ctx):
     use_dir = not ctx.attr.out.endswith(".tar.gz")
     out = ctx.actions.declare_directory(ctx.attr.out) if use_dir else ctx.actions.declare_file(ctx.attr.out)
-    interpreter_path = "/opt/redpanda/lib"
-    if ctx.attr.install_path:
-        interpreter_path = "{}/lib".format(ctx.attr.install_path[BuildSettingInfo].value)
-    package_content = _prepare_redpanda_package_content(ctx, interpreter_path)
+    package_content = _prepare_redpanda_package_content(ctx, "{}/lib".format(ctx.attr.install_path))
 
     fips_enabled = ctx.file.fips_module != None
     if fips_enabled != (ctx.file.fips_config != None):
@@ -339,7 +335,10 @@ redpanda_package = rule(
         ),
         "include_sysroot_libs": attr.bool(),
         "rpath_override": attr.string(mandatory = False),
-        "install_path": attr.label(),
+        "install_path": attr.string(
+            default = "/opt/redpanda",
+            doc = "The path where the package will be installed, used to set the interpreter path.",
+        ),
         "_tool": attr.label(
             executable = True,
             allow_files = True,
@@ -364,11 +363,11 @@ def _prepapare_package_conent(ctx):
     ]
     for b in ctx.attr.cc_binaries:
         cc_binaries += [struct(attr = b, file = file) for file in b.files.to_list()]
-    install_path_value = ctx.attr.install_path[BuildSettingInfo].value if ctx.attr.install_path else "/opt/{}".format(ctx.attr.name)
+
     package_cc_binaries = _prepare_package_binaries(
         ctx,
         cc_binaries,
-        "{}/lib".format(install_path_value),
+        "{}/lib".format(ctx.attr.install_path),
     )
 
     return struct(
@@ -437,10 +436,17 @@ native_package = rule(
         "out": attr.string(
             mandatory = True,
         ),
-        "include_sysroot_libs": attr.bool(),
-        "rpath_override": attr.string(mandatory = False),
+        "include_sysroot_libs": attr.bool(
+            default = True,
+        ),
+        "rpath_override": attr.string(
+            default = "$ORIGIN/../lib",
+        ),
         "owner": attr.int(),
-        "install_path": attr.label(),
+        "install_path": attr.string(
+            mandatory = True,
+            doc = "The path where the package will be installed, used to set the interpreter path.",
+        ),
         "_tool": attr.label(
             executable = True,
             allow_files = True,

--- a/bazel/packaging/packaging.bzl
+++ b/bazel/packaging/packaging.bzl
@@ -25,8 +25,17 @@ def _is_versioned_so(file):
 def _is_dynamic_loader(file):
     return _is_versioned(file, "ld")
 
+def _patched_file(ctx, original, suffix):
+    """Return a new File for patching.
+
+    Based on an input File, declare a new File with a given suffix, in a directory
+    named by the target name (so that patched files from different targets do not
+    collide."""
+    name = "patched/{}/{}_{}".format(ctx.label.name, original.basename, suffix)
+    return ctx.actions.declare_file(name)
+
 def _override_binary_rpath(ctx, path_override, original_binary):
-    patched_binary = ctx.actions.declare_file("{}_patched".format(original_binary.path))
+    patched_binary = _patched_file(ctx, original_binary, "patched")
 
     ctx.actions.run(
         inputs = [original_binary],
@@ -40,7 +49,7 @@ def _override_binary_rpath(ctx, path_override, original_binary):
 
 def _set_dynamic_loader(ctx, binary, loader, interpreter_path):
     """Uses provided dynamic loader as the interpreter for the binary"""
-    patched_binary = ctx.actions.declare_file("{}_ld".format(binary.path))
+    patched_binary = _patched_file(ctx, binary, "ld")
     ctx.actions.run(
         inputs = [binary, loader],
         outputs = [patched_binary],


### PR DESCRIPTION
We use fixed install_path in packaging now: this path is used to set the interpreter and exists in the container. This path is

/opt/redpanda_installs/redpanda for redpanda
/opt/redpanda_installs/distributed_consumer_verifier for DVC

We still leave the `install_path` build setting in place for now because we need to coordinate the changes here and in vtools, so we check this in, then remove the vtools dependency, then remove the build setting.

Change needs to be in 4 steps because of rp/vtools split:

1) https://github.com/redpanda-data/vtools/pull/3852
2) https://github.com/redpanda-data/redpanda/pull/27378 (this PR)
3) https://github.com/redpanda-data/vtools/pull/3853 vtools part 2 (remove install_path setting)
4) https://github.com/redpanda-data/redpanda/pull/27385 (remove install path setting from RP side)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

