### PR TITLE
`config`: add support for `message.timestamp.{before/after}.max.ms`

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -515,6 +515,8 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      std::nullopt,
+      std::nullopt,
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -348,6 +348,16 @@ metadata_cache::get_default_max_compaction_lag_ms() const {
     return config::shard_local_cfg().max_compaction_lag_ms();
 }
 
+std::chrono::milliseconds
+metadata_cache::get_default_message_timestamp_before_max_ms() const {
+    return config::shard_local_cfg().log_message_timestamp_before_max_ms();
+}
+
+std::chrono::milliseconds
+metadata_cache::get_default_message_timestamp_after_max_ms() const {
+    return config::shard_local_cfg().log_message_timestamp_after_max_ms();
+}
+
 topic_properties metadata_cache::get_default_properties() const {
     topic_properties tp;
     tp.compression = {get_default_compression()};
@@ -371,6 +381,10 @@ topic_properties metadata_cache::get_default_properties() const {
       get_default_min_cleanable_dirty_ratio()};
     tp.min_compaction_lag_ms = get_default_min_compaction_lag_ms();
     tp.max_compaction_lag_ms = get_default_max_compaction_lag_ms();
+    tp.message_timestamp_before_max_ms
+      = get_default_message_timestamp_before_max_ms();
+    tp.message_timestamp_after_max_ms
+      = get_default_message_timestamp_after_max_ms();
 
     return tp;
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -213,6 +213,10 @@ public:
     std::optional<double> get_default_min_cleanable_dirty_ratio() const;
     std::chrono::milliseconds get_default_min_compaction_lag_ms() const;
     std::chrono::milliseconds get_default_max_compaction_lag_ms() const;
+    std::chrono::milliseconds
+    get_default_message_timestamp_before_max_ms() const;
+    std::chrono::milliseconds
+    get_default_message_timestamp_after_max_ms() const;
 
     topic_properties get_default_properties() const;
     std::optional<partition_assignment>

--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -49,7 +49,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "iceberg_target_lag_ms: {}, "
       "min_cleanable_dirty_ratio: {}, "
       "min_compaction_lag_ms: {}, "
-      "max_compaction_lag_ms: {}",
+      "max_compaction_lag_ms: {},"
+      "message_timestamp_before_max_ms: {},"
+      "message_timestamp_after_max_ms: {}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -93,7 +95,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.iceberg_target_lag_ms,
       properties.min_cleanable_dirty_ratio,
       properties.min_compaction_lag_ms,
-      properties.max_compaction_lag_ms);
+      properties.max_compaction_lag_ms,
+      properties.message_timestamp_before_max_ms,
+      properties.message_timestamp_after_max_ms);
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         fmt::print(
@@ -145,7 +149,9 @@ bool topic_properties::has_overrides() const {
         || min_cleanable_dirty_ratio.is_engaged()
         || min_compaction_lag_ms.has_value()
         || max_compaction_lag_ms.has_value()
-        || remote_topic_allow_gaps.has_value();
+        || remote_topic_allow_gaps.has_value()
+        || message_timestamp_before_max_ms.has_value()
+        || message_timestamp_after_max_ms.has_value();
 
     if (config::shard_local_cfg().development_enable_cloud_topics()) {
         return overrides
@@ -289,6 +295,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       tristate<double>{std::nullopt},
+      std::nullopt,
+      std::nullopt,
       std::nullopt,
       std::nullopt,
       std::nullopt,

--- a/src/v/cluster/topic_properties.h
+++ b/src/v/cluster/topic_properties.h
@@ -33,7 +33,7 @@ namespace cluster {
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<11>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<12>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -84,7 +84,9 @@ struct topic_properties
       tristate<double> min_cleanable_dirty_ratio,
       std::optional<std::chrono::milliseconds> min_compaction_lag_ms,
       std::optional<std::chrono::milliseconds> max_compaction_lag_ms,
-      std::optional<bool> remote_topic_allow_gaps)
+      std::optional<bool> remote_topic_allow_gaps,
+      std::optional<std::chrono::milliseconds> message_timestamp_before_max_ms,
+      std::optional<std::chrono::milliseconds> message_timestamp_after_max_ms)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -133,7 +135,9 @@ struct topic_properties
       , iceberg_target_lag_ms(iceberg_target_lag_ms)
       , min_cleanable_dirty_ratio(min_cleanable_dirty_ratio)
       , min_compaction_lag_ms(min_compaction_lag_ms)
-      , max_compaction_lag_ms(max_compaction_lag_ms) {}
+      , max_compaction_lag_ms(max_compaction_lag_ms)
+      , message_timestamp_before_max_ms(message_timestamp_before_max_ms)
+      , message_timestamp_after_max_ms(message_timestamp_after_max_ms) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -226,6 +230,9 @@ struct topic_properties
     std::optional<std::chrono::milliseconds> min_compaction_lag_ms{};
     std::optional<std::chrono::milliseconds> max_compaction_lag_ms{};
 
+    std::optional<std::chrono::milliseconds> message_timestamp_before_max_ms{};
+    std::optional<std::chrono::milliseconds> message_timestamp_after_max_ms{};
+
     bool is_compacted() const;
     bool has_overrides() const;
     bool requires_remote_erase() const;
@@ -279,7 +286,9 @@ struct topic_properties
           min_cleanable_dirty_ratio,
           remote_topic_allow_gaps,
           min_compaction_lag_ms,
-          max_compaction_lag_ms);
+          max_compaction_lag_ms,
+          message_timestamp_before_max_ms,
+          message_timestamp_after_max_ms);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1158,6 +1158,12 @@ topic_properties topic_table::update_topic_properties(
       overrides.max_compaction_lag_ms);
     incremental_update(
       updated_properties.remote_topic_allow_gaps, overrides.remote_allow_gaps);
