### PR TITLE
ct/l1/metastore: Add object size

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -211,6 +211,7 @@ domain_manager::get_first_offset_ge(rpc::get_first_offset_ge_request req) {
         .object = rpc::object_metadata{
             .oid = obj.oid,
             .footer_pos = obj.footer_pos,
+            .object_size = obj.object_size,
         },
     };
 }
@@ -243,6 +244,7 @@ domain_manager::get_first_timestamp_ge(
         .object = rpc::object_metadata{
             .oid = obj.oid,
             .footer_pos = obj.footer_pos,
+            .object_size = obj.object_size,
         },
     };
 }

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -71,11 +71,13 @@ public:
 
         object_id oid;
         size_t footer_pos;
+        size_t object_size;
         ntp_metas_list_t ntp_metas;
     };
     struct object_response {
         object_id oid;
         size_t footer_pos;
+        size_t object_size;
     };
 
     // Interface to build object metadata for the L1 metastore. Meant to be
@@ -102,7 +104,7 @@ public:
         // Tracks the given object as finished. Further calls to
         // get_or_create_object_for() will not return the finished object ID.
         virtual std::expected<void, error>
-        finish(object_id, size_t footer_pos) = 0;
+        finish(object_id, size_t footer_pos, size_t object_size) = 0;
     };
 
     struct offsets_response {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -42,6 +42,7 @@ new_object meta_to_rpc_obj(const metastore::object_metadata& obj) {
     new_object rpc_obj;
     rpc_obj.oid = obj.oid;
     rpc_obj.footer_pos = obj.footer_pos;
+    rpc_obj.object_size = obj.object_size;
 
     for (const auto& ntp_meta : obj.ntp_metas) {
         auto& topic_map = rpc_obj.extent_metas[ntp_meta.tidp.topic_id];
@@ -93,7 +94,8 @@ public:
     get_or_create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error>
       add(object_id, metastore::object_metadata::ntp_metadata) override;
-    std::expected<void, error> finish(object_id, size_t footer_pos) override;
+    std::expected<void, error>
+    finish(object_id, size_t footer_pos, size_t object_size) override;
 
 private:
     friend class cloud_topics::l1::replicated_metastore;
@@ -144,7 +146,8 @@ replicated_object_builder::add(
 }
 
 std::expected<void, replicated_object_builder::error>
-replicated_object_builder::finish(object_id oid, size_t footer_pos) {
+replicated_object_builder::finish(
+  object_id oid, size_t footer_pos, size_t object_size) {
     auto p_it = std::find_if(
       partitions_.begin(), partitions_.end(), [oid](auto& p) {
           return p.second.pending_objects_.contains(oid);
@@ -163,6 +166,7 @@ replicated_object_builder::finish(object_id oid, size_t footer_pos) {
       metastore::object_metadata{
         .oid = oid,
         .footer_pos = footer_pos,
+        .object_size = object_size,
         .ntp_metas = std::move(it->second),
       });
     objects.pending_objects_.erase(it);
@@ -386,6 +390,7 @@ replicated_metastore::get_first_ge(
     metastore::object_response resp;
     resp.oid = reply.object.oid;
     resp.footer_pos = reply.object.footer_pos;
+    resp.object_size = reply.object.object_size;
     co_return resp;
 }
 
@@ -412,6 +417,7 @@ replicated_metastore::get_first_ge(
     metastore::object_response resp;
     resp.oid = reply.object.oid;
     resp.footer_pos = reply.object.footer_pos;
+    resp.object_size = reply.object.object_size;
     co_return resp;
 }
 

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -86,10 +86,11 @@ struct replace_objects_request
 struct object_metadata
   : serde::
       envelope<object_metadata, serde::version<0>, serde::compat_version<0>> {
-    auto serde_fields() { return std::tie(oid, footer_pos); }
+    auto serde_fields() { return std::tie(oid, footer_pos, object_size); }
 
     object_id oid;
     size_t footer_pos;
+    size_t object_size;
 };
 
 struct get_first_offset_ge_reply

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -59,7 +59,8 @@ simple_object_builder::add(
 }
 
 std::expected<void, metastore::object_metadata_builder::error>
-simple_object_builder::finish(object_id oid, size_t footer_pos) {
+simple_object_builder::finish(
+  object_id oid, size_t footer_pos, size_t object_size) {
     auto it = pending_objects_.find(oid);
     if (it == pending_objects_.end()) {
         return std::unexpected(
@@ -69,6 +70,7 @@ simple_object_builder::finish(object_id oid, size_t footer_pos) {
       metastore::object_metadata{
         .oid = oid,
         .footer_pos = footer_pos,
+        .object_size = object_size,
         .ntp_metas = std::move(it->second),
       });
     pending_objects_.erase(it);
@@ -91,6 +93,7 @@ new_object make_new_object(const metastore::object_metadata& o) {
     new_object new_o{
       .oid = o.oid,
       .footer_pos = o.footer_pos,
+      .object_size = o.object_size,
     };
     for (const auto& c : o.ntp_metas) {
         auto& extents = new_o.extent_metas[c.tidp.topic_id];
@@ -239,9 +242,11 @@ simple_metastore::get_first_ge(
             return std::unexpected(metastore::errc::out_of_range);
         }
         auto footer_pos = object_it->second.footer_pos;
+        auto object_size = object_it->second.object_size;
         return metastore::object_response{
           .oid = it->oid,
           .footer_pos = footer_pos,
+          .object_size = object_size,
         };
     }
     return std::unexpected(metastore::errc::out_of_range);
@@ -271,9 +276,11 @@ simple_metastore::get_first_ge(
                 return std::unexpected(metastore::errc::out_of_range);
             }
             auto footer_pos = object_it->second.footer_pos;
+            auto object_size = object_it->second.object_size;
             return metastore::object_response{
               .oid = obj.oid,
               .footer_pos = footer_pos,
+              .object_size = object_size,
             };
         }
     }

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -32,7 +32,8 @@ public:
     get_or_create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error>
       add(object_id, metastore::object_metadata::ntp_metadata) override;
-    std::expected<void, error> finish(object_id, size_t footer_pos) override;
+    std::expected<void, error>
+    finish(object_id, size_t footer_pos, size_t object_size) override;
 
     std::expected<chunked_vector<metastore::object_metadata>, error> release();
 

--- a/src/v/cloud_topics/level_one/metastore/state.h
+++ b/src/v/cloud_topics/level_one/metastore/state.h
@@ -235,11 +235,13 @@ struct object_entry
       envelope<object_entry, serde::version<0>, serde::compat_version<0>> {
     friend bool operator==(const object_entry&, const object_entry&) = default;
     auto serde_fields() {
-        return std::tie(total_data_size, removed_data_size, footer_pos);
+        return std::tie(
+          total_data_size, removed_data_size, footer_pos, object_size);
     }
     size_t total_data_size{0};
     size_t removed_data_size{0};
     size_t footer_pos{0};
+    size_t object_size{0};
 };
 
 // Tracks the state of each topic revision.

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -233,6 +233,7 @@ add_objects_update::apply(state& state) {
             .total_data_size = 0,
             .removed_data_size = 0,
             .footer_pos = o.footer_pos,
+            .object_size = o.object_size,
           });
     }
     for (const auto& [tidp, extents] : extents_by_tp) {
@@ -464,6 +465,7 @@ replace_objects_update::apply(state& state) {
             .total_data_size = 0,
             .removed_data_size = 0,
             .footer_pos = o.footer_pos,
+            .object_size = o.object_size,
           });
     }
     for (const auto& [tidp, new_extents] : new_extents_by_tp) {

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -48,10 +48,13 @@ struct new_object
     };
 
     friend bool operator==(const new_object&, const new_object&) = default;
-    auto serde_fields() { return std::tie(oid, extent_metas); }
+    auto serde_fields() {
+        return std::tie(oid, footer_pos, object_size, extent_metas);
+    }
 
     object_id oid;
     size_t footer_pos;
+    size_t object_size;
     chunked_hash_map<
       model::topic_id,
       chunked_hash_map<model::partition_id, metadata>>

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -63,7 +63,7 @@ public:
                 .size = 500,
               });
             ASSERT_TRUE(add_res.has_value()) << add_res.error();
-            auto fin_res = ret->finish(oid, 500);
+            auto fin_res = ret->finish(oid, 500, 1000);
             ASSERT_TRUE(fin_res.has_value()) << fin_res.error();
         }
         *objs = std::move(ret);
@@ -320,7 +320,7 @@ TEST_F(ReplicatedMetastoreTest, TestNotLeader) {
             .size = 500,
           });
         ASSERT_TRUE(add_res.has_value()) << add_res.error();
-        auto fin_res = obj_builder->finish(oid, 500);
+        auto fin_res = obj_builder->finish(oid, 500, 1000);
         ASSERT_TRUE(fin_res.has_value()) << fin_res.error();
 
         metastore::term_offset_map_t terms;
@@ -416,7 +416,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetTermForOffset) {
         .size = 500,
       });
     ASSERT_TRUE(add_res1.has_value()) << add_res1.error();
-    auto fin_res1 = obj_builder->finish(oid1, 500);
+    auto fin_res1 = obj_builder->finish(oid1, 500, 1000);
     ASSERT_TRUE(fin_res1.has_value()) << fin_res1.error();
 
     // Add a couple terms.
@@ -475,7 +475,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
         .size = 500,
       });
     ASSERT_TRUE(add_res1.has_value()) << add_res1.error();
