### PR TITLE
cl/topic_sync: do not mirror `__consumer_offsets` topic

### DIFF
--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -27,6 +27,10 @@ const absl::flat_hash_set<ss::sstring> required_topic_properties{
   ss::sstring{kafka::topic_property_timestamp_type},
 };
 
+const absl::flat_hash_set<::model::topic> topic_denylist{
+  ::model::kafka_consumer_offsets_topic,
+};
+
 bool has_required_permissions(
   kafka::topic_authorized_operations permissions_to_check,
   kafka::topic_authorized_operations required_permissions) {
@@ -480,8 +484,15 @@ source_topic_syncer::find_candidate_topics_for_update(
     candidate_topics.reserve(mirror_topics->size());
 
     for (auto& [topic, mirror_metadata] : *mirror_topics) {
-        vlog(logger().trace, "Checking metadata cache for topic {}", topic);
+        if (topic_denylist.contains(topic)) {
+            vlog(
+              logger().trace,
+              "Skipping mirroring of {} topic, it is in the denylist",
+              topic);
+            continue;
+        }
 
+        vlog(logger().trace, "Checking metadata cache for topic {}", topic);
         auto metadata_value = validate_topic_cache_entry(
           logger(), cluster.get_topics(), topic);
 
@@ -524,6 +535,13 @@ source_topic_syncer::find_candidate_topics_for_creation(
 
     for (const auto& topic : topics) {
         vlog(logger().trace, "Checking topic: {}", topic);
+        if (topic_denylist.contains(topic)) {
+            vlog(
+              logger().trace,
+              "Skipping mirroring of {} topic, it is in the denylist",
+              topic);
+            continue;
+        }
 
         auto metadata_value = validate_topic_cache_entry(
           logger(), topic_cache, topic);


### PR DESCRIPTION
The `__consumer_offsets` topic has its own mechanism for cluster linking. Explicitly exclude it from being mirrored by adding a deny list in the topic syncer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