+    incremental_update(
+      updated_properties.message_timestamp_before_max_ms,
+      overrides.message_timestamp_before_max_ms);
+    incremental_update(
+      updated_properties.message_timestamp_after_max_ms,
+      overrides.message_timestamp_after_max_ms);
     return updated_properties;
 }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -562,7 +562,7 @@ struct property_update<tristate<T>>
 struct incremental_topic_updates
   : serde::envelope<
       incremental_topic_updates,
-      serde::version<8>,
+      serde::version<9>,
       serde::compat_version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
@@ -648,6 +648,11 @@ struct incremental_topic_updates
     property_update<std::optional<std::chrono::milliseconds>>
       iceberg_target_lag_ms;
 
+    property_update<std::optional<std::chrono::milliseconds>>
+      message_timestamp_before_max_ms;
+    property_update<std::optional<std::chrono::milliseconds>>
+      message_timestamp_after_max_ms;
+
     // Not a regular topic property. Used to assign topic UUIDs to pre-25-2
     // topics that were created without one.
     property_update<std::optional<model::topic_id>> topic_id;
@@ -698,7 +703,9 @@ struct incremental_topic_updates
           remote_allow_gaps,
           topic_id,
           min_compaction_lag_ms,
-          max_compaction_lag_ms);
+          max_compaction_lag_ms,
+          message_timestamp_before_max_ms,
+          message_timestamp_after_max_ms);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -674,6 +674,8 @@ struct instance_generator<cluster::topic_properties> {
           std::nullopt,
           std::nullopt,
           std::nullopt,
+          std::nullopt,
+          std::nullopt,
         };
     }
 

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -634,6 +634,12 @@ inline void rjson_serialize(
     write_member(w, "min_cleanable_dirty_ratio", tps.min_cleanable_dirty_ratio);
     write_member(w, "min_compaction_lag_ms", tps.min_compaction_lag_ms);
     write_member(w, "max_compaction_lag_ms", tps.max_compaction_lag_ms);
+    write_member(
+      w,
+      "message_timestamp_before_max_ms",
+      tps.message_timestamp_before_max_ms);
+    write_member(
+      w, "message_timestamp_after_max_ms", tps.message_timestamp_after_max_ms);
     w.EndObject();
 }
 
@@ -712,6 +718,12 @@ inline void read_value(const json::Value& rd, cluster::topic_properties& obj) {
     read_member(rd, "min_cleanable_dirty_ratio", obj.min_cleanable_dirty_ratio);
     read_member(rd, "min_compaction_lag_ms", obj.min_compaction_lag_ms);
     read_member(rd, "max_compaction_lag_ms", obj.max_compaction_lag_ms);
+    read_member(
+      rd,
+      "message_timestamp_before_max_ms",
+      obj.message_timestamp_before_max_ms);
+    read_member(
+      rd, "message_timestamp_after_max_ms", obj.message_timestamp_after_max_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -825,27 +825,9 @@ configuration::configuration()
       model::timestamp_type::create_time,
       {model::timestamp_type::create_time, model::timestamp_type::append_time})
   , log_message_timestamp_alert_before_ms(
-      *this,
-      "log_message_timestamp_alert_before_ms",
-      "Threshold in milliseconds for alerting on messages with a timestamp "
-      "before the broker's time, meaning the messages are in the past relative "
-      "to the broker's clock. To disable this check, set to `null`.",
-      {.needs_restart = needs_restart::no,
-       .example = "604800000",
-       .visibility = visibility::tunable},
-      std::nullopt,
-      {.min = 5min})
+      *this, "log_message_timestamp_alert_before_ms")
   , log_message_timestamp_alert_after_ms(
-      *this,
-      "log_message_timestamp_alert_after_ms",
-      "Threshold in milliseconds for alerting on messages with a timestamp "
-      "after the broker's time, meaning the messages are in the future "
-      "relative to the broker's clock.",
-      {.needs_restart = needs_restart::no,
-       .example = "3600000",
-       .visibility = visibility::tunable},
-      2h,
-      {.min = 5min})
+      *this, "log_message_timestamp_alert_after_ms")
   , log_message_timestamp_before_max_ms(
       *this,
       "log_message_timestamp_before_max_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -846,6 +846,34 @@ configuration::configuration()
        .visibility = visibility::tunable},
       2h,
       {.min = 5min})
