### PR TITLE
tuner: Fix irqbalance options on ubuntu & systemd

### DIFF
--- a/src/go/rpk/pkg/tuners/irq/balance_service.go
+++ b/src/go/rpk/pkg/tuners/irq/balance_service.go
@@ -202,6 +202,14 @@ func (balanceService *balanceService) getBalanceServiceInfo() (
 	optionsKey := "OPTIONS"
 	configFile := "/etc/default/irqbalance"
 	systemd := false
+
+	libSystemdServiceExists, _ := afero.Exists(fs, "/lib/systemd/system/irqbalance.service")
+	usrLibSystemdServiceExists, _ := afero.Exists(fs, "/usr/lib/systemd/system/irqbalance.service")
+	if libSystemdServiceExists || usrLibSystemdServiceExists {
+		optionsKey = "IRQBALANCE_ARGS"
+		systemd = true
+	}
+
 	if exists, _ := afero.Exists(fs, configFile); !exists {
 		zap.L().Sugar().Debugf("File '%s' does not exist", configFile)
 		if exists, _ := afero.Exists(fs, "/etc/sysconfig/irqbalance"); exists {

--- a/src/go/rpk/pkg/tuners/irq/balance_service_test.go
+++ b/src/go/rpk/pkg/tuners/irq/balance_service_test.go
@@ -176,6 +176,33 @@ func Test_BalanceService_BanIRQsAndRestart(t *testing.T) {
 		},
 		{
 			name: "Shall update the config and then restart IRQ " +
+				"balance service with config in /etc/default/irqbalance & systemd",
+			proc: &procMock{
+				isRunning: running,
+				run: func(command string, args ...string) ([]string, error) {
+					require.Equal(t, "systemctl", command)
+					require.Equal(t, []string{"try-restart", "irqbalance"}, args)
+					return nil, nil
+				},
+			},
+			bannedIRQs:            []int{5, 12, 15},
+			testadataInitFilename: "testdata/irqbalance-03-init",
+			configFilename:        "/etc/default/irqbalance",
+			backupFilename:        "/etc/default/irqbalance.vectorized.911727b5a516f8e315b36f97e54facda.bk",
+			before: func(fs afero.Fs) {
+				_ = utils.WriteFileLines(fs, []string{""}, "/lib/systemd/system/irqbalance.service")
+			},
+			assert: func(fs afero.Fs, configFilename string, backupContent []string) {
+				require.Equal(t, 2, len(backupContent))
+				// Check if IRQs were banned in the file
+				fileContent, err := utils.ReadFileLines(fs, configFilename)
+				require.NoError(t, err)
+				require.Equal(t, 3, len(fileContent))
+				require.Equal(t, "IRQBALANCE_ARGS=\" --banirq=5 --banirq=12 --banirq=15\"", fileContent[2])
+			},
+		},
+		{
+			name: "Shall update the config and then restart IRQ " +
 				"balance service with config in /etc/conf.d/irqbalance & init daemon",
 			proc: &procMock{
 				isRunning: running,


### PR DESCRIPTION
This patch effectively backports
https://github.com/scylladb/seastar/commit/9ed5fca9207f81662dd205b5c778890165959f3f

On Ubuntu versions with systemd the tuner would use the incorrect
options flag. Hence irqbalance would happily override the interrupt
tuning the tuner had done.

Make it set the correct options flag (`IRQBALANCE_ARGS` vs `OPTIONS`).

Fixes CORE-1866

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


