### PR TITLE
iceberg: add some snapshot summary metrics

### DIFF
--- a/src/v/iceberg/merge_append_action.cc
+++ b/src/v/iceberg/merge_append_action.cc
@@ -173,6 +173,8 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
       new_data_files_.size());
 
     // Validate our input files that their partition keys look sane.
+    size_t added_records{0};
+    size_t added_files_size{0};
     for (const auto& f : new_data_files_) {
         if (f.file.partition.val == nullptr) {
             vlog(
@@ -200,11 +202,15 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
               pspec->fields.size());
             co_return action::errc::unexpected_state;
         }
+        added_records += f.file.record_count;
+        added_files_size += f.file.file_size_bytes;
     }
+    auto added_data_files = new_data_files_.size();
 
     // Get the manifest list for the current snapshot, if any.
     manifest_list mlist;
     std::optional<snapshot_id> old_snap_id;
+    std::optional<snapshot_summary> old_summary;
     if (table_.snapshots.has_value() && !table_.snapshots->empty()) {
         if (!table_.current_snapshot_id.has_value()) {
             // We have snapshots, but it's unclear which one to base our update
@@ -237,6 +243,7 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
         }
         mlist = std::move(mlist_res).value();
         old_snap_id = table_cur_snap_id;
+        old_summary = snap_it->summary;
     } else if (
       table_.current_snapshot_id.has_value()
       && table_.current_snapshot_id.value() != invalid_snapshot_id) {
@@ -281,16 +288,44 @@ ss::future<action::action_outcome> merge_append_action::build_updates() && {
         co_return to_action_errc(mlist_up_res.error());
     }
 
+    snapshot_summary new_summary = {
+      .operation = snapshot_operation::append,
+      .added_data_files = added_data_files,
+      .added_records = added_records,
+      .added_files_size = added_files_size,
+      // TODO: serialize other fields.
+      .other = {},
+    };
+    if (old_summary) {
+        // Only update existing total metrics; otherwise we wouldn't have an
+        // accurate starting point.
+        if (old_summary->total_data_files.has_value()) {
+            new_summary.total_data_files = added_data_files
+                                           + *old_summary->total_data_files;
+        }
+        if (old_summary->total_records.has_value()) {
+            new_summary.total_records = added_records
+                                        + *old_summary->total_records;
+        }
+        if (old_summary->total_files_size.has_value()) {
+            new_summary.total_files_size = added_files_size
+                                           + *old_summary->total_files_size;
+        }
+    } else {
+        // This is the first summary. The totals are just what we're adding in
+        // (presumably) this first snapshot.
+        new_summary.total_data_files = added_data_files;
+        new_summary.total_records = added_records;
+        new_summary.total_files_size = added_files_size;
+    }
+
     // Return the snapshot metadata.
     snapshot s{
       .id = new_snap_id,
       .parent_snapshot_id = old_snap_id,
       .sequence_number = new_seq_num,
       .timestamp_ms = model::timestamp::now(),
-      .summary = {
-          .operation = snapshot_operation::append,
-          .other = {},
-      },
+      .summary = std::move(new_summary),
       .manifest_list_path = new_mlist_path,
       .schema_id = table_.current_schema_id,
     };

--- a/src/v/iceberg/snapshot.h
+++ b/src/v/iceberg/snapshot.h
@@ -40,6 +40,17 @@ struct snapshot_summary {
     // The operation that this snapshot represents.
     snapshot_operation operation;
 
+    // A subset of the optional snapshot summary fields that get updated by an
+    // append only system like Redpanda.
+    // NOTE: these are noted as optional, but some systems require them to
+    // query the snapshot.
+    std::optional<int64_t> added_data_files;
+    std::optional<int64_t> total_data_files;
+    std::optional<int64_t> added_records;
+    std::optional<int64_t> total_records;
+    std::optional<int64_t> added_files_size;
+    std::optional<int64_t> total_files_size;
+
     // All other properties of the snapshot, besides 'operation'.
     // NOTE: these aren't necessarily important to Redpanda's Iceberg write
     // path, but are still important to serialize, as they may be used for

--- a/src/v/iceberg/snapshot_json.cc
+++ b/src/v/iceberg/snapshot_json.cc
@@ -108,18 +108,41 @@ snapshot parse_snapshot(const json::Value& v) {
         throw std::invalid_argument(
           "Expected 'summary' field to have 'operation' member");
     }
+    snapshot_summary summary{
+      .operation = operation.value(),
+      .other = std::move(other_map),
+    };
+    const auto maybe_parse_metric =
+      [&summary](std::string_view metric_name, std::optional<int64_t>* out) {
+          // Look for the given metric in the map and assign `out` if it
+          // exists. If so, the metric is removed from the map.
+          auto it = summary.other.find(ss::sstring(metric_name));
+          if (it == summary.other.end()) {
+              return;
+          }
+          try {
+              auto m = std::stol(it->second);
+              summary.other.erase(it);
+              *out = m;
+          } catch (...) {
+              // Ignore surprising values.
+          }
+      };
+    maybe_parse_metric("added-data-files", &summary.added_data_files);
+    maybe_parse_metric("total-data-files", &summary.total_data_files);
+    maybe_parse_metric("added-records", &summary.added_records);
+    maybe_parse_metric("total-records", &summary.total_records);
+    maybe_parse_metric("added-files-size", &summary.added_files_size);
+    maybe_parse_metric("total-files-size", &summary.total_files_size);
     auto operation_str = parse_required_str(summary_json, "operation");
     return snapshot{
-          .id = snapshot_id{id},
-          .parent_snapshot_id = parent_id,
-          .sequence_number = sequence_number{seq_num},
-          .timestamp_ms = model::timestamp{timestamp_ms},
-          .summary = snapshot_summary{
-              .operation = operation.value(),
-              .other = std::move(other_map),
-          },
-          .manifest_list_path = uri(manifest_list_path),
-          .schema_id = schema_id,
+      .id = snapshot_id{id},
+      .parent_snapshot_id = parent_id,
+      .sequence_number = sequence_number{seq_num},
+      .timestamp_ms = model::timestamp{timestamp_ms},
+      .summary = std::move(summary),
+      .manifest_list_path = uri(manifest_list_path),
+      .schema_id = schema_id,
     };
 }
 
@@ -169,6 +192,23 @@ void rjson_serialize(iceberg::json_writer& w, const iceberg::snapshot& s) {
         w.Key(k);
         w.String(v);
     }
+    const auto maybe_serialize_metric =
+      [&w](std::string_view metric_name, const std::optional<int64_t>& metric) {
+          if (!metric.has_value()) {
+              return;
+          }
+          w.Key(ss::sstring(metric_name));
+          w.String(fmt::to_string(*metric));
+
+          // TODO: is it important to make sure we don't double-serialize if
+          // it's in `other`?
+      };
+    maybe_serialize_metric("added-data-files", s.summary.added_data_files);
+    maybe_serialize_metric("total-data-files", s.summary.total_data_files);
+    maybe_serialize_metric("added-records", s.summary.added_records);
+    maybe_serialize_metric("total-records", s.summary.total_records);
+    maybe_serialize_metric("added-files-size", s.summary.added_files_size);
+    maybe_serialize_metric("total-files-size", s.summary.total_files_size);
     w.EndObject();
 
     w.EndObject();

--- a/src/v/iceberg/tests/merge_append_action_test.cc
+++ b/src/v/iceberg/tests/merge_append_action_test.cc
@@ -889,3 +889,100 @@ TEST_F(MergeAppendActionTest, TestWriteMetadataPathProperty) {
     const auto& manifest_path = mlist_res.value().files[0].manifest_path;
     ASSERT_TRUE(manifest_path().starts_with(custom_path));
 }
+
+TEST_F(MergeAppendActionTest, TestSnapshotSummaryFirstSnapshot) {
+    transaction tx(create_table());
+    const size_t files_count = 3;
+    const size_t records_count = 150;
+
+    auto files = create_data_files(
+      tx.table(), "test", files_count, records_count);
+    auto res = tx.merge_append(io, std::move(files)).get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+
+    const auto& table = tx.table();
+    ASSERT_TRUE(table.snapshots.has_value());
+    const auto& summary = table.snapshots->back().summary;
+
+    // First snapshot: totals should equal added values
+    const size_t file_size = 1_KiB * files_count;
+    ASSERT_EQ(summary.operation, snapshot_operation::append);
+    ASSERT_EQ(summary.added_data_files, files_count);
+    ASSERT_EQ(summary.added_records, records_count);
+    ASSERT_EQ(summary.added_files_size, file_size);
+    ASSERT_EQ(summary.total_data_files, files_count);
+    ASSERT_EQ(summary.total_records, records_count);
+    ASSERT_EQ(summary.total_files_size, file_size);
+}
+
+TEST_F(MergeAppendActionTest, TestSnapshotSummaryAdds) {
+    transaction tx(create_table());
+
+    // First append.
+    const size_t first_files = 2;
+    const size_t first_records = 100;
+    auto files1 = create_data_files(
+      tx.table(), "test1", first_files, first_records);
+    auto res1 = tx.merge_append(io, std::move(files1)).get();
+    ASSERT_FALSE(res1.has_error());
+
+    // Second append.
+    const size_t second_files = 3;
+    const size_t second_records = 200;
+    auto files2 = create_data_files(
+      tx.table(), "test2", second_files, second_records);
+    auto res2 = tx.merge_append(io, std::move(files2)).get();
+    ASSERT_FALSE(res2.has_error());
+
+    const auto& table = tx.table();
+    const auto& latest_summary = table.snapshots->back().summary;
+
+    // The second snapshot should add onto existing totals.
+    ASSERT_EQ(latest_summary.added_data_files, second_files);
+    ASSERT_EQ(latest_summary.added_records, second_records);
+    ASSERT_EQ(latest_summary.total_data_files, first_files + second_files);
+    ASSERT_EQ(latest_summary.total_records, first_records + second_records);
+    ASSERT_EQ(
+      latest_summary.total_files_size, 1_KiB * (first_files + second_files));
+}
+
+TEST_F(MergeAppendActionTest, TestSnapshotSummaryMissingMetrics) {
+    auto table = create_table();
+    auto initial_mlist_path = uri(
+      fmt::format("s3://{}/manifest1.avro", bucket_name()));
+    snapshot initial_snap{
+        .id = snapshot_id{1},
+        .sequence_number = sequence_number{1},
+        .timestamp_ms = model::timestamp::now(),
+        .summary = snapshot_summary{
+            .operation = snapshot_operation::append,
+            // Only set total_records, leave others unset.
+            .total_records = 100,
+        },
+        .manifest_list_path = initial_mlist_path,
+        .schema_id = table.current_schema_id,
+    };
+    manifest_list initial_mlist;
+    auto up_res
+      = io.upload_manifest_list(initial_mlist_path, initial_mlist).get();
+    ASSERT_TRUE(up_res.has_value());
+
+    table.snapshots = chunked_vector<snapshot>{};
+    table.snapshots->emplace_back(std::move(initial_snap));
+    table.current_snapshot_id = snapshot_id{1};
+    table.last_sequence_number = sequence_number{1};
+
+    transaction tx(std::move(table));
+    auto files = create_data_files(tx.table(), "test", 1, 50);
+    auto res = tx.merge_append(io, std::move(files)).get();
+    ASSERT_FALSE(res.has_error()) << res.error();
+
+    const auto& updated_table = tx.table();
+    const auto& latest_summary = updated_table.snapshots->back().summary;
+
+    // We should only update the total_records metric, since the others were
+    // missing.
+    ASSERT_EQ(latest_summary.total_records, 150);
+    ASSERT_FALSE(latest_summary.total_data_files.has_value());
+    ASSERT_FALSE(latest_summary.total_files_size.has_value());
+}

--- a/src/v/iceberg/tests/snapshot_json_test.cc
+++ b/src/v/iceberg/tests/snapshot_json_test.cc
@@ -26,6 +26,12 @@ TEST(SnapshotJsonSerde, TestSnapshot) {
             "timestamp-ms": 1515100955770,
             "summary": {
                 "operation": "append",
+                "added-data-files": "100",
+                "total-data-files": "101",
+                "added-records": "102",
+                "total-records": "103",
+                "added-files-size": "104",
+                "total-files-size": "105",
                 "foo": "bar"
             },
             "manifest-list": "s3://b/wh/.../s1.avro",
@@ -41,6 +47,12 @@ TEST(SnapshotJsonSerde, TestSnapshot) {
     ASSERT_EQ(10, snap.sequence_number());
     ASSERT_EQ(1515100955770, snap.timestamp_ms.value());
     ASSERT_EQ(snapshot_operation::append, snap.summary.operation);
+    ASSERT_EQ(snap.summary.added_data_files, 100);
+    ASSERT_EQ(snap.summary.total_data_files, 101);
+    ASSERT_EQ(snap.summary.added_records, 102);
+    ASSERT_EQ(snap.summary.total_records, 103);
+    ASSERT_EQ(snap.summary.added_files_size, 104);
+    ASSERT_EQ(snap.summary.total_files_size, 105);
     ASSERT_EQ(1, snap.summary.other.size());
     ASSERT_EQ("bar", snap.summary.other.at("foo"));
     ASSERT_STREQ("s3://b/wh/.../s1.avro", snap.manifest_list_path().c_str());


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
    Certain query engines (e.g. Redshift) require some optional metrics[1] to
    be set in our snapshot summaries. It isn't clear exactly which all
    metrics are actually required, but at the very least, Redshift will
    complain about a missing "total-records" field.

    This commit updates the merge append action to do accounting for some of
    these metrics (num records, num data files, size).

    There are "added" metrics which account for just what is added in the
    given snapshot, and "total" metrics, which account for the whole
    snapshot. The spec includes "deleted" metrics, but as Redpanda doesn't
    delete anything, we are omitting them for now.

    "Total" metrics will be omitted if the previous snapshot was missing the
    metric, following the Python[2] and Java[3] implementations.

    I tested this manually against Redshift. Without this change, we would
    see errors like:

    ```
    ERROR: ----------------------------------------------- error: Error parsing table metadata. code: 15003 context: Required field total-records missing. query: 409612[child_sequence:1] location: json_utils.hpp:56 process: padbmaster [pid=1073848668] ----------------------------------------------- [ErrorId: 1-68b0b26f-4870c0806c81008553e63bc0]
    ```

    [1] https://iceberg.apache.org/spec/#metrics
    [2] https://github.com/apache/iceberg-python/blob/06b9467f1db2b71c51d4c1be5f3a5144afa52880/pyiceberg/table/snapshots.py#L370-L392
    [3] https://github.com/apache/iceberg/blob/2b66fc553acc0e7ddc9edcdb26095daf4e8a04c2/core/src/main/java/org/apache/iceberg/SnapshotProducer.java#L341-L411

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Redpanda Iceberg topics will now serialize some Iceberg snapshot summary metrics that are required for certain query engines (e.g. Redshift) to run against Redpanda's tables.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
