### PR TITLE
[CORE-13215] ct/l1: Add a level one reader

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = [
     "//src/v/cloud_topics/core:__pkg__",
     "//src/v/cloud_topics/core/tests:__pkg__",
     "//src/v/cloud_topics/frontend:__pkg__",
-    "//src/v/cloud_topics/frontend/tests:__pkg__",
     "//src/v/cloud_topics/level_zero:__subpackages__",
     "//src/v/cloud_topics/level_zero/throttler:__pkg__",
     "//src/v/cloud_topics/level_zero/throttler/tests:__pkg__",
@@ -53,6 +52,8 @@ redpanda_cc_library(
     visibility = [
         "//src/v/cloud_topics/frontend:__pkg__",
         "//src/v/cloud_topics/frontend/tests:__pkg__",
+        "//src/v/cloud_topics/level_one/frontend_reader:__pkg__",
+        "//src/v/cloud_topics/level_one/frontend_reader/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/frontend_reader:__pkg__",
         "//src/v/cloud_topics/reconciler:__pkg__",
         "//src/v/kafka/data:__pkg__",

--- a/src/v/cloud_topics/level_one/common/fake_io.cc
+++ b/src/v/cloud_topics/level_one/common/fake_io.cc
@@ -15,6 +15,8 @@
 
 namespace cloud_topics::l1 {
 
+fake_io::fake_io() = default;
+
 class fake_file : public staging_file {
 public:
     fake_file() = default;

--- a/src/v/cloud_topics/level_one/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/BUILD
@@ -1,0 +1,25 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+redpanda_cc_library(
+    name = "reader",
+    srcs = [
+        "reader.cc",
+    ],
+    hdrs = [
+        "reader.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_topics:log_reader_config",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/model:timeout_clock",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/reader.cc
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/frontend_reader/reader.h"
+
+#include "bytes/iostream.h"
+#include "cloud_topics/logger.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+#include <exception>
+#include <iterator>
+#include <utility>
+
+namespace cloud_topics {
+
+static ss::future<>
+close_reader_safe(std::unique_ptr<l1::object_reader>& reader) {
+    try {
+        co_await reader->close();
+    } catch (const std::exception& e) {
+        vlog(
+          cd_log.warn,
+          "Exception while closing L1 object reader: {}",
+          e.what());
+    }
+}
+
+level_one_log_reader_impl::level_one_log_reader_impl(
+  cloud_topic_log_reader_config& cfg,
+  model::ntp ntp,
+  model::topic_id_partition tidp,
+  l1::metastore* metastore,
+  l1::io* io_interface)
+  : _config(cfg)
+  , _ntp(std::move(ntp))
+  , _tidp(tidp)
+  , _next_offset(cfg.start_offset)
+  , _metastore(metastore)
+  , _io(io_interface) {}
+
+ss::future<model::record_batch_reader::storage_t>
+level_one_log_reader_impl::do_load_slice(
+  model::timeout_clock::time_point deadline) {
+    chunked_circular_buffer<model::record_batch> res;
+
+    // First switch: ensure batches are materialized or the reader
+    // reaches end-of-stream.
+    switch (_state) {
+    case state::empty:
+        co_await fetch_metadata(deadline);
+        [[fallthrough]];
+    case state::ready:
+        co_await materialize_batches(deadline);
+        [[fallthrough]];
+    case state::materialized:
+    case state::end_of_stream:
+        // Handled in the next switch statement.
+        break;
+    }
+
+    // Second switch: enforces that the reader has materialized batches
+    // or reached end-of-stream.
+    switch (_state) {
+    case state::empty:
+    case state::ready:
+        vassert(
+          false,
+          "Invalid reader state after materialization for {} ({}): got {}",
+          _ntp,
+          _tidp,
+          std::to_underlying(_state));
+    case state::materialized:
+        consume_materialized_batches(&res);
+        [[fallthrough]];
+    case state::end_of_stream:
+        break;
+    }
+    co_return res;
+}
+
+ss::future<> level_one_log_reader_impl::fetch_metadata(
+  model::timeout_clock::time_point /*deadline*/) {
+    vassert(
+      _state == state::empty,
+      "Invalid state for metadata fetch: {}",
+      std::to_underlying(_state));
+
+    vassert(
+      !_current_obj.has_value(),
+      "Empty state should not have a current object");
+
+    if (_next_offset > _config.max_offset) {
+        vlog(
+          cd_log.debug,
+          "L1 reader next_offset {} > max_offset {} for {} ({}): ending "
+          "stream",
+          _next_offset,
+          _config.max_offset,
+          _ntp,
+          _tidp);
+        _state = state::end_of_stream;
+        co_return;
+    }
+
+    if (is_over_limit(0)) {
+        vlog(
+          cd_log.debug,
+          "L1 reader over byte budget for {} ({}): ending stream",
+          _ntp,
+          _tidp);
+        _state = state::end_of_stream;
+        co_return;
+    }
+
+    auto response_fut = co_await ss::coroutine::as_future(
+      _metastore->get_first_ge(_tidp, _next_offset));
+    if (response_fut.failed()) {
+        auto ex = response_fut.get_exception();
+        vlog(
+          cd_log.error,
+          "Exception fetching metadata from metastore for {} ({}): {}",
+          _ntp,
+          _tidp,
+          ex);
+        _state = state::end_of_stream;
+        std::rethrow_exception(ex);
+    }
+
+    auto response = response_fut.get();
+    if (!response.has_value()) {
+        switch (response.error()) {
+        case l1::metastore::errc::out_of_range:
+            vlog(
+              cd_log.debug,
+              "No L1 objects found for {} ({}) at offset {} or later",
+              _ntp,
+              _tidp,
+              _next_offset);
+            _state = state::end_of_stream;
+            co_return;
+        case l1::metastore::errc::missing_ntp:
+            vlog(
+              cd_log.debug,
+              "Partition {} ({}) not tracked in metastore",
+              _ntp,
+              _tidp);
+            _state = state::end_of_stream;
+            co_return;
+        default:
+            vlog(
+              cd_log.error,
+              "Failed to query metastore for {} ({}) offset {}: {}",
+              _ntp,
+              _tidp,
+              _next_offset,
+              response.error());
+            _state = state::end_of_stream;
+            throw std::runtime_error(
+              fmt::format(
+                "Metastore query failed for {} ({}) offset {}: {}",
+                _ntp,
+                _tidp,
+                _next_offset,
+                response.error()));
+        }
+    }
+
+    auto& obj = response.value();
+    vlog(
+      cd_log.debug,
+      "Found L1 object {} for {} ({}) at offset {}",
+      obj.oid,
+      _ntp,
+      _tidp,
+      _next_offset);
+
+    auto footer = co_await read_footer(
+      obj.oid, obj.footer_pos, obj.object_size);
+    _current_obj = current_object{.oid = obj.oid, .footer = std::move(footer)};
+    _state = state::ready;
+}
+
+ss::future<l1::footer> level_one_log_reader_impl::read_footer(
+  l1::object_id oid, size_t footer_pos, size_t object_size) {
+    size_t footer_total_size = object_size - footer_pos;
+
+    l1::object_extent extent{
+      .id = oid,
+      .position = footer_pos,
+      .size = footer_total_size,
+    };
+
+    ss::abort_source default_abort_source;
+    auto* abort_source = _config.abort_source
+                           ? &_config.abort_source.value().get()
+                           : &default_abort_source;
+    auto stream_fut = co_await ss::coroutine::as_future(
+      _io->read_object(extent, abort_source));
+    if (stream_fut.failed()) {
+        auto ex = stream_fut.get_exception();
+        vlog(
+          cd_log.error,
+          "Exception opening stream for footer from object {} (pos {} object "
+          "size {}): {}",
+          oid,
+          extent.position,
+          object_size,
+          ex);
+        std::rethrow_exception(ex);
+    }
+    auto stream_result = stream_fut.get();
+    if (!stream_result.has_value()) {
+        throw std::runtime_error(
+          fmt::format(
+            "Failed to open stream for footer from object {} (pos {} size {}): "
+            "{}",
+            oid,
+            extent.position,
+            object_size,
+            std::to_underlying(stream_result.error())));
+    }
+
+    auto& stream = stream_result.value();
+
+    auto footer_fut = co_await ss::coroutine::as_future(
+      read_iobuf_exactly(stream, footer_total_size));
+    if (footer_fut.failed()) {
+        auto ex = footer_fut.get_exception();
+        vlog(
+          cd_log.error,
+          "Exception reading footer from object {} (pos {} object size {}): {}",
+          oid,
+          extent.position,
+          object_size,
+          ex);
+        co_await stream.close();
+        std::rethrow_exception(ex);
+    }
+
+    iobuf footer_buf = footer_fut.get();
+    co_await stream.close();
+
+    // Parse the footer - we have the complete footer so this should succeed.
+    auto footer_result = co_await l1::footer::read(std::move(footer_buf));
+
+    if (!std::holds_alternative<l1::footer>(footer_result)) {
+        vlog(
+          cd_log.error,
+          "Failed to parse footer from object {} despite reading complete "
+          "footer (pos {} object size {})",
+          oid,
+          extent.position,
+          object_size);
+        throw std::runtime_error(
+          fmt::format(
+            "Failed to parse footer from object {} (pos {} size {})",
+            oid,
+            extent.position,
+            object_size));
+    }
+
+    co_return std::get<l1::footer>(std::move(footer_result));
+}
+
+ss::future<>
+level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
+    while (true) {
+        auto result = co_await reader.read_next();
+
+        if (std::holds_alternative<model::record_batch>(result)) {
+            auto batch = std::move(std::get<model::record_batch>(result));
+
+            // Skip batches before our start offset.
+            if (batch.last_offset() < kafka::offset_cast(_next_offset)) {
+                continue;
+            }
+
+            // Stop if we've gone beyond our max offset.
+            if (batch.base_offset() > kafka::offset_cast(_config.max_offset)) {
+                break;
+            }
+
+            // Check if adding this batch would exceed our byte limit.
+            size_t batch_size = batch.size_bytes();
+            if (is_over_limit(batch_size)) {
+                break;
+            }
+            _config.bytes_consumed += batch_size;
+
+            // If we make it past all that, emit the batch.
+            _batches.push_back(std::move(batch));
+        } else if (std::holds_alternative<model::topic_id_partition>(result)) {
+            // Partition marker. Done with this ntp's partition.
+            break;
+        } else if (
+          std::holds_alternative<l1::footer>(result)
+          || std::holds_alternative<l1::object_reader::eof>(result)) {
+            // End of data.
+            break;
+        }
+    }
+}
+
+ss::future<> level_one_log_reader_impl::materialize_batches(
+  model::timeout_clock::time_point /*deadline*/) {
+    // Could be EOS because there are no more objects, but
+    // there should never be materialized batches remaining.
+    vassert(
+      _batches.empty(),
+      "Materialize batches called with batches already materialized");
+
+    if (_state == state::end_of_stream) {
+        co_return;
+    }
+
+    vassert(
+      _state == state::ready,
+      "Invalid state to materialize batches: {}",
+      std::to_underlying(_state));
+
+    // I wish I had ADTs to enforce these invariants...
+    vassert(
+      _current_obj.has_value(),
+      "Expected to have current object in ready state");
+
+    auto seek_res = _current_obj->footer.file_position_before_kafka_offset(
+      _tidp, _next_offset);
+    if (seek_res == l1::footer::npos) {
+        // Perhaps this object spans offsets in the metastore but has
+        // no data because of compaction.
+        vlog(
+          cd_log.debug,
+          "No data for {} ({}) in object {}: materializing 0 batches",
+          _ntp,
+          _tidp,
+          _current_obj->oid);
+        _state = state::materialized;
+        co_return;
+    }
+
+    l1::object_extent extent{
+      .id = _current_obj->oid,
+      .position = seek_res.file_position,
+      .size = seek_res.length,
+    };
+    ss::abort_source default_abort_source;
+    auto* abort_source = _config.abort_source
+                           ? &_config.abort_source.value().get()
+                           : &default_abort_source;
+    auto stream_fut = co_await ss::coroutine::as_future(
+      _io->read_object(extent, abort_source));
+    if (stream_fut.failed()) {
+        auto ex = stream_fut.get_exception();
+        vlog(
+          cd_log.error,
+          "Exception opening stream for L1 object {} for {} ({}): {}",
+          _current_obj->oid,
+          _ntp,
+          _tidp,
+          ex);
+        _state = state::end_of_stream;
+        std::rethrow_exception(ex);
+    }
+    auto stream_result = stream_fut.get();
+    if (!stream_result.has_value()) {
+        vlog(
+          cd_log.error,
+          "Failed to open stream for L1 object {} for {} ({}): {}",
+          _current_obj->oid,
+          _ntp,
+          _tidp,
+          std::to_underlying(stream_result.error()));
+        _state = state::end_of_stream;
+        throw std::runtime_error(
+          fmt::format(
+            "Failed to open stream for L1 object {} for {} ({}): {}",
+            _current_obj->oid,
+            _ntp,
+            _tidp,
+            std::to_underlying(stream_result.error())));
+    }
+
+    auto reader = l1::object_reader::create(std::move(stream_result).value());
+    auto read_fut = co_await ss::coroutine::as_future(read_batches(*reader));
+    if (read_fut.failed()) {
+        auto ex = read_fut.get_exception();
+        vlog(
+          cd_log.error,
+          "Exception reading L1 object {} for {} ({}): {}",
+          _current_obj->oid,
+          _ntp,
+          _tidp,
+          ex);
+        co_await close_reader_safe(reader);
+        _state = state::end_of_stream;
+        std::rethrow_exception(ex);
+    }
+
+    co_await close_reader_safe(reader);
+
+    // Note that it's possible to materialize zero batches.
+    vlog(
+      cd_log.debug,
+      "Materialized {} batches from L1 object {} for {} ({})",
+      _batches.size(),
+      _current_obj->oid,
+      _ntp,
+      _tidp);
+    _state = state::materialized;
+}
+
+void level_one_log_reader_impl::consume_materialized_batches(
+  chunked_circular_buffer<model::record_batch>* dest) {
+    vlog(
+      cd_log.debug,
+      "Consuming {} materialized batches for {} ({})",
+      _batches.size(),
+      _ntp,
+      _tidp);
+
+    dest->swap(_batches);
+
+    // Increment the next offset for the next metastore query.
+    // The offset is always incremented so the reader makes
+    // progress even if the offset range in the object is
+    // smaller than the metastore's metadata about the offset
+    // range covered by the object (because of, e.g. compaction).
+    // TODO: The metastore API should return the endpoint of the
+    // range covered by each object, which would be easier to
+    // understand than the increment here, and which would permit
+    // optimizations like read-ahead.
+    _next_offset = dest->empty()
+                     ? kafka::next_offset(_next_offset)
+                     : model::offset_cast(
+                         model::next_offset(dest->back().last_offset()));
+
+    _current_obj.reset();
+    _state = state::empty;
+}
+
+void level_one_log_reader_impl::print(std::ostream& o) {
+    o << "level_one_cloud_topics_reader";
+}
+
+bool level_one_log_reader_impl::is_end_of_stream() const {
+    return _state == state::end_of_stream;
+}
+
+bool level_one_log_reader_impl::is_over_limit(size_t size) const {
+    return (_config.strict_max_bytes || _config.bytes_consumed > 0)
+           && (_config.bytes_consumed + size) > _config.max_bytes;
+}
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/frontend_reader/reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/reader.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/log_reader_config.h"
+#include "model/record_batch_reader.h"
+
+namespace cloud_topics {
+
+/*
+ * This class implements a record batch reader for level one.
+ *
+ * The reader is a state machine with the following states:
+ * - empty: no metadata is cached, no data is materialized
+ * - ready: metadata is available but no data is materialized
+ * - materialized: the reader contains materialized batches
+ * - end_of_stream: no more data to read
+ *
+ * The state transitions are:
+ *              ┌───┐
+ *              │EOS├───┤Terminate│
+ *              └───┘
+ *                ▲
+ *                │
+ *              ┌─┴───┐   ┌─────┐
+ * │Init├──────►│empty├──►│ready│
+ *              └─────┘   └──┬──┘
+ *                  ▲        │
+ *                  │        ▼
+ *                ┌─┴──────────┐
+ *                │materialized│
+ *                └────────────┘
+ *
+ * The reader starts in the 'empty' state.
+ *
+ * In 'empty' state, the reader queries the metastore to find the L1 object
+ * containing data at or after the requested offset. When metadata is found,
+ * it transitions to 'ready' state. If no data is available, it transitions
+ * to 'end_of_stream'.
+ *
+ * In 'ready' state, the reader reads the object footer to determine what
+ * partition data to materialize, then fetches the required ranges from
+ * object storage. When batches are materialized, it transitions to
+ * 'materialized' state.
+ *
+ * In 'materialized' state, data can be consumed. When all materialized
+ * batches are consumed, the reader transitions back to 'empty' state
+ * and queries the metastore for the next L1 object partition that.
+ */
+class level_one_log_reader_impl : public model::record_batch_reader::impl {
+public:
+    level_one_log_reader_impl(
+      cloud_topic_log_reader_config& cfg,
+      model::ntp ntp,
+      model::topic_id_partition tidp,
+      l1::metastore* metastore,
+      l1::io* io_interface);
+
+    bool is_end_of_stream() const final;
+
+    ss::future<model::record_batch_reader::storage_t>
+      do_load_slice(model::timeout_clock::time_point) final;
+
+    void print(std::ostream& o) final;
+
+private:
+    enum class state {
+        empty,
+        ready,
+        materialized,
+        end_of_stream,
+    };
+
+    // Represents the current L1 object being read.
+    struct current_object {
+        l1::object_id oid;
+        l1::footer footer;
+    };
+
+    ss::future<> fetch_metadata(model::timeout_clock::time_point deadline);
+
+    ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
+
+    void consume_materialized_batches(
+      chunked_circular_buffer<model::record_batch>* dest);
+
+    ss::future<l1::footer>
+    read_footer(l1::object_id oid, size_t footer_pos, size_t object_size);
+
+    ss::future<> read_batches(l1::object_reader& reader);
+
+    bool is_over_limit(size_t size) const;
+
+    state _state{state::empty};
+
+    // Current object being processed.
+    // Present in ready and materialized states, empty in empty state.
+    std::optional<current_object> _current_obj;
+
+    // Materialized batches ready to be consumed.
+    chunked_circular_buffer<model::record_batch> _batches;
+
+    cloud_topic_log_reader_config _config;
+    model::ntp _ntp;
+    model::topic_id_partition _tidp;
+    kafka::offset _next_offset;
+    l1::metastore* _metastore;
+    l1::io* _io;
+};
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/BUILD
@@ -1,0 +1,26 @@
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+
+redpanda_cc_gtest(
+    name = "reader_test",
+    timeout = "short",
+    srcs = [
+        "reader_test.cc",
+    ],
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_topics:log_reader_config",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:fake_io",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/cloud_topics/level_one/frontend_reader:reader",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/container:chunked_circular_buffer",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -1,0 +1,597 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iostream.h"
+#include "cloud_topics/level_one/common/fake_io.h"
+#include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/level_one/common/object_id.h"
+#include "cloud_topics/level_one/frontend_reader/reader.h"
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/log_reader_config.h"
+#include "container/chunked_circular_buffer.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <map>
+#include <optional>
+
+using namespace cloud_topics;
+using namespace std::chrono_literals;
+
+namespace {
+
+std::pair<model::ntp, model::topic_id_partition>
+make_ntidp(std::string_view topic_name) {
+    static constexpr auto test_namespace = "test_ns";
+    static constexpr model::partition_id test_partition_id{0};
+
+    auto ntp = model::ntp{
+      model::ns{test_namespace}, model::topic{topic_name}, test_partition_id};
+    auto tidp = model::topic_id_partition{
+      model::topic_id{uuid_t::create()}, test_partition_id};
+    return std::make_pair(ntp, tidp);
+}
+
+chunked_circular_buffer<model::record_batch>
+copy(chunked_circular_buffer<model::record_batch>& input) {
+    chunked_circular_buffer<model::record_batch> ret;
+    for (auto& b : input) {
+        ret.push_back(b.share());
+    }
+    return ret;
+}
+
+// Slice by index range (copy-based, preserves original)
+chunked_circular_buffer<model::record_batch> slice(
+  chunked_circular_buffer<model::record_batch>& source,
+  size_t start,
+  size_t count) {
+    chunked_circular_buffer<model::record_batch> result;
+    for (size_t i = 0; i < count; ++i) {
+        result.push_back(source[start + i].share());
+    }
+    return result;
+}
+
+// Slice batches by offset range (doesn't split batches).
+chunked_circular_buffer<model::record_batch> slice_by_offset(
+  chunked_circular_buffer<model::record_batch>& source,
+  kafka::offset start_offset,
+  kafka::offset end_offset) {
+    chunked_circular_buffer<model::record_batch> result;
+    for (auto& batch : source) {
+        if (
+          batch.last_offset() >= kafka::offset_cast(start_offset)
+          && batch.base_offset() <= kafka::offset_cast(end_offset)) {
+            result.push_back(batch.share());
+        }
+    }
+    return result;
+}
+
+} // anonymous namespace
+
+class l1_reader_test : public seastar_test {
+protected:
+    using tidp_batches_t = std::pair<
+      model::topic_id_partition,
+      chunked_circular_buffer<model::record_batch>>;
+
+    void make_l1_objects(std::vector<tidp_batches_t>& batches_by_tidp) {
+        auto meta_builder = _metastore.object_builder();
+
+        // First record the object ID for each tidp,
+        std::map<model::topic_id_partition, l1::object_id> oid_by_tidp;
+        for (auto& [tidp, unused] : batches_by_tidp) {
+            oid_by_tidp[tidp] = meta_builder->get_or_create_object_for(tidp);
+        }
+
+        // Then create output streams and builders for each object.
+        std::map<l1::object_id, iobuf> bufs_by_oid;
+        std::map<l1::object_id, std::unique_ptr<l1::object_builder>>
+          builders_by_oid;
+        for (auto& [unused, oid] : oid_by_tidp) {
+            if (!builders_by_oid.contains(oid)) {
+                bufs_by_oid[oid] = iobuf{};
+                builders_by_oid[oid] = l1::object_builder::create(
+                  make_iobuf_ref_output_stream(bufs_by_oid[oid]), {});
+            }
+        }
+
+        // Create the term offset map first before consuming batches.
+        l1::metastore::term_offset_map_t term_map;
+        for (auto& [tidp, batches] : batches_by_tidp) {
+            term_map[tidp].push_back(
+              l1::metastore::term_offset{
+                .term = model::term_id{1},
+                .first_offset = model::offset_cast(
+                  batches.front().base_offset()),
+              });
+        }
+
+        // Load each ntp's batches into the object.
+        for (auto& [tidp, batches] : batches_by_tidp) {
+            auto& oid = oid_by_tidp[tidp];
+            auto& builder = builders_by_oid[oid];
+            builder->start_partition(tidp).get();
+            for (auto& batch : batches) {
+                builder->add_batch(std::move(batch)).get();
+            }
+        }
+
+        // Finish all the objects, upload them, and use the metadata
+        // to prepare the metastore registration.
+        for (auto& [oid, builder] : builders_by_oid) {
+            auto obj_info = builder->finish().get();
+            builder->close().get();
+
+            _io.put_object(oid, std::move(bufs_by_oid[oid]));
+
+            for (auto& [tidp, partition] : obj_info.index.partitions) {
+                meta_builder
+                  ->add(
+                    oid,
+                    l1::metastore::object_metadata::ntp_metadata{
+                      .tidp = tidp,
+                      .base_offset = partition.first_offset,
+                      .last_offset = partition.last_offset,
+                      .max_timestamp = partition.max_timestamp,
+                      .pos = partition.file_position,
+                      .size = partition.length,
+                    })
+                  .value();
+            }
+
+            meta_builder
+              ->finish(oid, obj_info.footer_offset, obj_info.size_bytes)
+              .value();
+        }
+
+        _metastore.add_objects(std::move(meta_builder), term_map).get().value();
+    }
+
+    model::record_batch_reader make_reader(
+      const model::ntp& ntp,
+      const model::topic_id_partition& tidp,
+      kafka::offset start_offset = kafka::offset{0},
+      kafka::offset max_offset = kafka::offset::max(),
+      size_t max_bytes = std::numeric_limits<size_t>::max(),
+      bool strict_max_bytes = false) {
+        cloud_topic_log_reader_config config(
+          start_offset,
+          max_offset,
+          /*min_bytes=*/0, // min_bytes
+          max_bytes,
+          /*type_filter=*/std::nullopt,
+          /*first_timestamp=*/std::nullopt,
+          /*abort_source=*/std::nullopt,
+          /*client_addr=*/std::nullopt,
+          /*strict_max_bytes=*/strict_max_bytes);
+        return model::record_batch_reader(
+          std::make_unique<level_one_log_reader_impl>(
+            config, ntp, tidp, &_metastore, &_io));
+    }
+
+    chunked_circular_buffer<model::record_batch>
+    read_all(model::record_batch_reader reader) {
+        auto data = model::consume_reader_to_memory(
+                      std::move(reader), model::no_timeout)
+                      .get();
+        chunked_circular_buffer<model::record_batch> result;
+        std::move(data.begin(), data.end(), std::back_inserter(result));
+        return result;
+    }
+
+    l1::simple_metastore _metastore{};
+    l1::fake_io _io{};
+};
+
+TEST_F(l1_reader_test, empty_read) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+    auto reader = make_reader(ntp, tidp);
+
+    auto result = read_all(std::move(reader));
+
+    EXPECT_TRUE(result.empty());
+}
+
+TEST_F(l1_reader_test, read_single_object) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    auto batches = model::test::make_random_batches(model::offset{0}, 10).get();
+    auto expected = copy(batches);
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(tidp_batches);
+
+    // Read everything.
+    auto reader = make_reader(ntp, tidp);
+    auto result = read_all(std::move(reader));
+    EXPECT_EQ(result, expected);
+}
+
+TEST_F(l1_reader_test, read_multiple_objects) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, 250).get();
+
+    for (auto start = 0; start <= 200; start += 50) {
+        std::vector<tidp_batches_t> tidp_batches;
+        auto subbatches = slice(batches, start, 50);
+        tidp_batches.emplace_back(tidp, std::move(subbatches));
+        make_l1_objects(tidp_batches);
+    }
+
+    auto reader = make_reader(ntp, tidp);
+    auto result = read_all(std::move(reader));
+
+    EXPECT_EQ(result, batches);
+}
+
+TEST_F(l1_reader_test, read_multiple_ntps_multiple_objects) {
+    auto ntps = std::vector<std::pair<model::ntp, model::topic_id_partition>>{
+      make_ntidp("tapioca"), make_ntidp("taco"), make_ntidp("turkey")};
+
+    std::vector<chunked_circular_buffer<model::record_batch>> batches;
+    batches.push_back(
+      model::test::make_random_batches(model::offset{0}, 250).get());
+    batches.push_back(
+      model::test::make_random_batches(model::offset{0}, 250).get());
+    batches.push_back(
+      model::test::make_random_batches(model::offset{0}, 250).get());
+
+    for (auto start = 0; start <= 200; start += 50) {
+        std::vector<tidp_batches_t> tidp_batches;
+        for (auto i = 0; i < 3; i++) {
+            auto subbatches = slice(batches[i], start, 50);
+            tidp_batches.emplace_back(ntps[i].second, std::move(subbatches));
+        }
+        make_l1_objects(tidp_batches);
+    }
+
+    for (auto i = 0; i < 3; i++) {
+        auto [ntp, tidp] = ntps[i];
+        auto reader = make_reader(ntp, tidp);
+        auto result = read_all(std::move(reader));
+
+        EXPECT_EQ(result, batches[i]);
+    }
+}
+
+TEST_F(l1_reader_test, read_offset_range_one_object) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    auto batches = model::test::make_random_batches(model::offset{0}, 10).get();
+    auto expected = copy(batches);
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(tidp_batches);
+
+    auto min = kafka::offset{10};
+    auto max = kafka::offset{250};
+    auto reader = make_reader(ntp, tidp, min, max);
+    auto result = read_all(std::move(reader));
+    EXPECT_EQ(result, slice_by_offset(expected, min, max));
+}
+
+TEST_F(l1_reader_test, read_offset_range_multiple_objects) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    auto batches = model::test::make_random_batches(model::offset{0}, 20).get();
+
+    {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, slice(batches, 0, 10));
+        make_l1_objects(tidp_batches);
+    }
+    {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, slice(batches, 10, 10));
+        make_l1_objects(tidp_batches);
+    }
+
+    auto offset_in_second_obj = batches[15].base_offset();
+    auto min = kafka::offset{10};
+    auto max = model::offset_cast(offset_in_second_obj);
+    auto reader = make_reader(ntp, tidp, min, max);
+    auto result = read_all(std::move(reader));
+    EXPECT_EQ(result, slice_by_offset(batches, min, max));
+}
+
+TEST_F(l1_reader_test, read_with_max_bytes) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Use a pretty big number so we don't randomly get too many small batches.
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, 100).get();
+    auto expected = copy(batches);
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(tidp_batches);
+
+    {
+        // Set tiny max bytes to check we get one batch.
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset::min(), kafka::offset::max(), 1);
+        auto result = read_all(std::move(reader));
+        EXPECT_EQ(result, slice(expected, 0, 1));
+    }
+
+    {
+        // Set a bigger max bytes to check we get some batches but not all.
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset::min(), kafka::offset::max(), 10_KiB);
+        auto result = read_all(std::move(reader));
+        EXPECT_LT(result.size(), expected.size());
+    }
+}
+
+TEST_F(l1_reader_test, read_with_strict_max_bytes) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Use a pretty big number so we don't randomly get too many small batches.
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, 100).get();
+    auto expected = copy(batches);
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(tidp_batches);
+
+    {
+        // Set tiny max bytes to check we get no batches
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset::min(), kafka::offset::max(), 1, true);
+        auto result = read_all(std::move(reader));
+        EXPECT_TRUE(result.empty());
+    }
+
+    {
+        // Set a bigger max bytes to check we get some batches but not all.
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset::min(), kafka::offset::max(), 10_KiB, true);
+        auto result = read_all(std::move(reader));
+        EXPECT_LT(result.size(), expected.size());
+    }
+}
+
+TEST_F(l1_reader_test, out_of_range) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Start the object at offset 100.
+    auto batches
+      = model::test::make_random_batches(model::offset{100}, 10).get();
+    auto last_offset = model::offset_cast(batches.back().last_offset());
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(tidp_batches);
+
+    // Test reading before the available range.
+    {
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset{0}, kafka::offset{99});
+        auto result = read_all(std::move(reader));
+        EXPECT_TRUE(result.empty());
+    }
+
+    // Test reading after the available range.
+    {
+        auto reader = make_reader(ntp, tidp, kafka::next_offset(last_offset));
+        auto result = read_all(std::move(reader));
+        EXPECT_TRUE(result.empty());
+    }
+}
+
+TEST_F(l1_reader_test, missing_object) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Register object in metastore but don't upload.
+    // This is corruption and readers should throw.
+    auto builder = _metastore.object_builder();
+    auto oid = builder->get_or_create_object_for(tidp);
+    builder
+      ->add(
+        oid,
+        l1::metastore::object_metadata::ntp_metadata{
+          .tidp = tidp,
+          .base_offset = kafka::offset{0},
+          .last_offset = kafka::offset{9},
+          .max_timestamp = model::timestamp::now(),
+          .pos = 0,
+          .size = 1000,
+        })
+      .value();
+    builder->finish(oid, 1001, 1500).value();
+
+    l1::metastore::term_offset_map_t term_map;
+    term_map[tidp].push_back(
+      l1::metastore::term_offset{
+        .term = model::term_id{1},
+        .first_offset = kafka::offset{0},
+      });
+
+    _metastore.add_objects(std::move(builder), term_map).get().value();
+
+    auto reader = make_reader(ntp, tidp);
+    EXPECT_THROW(read_all(std::move(reader)), std::runtime_error);
+}
+
+TEST_F(l1_reader_test, empty_offset_range) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Write some initial objects.
+    auto batches
+      = model::test::make_random_batches(model::offset{0}, 250).get();
+
+    for (auto start = 0; start <= 200; start += 50) {
+        std::vector<tidp_batches_t> tidp_batches;
+        auto subbatches = slice(batches, start, 50);
+        tidp_batches.emplace_back(tidp, std::move(subbatches));
+        make_l1_objects(tidp_batches);
+    }
+
+    // Mimic an object from which all partition data has been compacted.
+    // The object has no data for the partition, but is registered
+    // to cover a non-empty offset range in the metastore.
+    auto meta_builder = _metastore.object_builder();
+
+    auto oid = meta_builder->get_or_create_object_for(tidp);
+
+    auto buf = iobuf{};
+    auto builder = l1::object_builder::create(
+      make_iobuf_ref_output_stream(buf), {});
+
+    auto obj_info = builder->finish().get();
+    builder->close().get();
+
+    _io.put_object(oid, std::move(buf));
+
+    auto high_watermark = kafka::next_offset(
+      model::offset_cast(batches.back().last_offset()));
+    meta_builder
+      ->add(
+        oid,
+        l1::metastore::object_metadata::ntp_metadata{
+          .tidp = tidp,
+          .base_offset = high_watermark,
+          .last_offset = high_watermark,
+          .max_timestamp = model::timestamp::now(),
+          .pos = 0,
+          .size = 0,
+        })
+      .value();
+
+    meta_builder->finish(oid, obj_info.footer_offset, obj_info.size_bytes)
+      .value();
+
+    l1::metastore::term_offset_map_t term_map;
+    term_map[tidp].push_back(
+      l1::metastore::term_offset{
+        .term = model::term_id{1},
+        .first_offset = high_watermark,
+      });
+    _metastore.add_objects(std::move(meta_builder), term_map).get().value();
+
+    // Write some objects after the empty object.
+    auto final_batches
+      = model::test::make_random_batches(
+          kafka::offset_cast(kafka::next_offset(high_watermark)), 250)
+          .get();
+
+    for (auto start = 0; start <= 200; start += 50) {
+        std::vector<tidp_batches_t> tidp_batches;
+        auto subbatches = slice(final_batches, start, 50);
+        tidp_batches.emplace_back(tidp, std::move(subbatches));
+        make_l1_objects(tidp_batches);
+    }
+
+    auto reader = make_reader(ntp, tidp);
+    auto result = read_all(std::move(reader));
+
+    batches.insert(
+      batches.end(),
+      std::make_move_iterator(final_batches.begin()),
+      std::make_move_iterator(final_batches.end()));
+    EXPECT_EQ(result, batches);
+}
+
+TEST_F(l1_reader_test, sparse_offset_ranges) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    auto all_batches
+      = model::test::make_random_batches(model::offset{0}, 250).get();
+
+    // Slice up the range of batches, and punch gaps within the slices.
+    // This simulates compaction swiss-cheesing the log.
+    auto slice0 = slice(all_batches, 0, 50);
+    auto slice1 = slice(all_batches, 50, 150);
+    auto slice2 = slice(all_batches, 200, 50);
+
+    slice0.erase(slice0.begin() + 5, slice0.begin() + 25);
+    slice1.erase(slice1.begin() + 10, slice1.begin() + 35);
+    slice2.erase(slice2.begin() + 15, slice2.begin() + 30);
+
+    {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, copy(slice0));
+        make_l1_objects(tidp_batches);
+    }
+    {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, copy(slice1));
+        make_l1_objects(tidp_batches);
+    }
+    {
+        std::vector<tidp_batches_t> tidp_batches;
+        tidp_batches.emplace_back(tidp, copy(slice2));
+        make_l1_objects(tidp_batches);
+    }
+
+    auto reader = make_reader(ntp, tidp);
+    auto result = read_all(std::move(reader));
+
+    chunked_circular_buffer<model::record_batch> batches;
+    batches.insert(
+      batches.end(),
+      std::make_move_iterator(slice0.begin()),
+      std::make_move_iterator(slice0.end()));
+    batches.insert(
+      batches.end(),
+      std::make_move_iterator(slice1.begin()),
+      std::make_move_iterator(slice1.end()));
+    batches.insert(
+      batches.end(),
+      std::make_move_iterator(slice2.begin()),
+      std::make_move_iterator(slice2.end()));
+
+    EXPECT_EQ(result, batches);
+}
+
+TEST_F(l1_reader_test, max_bytes_zero_behavior) {
+    auto [ntp, tidp] = make_ntidp("test_topic");
+
+    // Create an object with multiple batches
+    auto batches = model::test::make_random_batches(model::offset{0}, 10).get();
+    auto expected = copy(batches);
+
+    std::vector<tidp_batches_t> tidp_batches;
+    tidp_batches.emplace_back(tidp, std::move(batches));
+    make_l1_objects(tidp_batches);
+
+    {
+        // Test max_bytes=0 with strict_max_bytes=false
+        // Should return exactly one batch (non-strict mode allows at least one)
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset::min(), kafka::offset::max(), 0, false);
+        auto result = read_all(std::move(reader));
+        EXPECT_EQ(result.size(), 1);
+        EXPECT_EQ(result[0], expected[0]);
+    }
+
+    {
+        // Test max_bytes=0 with strict_max_bytes=true
+        // Should return zero batches (strict mode respects the byte limit)
+        auto reader = make_reader(
+          ntp, tidp, kafka::offset::min(), kafka::offset::max(), 0, true);
+        auto result = read_all(std::move(reader));
+        EXPECT_TRUE(result.empty());
+    }
+}


### PR DESCRIPTION
Basically follows the design of the L0 reader, which works well and is easy to understand.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
