### PR TITLE
direct_consumer: Random node failures and fixes

### DIFF
--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -386,7 +386,17 @@ ss::future<> fetcher::do_fetch() {
           partitions_with_epochs.partitions);
 
         if (fetch_result.has_error()) {
-            if (is_retriable_error(fetch_result.error())) {
+            auto ec = fetch_result.error();
+
+            // no need for backoff, reset fetch session and rerequest
+            if (ec == kafka::error_code::fetch_session_id_not_found) {
+                vlog(logger().trace, "fetch session invalidated");
+                _session_state.reset();
+                co_return;
+            }
+
+            // retriable error, backoff
+            if (is_retriable_error(ec)) {
                 needs_backoff = true;
             } else {
                 // propagate non retriable error to the queue

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_fixture_test.cc
@@ -122,6 +122,72 @@ TEST_P(BasicConsumerFixture, TestBasicLeadershipTransfer) {
     }
 }
 
+TEST_P(BasicConsumerFixture, TestBasicNodeRestart) {
+    // constants
+    constexpr uint first_produce_count = 10;
+    constexpr uint second_produce_count = 20;
+    const auto test_partition_number = 0;
+    const auto test_partition_id = model::partition_id(test_partition_number);
+    const auto test_ntp = model::ntp(
+      model::kafka_namespace, topic, test_partition_id);
+
+    assign_partitions(make_assignment(topic, {test_partition_number}));
+
+    produce_to_partition(topic, test_partition_number, first_produce_count)
+      .get();
+
+    { // fist fetch and assert
+        auto fetched = fetch_until_empty(*consumer);
+
+        ASSERT_EQ(
+          fetched[model::topic_partition(topic, test_partition_id)]
+            .back()
+            .last_offset(),
+          model::offset(first_produce_count - 1));
+    }
+
+    auto leader = this->get_partition_leader(test_ntp);
+
+    // restart the leader for the partition
+    this->remove_node_application(leader);
+    this->create_node_application(leader);
+
+    this->wait_for_all_members(5s).get();
+
+    // attempt to produce, with retry
+    bool did_produce{false};
+    for (int i{0}; i < 5; ++i) {
+        try {
+            produce_to_partition(
+              topic, test_partition_number, second_produce_count)
+              .get();
+            did_produce = true;
+            break;
+        } catch (...) {
+            vlog(
+              logger.info,
+              "attempt to produce failed for iteration: {} with: {}",
+              i,
+              std::current_exception());
+        }
+        // backoff
+        ss::sleep(1s).get();
+    }
+    ASSERT_TRUE(did_produce);
+    ASSERT_EQ(leader, this->get_partition_leader(test_ntp));
+
+    { // second fetch and assert
+        auto fetched = fetch_until_empty(*consumer);
+        ASSERT_EQ(fetched.size(), 1);
+
+        ASSERT_EQ(
+          fetched[model::topic_partition(topic, test_partition_id)]
+            .back()
+            .last_offset(),
+          model::offset(first_produce_count + second_produce_count - 1));
+    }
+}
+
 TEST_P(BasicConsumerFixture, TestUnassignPartition) {
     assign_partitions(make_assignment(topic, {0, 1}));
 

--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -9,9 +9,11 @@
 
 import random
 import threading
+from enum import Enum
 from typing import Any, Callable
 
 from ducktape.tests.test import TestContext
+from ducktape.mark import matrix
 
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -31,6 +33,26 @@ from rptest.services.direct_consumer_verifier import (
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until_with_progress_check
+from rptest.utils.node_operations import (
+    FailureInjectorBackgroundThread,
+    NodeOpsExecutor,
+    generate_random_workload,
+    verify_offset_translator_state_consistent,
+)
+
+
+class FailureMode(str, Enum):
+    NONE = "NONE"
+    LEADERSHIP_TRANSFER = "LEADERSHIP_TRANSFER"
+    RANDOM = "RANDOM"
+
+
+class NoopThread:
+    def stop(self):
+        pass
+
+    def start(self):
+        pass
 
 
 class LoopThread(threading.Thread):
@@ -83,8 +105,32 @@ class DirectConsumerVerifierTest(RedpandaTest):
         )
         return thread
 
+    def get_failure_thread(self, failure_mode: FailureMode, topic_spec: str):
+        match failure_mode:
+            case FailureMode.LEADERSHIP_TRANSFER:
+                return self.create_troublemaker_thread(topic_spec)
+            case FailureMode.RANDOM:
+                return FailureInjectorBackgroundThread(
+                    self.redpanda,
+                    self.logger,
+                    max_inter_failure_time=30,
+                    min_inter_failure_time=10,
+                    max_suspend_duration_seconds=7,
+                )
+            case FailureMode.NONE:
+                return NoopThread()
+            case _:
+                return NoopThread()
+
     @cluster(num_nodes=5)
-    def test_basic_consuming_from_topic(self):
+    @matrix(
+        failure_mode=[
+            FailureMode.NONE,
+            FailureMode.LEADERSHIP_TRANSFER,
+            FailureMode.RANDOM,
+        ]
+    )
+    def test_basic_consuming_from_topic(self, failure_mode):
         topic_name = "test-topic"
         msg_count = 200000
         msg_size = 128
@@ -108,7 +154,7 @@ class DirectConsumerVerifierTest(RedpandaTest):
         verifier = DirectConsumerVerifier(self.test_context, log_level="DEBUG")
         verifier.start()
 
-        troublemaker = self.create_troublemaker_thread(topic_spec=topic_spec)
+        troublemaker = self.get_failure_thread(failure_mode, topic_spec)
         troublemaker.start()
 
         try:


### PR DESCRIPTION
Adds random node failures to direct_consumer_test.py alongside fixes for the issues this has surfaced.

Issue fixed:
    direct_consumer/fetcher previously did not reset on a broker
    dropping its fetch session id, now this resets the session

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes

* Reset fetcher state when the broker drops the fetch session

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
