### PR TITLE
datalake: bump translation start to log start

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -361,14 +361,20 @@ public:
 
     ss::future<std::optional<model::record_batch_reader>>
     make_log_reader(kafka::offset begin_offset, ss::abort_source& as) final {
+        // Bump the reader start offset up to the log start. Untranslated data
+        // should typically be pinned, so the input offset should be above the
+        // log start in normal circumstances, but it's possible that e.g. data
+        // was removed when Iceberg was disabled.
+        auto reader_start_offset = std::max(
+          begin_offset, model::offset_cast(_partition_proxy->start_offset()));
         auto max_translatable_offset = max_offset_for_translation();
         if (
           !max_translatable_offset
-          || max_translatable_offset.value() < begin_offset) {
+          || max_translatable_offset.value() < reader_start_offset) {
             co_return std::nullopt;
         }
         auto log_reader = co_await _partition_proxy->make_reader(
-          {begin_offset,
+          {reader_start_offset,
            max_translatable_offset.value(),
            0,
            std::numeric_limits<size_t>::max(),

--- a/tests/rptest/tests/datalake/blocked_catalog_test.py
+++ b/tests/rptest/tests/datalake/blocked_catalog_test.py
@@ -310,3 +310,52 @@ class DatalakeBlockedCatalogTest(RedpandaTest):
             hwm, _ = self.get_hwm_lso()
             dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)
             self.check_offsets(spark, hwm)
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_disable_reenable_after_blocking(self, cloud_storage_type):
+        """
+        Test that blocks the catalog, disables Iceberg, allows for retention to
+        happen, reenables Iceberg, and then ensures that we can make progress.
+
+        This is a regression test: in older versions of Redpanda we would be
+        unable to translate after reenabling Iceberg.
+        """
+        with DatalakeServices(
+            self.test_context,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+            catalog_type=CatalogType.REST_JDBC,
+        ) as dl:
+
+            def hwm_gt(target_o):
+                hwm, _ = self.get_hwm_lso()
+                return hwm > target_o
+
+            rpk = RpkTool(self.redpanda)
+            with firewall_blocked(
+                self.redpanda.nodes, dl.catalog_service.iceberg_rest_port
+            ):
+                dl.create_iceberg_enabled_topic(
+                    self.topic_name, config=dict({"retention.ms": 1})
+                )
+                self.rpcn.start_stream(self.stream_name, self.make_rpcn_config())
+
+                # Wait for some amount of data to be produced.
+                wait_until(lambda: hwm_gt(100), timeout_sec=10, backoff_sec=1)
+
+                # Sanity check that the data is pinned and can't be trimmed.
+                _, lso = self.get_hwm_lso()
+                assert lso == 0, f"Expected {lso} = 0"
+
+                # Now disable Iceberg and wait for data to be trimmed.
+                rpk.cluster_config_set("iceberg_enabled", "false")
+                wait_until(self.cloud_log_trimmed, timeout_sec=30, backoff_sec=1)
+
+            # Now reenable Iceberg and check that we commit data.
+            rpk.cluster_config_set("iceberg_enabled", "true")
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+
+            hwm, _ = self.get_hwm_lso()
+            dl.wait_for_translation_until_offset(self.topic_name, hwm - 1)
+            self.rpcn.stop_stream(self.stream_name, should_finish=None)


### PR DESCRIPTION
Bump the reader start offset up to the log start. Untranslated data should typically be pinned, so the input offset should be above the log start in normal circumstances, but it's possible that e.g. data was removed when Iceberg was disabled.

This was the case in one cluster, where translation got stuck with exceptions like:

```
WARN  2025-08-22 14:21:53,403 [shard 0:data] datalake - {kafka/topic/0}-term-295 - partition_translator.cc:312 - Translation attempt ran into an unexpected exception: std::runtime_error (ntp {kafka/topic/0}: data offset 0 is outside the translation range (starting at 563))
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug that prevented Iceberg uploads from proceeding after uncommitted data was removed by Kafka retention during a period where Iceberg was disabled.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
