### PR TITLE
tools: Fix uv ruff version string

### DIFF
--- a/tools/format-py
+++ b/tools/format-py
@@ -4,5 +4,5 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 root_dir=$(git -C ${script_dir} rev-parse --show-toplevel)
 
 pushd ${root_dir}
-uv tool run --with 'ruff=0.12.10' ruff format
+uv tool run --with 'ruff==0.12.10' ruff format
 popd


### PR DESCRIPTION
Needs `==` and not `=`.

Otherwise getting:

```
stephan@rp:/build/redpanda$ ./tools/format-py
/build/redpanda /build/redpanda
error: Failed to parse: `ruff=0.12.10`
  Caused by: no such comparison operator "=", must be one of ~= == != <= >= < > ===
ruff=0.12.10
    ^^^^^^^^
/build/redpanda
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

