### PR TITLE
boost_rules: patch BOOST_NO_CXX98_FUNCTION_BASE

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,9 @@ bazel_dep(name = "rules_boost", repo_name = "com_github_nelhage_rules_boost")
 archive_override(
     module_name = "rules_boost",
     integrity = "sha256-ICuTlyfxD3u1tr12YyeT5qPcA/ZkEUvtMDA2ZRzz1zc=",
+    patches = [
+        "//bazel/thirdparty:boost_rules_function_base.patch",
+    ],
     strip_prefix = "rules_boost-e23cc59f87d5049618472d6ce0ca0ed5ef0c23dc",
     urls = ["https://github.com/nelhage/rules_boost/archive/e23cc59f87d5049618472d6ce0ca0ed5ef0c23dc.tar.gz"],
 )

--- a/bazel/thirdparty/boost_rules_function_base.patch
+++ b/bazel/thirdparty/boost_rules_function_base.patch
@@ -1,0 +1,13 @@
+diff --git boost.BUILD boost.BUILD
+index 0e98704..389ad71 100644
+--- boost.BUILD
++++ boost.BUILD
+@@ -648,7 +648,7 @@ boost_library(
+ 
+ boost_library(
+     name = "container_hash",
+-    defines = ["BOOST_NO_CXX98_FUNCTION_BASE"],
++    defines = ["BOOST_NO_CXX98_FUNCTION_BASE="],
+     deps = [
+         ":assert",
+         ":config",


### PR DESCRIPTION
Patch boost rules to define BOOST_NO_CXX98_FUNCTION_BASE= instead of BOOST_NO_CXX98_FUNCTION_BASE, to avoid a compile failure (which can affect clangd and prevent it from finding later errors).

See: https://github.com/nelhage/rules_boost/pull/607 for details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
