### PR TITLE
Added e2e tests for DR

### DIFF
--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -125,6 +125,8 @@ public:
 
     virtual ss::future<kafka::offset_commit_response>
       offset_commit(kafka::offset_commit_request) = 0;
+
+    virtual ss::future<bool> assure_topic_exists() = 0;
 };
 
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -136,6 +136,8 @@ manager::upsert_cluster_link(model::metadata md) {
     auto name = md.name;
     vlog(cllog.info, "Attempting to create cluster link named '{}'", md.name);
     vlog(cllog.trace, "Cluster link metadata: {}", md);
+    const auto needs_consumer_offsets_topic
+      = md.configuration.consumer_groups_mirroring_cfg.is_enabled;
     auto ec = co_await _registry->upsert_link(
       std::move(md), ::model::timeout_clock::now() + 30s);
     auto err = map_cluster_errc(ec);
@@ -145,6 +147,9 @@ manager::upsert_cluster_link(model::metadata md) {
     }
 
     try {
+        if (needs_consumer_offsets_topic) {
+            co_await _group_router->assure_topic_exists();
+        }
         co_await _link_created_cv.wait(
           wait_for_link_creation_timeout, [this, name] {
               return _registry->find_link_by_name(name).has_value();

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -183,6 +183,10 @@ public:
         co_return result.get();
     }
 
+    ss::future<bool> assure_topic_exists() final {
+        return _router->local().group_initializer().assure_topic_exists(false);
+    }
+
 private:
     ss::sharded<kafka::group_router>* _router;
 };

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -398,6 +398,8 @@ struct test_consumer_group_router : public consumer_groups_router {
     ss::future<kafka::offset_commit_response>
       offset_commit(kafka::offset_commit_request) override;
 
+    ss::future<bool> assure_topic_exists() override { co_return true; }
+
     chunked_hash_map<kafka::group_id, group_state> groups;
 
     int partition_count = 1;

--- a/src/v/redpanda/admin/services/shadow_link/converter.cc
+++ b/src/v/redpanda/admin/services/shadow_link/converter.cc
@@ -106,6 +106,20 @@ create_topic_metadata_mirroring_config(
     return config;
 }
 
+cluster_link::model::consumer_groups_mirroring_config
+create_consumer_groups_mirroring_config(
+  const proto::admin::consumer_offset_sync_options& options) {
+    cluster_link::model::consumer_groups_mirroring_config config;
+
+    if (options.get_interval() > absl::ZeroDuration()) {
+        config.task_interval = absl::ToChronoNanoseconds(
+          options.get_interval());
+    }
+
+    config.filters = to_filter_patterns(options.get_group_filters());
+
+    return config;
+}
 cluster_link::model::link_configuration
 create_link_configuration(const create_shadow_link_request& req) {
     cluster_link::model::link_configuration config;
@@ -114,6 +128,12 @@ create_link_configuration(const create_shadow_link_request& req) {
         req.get_shadow_link()
           .get_configurations()
           .get_topic_metadata_sync_options());
+
+    config.consumer_groups_mirroring_cfg
+      = create_consumer_groups_mirroring_config(
+        req.get_shadow_link()
+          .get_configurations()
+          .get_consumer_offset_sync_options());
 
     return config;
 }

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -14,6 +14,7 @@ from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
     shadow_link_pb2,
     shadow_link_pb2_connect,
 )
+from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.multi_cluster_services import (
     Cluster,
@@ -22,7 +23,12 @@ from rptest.services.multi_cluster_services import (
 )
 from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import expect_exception, wait_until_result
+from rptest.util import expect_exception, wait_until, wait_until_result
+from rptest.services.kgo_verifier_services import (
+    KgoVerifierProducer,
+    KgoVerifierConsumerGroupConsumer,
+)
+from rptest.clients.rpk import RpkTool
 
 
 class MultiClusterTestBase(RedpandaTest):
@@ -180,3 +186,61 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
             assert e.code == ConnectErrorCode.RESOURCE_EXHAUSTED, (
                 f"Expected {ConnectErrorCode.RESOURCE_EXHAUSTED}, got {e.code}"
             )
+
+    def create_source_consumer(self, topic, group_name="test_group", consumer_count=1):
+        return KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.source_cluster.service,
+            topic=topic,
+            group_name=group_name,
+            msg_size=128,
+            readers=consumer_count,
+        )
+
+    @cluster(num_nodes=7)
+    def test_consumer_groups_mirroring(self):
+        # Create a shadow link
+
+        topic = TopicSpec(name="source-topic", partition_count=5, replication_factor=3)
+
+        self.source_default_client().create_topic(topic)
+        # produce some data to the source cluster
+
+        KgoVerifierProducer.oneshot(
+            self.test_context, self.source_cluster.service, topic.name, 128, 10000
+        )
+
+        consumer = self.create_source_consumer(
+            topic=topic.name, group_name="test_group", consumer_count=1
+        )
+        consumer.start()
+        consumer.wait()
+        consumer.stop()
+        source_rpk = RpkTool(self.source_cluster.service)
+        description = source_rpk.group_describe(group="test_group")
+        self.logger.info(f">>> source_state: {description}")
+
+        self.create_link("test-link")
+
+        def _group_present_in_target_cluster():
+            target_rpk = RpkTool(self.target_cluster.service)
+            groups = target_rpk.group_list()
+
+            if not any(g.group == "test_group" for g in groups):
+                return False, None
+
+            desc = target_rpk.group_describe(
+                group="test_group", tolerant=True, summary=False
+            )
+
+            return True, desc
+
+        target_cluster_group = wait_until_result(
+            lambda: _group_present_in_target_cluster(),
+            timeout_sec=20,
+            err_msg="Failed to find consumer group in the target cluster",
+        )
+
+        assert target_cluster_group.state == "Empty", (
+            "Group test_group state expected to be empty on target cluster"
+        )

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -75,11 +75,35 @@ class ShadowLinkTestBase(RedpandaTest):
     def target_cluster(self) -> RedpandaCluster:
         return self.services.primary
 
-    def create_link(self, link_name: str):
-        topic_sync_options = shadow_link_pb2.TopicMetadataSyncOptions(
-            interval=google.protobuf.duration_pb2.Duration(seconds=1)
-        )
+    def create_link(
+        self,
+        link_name: str,
+        mirror_all_topics: bool = True,
+        mirror_all_groups: bool = True,
+    ):
+        if mirror_all_topics:
+            topic_sync_options = shadow_link_pb2.TopicMetadataSyncOptions(
+                interval=google.protobuf.duration_pb2.Duration(seconds=1),
+                topic_filters=[
+                    shadow_link_pb2.NameFilter(
+                        pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                        filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                        name="*",
+                    )
+                ],
+            )
 
+        if mirror_all_groups:
+            group_sync_options = shadow_link_pb2.ConsumerOffsetSyncOptions(
+                interval=google.protobuf.duration_pb2.Duration(seconds=1),
+                group_filters=[
+                    shadow_link_pb2.NameFilter(
+                        pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                        filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                        name="*",
+                    )
+                ],
+            )
         client_options = shadow_link_pb2.ShadowLinkClientOptions(
             bootstrap_servers=self.source_cluster.service.brokers_list()
         )
@@ -87,6 +111,7 @@ class ShadowLinkTestBase(RedpandaTest):
         link_cfg = shadow_link_pb2.ShadowLinkConfigurations(
             client_options=client_options,
             topic_metadata_sync_options=topic_sync_options,
+            consumer_offset_sync_options=group_sync_options,
         )
 
         link_resource = shadow_link_pb2.ShadowLink(configurations=link_cfg)


### PR DESCRIPTION
Added first e2e cluster linking test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none