### PR TITLE
`storage`: use `max_ts` for `retention_ms`

### DIFF
--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -129,7 +129,8 @@ struct reupload_fixture : public archiver_fixture {
                            10,
                            1_MiB)
                          .get();
-        write_random_batches(segment, seg.num_records.value(), 2);
+        write_random_batches(
+          segment, seg.num_records.value(), 2, model::timestamp::min());
         disk_log_impl()->segments().add(segment);
     }
 
@@ -540,7 +541,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
     // Close current segment and add a new open segment, so both compacted and
     // non-compacted uploads run together.
     auto& last_segment = disk_log_impl()->segments().back();
-    write_random_batches(last_segment, 20, 2);
+    write_random_batches(last_segment, 20, 2, model::timestamp::min());
     last_segment->appender().close().get();
     last_segment->release_appender();
     add_segment_bytes(last_segment, last_segment->size_bytes());
@@ -610,7 +611,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     // Close current segment and add a new open segment, so both compacted and
     // non-compacted uploads run together.
     auto& last_segment = disk_log_impl()->segments().back();
-    write_random_batches(last_segment, 20, 2);
+    write_random_batches(last_segment, 20, 2, model::timestamp::min());
     last_segment->appender().close().get();
     last_segment->release_appender();
     add_segment_bytes(last_segment, last_segment->size_bytes());
@@ -798,7 +799,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
     // NOTE: uploaded 4 segments, so offset is 54 at the start
     for (auto i = 0; i < 3; ++i) {
         auto& last_segment = disk_log_impl()->segments().back();
-        write_random_batches(last_segment, 10, 2);
+        write_random_batches(last_segment, 10, 2, model::timestamp::min());
         last_segment->appender().close().get();
         last_segment->release_appender();
         add_segment_bytes(last_segment, last_segment->size_bytes());

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -416,18 +416,16 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
        .term = model::term_id(2),
        .num_records = 1000,
        .timestamp = old_stamp},
-      {
-        .ntp = manifest_ntp,
-        .base_offset = model::offset(2000),
-        .term = model::term_id(3),
-        .num_records = 1000,
-      },
-      {
-        .ntp = manifest_ntp,
-        .base_offset = model::offset(3000),
-        .term = model::term_id(4),
-        .num_records = 1000,
-      }};
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(2000),
+       .term = model::term_id(3),
+       .num_records = 1000,
+       .timestamp = model::timestamp::now()},
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(3000),
+       .term = model::term_id(4),
+       .num_records = 1000,
+       .timestamp = model::timestamp::now()}};
 
     init_storage_api_local(segments);
     vlog(test_log.info, "Initialized, start waiting for partition leadership");
@@ -732,12 +730,11 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
        .term = model::term_id(3),
        .num_records = 1000,
        .timestamp = old_stamp},
-      {
-        .ntp = manifest_ntp,
-        .base_offset = model::offset(3000),
-        .term = model::term_id(4),
-        .num_records = 1000,
-      }};
+      {.ntp = manifest_ntp,
+       .base_offset = model::offset(3000),
+       .term = model::term_id(4),
+       .num_records = 1000,
+       .timestamp = model::timestamp::now()}};
 
     init_storage_api_local(segments);
 

