### PR TITLE
.clangd: ignore -ferror-limit

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,3 +1,5 @@
 Diagnostics:
   ClangTidy:
     Remove: bugprone-unchecked-optional-access
+CompileFlags:
+  Remove: [-ferror-limit=*]


### PR DESCRIPTION
You might reasonably put `-ferror-limit=1` in your user.bazelrc, but that would cause clangd to also use that flag, which is annoying because it means that broken code won't be highlighted after the first error: but often the first error may be way in some system header file, not even in the file you are editing (in particular because clangd seems to have a more expansive definition of error than clang).

So remove this from clangd's compile flags.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