+  , log_message_timestamp_before_max_ms(
+      *this,
+      "log_message_timestamp_before_max_ms",
+      "The maximum allowable timestamp difference between the broker's "
+      "timestamp and a record's timestamp. For topics with "
+      "`message.timestamp.type` set to `CreateTime`, Redpanda rejects records "
+      "that have timestamps earlier than the broker timestamp and exceed this "
+      "difference. Redpanda ignores this property for topics with "
+      "`message.timestamp.type` set to `AppendTime`. The topic property "
+      "`message.timestamp.before.max.ms` overrides the value of "
+      "`log_message_timestamp_before_max_ms` at the topic level.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      serde::max_serializable_ms,
+      {.min = 0ms, .max = serde::max_serializable_ms})
+  , log_message_timestamp_after_max_ms(
+      *this,
+      "log_message_timestamp_after_max_ms",
+      "The maximum allowable timestamp difference between the broker's "
+      "timestamp and a record's timestamp. For topics with "
+      "`message.timestamp.type` set to `CreateTime`, Redpanda rejects records "
+      "that have timestamps later than the broker timestamp and exceed this "
+      "difference. Redpanda ignores this property for topics with "
+      "`message.timestamp.type` set to `AppendTime`. The topic property "
+      "`message.timestamp.after.max.ms` overrides the value of "
+      "`log_message_timestamp_after_max_ms` at the topic level.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1h,
+      {.min = 0ms, .max = serde::max_serializable_ms})
   , log_compression_type(
       *this,
       "log_compression_type",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -228,10 +228,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
     enum_property<model::timestamp_type> log_message_timestamp_type;
-    bounded_property<std::optional<std::chrono::milliseconds>>
-      log_message_timestamp_alert_before_ms;
-    bounded_property<std::chrono::milliseconds>
-      log_message_timestamp_alert_after_ms;
+    deprecated_property log_message_timestamp_alert_before_ms;
+    deprecated_property log_message_timestamp_alert_after_ms;
     bounded_property<std::chrono::milliseconds>
       log_message_timestamp_before_max_ms;
     bounded_property<std::chrono::milliseconds>

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -232,6 +232,10 @@ struct configuration final : public config_store {
       log_message_timestamp_alert_before_ms;
     bounded_property<std::chrono::milliseconds>
       log_message_timestamp_alert_after_ms;
+    bounded_property<std::chrono::milliseconds>
+      log_message_timestamp_before_max_ms;
+    bounded_property<std::chrono::milliseconds>
+      log_message_timestamp_after_max_ms;
     enum_property<model::compression> log_compression_type;
     property<size_t> fetch_max_bytes;
     property<bool> use_fetch_scheduler_group;

--- a/src/v/kafka/client/test/cluster_mock.cc
+++ b/src/v/kafka/client/test/cluster_mock.cc
@@ -115,6 +115,14 @@ public:
     get_default_max_compaction_lag_ms() const override {
         return _config->max_compaction_lag_ms();
     }
+    std::chrono::milliseconds
+    get_default_message_timestamp_before_max_ms() const override {
+        return _config->log_message_timestamp_before_max_ms();
+    }
+    std::chrono::milliseconds
+    get_default_message_timestamp_after_max_ms() const override {
+        return _config->log_message_timestamp_after_max_ms();
+    }
 
 private:
     config::configuration* _config;

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -18,6 +18,7 @@
 #include "kafka/protocol/wire.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "model/timestamp.h"
 
 #include <seastar/core/smp.hh>
 
@@ -191,13 +192,33 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
      * Perform some type of validation on the uncompressed input. In this case
      * we make sure that the records can be materialized but we avoid
      * re-encoding them using the lazy-record optimization.
+     *
+     * TODO(kafka): we should also be validating compressed batches - the
+     * reference implementation does this, and this also means they are able to
+     * set the max_timestamp when using timestamp_type::create_time.
      */
     if (!new_batch.compressed()) {
+        int64_t max_timestamp_delta = 0;
         try {
-            new_batch.for_each_record([](model::record r) { (void)r; });
+            new_batch.for_each_record([&max_timestamp_delta](model::record r) {
+                max_timestamp_delta = std::max(
+                  r.timestamp_delta(), max_timestamp_delta);
+            });
         } catch (const std::exception& e) {
             vlog(klog.error, "Parsing uncompressed records: {}", e.what());
             return remainder;
+        }
+        // If using append_time, we'll override the timestamp in the produce
+        // handler. Otherwise if the client does not set the max_timestamp we
+        // need to so that timequeries work correctly.
+        if (
+          header.max_timestamp == model::timestamp::missing()
+          && header.attrs.timestamp_type()
+               == model::timestamp_type::create_time) {
+            model::timestamp max_timestamp(
+              header.first_timestamp() + max_timestamp_delta);
+            new_batch.set_max_timestamp(
+              model::timestamp_type::create_time, max_timestamp);
         }
     }
 

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -85,7 +85,7 @@ create_topic_properties_update(
     std::apply(apply_op(op_t::none), update.custom_properties.serde_fields());
 
     static_assert(
-      std::tuple_size_v<decltype(update.properties.serde_fields())> == 40,
+      std::tuple_size_v<decltype(update.properties.serde_fields())> == 42,
       "If you add a property, decide on its default alter config "
       "policy, and handle the update in the loop below");
     static_assert(
@@ -439,6 +439,26 @@ create_topic_properties_update(
                   update.properties.remote_allow_gaps,
                   cfg.value,
                   kafka::config_resource_operation::set);
+                continue;
+            }
+
+            if (cfg.name == topic_property_message_timestamp_before_max_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.message_timestamp_before_max_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  message_timestamp_before_max_ms_validator,
+                  /*clamp_to_duration_max=*/true);
+                continue;
+            }
+
+            if (cfg.name == topic_property_message_timestamp_after_max_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.message_timestamp_after_max_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  message_timestamp_after_max_ms_validator,
+                  /*clamp_to_duration_max=*/true);
                 continue;
             }
 

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -116,6 +116,14 @@ std::chrono::milliseconds
 metadata_cache_adapter::get_default_max_compaction_lag_ms() const {
     return _metadata_cache.get_default_max_compaction_lag_ms();
 }
+std::chrono::milliseconds
+metadata_cache_adapter::get_default_message_timestamp_before_max_ms() const {
+    return _metadata_cache.get_default_message_timestamp_before_max_ms();
+}
+std::chrono::milliseconds
+metadata_cache_adapter::get_default_message_timestamp_after_max_ms() const {
+    return _metadata_cache.get_default_message_timestamp_after_max_ms();
+}
 
 bool config_property_requested(
   const config_key_t& configuration_keys,
@@ -1170,6 +1178,32 @@ config_response_container_t make_topic_configs(
         config::shard_local_cfg()
           .cloud_storage_enable_remote_allow_gaps.desc()),
       &describe_as_string<bool>);
+
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      topic_property_message_timestamp_before_max_ms,
+      metadata_cache.get_default_message_timestamp_before_max_ms(),
+      topic_property_message_timestamp_before_max_ms,
+      topic_properties.message_timestamp_before_max_ms,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().log_message_timestamp_before_max_ms.desc()),
+      describe_as_string<std::chrono::milliseconds>);
+
+    add_topic_config_if_requested(
+      config_keys,
+      result,
+      topic_property_message_timestamp_after_max_ms,
+      metadata_cache.get_default_message_timestamp_after_max_ms(),
+      topic_property_message_timestamp_after_max_ms,
+      topic_properties.message_timestamp_after_max_ms,
+      include_synonyms,
+      maybe_make_documentation(
+        include_documentation,
+        config::shard_local_cfg().log_message_timestamp_after_max_ms.desc()),
+      describe_as_string<std::chrono::milliseconds>);
 
     return result;
 }

