### PR TITLE
r/buffered_proto: removed status log line

### DIFF
--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -225,7 +225,6 @@ void buffered_protocol::garbage_collect_unused_queues() {
     for (auto it = _append_entries_queues.begin(),
               last = _append_entries_queues.end();
          it != last;) {
-        it->second->log_status();
         if (it->second->is_idle()) {
             std::unique_ptr<internal::append_entries_queue> queue;
             queue.swap(it->second);
@@ -369,15 +368,6 @@ ss::future<> append_entries_queue::stop() {
     _internal_metrics.clear();
     return _gate.close().finally(
       [this] { vlog(_logger.debug, "stopped queue"); });
-}
-
-void append_entries_queue::log_status() const {
-    vlog(
-      _logger.info,
-      "inflight requests: {}, buffered requests: {}, buffered_bytes: {}",
-      inflight_requests(),
-      _requests.size(),
-      _buffered_bytes);
 }
 
 void append_entries_queue::setup_internal_metrics() {

--- a/src/v/raft/buffered_protocol.h
+++ b/src/v/raft/buffered_protocol.h
@@ -53,8 +53,8 @@ public:
         return _current_max_inflight_requests
                - _inflight_requests_sem.available_units();
     };
+
     bool is_idle() const;
-    void log_status() const;
 
 private:
     ss::future<> dispatch_loop();


### PR DESCRIPTION
The status log line was introduced to easily spot any issues in buffered protocol implementation. Now that we have it working in production for some time and we have metrics covering all logged information we may delete the overly verbose log entry.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none