### PR TITLE
[v25.1.x] rpk: add `--wait` to `remote-bundle start`

### DIFF
--- a/src/go/rpk/pkg/cli/debug/remotebundle/download.go
+++ b/src/go/rpk/pkg/cli/debug/remotebundle/download.go
@@ -66,7 +66,7 @@ Use the flag '--no-confirm' to avoid the confirmation prompt.
 			if jobID != "" {
 				status = filterStatusByJobID(status, jobID)
 			}
-			ready := filterReadyBrokers(status)
+			ready, _ := filterCompletedBrokers(status)
 			if len(ready) == 0 {
 				out.Die("There are no bundles ready for download; to check status run 'rpk debug remote-bundle status'")
 			}
@@ -192,14 +192,17 @@ func downloadBundle(ctx context.Context, fs afero.Fs, downloadPath string, statu
 	return anyErr, response, nil
 }
 
-func filterReadyBrokers(status []statusResponse) []statusResponse {
-	var filtered []statusResponse
+func filterCompletedBrokers(status []statusResponse) (readyBrokers, erroredBrokers []statusResponse) {
+	var ready []statusResponse
+	var errored []statusResponse
 	for _, s := range status {
 		if strings.EqualFold(s.Status, "success") {
-			filtered = append(filtered, s)
+			ready = append(ready, s)
+		} else if strings.EqualFold(s.Status, "error") {
+			errored = append(ready, s)
 		}
 	}
-	return filtered
+	return ready, errored
 }
 
 func fileLocation(fs afero.Fs, path string) (string, error) {

--- a/src/go/rpk/pkg/cli/debug/remotebundle/start.go
+++ b/src/go/rpk/pkg/cli/debug/remotebundle/start.go
@@ -10,10 +10,12 @@
 package remotebundle
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/google/uuid"
@@ -35,9 +37,11 @@ type startResponse struct {
 
 func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		noConfirm bool
-		jobID     string
-		opts      remoteBundleOptions
+		noConfirm   bool
+		jobID       string
+		opts        remoteBundleOptions
+		wait        bool
+		waitTimeout time.Duration
 	)
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -145,7 +149,48 @@ A debug bundle collection is already in process. To cancel it, run:
   rpk debug remote-bundle cancel
 `)
 			}
-			if anyOK {
+			if wait {
+				fmt.Printf(`
+The debug bundle collection process has started with Job-ID %v.
+Waiting for collection to complete...
+`, jobID)
+				ctx, cancel := context.WithTimeout(cmd.Context(), waitTimeout)
+				defer cancel()
+
+				statusCR := "\n"
+				if !noConfirm {
+					// Only use CRs if we've been launched interactively, so we don't break logging redirection for scripts
+					statusCR = "\r"
+				}
+
+				var done bool
+				for !done {
+					select {
+					case <-ctx.Done():
+						// Context canceled or timed out
+						out.Die("%s", ctx.Err())
+					case <-time.After(10 * time.Second):
+						status, _, _, _ := executeBundleStatus(ctx, fs, p)
+						ready, errorred := filterCompletedBrokers(status)
+						// Print in all cases, even if we're about to follow with a completion, to ensure the last print of the CR'd line is correct
+						fmt.Printf("%sJob-ID %v status: %v/%v ready (%v errored)...", statusCR, jobID, len(ready), len(status), len(errorred))
+						if len(ready)+len(errorred) == len(status) {
+							if len(ready) == 0 {
+								out.Die(`
+The debug bundle collection process with Job-ID %v has completed, but no bundles were successfully created.
+To check the status, run:
+	rpk debug remote-bundle status
+`, jobID)
+							}
+							fmt.Printf(`
+The debug bundle collection process with Job-ID %v has completed. To download the bundles, run:
+  rpk debug remote-bundle download
+`, jobID)
+							done = true
+						}
+					}
+				}
+			} else if anyOK {
 				fmt.Printf(`
 The debug bundle collection process has started with Job-ID %v. To check the 
 status, run:
@@ -157,6 +202,9 @@ status, run:
 	f := cmd.Flags()
 	f.StringVar(&jobID, "job-id", "", "Custom UUID to assign to the job that generates the debug bundle")
 	f.BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	f.BoolVar(&wait, "wait", false, "Wait for completion of remote bundle before returning")
+	f.DurationVar(&waitTimeout, "wait-timeout", 300*time.Second, "How long to wait locally for remote-bundle completion if --wait is specified. Collection on cluster will continue regardless.")
+
 	// Debug bundle options:
 	opts.InstallFlags(f)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/26486 