--- a/src/v/kafka/server/handlers/configs/config_response_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.h
@@ -89,6 +89,12 @@ struct metadata_cache_info {
       = 0;
     virtual std::chrono::milliseconds get_default_max_compaction_lag_ms() const
       = 0;
+    virtual std::chrono::milliseconds
+    get_default_message_timestamp_before_max_ms() const
+      = 0;
+    virtual std::chrono::milliseconds
+    get_default_message_timestamp_after_max_ms() const
+      = 0;
 };
 /// This is the adapter to use cluster::metadata_cache
 struct metadata_cache_adapter : public metadata_cache_info {
@@ -135,6 +141,10 @@ public:
     get_default_min_compaction_lag_ms() const override;
     std::chrono::milliseconds
     get_default_max_compaction_lag_ms() const override;
+    std::chrono::milliseconds
+    get_default_message_timestamp_before_max_ms() const override;
+    std::chrono::milliseconds
+    get_default_message_timestamp_after_max_ms() const override;
 
 private:
     const cluster::metadata_cache& _metadata_cache;

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -236,6 +236,10 @@ const auto min_compaction_lag_ms_validator = duration_validator{
   .name = "min.compaction.lag.ms"};
 const auto max_compaction_lag_ms_validator = duration_validator{
   .name = "max.compaction.lag.ms", .min = 1ms};
+const auto message_timestamp_before_max_ms_validator = duration_validator{
+  .name = "message.timestamp.before.max.ms", .min = 0ms};
+const auto message_timestamp_after_max_ms_validator = duration_validator{
+  .name = "message.timestamp.after.max.ms", .min = 0ms};
 
 struct flush_bytes_validator {
     std::optional<ss::sstring>

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -83,7 +83,9 @@ bool is_supported(std::string_view name) {
        topic_property_min_cleanable_dirty_ratio,
        topic_property_min_compaction_lag_ms,
        topic_property_max_compaction_lag_ms,
-       topic_property_remote_allow_gaps});
+       topic_property_remote_allow_gaps,
+       topic_property_message_timestamp_before_max_ms,
+       topic_property_message_timestamp_after_max_ms});
 
     if (std::any_of(
           supported_configs.begin(),

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -431,6 +431,26 @@ create_topic_properties_update(
                   max_compaction_lag_ms_validator);
                 continue;
             }
+
+            if (cfg.name == topic_property_message_timestamp_before_max_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.message_timestamp_before_max_ms,
+                  cfg.value,
+                  op,
+                  message_timestamp_before_max_ms_validator,
+                  /*clamp_to_duration_max=*/true);
+                continue;
+            }
+
+            if (cfg.name == topic_property_message_timestamp_after_max_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.message_timestamp_after_max_ms,
+                  cfg.value,
+                  op,
+                  message_timestamp_after_max_ms_validator,
+                  /*clamp_to_duration_max=*/true);
+                continue;
+            }
         } catch (const validation_error& e) {
             vlog(
               klog.debug,
@@ -486,6 +506,12 @@ inline std::string_view map_config_name(std::string_view input) {
       .match("log.compression.type", "log_compression_type")
       .match("log.roll.ms", "log_segment_ms")
       .match("log.cleaner.delete.retention.ms", "tombstone_retention_ms")
+      .match(
+        "log.message.timestamp.before.max.ms",
+        "log_message_timestamp_before_max_ms")
+      .match(
+        "log.message.timestamp.after.max.ms",
+        "log_message_timestamp_after_max_ms")
       .default_match(input);
 }
 

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -209,63 +209,6 @@ auto validate_batch_timestamps(
   const model::record_batch_header& header,
   model::timestamp_type timestamp_type,
   kafka::kafka_probe& probe) -> std::optional<model::timestamp> {
-    // we compute in std::chrono::timepoints, we print in model::timestamps
-    auto broker_time = model::timestamp::now();
-    auto broker_timepoint = model::duration_since_epoch(broker_time);
-
-    // alert if first_timestamp is too far in the past
-    // default value for threshold basically disables this check, so it's
-    // wrapped in a if check
-    if (auto max_before = config::shard_local_cfg()
-                            .log_message_timestamp_alert_before_ms.value();
-        unlikely(max_before)) {
-        auto first_timepoint = model::duration_since_epoch(
-          header.first_timestamp);
-        if (
-          broker_timepoint > first_timepoint
-          && std::chrono::duration_cast<std::chrono::milliseconds>(
-               broker_timepoint - first_timepoint)
-               > max_before.value()) {
-            // generate an alert
-            thread_local static ss::logger::rate_limit rate(despam_interval);
-            klog.log(
-              ss::log_level::warn,
-              rate,
-              "produce request timestamp for {} was before the alert "
-              "threshold, broker time: {}, timestamp: {}",
-              ntp,
-              broker_time,
-              header.first_timestamp);
-            // it's expected that to debug this, the observer will need to check
-            // the logs for the npt that triggered the alert
-            probe.produce_bad_create_time();
-        }
-    }
-
-    // alert if max_timestamp is too far in the future
-    if (timestamp_type == model::timestamp_type::create_time) {
-        auto max_after = config::shard_local_cfg()
-                           .log_message_timestamp_alert_after_ms.value();
-        auto max_timepoint = model::duration_since_epoch(header.max_timestamp);
-        if (
-          broker_timepoint < max_timepoint
-          && std::chrono::duration_cast<std::chrono::milliseconds>(
-               max_timepoint - broker_timepoint)
-               > max_after) {
-            // same as above, generate an alert
-            thread_local static ss::logger::rate_limit rate(despam_interval);
-            klog.log(
-              ss::log_level::warn,
-              rate,
-              "produce request timestamp for {} was past the alert threshold, "
-              "broker time: {}, timestamp: {}",
-              ntp,
-              broker_time,
-              header.max_timestamp);
-            probe.produce_bad_create_time();
-        }
-    }
-
     /*
      * For append time setting we have to recompute
      * the CRC.

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -35,6 +35,8 @@
 #include <boost/container_hash/extensions.hpp>
 #include <fmt/ostream.h>
 
+#include <chrono>
+
 namespace kafka {
 namespace {
 static constexpr auto despam_interval = std::chrono::minutes(5);
@@ -201,27 +203,99 @@ ss::future<produce_response::partition> finalize_request_with_error_code(
 
 /**
  * @brief Validate the timestamps of the batch, they have to be within a window
- * to the broker's time. returns the new timestamp to set as max_timestamp to
- * the batch, if present
+ * to the broker's time. returns an optional containing an error message if the
+ * batch should be rejected, or may set the passed `batch`'s `max_timestamp` to
+ * the current timestamp if using `AppendTime`.
  */
 auto validate_batch_timestamps(
   const model::ntp& ntp,
-  const model::record_batch_header& header,
+  model::record_batch& batch,
   model::timestamp_type timestamp_type,
-  kafka::kafka_probe& probe) -> std::optional<model::timestamp> {
+  std::chrono::milliseconds message_timestamp_before_max_ms,
+  std::chrono::milliseconds message_timestamp_after_max_ms,
+  kafka::kafka_probe& probe) -> std::optional<ss::sstring> {
+    auto broker_time = model::timestamp::now();
+    const auto& header = batch.header();
     /*
      * For append time setting we have to recompute
      * the CRC.
      */
     if (timestamp_type == model::timestamp_type::append_time) {
-        return broker_time;
-    } else {
+        batch.set_max_timestamp(
+          model::timestamp_type::append_time, broker_time);
         return std::nullopt;
     }
+
+    // `message.timestamp_type` is `CreateTime`. Validate record timestamps
+    // using `message.timestamp.before.max.ms` and
+    // `message.timestamp.after.max.ms`.
+    auto broker_timepoint = model::duration_since_epoch(broker_time);
+
+    // reject if first_timestamp is too far in the past
+    auto first_timepoint = model::duration_since_epoch(header.first_timestamp);
+    if (
+      broker_timepoint > first_timepoint
+      && std::chrono::duration_cast<std::chrono::milliseconds>(
+           broker_timepoint - first_timepoint)
+           > message_timestamp_before_max_ms) {
+        thread_local static ss::logger::rate_limit rate(despam_interval);
+        klog.log(
+          ss::log_level::warn,
+          rate,
+          "produce request timestamp for {} was before the threshold set by "
+          "message.timestamp.before.max.ms: {}, broker time: {}, timestamp: "
+          "{}. Rejecting batch {}",
+          ntp,
+          message_timestamp_before_max_ms,
+          broker_time,
+          header.first_timestamp,
+          header);
+        probe.produce_bad_create_time();
+        return ssx::sformat(
+          "Timestamp {} of message with offset {} is out of range. The "
+          "timestamp should be within [{}, {}] of the broker time.",
+          header.first_timestamp,
+          header.base_offset,
+          message_timestamp_before_max_ms,
+          message_timestamp_after_max_ms);
+    }
+
+    // reject if max_timestamp is too far in the future.
+    auto max_timepoint = model::duration_since_epoch(header.max_timestamp);
+    if (
+      broker_timepoint < max_timepoint
+      && std::chrono::duration_cast<std::chrono::milliseconds>(
+           max_timepoint - broker_timepoint)
+           > message_timestamp_after_max_ms) {
+        thread_local static ss::logger::rate_limit rate(despam_interval);
+        klog.log(
+          ss::log_level::warn,
+          rate,
+          "produce request timestamp for {} was past the threshold set by "
+          "message.timestamp.after.max.ms: {}, broker time: {}, timestamp: {}. "
+          "Rejecting batch {}",
+          ntp,
+          message_timestamp_after_max_ms,
+          broker_time,
+          header.max_timestamp,
+          header);
+        probe.produce_bad_create_time();
+        return ssx::sformat(
+          "Timestamp {} of message with offset {} is out of range. The "
+          "timestamp should be within [{}, {}] of the broker time.",
+          header.max_timestamp,
+          header.last_offset(),
+          message_timestamp_before_max_ms,
+          message_timestamp_after_max_ms);
+    }
+
+    return std::nullopt;
 }
 struct topic_configuration_context {
     size_t batch_max_bytes;
     model::timestamp_type timestamp_type;
+    std::chrono::milliseconds message_timestamp_before_max_ms;
+    std::chrono::milliseconds message_timestamp_after_max_ms;
     const cluster::topic_properties* properties;
 };
 /**
@@ -253,11 +327,22 @@ partition_produce_stages produce_topic_partition(
       std::move(part.records->adapter.batch.value()));
 
     // validate the batch timestamps by checking skew against broker time
-    if (
-      auto new_timestamp = validate_batch_timestamps(
-        ntp, batch->header(), cfg_ctx.timestamp_type, octx.rctx.probe())) {
-        batch->set_max_timestamp(
-          model::timestamp_type::append_time, new_timestamp.value());
+    auto validate_timestamp = validate_batch_timestamps(
+      ntp,
+      *batch,
+      cfg_ctx.timestamp_type,
+      cfg_ctx.message_timestamp_before_max_ms,
+      cfg_ctx.message_timestamp_after_max_ms,
+      octx.rctx.probe());
+    if (validate_timestamp.has_value()) {
+        auto dispatch_f = ss::now();
+        auto f = ss::make_ready_future<produce_response::partition>(
+          produce_response::partition{
+            .partition_index = ntp.tp.partition,
+            .error_code = error_code::invalid_timestamp,
+            .error_message = std::move(validate_timestamp).value()});
+        return partition_produce_stages{
+          .dispatched = std::move(dispatch_f), .produced = std::move(f)};
     }
 
     const auto& hdr = batch->header();
@@ -469,6 +554,14 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
         octx.rctx.metadata_cache().get_default_batch_max_bytes()),
       .timestamp_type = topic_cfg.properties.timestamp_type.value_or(
         octx.rctx.metadata_cache().get_default_timestamp_type()),
+      .message_timestamp_before_max_ms
+      = topic_cfg.properties.message_timestamp_before_max_ms.value_or(
+        octx.rctx.metadata_cache()
+          .get_default_message_timestamp_before_max_ms()),
+      .message_timestamp_after_max_ms
+      = topic_cfg.properties.message_timestamp_after_max_ms.value_or(
+        octx.rctx.metadata_cache()
+          .get_default_message_timestamp_after_max_ms()),
       .properties = &topic_cfg.properties,
     };
 
@@ -603,6 +696,14 @@ partition_produce_stages produce_single_partition(
         octx.rctx.metadata_cache().get_default_batch_max_bytes()),
       .timestamp_type = topic_cfg.properties.timestamp_type.value_or(
         octx.rctx.metadata_cache().get_default_timestamp_type()),
+      .message_timestamp_before_max_ms
+      = topic_cfg.properties.message_timestamp_before_max_ms.value_or(
+        octx.rctx.metadata_cache()
+          .get_default_message_timestamp_before_max_ms()),
+      .message_timestamp_after_max_ms
+      = topic_cfg.properties.message_timestamp_after_max_ms.value_or(
+        octx.rctx.metadata_cache()
+          .get_default_message_timestamp_after_max_ms()),
       .properties = &topic_cfg.properties,
     };
     return produce_topic_partition(octx, topic, part, cfg_ctx);

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -229,15 +229,12 @@ auto validate_batch_timestamps(
     // `message.timestamp_type` is `CreateTime`. Validate record timestamps
     // using `message.timestamp.before.max.ms` and
     // `message.timestamp.after.max.ms`.
-    auto broker_timepoint = model::duration_since_epoch(broker_time);
 
     // reject if first_timestamp is too far in the past
-    auto first_timepoint = model::duration_since_epoch(header.first_timestamp);
     if (
-      broker_timepoint > first_timepoint
-      && std::chrono::duration_cast<std::chrono::milliseconds>(
-           broker_timepoint - first_timepoint)
-           > message_timestamp_before_max_ms) {
+      broker_time > header.first_timestamp
+      && (broker_time - header.first_timestamp)
+           > model::timestamp(message_timestamp_before_max_ms.count())) {
         thread_local static ss::logger::rate_limit rate(despam_interval);
         klog.log(
           ss::log_level::warn,
@@ -261,12 +258,10 @@ auto validate_batch_timestamps(
     }
 
     // reject if max_timestamp is too far in the future.
-    auto max_timepoint = model::duration_since_epoch(header.max_timestamp);
     if (
-      broker_timepoint < max_timepoint
-      && std::chrono::duration_cast<std::chrono::milliseconds>(
-           max_timepoint - broker_timepoint)
-           > message_timestamp_after_max_ms) {
+      broker_time < header.max_timestamp
+      && (header.max_timestamp - broker_time)
+           > model::timestamp(message_timestamp_after_max_ms.count())) {
         thread_local static ss::logger::rate_limit rate(despam_interval);
         klog.log(
           ss::log_level::warn,

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -302,6 +302,18 @@ to_cluster_type(const creatable_topic& t) {
         topic_property_max_compaction_lag_ms,
         /*clamp_to_duration_max=*/true);
 
+    cfg.properties.message_timestamp_before_max_ms
+      = get_duration_value<std::chrono::milliseconds>(
+        config_entries,
+        topic_property_message_timestamp_before_max_ms,
+        /*clamp_to_duration_max=*/true);
+
+    cfg.properties.message_timestamp_after_max_ms
+      = get_duration_value<std::chrono::milliseconds>(
+        config_entries,
+        topic_property_message_timestamp_after_max_ms,
+        /*clamp_to_duration_max=*/true);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -129,6 +129,12 @@ inline constexpr std::string_view topic_property_min_compaction_lag_ms
 inline constexpr std::string_view topic_property_max_compaction_lag_ms
   = "max.compaction.lag.ms";
 
+inline constexpr std::string_view topic_property_message_timestamp_before_max_ms
+  = "message.timestamp.before.max.ms";
+
+inline constexpr std::string_view topic_property_message_timestamp_after_max_ms
+  = "message.timestamp.after.max.ms";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 inline constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -754,7 +754,9 @@ FIXTURE_TEST(
       "min.cleanable.dirty.ratio",
       "redpanda.remote.allowgaps",
       "min.compaction.lag.ms",
-      "max.compaction.lag.ms"};
+      "max.compaction.lag.ms",
+      "message.timestamp.before.max.ms",
+      "message.timestamp.after.max.ms"};
 
     // All properties_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -873,17 +873,21 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
     // timestamps. the drift is the same for all the messages, but a more
     // advaced test would be to have a range of drifts from start to finish
     auto produce_messages = [&](std::chrono::system_clock::duration drift) {
-        producer
-          .produce_to_partition(
-            ntp.tp.topic,
-            ntp.tp.partition,
-            {
-              {"key0", "val0"},
-              {"key1", "val1"},
-              {"key2", "val2"},
-            },
-            model::to_timestamp(std::chrono::system_clock::now() + drift))
-          .get();
+        try {
+            producer
+              .produce_to_partition(
+                ntp.tp.topic,
+                ntp.tp.partition,
+                {
+                  {"key0", "val0"},
+                  {"key1", "val1"},
+                  {"key2", "val2"},
+                },
+                model::to_timestamp(std::chrono::system_clock::now() + drift))
+              .get();
+        } catch (...) {
+            // Fall through
+        }
     };
 
     BOOST_TEST_INFO("expect produce_bad_create_time to be 0");
@@ -896,7 +900,7 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
 
     BOOST_TEST_INFO(
       "messages with a skew towards the future trigger the probe");
-    config::shard_local_cfg().log_message_timestamp_alert_after_ms.set_value(
+    config::shard_local_cfg().log_message_timestamp_after_max_ms.set_value(
       std::chrono::duration_cast<std::chrono::milliseconds>(1h));
     produce_messages(2h);
     BOOST_CHECK_LT(bad_timestamps_metric, produce_bad_ts_count());
@@ -904,8 +908,8 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
     bad_timestamps_metric = produce_bad_ts_count();
 
     BOOST_TEST_INFO("messages with a skew towards the past trigger the probe");
-    config::shard_local_cfg().log_message_timestamp_alert_before_ms.set_value(
-      std::optional{std::chrono::duration_cast<std::chrono::milliseconds>(1h)});
+    config::shard_local_cfg().log_message_timestamp_before_max_ms.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(1h));
     produce_messages(-2h);
     BOOST_CHECK_LT(bad_timestamps_metric, produce_bad_ts_count());
 
@@ -919,8 +923,8 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
     BOOST_TEST_INFO(
       "disabling the alert for the past allows messages in the "
       "past without triggering the probe");
-    config::shard_local_cfg().log_message_timestamp_alert_before_ms.set_value(
-      std::optional<std::chrono::milliseconds>{});
+    config::shard_local_cfg().log_message_timestamp_before_max_ms.set_value(
+      std::chrono::milliseconds::max());
     produce_messages(-365 * 24h);
     BOOST_CHECK_EQUAL(bad_timestamps_metric, produce_bad_ts_count());
 }
