### PR TITLE
bench_wrapper.py: fix MB_REDIRECT_STDERR

### DIFF
--- a/bazel/bench_wrapper.py
+++ b/bazel/bench_wrapper.py
@@ -24,7 +24,7 @@ def main():
     rundir = Path(
         os.getenv("MB_RUNDIR",
                   "/dev/shm/vectorized_io" if exec_in_shm == 1 else "."))
-    redirect_stderr = bool(
+    redirect_stderr = int(
         os.getenv("MB_REDIRECT_STDERR",
                   os.getenv("MB_REDIRECT_STDERR_DEFAULT", "0")))
     verbose = int(os.getenv("MB_VERBOSE", "0"))


### PR DESCRIPTION
Correctly interpret MB_REDIRECT_STDERR as an integer (used as a boolean).

`bool("0")` is True, so the previous code always redirected stderr.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

