### PR TITLE
kafka/server: find_coordinator v4 support

### DIFF
--- a/src/v/kafka/protocol/find_coordinator.h
+++ b/src/v/kafka/protocol/find_coordinator.h
@@ -33,6 +33,14 @@ struct find_coordinator_request final {
           .key_type = key_type,
         }) {}
 
+    explicit find_coordinator_request(
+      chunked_vector<ss::sstring> coordinator_keys,
+      coordinator_type key_type = coordinator_type::group)
+      : data{
+          .key = "",
+          .key_type = key_type,
+          .coordinator_keys = std::move(coordinator_keys)} {}
+
     void encode(protocol::encoder& writer, api_version version) {
         data.encode(writer, version);
     }
@@ -45,6 +53,33 @@ struct find_coordinator_request final {
     operator<<(std::ostream& os, const find_coordinator_request& r) {
         return os << r.data;
     }
+};
+
+struct coordinator_response final : kafka::coordinator {
+    coordinator_response() = default;
+
+    // error constructor
+    explicit coordinator_response(
+      ss::sstring key,
+      kafka::error_code error,
+      std::optional<ss::sstring> error_message = std::nullopt)
+      : coordinator{
+          .key = std::move(key),
+          .node_id = model::node_id{-1},
+          .host = "",
+          .port = -1,
+          .error_code = error,
+          .error_message = std::move(error_message)} {}
+
+    explicit coordinator_response(
+      ss::sstring key, model::node_id node, ss::sstring host, int32_t port)
+      : coordinator{
+          .key = std::move(key),
+          .node_id = node,
+          .host = std::move(host),
+          .port = port,
+          .error_code = kafka::error_code::none,
+          .error_message = std::nullopt} {}
 };
 
 struct find_coordinator_response final {

--- a/src/v/kafka/protocol/find_coordinator.h
+++ b/src/v/kafka/protocol/find_coordinator.h
@@ -26,7 +26,7 @@ struct find_coordinator_request final {
 
     find_coordinator_request() = default;
 
-    find_coordinator_request(
+    explicit find_coordinator_request(
       ss::sstring key, coordinator_type key_type = coordinator_type::group)
       : data({
           .key = std::move(key),

--- a/src/v/kafka/protocol/schemata/find_coordinator_request.json
+++ b/src/v/kafka/protocol/schemata/find_coordinator_request.json
@@ -22,12 +22,17 @@
   // Version 2 is the same as version 1.
   //
   // Version 3 is the first flexible version.
-  "validVersions": "0-3",
+  //
+  // Version 4 adds support for batching via CoordinatorKeys (KIP-699)
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
-    { "name": "Key", "type": "string", "versions": "0+",
+    { "name": "Key", "type": "string", "versions": "0-3",
       "about": "The coordinator key." },
     { "name": "KeyType", "type": "int8", "versions": "1+", "default": "0", "ignorable": false,
-      "about": "The coordinator key type.  (Group, transaction, etc.)" }
+      "about": "The coordinator key type. (Group, transaction, etc.)" },
+    { "name": "CoordinatorKeys", "type": "[]string", "versions": "4+",
+      "about": "The coordinator keys." }
   ]
 }
+

--- a/src/v/kafka/protocol/schemata/find_coordinator_response.json
+++ b/src/v/kafka/protocol/schemata/find_coordinator_response.json
@@ -22,20 +22,34 @@
   // Starting in version 2, on quota violation, brokers send out responses before throttling.
   //
   // Version 3 is the first flexible version.
-  "validVersions": "0-3",
+  //
+  // Version 4 adds support for batching via Coordinators (KIP-699)
+  "validVersions": "0-4",
   "flexibleVersions": "3+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+    { "name": "ErrorCode", "type": "int16", "versions": "0-3",
       "about": "The error code, or 0 if there was no error." },
-    { "name": "ErrorMessage", "type": "string", "versions": "1+", "nullableVersions": "1+", "ignorable": true,
+    { "name": "ErrorMessage", "type": "string", "versions": "1-3", "nullableVersions": "1-3", "ignorable": true,
       "about": "The error message, or null if there was no error." },
-    { "name": "NodeId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+    { "name": "NodeId", "type": "int32", "versions": "0-3", "entityType": "brokerId",
       "about": "The node id." },
-    { "name": "Host", "type": "string", "versions": "0+",
+    { "name": "Host", "type": "string", "versions": "0-3",
       "about": "The host name." },
-    { "name": "Port", "type": "int32", "versions": "0+",
-      "about": "The port." }
+    { "name": "Port", "type": "int32", "versions": "0-3",
+      "about": "The port." },
+    { "name": "Coordinators", "type": "[]Coordinator", "versions": "4+", "about": "Each coordinator result in the response", "fields": [
+      { "name": "Key", "type": "string", "versions": "4+", "about": "The coordinator key." },
+      { "name": "NodeId", "type": "int32", "versions": "4+", "entityType": "brokerId",
+        "about": "The node id." },
+      { "name": "Host", "type": "string", "versions": "4+", "about": "The host name." },
+      { "name": "Port", "type": "int32", "versions": "4+", "about": "The port." },
+      { "name": "ErrorCode", "type": "int16", "versions": "4+",
+        "about": "The error code, or 0 if there was no error." },
+      { "name": "ErrorMessage", "type": "string", "versions": "4+", "nullableVersions": "4+", "ignorable": true,
+        "about": "The error message, or null if there was no error." }
+    ]}
   ]
 }
+

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -697,6 +697,7 @@ STRUCT_TYPES = [
     "ScramCredentialDeletion",
     "ScramCredentialUpsertion",
     "AlterUserScramCredentialsResult",
+    "Coordinator",
 ]
 
 # A list of StructTypes that are allowed to be not arrays in the schema.

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -17,12 +17,14 @@
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/rm_group_frontend.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 
 #include <seastar/util/log.hh>
 
 #include <fmt/ostream.h>
 
-#include <string_view>
+#include <expected>
+#include <iterator>
 
 namespace kafka {
 
@@ -74,6 +76,281 @@ static ss::future<response_ptr> handle_partition(
           return ctx.respond(
             find_coordinator_response(error_code::coordinator_not_available));
       });
+}
+
+constexpr size_t max_concurrency = 10;
+
+// maps a given leader id to its relevant coordinator response struct
+template<typename KeyType>
+kafka::coordinator_response leader_to_coordinator(
+  request_context* ctx, const KeyType& key, model::node_id leader) {
+    auto broker = ctx->metadata_cache().get_node_metadata(leader);
+    if (broker) {
+        auto& b = *broker;
+        for (const auto& listener : b.broker.kafka_advertised_listeners()) {
+            if (listener.name == ctx->listener()) {
+                return kafka::coordinator_response{
+                  key,
+                  b.broker.id(),
+                  listener.address.host(),
+                  listener.address.port()};
+            }
+        }
+    }
+    return kafka::coordinator_response{
+      key, kafka::error_code::coordinator_not_available};
+}
+
+// given a partition id, find its leader, then turn that leader into the
+// coordinator response struct
+ss::future<kafka::coordinator_response> partition_to_coordinator(
+  group_id group_id,
+  request_context* ctx,
+  std::optional<model::partition_id> maybe_partition) {
+    kafka::coordinator_response return_element{
+      group_id, error_code::coordinator_not_available};
+
+    if (!maybe_partition) {
+        co_return return_element;
+    }
+
+    auto timeout = ss::lowres_clock::now()
+                   + config::shard_local_cfg().wait_for_leader_timeout_ms();
+
+    model::ntp consumer_offsets_ntp{
+      model::kafka_namespace,
+      model::kafka_consumer_offsets_topic,
+      *maybe_partition};
+
+    auto leader_future = co_await ss::coroutine::as_future(
+      ctx->metadata_cache().get_leader(consumer_offsets_ntp, timeout));
+    if (leader_future.failed()) {
+        vlog(
+          klog.info,
+          "exception while waiting for leader on ntp {}: {}",
+          consumer_offsets_ntp,
+          leader_future.get_exception());
+        co_return return_element;
+    }
+    co_return leader_to_coordinator(ctx, group_id, leader_future.get());
+}
+
+template<typename KeyType>
+struct audit_success {
+    chunked_vector<KeyType> authorized_keys;
+    chunked_vector<KeyType> unauthorized_keys;
+};
+
+template<typename KeyType>
+struct audit_failure {
+    chunked_vector<KeyType> all_keys;
+};
+
+// carve an input key list into a list of authorized keys and a list of
+// unauthorized keys. On failure of the auth system, hand all keys back in the
+// error result
+template<typename KeyType>
+std::expected<audit_success<KeyType>, audit_failure<KeyType>>
+check_authorization(request_context* ctx, chunked_vector<KeyType> all_keys) {
+    // split the vector into subsegments [unautorized, authorized]
+    auto authorized_range = std::ranges::partition(
+      all_keys, [&ctx](const KeyType& key) {
+          return !ctx->authorized(security::acl_operation::describe, key);
+      });
+
+    // audit system failure, return all keys as err value
+    if (!ctx->audit()) {
+        // error result
+        return std::unexpected<audit_failure<KeyType>>(std::move(all_keys));
+    }
+
+    chunked_vector<KeyType> authorized_keys{};
+    authorized_keys.reserve(authorized_range.size());
+    std::ranges::move(authorized_range, std::back_inserter(authorized_keys));
+
+    // truncate the authorized keys off of the original
+    auto authorized_it = all_keys.end() - authorized_keys.size();
+    all_keys.erase_to_end(authorized_it);
+
+    // value result
+    return audit_success<KeyType>{
+      .authorized_keys = std::move(authorized_keys),
+      .unauthorized_keys = std::move(all_keys)};
+}
+
+template<typename KeyType>
+chunked_vector<kafka::coordinator> map_errored_keys(
+  chunked_vector<KeyType> errored_keys,
+  kafka::error_code error_code,
+  const std::optional<ss::sstring>& error_message = std::nullopt) {
+    chunked_vector<coordinator> unauthorized_key_responses{};
+    unauthorized_key_responses.reserve(errored_keys.size());
+
+    std::ranges::transform(
+      std::move(errored_keys),
+      std::back_inserter(unauthorized_key_responses),
+      [error_code, error_message](const KeyType& key) {
+          kafka::coordinator_response response_element{
+            key, error_code, error_message};
+          return response_element;
+      });
+
+    return unauthorized_key_responses;
+}
+
+// handler for the subset of authorized transaction ids
+ss::future<chunked_vector<kafka::coordinator>> handle_authorized_txn_id(
+  request_context* ctx, chunked_vector<transactional_id> authorized_keys) {
+    chunked_vector<kafka::coordinator> out_vector{};
+    co_await ss::max_concurrent_for_each(
+      std::move(authorized_keys),
+      max_concurrency,
+      [&ctx, &out_vector](auto authorized_key) {
+          return ctx->tx_gateway_frontend()
+            .find_coordinator(authorized_key)
+            .then([&ctx, &out_vector, authorized_key](const auto& response) {
+                kafka::coordinator_response response_element{
+                  authorized_key, error_code::coordinator_not_available};
+                auto maybe_leader = response.coordinator;
+                if (maybe_leader) {
+                    response_element = leader_to_coordinator(
+                      ctx, authorized_key, *maybe_leader);
+                }
+                out_vector.emplace_back(std::move(response_element));
+            });
+      });
+    co_return out_vector;
+}
+
+// handler for the subset of authorized group ids
+ss::future<chunked_vector<kafka::coordinator>> handle_authorized_group_id(
+  request_context* ctx, chunked_vector<group_id> authorized_keys) {
+    chunked_vector<kafka::coordinator> out_vector{};
+
+    if (!ctx->coordinator_mapper().topic_exists()) {
+        bool success = co_await ctx->group_initializer().assure_topic_exists();
+        if (!success) {
+            co_return map_errored_keys(
+              std::move(authorized_keys),
+              kafka::error_code::coordinator_not_available);
+        }
+    }
+
+    auto loop_body = [ctx, &out_vector](const group_id& group_id) {
+        auto partition_id = ctx->coordinator_mapper().partition_for(group_id);
+        return partition_to_coordinator(group_id, ctx, partition_id)
+          .then(
+            [&out_vector, group_id](kafka::coordinator coordinator) mutable {
+                out_vector.emplace_back(std::move(coordinator));
+            });
+    };
+
+    co_await ss::max_concurrent_for_each(
+      std::move(authorized_keys), max_concurrency, std::move(loop_body));
+
+    co_return out_vector;
+}
+
+template<typename KeyType>
+kafka::error_code unauthorized_key_ec() {
+    if constexpr (std::is_same_v<KeyType, transactional_id>) {
+        return kafka::error_code::transactional_id_authorization_failed;
+    } else if constexpr (std::is_same_v<KeyType, group_id>) {
+        return kafka::error_code::group_authorization_failed;
+    } else {
+        static_assert(false, "Unimplemented type");
+    }
+};
+
+template<typename KeyType>
+ss::future<chunked_vector<kafka::coordinator>> handle_authorized_keys(
+  request_context* ctx, chunked_vector<KeyType> authorized_keys) {
+    if constexpr (std::is_same_v<KeyType, transactional_id>) {
+        return handle_authorized_txn_id(ctx, std::move(authorized_keys));
+    } else if constexpr (std::is_same_v<KeyType, group_id>) {
+        return handle_authorized_group_id(ctx, std::move(authorized_keys));
+    } else {
+        static_assert(false, "Unimplemented type");
+    }
+}
+
+// routes a request to its relevant key type.
+// Generically this does
+//   1. transmute sstring keys into the relevant key type
+//   2. check auth
+//      a. fail all if auth system failure
+//      b. split keys into authed and unauthed
+//   3. error unauthed keys
+//   4. fetch response for authed keys
+//   5. glue all together into response vector
+template<typename KeyType>
+ss::future<find_coordinator_response> handle_generic_request(
+  request_context* ctx, chunked_vector<ss::sstring> generic_keys) {
+    find_coordinator_response return_value{};
+    auto& return_vector = return_value.data.coordinators;
+
+    // 1. transmute sstring keys into relevant key type
+    auto keys = std::ranges::to<chunked_vector<KeyType>>(
+      std::move(generic_keys) | std::views::as_rvalue);
+
+    // 2. check auth
+    auto auth_result = check_authorization<KeyType>(ctx, std::move(keys));
+    if (!auth_result.has_value()) {
+        auto error_result = std::move(auth_result).error();
+        return_vector = map_errored_keys(
+          std::move(error_result.all_keys),
+          kafka::error_code::broker_not_available,
+          "Broker not available - audit system failure");
+        co_return return_value;
+    }
+    auto [authorized_keys, unauthorized_keys] = *std::move(auth_result);
+
+    // 3. error unauthed keys
+    return_vector = map_errored_keys(
+      std::move(unauthorized_keys), unauthorized_key_ec<KeyType>());
+
+    // 4. fetch response for authed keys
+    auto authorized_coordinators = co_await handle_authorized_keys<KeyType>(
+      ctx, std::move(authorized_keys));
+
+    // 5. all keys are emplace_back'd onto the response vector
+    std::ranges::move(
+      std::move(authorized_coordinators), std::back_inserter(return_vector));
+
+    co_return return_value;
+}
+
+// on some validation failure do for each key, make an error coordinator
+// response struct
+template<typename KeyType>
+find_coordinator_response error_entire_request(
+  chunked_vector<KeyType> keys, kafka::error_code error_code) {
+    find_coordinator_response failed_responses{};
+    auto& response_vector = failed_responses.data.coordinators;
+    response_vector = map_errored_keys(std::move(keys), error_code);
+    return failed_responses;
+}
+
+// multiple key handler
+[[maybe_unused]] ss::future<find_coordinator_response>
+handle_multiple_keys(find_coordinator_request request, request_context* ctx) {
+    auto& keys = request.data.coordinator_keys;
+
+    switch (request.data.key_type) {
+    case kafka::coordinator_type::transaction: {
+        if (!ctx->are_transactions_enabled()) {
+            co_return error_entire_request(
+              std::move(keys), kafka::error_code::unsupported_version);
+        }
+        co_return co_await handle_generic_request<transactional_id>(
+          ctx, std::move(keys));
+    }
+    case kafka::coordinator_type::group:
+        co_return co_await handle_generic_request<group_id>(
+          ctx, std::move(keys));
+    }
+    co_return error_entire_request(
+      std::move(keys), kafka::error_code::unsupported_version);
 }
 
 } // namespace

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -26,6 +26,8 @@
 
 namespace kafka {
 
+namespace {
+
 static ss::future<response_ptr>
 handle_leader(request_context& ctx, model::node_id leader) {
     auto broker = ctx.metadata_cache().get_node_metadata(leader);
@@ -73,6 +75,8 @@ static ss::future<response_ptr> handle_partition(
             find_coordinator_response(error_code::coordinator_not_available));
       });
 }