@@ -942,7 +946,7 @@ FIXTURE_TEST(test_compression_metrics, prod_consume_fixture) {
             ntp.tp.topic,
             ntp.tp.partition,
             {{"key0", "val0"}},
-            std::nullopt,
+            model::timestamp::now(),
             compression)
           .get();
     };

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -13,6 +13,7 @@
 #include "kafka/client/transport.h"
 #include "kafka/protocol/schemata/produce_request.h"
 #include "model/compression.h"
+#include "model/timestamp.h"
 
 #include <optional>
 
@@ -85,7 +86,7 @@ public:
     ss::future<pid_to_offset_map_t> produce(
       model::topic topic_name,
       pid_to_kvs_map_t records_per_partition,
-      std::optional<model::timestamp> ts = std::nullopt,
+      std::optional<model::timestamp> ts = model::timestamp::now(),
       model::compression compression_type = model::compression::none);
 
     // Produces the given records to the given topic partition.
@@ -93,7 +94,7 @@ public:
       model::topic topic_name,
       model::partition_id pid,
       std::vector<kv_t> records,
-      std::optional<model::timestamp> ts = std::nullopt,
+      std::optional<model::timestamp> ts = model::timestamp::now(),
       model::compression compression_type = model::compression::none);
 
 private:

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -34,11 +34,13 @@ class KafkaStreamsTest(RedpandaTest):
         test_context,
         pandaproxy_config: PandaproxyConfig,
         schema_registry_config: SchemaRegistryConfig,