-    auto fin_res1 = obj_builder->finish(oid1, 500);
+    auto fin_res1 = obj_builder->finish(oid1, 500, 1000);
     ASSERT_TRUE(fin_res1.has_value()) << fin_res1.error();
 
     // Add a couple terms.

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -64,9 +64,10 @@ using om_list_t = chunked_vector<metastore::object_metadata>;
 using cmap_t = metastore::compaction_map_t;
 class om_builder {
 public:
-    om_builder(object_id oid, size_t footer_pos) {
+    om_builder(object_id oid, size_t footer_pos, size_t object_size) {
         out.oid = oid;
         out.footer_pos = footer_pos;
+        out.object_size = object_size;
     }
     om_builder& add(
       std::string_view tpr_str,
@@ -140,7 +141,7 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
     ASSERT_FALSE(get_res.has_value());
     ASSERT_EQ(metastore::errc::missing_ntp, get_res.error());
 
-    auto ometa = om_builder(oid1, 200)
+    auto ometa = om_builder(oid1, 200, 1200)
                    .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                    .add(tid_b, 0_o, 10_o, 2000_t, 100, 199)
                    .build();
@@ -175,13 +176,15 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
     ASSERT_TRUE(get_res.has_value()) << int(get_res.error());
     ASSERT_EQ(get_res->oid, oid1);
     ASSERT_EQ(get_res->footer_pos, 200);
+    ASSERT_EQ(get_res->object_size, 1200);
 }
 
 TEST(SimpleMetastoreTest, TestAddWithGap) {
     simple_metastore m;
     {
-        auto ometa
-          = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+        auto ometa = om_builder(oid1, 100, 1100)
+                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                       .build();
         auto add_res = m.add_objects(
                           om_list_t::single(std::move(ometa)),
                           terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -198,8 +201,9 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
 
     {
         // Add another object just past where we expect it.
-        auto ometa
-          = om_builder(oid2, 100).add(tid_a, 12_o, 20_o, 2000_t, 0, 99).build();
+        auto ometa = om_builder(oid2, 100, 1100)
+                       .add(tid_a, 12_o, 20_o, 2000_t, 0, 99)
+                       .build();
         auto add_res = m.add_objects(
                           om_list_t::single(std::move(ometa)),
                           terms_builder().add(tid_a, 0_tm, 12_o).build())
@@ -216,8 +220,9 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
     }
 
     // Now add the object right at the end, where it should be.
-    auto ometa
-      = om_builder(oid3, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid3, 100, 1100)
+                   .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 11_o).build())
@@ -235,8 +240,9 @@ TEST(SimpleMetastoreTest, TestAddWithGap) {
 TEST(SimpleMetastoreTest, TestAddWithOverlap) {
     simple_metastore m;
     {
-        auto ometa
-          = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+        auto ometa = om_builder(oid1, 100, 1100)
+                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                       .build();
         auto add_res = m.add_objects(
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)),
@@ -248,8 +254,9 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
 
     {
         // Add another object just below where we expect it.
-        auto ometa
-          = om_builder(oid2, 100).add(tid_a, 10_o, 20_o, 2000_t, 0, 99).build();
+        auto ometa = om_builder(oid2, 100, 1100)
+                       .add(tid_a, 10_o, 20_o, 2000_t, 0, 99)
+                       .build();
         auto add_res = m.add_objects(
                           chunked_vector<metastore::object_metadata>::single(
                             std::move(ometa)),
@@ -260,8 +267,9 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
     }
     {
         // Add another object that fully overlaps with what exists.
-        auto ometa
-          = om_builder(oid3, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+        auto ometa = om_builder(oid3, 100, 1100)
+                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                       .build();
         auto add_res = m.add_objects(
                           om_list_t::single(std::move(ometa)),
                           terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -274,8 +282,9 @@ TEST(SimpleMetastoreTest, TestAddWithOverlap) {
 TEST(SimpleMetastoreTest, TestAddPastBeginning) {
     simple_metastore m;
     // Add the first object so it doesn't start at 0.
-    auto ometa
-      = om_builder(oid1, 100).add(tid_a, 1_o, 10_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 1_o, 10_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -288,11 +297,13 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 21_o, 30_o, 2000_t, 0, 99)
+                      .build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -304,25 +315,29 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     for (const auto& o : std::views::iota(11, 21)) {
         auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     for (const auto& o : std::views::iota(21, 31)) {
         auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
 }
 
 TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     simple_metastore m;
-    auto ometa
-      = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -336,12 +351,14 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     ASSERT_TRUE(get_res.has_value());
     ASSERT_EQ(get_res->oid, oid1);
     ASSERT_EQ(get_res->footer_pos, 100);
+    ASSERT_EQ(get_res->object_size, 1100);
 }
 
 TEST(SimpleMetastoreTest, TestAddGetOffsetOutOfRange) {
     simple_metastore m;
-    auto ometa
-      = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -360,11 +377,13 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 1999_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2999_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 3999_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 1999_t, 0, 99).build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 11_o, 20_o, 2999_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 21_o, 30_o, 3999_t, 0, 99)
+                      .build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -376,25 +395,29 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     for (const auto& t : {2000_t, 2999_t}) {
         auto get_res = m.get_first_ge(tpr, t).get();
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     for (const auto& t : {3000_t, 3999_t}) {
         auto get_res = m.get_first_ge(tpr, t).get();
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
 }
 
 TEST(SimpleMetastoreTest, TestAddGetTimestampBelowStart) {
     simple_metastore m;
-    auto ometa
-      = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -410,8 +433,9 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBelowStart) {
 
 TEST(SimpleMetastoreTest, TestAddGetTimestampOutOfRange) {
     simple_metastore m;
-    auto ometa
-      = om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid1, 100, 1100)
+                   .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder().add(tid_a, 0_tm, 0_o).build())
@@ -429,7 +453,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -437,7 +461,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
 
     om_list_t new_os;
     new_os.emplace_back(
-      om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid2, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto replace_res = m.replace_objects(new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
@@ -452,11 +476,11 @@ TEST(StateUpdateTest, TestReplaceBasic) {
 TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
     simple_metastore m;
     om_list_t os;
-    os.emplace_back(om_builder(oid1, 100)
+    os.emplace_back(om_builder(oid1, 100, 1100)
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
-    os.emplace_back(om_builder(oid2, 100)
+    os.emplace_back(om_builder(oid2, 100, 1100)
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
@@ -469,7 +493,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
 
     om_list_t new_os;
     new_os.emplace_back(
-      om_builder(oid3, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+      om_builder(oid3, 100, 1100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
     auto replace_res = m.replace_objects(new_os).get();
     ASSERT_TRUE(replace_res.has_value());
 
@@ -480,6 +504,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     // Others should be served from oid1 or oid2.
     tpr = model::topic_id_partition::from(tid_b);
@@ -488,12 +513,14 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     for (const auto& o : std::views::iota(11, 21)) {
         auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     // Sanity check that replacement leaves us with expected offsets.
     for (const auto& tid : {tid_a, tid_b}) {
@@ -508,11 +535,11 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
 TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
     simple_metastore m;
     om_list_t os;
-    os.emplace_back(om_builder(oid1, 100)
+    os.emplace_back(om_builder(oid1, 100, 1100)
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
-    os.emplace_back(om_builder(oid2, 100)
+    os.emplace_back(om_builder(oid2, 100, 1100)
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
@@ -527,7 +554,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
     // For one partition, replace the entire range. For another, replace part
     // of the range. As long as they're both aligned this should succeed.
     om_list_t new_os;
-    new_os.emplace_back(om_builder(oid3, 100)
+    new_os.emplace_back(om_builder(oid3, 100, 1100)
                           .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
                           .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                           .build());
@@ -541,6 +568,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     tpr = model::topic_id_partition::from(tid_b);
     for (const auto& o : std::views::iota(11, 21)) {
@@ -548,6 +576,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     // Others should be served from oid1 or oid2.
     for (const auto& o : std::views::iota(0, 11)) {
@@ -555,6 +584,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_TRUE(get_res.has_value());
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
+        ASSERT_EQ(get_res->object_size, 1100);
     }
     // Sanity check that replacement leaves us with expected offsets.
     for (const auto& tid : {tid_a, tid_b}) {
@@ -570,7 +600,7 @@ TEST(StateUpdateTest, TestReplaceEmptyRequest) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -594,8 +624,9 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
     {
         // Now try with an actual object. It should be rejected.
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid1, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -606,7 +637,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -615,7 +646,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
          std::initializer_list<std::pair<kafka::offset, kafka::offset>>{
            {0_o, 11_o}, {1_o, 11_o}, {1_o, 10_o}, {1_o, 9_o}}) {
         om_list_t new_os;
-        new_os.emplace_back(om_builder(oid2, 100)
+        new_os.emplace_back(om_builder(oid2, 100, 1100)
                               .add(tid_a, base_o, last_o, 2000_t, 0, 99)
                               .build());
         auto replace_res = m.replace_objects(new_os).get();
@@ -628,7 +659,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -637,7 +668,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
         // Even though one extent overlaps, the complete range for tid_a does
         // not align.
         om_list_t new_os;
-        new_os.emplace_back(om_builder(oid2, 100)
+        new_os.emplace_back(om_builder(oid2, 100, 1100)
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_a, 11_o, 12_o, 2000_t, 0, 99)
                               .build());
@@ -648,7 +679,7 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
     {
         // Even though tid_a overlaps exactly, tid_b does not exist.
         om_list_t new_os;
-        new_os.emplace_back(om_builder(oid2, 100)
+        new_os.emplace_back(om_builder(oid2, 100, 1100)
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                               .build());
@@ -661,11 +692,11 @@ TEST(StateUpdateTest, TestReplaceOneWithMultipleMisaligned) {
 TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
     simple_metastore m;
     om_list_t os;
-    os.emplace_back(om_builder(oid1, 100)
+    os.emplace_back(om_builder(oid1, 100, 1100)
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
-    os.emplace_back(om_builder(oid2, 100)
+    os.emplace_back(om_builder(oid2, 100, 1100)
                       .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
                       .add(tid_b, 11_o, 20_o, 2000_t, 0, 99)
                       .build());
@@ -678,8 +709,9 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
 
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid3, 100).add(tid_a, 0_o, 19_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid3, 100, 1100)
+                              .add(tid_a, 0_o, 19_o, 2000_t, 0, 99)
+                              .build());
         auto replace_res = m.replace_objects(new_os).get();
         ASSERT_FALSE(replace_res.has_value());
         EXPECT_EQ(replace_res.error(), metastore::errc::invalid_request);
@@ -687,7 +719,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMisaligned) {
     {
         // Even though tid_a overlaps exactly, tid_b is misaligned.
         om_list_t new_os;
-        new_os.emplace_back(om_builder(oid3, 100)
+        new_os.emplace_back(om_builder(oid3, 100, 1100)
                               .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                               .add(tid_b, 0_o, 19_o, 2000_t, 0, 99)
                               .build());
@@ -701,7 +733,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsMissingPartition) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_b, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_b, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_b, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -717,7 +749,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsMissingPartition) {
 TEST(SimpleMetastoreTest, TestCompactionOffsetsAllDirty) {
     simple_metastore m;
     om_list_t os;
-    os.emplace_back(om_builder(oid1, 100)
+    os.emplace_back(om_builder(oid1, 100, 1100)
                       .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
                       .add(tid_b, 0_o, 10_o, 2000_t, 0, 99)
                       .build());
@@ -742,7 +774,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -750,8 +782,9 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     // Simple compaction to clean offsets [3, 5].
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid2, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 3_o, 5_o, 3000_t);
@@ -793,8 +826,9 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     // Now perform another replacement and remove some tombstones.
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid3, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid3, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 2_o);
@@ -816,8 +850,9 @@ TEST(SimpleMetastoreTest, TestCompactionOffsets) {
     // Remove the rest of the tombstones and dirty ranges.
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid4, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid4, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 10_o);
@@ -838,7 +873,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -846,8 +881,9 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     // Simple compaction to clean offsets [3, 5].
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid2, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid2, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 3_o, 5_o);
@@ -888,8 +924,9 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     // Now perform another replacement.
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid3, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid3, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 0_o, 2_o);
@@ -909,8 +946,9 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
     // Remove the rest of the dirty ranges.
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid4, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid4, 100, 1100)
+                              .add(tid_a, 0_o, 10_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 6_o, 10_o);
@@ -948,14 +986,14 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
     ASSERT_TRUE(ob->add(o_a, {}).has_value());
 
     // Finish the current object. The next object will be different.
-    ASSERT_TRUE(ob->finish(o_a, 0).has_value());
+    ASSERT_TRUE(ob->finish(o_a, 0, 1000).has_value());
 
     auto o_a_3 = ob->get_or_create_object_for(tp_a);
     ASSERT_NE(o_a_2, o_a_3);
 
     // We can't release the result until we finish all objects.
     ASSERT_FALSE(dynamic_cast<simple_object_builder*>(ob.get())->release());
-    ASSERT_TRUE(ob->finish(o_a_3, 0).has_value());
+    ASSERT_TRUE(ob->finish(o_a_3, 0, 1000).has_value());
 
     auto release_res
       = dynamic_cast<simple_object_builder*>(ob.get())->release();
@@ -972,7 +1010,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
     auto add_res = ob->add(create_object_id(), {});
     ASSERT_FALSE(add_res.has_value());
 
-    auto finish_res = ob->finish(create_object_id(), 0);
+    auto finish_res = ob->finish(create_object_id(), 0, 1000);
     ASSERT_FALSE(finish_res.has_value());
 
     // Both operations failed -- the builder should be empty.
@@ -999,7 +1037,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
             .size = 0,
           });
         ASSERT_TRUE(add_res.has_value());
-        auto fin_res = ob->finish(o_a, 0);
+        auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
         auto add_obj_res = m.add_objects(
                               std::move(ob),
@@ -1026,7 +1064,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
             .size = 0,
           });
         ASSERT_TRUE(add_res.has_value());
-        auto fin_res = ob->finish(o_a, 0);
+        auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
         auto add_obj_res = m.add_objects(
                               std::move(ob),
@@ -1053,7 +1091,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
             .size = 0,
           });
         ASSERT_TRUE(add_res.has_value());
-        auto fin_res = ob->finish(o_a, 0);
+        auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
         auto replace_obj_res = m.replace_objects(std::move(ob)).get();
         ASSERT_TRUE(replace_obj_res.has_value());
@@ -1077,7 +1115,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
             .size = 0,
           });
         ASSERT_TRUE(add_res.has_value());
-        auto fin_res = ob->finish(o_a, 0);
+        auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
 
         cm_builder cmb;
@@ -1101,7 +1139,7 @@ TEST(SimpleMetastoreState, TestInvalidTermRequest) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
     // Make the term misaligned with the extent.
     auto add_res = m.add_objects(
                       os, terms_builder().add(tid_a, 0_tm, 1337_o).build())
@@ -1112,8 +1150,9 @@ TEST(SimpleMetastoreState, TestInvalidTermRequest) {
 
 TEST(SimpleMetastoreTest, TestEndOffsetForEpoch) {
     simple_metastore m;
-    auto ometa
-      = om_builder(oid1, 200).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build();
+    auto ometa = om_builder(oid1, 200, 1200)
+                   .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
+                   .build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder()
@@ -1168,7 +1207,7 @@ TEST(SimpleMetastoreTest, TestEndOffsetForEpoch) {
 TEST(SimpleMetastoreTest, TestEpochForOffset) {
     simple_metastore m;
     auto ometa
-      = om_builder(oid1, 200).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
+      = om_builder(oid1, 200, 1200).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder()
@@ -1223,11 +1262,13 @@ TEST(SimpleMetastoreTest, TestSetStartAlignedWithExtent) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 21_o, 30_o, 2000_t, 0, 99)
+                      .build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1264,11 +1305,13 @@ TEST(SimpleMetastoreTest, TestSetStartNotAlignedWithExtent) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid2, 100).add(tid_a, 11_o, 20_o, 2000_t, 0, 99).build());
-    os.emplace_back(
-      om_builder(oid3, 100).add(tid_a, 21_o, 30_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 10_o, 2000_t, 0, 99).build());
+    os.emplace_back(om_builder(oid2, 100, 1100)
+                      .add(tid_a, 11_o, 20_o, 2000_t, 0, 99)
+                      .build());
+    os.emplace_back(om_builder(oid3, 100, 1100)
+                      .add(tid_a, 21_o, 30_o, 2000_t, 0, 99)
+                      .build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1305,7 +1348,7 @@ TEST(SimpleMetastoreTest, TestSetStartNotAlignedWithExtent) {
 TEST(SimpleMetastoreTest, TestSetStartEmptyWithTerms) {
     simple_metastore m;
     auto ometa
-      = om_builder(oid1, 100).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
+      = om_builder(oid1, 100, 1100).add(tid_a, 0_o, 9_o, 2000_t, 0, 99).build();
     auto add_res = m.add_objects(
                       om_list_t::single(std::move(ometa)),
                       terms_builder()
@@ -1345,7 +1388,7 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
     simple_metastore m;
     om_list_t os;
     os.emplace_back(
-      om_builder(oid1, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+      om_builder(oid1, 100, 1100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
     auto add_res
       = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
     ASSERT_TRUE(add_res.has_value());
@@ -1353,8 +1396,9 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
     // Clean range is [5, 15].
     {
         om_list_t new_os;
-        new_os.emplace_back(
-          om_builder(oid2, 100).add(tid_a, 0_o, 20_o, 2000_t, 0, 99).build());
+        new_os.emplace_back(om_builder(oid2, 100, 1100)
+                              .add(tid_a, 0_o, 20_o, 2000_t, 0, 99)
+                              .build());
 
         auto cmb = cm_builder();
         cmb.clean(tid_a, 5_o, 15_o, 3000_t);

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -43,9 +43,10 @@ model::term_id operator""_tm(unsigned long long t) {
 
 class new_obj_builder {
 public:
-    new_obj_builder(object_id oid, size_t footer_pos) {
+    new_obj_builder(object_id oid, size_t footer_pos, size_t object_size) {
         out.oid = oid;
         out.footer_pos = footer_pos;
+        out.object_size = object_size;
     }
     new_obj_builder(const new_obj_builder&) = delete;
     new_obj_builder(new_obj_builder&&) = default;
@@ -133,7 +134,7 @@ TEST(StateUpdateTest, TestAddBasic) {
     state s;
     {
         auto update = add_objects_builder()
-                        .add(new_obj_builder(oid1, 100)
+                        .add(new_obj_builder(oid1, 100, 1100)
                                .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                                .build())
@@ -147,7 +148,7 @@ TEST(StateUpdateTest, TestAddBasic) {
     }
     {
         auto update = add_objects_builder()
-                        .add(new_obj_builder(oid2, 100)
+                        .add(new_obj_builder(oid2, 100, 1100)
                                .add(tidp_c, 0_o, 10_o, 1999_t, 0, 99)
                                .add(tidp_b, 11_o, 20_o, 1999_t, 100, 199)
                                .build())
@@ -164,10 +165,10 @@ TEST(StateUpdateTest, TestAddBasic) {
 TEST(StateUpdateTest, TestDuplicateAddSingleUpdate) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
-                    .add(new_obj_builder(oid2, 100)
+                    .add(new_obj_builder(oid2, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 0_tm, 0_o)
@@ -182,7 +183,7 @@ TEST(StateUpdateTest, TestDuplicateAddSingleUpdate) {
 
 TEST(StateUpdateTest, TestStartAfterZero) {
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 0_tm, 11_o)
@@ -200,7 +201,7 @@ TEST(StateUpdateTest, TestStartAfterZero) {
 
 TEST(StateUpdateTest, TestDuplicateObject) {
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                            .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
@@ -226,7 +227,7 @@ TEST(StateUpdateTest, TestDuplicateObject) {
 
 TEST(StateUpdateTest, TestDuplicateAddMultipleUpdates) {
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                            .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
@@ -265,7 +266,7 @@ TEST(StateUpdateTest, TestOverlapSomePartitions) {
     state s;
     {
         auto update = add_objects_builder()
-                        .add(new_obj_builder(oid1, 100)
+                        .add(new_obj_builder(oid1, 100, 1100)
                                .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                                .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                                .build())
@@ -285,7 +286,7 @@ TEST(StateUpdateTest, TestOverlapSomePartitions) {
     // Now send a bogus range for one of the partitions, but a correct extent
     // for another.
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid2, 100)
+                    .add(new_obj_builder(oid2, 100, 1100)
                            .add(tidp_a, 1337_o, 1337_o, 1999_t, 0, 5)
                            .add(tidp_b, 11_o, 20_o, 1999_t, 100, 199)
                            .build())
@@ -330,12 +331,12 @@ MATCHER_P2(MatchesTermStart, term, offset, "") {
 TEST(StateUpdateTest, TestReplaceBasic) {
     using testing::ElementsAre;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
                         .build())
-                 .add(new_obj_builder(oid2, 100)
+                 .add(new_obj_builder(oid2, 100, 1100)
                         .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                         .add(tidp_c, 11_o, 20_o, 1999_t, 0, 99)
                         .build())
@@ -349,7 +350,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
 
     // Fully replace partition a, partially replace c.
     auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid3, 100)
+                     .add(new_obj_builder(oid3, 100, 1100)
                             .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
                             .add(tidp_c, 0_o, 10_o, 1999_t, 100, 199)
                             .build())
@@ -384,7 +385,7 @@ TEST(StateUpdateTest, TestReplaceBasic) {
 TEST(StateUpdateTest, TestReplaceEmptyState) {
     state s;
     auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid1, 100)
+                     .add(new_obj_builder(oid1, 100, 1100)
                             .add(tidp_a, 0_o, 20_o, 1999_t, 0, 99)
                             .build())
                      .build();
@@ -399,7 +400,7 @@ TEST(StateUpdateTest, TestReplaceEmptyState) {
 TEST(StateUpdateTest, TestReplaceDuplicate) {
     using testing::ElementsAre;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 100)
+                 .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
@@ -409,7 +410,7 @@ TEST(StateUpdateTest, TestReplaceDuplicate) {
     ASSERT_TRUE(add_res.has_value());
 
     auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid1, 100)
+                     .add(new_obj_builder(oid1, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
                      .build();
@@ -424,7 +425,7 @@ TEST(StateUpdateTest, TestReplaceDuplicate) {
 TEST(StateUpdateTest, TestReplaceMisaligned) {
     using testing::ElementsAre;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 100)
+                 .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
@@ -434,7 +435,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
     ASSERT_TRUE(add_res.has_value());
 
     auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid2, 100)
+                     .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 9_o, 1999_t, 0, 99)
                             .build())
                      .build();
@@ -450,7 +451,7 @@ TEST(StateUpdateTest, TestReplaceMisaligned) {
 TEST(StateUpdateTest, TestReplaceBadOrdering) {
     using testing::ElementsAre;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 100)
+                 .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
@@ -461,10 +462,10 @@ TEST(StateUpdateTest, TestReplaceBadOrdering) {
 
     // Make the replacement overlap with itself.
     auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid2, 100)
+                     .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 7_o, 1999_t, 0, 99)
                             .build())
-                     .add(new_obj_builder(oid3, 100)
+                     .add(new_obj_builder(oid3, 100, 1100)
                             .add(tidp_a, 5_o, 10_o, 1999_t, 0, 99)
                             .build())
                      .build();
@@ -479,7 +480,7 @@ TEST(StateUpdateTest, TestReplaceBadOrdering) {
 TEST(StateUpdateTest, TestEmptyReplace) {
     using testing::ElementsAre;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 100)
+                 .add(new_obj_builder(oid1, 100, 1100)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .build())
                  .add_term_start(tidp_a, 0_tm, 0_o)
@@ -501,7 +502,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .add(tidp_c, 0_o, 10_o, 1999_t, 200, 299)
@@ -517,7 +518,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
     // Fully replace partition a and clean part of it.
     auto replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid2, 100)
+          .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -545,7 +546,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
     // Compact an extent, marking [3, 4] cleaned with tombstones.
     replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid3, 100)
+          .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -567,7 +568,7 @@ TEST(StateUpdateTest, TestReplaceWithCompaction) {
 
     // Now mark [3, 8] as having removed tombstones.
     replace = replace_objects_builder()
-                .add(new_obj_builder(oid4, 100)
+                .add(new_obj_builder(oid4, 100, 1100)
                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                        .build())
                 .clean_tombstones(tidp_a, 3_o, 8_o)
@@ -588,7 +589,7 @@ TEST(StateUpdateTest, TestCompactionMissingExtent) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
@@ -602,7 +603,7 @@ TEST(StateUpdateTest, TestCompactionMissingExtent) {
     // Add a clean range for tidp_a but only supply an extent with tidp_b.
     auto replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid2, 100)
+          .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_b, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -623,7 +624,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtents) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
@@ -636,7 +637,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtents) {
 
     auto replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid3, 100)
+          .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -658,7 +659,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtentsStart) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
@@ -669,7 +670,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtentsStart) {
     auto add_res = add.apply(s);
     ASSERT_TRUE(add_res.has_value());
     add = add_objects_builder()
-            .add(new_obj_builder(oid2, 300)
+            .add(new_obj_builder(oid2, 300, 1300)
                    .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                    .build())
             .add_term_start(tidp_a, 0_tm, 11_o)
@@ -680,7 +681,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceExtentsStart) {
     // Add a replacement extent and claim that it cleans a larger offset range.
     auto replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid3, 100)
+          .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -701,7 +702,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceLogStart) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
@@ -712,7 +713,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceLogStart) {
     auto add_res = add.apply(s);
     ASSERT_TRUE(add_res.has_value());
     add = add_objects_builder()
-            .add(new_obj_builder(oid2, 300)
+            .add(new_obj_builder(oid2, 300, 1300)
                    .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                    .build())
             .add_term_start(tidp_a, 0_tm, 11_o)
@@ -723,7 +724,7 @@ TEST(StateUpdateTest, TestCompactionDoesntReplaceLogStart) {
     // Add a replacement extent and claim that it makes a larger range clean.
     auto replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid3, 100)
+          .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -744,7 +745,7 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
     using testing::ElementsAre;
     using range = struct compaction_state_update::cleaned_range;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
@@ -757,7 +758,7 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
 
     auto replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid2, 100)
+          .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -771,7 +772,7 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
 
     replace
       = replace_objects_builder()
-          .add(new_obj_builder(oid3, 100)
+          .add(new_obj_builder(oid3, 100, 1100)
                  .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                  .build())
           .clean(
@@ -792,7 +793,7 @@ TEST(StateUpdateTest, TestOverlappingTombstones) {
 TEST(StateUpdateTest, TestRemoveNonExistingTombstones) {
     using testing::ElementsAre;
     auto add = add_objects_builder()
-                 .add(new_obj_builder(oid1, 300)
+                 .add(new_obj_builder(oid1, 300, 1300)
                         .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                         .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                         .build())
@@ -804,7 +805,7 @@ TEST(StateUpdateTest, TestRemoveNonExistingTombstones) {
     ASSERT_TRUE(add_res.has_value());
 
     auto replace = replace_objects_builder()
-                     .add(new_obj_builder(oid2, 100)
+                     .add(new_obj_builder(oid2, 100, 1100)
                             .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                             .build())
                      .clean_tombstones(tidp_a, 5_o, 10_o)
@@ -821,7 +822,7 @@ TEST(StateUpdateTest, TestRemoveNonExistingTombstones) {
 TEST(StateUpdateTest, TestAddIncreasingTerms) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 1_tm, 0_o)
@@ -832,7 +833,7 @@ TEST(StateUpdateTest, TestAddIncreasingTerms) {
     EXPECT_EQ(1, s.topic_to_state.size());
 
     update = add_objects_builder()
-               .add(new_obj_builder(oid2, 100)
+               .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                       .build())
                .add_term_start(tidp_a, 3_tm, 11_o)
@@ -857,7 +858,7 @@ TEST(StateUpdateTest, TestAddIncreasingTerms) {
 TEST(StateUpdateTest, TestAddSameSubsequentTerm) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 1_tm, 0_o)
@@ -877,7 +878,7 @@ TEST(StateUpdateTest, TestAddSameSubsequentTerm) {
 
     // The start of term 2 shouldn't be changed, but term 3 should be added.
     update = add_objects_builder()
-               .add(new_obj_builder(oid2, 100)
+               .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                       .build())
                .add_term_start(tidp_a, 2_tm, 11_o)
@@ -900,7 +901,7 @@ TEST(StateUpdateTest, TestAddSameSubsequentTerm) {
 TEST(StateUpdateTest, TestAddNoTerms) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .build();
@@ -915,7 +916,7 @@ TEST(StateUpdateTest, TestAddNoTerms) {
 TEST(StateUpdateTest, TestAddMissingTermsForPartition) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
                            .build())
@@ -931,7 +932,7 @@ TEST(StateUpdateTest, TestAddMissingTermsForPartition) {
 TEST(StateUpdateTest, TestAddDecreasingTermInUpdate) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 2_tm, 0_o)
@@ -945,7 +946,7 @@ TEST(StateUpdateTest, TestAddDecreasingTermInUpdate) {
 TEST(StateUpdateTest, TestAddDecreasingTerm) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 2_tm, 0_o)
@@ -954,7 +955,7 @@ TEST(StateUpdateTest, TestAddDecreasingTerm) {
     EXPECT_TRUE(res.has_value());
 
     update = add_objects_builder()
-               .add(new_obj_builder(oid2, 100)
+               .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                       .build())
                .add_term_start(tidp_a, 1_tm, 11_o)
@@ -967,7 +968,7 @@ TEST(StateUpdateTest, TestAddDecreasingTerm) {
 
 TEST(StateUpdateTest, TestAllowBogusTermWithBogusExtent) {
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 10_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 2_tm, 10_o)
@@ -993,7 +994,7 @@ TEST(StateUpdateTest, TestAllowBogusTermWithBogusExtent) {
 
 TEST(StateUpdateTest, TestTermsWithNoExtent) {
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 0_tm, 0_o)
@@ -1011,7 +1012,7 @@ TEST(StateUpdateTest, TestTermsWithNoExtent) {
 TEST(StateUpdateTest, TestAddMismatchedStartOffset) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 1_tm, 0_o)
@@ -1021,7 +1022,7 @@ TEST(StateUpdateTest, TestAddMismatchedStartOffset) {
 
     // Add an update where the term's start offset doesn't match the extent.
     update = add_objects_builder()
-               .add(new_obj_builder(oid2, 100)
+               .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                       .build())
                .add_term_start(tidp_a, 2_tm, 0_o)
@@ -1036,7 +1037,7 @@ TEST(StateUpdateTest, TestAddMismatchedStartOffset) {
 TEST(StateUpdateTest, TestAddExtentEndsBelowLastTermStart) {
     state s;
     auto update = add_objects_builder()
-                    .add(new_obj_builder(oid1, 100)
+                    .add(new_obj_builder(oid1, 100, 1100)
                            .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
                            .build())
                     .add_term_start(tidp_a, 1_tm, 0_o)
@@ -1047,7 +1048,7 @@ TEST(StateUpdateTest, TestAddExtentEndsBelowLastTermStart) {
     EXPECT_TRUE(res.has_value());
 
     update = add_objects_builder()
-               .add(new_obj_builder(oid2, 100)
+               .add(new_obj_builder(oid2, 100, 1100)
                       .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
                       .build())
                .add_term_start(tidp_a, 3_tm, 11_o)
@@ -1065,13 +1066,13 @@ TEST(StateUpdateTest, TestSetStartOffsetAlignedWithExtent) {
     state s;
     // Add some extents
     auto add_update = add_objects_builder()
-                        .add(new_obj_builder(oid1, 100)
+                        .add(new_obj_builder(oid1, 100, 1100)
                                .add(tidp_a, 0_o, 10_o, 2000_t, 0, 99)
                                .build())
-                        .add(new_obj_builder(oid2, 100)
+                        .add(new_obj_builder(oid2, 100, 1100)
                                .add(tidp_a, 11_o, 20_o, 2000_t, 0, 99)
                                .build())
-                        .add(new_obj_builder(oid3, 100)
+                        .add(new_obj_builder(oid3, 100, 1100)
                                .add(tidp_a, 21_o, 30_o, 2000_t, 0, 99)
                                .build())
                         .add_term_start(tidp_a, 0_tm, 0_o)
@@ -1106,13 +1107,13 @@ TEST(StateUpdateTest, TestSetStartOffsetNotAlignedWithExtent) {
     state s;
     // Add some extents
     auto add_update = add_objects_builder()
-                        .add(new_obj_builder(oid1, 100)
+                        .add(new_obj_builder(oid1, 100, 1100)
                                .add(tidp_a, 0_o, 10_o, 2000_t, 0, 99)
                                .build())
-                        .add(new_obj_builder(oid2, 100)
+                        .add(new_obj_builder(oid2, 100, 1100)
                                .add(tidp_a, 11_o, 20_o, 2000_t, 0, 99)
                                .build())
-                        .add(new_obj_builder(oid3, 100)
+                        .add(new_obj_builder(oid3, 100, 1100)
                                .add(tidp_a, 21_o, 30_o, 2000_t, 0, 99)
                                .build())
                         .add_term_start(tidp_a, 0_tm, 0_o)
@@ -1148,7 +1149,7 @@ TEST(StateUpdateTest, TestSetStartOffsetEmptyWithTerms) {
     state s;
     // Add extents with various terms
     auto add_update = add_objects_builder()
-                        .add(new_obj_builder(oid1, 100)
+                        .add(new_obj_builder(oid1, 100, 1100)
                                .add(tidp_a, 0_o, 9_o, 2000_t, 0, 99)
                                .build())
                         .add_term_start(tidp_a, 1_tm, 0_o)
@@ -1191,7 +1192,7 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
     state s;
     // Add an extent and then compact it
     auto add_update = add_objects_builder()
-                        .add(new_obj_builder(oid1, 100)
+                        .add(new_obj_builder(oid1, 100, 1100)
                                .add(tidp_a, 0_o, 20_o, 2000_t, 0, 99)
                                .build())
                         .add_term_start(tidp_a, 0_tm, 0_o)
@@ -1202,7 +1203,7 @@ TEST(StateUpdateTest, TestSetStartOffsetWithCompactionState) {
     // Compact part of the extent (clean offsets [5, 15])
     auto replace_update
       = replace_objects_builder()
-          .add(new_obj_builder(oid2, 100)
+          .add(new_obj_builder(oid2, 100, 1100)
                  .add(tidp_a, 0_o, 20_o, 2000_t, 0, 99)
                  .build())
           .clean(


### PR DESCRIPTION
This adds the object size to object_metadata. With the footer size, it makes it possible to read the footer, which the l1 reader needs to do in order to find its ntp's batches inside the object.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
