### PR TITLE
pb/rpc: add google.rpc.ErrorInfo into rpc exceptions

### DIFF
--- a/proto/redpanda/core/admin/internal/debug.proto
+++ b/proto/redpanda/core/admin/internal/debug.proto
@@ -36,12 +36,29 @@ message StopStressFiberRequest {}
 
 message StopStressFiberResponse {}
 
+message ThrowStructuredExceptionRequest {
+    int32 node_id = 1;
+    string reason = 2;
+    map<string, string> metadata = 3;
+}
+message ThrowStructuredExceptionResponse {}
+
 // The DebugService provides access to internal debugging information and debug
 // operations for the cluster or node.
 //
 // NOTE: if you're adding a larger group of RPCs here, please consider splitting
 // it out into another service.
 service DebugService {
+    // This RPC throws a structured exception with the given reason and
+    // metadata, it should be accessible as an exception in the RPC protocol.
+    //
+    // This is used to test the RPC framework itself.
+    rpc ThrowStructuredException(ThrowStructuredExceptionRequest)
+        returns (ThrowStructuredExceptionResponse) {
+        option (redpanda.pbgen.rpc) = {
+            authz: SUPERUSER,
+        };
+    }
     rpc StartStressFiber(StartStressFiberRequest)
         returns (StartStressFiberResponse) {
         option (redpanda.pbgen.rpc) = {

--- a/src/v/kafka/client/direct_consumer/verifier/application.cc
+++ b/src/v/kafka/client/direct_consumer/verifier/application.cc
@@ -366,16 +366,8 @@ verifier_server::handler_impl::handle(
         co_return reply;
     }
     reply->write_body(
-      "json",
-      [b = std::move(payload)](
-        ss::output_stream<char>&& output_stream) mutable {
-          return ss::do_with(
-            std::move(output_stream),
-            [&b](ss::output_stream<char>& os) mutable {
-                return write_iobuf_to_output_stream(
-                         b.share(0, b.size_bytes()), os)
-                  .finally([&os] { return os.close(); });
-            });
+      "json", [b = std::move(payload)](ss::output_stream<char>& os) mutable {
+          return write_iobuf_to_output_stream(b.share(0, b.size_bytes()), os);
       });
     reply->done();
     co_return reply;

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -66,6 +66,7 @@ redpanda_cc_library(
         "//src/v/raft",
         "//src/v/redpanda/admin",
         "//src/v/redpanda/admin/proxy:service",
+        "//src/v/redpanda/admin/proxy:client",
         "//src/v/redpanda/admin/services/shadow_link",
         "//src/v/redpanda/admin/services/internal:debug",
         "//src/v/resource_mgmt:cpu_profiler",

--- a/src/v/redpanda/admin/proxy/client.cc
+++ b/src/v/redpanda/admin/proxy/client.cc
@@ -27,15 +27,25 @@ namespace {
 ss::logger log{"admin/proxy/client"};
 
 template<typename T>
-[[noreturn]] void throw_rpc_exception(iobuf payload) {
-    if (payload.empty()) {
-        throw T();
+[[noreturn]] void throw_rpc_exception(proxy_response resp) {
+    auto ei = resp.info.transform([](const proxy_response::error_info& ei) {
+        serde::pb::rpc::error_info copy{
+          .reason = ei.reason,
+          .domain = ei.domain,
+        };
+        for (const auto& [k, v] : ei.metadata) {
+            copy.metadata.emplace(k, v);
+        }
+        return copy;
+    });
+    if (resp.payload.empty()) {
+        throw T(std::move(ei));
     }
-    iobuf_parser parser(std::move(payload));
+    iobuf_parser parser(std::move(resp.payload));
     constexpr size_t max_error_message_size = 4_KiB;
     auto msg = parser.read_string_safe(
       std::min(parser.bytes_left(), max_error_message_size));
-    throw T(std::move(msg));
+    throw T(std::move(msg), std::move(ei));
 }
 
 } // namespace
@@ -96,52 +106,52 @@ ss::future<iobuf> client::send(
         co_return std::move(proxy_resp.payload);
     case errc::cancelled:
         throw_rpc_exception<serde::pb::rpc::cancelled_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::unknown:
         throw_rpc_exception<serde::pb::rpc::unknown_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::invalid_argument:
         throw_rpc_exception<serde::pb::rpc::invalid_argument_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::deadline_exceeded:
         throw_rpc_exception<serde::pb::rpc::deadline_exceeded_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::not_found:
         throw_rpc_exception<serde::pb::rpc::not_found_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::already_exists:
         throw_rpc_exception<serde::pb::rpc::already_exists_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::permission_denied:
         throw_rpc_exception<serde::pb::rpc::permission_denied_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::resource_exhausted:
         throw_rpc_exception<serde::pb::rpc::resource_exhausted_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::failed_precondition:
         throw_rpc_exception<serde::pb::rpc::failed_precondition_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::aborted:
         throw_rpc_exception<serde::pb::rpc::aborted_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::out_of_range:
         throw_rpc_exception<serde::pb::rpc::out_of_range_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::unimplemented:
         throw_rpc_exception<serde::pb::rpc::unimplemented_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::internal_error:
         throw_rpc_exception<serde::pb::rpc::internal_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::unavailable:
         throw_rpc_exception<serde::pb::rpc::unavailable_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::data_loss:
         throw_rpc_exception<serde::pb::rpc::data_loss_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     case errc::unauthenticated:
         throw_rpc_exception<serde::pb::rpc::unauthenticated_exception>(
-          std::move(proxy_resp.payload));
+          std::move(proxy_resp));
     }
     std::unreachable();
 }

--- a/src/v/redpanda/admin/proxy/client.h
+++ b/src/v/redpanda/admin/proxy/client.h
@@ -50,7 +50,7 @@ public:
         absl::flat_hash_map<model::node_id, ProtobufServiceClient> clients;
         clients.reserve(node_ids.size() - 1);
         for (const auto& node : node_ids) {
-            if (node == _self) {
+            if (node == self_node_id()) {
                 continue;
             }
             clients.emplace(

--- a/src/v/redpanda/admin/proxy/service.cc
+++ b/src/v/redpanda/admin/proxy/service.cc
@@ -21,6 +21,23 @@ namespace admin::proxy {
 namespace {
 // NOLINTNEXTLINE(*-non-const-global-variables,*-err58-cpp)
 ss::logger log{"admin/proxy/service"};
+
+void handle_exception(
+  errc ec, const serde::pb::rpc::base_exception& ex, proxy_response* resp) {
+    resp->error_code = ec;
+    resp->payload = iobuf::from(ex.message());
+    if (const auto& ei = ex.info()) {
+        proxy_response::error_info copy{
+          .reason = ei->reason,
+          .domain = ei->domain,
+        };
+        for (const auto& [k, v] : ei->metadata) {
+            copy.metadata.emplace(k, v);
+        }
+        resp->info = std::move(copy);
+    }
+}
+
 } // namespace
 
 ss::future<proxy_response>
@@ -39,53 +56,37 @@ service_impl::proxy_rpc(proxy_request req, rpc::streaming_context&) {
         response.payload = std::move(payload);
         co_return response;
     } catch (const serde::pb::rpc::cancelled_exception& e) {
-        response.error_code = errc::cancelled;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::cancelled, e, &response);
     } catch (const serde::pb::rpc::unknown_exception& e) {
-        response.error_code = errc::unknown;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::unknown, e, &response);
     } catch (const serde::pb::rpc::invalid_argument_exception& e) {
-        response.error_code = errc::invalid_argument;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::invalid_argument, e, &response);
     } catch (const serde::pb::rpc::deadline_exceeded_exception& e) {
-        response.error_code = errc::deadline_exceeded;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::deadline_exceeded, e, &response);
     } catch (const serde::pb::rpc::not_found_exception& e) {
-        response.error_code = errc::not_found;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::not_found, e, &response);
     } catch (const serde::pb::rpc::already_exists_exception& e) {
-        response.error_code = errc::already_exists;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::already_exists, e, &response);
     } catch (const serde::pb::rpc::permission_denied_exception& e) {
-        response.error_code = errc::permission_denied;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::permission_denied, e, &response);
     } catch (const serde::pb::rpc::resource_exhausted_exception& e) {
-        response.error_code = errc::resource_exhausted;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::resource_exhausted, e, &response);
     } catch (const serde::pb::rpc::failed_precondition_exception& e) {
-        response.error_code = errc::failed_precondition;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::failed_precondition, e, &response);
     } catch (const serde::pb::rpc::aborted_exception& e) {
-        response.error_code = errc::aborted;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::aborted, e, &response);
     } catch (const serde::pb::rpc::out_of_range_exception& e) {
-        response.error_code = errc::out_of_range;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::out_of_range, e, &response);
     } catch (const serde::pb::rpc::unimplemented_exception& e) {
-        response.error_code = errc::unimplemented;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::unimplemented, e, &response);
     } catch (const serde::pb::rpc::internal_exception& e) {
-        response.error_code = errc::internal_error;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::internal_error, e, &response);
     } catch (const serde::pb::rpc::unavailable_exception& e) {
-        response.error_code = errc::unavailable;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::unavailable, e, &response);
     } catch (const serde::pb::rpc::data_loss_exception& e) {
-        response.error_code = errc::data_loss;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::data_loss, e, &response);
     } catch (const serde::pb::rpc::unauthenticated_exception& e) {
-        response.error_code = errc::unauthenticated;
-        response.payload = iobuf::from(e.what());
+        handle_exception(errc::unauthenticated, e, &response);
     } catch (...) {
         vlog(
           log.warn,

--- a/src/v/redpanda/admin/proxy/types.h
+++ b/src/v/redpanda/admin/proxy/types.h
@@ -13,11 +13,15 @@
 
 #include "base/format_to.h"
 #include "bytes/iobuf.h"
+#include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
 #include "serde/envelope.h"
 #include "serde/rw/enum.h"
 #include "serde/rw/envelope.h"
 #include "serde/rw/iobuf.h"
+#include "serde/rw/map.h"
+#include "serde/rw/optional.h"
+#include "utils/to_string.h"
 
 namespace admin::proxy {
 
@@ -75,13 +79,32 @@ struct proxy_response
     // response. Otherwise, this will be the error message for the error_code.
     iobuf payload;
 
-    auto serde_fields() { return std::tie(error_code, payload); }
+    struct error_info
+      : serde::
+          envelope<error_info, serde::version<0>, serde::compat_version<0>> {
+        ss::sstring reason;
+        ss::sstring domain;
+        chunked_hash_map<ss::sstring, ss::sstring> metadata;
+        auto serde_fields() { return std::tie(reason, domain, metadata); }
+        fmt::iterator format_to(fmt::iterator it) const {
+            return fmt::format_to(
+              it,
+              "{{reason={}, domain={}, metadata={}}}",
+              reason,
+              domain,
+              metadata);
+        }
+    };
+    std::optional<error_info> info;
+
+    auto serde_fields() { return std::tie(error_code, payload, info); }
     fmt::iterator format_to(fmt::iterator it) const {
         return fmt::format_to(
           it,
-          "{{error_code={}, message={}}}",
+          "{{error_code={}, message={}, error_info={}}}",
           std::to_underlying(error_code),
-          payload);
+          payload,
+          info);
     }
 };
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -373,10 +373,10 @@ public:
             // correct content-type in the next line.
             rep->write_body(
               "bin",
-              [this, payload = std::move(reply_payload)](
-                ss::output_stream<char>&& writer) mutable {
-                  return write_payload(
-                    std::move(writer), payload.share(0, payload.size_bytes()));
+              [payload = std::move(reply_payload)](
+                ss::output_stream<char>& writer) mutable {
+                  return write_iobuf_to_output_stream(
+                    payload.share(0, payload.size_bytes()), writer);
               });
             rep->set_mime_type(
               is_proto ? "application/proto" : "application/json");
@@ -445,12 +445,6 @@ private:
               "request too large");
         }
         co_return payload;
