### PR TITLE
Remove //bazel/packaging:install_path

### DIFF
--- a/bazel/packaging/BUILD
+++ b/bazel/packaging/BUILD
@@ -1,4 +1,3 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load(":packaging.bzl", "native_package", "redpanda_package")
@@ -11,13 +10,6 @@ redpanda_package(
     redpanda_binary = "//:redpanda",
     rpath_override = "$ORIGIN/../lib",
     rpk_binary = "//:rpk",
-)
-
-# Flag to control the install path of the redpanda package.
-# This flag is used to set the interpret path for redpanda binary.
-string_flag(
-    name = "install_path",
-    build_setting_default = "/opt/redpanda",
 )
 
 redpanda_package(

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -557,3 +557,7 @@ class RedpandaServiceSelfTest(RedpandaTest):
         # the method in the admin API that was called to capture the backtrace
         assert "::log_backtrace" in backtrace_contents, \
             "Didn't find expected string in backtrace (see debug log for contents)"
+
+    @cluster(num_nodes=1)
+    def test_start(self):
+        pass


### PR DESCRIPTION
Finally, we can remove //bazel/packaging:install_path, as it is not being used, this is step 4 here: https://github.com/redpanda-data/redpanda/pull/27378#issue-3356217940

~This needs to wait for PR in step 3 to merge first.~ Step 3 has merged.

This pull request removes an unused Bazel flag and the addition of a basic redpanda start test in `services_self_test.py`.

Build system cleanup:

* Removed the unused `string_flag` for `install_path` from `bazel/packaging/BUILD`, simplifying the Bazel build configuration.
* Removed the import of `string_flag` from `@bazel_skylib//rules:common_settings.bzl` in `bazel/packaging/BUILD`, as it is no longer needed.

Testing:

* Added a new placeholder test method `test_start` to `tests/rptest/tests/services_self_test.py` using the `@cluster(num_nodes=1)` decorator.

Fixes [CORE-13206].

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-13206]: https://redpandadata.atlassian.net/browse/CORE-13206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