### PR TITLE
gha: add workaround for publishing to BCR

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -70,10 +70,25 @@ jobs:
             ,sdlc/prod/github/buf_token
           parse-json-secrets: true
       - uses: actions/checkout@v4
+      - name: Preprocess proto files for buf publishing
+        run: |
+          # WORKAROUND: Our Bazel structure puts proto files to live under a "proto/"
+          # directory, but when publishing to Buf's BCR this creates undesirable import paths
+          # like "proto/redpanda/..." instead of "redpanda/..." paths, which doesn't work with
+          # Buf.
+          #
+          # This preprocessing step:
+          # 1. Updates buf.yaml to use path: proto instead of includes
+          # 2. Strips "proto/" prefixes from buf.yaml paths and proto file imports
+          # 3. Allows buf to publish with import paths that match protoc plugin expectations
+
+          sed -i 's|path: \.|path: proto|' buf.yaml
+          sed -i '/includes:/,/- proto/d' buf.yaml
+          # Fix proto file imports to remove proto/ prefix
+          find proto -name "*.proto" -exec sed -i 's|import "proto/|import "|g' {} \;
       - name: Buf – push to registry
         uses: bufbuild/buf-action@v1
         with:
-          paths: proto
           # No validation - already done in validate job
           lint: false
           format: false
@@ -100,10 +115,25 @@ jobs:
             ,sdlc/prod/github/buf_token
           parse-json-secrets: true
       - uses: actions/checkout@v4
+      - name: Preprocess proto files for buf publishing
+        run: |
+          # WORKAROUND: Our Bazel structure puts proto files to live under a "proto/"
+          # directory, but when publishing to Buf's BCR this creates undesirable import paths
+          # like "proto/redpanda/..." instead of "redpanda/..." paths, which doesn't work with
+          # Buf.
+          #
+          # This preprocessing step:
+          # 1. Updates buf.yaml to use path: proto instead of includes
+          # 2. Strips "proto/" prefixes from buf.yaml paths and proto file imports
+          # 3. Allows buf to publish with import paths that match protoc plugin expectations
+
+          sed -i 's|path: \.|path: proto|' buf.yaml
+          sed -i '/includes:/,/- proto/d' buf.yaml
+          # Fix excludes and other paths to be relative to proto directory
+          sed -i 's|proto/redpanda|redpanda|g' buf.yaml
       - name: Buf – archive label (ignore if not found)
         uses: bufbuild/buf-action@v1
         with:
-          paths: proto
           # Only archive - no other operations
           push: true
           token: ${{ env.BUF_TOKEN }}


### PR DESCRIPTION
Buf doesn't like to generate code where protos don't match the
directory structure.

See: https://redpandadata.slack.com/archives/C09C27KTCPK/p1756489960830479

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
