### PR TITLE
dt/data_migrations_api_test: prevent timeouts and add logging

### DIFF
--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -795,7 +795,9 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                     try:
                         with self.ck_consumer(group) as consumer:
                             consumer.subscribe([topic])
+                            self.logger.debug("start polling consumer")
                             msg = consumer.poll(20)
+                            self.logger.debug("done polling consumer")
                             if msg is None or msg.error() is not None:
                                 raise ck.KafkaException(
                                     f"Failed to read from topic {topic} "
@@ -803,6 +805,9 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                                 )
                         break
                     except ck.KafkaException as e:
+                        self.logger.debug(
+                            f"exception when polling consumer: {e} (full exception follows)",
+                            exc_info=True)
                         if "Failed to fetch committed offsets for 0 partition" \
                                 in str(e.args[0]):
                             self.logger.info(

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -798,15 +798,17 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                             msg = consumer.poll(20)
                             if msg is None or msg.error() is not None:
                                 raise ck.KafkaException(
-                                    f"Failed to read from topic {topic} with group {group}: {msg and msg.error()}"
+                                    f"Failed to read from topic {topic} "
+                                    f"with group {group}: {msg and msg.error()}"
                                 )
                         break
                     except ck.KafkaException as e:
-                        if "Failed to fetch committed offsets for 0 partition" in str(
-                                e.args[0]):
+                        if "Failed to fetch committed offsets for 0 partition" \
+                                in str(e.args[0]):
                             self.logger.info(
-                                f"Hit https://github.com/confluentinc/librdkafka/issues/4963 bug, retrying"
-                            )
+                                "Hit "
+                                "https://github.com/confluentinc/librdkafka/issues/4963 "
+                                "bug, retrying")
                             continue
                         raise
 

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -730,6 +730,11 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
         consumer.start(clean=False)
         return consumer
 
+    class OperationValidationException(Exception):
+        """Indicates operation validation neither failed nor succeeded
+        but is not complete."""
+        pass
+
     def _do_validate_operation(self, topic: str | None, group: str | None,
                                op_name: str, expected_to_pass: bool | None,
                                operation: Callable[[str | None, str | None],
@@ -741,12 +746,14 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                          f" against {topic=} {group=}")
         try:
             result = operation(topic, group)
+        except DataMigrationsApiTest.OperationValidationException:
+            raise
         except Exception as e:
             self.logger.info(
                 f"Operation {op_name} executed against"
                 f" {topic=} {group=} failed - {e} (full exception follows)",
                 exc_info=True)
-            result = False  # assume real op cannot return False
+            result = False
         success = result is not False
 
         assert expected_to_pass == success, f"Operation {op_name} outcome is not " \
@@ -791,7 +798,8 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
         if group is not None:
 
             def read_with_group(topic, group):
-                while True:
+                def try_once():
+                    """ returns True if success, False to retry, throws on failure """
                     try:
                         with self.ck_consumer(group) as consumer:
                             consumer.subscribe([topic])
@@ -803,7 +811,7 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                                     f"Failed to read from topic {topic} "
                                     f"with group {group}: {msg and msg.error()}"
                                 )
-                        break
+                        return True
                     except ck.KafkaException as e:
                         self.logger.debug(
                             f"exception when polling consumer: {e} (full exception follows)",
@@ -814,8 +822,14 @@ class DataMigrationsApiTest(RedpandaTest, DataMigrationTestMixin):
                                 "Hit "
                                 "https://github.com/confluentinc/librdkafka/issues/4963 "
                                 "bug, retrying")
-                            continue
+                            return False
                         raise
+
+                try:
+                    wait_until(try_once, timeout_sec=120, backoff_sec=1)
+                    return True
+                except ducktape.errors.TimeoutError as e:
+                    raise DataMigrationsApiTest.OperationValidationException(e)
 
             self._do_validate_operation(**entities,
                                         op_name="read_with_group",


### PR DESCRIPTION
`read_with_group` function had a potentially indefinite loop. Limit it with 120+20 seconds and add logging to track individual Consumer.poll() calls

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