-    }
-
-    ss::future<>
-    write_payload(ss::output_stream<char> output_stream, iobuf payload) {
-        co_await write_iobuf_to_output_stream(std::move(payload), output_stream)
-          .finally([&output_stream] { return output_stream.close(); });
     }
 
     ss::noncopyable_function<void(const ss::http::request&)>

--- a/src/v/redpanda/admin/services/internal/BUILD
+++ b/src/v/redpanda/admin/services/internal/BUILD
@@ -12,6 +12,7 @@ redpanda_cc_library(
         "//proto/redpanda/core/admin/internal:debug_redpanda_proto",
         "//src/v/base",
         "//src/v/finjector",
+        "//src/v/redpanda/admin/proxy:client",
         "//src/v/serde/protobuf:rpc",
         "//src/v/utils:to_string",
         "@fmt",

--- a/src/v/redpanda/admin/services/internal/debug.cc
+++ b/src/v/redpanda/admin/services/internal/debug.cc
@@ -29,6 +29,25 @@ namespace {
 ss::logger log{"admin_api_server/internal_debug_service"};
 } // namespace
 
+seastar::future<proto::admin::throw_structured_exception_response>
+debug_service_impl::throw_structured_exception(
+  serde::pb::rpc::context ctx,
+  proto::admin::throw_structured_exception_request req) {
+    auto target = model::node_id(req.get_node_id());
+    if (target != model::node_id(-1) && target != _client.self_node_id()) {
+        co_return co_await _client
+          .make_client_for_node<proto::admin::debug_service_client>(target)
+          .throw_structured_exception(ctx, std::move(req));
+    }
+    serde::pb::rpc::error_info info;
+    info.reason = std::move(req.get_reason());
+    if (info.reason.empty()) {
+        info.reason = "UNKNOWN";
+    }
+    info.metadata = std::move(req.get_metadata());
+    throw serde::pb::rpc::unknown_exception("test exception", std::move(info));
+}
+
 seastar::future<proto::start_stress_fiber_response>
 debug_service_impl::start_stress_fiber(
   serde::pb::rpc::context, proto::start_stress_fiber_request req) {

--- a/src/v/redpanda/admin/services/internal/debug.h
+++ b/src/v/redpanda/admin/services/internal/debug.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "proto/redpanda/core/admin/internal/debug.proto.h"
+#include "redpanda/admin/proxy/client.h"
 
 #include <seastar/core/distributed.hh>
 
@@ -25,8 +26,15 @@ namespace admin {
 class debug_service_impl : public proto::admin::debug_service {
 public:
     explicit debug_service_impl(
+      admin::proxy::client client,
       ss::sharded<stress_fiber_manager>& stress_fiber_manager)
-      : _stress_fiber_manager(stress_fiber_manager) {}
+      : _client(std::move(client))
+      , _stress_fiber_manager(stress_fiber_manager) {}
+
+    seastar::future<proto::admin::throw_structured_exception_response>
+      throw_structured_exception(
+        serde::pb::rpc::context,
+        proto::admin::throw_structured_exception_request) override;
 
     seastar::future<proto::admin::start_stress_fiber_response>
       start_stress_fiber(
@@ -38,6 +46,7 @@ public:
       proto::admin::stop_stress_fiber_request) override;
 
 private:
+    admin::proxy::client _client;
     ss::sharded<stress_fiber_manager>& _stress_fiber_manager;
 };
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -135,6 +135,7 @@
 #include "raft/coordinated_recovery_throttle.h"
 #include "raft/group_manager.h"
 #include "raft/service.h"
+#include "redpanda/admin/proxy/client.h"
 #include "redpanda/admin/proxy/service.h"
 #include "redpanda/admin/server.h"
 #include "redpanda/admin/services/internal/debug.h"
@@ -1114,7 +1115,7 @@ admin_server_cfg_from_global_cfg(scheduling_groups& sgs) {
       .sg = sgs.admin_sg()};
 }
 
-void application::configure_admin_server() {
+void application::configure_admin_server(model::node_id node_id) {
     if (config::node().admin().empty()) {
         return;
     }
@@ -1149,13 +1150,17 @@ void application::configure_admin_server() {
       std::ref(_debug_bundle_service))
       .get();
     _admin
-      .invoke_on_all([this](admin_server& s) {
+      .invoke_on_all([this, node_id](admin_server& s) {
+          admin::proxy::client client(node_id, &_connection_cache, [this] {
+              return controller->get_members_table().local().node_ids();
+          });
           // Add RPC services
-          s.add_service(
-            std::make_unique<admin::debug_service_impl>(stress_fiber_manager));
           s.add_service(
             std::make_unique<admin::shadow_link_service_impl>(
               &_cluster_link_service));
+          s.add_service(
+            std::make_unique<admin::debug_service_impl>(
+              std::move(client), stress_fiber_manager));
       })
       .get();
 }
@@ -1542,7 +1547,7 @@ void application::wire_up_runtime_services(
 
     construct_single_service(_host_metrics_watcher, std::ref(_log));
 
-    configure_admin_server();
+    configure_admin_server(node_id);
 }
 
 void application::wire_up_redpanda_services(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -234,7 +234,7 @@ private:
     // Constructs services across shards meant for Redpanda runtime.
     void
     wire_up_runtime_services(model::node_id node_id, ::stop_signal& app_signal);
-    void configure_admin_server();
+    void configure_admin_server(model::node_id);
     void wire_up_redpanda_services(
       model::node_id,
       ::stop_signal& app_signal,

--- a/src/v/serde/json/tests/writer_test.cc
+++ b/src/v/serde/json/tests/writer_test.cc
@@ -175,6 +175,12 @@ TEST_F(JsonWriterTest, Primatives) {
       R"({"pi":3.14159,"null":null,"boolean":true,"integer":42,"array":[2.71828,false,null,-42]})");
 }
 
+TEST_F(JsonWriterTest, Base64) {
+    auto result = serialize_value(
+      [](serde::json::writer& w) { w.base64_string(iobuf::from("testing")); });
+    EXPECT_EQ(result, R"("dGVzdGluZw==")");
+}
+
 TEST_F(JsonWriterTest, EmptyArrayAndObject) {
     auto result = serialize_object([](serde::json::writer& w) {
         w.key("emptyArr");

--- a/src/v/serde/json/writer.cc
+++ b/src/v/serde/json/writer.cc
@@ -174,7 +174,7 @@ void writer::integer_string(uint64_t i) {
 }
 void writer::base64_string(const iobuf& b) {
     append_delimiter();
-    append_string(base64_to_iobuf(b));
+    append_string(iobuf_to_base64(b));
     _next_delimiter = ',';
 }
 } // namespace serde::json

--- a/src/v/serde/protobuf/BUILD
+++ b/src/v/serde/protobuf/BUILD
@@ -97,8 +97,13 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":wire_format",
         "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iostream",
+        "//src/v/container:chunked_hash_map",
         "//src/v/model",
+        "//src/v/serde/json:writer",
         "@seastar",
     ],
 )

--- a/src/v/serde/protobuf/rpc.cc
+++ b/src/v/serde/protobuf/rpc.cc
@@ -11,161 +11,161 @@
 
 #include "serde/protobuf/rpc.h"
 
+#include "bytes/iostream.h"
+#include "serde/json/writer.h"
+#include "serde/protobuf/wire_format.h"
+
 #include <seastar/http/reply.hh>
 #include <seastar/json/formatter.hh>
-
-#include <unordered_map>
 
 namespace serde::pb::rpc {
 
 // NOLINTNEXTLINE(*-non-const-global-variables,cert-err58-cpp)
 ss::logger logger{"connectrpc"};
 
+namespace {
+iobuf error_info_to_proto(const error_info& ei) {
+    iobuf buf;
+    // reason
+    serde::pb::tag::write(
+      {.wire_type = serde::pb::wire_type::length, .field_number = 1}, &buf);
+    write_length(static_cast<int32_t>(ei.reason.size()), &buf);
+    buf.append_str(ei.reason);
+    // domain
+    serde::pb::tag::write(
+      {.wire_type = serde::pb::wire_type::length, .field_number = 2}, &buf);
+    write_length(static_cast<int32_t>(ei.domain.size()), &buf);
+    buf.append_str(ei.domain);
+    // metadata
+    for (const auto& [key, value] : ei.metadata) {
+        iobuf entry;
+        {
+            // key
+            serde::pb::tag::write(
+              {.wire_type = serde::pb::wire_type::length, .field_number = 1},
+              &entry);
+            write_length(static_cast<int32_t>(key.size()), &entry);
+            entry.append_str(key);
+            // value
+            serde::pb::tag::write(
+              {.wire_type = serde::pb::wire_type::length, .field_number = 2},
+              &entry);
+            write_length(static_cast<int32_t>(value.size()), &entry);
+            entry.append_str(value);
+        }
+        serde::pb::tag::write(
+          {.wire_type = serde::pb::wire_type::length, .field_number = 3}, &buf);
+        write_length(static_cast<int32_t>(entry.size_bytes()), &buf);
+        buf.append(std::move(entry));
+    }
+    return buf;
+}
+
+void error_info_to_json(const error_info& ei, serde::json::writer* w) {
+    w->begin_object();
+    w->key("reason");
+    w->string(ei.reason);
+    w->key("domain");
+    w->string(ei.domain);
+    if (!ei.metadata.empty()) {
+        w->key("metadata");
+        w->begin_object();
+        for (const auto& [k, v] : ei.metadata) {
+            w->key(k);
+            w->string(v);
+        }
+        w->end_object();
+    }
+    w->end_object();
+}
+
+} // namespace
+
 base_exception::base_exception(
-  int status_code, ss::sstring code, ss::sstring message)
+  int status_code,
+  ss::sstring code,
+  ss::sstring message,
+  std::optional<error_info> error_info)
   : _status_code(status_code)
   , _code(std::move(code))
-  , _message(std::move(message)) {}
+  , _message(std::move(message))
+  , _error_info(std::move(error_info)) {}
+
+const char* base_exception::what() const noexcept { return _message.c_str(); }
+const ss::sstring& base_exception::message() const { return _message; }
+const std::optional<error_info>& base_exception::info() const {
+    return _error_info;
+}
 
 std::unique_ptr<ss::http::reply>
 base_exception::handle(std::unique_ptr<ss::http::reply> reply) const {
-    std::unordered_map<ss::sstring, ss::sstring> body = {
-      {"code", _code},
-      {"message", _message},
-    };
+    serde::json::writer w;
+    w.begin_object();
+    w.key("code");
+    w.string(_code);
+    w.key("message");
+    w.string(_message);
+    if (_error_info) {
+        w.key("details");
+        w.begin_array();
+        {
+            w.begin_object();
+            w.key("type");
+            w.string("google.rpc.ErrorInfo");
+            w.key("value");
+            w.base64_string(error_info_to_proto(*_error_info));
+            w.key("debug");
+            error_info_to_json(*_error_info, &w);
+            w.end_object();
+        }
+        w.end_array();
+    }
+    w.end_object();
     reply->set_status(static_cast<ss::http::reply::status_type>(_status_code));
-    reply->write_body("json", ss::json::formatter::to_json(body));
+    reply->write_body(
+      "json", [b = std::move(w).finish()](ss::output_stream<char>& w) mutable {
+          return write_iobuf_to_output_stream(std::move(b), w);
+      });
     return reply;
 }
 
-cancelled_exception::cancelled_exception()
-  : cancelled_exception("Canceled") {}
-cancelled_exception::cancelled_exception(ss::sstring message)
-  : base_exception(
-      // TODO(rpc): Should be 499
-      static_cast<int>(ss::http::reply::status_type::unprocessable_entity),
-      "canceled",
-      std::move(message)) {}
+#define CONNECTRPC_EXCEPTION_IMPL(name, default_message, http_code)            \
+    name##_exception::name##_exception()                                       \
+      : name##_exception(default_message) {}                                   \
+    name##_exception::name##_exception(ss::sstring message)                    \
+      : name##_exception(std::move(message), std::nullopt) {}                  \
+    name##_exception::name##_exception(std::optional<error_info> ei)           \
+      : name##_exception(default_message, std::move(ei)) {}                    \
+    name##_exception::name##_exception(                                        \
+      ss::sstring message, std::optional<error_info> ei)                       \
+      : base_exception(                                                        \
+          static_cast<int>(ss::http::reply::status_type::http_code),           \
+          #name,                                                               \
+          std::move(message),                                                  \
+          std::move(ei)) {}
 
-unknown_exception::unknown_exception()
-  : unknown_exception("Unknown error") {}
-unknown_exception::unknown_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::internal_server_error),
-      "unknown",
-      std::move(message)) {}
+// TODO(rpc): Use 499 when supported by seastar
+CONNECTRPC_EXCEPTION_IMPL(cancelled, "Canceled", unprocessable_entity)
+CONNECTRPC_EXCEPTION_IMPL(unknown, "Unknown error", internal_server_error)
+CONNECTRPC_EXCEPTION_IMPL(invalid_argument, "Invalid argument", bad_request)
+CONNECTRPC_EXCEPTION_IMPL(
+  deadline_exceeded, "Deadline exceeded", gateway_timeout)
+CONNECTRPC_EXCEPTION_IMPL(not_found, "Resource not found", not_found)
+CONNECTRPC_EXCEPTION_IMPL(already_exists, "Resource already exists", conflict)
+CONNECTRPC_EXCEPTION_IMPL(permission_denied, "Permission denied", forbidden)
+CONNECTRPC_EXCEPTION_IMPL(
+  resource_exhausted, "Resource exhausted", too_many_requests)
+CONNECTRPC_EXCEPTION_IMPL(
+  failed_precondition, "Failed precondition", bad_request)
+CONNECTRPC_EXCEPTION_IMPL(aborted, "Operation aborted", conflict)
+CONNECTRPC_EXCEPTION_IMPL(out_of_range, "Out of range", bad_request)
+CONNECTRPC_EXCEPTION_IMPL(unimplemented, "Not implemented", not_implemented)
+CONNECTRPC_EXCEPTION_IMPL(internal, "Internal error", internal_server_error)
+CONNECTRPC_EXCEPTION_IMPL(
+  unavailable, "Service unavailable", service_unavailable)
+CONNECTRPC_EXCEPTION_IMPL(data_loss, "Data loss", internal_server_error)
+CONNECTRPC_EXCEPTION_IMPL(unauthenticated, "Unauthenticated", unauthorized)
 
-invalid_argument_exception::invalid_argument_exception()
-  : invalid_argument_exception("Invalid argument") {}
-invalid_argument_exception::invalid_argument_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::bad_request),
-      "invalid_argument",
-      std::move(message)) {}
-
-deadline_exceeded_exception::deadline_exceeded_exception()
-  : deadline_exceeded_exception("Deadline exceeded") {}
-deadline_exceeded_exception::deadline_exceeded_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::gateway_timeout),
-      "deadline_exceeded",
-      std::move(message)) {}
-
-not_found_exception::not_found_exception()
-  : not_found_exception("Resource not found") {}
-not_found_exception::not_found_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::not_found),
-      "not_found",
-      std::move(message)) {}
-
-already_exists_exception::already_exists_exception()
-  : already_exists_exception("Resource already exists") {}
-already_exists_exception::already_exists_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::conflict),
-      "already_exists",
-      std::move(message)) {}
-
-permission_denied_exception::permission_denied_exception()
-  : permission_denied_exception("Permission denied") {}
-permission_denied_exception::permission_denied_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::forbidden),
-      "permission_denied",
-      std::move(message)) {}
-
-resource_exhausted_exception::resource_exhausted_exception()
-  : resource_exhausted_exception("Resource exhausted") {}
-resource_exhausted_exception::resource_exhausted_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::too_many_requests),
-      "resource_exhausted",
-      std::move(message)) {}
-
-failed_precondition_exception::failed_precondition_exception()
-  : failed_precondition_exception("Failed precondition") {}
-failed_precondition_exception::failed_precondition_exception(
-  ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::bad_request),
-      "failed_precondition",
-      std::move(message)) {}
-
-aborted_exception::aborted_exception()
-  : aborted_exception("Operation aborted") {}
-aborted_exception::aborted_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::conflict),
-      "aborted",
-      std::move(message)) {}
-
-out_of_range_exception::out_of_range_exception()
-  : out_of_range_exception("Out of range") {}
-out_of_range_exception::out_of_range_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::bad_request),
-      "out_of_range",
-      std::move(message)) {}
-
-unimplemented_exception::unimplemented_exception()
-  : unimplemented_exception("Not implemented") {}
-unimplemented_exception::unimplemented_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::not_implemented),
-      "unimplemented",
-      std::move(message)) {}
-
-internal_exception::internal_exception()
-  : internal_exception("Internal error") {}
-internal_exception::internal_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::internal_server_error),
-      "internal",
-      std::move(message)) {}
-
-unavailable_exception::unavailable_exception()
-  : unavailable_exception("Service unavailable") {}
-unavailable_exception::unavailable_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::service_unavailable),
-      "unavailable",
-      std::move(message)) {}
-
-data_loss_exception::data_loss_exception()
-  : data_loss_exception("Data loss") {}
-data_loss_exception::data_loss_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::internal_server_error),
-      "data_loss",
-      std::move(message)) {}
-
-unauthenticated_exception::unauthenticated_exception()
-  : unauthenticated_exception("Unauthenticated") {}
-unauthenticated_exception::unauthenticated_exception(ss::sstring message)
-  : base_exception(
-      static_cast<int>(ss::http::reply::status_type::unauthorized),
-      "unauthenticated",
-      std::move(message)) {}
+#undef CONNECTRPC_DEFINE_EXCEPTION
 
 } // namespace serde::pb::rpc

