### PR TITLE
Made `kafka::client::cluster` non movable

### DIFF
--- a/src/v/cluster_link/deps.cc
+++ b/src/v/cluster_link/deps.cc
@@ -16,9 +16,10 @@
 
 namespace cluster_link {
 
-kafka::client::cluster
+std::unique_ptr<kafka::client::cluster>
 cluster_factory::create_cluster(const model::metadata& md) {
-    return kafka::client::cluster(metadata_to_kafka_config(md));
+    return std::make_unique<kafka::client::cluster>(
+      metadata_to_kafka_config(md));
 }
 
 } // namespace cluster_link

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -87,7 +87,7 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata config,
-      kafka::client::cluster cluster_connection)
+      std::unique_ptr<kafka::client::cluster> cluster_connection)
       = 0;
 };
 
@@ -104,6 +104,7 @@ public:
     cluster_factory& operator=(cluster_factory&&) = delete;
     virtual ~cluster_factory() = default;
 
-    virtual kafka::client::cluster create_cluster(const model::metadata& md);
+    virtual std::unique_ptr<kafka::client::cluster>
+    create_cluster(const model::metadata& md);
 };
 } // namespace cluster_link

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -56,7 +56,7 @@ link::link(
   manager* manager,
   ss::lowres_clock::duration task_reconciler_interval,
   model::metadata config,
-  kafka::client::cluster cluster_connection)
+  std::unique_ptr<kafka::client::cluster> cluster_connection)
   : _self(self)
   , _link_id(link_id)
   , _manager(manager)
