### PR TITLE
[v25.1.x] [CORE-13087] dl/coordinator: don't purge data when dropping Glue table

### DIFF
--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -742,12 +742,17 @@ coordinator::update_lifecycle_state(
           model::topic_namespace_view{model::kafka_namespace, t});
         if (tombstone_it != topic_table_.get_iceberg_tombstones().end()) {
             auto tombstone_rev = tombstone_it->second.last_deleted_revision;
+            // The Glue REST catalog doesn't support purging data; explicitly
+            // pass that down to the drop operations.
+            auto should_purge = using_glue_catalog()
+                                  ? file_committer::purge_data::no
+                                  : file_committer::purge_data::yes;
             if (tombstone_rev >= topic.revision) {
                 // Drop the main table if it exists.
                 {
                     auto table_id = table_id_provider::table_id(t);
                     auto drop_res = co_await file_committer_.drop_table(
-                      table_id);
+                      table_id, should_purge);
                     if (drop_res.has_error()) {
                         switch (drop_res.error()) {
                         case file_committer::errc::shutting_down:
@@ -766,7 +771,7 @@ coordinator::update_lifecycle_state(
                 {
                     auto dlq_table_id = table_id_provider::dlq_table_id(t);
                     auto drop_res = co_await file_committer_.drop_table(
-                      dlq_table_id);
+                      dlq_table_id, should_purge);
                     if (drop_res.has_error()) {
                         switch (drop_res.error()) {
                         case file_committer::errc::shutting_down:

--- a/src/v/datalake/coordinator/coordinator.cc
+++ b/src/v/datalake/coordinator/coordinator.cc
@@ -828,31 +828,6 @@ coordinator::update_lifecycle_state(
     co_return ss::stop_iteration::no;
 }
 
-ss::sstring coordinator::get_effective_default_partition_spec(
-  const std::optional<ss::sstring>& partition_spec) const {
-    const auto& cfg = config::shard_local_cfg();
-    auto current_spec = partition_spec.value_or(default_partition_spec_());
-
-    bool is_glue = cfg.iceberg_catalog_type()
-                     == config::datalake_catalog_type::rest
-                   && cfg.iceberg_rest_catalog_authentication_mode()
-                        == config::datalake_catalog_auth_mode::aws_sigv4
-                   && cfg.iceberg_rest_catalog_aws_service_name().value_or("")
-                        == "glue";
-    if (
-      is_glue
-      && current_spec == cfg.iceberg_default_partition_spec.default_value()) {
-        // Glue can't partition on nested fields like redpanda.timestamp.
-        vlog(
-          datalake_log.warn,
-          "Overriding default partition spec to '()' for AWS Glue "
-          "compatibility");
-        return "()";
-    }
-
-    return current_spec;
-}
-
 ss::future<checked<datalake_usage_stats, coordinator::errc>>
 coordinator::sync_get_usage_stats() {
     auto gate = maybe_gate();
@@ -871,4 +846,31 @@ coordinator::sync_get_usage_stats() {
     }
     co_return result;
 }
+
+ss::sstring coordinator::get_effective_default_partition_spec(
+  const std::optional<ss::sstring>& partition_spec) const {
+    const auto& cfg = config::shard_local_cfg();
+    auto current_spec = partition_spec.value_or(default_partition_spec_());
+    if (
+      using_glue_catalog()
+      && current_spec == cfg.iceberg_default_partition_spec.default_value()) {
+        // Glue can't partition on nested fields like redpanda.timestamp.
+        vlog(
+          datalake_log.warn,
+          "Overriding default partition spec to '()' for AWS Glue "
+          "compatibility");
+        return "()";
+    }
+
+    return current_spec;
+}
+
+bool coordinator::using_glue_catalog() const {
+    const auto& cfg = config::shard_local_cfg();
+    return cfg.iceberg_catalog_type() == config::datalake_catalog_type::rest
+           && cfg.iceberg_rest_catalog_authentication_mode()
+                == config::datalake_catalog_auth_mode::aws_sigv4
+           && cfg.iceberg_rest_catalog_aws_service_name() == "glue";
+}
+
 } // namespace datalake::coordinator

--- a/src/v/datalake/coordinator/coordinator.h
+++ b/src/v/datalake/coordinator/coordinator.h
@@ -149,6 +149,11 @@ private:
     ss::sstring get_effective_default_partition_spec(
       const std::optional<ss::sstring>& partition_spec) const;
 
+    // Return whether the underlying catalog is the Glue REST catalog.
+    // TODO: if the kludges start piling up, we should abstract some "catalog
+    // capabilities" out.
+    bool using_glue_catalog() const;
+
     ss::shared_ptr<coordinator_stm> stm_;
     cluster::topic_table& topic_table_;
     type_resolver& type_resolver_;

--- a/src/v/datalake/coordinator/file_committer.h
+++ b/src/v/datalake/coordinator/file_committer.h
@@ -28,8 +28,9 @@ public:
       checked<chunked_vector<mark_files_committed_update>, errc>>
     commit_topic_files_to_catalog(model::topic, const topics_state&) const = 0;
 
+    using purge_data = ss::bool_class<struct purge_data_tag>;
     virtual ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const = 0;
+    drop_table(const iceberg::table_identifier&, purge_data) const = 0;
 
     virtual ~file_committer() = default;
 };

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -596,7 +596,7 @@ iceberg_file_committer::commit_topic_files_to_catalog(
 
 ss::future<checked<std::nullopt_t, file_committer::errc>>
 iceberg_file_committer::drop_table(
-  const iceberg::table_identifier& table_id) const {
+  const iceberg::table_identifier& table_id, purge_data should_purge) const {
     auto load_res = co_await catalog_.load_table(table_id);
     if (load_res.has_error()) {
         if (load_res.error() == iceberg::catalog::errc::not_found) {
@@ -609,7 +609,8 @@ iceberg_file_committer::drop_table(
             "anyway",
             table_id));
     }
-    auto drop_res = co_await catalog_.drop_table(table_id, true);
+    auto drop_res = co_await catalog_.drop_table(
+      table_id, should_purge == purge_data::yes);
     if (
       drop_res.has_error()
       && drop_res.error() != iceberg::catalog::errc::not_found) {

--- a/src/v/datalake/coordinator/iceberg_file_committer.h
+++ b/src/v/datalake/coordinator/iceberg_file_committer.h
@@ -59,7 +59,7 @@ public:
       model::topic, const topics_state&) const final;
 
     ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const final;
+    drop_table(const iceberg::table_identifier&, purge_data) const final;
 
 private:
     // Must outlive this committer.

--- a/src/v/datalake/coordinator/tests/coordinator_test.cc
+++ b/src/v/datalake/coordinator/tests/coordinator_test.cc
@@ -43,7 +43,7 @@ public:
     }
 
     ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const final {
+    drop_table(const iceberg::table_identifier&, purge_data) const final {
         co_return std::nullopt;
     }
 

--- a/src/v/datalake/coordinator/tests/state_test_utils.h
+++ b/src/v/datalake/coordinator/tests/state_test_utils.h
@@ -56,7 +56,7 @@ public:
     }
 
     ss::future<checked<std::nullopt_t, errc>>
-    drop_table(const iceberg::table_identifier&) const final {
+    drop_table(const iceberg::table_identifier&, purge_data) const final {
         co_return std::nullopt;
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27367

CONFLICT:
- first commit needed a trivial tweak because `get_effective_default_partition_spec()` is slightly relocated in this branch