### PR TITLE
[CORE-13129] kafka/server: fix unstable atomic token bucket unit tests

### DIFF
--- a/src/v/kafka/server/atomic_token_bucket.h
+++ b/src/v/kafka/server/atomic_token_bucket.h
@@ -78,6 +78,11 @@ public:
     /// replenished
     uint64_t rate() const { return _bucket.rate(); }
 
+    /// Returns the time point that the last replenishment happened
+    clock::time_point replenished_ts() const noexcept {
+        return _bucket.replenished_ts();
+    }
+
 private:
     template<typename delay_t>
     delay_t delay_for(uint64_t grab_result) {

--- a/src/v/kafka/server/tests/atomic_token_bucket_test.cc
+++ b/src/v/kafka/server/tests/atomic_token_bucket_test.cc
@@ -23,10 +23,24 @@ using std::chrono::milliseconds;
 // compensate for this.
 const auto epsilon = 100ms;
 
+using time_point = atomic_token_bucket::clock::time_point;
+
+namespace {
+// seastar makes use of compare_exchange_weak inside the replenish call
+// which may spuriously fail on arm. As a workaround, to ensure test stability
+// we guard against it here.
+void strong_replenish(atomic_token_bucket& bucket, const time_point& tp) {
+    while (bucket.replenished_ts() != tp) {
+        bucket.replenish(tp);
+    }
+}
+} // namespace
+
 BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_limit) {
     auto now = ss::lowres_clock::now();
 
     atomic_token_bucket bucket{10, 10, 1, true};
+    strong_replenish(bucket, now);
 
     // Observe that the bucket starts returning a positive delay proportional to
     // the bucket deficit once the limit is crossed
@@ -40,11 +54,11 @@ BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_limit) {
     BOOST_CHECK_EQUAL(1000ms, bucket.calculate_delay<milliseconds>());
 
     // "Wait" 1 second to refill by 10 units as per the bucket rate
-    bucket.replenish(now + 1s + epsilon);
+    strong_replenish(bucket, now + 1s + epsilon);
     BOOST_CHECK_EQUAL(0ms, bucket.calculate_delay<milliseconds>());
 
     // "Wait" a long time to refill the bucket as much as possible
-    bucket.replenish(now + 10s + 2 * epsilon);
+    strong_replenish(bucket, now + 10s + 2 * epsilon);
     BOOST_CHECK_EQUAL(0ms, bucket.calculate_delay<milliseconds>());
     bucket.record(11);
     BOOST_CHECK_EQUAL(100ms, bucket.calculate_delay<milliseconds>());
@@ -54,6 +68,7 @@ BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_start_full) {
     // start_full=true should ensure that we start with a bucket filled up to
     // the limit
     atomic_token_bucket full_bucket{10, 10, 1, true};
+    strong_replenish(full_bucket, ss::lowres_clock::now());
 
     full_bucket.record(10 + 1);
     BOOST_CHECK_EQUAL(100ms, full_bucket.calculate_delay<milliseconds>());
@@ -67,7 +82,7 @@ BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_start_full) {
     empty_bucket.record(10 + 1);
     BOOST_CHECK_EQUAL(1100ms, empty_bucket.calculate_delay<milliseconds>());
 
-    empty_bucket.replenish(now + 1100ms + 1s + epsilon);
+    strong_replenish(empty_bucket, now + 1100ms + 1s + epsilon);
     BOOST_CHECK_EQUAL(0ms, empty_bucket.calculate_delay<milliseconds>());
 
     empty_bucket.record(10 + 1);
@@ -77,23 +92,26 @@ BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_start_full) {
 BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_threshold) {
     auto now = ss::lowres_clock::now();
     atomic_token_bucket bucket{10, 10, 10, true};
+    strong_replenish(bucket, now);
 
     bucket.record(10 + 1);
     BOOST_CHECK_EQUAL(100ms, bucket.calculate_delay<milliseconds>());
 
     // Replenishing before we have the threshold's worth of tokens
-    // re-accumulated should have no effect
+    // re-accumulated should have no effect. Since the replenished_ts is not
+    // updated, the strong_replenish workaround can't be used here.
     bucket.replenish(now + 100ms + epsilon);
     BOOST_CHECK_EQUAL(100ms, bucket.calculate_delay<milliseconds>());
 
     // Replenishing once we are above the threshold updates the deficit
-    bucket.replenish(now + 1s + 2 * epsilon);
+    strong_replenish(bucket, now + 1s + 2 * epsilon);
     BOOST_CHECK_EQUAL(0ms, bucket.calculate_delay<milliseconds>());
 }
 
 BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_burst) {
     auto now = ss::lowres_clock::now();
     atomic_token_bucket bucket{10, 100, 1, true};
+    strong_replenish(bucket, now);
 
     // There should be no limit applied until the burst capacity is reached
     bucket.record(11);
@@ -106,9 +124,9 @@ BOOST_AUTO_TEST_CASE(test_atomic_token_bucket_burst) {
     BOOST_CHECK_EQUAL(200ms, bucket.calculate_delay<milliseconds>());
 
     // The bucket gets refilled based on the rate, up to the burst capacity
-    bucket.replenish(now + 200ms + epsilon);
+    strong_replenish(bucket, now + 200ms + epsilon);
     BOOST_CHECK_EQUAL(0ms, bucket.calculate_delay<milliseconds>());
-    bucket.replenish(now + 10s + 2 * epsilon);
+    strong_replenish(bucket, now + 10s + 2 * epsilon);
     bucket.record(100);
     BOOST_CHECK_EQUAL(0ms, bucket.calculate_delay<milliseconds>());
 }


### PR DESCRIPTION
Fixes: [CORE-13129](https://redpandadata.atlassian.net/browse/CORE-13129)

The atomic token bucket unit tests seem to be unstable due to spurious failures inside the replenish call. A utility to protect against such failures is added in the unit tests to fix flackyness.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-13129]: https://redpandadata.atlassian.net/browse/CORE-13129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