### PR TITLE
tuner: Fix NIC auto addr detection

### DIFF
--- a/src/go/rpk/pkg/net/interfaces.go
+++ b/src/go/rpk/pkg/net/interfaces.go
@@ -25,17 +25,24 @@ func GetInterfacesByIps(addresses ...string) ([]string, error) {
 	}
 	nics := make(map[string]bool)
 	for _, iface := range ifaces {
+		if (iface.Flags & net.FlagLoopback) == net.FlagLoopback {
+			continue
+		}
+
 		addr, err := iface.Addrs()
 		if err != nil {
 			return nil, err
 		}
 		for _, address := range addr {
 			zap.L().Sugar().Debugf("Checking '%s' address '%s'", iface.Name, address)
+			nicIP, _, err := net.ParseCIDR(address.String())
+			if err != nil {
+				zap.L().Sugar().Debugf("Skipping address '%s' as not a valid CIDR, err: %s", address, err)
+				continue
+			}
 			for _, requestedAddr := range addresses {
-				if requestedAddr == "0.0.0.0" {
-					if (iface.Flags & net.FlagLoopback) == 0 {
-						nics[iface.Name] = true
-					}
+				if requestedAddr == nicIP.String() || requestedAddr == "0.0.0.0" {
+					nics[iface.Name] = true
 				}
 			}
 		}

--- a/src/go/rpk/pkg/net/interfaces.go
+++ b/src/go/rpk/pkg/net/interfaces.go
@@ -23,6 +23,20 @@ func GetInterfacesByIps(addresses ...string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	for i, address := range addresses {
+		resolvedIps, err := net.LookupIP(address)
+		if err != nil {
+			zap.L().Sugar().Debugf("Can't resolve address '%s', err: %s", address, err)
+		}
+		for _, resolvedIP := range resolvedIps {
+			if resolvedIP.To4() != nil {
+				addresses[i] = resolvedIP.String()
+				break
+			}
+		}
+	}
+
 	nics := make(map[string]bool)
 	for _, iface := range ifaces {
 		if (iface.Flags & net.FlagLoopback) == net.FlagLoopback {

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -293,8 +293,8 @@ func (factory *tunersFactory) newBallastFileTuner(
 func MergeTunerParamsConfig(params *TunerParams, y *config.RedpandaYaml) (*TunerParams, error) {
 	if len(params.Nics) == 0 {
 		addrs := []string{y.Redpanda.RPCServer.Address}
-		if len(y.Redpanda.KafkaAPI) > 0 {
-			addrs = append(addrs, y.Redpanda.KafkaAPI[0].Address)
+		for _, address := range y.Redpanda.KafkaAPI {
+			addrs = append(addrs, address.Address)
 		}
 		nics, err := net.GetInterfacesByIps(
 			addrs...,
@@ -312,8 +312,8 @@ func MergeTunerParamsConfig(params *TunerParams, y *config.RedpandaYaml) (*Tuner
 
 func FillTunerParamsWithValuesFromConfig(params *TunerParams, y *config.RedpandaYaml) error {
 	addrs := []string{y.Redpanda.RPCServer.Address}
-	if len(y.Redpanda.KafkaAPI) > 0 {
-		addrs = append(addrs, y.Redpanda.KafkaAPI[0].Address)
+	for _, address := range y.Redpanda.KafkaAPI {
+		addrs = append(addrs, address.Address)
 	}
 	nics, err := net.GetInterfacesByIps(
 		addrs...,

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -220,9 +220,12 @@ func RedpandaCheckers(
 	if len(y.Redpanda.KafkaAPI) == 0 {
 		return nil, errors.New("'redpanda.kafka_api' is empty")
 	}
+	addrs := []string{y.Redpanda.RPCServer.Address}
+	for _, address := range y.Redpanda.KafkaAPI {
+		addrs = append(addrs, address.Address)
+	}
 	interfaces, err := net.GetInterfacesByIps(
-		y.Redpanda.KafkaAPI[0].Address,
-		y.Redpanda.RPCServer.Address,
+		addrs...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The net tuner would effectively only work automatically if the user
would be listening on "0.0.0.0".

This is very unlikely and hence it would never apply any `net` tuning
unless the interface was manually specified.

Fix the detection by actually checking the interfaces for the right IP
and not a hardcoded "0.0.0.0".

Fixes CORE-1865

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