--- a/src/v/serde/protobuf/rpc.h
+++ b/src/v/serde/protobuf/rpc.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
 
 #include <seastar/core/future.hh>
@@ -114,14 +115,74 @@ public:
     virtual std::vector<route_descriptor> all_routes() = 0;
 };
 
+// Describes the cause of the error with structured details.
+//
+// Example of an error when contacting the "pubsub.googleapis.com" API when it
+// is not enabled:
+//     { "reason":   "API_DISABLED"
+//       "domain": "googleapis.com"
+//       "metadata": {
+//         "resource": "projects/123",
+//         "service": "pubsub.googleapis.com"
+//       }
+//     }
+// This response indicates that the pubsub.googleapis.com API is not enabled.
+//
+// Example of an error that is returned when attempting to create a Spanner
+// instance in a region that is out of stock:
+//     { "reason":   "STOCKOUT"
+//       "domain": "spanner.googleapis.com",
+//       "metadata": {
+//         "availableRegions": "us-central1,us-east2"
+//       }
+//     }
+struct error_info {
+    // The reason of the error. This is a constant value that identifies the
+    // proximate cause of the error. Error reasons are unique within a
+    // particular domain of errors. This should be at most 63 characters and
+    // match
+    // /[A-Z0-9_]+/.
+    ss::sstring reason;
+
+    // The domain of errors that originate from Redpanda core.
+    constexpr static std::string_view redpanda_core_domain
+      = "redpanda.com/core";
+
+    // The logical grouping to which the "reason" belongs.  Often "domain" will
+    // contain the registered service name of the tool or product that is the
+    // source of the error. Example: "pubsub.googleapis.com". If the error is
+    // common across many APIs, the first segment of the example above will be
+    // omitted.  The value will be, "googleapis.com".
+    ss::sstring domain = ss::sstring(redpanda_core_domain);
+
+    // Additional structured details about this error.
+    //
+    // Keys should match /[a-zA-Z0-9-_]/ and be limited to 64 characters in
+    // length. When identifying the current value of an exceeded limit, the
+    // units should be contained in the key, not the value.  For example, rather
+    // than
+    // {"instanceLimit": "100/request"}, should be returned as,
+    // {"instanceLimitPerRequest": "100"}, if the client exceeds the number of
+    // instances that can be created in a single (batch) request.
+    chunked_hash_map<ss::sstring, ss::sstring> metadata;
+};
+
 // Base Exception when handling RPC requests.
 //
 // See: https://connectrpc.com/docs/protocol#error-codes
 class base_exception : public std::exception {
 protected:
-    base_exception(int status_code, ss::sstring code, ss::sstring message);
+    base_exception(
+      int status_code,
+      ss::sstring code,
+      ss::sstring message,
+      std::optional<error_info> error_info);
 
 public:
+    const char* what() const noexcept override;
+    const ss::sstring& message() const;
+    const std::optional<error_info>& info() const;
+
     // Handle the HTTP reply to report the error as suggested.
     std::unique_ptr<ss::http::reply>
       handle(std::unique_ptr<ss::http::reply>) const;
@@ -130,126 +191,74 @@ private:
     int _status_code;
     ss::sstring _code;
     ss::sstring _message;
+    std::optional<error_info> _error_info;
 };
 