+
+} // namespace
 
 template<>
 ss::future<response_ptr> find_coordinator_handler::handle(

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -30,54 +30,6 @@ namespace kafka {
 
 namespace {
 
-static ss::future<response_ptr>
-handle_leader(request_context& ctx, model::node_id leader) {
-    auto broker = ctx.metadata_cache().get_node_metadata(leader);
-    if (broker) {
-        auto& b = *broker;
-        for (const auto& listener : b.broker.kafka_advertised_listeners()) {
-            if (listener.name == ctx.listener()) {
-                return ctx.respond(find_coordinator_response(
-                  b.broker.id(),
-                  listener.address.host(),
-                  listener.address.port()));
-            }
-        }
-    }
-    return ctx.respond(
-      find_coordinator_response(error_code::coordinator_not_available));
-}
-
-/*
- * map the ntp to it's leader broker connection information. also wait for the
- * leader to be elected if it isn't yet available immediately, like in the case
- * of creating the internal metadata topic on-demand.
- */
-static ss::future<response_ptr> handle_partition(
-  request_context& ctx, std::optional<model::partition_id> partition) {
-    if (!partition) {
-        return ctx.respond(
-          find_coordinator_response(error_code::coordinator_not_available));
-    }
-
-    auto timeout = ss::lowres_clock::now()
-                   + config::shard_local_cfg().wait_for_leader_timeout_ms();
-
-    return ctx.metadata_cache()
-      .get_leader(
-        model::ntp(
-          model::kafka_namespace,
-          model::kafka_consumer_offsets_topic,
-          *partition),
-        timeout)
-      .then(
-        [&ctx](model::node_id leader) { return handle_leader(ctx, leader); })
-      .handle_exception([&ctx](const std::exception_ptr&) {
-          return ctx.respond(
-            find_coordinator_response(error_code::coordinator_not_available));
-      });
-}
-
 constexpr size_t max_concurrency = 10;
 
 // maps a given leader id to its relevant coordinator response struct
@@ -332,7 +284,7 @@ find_coordinator_response error_entire_request(
 }
 
 // multiple key handler
-[[maybe_unused]] ss::future<find_coordinator_response>
+ss::future<find_coordinator_response>
 handle_multiple_keys(find_coordinator_request request, request_context* ctx) {
     auto& keys = request.data.coordinator_keys;
 
@@ -355,97 +307,51 @@ handle_multiple_keys(find_coordinator_request request, request_context* ctx) {
 
 } // namespace
 
+// v4+ is multi key, v3- simply gets packed into a vector to be handled
 template<>
 ss::future<response_ptr> find_coordinator_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     find_coordinator_request request;
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
+    bool is_single_element_request = ctx.header().version <= api_version(3);
 
-    if (request.data.key_type == coordinator_type::transaction) {
-        if (!ctx.are_transactions_enabled()) {
-            return ctx.respond(
-              find_coordinator_response(error_code::unsupported_version));
+    auto& keys = request.data.coordinator_keys;
+
+    // pack v1-3 requests into list form
+    if (is_single_element_request) {
+        if (!keys.empty()) {
+            co_return co_await ctx.respond(
+              find_coordinator_response(kafka::error_code::invalid_request));
         }
-
-        transactional_id tx_id(request.data.key);
-
-        auto authz = ctx.authorized(security::acl_operation::describe, tx_id);
-
-        if (!ctx.audit()) {
-            return ctx.respond(find_coordinator_response(
-              error_code::broker_not_available,
-              "Broker not available - audit system failure"));
-        }
-
-        if (!authz) {
-            return ctx.respond(find_coordinator_response(
-              error_code::transactional_id_authorization_failed));
-        }
-
-        return ss::do_with(
-          std::move(ctx),
-          [request = std::move(request),
-           tx_id = std::move(tx_id)](request_context& ctx) mutable {
-              return ctx.tx_gateway_frontend().find_coordinator(tx_id).then(
-                [&ctx](cluster::find_coordinator_reply r) {
-                    if (r.coordinator) {
-                        return handle_leader(ctx, *r.coordinator);
-                    }
-                    return ctx.respond(find_coordinator_response(
-                      error_code::coordinator_not_available));
-                });
-          });
+        keys.emplace_back(std::move(request.data.key));
+        request.data.key = "";
     }
 
-    if (request.data.key_type != coordinator_type::group) {
-        return ctx.respond(
-          find_coordinator_response(error_code::unsupported_version));
+    auto response = co_await handle_multiple_keys(std::move(request), &ctx);
+
+    // if needed, unpack a multi-key, v4+ style response back into a v1-3 single
+    // key response
+    if (is_single_element_request) {
+        auto& response_vector = response.data.coordinators;
+        vassert(
+          response_vector.size() == 1,
+          "legacy requests should only yield one response, had {}",
+          response_vector.size());
+        auto output_element = std::move(response_vector[0]);
+
+        // reset response vector
+        response_vector.clear();
+
+        // repack
+        response.data.host = std::move(output_element.host);
+        response.data.port = output_element.port;
+        response.data.node_id = output_element.node_id;
+        response.data.error_code = output_element.error_code;
+        response.data.error_message = std::move(output_element.error_message);
     }
 
-    auto authz = ctx.authorized(
-      security::acl_operation::describe, group_id(request.data.key));
-
-    if (!ctx.audit()) {
-        return ctx.respond(find_coordinator_response(
-          error_code::broker_not_available,
-          "Broker not available - audit system failure"));
-    }
-
-    if (!authz) {
-        return ctx.respond(
-          find_coordinator_response(error_code::group_authorization_failed));
-    }
-
-    return ss::do_with(
-      std::move(ctx),
-      [request = std::move(request)](request_context& ctx) mutable {
-          /*
-           * map the group to a target ntp. this may fail because the internal
-           * metadata topic doesn't exist. in this case fall through and create
-           * the topic on-demand.
-           */
-          if (auto partition_id = ctx.coordinator_mapper().partition_for(
-                kafka::group_id(request.data.key));
-              partition_id) {
-              return handle_partition(ctx, partition_id);
-          }
-
-          return ctx.group_initializer().assure_topic_exists().then(
-            [&ctx, request = std::move(request)](bool created) {
-                /*
-                 * if the topic is successfully created then the metadata cache
-                 * will be updated and we can retry the group-ntp mapping.
-                 */
-                if (created) {
-                    auto partition_id = ctx.coordinator_mapper().partition_for(
-                      kafka::group_id(request.data.key));
-                    return handle_partition(ctx, partition_id);
-                }
-                return ctx.respond(find_coordinator_response(
-                  error_code::coordinator_not_available));
-            });
-      });
+    co_return co_await ctx.respond(std::move(response));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/find_coordinator.h
+++ b/src/v/kafka/server/handlers/find_coordinator.h
@@ -15,6 +15,6 @@
 namespace kafka {
 
 using find_coordinator_handler
-  = single_stage_handler<find_coordinator_api, 0, 3>;
+  = single_stage_handler<find_coordinator_api, 0, 4>;
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -276,7 +276,7 @@ public:
         return _conn->server().credentials();
     }
 
-    bool audit() { return _audit_successful; }
+    bool audit() const { return _audit_successful; }
 
     bool audit_authn_failure(ss::sstring reason) {
         return audit_authn_failure(std::move(reason), "");

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -25,7 +25,7 @@ FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
     req.data.key_type = kafka::coordinator_type(
       std::numeric_limits<underlying_t>::max());
 
-    auto resp = client.dispatch(req, kafka::api_version(1)).get();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_TEST(resp.data.error_code == kafka::error_code::unsupported_version);
@@ -42,7 +42,7 @@ FIXTURE_TEST(find_coordinator, redpanda_thread_fixture) {
 
     kafka::find_coordinator_request req("key");
 
-    auto resp = client.dispatch(req, kafka::api_version(1)).get();
+    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
     BOOST_TEST(resp.data.error_code == kafka::error_code::none);

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -13,40 +13,140 @@
 
 #include <seastar/core/smp.hh>
 
-#include <chrono>
 #include <limits>
 
-FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
-    auto client = make_kafka_client().get();
+namespace {
+
+void test_single_key(
+  redpanda_thread_fixture* fixture,
+  kafka::coordinator_type request_type,
+  const kafka::find_coordinator_response_data& expected_response) {
+    fixture->wait_for_controller_leadership().get();
+
+    auto client = fixture->make_kafka_client().get();
     client.connect().get();
 
-    using underlying_t = std::underlying_type_t<kafka::coordinator_type>;
-    kafka::find_coordinator_request req("key");
-    req.data.key_type = kafka::coordinator_type(
-      std::numeric_limits<underlying_t>::max());
+    // default is group
+    kafka::find_coordinator_request req("key", request_type);
 
     auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_TEST(resp.data.error_code == kafka::error_code::unsupported_version);
-    BOOST_TEST(resp.data.node_id == model::node_id(-1));
-    BOOST_TEST(resp.data.host == "");
-    BOOST_TEST(resp.data.port == -1);
+    BOOST_TEST(resp.data.error_code == expected_response.error_code);
+    BOOST_TEST(resp.data.node_id == expected_response.node_id);
+    BOOST_TEST(resp.data.host == expected_response.host);
+    BOOST_TEST(resp.data.port == expected_response.port);
 }
 
-FIXTURE_TEST(find_coordinator, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get();
+void test_single_key_success(
+  redpanda_thread_fixture* fixture, kafka::coordinator_type request_type) {
+    kafka::find_coordinator_response_data expected_response;
+    expected_response.error_code = kafka::error_code::none;
+    expected_response.node_id = model::node_id(1);
+    expected_response.host = "127.0.0.1";
+    expected_response.port = 9092;
 
-    auto client = make_kafka_client().get();
+    test_single_key(fixture, request_type, expected_response);
+}
+
+void test_single_key_unsupported(redpanda_thread_fixture* fixture) {
+    kafka::find_coordinator_response_data expected_response;
+    expected_response.error_code = kafka::error_code::unsupported_version;
+    expected_response.node_id = model::node_id(-1);
+    expected_response.host = "";
+    expected_response.port = -1;
+
+    using underlying_t = std::underlying_type_t<kafka::coordinator_type>;
+    auto request_type = kafka::coordinator_type(
+      std::numeric_limits<underlying_t>::max());
+
+    test_single_key(fixture, request_type, expected_response);
+}
+
+void test_multi_key(
+  redpanda_thread_fixture* fixture,
+  kafka::coordinator_type request_type,
+  const kafka::coordinator& expected_response) {
+    fixture->wait_for_controller_leadership().get();
+
+    auto client = fixture->make_kafka_client().get();
     client.connect().get();
 
-    kafka::find_coordinator_request req("key");
+    const std::initializer_list<ss::sstring> init_keys = {
+      "key1", "key2", "key3"};
 
-    auto resp = client.dispatch(std::move(req), kafka::api_version(1)).get();
+    kafka::find_coordinator_request request{init_keys, request_type};
+
+    auto resp
+      = client.dispatch(std::move(request), kafka::api_version(4)).get();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_TEST(resp.data.error_code == kafka::error_code::none);
-    BOOST_TEST(resp.data.node_id == model::node_id(1));
-    BOOST_TEST(resp.data.host == "127.0.0.1");
-    BOOST_TEST(resp.data.port == 9092);
+    auto& coordinator_responses = resp.data.coordinators;
+    std::vector<ss::sstring> validation_keys = init_keys;
+    for (const auto& coordinator_response : coordinator_responses) {
+        // make sure we found the key
+        auto found_key_it = std::ranges::find(
+          validation_keys, coordinator_response.key);
+
+        bool key_was_found = (found_key_it != validation_keys.end());
+        BOOST_TEST(key_was_found);
+
+        // remove the key so it can only be used once
+        validation_keys.erase(found_key_it);
+
+        BOOST_TEST(
+          coordinator_response.error_code == expected_response.error_code);
+        BOOST_TEST(coordinator_response.node_id == expected_response.node_id);
+        BOOST_TEST(coordinator_response.host == expected_response.host);
+        BOOST_TEST(coordinator_response.port == expected_response.port);
+    }
+    BOOST_TEST(validation_keys.size() == 0);
+}
+
+void test_multi_key_success(
+  redpanda_thread_fixture* fixture, kafka::coordinator_type request_type) {
+    kafka::coordinator expected_response{};
+    expected_response.error_code = kafka::error_code::none;
+    expected_response.node_id = model::node_id(1);
+    expected_response.host = "127.0.0.1";
+    expected_response.port = 9092;
+    test_multi_key(fixture, request_type, expected_response);
+}
+
+void test_multi_key_unsupported(redpanda_thread_fixture* fixture) {
+    using underlying_t = std::underlying_type_t<kafka::coordinator_type>;
+    auto request_type = kafka::coordinator_type(
+      std::numeric_limits<underlying_t>::max());
+    kafka::coordinator expected_response{};
+    expected_response.error_code = kafka::error_code::unsupported_version;
+    expected_response.node_id = model::node_id(-1);
+    expected_response.host = "";
+    expected_response.port = -1;
+    test_multi_key(fixture, request_type, expected_response);
+}
+
+} // namespace
+
+FIXTURE_TEST(find_coordinator_unsupported_key, redpanda_thread_fixture) {
+    test_single_key_unsupported(this);
+}
+
+FIXTURE_TEST(find_coordinator_group, redpanda_thread_fixture) {
+    test_single_key_success(this, kafka::coordinator_type::group);
+}
+
+FIXTURE_TEST(find_coordinator_tx, redpanda_thread_fixture) {
+    test_single_key_success(this, kafka::coordinator_type::transaction);
+}
+
+FIXTURE_TEST(find_coordinator_tx_v4, redpanda_thread_fixture) {
+    test_multi_key_success(this, kafka::coordinator_type::transaction);
+}
+
+FIXTURE_TEST(find_coordinator_group_v4, redpanda_thread_fixture) {
+    test_multi_key_success(this, kafka::coordinator_type::group);
+}
+
+FIXTURE_TEST(find_coordinator_unsupported_v4, redpanda_thread_fixture) {
+    test_multi_key_unsupported(this);
 }


### PR DESCRIPTION
find_coordinator v4 is specified in KIP-699. It adds support for batched find_coordinator requests by swapping from a singular request key to a list of request keys.

This PR adds support for v4 find_coordinator alongside unit tests to validate it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Features

* Upgrade find_coordinator api from v3 to v4


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