+        extra_rp_conf={},
     ):
         super(KafkaStreamsTest, self).__init__(
             test_context=test_context,
             pandaproxy_config=pandaproxy_config,
             schema_registry_config=schema_registry_config,
+            extra_rp_conf=extra_rp_conf,
         )
 
         self._ctx = test_context
@@ -71,11 +73,13 @@ class KafkaStreamsDriverBase(KafkaStreamsTest):
         test_context,
         pandaproxy_config: PandaproxyConfig,
         schema_registry_config: SchemaRegistryConfig,
+        extra_rp_conf={},
     ):
         super(KafkaStreamsDriverBase, self).__init__(
             test_context=test_context,
             pandaproxy_config=pandaproxy_config,
             schema_registry_config=schema_registry_config,
+            extra_rp_conf=extra_rp_conf,
         )
 
     @cluster(num_nodes=5)
@@ -197,6 +201,9 @@ class KafkaStreamsSessionWindow(KafkaStreamsDriverBase):
             test_context=test_context,
             pandaproxy_config=PandaproxyConfig(),
             schema_registry_config=SchemaRegistryConfig(),
+            # This example produces a message with a timestamp 1.5hours in the future:
+            # https://github.com/confluentinc/kafka-streams-examples/blob/57f5b4163c5e2e42959c8a4355736e1c8be08db1/src/main/java/io/confluent/examples/streams/SessionWindowsExampleDriver.java#L124
+            extra_rp_conf={"log_message_timestamp_after_max_ms": 2 * 3600 * 1000},
         )
 
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -303,6 +303,30 @@ class DescribeTopicsTest(RedpandaTest):
                 "for compaction. The topic property `max.compaction.lag.ms` overrides "
                 "this property.",
             ),