--- a/src/v/cluster/archival/tests/service_fixture.h
+++ b/src/v/cluster/archival/tests/service_fixture.h
@@ -36,7 +36,7 @@ struct segment_desc {
     model::term_id term;
     std::optional<size_t> num_records;
     std::optional<size_t> records_per_batch;
-    std::optional<model::timestamp> timestamp;
+    std::optional<model::timestamp> timestamp = model::timestamp::min();
 };
 
 struct offset_range {

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -38,6 +38,8 @@ std::string_view to_string_view(feature f) {
     switch (f) {
     case feature::iceberg_schema_merging:
         return "iceberg_schema_merging";
+    case feature::validated_batch_timestamps:
+        return "validated_batch_timestamps";
     case feature::consumer_groups_migrations:
         return "consumer_groups_migrations";
     case feature::shadow_linking:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -41,6 +41,7 @@ struct feature_table_snapshot;
 /// has been made available by another feature being retired.
 enum class feature : std::uint64_t {
     iceberg_schema_merging = 1ULL << 0U,
+    validated_batch_timestamps = 1ULL << 1U,
     topic_locations_in_outbound_migrations = 1ULL << 2U,
     schema_registry_authz = 1ULL << 3U,
     topic_ids_api = 1ULL << 4U,
@@ -496,6 +497,12 @@ inline constexpr std::array feature_schema{
     "shadow_linking",
     feature::shadow_linking,
     feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    release_version::v25_3_1,
+    "validated_batch_timestamps",
+    feature::validated_batch_timestamps,
+    feature_spec::available_policy::new_clusters_only,
     feature_spec::prepare_policy::always},
 };
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -398,6 +398,8 @@ disk_log_impl::time_based_gc_max_offset(gc_config cfg) const {
                     : _segs.front()->index().retention_timestamp(retention_cfg),
       retention_cfg);
 
+    auto validated_timestamps = _feature_table.local().is_active(
+      features::feature::validated_batch_timestamps);
     static constexpr auto const_threshold = 1min;
     auto bogus_threshold = model::timestamp(
       model::timestamp::now().value() + const_threshold / 1ms);
@@ -405,23 +407,33 @@ disk_log_impl::time_based_gc_max_offset(gc_config cfg) const {
     auto it = std::find_if(
       std::cbegin(_segs),
       std::cend(_segs),
-      [this, time = cfg.eviction_time, bogus_threshold, retention_cfg](
-        const ss::lw_shared_ptr<segment>& s) {
+      [this,
+       time = cfg.eviction_time,
+       bogus_threshold,
+       retention_cfg,
+       validated_timestamps](const ss::lw_shared_ptr<segment>& s) {
           auto retention_ts = s->index().retention_timestamp(retention_cfg);
 
-          if (retention_ts > bogus_threshold) {
-              // Warn on timestamps more than the "bogus" threshold in future
-              // this should not fire for segments created after v23.3
-              vlog(
-                gclog.warn,
-                "[{}] found segment with bogus retention timestamp: {} (base "
-                "{}, max {}) - {}",
-                config().ntp(),
-                retention_ts,
-                s->index().base_timestamp(),
-                s->index().max_timestamp(),
-                s->index().broker_timestamp(),
-                s);
+          if (!validated_timestamps) {
+              // This legacy behavior of warning on timestamps above
+              // `bogus_threshold` is only needed in older clusters that didn't
+              // validate timestamps.
+              if (retention_ts > bogus_threshold) {
+                  // Warn on timestamps more than the "bogus" threshold in
+                  // future this should not fire for segments created after
+                  // v23.3
+                  vlog(
+                    gclog.warn,
+                    "[{}] found segment with bogus retention timestamp: {} "
+                    "(base "
+                    "{}, max {}) - {}",
+                    config().ntp(),
+                    retention_ts,
+                    s->index().base_timestamp(),
+                    s->index().max_timestamp(),
+                    s->index().broker_timestamp(),
+                    s);
+              }
           }
 
           // first that is not going to be collected
@@ -1776,6 +1788,13 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
 }
 
 ss::future<> disk_log_impl::maybe_adjust_retention_timestamps() {
+    auto validated_timestamps = _feature_table.local().is_active(
+      features::feature::validated_batch_timestamps);
+    if (validated_timestamps) {
+        // Legacy behavior of adjusting retention timestamps is only needed in
+        // older clusters that didn't validate timestamps.
+        co_return;
+    }
     // Correct any timestamps too far in the future, meant to be called before
     // calculating the retention offset for garbage collection.
     // It's expected that this will be used only for segments pre v23.3,

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -36,25 +36,46 @@ using broker_timestamp_t = ss::lowres_system_clock::time_point;
 
 // clang-format off
 // this truth table shows which timestamps gets used as retention_timestamp
+// `validated_batch_timestamps` ensures that the `max_timestamp` of a batch
+// produced to `redpanda` has been validated by properties
+// `message.timestamp.{before/after}.max.ms` and are valid for retention enforcement.
+// Prior to this, the broker timestamp would be used for retention enforcement,
+// and even prior to this, the unvalidated `max_timestamp` would be used.
 //
-// use_broker_ts  has_broker_ts  ignore_future_ts  has_alternative_to_future_ts  retention_ts
+// use_broker_ts  has_broker_ts  ignore_future_ts  has_alternative_to_future_ts  validated_batch_timestamps  retention_ts
 //                               (likely false)
-// TRUE           TRUE           TRUE              TRUE                          broker_timestamp
-// TRUE           TRUE           TRUE              FALSE                         broker_timestamp
-// TRUE           TRUE           FALSE             TRUE                          broker_timestamp
-// TRUE           TRUE           FALSE             FALSE                         broker_timestamp             // new segment, new cluster
-// TRUE           FALSE          TRUE              TRUE                          segment_index::_retention_ms // buggy old segment, new cluster
-// TRUE           FALSE          TRUE              FALSE                         max_timestamp
-// TRUE           FALSE          FALSE             TRUE                          max_timestamp
-// TRUE           FALSE          FALSE             FALSE                         max_timestamp                // old segment, new cluster
-// FALSE          TRUE           TRUE              TRUE                          segment_index::_retention_ms
-// FALSE          TRUE           TRUE              FALSE                         max_timestamp
-// FALSE          TRUE           FALSE             TRUE                          max_timestamp
-// FALSE          TRUE           FALSE             FALSE                         max_timestamp                // new segment, upgraded cluster
-// FALSE          FALSE          TRUE              TRUE                          segment_index::_retention_ms // buggy old segments
-// FALSE          FALSE          TRUE              FALSE                         max_timestamp
-// FALSE          FALSE          FALSE             TRUE                          max_timestamp
-// FALSE          FALSE          FALSE             FALSE                         max_timestamp                // old segment, upgraded cluster
+// TRUE           TRUE           TRUE              TRUE                          TRUE                        max_timestamp
+// TRUE           TRUE           TRUE              FALSE                         TRUE                        max_timestamp
+// TRUE           TRUE           FALSE             TRUE                          TRUE                        max_timestamp
+// TRUE           TRUE           FALSE             FALSE                         TRUE                        max_timestamp
+// TRUE           FALSE          TRUE              TRUE                          TRUE                        max_timestamp
+// TRUE           FALSE          TRUE              FALSE                         TRUE                        max_timestamp
+// TRUE           FALSE          FALSE             TRUE                          TRUE                        max_timestamp
+// TRUE           FALSE          FALSE             FALSE                         TRUE                        max_timestamp
+// TRUE           TRUE           TRUE              TRUE                          FALSE                       broker_timestamp
+// TRUE           TRUE           TRUE              FALSE                         FALSE                       broker_timestamp
+// TRUE           TRUE           FALSE             TRUE                          FALSE                       broker_timestamp
+// TRUE           TRUE           FALSE             FALSE                         FALSE                       broker_timestamp               // new segment, new cluster
+// TRUE           FALSE          TRUE              TRUE                          FALSE                       segment_index::_retention_ms   // buggy old segment, new cluster
+// TRUE           FALSE          TRUE              FALSE                         FALSE                       max_timestamp
+// TRUE           FALSE          FALSE             TRUE                          FALSE                       max_timestamp
+// TRUE           FALSE          FALSE             FALSE                         FALSE                       max_timestamp                  // old segment, new cluster
+// FALSE          TRUE           TRUE              TRUE                          FALSE                       segment_index::_retention_ms
+// FALSE          TRUE           TRUE              FALSE                         FALSE                       max_timestamp
+// FALSE          TRUE           FALSE             TRUE                          FALSE                       max_timestamp
+// FALSE          TRUE           FALSE             FALSE                         FALSE                       max_timestamp                  // new segment, upgraded cluster
+// FALSE          FALSE          TRUE              TRUE                          FALSE                       segment_index::_retention_ms   // buggy old segments
+// FALSE          FALSE          TRUE              FALSE                         FALSE                       max_timestamp
+// FALSE          FALSE          FALSE             TRUE                          FALSE                       max_timestamp
+// FALSE          FALSE          FALSE             FALSE                         FALSE                       max_timestamp                  // old segment, upgraded cluster
+// FALSE          TRUE           TRUE              TRUE                          TRUE                        max_timestamp
+// FALSE          TRUE           TRUE              FALSE                         TRUE                        max_timestamp
+// FALSE          TRUE           FALSE             TRUE                          TRUE                        max_timestamp
+// FALSE          TRUE           FALSE             FALSE                         TRUE                        max_timestamp
+// FALSE          FALSE          TRUE              TRUE                          TRUE                        max_timestamp
+// FALSE          FALSE          TRUE              FALSE                         TRUE                        max_timestamp
+// FALSE          FALSE          FALSE             TRUE                          TRUE                        max_timestamp
+// FALSE          FALSE          FALSE             FALSE                         TRUE                        max_timestamp
 // clang-format on
 
 // this struct is meant to be a local copy of the feature
@@ -62,6 +83,7 @@ using broker_timestamp_t = ss::lowres_system_clock::time_point;
 // storage_ignore_timestamps_in_future_secs
 struct time_based_retention_cfg {
     bool use_broker_time;
+    bool use_validated_batch_time;
     bool use_escape_hatch_for_timestamps_in_the_future;
 
     static auto make(const features::feature_table& ft)
@@ -69,6 +91,8 @@ struct time_based_retention_cfg {
         return {
           .use_broker_time = ft.is_active(
             features::feature::broker_time_based_retention),
+          .use_validated_batch_time = ft.is_active(
+            features::feature::validated_batch_timestamps),
           .use_escape_hatch_for_timestamps_in_the_future
           = config::shard_local_cfg()
               .storage_ignore_timestamps_in_future_sec()
@@ -81,7 +105,14 @@ struct time_based_retention_cfg {
       std::optional<model::timestamp> broker_ts,
       model::timestamp max_ts,
       std::optional<model::timestamp> alternative_retention_ts) const noexcept {
-        // new clusters and new segments should hit this branch
+        // For versions of `redpanda` that have `max_timestamp` in batches
+        // validated by `message.timestamp.{before/after}.max.ms` and
+        // unconditionally set in the produce path (see:
+        // v/kafka/server/handlers/produce_validation.cc)
+        if (use_validated_batch_time) {
+            return max_ts;
+        }
+
         if (likely(use_broker_time && broker_ts.has_value())) {
             return *broker_ts;
         }
@@ -350,8 +381,10 @@ struct fmt::formatter<storage::time_based_retention_cfg>
   : public fmt::formatter<std::string_view> {
     auto format(const storage::time_based_retention_cfg& cfg, auto& ctx) const {
         auto str = ssx::sformat(
-          "[.use_broker_time={}, "
+          "[.use_validated_batch_time={}, "
+          ".use_broker_time={}, "
           ".use_escape_hatch_for_timestamps_in_the_future={}]",
+          cfg.use_validated_batch_time,
           cfg.use_broker_time,
           cfg.use_escape_hatch_for_timestamps_in_the_future);
         return formatter<std::string_view>::format(

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -279,6 +279,7 @@ TEST_F(storage_test_fixture, test_truncate_last_single_record_batch) {
       log,
       15,
       model::term_id(0),
+      std::nullopt,
       [](std::optional<model::timestamp> ts = std::nullopt) {
           chunked_circular_buffer<model::record_batch> ret;
           ret.push_back(
@@ -544,9 +545,10 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
                    storage::ntp_config(
                      ntp, mgr.config().base_dir, std::move(overrides)))
                  .get();
+    auto ts = model::timestamp::now() - model::timestamp(1000);
     for (int seg = 0; seg < 2; seg++) {
         for (int i = 0; i < 5; i++) {
-            append_random_batches(log, 1, model::term_id(0));
+            append_random_batches(log, 1, model::term_id(0), ts);
         }
         log->flush().get();
         log->force_roll().get();
@@ -577,7 +579,6 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
     }
 
     // Now race windowed compaction and truncation.
-    auto ts = now();
     auto sleep_ms1 = random_generators::get_int(0, 100);
     housekeeping_config housekeeping_cfg(
       ts,

--- a/src/v/storage/tests/segment_concatenation_test.cc
+++ b/src/v/storage/tests/segment_concatenation_test.cc
@@ -11,6 +11,7 @@
 #include "bytes/iostream.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
+#include "model/timestamp.h"
 #include "random/generators.h"
 #include "storage/disk_log_impl.h"
 #include "storage/parser.h"
@@ -206,11 +207,18 @@ TEST_P(MakeConcatenatedSegmentFixture, ConcatenateSegments) {
 
     auto [num_segments, maybe_compress] = GetParam();
     auto records_per_seg = random_generators::get_int(50, 200);
+    model::timestamp base_ts = model::timestamp::min();
     for (size_t i = 0; i < num_segments; ++i) {
         auto offset = i * records_per_seg;
         b
           | add_random_batch(
-            offset, records_per_seg, maybe_compress_batches(maybe_compress));
+            offset,
+            records_per_seg,
+            maybe_compress_batches(maybe_compress),
+            model::record_batch_type::raft_data,
+            append_config(),
+            disk_log_builder::should_flush_after::yes,
+            base_ts);
         disk_log.force_roll().get();
     }
 

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -53,7 +53,13 @@ void add_segments(
         auto offset = start_offset + i * records_per_seg;
         b | add_segment(offset)
           | add_random_batch(
-            offset, records_per_seg, maybe_compress_batches::yes);
+            offset,
+            records_per_seg,
+            maybe_compress_batches::yes,
+            model::record_batch_type::raft_data,
+            append_config(),
+            disk_log_builder::should_flush_after::yes,
+            model::timestamp::min());
     }
     for (auto& seg : disk_log.segments()) {
         if (mark_compacted) {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -184,6 +184,7 @@ TEST_F(storage_test_fixture, test_single_record_per_segment) {
       log,
       10,
       model::term_id(1),
+      std::nullopt,
       [](std::optional<model::timestamp> ts = std::nullopt) {
           chunked_circular_buffer<model::record_batch> batches;
           batches.push_back(
@@ -221,6 +222,7 @@ TEST_F(storage_test_fixture, test_segment_rolling) {
       log,
       10,
       model::term_id(1),
+      std::nullopt,
       [](std::optional<model::timestamp> ts = std::nullopt)
         -> chunked_circular_buffer<model::record_batch> {
           chunked_circular_buffer<model::record_batch> batches;
@@ -251,6 +253,7 @@ TEST_F(storage_test_fixture, test_segment_rolling) {
       log,
       10,
       model::term_id(1),
+      std::nullopt,
       [](std::optional<model::timestamp> ts = std::nullopt) {
           chunked_circular_buffer<model::record_batch> batches;
           batches.push_back(
@@ -334,6 +337,7 @@ TEST_F(storage_test_fixture, test_reading_range_from_a_log_with_write_caching) {
       log,
       10,
       model::term_id(0),
+      std::nullopt,
       {},
       storage::log_append_config::fsync::no,
       false);
@@ -384,6 +388,7 @@ TEST_F(storage_test_fixture, test_truncation_with_write_caching) {
       log,
       10,
       model::term_id(0),
+      std::nullopt,
       {},
       storage::log_append_config::fsync::no,
       false);
@@ -695,29 +700,8 @@ TEST_F(storage_test_fixture, test_time_based_eviction) {
             as);
       };
 
-    // gc with timestamp -1s, no segments should be evicted
+    // gc with timestamp -1s, all segments should be evicted
     compact_and_prefix_truncate(*disk_log, make_compaction_cfg(broker_t0 - 2s));
-    ASSERT_EQ(disk_log->segments().size(), 3);
-    ASSERT_EQ(
-      disk_log->segments().front()->offsets().get_base_offset(),
-      model::offset(0));
-    ASSERT_EQ(
-      disk_log->segments().back()->offsets().get_dirty_offset(),
-      model::offset(59));
-
-    // gc with timestamp +sep/2, should evict first segment
-    compact_and_prefix_truncate(
-      *disk_log, make_compaction_cfg(broker_t0 + (broker_ts_sep / 2)));
-    ASSERT_EQ(disk_log->segments().size(), 2);
-    ASSERT_EQ(
-      disk_log->segments().front()->offsets().get_base_offset(),
-      model::offset(10));
-    ASSERT_EQ(
-      disk_log->segments().back()->offsets().get_dirty_offset(),
-      model::offset(59));
-    // gc with timestamp +sep3/2, should evict another segment
-    compact_and_prefix_truncate(
-      *disk_log, make_compaction_cfg(broker_t0 + (3 * broker_ts_sep / 2)));
     ASSERT_EQ(disk_log->segments().size(), 1);
     ASSERT_EQ(
       disk_log->segments().front()->offsets().get_base_offset(),
@@ -849,6 +833,7 @@ TEST_F(storage_test_fixture, test_eviction_notification) {
       log,
       10,
       model::term_id(0),
+      std::nullopt,
       custom_ts_batch_generator(model::timestamp::now()));
     log->flush().get();
     ss::sleep(1s).get(); // ensure time separation for broker timestamp
@@ -861,6 +846,7 @@ TEST_F(storage_test_fixture, test_eviction_notification) {
       log,
       10,
       model::term_id(0),
+      std::nullopt,
       custom_ts_batch_generator(model::timestamp(gc_ts() + 10)));
     storage::housekeeping_config ccfg(
       gc_ts,
@@ -873,23 +859,11 @@ TEST_F(storage_test_fixture, test_eviction_notification) {
 
     log->housekeeping(ccfg).get();
 
-    auto offset = last_evicted_offset.get_future().get();
+    std::ignore = last_evicted_offset.get_future().get();
     log->housekeeping(ccfg).get();
     auto lstats_after = log->offsets();
 
     ASSERT_EQ(lstats_before.start_offset, lstats_after.start_offset);
-    // wait for compaction
-    log->housekeeping(ccfg).get();
-    log
-      ->truncate_prefix(
-        storage::truncate_prefix_config{model::next_offset(offset)})
-      .get();
-    auto compacted_lstats = log->offsets();
-    SUCCEED() << fmt::format("Compacted offsets {}", compacted_lstats);
-    // check if compaction happened
-    ASSERT_EQ(
-      compacted_lstats.start_offset,
-      lstats_before.dirty_offset + model::offset(1));
 };
 
 /**
@@ -3404,7 +3378,7 @@ TEST_F(storage_test_fixture, test_max_compact_offset) {
     // (1) append some random data, with limited number of distinct keys, so
     // compaction can make progress.
     auto headers = append_random_batches<key_limited_random_batch_generator>(
-      log, 20);
+      log, 20, model::term_id{0}, model::timestamp::now());
 
     // (2) remember log offset, roll log, and produce more messages
     log->flush().get();
@@ -3412,7 +3386,9 @@ TEST_F(storage_test_fixture, test_max_compact_offset) {
     SUCCEED() << fmt::format("Offsets to be compacted {}", first_stats);
     disk_log->force_roll().get();
     headers = append_random_batches<key_limited_random_batch_generator>(
-      log, 20);
+      log, 20, model::term_id{0}, model::timestamp::now());
+
+    ss::sleep(1s).get(); // ensure time separation for max.compaction.lag.ms
 
     // (3) roll log and trigger compaction, analyzing offset gaps before and
     // after, to observe compaction behavior.
@@ -3524,7 +3500,8 @@ TEST_F(storage_test_fixture, test_simple_compaction_rebuild_index) {
 
     // Append some linear kv ints
     int num_appends = 5;
-    append_random_batches<linear_int_kv_batch_generator>(log, num_appends);
+    append_random_batches<linear_int_kv_batch_generator>(
+      log, num_appends, model::term_id(0), model::timestamp::min());
     log->flush().get();
     disk_log->force_roll().get();
     ASSERT_EQ(disk_log->segment_count(), 2);
@@ -4267,6 +4244,7 @@ TEST_F(
           log,
           10,
           model::term_id(0),
+          std::nullopt,
           custom_ts_batch_generator(model::timestamp::now()));
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
@@ -4326,6 +4304,7 @@ TEST_F(storage_test_fixture, test_offset_range_size) {
           log,
           10,
           model::term_id(0),
+          std::nullopt,
           custom_ts_batch_generator(model::timestamp::now()));
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
@@ -4438,6 +4417,7 @@ TEST_F(storage_test_fixture, test_offset_range_size2) {
           log,
           10,
           model::term_id(0),
+          std::nullopt,
           custom_ts_batch_generator(model::timestamp::now()));
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
@@ -4631,7 +4611,11 @@ TEST_F(storage_test_fixture, test_offset_range_size_compacted) {
     model::offset first_segment_last_offset;
     for (size_t i = 0; i < num_segments; i++) {
         append_random_batches(
-          log, 10, model::term_id(i), key_limited_random_batch_generator());
+          log,
+          10,
+          model::term_id(i),
+          model::timestamp::now(),
+          key_limited_random_batch_generator());
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
         }
@@ -4824,7 +4808,11 @@ TEST_F(storage_test_fixture, test_offset_range_size2_compacted) {
     model::offset first_segment_last_offset;
     for (size_t i = 0; i < num_segments; i++) {
         append_random_batches(
-          log, 10, model::term_id(0), key_limited_random_batch_generator());
+          log,
+          10,
+          model::term_id(0),
+          model::timestamp::now(),
+          key_limited_random_batch_generator());
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
         }
@@ -5128,6 +5116,7 @@ TEST_F(storage_test_fixture, test_offset_range_size_incremental) {
           log,
           10,
           model::term_id(0),
+          std::nullopt,
           custom_ts_batch_generator(model::timestamp::now()));
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
@@ -5583,7 +5572,7 @@ TEST_F(storage_test_fixture, compaction_scheduling) {
 
     auto append_and_force_roll = [this](auto& log, int num_batches = 10) {
         auto headers = append_random_batches<linear_int_kv_batch_generator>(
-          log, num_batches);
+          log, num_batches, model::term_id{0}, model::timestamp::now());
         log->force_roll().get();
     };
 
@@ -5925,7 +5914,11 @@ TEST_F(storage_test_fixture, prefix_truncate_offset_range_size) {
     size_t num_segments = 1;
     for (size_t i = 0; i < num_segments; i++) {
         append_random_batches(
-          log, 10, model::term_id(0), key_limited_random_batch_generator());
+          log,
+          10,
+          model::term_id(0),
+          std::nullopt,
+          key_limited_random_batch_generator());
         log->force_roll().get();
     }
 
@@ -6716,6 +6709,7 @@ TEST_F(storage_test_fixture, test_get_file_offset_lock_precheck) {
           log,
           10,
           model::term_id(0),
+          std::nullopt,
           custom_ts_batch_generator(model::timestamp::now()));
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
@@ -6774,6 +6768,7 @@ TEST_F(storage_test_fixture, test_offset_range_size_lock_timeout) {
           log,
           10,
           model::term_id(0),
+          std::nullopt,
           custom_ts_batch_generator(model::timestamp::now()));
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
@@ -6829,12 +6824,18 @@ TEST_F(storage_test_fixture, test_max_eligible_for_compacted_reupload_offset) {
     model::offset first_segment_last_offset;
     for (size_t i = 0; i < num_segments; i++) {
         append_random_batches(
-          log, 10, model::term_id(i), key_limited_random_batch_generator());
+          log,
+          10,
+          model::term_id(i),
+          model::timestamp::now(),
+          key_limited_random_batch_generator());
         if (first_segment_last_offset == model::offset{}) {
             first_segment_last_offset = log->offsets().dirty_offset;
         }
         log->force_roll().get();
     }
+
+    ss::sleep(1s).get(); // ensure time separation for max.compaction.lag.ms
 
     auto& segments = log->segments();
     auto first = *std::next(segments.begin(), 0);

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -168,6 +168,7 @@ public:
       ss::shared_ptr<storage::log> log,
       int appends,
       model::term_id term = model::term_id(0),
+      std::optional<model::timestamp> ts_override = std::nullopt,
       T batch_generator = T{},
       storage::log_append_config::fsync sync
       = storage::log_append_config::fsync::no,
@@ -184,16 +185,18 @@ public:
         // do multiple append calls
 
         for ([[maybe_unused]] auto append : boost::irange(0, appends)) {
-            auto batches = batch_generator(ts_cursor);
+            auto ts = ts_override.has_value() ? ts_override : ts_cursor;
+            auto batches = batch_generator(ts);
             // Collect batches offsets
             for (auto& b : batches) {
                 headers.push_back(b.header());
                 b.set_term(term);
                 total_records += b.record_count();
             }
-
-            ts_cursor = model::timestamp{
-              batches.back().header().max_timestamp() + 1};
+            if (!ts_override.has_value()) {
+                ts_cursor = model::timestamp{
+                  batches.back().header().max_timestamp() + 1};
+            }
 
             // make expected offset inclusive
             auto reader = model::make_memory_record_batch_reader(

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -14,7 +14,6 @@ from ducktape.errors import TimeoutError
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
-from rptest.util import expect_timeout, wait_until
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -25,13 +24,17 @@ from rptest.services.redpanda import (
     SISettings,
     get_cloud_storage_type,
 )
+from rptest.services.redpanda_installer import InstallOptions, RedpandaVersionLine
+from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (
     expect_exception,
+    expect_timeout,
     produce_total_bytes,
     produce_until_segments,
     segments_count,
     wait_for_local_storage_truncate,
+    wait_until,
 )
 from rptest.utils.si_utils import BucketView, quiesce_uploads
 
@@ -208,7 +211,7 @@ class RetentionPolicyToggleTest(RedpandaTest):
             redpanda=self.redpanda, topic=self.topic, target_bytes=local_retention
         )
 
-        self.logger.debug(f"Toggling back to cleanup.policy=compact")
+        self.logger.debug("Toggling back to cleanup.policy=compact")
         self.client().alter_topic_configs(
             self.topic,
             {
@@ -319,7 +322,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
                 lambda: self.segments_removed(self.default_retention_segments + 1),
                 timeout_sec=15,
                 backoff_sec=1,
-                err_msg=f"Segments were not removed",
+                err_msg="Segments were not removed",
             )
         else:
             with expect_exception(TimeoutError, lambda e: True):
@@ -364,7 +367,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
             lambda: self.segments_removed(self.retention_segments + 1),
             timeout_sec=15,
             backoff_sec=1,
-            err_msg=f"Segments were not removed",
+            err_msg="Segments were not removed",
         )
 
     @cluster(num_nodes=1)
@@ -411,7 +414,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
             lambda: self.segments_removed(num_segs - 1),
             timeout_sec=60,
             backoff_sec=2,
-            err_msg=f"Initial segments were not removed",
+            err_msg="Initial segments were not removed",
         )
 
         # the expectation of retention is to remove up to the active segment.
@@ -425,7 +428,7 @@ class ShadowIndexingLocalRetentionTest(RedpandaTest):
                 lambda: self.segments_removed(num_segs - 1),
                 timeout_sec=30,
                 backoff_sec=5,
-                err_msg=f"Segments were not removed",
+                err_msg="Segments were not removed",
             )
             tmp = len(self.query_segments())
             assert tmp < num_segs
@@ -507,7 +510,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: 9 <= deleted_segments_count() <= 10,
             timeout_sec=30,
             backoff_sec=1,
-            err_msg=f"Segments were not removed from the cloud",
+            err_msg="Segments were not removed from the cloud",
         )
 
     @cluster(num_nodes=3)
@@ -562,7 +565,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: cloud_log_size().total() >= total_bytes,
             timeout_sec=30,
             backoff_sec=2,
-            err_msg=f"Segments not uploaded",
+            err_msg="Segments not uploaded",
         )
 
         # Alter the topic's retention.bytes config to trigger removal of
@@ -577,7 +580,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: cloud_log_size().total() <= retention_bytes,
             timeout_sec=30,
             backoff_sec=2,
-            err_msg=f"Too many bytes in the cloud",
+            err_msg="Too many bytes in the cloud",
         )
 
     @cluster(num_nodes=3)
@@ -642,7 +645,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: cloud_log_segment_count() >= local_seg_count - 1,
             timeout_sec=30,
             backoff_sec=2,
-            err_msg=f"Segments not uploaded",
+            err_msg="Segments not uploaded",
         )
 
         # Alter the topic's retention.ms config to trigger removal of
@@ -656,7 +659,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: cloud_log_segment_count() == 0,
             timeout_sec=30,
             backoff_sec=2,
-            err_msg=f"Not all segments were removed from the cloud",
+            err_msg="Not all segments were removed from the cloud",
         )
 
     @cluster(num_nodes=1)
@@ -740,7 +743,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: cloud_log_size().total() >= total_bytes,
             timeout_sec=30,
             backoff_sec=2,
-            err_msg=f"Segments not uploaded",
+            err_msg="Segments not uploaded",
         )
 
         # Modify retention settings
@@ -754,7 +757,7 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
             lambda: cloud_log_size().total() <= retention_bytes,
             timeout_sec=30,
             backoff_sec=2,
-            err_msg=f"Too many bytes in the cloud",
+            err_msg="Too many bytes in the cloud",
         )
 
     @cluster(num_nodes=1)
@@ -813,7 +816,16 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
         ), f"recreated topic {topic_name} cfg do not match {pre_cfg=} {post_cfg=}"
 
 
-class BogusTimestampTest(RedpandaTest):
+class TimestampDriftRetentionTest(RedpandaTest):
+    """
+    Tests that timestamps of records that have been allowed into `redpanda` are respected,
+    without any overrides or historical hacks applied. Previously we would fall back
+    to broker time or an adjusted mtime, both of which are deprecated behaviors now that
+    we have proper timestamp validation in the produce path as of v25.3.1
+    (`message.timestamp.{before/after}.max.ms`, as well as ensuring `max_timestamp` is set
+    in `produce_validation.cc`)
+    """
+
     segment_size = 1048576
     topics = (
         TopicSpec(
@@ -834,6 +846,121 @@ class BogusTimestampTest(RedpandaTest):
         )
 
     @cluster(num_nodes=2)
+    def test_future_timestamps(self):
+        """
+        Ensure record timestamps in the future are respected by retention enforcement.
+        """
+
+        # Allow for messages up to a week in the future to be produced.
+        self.client().alter_topic_config(
+            self.topic, "message.timestamp.after.max.ms", 7 * 24 * 3600 * 1000
+        )
+
+        # A fictional artificial timestamp base in milliseconds
+        future_timestamp = (int(time.time()) + 24 * 3600) * 1000
+
+        # Produce a run of messages with CreateTime-style timestamps, each
+        # record having a timestamp 1ms greater than the last.
+        msg_size = 14000
+        segments_count = 10
+        msg_count = (self.segment_size // msg_size) * segments_count
+
+        # Write msg_count messages with timestamps in the future
+        producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=self.redpanda,
+            topic=self.topic,
+            msg_size=msg_size,
+            msg_count=(self.segment_size // msg_size) * segments_count,
+            fake_timestamp_ms=future_timestamp,
+            batch_max_bytes=msg_size * 2,
+        )
+        producer.start()
+        producer.wait()
+
+        def prefix_truncated():
+            segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+                "kafka", self.topic, 0
+            )
+            self.logger.debug(f"Segments: {segs}")
+            return len(segs) <= 1
+
+        # Don't expect to see any prefix truncation.
+        with expect_timeout():
+            self.redpanda.wait_until(prefix_truncated, timeout_sec=5, backoff_sec=1)
+
+    @cluster(num_nodes=2)
+    def test_past_timestamps(self):
+        """
+        Ensure record timestamps in the past are respected by retention enforcement.
+        """
+
+        # Set `retention.ms` to 25 hours
+        retention_ms = 25 * 3600 * 1000
+        self.client().alter_topic_config(self.topic, "retention.ms", retention_ms)
+
+        # A fictional artificial timestamp base in milliseconds (one day previous)
+        past_timestamp = (int(time.time()) - 24 * 3600) * 1000
+
+        # Produce a run of messages with CreateTime-style timestamps, each
+        # record having a timestamp 1ms greater than the last.
+        msg_size = 14000
+        segments_count = 10
+        msg_count = (self.segment_size // msg_size) * segments_count
+
+        # Write msg_count messages with timestamps in the past
+        producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=self.redpanda,
+            topic=self.topic,
+            msg_size=msg_size,
+            msg_count=(self.segment_size // msg_size) * segments_count,
+            fake_timestamp_ms=past_timestamp,
+            batch_max_bytes=msg_size * 2,
+        )
+        producer.start()
+        producer.wait()
+
+        def prefix_truncated():
+            segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+                "kafka", self.topic, 0
+            )
+            self.logger.debug(f"Segments: {segs}")
+            return len(segs) <= 1
+
+        # Don't expect to see prefix truncation of day old records with `retention.ms=25h`.
+        with expect_timeout():
+            self.redpanda.wait_until(prefix_truncated, timeout_sec=5, backoff_sec=1)
+
+        # Set `retention.ms` to 23 hours
+        retention_ms = 23 * 3600 * 1000
+        self.client().alter_topic_config(self.topic, "retention.ms", retention_ms)
+
+        # Expect to see prefix truncation of day old records with `retention.ms=23h`.
+        self.redpanda.wait_until(prefix_truncated, timeout_sec=30, backoff_sec=1)
+
+
+class BogusTimestampTest(EndToEndTest):
+    def __init__(self, test_context):
+        self.test_context = test_context
+        super().__init__(
+            test_context=test_context,
+            extra_rp_conf={"log_compaction_interval_ms": 1000},
+        )
+        self.segment_size = 1048576
+        self.topic_spec = TopicSpec(
+            partition_count=1,
+            replication_factor=1,
+            cleanup_policy=TopicSpec.CLEANUP_DELETE,
+            # 1 megabyte segments
+            segment_bytes=self.segment_size,
+            # 10 second retention: in the case of mixed timestamps,
+            # give active segment time to help adjust retention timestamps and show up in log monitor.
+            retention_ms=10000,
+        )
+        self.topic = self.topic_spec.name
+
+    @cluster(num_nodes=2)
     @matrix(mixed_timestamps=[True, False], use_broker_timestamps=[True, False])
     def test_bogus_timestamps(
         self, mixed_timestamps: bool, use_broker_timestamps: bool
@@ -841,8 +968,30 @@ class BogusTimestampTest(RedpandaTest):
         """
         :param mixed_timestamps: if true, test with a mixture of valid and invalid
         timestamps in the same segment (i.e. timestamp adjustment should use the
-        valid timestamps rather than falling back to mtime)
+        valid timestamps rather than falling back to mtime).
+
+        This is a legacy test which depends on the fact that `validated_batch_timestamps`
+        is a feature flag with `available_policy::new_clusters_only` in `v25.3.x`.
+        For that reason, we start with a cluster of version `v25.2.x`, immediately
+        upgrade it, and expect to see the legacy behavior.
         """
+
+        pre_validated_batch_timestamps_version = RedpandaVersionLine((25, 2))
+
+        self.start_redpanda(
+            num_nodes=1,
+            install_opts=InstallOptions(version=pre_validated_batch_timestamps_version),
+        )
+
+        self.client().create_topic(self.topic_spec)
+
+        # Install the latest version of `redpanda` and restart nodes
+        for version in self.redpanda._installer.upgrade_path_to_head(
+            pre_validated_batch_timestamps_version
+        ):
+            self.redpanda._installer.install(self.redpanda.nodes, version)
+            self.redpanda.stop_node(self.redpanda.nodes[0])
+            self.redpanda.start_node(self.redpanda.nodes[0])
 
         # broker_time_based_retention fixes this test case for new segments. (disable it to simulate a legacy condition)
         self.redpanda.set_feature_active(
@@ -972,54 +1121,4 @@ class BogusTimestampTest(RedpandaTest):
 
         # Segments should be cleaned up now that we've switched on force-correction
         # of timestamps in the future
-        self.redpanda.wait_until(prefix_truncated, timeout_sec=30, backoff_sec=1)
-
-    @cluster(num_nodes=2)
-    def test_past_timestamps(self):
-        """
-        Ensure record timestamps in the past are respected by retention enforcement.
-        """
-
-        # Set `retention.ms` to 25 hours
-        retention_ms = 25 * 3600 * 1000
-        self.client().alter_topic_config(self.topic, "retention.ms", retention_ms)
-
-        # A fictional artificial timestamp base in milliseconds (one day previous)
-        past_timestamp = (int(time.time()) - 24 * 3600) * 1000
-
-        # Produce a run of messages with CreateTime-style timestamps, each
-        # record having a timestamp 1ms greater than the last.
-        msg_size = 14000
-        segments_count = 10
-        msg_count = (self.segment_size // msg_size) * segments_count
-
-        # Write msg_count messages with timestamps in the past
-        producer = KgoVerifierProducer(
-            context=self.test_context,
-            redpanda=self.redpanda,
-            topic=self.topic,
-            msg_size=msg_size,
-            msg_count=(self.segment_size // msg_size) * segments_count,
-            fake_timestamp_ms=past_timestamp,
-            batch_max_bytes=msg_size * 2,
-        )
-        producer.start()
-        producer.wait()
-
-        def prefix_truncated():
-            segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
-                "kafka", self.topic, 0
-            )
-            self.logger.debug(f"Segments: {segs}")
-            return len(segs) <= 1
-
-        # Don't expect to see prefix truncation of day old records with `retention.ms=25h`.
-        with expect_timeout():
-            self.redpanda.wait_until(prefix_truncated, timeout_sec=5, backoff_sec=1)
-
-        # Set `retention.ms` to 23 hours
-        retention_ms = 23 * 3600 * 1000
-        self.client().alter_topic_config(self.topic, "retention.ms", retention_ms)
-
-        # Expect to see prefix truncation of day old records with `retention.ms=23h`.
         self.redpanda.wait_until(prefix_truncated, timeout_sec=30, backoff_sec=1)

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -14,6 +14,7 @@ from ducktape.errors import TimeoutError
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
+from rptest.util import expect_timeout, wait_until
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
@@ -971,4 +972,54 @@ class BogusTimestampTest(RedpandaTest):
 
         # Segments should be cleaned up now that we've switched on force-correction
         # of timestamps in the future
+        self.redpanda.wait_until(prefix_truncated, timeout_sec=30, backoff_sec=1)
+
+    @cluster(num_nodes=2)
+    def test_past_timestamps(self):
+        """
+        Ensure record timestamps in the past are respected by retention enforcement.
+        """
+
+        # Set `retention.ms` to 25 hours
+        retention_ms = 25 * 3600 * 1000
+        self.client().alter_topic_config(self.topic, "retention.ms", retention_ms)
+
+        # A fictional artificial timestamp base in milliseconds (one day previous)
+        past_timestamp = (int(time.time()) - 24 * 3600) * 1000
+
+        # Produce a run of messages with CreateTime-style timestamps, each
+        # record having a timestamp 1ms greater than the last.
+        msg_size = 14000
+        segments_count = 10
+        msg_count = (self.segment_size // msg_size) * segments_count
+
+        # Write msg_count messages with timestamps in the past
+        producer = KgoVerifierProducer(
+            context=self.test_context,
+            redpanda=self.redpanda,
+            topic=self.topic,
+            msg_size=msg_size,
+            msg_count=(self.segment_size // msg_size) * segments_count,
+            fake_timestamp_ms=past_timestamp,
+            batch_max_bytes=msg_size * 2,
+        )
+        producer.start()
+        producer.wait()
+
+        def prefix_truncated():
+            segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+                "kafka", self.topic, 0
+            )
+            self.logger.debug(f"Segments: {segs}")
+            return len(segs) <= 1
+
+        # Don't expect to see prefix truncation of day old records with `retention.ms=25h`.
+        with expect_timeout():
+            self.redpanda.wait_until(prefix_truncated, timeout_sec=5, backoff_sec=1)
+
+        # Set `retention.ms` to 23 hours
+        retention_ms = 23 * 3600 * 1000
+        self.client().alter_topic_config(self.topic, "retention.ms", retention_ms)
+
+        # Expect to see prefix truncation of day old records with `retention.ms=23h`.
         self.redpanda.wait_until(prefix_truncated, timeout_sec=30, backoff_sec=1)


### PR DESCRIPTION
The motivating case for `broker_time_based_retention` was the fact that records with bad timestamps produced in the future could lead to time-based retention being stuck indefinitely [1].

However, using the `broker_ts` can lead to unexpected behavior when e.g. replicating data from an existing cluster using MM2, as the timestamps of the Kafka records themselves are correctly preserved, but internally, `redpanda` data structures are not.

To avoid the potentially curious behavior of a divergence in retention enforcement, go back to using the `max_timestamp` for batches whose timestamps have been [validated](https://github.com/redpanda-data/redpanda/pull/27419) and [unconditionally set](https://github.com/redpanda-data/redpanda/pull/27529) in the produce path (see: `v/kafka/server/handlers/produce_validation.cc`) as of `v25.3.1`. 

All of the changes described here are featured gated by the flag `min_broker_batch_time_based_retention`. This flag will only be default activated for new clusters created with minimum version `v25.3.1`. Older clusters can still opt into its behavior via the admin API, e.g. 

```
curl  --request PUT http://localhost:9644/v1/features/validated_batch_timestamps -d '{"state":"active"}'
```

[1]:
* https://github.com/redpanda-data/redpanda/issues/9820
* https://github.com/redpanda-data/redpanda/pull/12991

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Respect existing record timestamps in the past even if `broker_time_based_retention` is enabled for enforcement of time-based local retention in the `storage` layer.
