### PR TITLE
rptest/redpanda: report crash during startup ASAP

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3577,15 +3577,30 @@ class RedpandaService(RedpandaServiceBase):
                     err_msg=f"Redpanda processes did not terminate on {node.name} during startup as expected in {timeout} sec",
                 )
             elif not skip_readiness_check:
-                wait_until(
-                    lambda: self.is_node_ready(node),
-                    timeout_sec=timeout,
-                    backoff_sec=self._startup_poll_interval(first_start),
-                    err_msg=f"Redpanda service {node.account.hostname} failed to start within {timeout} sec",
-                    retry_on_exc=True,
-                )
+                last_check_exc = None
 
-        self.logger.debug(f"Node status prior to redpanda startup:")
+                def check_redpanda_ready():
+                    nonlocal last_check_exc
+                    if self.redpanda_pid(node) is None:
+                        raise RuntimeError(
+                            f"Redpanda died on {node.name} during startup"
+                        )
+                    try:
+                        return self.is_node_ready(node)
+                    except Exception as e:
+                        last_check_exc = e
+                        return False
+
+                try:
+                    wait_until(
+                        check_redpanda_ready,
+                        timeout_sec=timeout,
+                        backoff_sec=self._startup_poll_interval(first_start),
+                        err_msg=f"Redpanda service {node.account.hostname} failed to start within {timeout} sec",
+                    )
+                except TimeoutError as e:
+                    raise e from last_check_exc
+
         self.start_service(node, start_rp)
         if not expect_fail:
             self._started.add(node)


### PR DESCRIPTION
Do not wait for timeout if redpanda process does not exist anymore.

Quality of life improvement for the rare case when we crash at start. No need to wait almost a minute to learn about it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