+#define CONNECTRPC_DECLARE_EXCEPTION(name)                                     \
+    class name##_exception : public base_exception {                           \
+    public:                                                                    \
+        name##_exception();                                                    \
+        explicit name##_exception(ss::sstring message);                        \
+        explicit name##_exception(std::optional<error_info>);                  \
+        name##_exception(ss::sstring message, std::optional<error_info>);      \
+    }
+
 // RPC canceled, usually by the caller.
-class cancelled_exception : public base_exception {
-public:
-    cancelled_exception();
-    explicit cancelled_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(cancelled);
 
 // Catch-all for errors of unclear origin and errors without a more appropriate
 // code.
-class unknown_exception : public base_exception {
-public:
-    unknown_exception();
-    explicit unknown_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(unknown);
 
 // Request is invalid, regardless of system state.
-class invalid_argument_exception : public base_exception {
-public:
-    invalid_argument_exception();
-    explicit invalid_argument_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(invalid_argument);
 
 // Deadline expired before RPC could complete or before the client received the
 // response.
-class deadline_exceeded_exception : public base_exception {
-public:
-    deadline_exceeded_exception();
-    explicit deadline_exceeded_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(deadline_exceeded);
 
 // User requested a resource (for example, a file or directory) that can't be
 // found.
-class not_found_exception : public base_exception {
-public:
-    not_found_exception();
-    explicit not_found_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(not_found);
 
 // Caller attempted to create a resource that already exists.
-class already_exists_exception : public base_exception {
-public:
-    already_exists_exception();
-    explicit already_exists_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(already_exists);
 
 // Caller isn't authorized to perform the operation.
-class permission_denied_exception : public base_exception {
-public:
-    permission_denied_exception();
-    explicit permission_denied_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(permission_denied);
 
 // Operation can't be completed because some resource is exhausted. Use
 // unavailable if the server is temporarily overloaded and the caller should
 // retry later.
-class resource_exhausted_exception : public base_exception {
-public:
-    resource_exhausted_exception();
-    explicit resource_exhausted_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(resource_exhausted);
 
 // Operation can't be completed because the system isn't in the required state.
-class failed_precondition_exception : public base_exception {
-public:
-    failed_precondition_exception();
-    explicit failed_precondition_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(failed_precondition);
 
 // The operation was aborted, often because of concurrency issues like a
 // database transaction abort.
-class aborted_exception : public base_exception {
-public:
-    aborted_exception();
-    explicit aborted_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(aborted);
 
 // The operation was attempted past the valid range.
-class out_of_range_exception : public base_exception {
-public:
-    out_of_range_exception();
-    explicit out_of_range_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(out_of_range);
 
 // The operation isn't implemented, supported, or enabled.
-class unimplemented_exception : public base_exception {
-public:
-    unimplemented_exception();
-    explicit unimplemented_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(unimplemented);
 
 // An invariant expected by the underlying system has been broken. Reserved for
 // serious errors.
-class internal_exception : public base_exception {
-public:
-    internal_exception();
-    explicit internal_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(internal);
 
 // The service is currently unavailable, usually transiently. Clients should
 // back off and retry idempotent operations.
-class unavailable_exception : public base_exception {
-public:
-    unavailable_exception();
-    explicit unavailable_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(unavailable);
 
 // Unrecoverable data loss or corruption.
-class data_loss_exception : public base_exception {
-public:
-    data_loss_exception();
-    explicit data_loss_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(data_loss);
 
 // Caller doesn't have valid authentication credentials for the operation.
-class unauthenticated_exception : public base_exception {
-public:
-    unauthenticated_exception();
-    explicit unauthenticated_exception(ss::sstring message);
-};
+CONNECTRPC_DECLARE_EXCEPTION(unauthenticated);
+
+#undef CONNECTRPC_DECLARE_EXCEPTION
 
 } // namespace serde::pb::rpc

--- a/src/v/serde/protobuf/rpc.h
+++ b/src/v/serde/protobuf/rpc.h
@@ -26,9 +26,6 @@ namespace seastar::http {
 struct request;
 struct reply;
 } // namespace seastar::http
-namespace seastar::httpd {
-class routes;
-} // namespace seastar::httpd
 
 // Supporting functions for ConnectRPC protocol support in seastar
 //

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/internal/debug_pb2.py
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/internal/debug_pb2.py
@@ -8,13 +8,17 @@ _runtime_version.ValidateProtobufRuntimeVersion(_runtime_version.Domain.PUBLIC, 
 _sym_db = _symbol_database.Default()
 from ......proto.redpanda.pbgen import options_pb2 as proto_dot_redpanda_dot_pbgen_dot_options__pb2
 from ......proto.redpanda.pbgen import rpc_pb2 as proto_dot_redpanda_dot_pbgen_dot_rpc__pb2
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n.proto/redpanda/core/admin/internal/debug.proto\x12\x1credpanda.core.admin.internal\x1a"proto/redpanda/pbgen/options.proto\x1a\x1eproto/redpanda/pbgen/rpc.proto"\xdd\x01\n\x17StartStressFiberRequest\x12&\n\x1emin_spins_per_scheduling_point\x18\x01 \x01(\x05\x12&\n\x1emax_spins_per_scheduling_point\x18\x02 \x01(\x05\x12\x13\n\x0bstack_depth\x18\x03 \x01(\x05\x12#\n\x1bmin_ms_per_scheduling_point\x18\x04 \x01(\x05\x12#\n\x1bmax_ms_per_scheduling_point\x18\x05 \x01(\x05\x12\x13\n\x0bfiber_count\x18\x06 \x01(\x05"\x1a\n\x18StartStressFiberResponse"\x18\n\x16StopStressFiberRequest"\x19\n\x17StopStressFiberResponse2\xa3\x02\n\x0cDebugService\x12\x89\x01\n\x10StartStressFiber\x125.redpanda.core.admin.internal.StartStressFiberRequest\x1a6.redpanda.core.admin.internal.StartStressFiberResponse"\x06\xea\x92\x19\x02\x10\x03\x12\x86\x01\n\x0fStopStressFiber\x124.redpanda.core.admin.internal.StopStressFiberRequest\x1a5.redpanda.core.admin.internal.StopStressFiberResponse"\x06\xea\x92\x19\x02\x10\x03B\x10\xea\x92\x19\x0cproto::adminb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n.proto/redpanda/core/admin/internal/debug.proto\x12\x1credpanda.core.admin.internal\x1a"proto/redpanda/pbgen/options.proto\x1a\x1eproto/redpanda/pbgen/rpc.proto"\xdd\x01\n\x17StartStressFiberRequest\x12&\n\x1emin_spins_per_scheduling_point\x18\x01 \x01(\x05\x12&\n\x1emax_spins_per_scheduling_point\x18\x02 \x01(\x05\x12\x13\n\x0bstack_depth\x18\x03 \x01(\x05\x12#\n\x1bmin_ms_per_scheduling_point\x18\x04 \x01(\x05\x12#\n\x1bmax_ms_per_scheduling_point\x18\x05 \x01(\x05\x12\x13\n\x0bfiber_count\x18\x06 \x01(\x05"\x1a\n\x18StartStressFiberResponse"\x18\n\x16StopStressFiberRequest"\x19\n\x17StopStressFiberResponse"\xd2\x01\n\x1fThrowStructuredExceptionRequest\x12\x0f\n\x07node_id\x18\x01 \x01(\x05\x12\x0e\n\x06reason\x18\x02 \x01(\t\x12]\n\x08metadata\x18\x03 \x03(\x0b2K.redpanda.core.admin.internal.ThrowStructuredExceptionRequest.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x028\x01""\n ThrowStructuredExceptionResponse2\xc7\x03\n\x0cDebugService\x12\xa1\x01\n\x18ThrowStructuredException\x12=.redpanda.core.admin.internal.ThrowStructuredExceptionRequest\x1a>.redpanda.core.admin.internal.ThrowStructuredExceptionResponse"\x06\xea\x92\x19\x02\x10\x03\x12\x89\x01\n\x10StartStressFiber\x125.redpanda.core.admin.internal.StartStressFiberRequest\x1a6.redpanda.core.admin.internal.StartStressFiberResponse"\x06\xea\x92\x19\x02\x10\x03\x12\x86\x01\n\x0fStopStressFiber\x124.redpanda.core.admin.internal.StopStressFiberRequest\x1a5.redpanda.core.admin.internal.StopStressFiberResponse"\x06\xea\x92\x19\x02\x10\x03B\x10\xea\x92\x19\x0cproto::adminb\x06proto3')
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'proto.redpanda.core.admin.internal.debug_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
     _globals['DESCRIPTOR']._loaded_options = None
     _globals['DESCRIPTOR']._serialized_options = b'\xea\x92\x19\x0cproto::admin'
+    _globals['_THROWSTRUCTUREDEXCEPTIONREQUEST_METADATAENTRY']._loaded_options = None
+    _globals['_THROWSTRUCTUREDEXCEPTIONREQUEST_METADATAENTRY']._serialized_options = b'8\x01'
+    _globals['_DEBUGSERVICE'].methods_by_name['ThrowStructuredException']._loaded_options = None
+    _globals['_DEBUGSERVICE'].methods_by_name['ThrowStructuredException']._serialized_options = b'\xea\x92\x19\x02\x10\x03'
     _globals['_DEBUGSERVICE'].methods_by_name['StartStressFiber']._loaded_options = None
     _globals['_DEBUGSERVICE'].methods_by_name['StartStressFiber']._serialized_options = b'\xea\x92\x19\x02\x10\x03'
     _globals['_DEBUGSERVICE'].methods_by_name['StopStressFiber']._loaded_options = None
@@ -27,5 +31,11 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals['_STOPSTRESSFIBERREQUEST']._serialized_end = 424
     _globals['_STOPSTRESSFIBERRESPONSE']._serialized_start = 426
     _globals['_STOPSTRESSFIBERRESPONSE']._serialized_end = 451
-    _globals['_DEBUGSERVICE']._serialized_start = 454
-    _globals['_DEBUGSERVICE']._serialized_end = 745
+    _globals['_THROWSTRUCTUREDEXCEPTIONREQUEST']._serialized_start = 454
+    _globals['_THROWSTRUCTUREDEXCEPTIONREQUEST']._serialized_end = 664
+    _globals['_THROWSTRUCTUREDEXCEPTIONREQUEST_METADATAENTRY']._serialized_start = 617
+    _globals['_THROWSTRUCTUREDEXCEPTIONREQUEST_METADATAENTRY']._serialized_end = 664
+    _globals['_THROWSTRUCTUREDEXCEPTIONRESPONSE']._serialized_start = 666
+    _globals['_THROWSTRUCTUREDEXCEPTIONRESPONSE']._serialized_end = 700
+    _globals['_DEBUGSERVICE']._serialized_start = 703
+    _globals['_DEBUGSERVICE']._serialized_end = 1158

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/internal/debug_pb2.pyi
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/internal/debug_pb2.pyi
@@ -16,7 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import builtins
+import collections.abc
 import google.protobuf.descriptor
+import google.protobuf.internal.containers
 import google.protobuf.message
 import typing
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
@@ -67,3 +69,45 @@ class StopStressFiberResponse(google.protobuf.message.Message):
     def __init__(self) -> None:
         ...
 global___StopStressFiberResponse = StopStressFiberResponse
+
+@typing.final
+class ThrowStructuredExceptionRequest(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    @typing.final
+    class MetadataEntry(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.str
+        value: builtins.str
+
+        def __init__(self, *, key: builtins.str=..., value: builtins.str=...) -> None:
+            ...
+
+        def ClearField(self, field_name: typing.Literal['key', b'key', 'value', b'value']) -> None:
+            ...
+    NODE_ID_FIELD_NUMBER: builtins.int
+    REASON_FIELD_NUMBER: builtins.int
+    METADATA_FIELD_NUMBER: builtins.int
+    node_id: builtins.int
+    reason: builtins.str
+
+    @property
+    def metadata(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
+        ...
+
+    def __init__(self, *, node_id: builtins.int=..., reason: builtins.str=..., metadata: collections.abc.Mapping[builtins.str, builtins.str] | None=...) -> None:
+        ...
+
+    def ClearField(self, field_name: typing.Literal['metadata', b'metadata', 'node_id', b'node_id', 'reason', b'reason']) -> None:
+        ...
+global___ThrowStructuredExceptionRequest = ThrowStructuredExceptionRequest
+
+@typing.final
+class ThrowStructuredExceptionResponse(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    def __init__(self) -> None:
+        ...
+global___ThrowStructuredExceptionResponse = ThrowStructuredExceptionResponse

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/internal/debug_pb2_connect.py
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/internal/debug_pb2_connect.py
@@ -34,6 +34,21 @@ class DebugServiceClient:
         self.base_url = base_url
         self._connect_client = ConnectClient(http_client, protocol)
 
+    def call_throw_structured_exception(self, req: proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> UnaryOutput[proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse]:
+        """Low-level method to call ThrowStructuredException, granting access to errors and metadata"""
+        url = self.base_url + '/redpanda.core.admin.internal.DebugService/ThrowStructuredException'
+        return self._connect_client.call_unary(url, req, proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse, extra_headers, timeout_seconds)
+
+    def throw_structured_exception(self, req: proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse:
+        response = self.call_throw_structured_exception(req, extra_headers, timeout_seconds)
+        err = response.error()
+        if err is not None:
+            raise err
+        msg = response.message()
+        if msg is None:
+            raise ConnectProtocolError('missing response message')
+        return msg
+
     def call_start_stress_fiber(self, req: proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> UnaryOutput[proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberResponse]:
         """Low-level method to call StartStressFiber, granting access to errors and metadata"""
         url = self.base_url + '/redpanda.core.admin.internal.DebugService/StartStressFiber'
@@ -70,6 +85,21 @@ class AsyncDebugServiceClient:
         self.base_url = base_url
         self._connect_client = AsyncConnectClient(http_client, protocol)
 
+    async def call_throw_structured_exception(self, req: proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> UnaryOutput[proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse]:
+        """Low-level method to call ThrowStructuredException, granting access to errors and metadata"""
+        url = self.base_url + '/redpanda.core.admin.internal.DebugService/ThrowStructuredException'
+        return await self._connect_client.call_unary(url, req, proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse, extra_headers, timeout_seconds)
+
+    async def throw_structured_exception(self, req: proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse:
+        response = await self.call_throw_structured_exception(req, extra_headers, timeout_seconds)
+        err = response.error()
+        if err is not None:
+            raise err
+        msg = response.message()
+        if msg is None:
+            raise ConnectProtocolError('missing response message')
+        return msg
+
     async def call_start_stress_fiber(self, req: proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None) -> UnaryOutput[proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberResponse]:
         """Low-level method to call StartStressFiber, granting access to errors and metadata"""
         url = self.base_url + '/redpanda.core.admin.internal.DebugService/StartStressFiber'
@@ -103,6 +133,9 @@ class AsyncDebugServiceClient:
 @typing.runtime_checkable
 class DebugServiceProtocol(typing.Protocol):
 
+    def throw_structured_exception(self, req: ClientRequest[proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionRequest]) -> ServerResponse[proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionResponse]:
+        ...
+
     def start_stress_fiber(self, req: ClientRequest[proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberRequest]) -> ServerResponse[proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberResponse]:
         ...
 
@@ -112,6 +145,7 @@ DEBUG_SERVICE_PATH_PREFIX = '/redpanda.core.admin.internal.DebugService'
 
 def wsgi_debug_service(implementation: DebugServiceProtocol) -> WSGIApplication:
     app = ConnectWSGI()
+    app.register_unary_rpc('/redpanda.core.admin.internal.DebugService/ThrowStructuredException', implementation.throw_structured_exception, proto.redpanda.core.admin.internal.debug_pb2.ThrowStructuredExceptionRequest)
     app.register_unary_rpc('/redpanda.core.admin.internal.DebugService/StartStressFiber', implementation.start_stress_fiber, proto.redpanda.core.admin.internal.debug_pb2.StartStressFiberRequest)
     app.register_unary_rpc('/redpanda.core.admin.internal.DebugService/StopStressFiber', implementation.stop_stress_fiber, proto.redpanda.core.admin.internal.debug_pb2.StopStressFiberRequest)
     return app

--- a/tests/rptest/tests/admin_api_auth_test.py
+++ b/tests/rptest/tests/admin_api_auth_test.py
@@ -13,7 +13,7 @@ from rptest.services.admin import Admin
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.schema_registry_test import SchemaRegistryEndpoints
 from rptest.clients.rpk import RpkTool
-from rptest.clients.admin.v2 import Admin as AdminV2, admin_pb
+from rptest.clients.admin.v2 import Admin as AdminV2, admin_pb, debug_pb
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SaslCredentials, SecurityConfig
 from rptest.util import expect_exception, expect_http_error
@@ -147,6 +147,42 @@ class AdminApiAuthTest(RedpandaTest):
                     admin_pb.ListRPCRoutesRequest(
                         node_id=self.redpanda.node_id(node)))
                 assert len(resp.routes) > 1, "Expected at least 2 routes"
+
+    @cluster(num_nodes=3)
+    def test_admin_v2_errors(self):
+        """
+        Check that admin v2 structured error returning works.
+        """
+
+        charles = SaslCredentials("charles", "highEntropyHipster",
+                                  "SCRAM-SHA-512")
+        create_user_and_wait(self.redpanda, self.superuser_admin, charles)
+        self.redpanda.set_cluster_config({
+            'superusers':
+            [charles.username, self.redpanda.SUPERUSER_CREDENTIALS.username]
+        })
+
+        for protocol in ['json', 'proto']:
+            admin_v2 = AdminV2(self.redpanda,
+                               auth=(charles.username, charles.password),
+                               protocol=protocol)
+            resp = admin_v2.debug().call_throw_structured_exception(
+                debug_pb.ThrowStructuredExceptionRequest(
+                    node_id=self.redpanda.node_id(self.redpanda.nodes[0]),
+                    reason="FOOBAR",
+                    metadata={"detail": "something"}))
+            assert resp.error() != None, "Expected an error in this RPC"
+            err = resp.error()
+            assert err.code == ConnectErrorCode.UNKNOWN, f"Expected UNKNOWN error code, got: {err}"
+            assert err.message == "test exception", f"Expected 'test exception' message, got: {err}"
+            assert len(
+                err.details) == 1, f"Expected 1 detail, got: {err.details}"
+            detail = err.details[0].message()
+            assert detail.reason == "FOOBAR", f"Expected reason=FOOBAR, got: {detail}"
+            assert detail.domain == "redpanda.com/core", f"Expected domain=redpanda.com/core, got: {detail}"
+            assert detail.metadata == {
+                "detail": "something"
+            }, f"Expected metadata.detail=something, got: {detail}"
 
     @cluster(num_nodes=3)
     def test_public_get_license(self):


### PR DESCRIPTION
Support using structured errors to return information back to clients.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