@@ -68,7 +68,7 @@ ss::future<> link::start() {
     vlog(
       cllog.info, "Starting cluster link {} ({})", _config.name, _config.uuid);
     // Allow exception to propagate to the caller
-    co_await _cluster_connection.start();
+    co_await _cluster_connection->start();
     co_await run_task_reconciler();
     _task_reconciler.set_callback([this] {
         ssx::spawn_with_gate(_gate, [this] { return run_task_reconciler(); });
@@ -104,7 +104,7 @@ ss::future<> link::stop() {
     }
 
     try {
-        co_await _cluster_connection.stop();
+        co_await _cluster_connection->stop();
     } catch (const std::exception& e) {
         vlog(cllog.warn, "Error shutting down cluster connection: {}", e);
     }
@@ -225,7 +225,7 @@ const partition_manager& link::partition_manager() const noexcept {
 }
 
 kafka::client::cluster& link::get_cluster_connection() noexcept {
-    return _cluster_connection;
+    return *_cluster_connection;
 }
 
 std::optional<chunked_hash_map<::model::topic, model::mirror_topic_metadata>>

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -31,7 +31,7 @@ public:
       manager* manager,
       ss::lowres_clock::duration task_reconciler_interval,
       model::metadata config,
-      kafka::client::cluster cluster_connection);
+      std::unique_ptr<kafka::client::cluster> cluster_connection);
     link(const link&) = delete;
     link(link&&) = delete;
     link& operator=(const link&) = delete;
@@ -108,7 +108,7 @@ private:
     manager* _manager;
     chunked_hash_map<ss::sstring, std::unique_ptr<task>> _tasks;
     model::metadata _config;
-    kafka::client::cluster _cluster_connection;
+    std::unique_ptr<kafka::client::cluster> _cluster_connection;
 
     notification_list<task_state_change_cb, task_state_notification_id>
       _task_state_change_notifications;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -91,7 +91,7 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata config,
-      kafka::client::cluster cluster_connection) override {
+      std::unique_ptr<kafka::client::cluster> cluster_connection) override {
         return std::make_unique<link>(
           self,
           link_id,

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -31,7 +31,7 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata metadata,
-      kafka::client::cluster cluster_connection) override {
+      std::unique_ptr<kafka::client::cluster> cluster_connection) override {
         auto name = metadata.name;
         auto created_link = std::make_unique<link>(
           self,
@@ -282,10 +282,11 @@ public:
     explicit cluster_mock_factory(kafka::client::cluster_mock* cluster_mock)
       : _cluster_mock(cluster_mock) {}
 
-    kafka::client::cluster create_cluster(const model::metadata& md) final {
-        return {
+    std::unique_ptr<kafka::client::cluster>
+    create_cluster(const model::metadata& md) final {
+        return std::make_unique<kafka::client::cluster>(
           metadata_to_kafka_config(md),
-          std::make_unique<kafka::client::broker_mock_factory>(_cluster_mock)};
+          std::make_unique<kafka::client::broker_mock_factory>(_cluster_mock));
     }
 
 private:

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -39,7 +39,7 @@ public:
       ss::lowres_clock::duration task_reconciler_interval,
       link_test* link_test,
       model::metadata metadata,
-      kafka::client::cluster cluster_connection);
+      std::unique_ptr<kafka::client::cluster> cluster_connection);
 
     ss::future<> start() override;
     ss::future<> stop() override;
@@ -60,7 +60,7 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata metadata,
-      kafka::client::cluster cluster_connection) override {
+      std::unique_ptr<kafka::client::cluster> cluster_connection) override {
         return std::make_unique<test_link>(
           self,
           link_id,
@@ -211,7 +211,7 @@ test_link::test_link(
   ss::lowres_clock::duration task_reconciler_interval,
   link_test* link_test,
   model::metadata metadata,
-  kafka::client::cluster cluster_connection)
+  std::unique_ptr<kafka::client::cluster> cluster_connection)
   : link(
       self,
       link_id,
@@ -371,7 +371,7 @@ public:
       model::id_t link_id,
       manager* manager,
       model::metadata metadata,
-      kafka::client::cluster cluster_connection) override {
+      std::unique_ptr<kafka::client::cluster> cluster_connection) override {
         return std::make_unique<evil_link>(
           self,
           link_id,

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -57,21 +57,21 @@ client::client(
   , _consumer_config(cfg.consumer_cfg)
   , _logger(kclog, cfg.connection_cfg.client_id.value_or("kafka-client"))
   , _external_mitigate(std::move(mitigater))
-  , _cluster(cfg.connection_cfg)
+  , _cluster(std::make_unique<cluster>(cfg.connection_cfg))
   , _producer(
       _producer_config,
       _retries_config,
-      _cluster.get_topics(),
-      _cluster.get_brokers(),
+      _cluster->get_topics(),
+      _cluster->get_brokers(),
       _logger,
       [this](std::exception_ptr ex) { return mitigate_error(std::move(ex)); }) {
-    _metadata_callback_id = _cluster.register_metadata_cb(
+    _metadata_callback_id = _cluster->register_metadata_cb(
       [this](const metadata_response_data& res) { on_metadata_update(res); });
 }
 
 ss::future<> client::connect() {
     if (!_is_started) {
-        co_await _cluster.start();
+        co_await _cluster->start();
         _is_started = true;
     }
 }
@@ -91,7 +91,7 @@ ss::future<> catch_and_log(const prefix_logger& logger, Func&& f) noexcept {
 ss::future<> client::stop() noexcept {
     _as.request_abort();
     co_await catch_and_log(_logger, [this]() { return _producer.stop(); });
-    _cluster.unregister_metadata_cb(_metadata_callback_id);
+    _cluster->unregister_metadata_cb(_metadata_callback_id);
     co_await _gate.close();
     for (auto& [id, group] : _consumers) {
         while (!group.empty()) {
@@ -103,7 +103,7 @@ ss::future<> client::stop() noexcept {
             });
         }
     }
-    co_await catch_and_log(_logger, [this]() { return _cluster.stop(); });
+    co_await catch_and_log(_logger, [this]() { return _cluster->stop(); });
 }
 
 void client::on_metadata_update(const metadata_response_data& res) {
@@ -112,7 +112,7 @@ void client::on_metadata_update(const metadata_response_data& res) {
 
 void client::set_credentials(std::optional<sasl_configuration> creds) {
     vlog(_logger.debug, "Setting credentials: {}", creds);
-    _cluster.set_sasl_configuration(std::move(creds));
+    _cluster->set_sasl_configuration(std::move(creds));
 }
 
 ss::future<> client::external_mitigate_error(std::exception_ptr ex) const {
@@ -131,7 +131,7 @@ ss::future<> client::update_metadata() {
           fmt::format(
             "max retries of {} exceeded", _retries_config.max_retries));
     }
-    return _cluster.request_metadata_update()
+    return _cluster->request_metadata_update()
       .then([this] {
           // reset retry counter after a successful metadata update
           _current_reconnect_retry = 0;
@@ -296,7 +296,7 @@ ss::future<produce_response> client::produce_records(
 ss::future<metadata_response> client::fetch_metadata(metadata_request req) {
     co_return co_await gated_retry_with_mitigation(
       [this, req = std::move(req)]() {
-          return _cluster.dispatch_to_any(
+          return _cluster->dispatch_to_any(
             req.copy(), api_version_for(metadata_api::key));
       });
 }
@@ -304,11 +304,11 @@ ss::future<metadata_response> client::fetch_metadata(metadata_request req) {
 ss::future<create_topics_response>
 client::create_topic(kafka::creatable_topic req) {
     return gated_retry_with_mitigation([this, req{std::move(req)}]() {
-        auto controller = _cluster.get_controller_id().value_or(
+        auto controller = _cluster->get_controller_id().value_or(
           unknown_node_id);
         chunked_vector<kafka::creatable_topic> cv;
         cv.push_back(std::move(req));
-        return _cluster.dispatch_to(controller, kafka::create_topics_request{
+        return _cluster->dispatch_to(controller, kafka::create_topics_request{
                 .data = {
                   .topics = std::move(cv),
                 }}, api_version_for(create_topics_api::key))
@@ -394,7 +394,7 @@ client::do_list_offsets(const list_offsets_request& unsharded_req) {
     for (const auto& topic : unsharded_req.data.topics) {
         for (const auto& partition : topic.partitions) {
             model::topic_partition tp{topic.name, partition.partition_index};
-            auto node_id = _cluster.get_topics().leader(tp);
+            auto node_id = _cluster->get_topics().leader(tp);
             if (!node_id) {
                 throw partition_error(
                   tp, error_code::unknown_topic_or_partition);
@@ -413,7 +413,7 @@ client::do_list_offsets(const list_offsets_request& unsharded_req) {
 
     auto mapper = [this](auto kv) {
         auto node_id = kv.first;
-        return _cluster.dispatch_to(
+        return _cluster->dispatch_to(
           node_id,
           std::move(kv.second),
           api_version_for(list_offsets_api::key));
@@ -495,14 +495,14 @@ ss::future<fetch_response> client::fetch_partition(
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
           return gated_retry_with_mitigation([this, &tp, &build_request]() {
-                     auto leader_id = _cluster.get_topics().leader(tp);
+                     auto leader_id = _cluster->get_topics().leader(tp);
                      if (!leader_id) {
                          return ss::make_exception_future<fetch_response>(
                            partition_error(
                              tp, error_code::unknown_topic_or_partition));
                      }
                      return _cluster
-                       .dispatch_to(
+                       ->dispatch_to(
                          *leader_id,
                          build_request(tp),
                          api_version_for(fetch_api::key))
@@ -523,7 +523,7 @@ client::create_consumer(const group_id& group_id, member_id name) {
              _gate,
              _retries_config.max_retries,
              _retries_config.retry_base_backoff,
-             _cluster.get_brokers(),
+             _cluster->get_brokers(),
              group_id,
              name,
              [this](std::exception_ptr ex) { return mitigate_error(ex); })
@@ -534,8 +534,8 @@ client::create_consumer(const group_id& group_id, member_id name) {
           return make_consumer(
             _consumer_config,
             _retries_config,
-            _cluster.get_topics(),
-            _cluster.get_brokers(),
+            _cluster->get_topics(),
+            _cluster->get_brokers(),
             std::move(coordinator),
             std::move(group_id),
             std::move(name),
@@ -657,7 +657,7 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
                           return p.error_code != error_code::none;
                       });
                 });
-              return (has_error ? _cluster.request_metadata_update()
+              return (has_error ? _cluster->request_metadata_update()
                                 : ss::now())
                 .then(
                   [res{std::move(res)}]() mutable { return std::move(res); });
@@ -692,7 +692,7 @@ ss::future<kafka::describe_configs_response> client::do_describe_topics(
           });
     }
 
-    co_return co_await _cluster.dispatch_to_any(
+    co_return co_await _cluster->dispatch_to_any(
       describe_configs_request{.data = {.resources = std::move(dcr)}},
       api_version_for(describe_configs_request::api_type::key));
 }

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -98,7 +98,7 @@ public:
     dispatch(Func func) {
         using api_type = std::invoke_result_t<Func>::api_type;
         return gated_retry_with_mitigation([this, func{std::move(func)}]() {
-            return _cluster.dispatch_to_any(
+            return _cluster->dispatch_to_any(
               func(), api_version_for(api_type::key));
         });
     }
@@ -176,7 +176,7 @@ public:
 
     ss::future<> update_metadata();
 
-    bool is_connected() const { return !_cluster.is_connected(); }
+    bool is_connected() const { return !_cluster->is_connected(); }
 
     void set_credentials(std::optional<sasl_configuration> creds);
 
@@ -201,7 +201,7 @@ public:
     }
 
     const std::optional<sasl_configuration>& get_credentials() const {
-        return _cluster.get_sasl_configuration();
+        return _cluster->get_sasl_configuration();
     }
 
 private:
@@ -244,7 +244,7 @@ private:
     consumer_configuration _consumer_config;
     prefix_logger _logger;
     std::optional<external_mitigate> _external_mitigate;
-    cluster _cluster;
+    std::unique_ptr<cluster> _cluster;
     /// \brief Batching producer.
     producer _producer;
     /// \brief Consumers

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -27,9 +27,16 @@ public:
       = ss::noncopyable_function<void(const metadata_response_data&)>;
 
     explicit cluster(connection_configuration config);
+
     cluster(
       connection_configuration config,
       std::unique_ptr<broker_factory> broker_factory);
+
+    cluster(cluster&&) = delete;
+    cluster(const cluster&) = delete;
+    cluster& operator=(cluster&&) = delete;
+    cluster& operator=(const cluster&) = delete;
+    ~cluster() noexcept = default;
 
     ss::future<> start();
     ss::future<> stop();


### PR DESCRIPTION
We are passing around a reference to abort source owned by
`kafka::client::cluster`. In order to make it safe we must make the type
non movable.

Includes one of the commits that @bharathv authored to migrate the cluster to be enclosed in `std::unique_ptr`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none