+            "message.timestamp.before.max.ms": ConfigProperty(
+                config_type="LONG",
+                value="9223372036854",
+                doc_string="The maximum allowable timestamp difference between the broker's "
+                "timestamp and a record's timestamp. For topics with "
+                "`message.timestamp.type` set to `CreateTime`, Redpanda rejects records "
+                "that have timestamps earlier than the broker timestamp and exceed this "
+                "difference. Redpanda ignores this property for topics with "
+                "`message.timestamp.type` set to `AppendTime`. The topic property "
+                "`message.timestamp.before.max.ms` overrides the value of "
+                "`log_message_timestamp_before_max_ms` at the topic level.",
+            ),
+            "message.timestamp.after.max.ms": ConfigProperty(
+                config_type="LONG",
+                value="3600000",
+                doc_string="The maximum allowable timestamp difference between the broker's "
+                "timestamp and a record's timestamp. For topics with "
+                "`message.timestamp.type` set to `CreateTime`, Redpanda rejects records "
+                "that have timestamps later than the broker timestamp and exceed this "
+                "difference. Redpanda ignores this property for topics with "
+                "`message.timestamp.type` set to `AppendTime`. The topic property "
+                "`message.timestamp.after.max.ms` overrides the value of "
+                "`log_message_timestamp_after_max_ms` at the topic level.",
+            ),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -852,6 +852,11 @@ class BogusTimestampTest(RedpandaTest):
             self.topic, "segment.bytes", str(self.segment_size)
         )
 
+        # Allow for messages up to a week in the future to be produced.
+        self.client().alter_topic_config(
+            self.topic, "message.timestamp.after.max.ms", 7 * 24 * 3600 * 1000
+        )
+
         # A fictional artificial timestamp base in milliseconds
         future_timestamp = (int(time.time()) + 24 * 3600) * 1000
 

--- a/tests/rptest/tests/timestamp_policy_test.py
+++ b/tests/rptest/tests/timestamp_policy_test.py
@@ -1,0 +1,134 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import datetime
+from dataclasses import dataclass
+from typing import Callable
+
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import expect_exception
+
+from confluent_kafka import Producer
+
+
+def expect_failure_callback(err, msg):
+    assert err is not None, "Expected failure"
+
+
+def expect_success_callback(err, msg):
+    assert err is None, "Expected success"
+
+
+@dataclass
+class TestCase:
+    key: str
+    value: str
+    timestamp: int
+    callback: Callable
+
+
+class TimestampPolicyTest(RedpandaTest):
+    topics = (
+        TopicSpec(
+            partition_count=1,
+            replication_factor=1,
+            cleanup_policy=TopicSpec.CLEANUP_DELETE,
+        ),
+    )
+
+    @cluster(num_nodes=1)
+    def test_produce_timestamps(self):
+        """
+        Test that bounds set by `message.timestamp.{before/after}.max.ms` are respected
+        when producing.
+        """
+
+        # Bound valid timestamps by one hour. Expect any records with timestamps
+        # outside this bound to be rejected at time of production.
+        hour = 3600 * 1000
+        self.client().alter_topic_config(
+            self.topic, "message.timestamp.before.max.ms", hour
+        )
+
+        self.client().alter_topic_config(
+            self.topic, "message.timestamp.after.max.ms", hour
+        )
+
+        producer = Producer({"bootstrap.servers": self.redpanda.brokers()})
+
+        test_cases = [
+            TestCase(
+                "Roads?",
+                "Where we're going, we don't need roads.",
+                int(datetime.datetime(1955, 11, 5, 0, 0).timestamp() * 1000),
+                expect_failure_callback,
+            ),
+            TestCase(
+                "Do you ever have deja vu?",
+                "I don't think so, but I could check with the kitchen.",
+                int(datetime.datetime(1993, 2, 2, 0, 0).timestamp() * 1000),
+                expect_failure_callback,
+            ),
+            TestCase(
+                "Drat.",
+                "Just barely missed it!",
+                int((time.time() - 61 * 60) * 1000),
+                expect_failure_callback,
+            ),
+            TestCase(
+                "I'll be back.",
+                "...in 59 minutes.",
+                int((time.time() - 59 * 60) * 1000),
+                expect_success_callback,
+            ),
+            TestCase(
+                "There's no time like the present.",
+                "Unless the present has traffic.",
+                int(time.time() * 1000),
+                expect_success_callback,
+            ),
+            TestCase(
+                "If I could turn back time...",
+                "...I’d go back 59 minutes and grab another donut.",
+                int((time.time() + 59 * 60) * 1000),
+                expect_success_callback,
+            ),
+            TestCase(
+                "Oops.",
+                "Missed it by a hair!",
+                int((time.time() + 61 * 60) * 1000),
+                expect_failure_callback,
+            ),
+            TestCase(
+                "Be excellent to each other.",
+                "Party on, dudes!",
+                int(datetime.datetime(2688, 1, 1, 0, 0).timestamp() * 1000),
+                expect_failure_callback,
+            ),
+            TestCase(
+                "Year 3000!",
+                "Here's to another lousy millennium.",
+                int(datetime.datetime(2999, 12, 31, 0, 0).timestamp() * 1000),
+                expect_failure_callback,
+            ),
+        ]
+
+        for test_case in test_cases:
+            producer.produce(
+                topic=self.topic,
+                key=test_case.key.encode("utf-8"),
+                value=test_case.value.encode("utf-8"),
+                timestamp=test_case.timestamp,
+                callback=test_case.callback,
+            )
+            producer.flush()


### PR DESCRIPTION
Implements KIP-937 [as described here](https://cwiki.apache.org/confluence/display/KAFKA/KIP-937%3A+Improve+Message+Timestamp+Validation).

Introduces `message.timestamp.{before/after}.max.ms` and `log_message_timestamp_{before/after}_max_ms` at the topic and cluster level.

These can be used to reject records produced with timestamps outside the set bounds by returning [Kafka error code 32](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=255071414#KIP937:ImproveMessageTimestampValidation-PublicInterfaces) (`INVALID_TIMESTAMP`).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Features

* Adds support for KIP-937 by implementing `message.timestamp.{before/after}.max.ms`.
* Deprecates `log_message_timestamp_alert_{before/after}_ms` cluster properties.