### PR TITLE
pbgen: add basic generic field lookup

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -333,6 +333,7 @@ func (g *headerGenerator) generateFile(w *codewriter) {
 		w.PreludePrintln(`#include "base/format_to.h"`)
 		w.PreludePrintln(`#include "bytes/iobuf.h"`)
 		w.PreludePrintln(`#include "serde/protobuf/base.h"`)
+		w.PreludePrintln(`#include "strings/static_str.h"`)
 		if g.needsChunkedHashMap {
 			w.PreludePrintln(`#include "container/chunked_hash_map.h"`)
 		}
@@ -499,7 +500,7 @@ func (g *headerGenerator) generateEnumSerde(msg protoreflect.EnumDescriptor, w *
 	w.Printf("void enum_to_proto(const %s&, iobuf*);\n", cppName)
 	w.Printf("void enum_from_proto(iobuf_parser*, %s*);\n", cppName)
 	w.Println("// Returns the name of the enum value")
-	w.Printf("std::string_view enum_to_string(const %s&);\n", cppName)
+	w.Printf("static_str enum_to_string(const %s&);\n", cppName)
 	w.Printf("void enum_from_json(serde::pb::json::peekable_parser*, %s*);\n", cppName)
 	// TODO: When we've upgraded to libfmt 11 we can change this to return std::string_view
 	w.Printf("int32_t format_as(%s);\n", cppName)
@@ -1113,7 +1114,7 @@ func (g *implGenerator) generateEnumWrite(enum protoreflect.EnumDescriptor, w *c
 }
 
 func (g *implGenerator) generateEnumToString(enum protoreflect.EnumDescriptor, w *codewriter) {
-	w.Printf("std::string_view enum_to_string(const %s& e) {\n", cppTypeName(enum))
+	w.Printf("static_str enum_to_string(const %s& e) {\n", cppTypeName(enum))
 	defer w.Println("}")
 	w.Indent()
 	defer w.Dedent()

--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -332,6 +332,7 @@ func (g *headerGenerator) generateFile(w *codewriter) {
 		w.PreludePrintln()
 		w.PreludePrintln(`#include "base/format_to.h"`)
 		w.PreludePrintln(`#include "bytes/iobuf.h"`)
+		w.PreludePrintln(`#include "serde/protobuf/base.h"`)
 		if g.needsChunkedHashMap {
 			w.PreludePrintln(`#include "container/chunked_hash_map.h"`)
 		}
@@ -538,7 +539,7 @@ func (g *headerGenerator) generateEnum(enum protoreflect.EnumDescriptor, w *code
 func (g *headerGenerator) generateMessage(msg protoreflect.MessageDescriptor, w *codewriter) {
 	g.leadingComments(msg, w)
 	typeName := cppTypeName(msg)
-	w.Printf("class %s {\n", typeName)
+	w.Printf("class %s : public serde::pb::base_message {\n", typeName)
 	defer w.Println("};")
 	w.Println("public:")
 	w.Indent()
@@ -605,6 +606,14 @@ func (g *headerGenerator) generateMessage(msg protoreflect.MessageDescriptor, w 
 			}
 		}
 	}
+	w.Println()
+	w.Printf("std::string_view full_name() const override { return %q; }\n", msg.FullName())
+	w.Println("// Convert a field path into a path of field numbers.")
+	w.Println("static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);")
+	w.Println("// Convert a field path into a path of field numbers.")
+	w.Println("std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;")
+	w.Println("// Look up a field based on the field numbers.")
+	w.Println("std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;")
 	w.Println()
 	w.Println("// NOTE: This is intended to be used by field_mask only. Do not use directly.")
 	w.Println("static bool is_valid_field_path(std::span<const ss::sstring> path);")
@@ -694,6 +703,8 @@ func (g *implGenerator) generateFile(w *codewriter) {
 		g.generateMessageReadJsonHelper(msg, w)
 		g.generateMessageFieldMaskIsValidHelper(msg, w)
 		g.generateMessageFieldMaskApplyHelper(msg, w)
+		g.generateMessagePathToNumbersHelper(msg, w)
+		g.generateMessageTraversalHelper(msg, w)
 		w.Println()
 	}
 	for _, enum := range enums {
@@ -711,6 +722,142 @@ func (g *implGenerator) generateFile(w *codewriter) {
 		g.generateServiceClient(service, w)
 		w.Println()
 	}
+}
+
+func (g *implGenerator) generateMessagePathToNumbersHelper(msg protoreflect.MessageDescriptor, w *codewriter) {
+	w.Printf("std::optional<std::vector<int32_t>> %s::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {\n", cppTypeName(msg))
+	w.Indent()
+	w.Println("std::vector<int32_t> numbers;")
+	w.Println("if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }")
+	w.Println("return std::nullopt;")
+	w.Dedent()
+	w.Println("}")
+	w.Printf("bool %s::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {\n", cppTypeName(msg))
+	defer w.Println("}")
+	w.Indent()
+	defer w.Dedent()
+	if msg.Fields().Len() == 0 {
+		w.Println("std::ignore = out;")
+		w.Println("return field_path.empty();")
+		return
+	}
+	w.Println("if (field_path.empty()) {")
+	w.Indent()
+	w.Println("return true;")
+	w.Dedent()
+	w.Println("}")
+	w.Printf("constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({\n")
+	w.Indent()
+	pairs := make([]string, 0, msg.Fields().Len()*2)
+	for i := range msg.Fields().Len() {
+		f := msg.Fields().Get(i)
+		msg := f.Message()
+		if f.Cardinality() == protoreflect.Repeated || msg == nil || isWellKnownType(msg) {
+			lambda := fmt.Sprintf("[](auto path, auto* out) { out->push_back(%d); return path.empty(); }", f.Number())
+			pairs = append(pairs, fmt.Sprintf("{%q, %s},", f.Name(), lambda))
+			continue
+		}
+		lambda := strings.Join([]string{
+			"[](auto path, auto* out) {",
+			fmt.Sprintf("out->push_back(%d);", f.Number()),
+			fmt.Sprintf("return %s::convert_field_path_to_numbers(path, out);", cppTypeName(msg)),
+			"}",
+		}, " ")
+		pairs = append(pairs, fmt.Sprintf("{%q, %s},", f.Name(), lambda))
+	}
+	// Sort the pairs for binary search.
+	slices.Sort(pairs)
+	for _, pair := range pairs {
+		w.Println(pair)
+	}
+	w.Dedent()
+	w.Println("});")
+	w.Println("auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });")
+	w.Println("if (fields.empty()) {")
+	w.Indent()
+	w.Println("return false;")
+	w.Dedent()
+	w.Println("}")
+	w.Println("return fields.front().second(field_path.subspan(1), out);")
+}
+
+func (g *implGenerator) generateMessageTraversalHelper(msg protoreflect.MessageDescriptor, w *codewriter) {
+	w.Printf("std::optional<serde::pb::field> %s::lookup_field(std::span<int32_t> field_numbers) {\n", cppTypeName(msg))
+	defer w.Println("}")
+	w.Indent()
+	defer w.Dedent()
+	w.Println()
+	w.Println("if (field_numbers.empty()) {")
+	w.Indent()
+	w.Println("return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};")
+	w.Dedent()
+	w.Println("}")
+	w.Println("serde::pb::field found;")
+	w.Println("switch (field_numbers.front()) {")
+	for i := range msg.Fields().Len() {
+		f := msg.Fields().Get(i)
+		func() {
+			w.Printf("case %v: { // %s\n", f.Number(), f.Name())
+			defer w.Println("}")
+			w.Indent()
+			defer w.Dedent()
+			defer w.Println("break;")
+			if f.IsMap() || f.IsList() {
+				base := "repeated_value"
+				if f.IsMap() {
+					base = "map_value"
+				}
+				w.Printf("struct %s_field_value : public serde::pb::field::%s {\n", f.Name(), base)
+				w.Indent()
+				typ, _ := g.translateType(f)
+				w.Printf("%s* value;\n", typ)
+				w.Dedent()
+				w.Println("};")
+				w.Printf("auto value = std::make_unique<%s_field_value>();\n", f.Name())
+				w.Printf("value->value = &get_%s();\n", f.Name())
+				w.Println("found.value = std::move(value);")
+				return
+			}
+			if oneof := f.ContainingOneof(); oneof != nil {
+				w.Printf("if (!has_%s()) {\n", f.Name())
+				w.Indent()
+				w.Printf("set_%s({});\n", f.Name())
+				w.Dedent()
+				w.Println("}")
+			}
+			if msg := f.Message(); msg != nil && !isWellKnownType(msg) {
+				if isPtr(f) {
+					w.Printf("if (!get_%s()) { set_%s(std::make_unique<%s>()); }\n", f.Name(), f.Name(), cppTypeName(msg))
+					w.Printf("found.value = get_%s().get();\n", f.Name())
+				} else {
+					w.Printf("found.value = &get_%s();\n", f.Name())
+				}
+			} else if enum := f.Enum(); enum != nil {
+				w.Println("found.value = serde::pb::raw_enum_value{")
+				w.Indent()
+				w.Printf(".number = static_cast<int32_t>(get_%s()),\n", f.Name())
+				w.Printf(".name = enum_to_string(get_%s()),\n", f.Name())
+				w.Dedent()
+				w.Println("};")
+			} else if f.Kind() == protoreflect.BytesKind {
+				w.Printf("found.value = get_%s().share();\n", f.Name())
+			} else {
+				w.Printf("found.value = get_%s();\n", f.Name())
+			}
+		}()
+	}
+	w.Println("default:")
+	w.Indent()
+	w.Println("return std::nullopt;")
+	w.Dedent()
+	w.Println("}")
+	w.Println("if (field_numbers.size() > 1) {")
+	w.Indent()
+	w.Println("if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }")
+	w.Println("return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));")
+	w.Dedent()
+	w.Println("}")
+	w.Println("return found;")
 }
 
 func (g *implGenerator) generateMessageFieldMaskIsValidHelper(msg protoreflect.MessageDescriptor, w *codewriter) {

--- a/bazel/pbgen/pbgen.bzl
+++ b/bazel/pbgen/pbgen.bzl
@@ -257,6 +257,7 @@ def redpanda_proto_library(name, protos, deps = [], **kwargs):
             "//src/v/base",
             "//src/v/bytes:iobuf",
             "//src/v/serde/protobuf:rpc",
+            "//src/v/strings:static_str",
             "//src/v/serde/protobuf:base",
             "//src/v/container:chunked_hash_map",
             "//src/v/container:chunked_vector",

--- a/bazel/pbgen/pbgen.bzl
+++ b/bazel/pbgen/pbgen.bzl
@@ -257,6 +257,7 @@ def redpanda_proto_library(name, protos, deps = [], **kwargs):
             "//src/v/base",
             "//src/v/bytes:iobuf",
             "//src/v/serde/protobuf:rpc",
+            "//src/v/serde/protobuf:base",
             "//src/v/container:chunked_hash_map",
             "//src/v/container:chunked_vector",
             "@seastar",

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -58,6 +58,7 @@ iobuf iobuf_copy(iobuf::iterator_consumer& in, size_t len) {
     return ret;
 }
 
+iobuf iobuf::share() { return share(0, size_bytes()); }
 iobuf iobuf::share(size_t pos, size_t len) {
     iobuf ret;
     size_t left = len;

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -124,6 +124,7 @@ public:
      * Since this call performs zero-copy operations, the sharing-mutation
      * caveat in the class comment applies.
      */
+    iobuf share();
     iobuf share(size_t pos, size_t len);
 
     /**

--- a/src/v/serde/protobuf/BUILD
+++ b/src/v/serde/protobuf/BUILD
@@ -118,3 +118,16 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "base",
+    srcs = ["base.cc"],
+    hdrs = ["base.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":field_mask",
+        "//src/v/bytes:iobuf",
+        "@abseil-cpp//absl/time",
+        "@seastar",
+    ],
+)

--- a/src/v/serde/protobuf/BUILD
+++ b/src/v/serde/protobuf/BUILD
@@ -127,6 +127,7 @@ redpanda_cc_library(
     deps = [
         ":field_mask",
         "//src/v/bytes:iobuf",
+        "//src/v/strings:static_str",
         "@abseil-cpp//absl/time",
         "@seastar",
     ],

--- a/src/v/serde/protobuf/base.cc
+++ b/src/v/serde/protobuf/base.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/protobuf/base.h"
+
+namespace serde::pb {
+
+std::optional<field>
+base_message::lookup_field_by_path(std::span<std::string_view> field_path) {
+    return convert_field_path_to_numbers(field_path)
+      .and_then([this](std::vector<int32_t> field_numbers) {
+          return lookup_field(field_numbers);
+      });
+}
+
+} // namespace serde::pb

--- a/src/v/serde/protobuf/base.h
+++ b/src/v/serde/protobuf/base.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "absl/time/time.h"
+#include "bytes/iobuf.h"
+#include "serde/protobuf/field_mask.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <optional>
+#include <span>
+#include <string_view>
+#include <variant>
+
+namespace serde::pb {
+
+// A type erased value of a protobuf enum.
+//
+// This allows generic handling of enum values and access to both the numeric
+// value and the string name.
+struct raw_enum_value {
+    int32_t number;
+    std::string_view name;
+
+    bool operator==(const raw_enum_value&) const = default;
+};
+
+class base_message;
+
+// A generic field within a proto. Can be used for generic operations on a
+// protobuf.
+struct field {
+    // A base class for a wrapper around a map value.
+    class map_value {
+    public:
+        map_value() = default;
+        map_value(const map_value&) = delete;
+        map_value(map_value&&) = delete;
+        map_value& operator=(const map_value&) = delete;
+        map_value& operator=(map_value&&) = delete;
+        virtual ~map_value() = default;
+    };
+
+    // A base class for a wrapper around a repeated value.
+    class repeated_value {
+    public:
+        repeated_value() = default;
+        repeated_value(const repeated_value&) = delete;
+        repeated_value(repeated_value&&) = delete;
+        repeated_value& operator=(const repeated_value&) = delete;
+        repeated_value& operator=(repeated_value&&) = delete;
+        virtual ~repeated_value() = default;
+    };
+
+    using value_t = std::variant<
+      std::monostate,
+      bool,
+      int32_t,
+      int64_t,
+      uint32_t,
+      uint64_t,
+      ss::sstring,
+      iobuf,
+      float,
+      double,
+      raw_enum_value,
+      // Well known messages are special in that we don't codegen them.
+      field_mask,
+      absl::Time,
+      absl::Duration,
+      // The following fields are pointers to field values.
+      //
+      // Be careful of the lifetime here, if the parent message
+      // is moved, then this pointer *could* become invalidated.
+      // However, these values will *never* be `nullptr` as unset
+      // is translated into std::monostate.
+      std::unique_ptr<map_value>,
+      std::unique_ptr<repeated_value>,
+      base_message*>;
+
+    // The field's value.
+    value_t value;
+
+    bool operator==(const field&) const = default;
+};
+
+// The base message for all generated protobufs.
+class base_message {
+public:
+    base_message() = default;
+    base_message(const base_message&) = default;
+    base_message(base_message&&) = default;
+    base_message& operator=(const base_message&) = default;
+    base_message& operator=(base_message&&) = default;
+    virtual ~base_message() = default;
+
+    // The fully qualified name of this protobuf.
+    virtual std::string_view full_name() const = 0;
+    // Lookup a field by it's path. Multiple field names are supported for
+    // nested message traversal.
+    //
+    // Note that dynamic field lookup can modify the original message if looking
+    // up a field with optional field presence. For example, if you have a proto
+    // like so:
+    //
+    // ```
+    // message YourProto {
+    //   string value = 1;
+    // }
+    // message MyProto {
+    //   oneof kind { YourProto nested = 1; }
+    //   MyProto recursive = 2 [(redpanda.core.pbgen).ptr = true];
+    // }
+    // ```
+    //
+    // The following is valid (does not assert):
+    // ```
+    // my_proto pb;
+    // vassert(!pb.has_nested(), "well by default it's unset");
+    // // This returns std::monostate as the field value.
+    // std::ignore = pb.lookup_field_by_path({"nested"});
+    // vassert(pb.has_nested(), "has been set");
+    // pb = {};
+    // // This returns 0 as the field value.
+    // std::ignore = pb.lookup_field_by_path({"nested", "value"});
+    // vassert(pb.has_nested(), "and this is also set");
+    // ```
+    //
+    // In order to lookup `value`, we *mutate* `pb` so that `nested` is set.
+    // This is similar to the offical proto library behavior for the mutable*
+    // methods.
+    //
+    // The same holds for field `recursive`.
+    //
+    // NOTE: If doing this in a potentially large loop, it's better
+    // performance-wise to first convert the field path to field numbers (using
+    // `convert_field_path_to_numbers`), then do the lookup from field
+    // numbers. This avoids extra string comparisons.
+    std::optional<field>
+    lookup_field_by_path(std::span<std::string_view> field_path);
+    // A virtual method to convert a field path into numbers.
+    virtual std::optional<std::vector<int32_t>>
+    convert_field_path_to_numbers(std::span<std::string_view> field_path) const
+      = 0;
+    // The same as `lookup_field_by_path`, except using field numbers instead of
+    // a field path.
+    virtual std::optional<field>
+    lookup_field(std::span<int32_t> field_numbers) = 0;
+};
+
+} // namespace serde::pb

--- a/src/v/serde/protobuf/base.h
+++ b/src/v/serde/protobuf/base.h
@@ -14,6 +14,7 @@
 #include "absl/time/time.h"
 #include "bytes/iobuf.h"
 #include "serde/protobuf/field_mask.h"
+#include "strings/static_str.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -30,7 +31,7 @@ namespace serde::pb {
 // value and the string name.
 struct raw_enum_value {
     int32_t number;
-    std::string_view name;
+    static_str name;
 
     bool operator==(const raw_enum_value&) const = default;
 };

--- a/src/v/serde/protobuf/tests/BUILD
+++ b/src/v/serde/protobuf/tests/BUILD
@@ -180,6 +180,25 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "reflection_test",
+    timeout = "short",
+    srcs = [
+        "reflection_test.cc",
+    ],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        ":codegen_test_cc_proto",
+        ":codegen_test_redpanda_proto",
+        ":test_messages_edition2023_cc_proto",
+        ":test_messages_edition2023_redpanda_proto",
+        "//src/v/test_utils:gtest",
+        "@fmt",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_golden_test(
     name = "protogen_golden_conformance_test",
     srcs = {

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -1784,7 +1784,7 @@ void enum_from_proto(iobuf_parser* p, corpus* e) {
 void enum_to_proto(const corpus& e, iobuf* buf) {
   serde::pb::write_varint<int32_t, serde::pb::zigzag::no>(static_cast<int32_t>(e), buf);
 }
-std::string_view enum_to_string(const corpus& e) {
+static_str enum_to_string(const corpus& e) {
   switch (e) {
   case corpus::unspecified:
     return "CORPUS_UNSPECIFIED";
@@ -1880,7 +1880,7 @@ void enum_from_proto(iobuf_parser* p, protobuf3_test* e) {
 void enum_to_proto(const protobuf3_test& e, iobuf* buf) {
   serde::pb::write_varint<int32_t, serde::pb::zigzag::no>(static_cast<int32_t>(e), buf);
 }
-std::string_view enum_to_string(const protobuf3_test& e) {
+static_str enum_to_string(const protobuf3_test& e) {
   switch (e) {
   case protobuf3_test::unspecified:
     return "PROTOBUF3_TEST_UNSPECIFIED";
@@ -1945,7 +1945,7 @@ void enum_from_proto(iobuf_parser* p, proto3_test* e) {
 void enum_to_proto(const proto3_test& e, iobuf* buf) {
   serde::pb::write_varint<int32_t, serde::pb::zigzag::no>(static_cast<int32_t>(e), buf);
 }
-std::string_view enum_to_string(const proto3_test& e) {
+static_str enum_to_string(const proto3_test& e) {
   switch (e) {
   case proto3_test::unspecified:
     return "PROTO3_TEST_UNSPECIFIED";

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.cc
@@ -142,6 +142,44 @@ void a::apply_field_path_from(std::span<const ss::sstring> path, a* update) {
     }
   }
 }
+std::optional<std::vector<int32_t>> a::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool a::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"c", [](auto path, auto* out) { out->push_back(1); return c::convert_field_path_to_numbers(path, out); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> a::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // c
+    found.value = &get_c();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
 
 b::b() noexcept = default;
 b::b(b&&) noexcept = default;
@@ -297,6 +335,49 @@ void b::apply_field_path_from(std::span<const ss::sstring> path, b* update) {
     }
   }
 }
+std::optional<std::vector<int32_t>> b::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool b::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"a", [](auto path, auto* out) { out->push_back(2); return a::convert_field_path_to_numbers(path, out); }},
+    {"c", [](auto path, auto* out) { out->push_back(1); return c::convert_field_path_to_numbers(path, out); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> b::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // c
+    found.value = &get_c();
+    break;
+  }
+  case 2: { // a
+    found.value = &get_a();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
 
 c::c() noexcept = default;
 c::c(c&&) noexcept = default;
@@ -370,6 +451,31 @@ void c::apply_field_path_from(std::span<const ss::sstring> path, c* update) {
     *this = std::move(*update);
     return;
   }
+}
+std::optional<std::vector<int32_t>> c::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool c::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  std::ignore = out;
+  return field_path.empty();
+}
+std::optional<serde::pb::field> c::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
 }
 
 super_duper_secret::super_duper_secret() noexcept = default;
@@ -480,6 +586,44 @@ void super_duper_secret::apply_field_path_from(std::span<const ss::sstring> path
       return apply(path.subspan(1), this, update);
     }
   }
+}
+std::optional<std::vector<int32_t>> super_duper_secret::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool super_duper_secret::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"value", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> super_duper_secret::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // value
+    found.value = get_value();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
 }
 
 mask_wrapper::mask_wrapper() noexcept = default;
@@ -597,6 +741,44 @@ void mask_wrapper::apply_field_path_from(std::span<const ss::sstring> path, mask
       return apply(path.subspan(1), this, update);
     }
   }
+}
+std::optional<std::vector<int32_t>> mask_wrapper::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool mask_wrapper::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"mask", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> mask_wrapper::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // mask
+    found.value = get_mask();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
 }
 
 well_known_protos::well_known_protos() noexcept = default;
@@ -1177,6 +1359,114 @@ void well_known_protos::apply_field_path_from(std::span<const ss::sstring> path,
     }
   }
 }
+std::optional<std::vector<int32_t>> well_known_protos::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool well_known_protos::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"duration_map", [](auto path, auto* out) { out->push_back(3); return path.empty(); }},
+    {"field_mask_map", [](auto path, auto* out) { out->push_back(6); return path.empty(); }},
+    {"repeated_duration", [](auto path, auto* out) { out->push_back(2); return path.empty(); }},
+    {"repeated_field_mask", [](auto path, auto* out) { out->push_back(5); return path.empty(); }},
+    {"repeated_timestamp", [](auto path, auto* out) { out->push_back(8); return path.empty(); }},
+    {"single_duration", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+    {"single_field_mask", [](auto path, auto* out) { out->push_back(4); return path.empty(); }},
+    {"single_timestamp", [](auto path, auto* out) { out->push_back(7); return path.empty(); }},
+    {"timestamp_map", [](auto path, auto* out) { out->push_back(9); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> well_known_protos::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // single_duration
+    found.value = get_single_duration();
+    break;
+  }
+  case 2: { // repeated_duration
+    struct repeated_duration_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<absl::Duration>* value;
+    };
+    auto value = std::make_unique<repeated_duration_field_value>();
+    value->value = &get_repeated_duration();
+    found.value = std::move(value);
+    break;
+  }
+  case 3: { // duration_map
+    struct duration_map_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, absl::Duration>* value;
+    };
+    auto value = std::make_unique<duration_map_field_value>();
+    value->value = &get_duration_map();
+    found.value = std::move(value);
+    break;
+  }
+  case 4: { // single_field_mask
+    found.value = get_single_field_mask();
+    break;
+  }
+  case 5: { // repeated_field_mask
+    struct repeated_field_mask_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<serde::pb::field_mask>* value;
+    };
+    auto value = std::make_unique<repeated_field_mask_field_value>();
+    value->value = &get_repeated_field_mask();
+    found.value = std::move(value);
+    break;
+  }
+  case 6: { // field_mask_map
+    struct field_mask_map_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, serde::pb::field_mask>* value;
+    };
+    auto value = std::make_unique<field_mask_map_field_value>();
+    value->value = &get_field_mask_map();
+    found.value = std::move(value);
+    break;
+  }
+  case 7: { // single_timestamp
+    found.value = get_single_timestamp();
+    break;
+  }
+  case 8: { // repeated_timestamp
+    struct repeated_timestamp_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<absl::Time>* value;
+    };
+    auto value = std::make_unique<repeated_timestamp_field_value>();
+    value->value = &get_repeated_timestamp();
+    found.value = std::move(value);
+    break;
+  }
+  case 9: { // timestamp_map
+    struct timestamp_map_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, absl::Time>* value;
+    };
+    auto value = std::make_unique<timestamp_map_field_value>();
+    value->value = &get_timestamp_map();
+    found.value = std::move(value);
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
 
 say_greeting_request::say_greeting_request() noexcept = default;
 say_greeting_request::say_greeting_request(say_greeting_request&&) noexcept = default;
@@ -1287,6 +1577,44 @@ void say_greeting_request::apply_field_path_from(std::span<const ss::sstring> pa
     }
   }
 }
+std::optional<std::vector<int32_t>> say_greeting_request::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool say_greeting_request::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"greeting", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> say_greeting_request::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // greeting
+    found.value = get_greeting();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
 
 say_greeting_response::say_greeting_response() noexcept = default;
 say_greeting_response::say_greeting_response(say_greeting_response&&) noexcept = default;
@@ -1396,6 +1724,44 @@ void say_greeting_response::apply_field_path_from(std::span<const ss::sstring> p
       return apply(path.subspan(1), this, update);
     }
   }
+}
+std::optional<std::vector<int32_t>> say_greeting_response::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool say_greeting_response::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"response", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> say_greeting_response::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // response
+    found.value = get_response();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
 }
 
 void enum_from_proto(iobuf_parser* p, corpus* e) {

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -6,6 +6,7 @@
 #include "base/format_to.h"
 #include "bytes/iobuf.h"
 #include "serde/protobuf/base.h"
+#include "strings/static_str.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "serde/protobuf/rpc.h"
@@ -53,7 +54,7 @@ enum class corpus : uint8_t {
 void enum_to_proto(const corpus&, iobuf*);
 void enum_from_proto(iobuf_parser*, corpus*);
 // Returns the name of the enum value
-std::string_view enum_to_string(const corpus&);
+static_str enum_to_string(const corpus&);
 void enum_from_json(serde::pb::json::peekable_parser*, corpus*);
 int32_t format_as(corpus);
 
@@ -66,7 +67,7 @@ enum class protobuf3_test : uint8_t {
 void enum_to_proto(const protobuf3_test&, iobuf*);
 void enum_from_proto(iobuf_parser*, protobuf3_test*);
 // Returns the name of the enum value
-std::string_view enum_to_string(const protobuf3_test&);
+static_str enum_to_string(const protobuf3_test&);
 void enum_from_json(serde::pb::json::peekable_parser*, protobuf3_test*);
 int32_t format_as(protobuf3_test);
 
@@ -78,7 +79,7 @@ enum class proto3_test : uint8_t {
 void enum_to_proto(const proto3_test&, iobuf*);
 void enum_from_proto(iobuf_parser*, proto3_test*);
 // Returns the name of the enum value
-std::string_view enum_to_string(const proto3_test&);
+static_str enum_to_string(const proto3_test&);
 void enum_from_json(serde::pb::json::peekable_parser*, proto3_test*);
 int32_t format_as(proto3_test);
 

--- a/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/codegen_test.proto.h
@@ -5,6 +5,7 @@
 
 #include "base/format_to.h"
 #include "bytes/iobuf.h"
+#include "serde/protobuf/base.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "serde/protobuf/rpc.h"
@@ -81,7 +82,7 @@ std::string_view enum_to_string(const proto3_test&);
 void enum_from_json(serde::pb::json::peekable_parser*, proto3_test*);
 int32_t format_as(proto3_test);
 
-class c {
+class c : public serde::pb::base_message {
 public:
   c() noexcept;
   c(const c&) = delete;
@@ -109,6 +110,14 @@ public:
   static seastar::future<> from_json(serde::pb::json::peekable_parser*, c*);
 
 
+  std::string_view full_name() const override { return "example.C"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -117,7 +126,7 @@ public:
 private:
 };
 
-class a {
+class a : public serde::pb::base_message {
 public:
   a() noexcept;
   a(const a&) = delete;
@@ -148,6 +157,14 @@ public:
   const c& get_c() const;
   void set_c(c&& v);
 
+  std::string_view full_name() const override { return "example.A"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -157,7 +174,7 @@ private:
   c c_;
 };
 
-class b {
+class b : public serde::pb::base_message {
 public:
   b() noexcept;
   b(const b&) = delete;
@@ -191,6 +208,14 @@ public:
   const a& get_a() const;
   void set_a(a&& v);
 
+  std::string_view full_name() const override { return "example.B"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -201,7 +226,7 @@ private:
   a a_;
 };
 
-class super_duper_secret {
+class super_duper_secret : public serde::pb::base_message {
 public:
   super_duper_secret() noexcept;
   super_duper_secret(const super_duper_secret&) = delete;
@@ -232,6 +257,14 @@ public:
   const ss::sstring& get_value() const;
   void set_value(ss::sstring&& v);
 
+  std::string_view full_name() const override { return "example.SuperDuperSecret"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -241,7 +274,7 @@ private:
   ss::sstring value_;
 };
 
-class mask_wrapper {
+class mask_wrapper : public serde::pb::base_message {
 public:
   mask_wrapper() noexcept;
   mask_wrapper(const mask_wrapper&) = delete;
@@ -272,6 +305,14 @@ public:
   const serde::pb::field_mask& get_mask() const;
   void set_mask(serde::pb::field_mask&& v);
 
+  std::string_view full_name() const override { return "example.MaskWrapper"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -281,7 +322,7 @@ private:
   serde::pb::field_mask mask_;
 };
 
-class well_known_protos {
+class well_known_protos : public serde::pb::base_message {
 public:
   well_known_protos() noexcept;
   well_known_protos(const well_known_protos&) = delete;
@@ -336,6 +377,14 @@ public:
   const chunked_hash_map<ss::sstring, absl::Time>& get_timestamp_map() const;
   void set_timestamp_map(chunked_hash_map<ss::sstring, absl::Time>&& v);
 
+  std::string_view full_name() const override { return "example.WellKnownProtos"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -353,7 +402,7 @@ private:
   chunked_hash_map<ss::sstring, absl::Time> timestamp_map_;
 };
 
-class say_greeting_request {
+class say_greeting_request : public serde::pb::base_message {
 public:
   say_greeting_request() noexcept;
   say_greeting_request(const say_greeting_request&) = delete;
@@ -384,6 +433,14 @@ public:
   const ss::sstring& get_greeting() const;
   void set_greeting(ss::sstring&& v);
 
+  std::string_view full_name() const override { return "example.SayGreetingRequest"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -393,7 +450,7 @@ private:
   ss::sstring greeting_;
 };
 
-class say_greeting_response {
+class say_greeting_response : public serde::pb::base_message {
 public:
   say_greeting_response() noexcept;
   say_greeting_response(const say_greeting_response&) = delete;
@@ -423,6 +480,14 @@ public:
   ss::sstring& get_response();
   const ss::sstring& get_response() const;
   void set_response(ss::sstring&& v);
+
+  std::string_view full_name() const override { return "example.SayGreetingResponse"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
 
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
@@ -6162,7 +6162,7 @@ void enum_from_proto(iobuf_parser* p, test_all_types_edition2023_nested_enum* e)
 void enum_to_proto(const test_all_types_edition2023_nested_enum& e, iobuf* buf) {
   serde::pb::write_varint<int32_t, serde::pb::zigzag::no>(static_cast<int32_t>(e), buf);
 }
-std::string_view enum_to_string(const test_all_types_edition2023_nested_enum& e) {
+static_str enum_to_string(const test_all_types_edition2023_nested_enum& e) {
   switch (e) {
   case test_all_types_edition2023_nested_enum::foo:
     return "FOO";
@@ -6233,7 +6233,7 @@ void enum_from_proto(iobuf_parser* p, foreign_enum_edition2023* e) {
 void enum_to_proto(const foreign_enum_edition2023& e, iobuf* buf) {
   serde::pb::write_varint<int32_t, serde::pb::zigzag::no>(static_cast<int32_t>(e), buf);
 }
-std::string_view enum_to_string(const foreign_enum_edition2023& e) {
+static_str enum_to_string(const foreign_enum_edition2023& e) {
   switch (e) {
   case foreign_enum_edition2023::foreign_foo:
     return "FOREIGN_FOO";

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.cc
@@ -179,6 +179,50 @@ void test_all_types_edition2023_nested_message::apply_field_path_from(std::span<
     }
   }
 }
+std::optional<std::vector<int32_t>> test_all_types_edition2023_nested_message::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool test_all_types_edition2023_nested_message::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"a", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+    {"corecursive", [](auto path, auto* out) { out->push_back(2); return test_all_types_edition2023::convert_field_path_to_numbers(path, out); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> test_all_types_edition2023_nested_message::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // a
+    found.value = get_a();
+    break;
+  }
+  case 2: { // corecursive
+    if (!get_corecursive()) { set_corecursive(std::make_unique<test_all_types_edition2023>()); }
+    found.value = get_corecursive().get();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
 
 test_all_types_edition2023_group_like_type::test_all_types_edition2023_group_like_type() noexcept = default;
 test_all_types_edition2023_group_like_type::test_all_types_edition2023_group_like_type(test_all_types_edition2023_group_like_type&&) noexcept = default;
@@ -309,6 +353,49 @@ void test_all_types_edition2023_group_like_type::apply_field_path_from(std::span
       return apply(path.subspan(1), this, update);
     }
   }
+}
+std::optional<std::vector<int32_t>> test_all_types_edition2023_group_like_type::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool test_all_types_edition2023_group_like_type::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"group_int32", [](auto path, auto* out) { out->push_back(202); return path.empty(); }},
+    {"group_uint32", [](auto path, auto* out) { out->push_back(203); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> test_all_types_edition2023_group_like_type::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 202: { // group_int32
+    found.value = get_group_int32();
+    break;
+  }
+  case 203: { // group_uint32
+    found.value = get_group_uint32();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
 }
 
 test_all_types_edition2023::test_all_types_edition2023() noexcept = default;
@@ -4996,6 +5083,922 @@ void test_all_types_edition2023::apply_field_path_from(std::span<const ss::sstri
     }
   }
 }
+std::optional<std::vector<int32_t>> test_all_types_edition2023::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool test_all_types_edition2023::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"delimited_field", [](auto path, auto* out) { out->push_back(202); return test_all_types_edition2023_group_like_type::convert_field_path_to_numbers(path, out); }},
+    {"groupliketype", [](auto path, auto* out) { out->push_back(201); return test_all_types_edition2023_group_like_type::convert_field_path_to_numbers(path, out); }},
+    {"map_bool_bool", [](auto path, auto* out) { out->push_back(68); return path.empty(); }},
+    {"map_fixed32_fixed32", [](auto path, auto* out) { out->push_back(62); return path.empty(); }},
+    {"map_fixed64_fixed64", [](auto path, auto* out) { out->push_back(63); return path.empty(); }},
+    {"map_int32_double", [](auto path, auto* out) { out->push_back(67); return path.empty(); }},
+    {"map_int32_float", [](auto path, auto* out) { out->push_back(66); return path.empty(); }},
+    {"map_int32_int32", [](auto path, auto* out) { out->push_back(56); return path.empty(); }},
+    {"map_int64_int64", [](auto path, auto* out) { out->push_back(57); return path.empty(); }},
+    {"map_sfixed32_sfixed32", [](auto path, auto* out) { out->push_back(64); return path.empty(); }},
+    {"map_sfixed64_sfixed64", [](auto path, auto* out) { out->push_back(65); return path.empty(); }},
+    {"map_sint32_sint32", [](auto path, auto* out) { out->push_back(60); return path.empty(); }},
+    {"map_sint64_sint64", [](auto path, auto* out) { out->push_back(61); return path.empty(); }},
+    {"map_string_bytes", [](auto path, auto* out) { out->push_back(70); return path.empty(); }},
+    {"map_string_foreign_enum", [](auto path, auto* out) { out->push_back(74); return path.empty(); }},
+    {"map_string_foreign_message", [](auto path, auto* out) { out->push_back(72); return path.empty(); }},
+    {"map_string_nested_enum", [](auto path, auto* out) { out->push_back(73); return path.empty(); }},
+    {"map_string_nested_message", [](auto path, auto* out) { out->push_back(71); return path.empty(); }},
+    {"map_string_string", [](auto path, auto* out) { out->push_back(69); return path.empty(); }},
+    {"map_uint32_uint32", [](auto path, auto* out) { out->push_back(58); return path.empty(); }},
+    {"map_uint64_uint64", [](auto path, auto* out) { out->push_back(59); return path.empty(); }},
+    {"oneof_bool", [](auto path, auto* out) { out->push_back(115); return path.empty(); }},
+    {"oneof_bytes", [](auto path, auto* out) { out->push_back(114); return path.empty(); }},
+    {"oneof_double", [](auto path, auto* out) { out->push_back(118); return path.empty(); }},
+    {"oneof_enum", [](auto path, auto* out) { out->push_back(119); return path.empty(); }},
+    {"oneof_float", [](auto path, auto* out) { out->push_back(117); return path.empty(); }},
+    {"oneof_nested_message", [](auto path, auto* out) { out->push_back(112); return test_all_types_edition2023_nested_message::convert_field_path_to_numbers(path, out); }},
+    {"oneof_string", [](auto path, auto* out) { out->push_back(113); return path.empty(); }},
+    {"oneof_uint32", [](auto path, auto* out) { out->push_back(111); return path.empty(); }},
+    {"oneof_uint64", [](auto path, auto* out) { out->push_back(116); return path.empty(); }},
+    {"optional_bool", [](auto path, auto* out) { out->push_back(13); return path.empty(); }},
+    {"optional_bytes", [](auto path, auto* out) { out->push_back(15); return path.empty(); }},
+    {"optional_cord", [](auto path, auto* out) { out->push_back(25); return path.empty(); }},
+    {"optional_double", [](auto path, auto* out) { out->push_back(12); return path.empty(); }},
+    {"optional_fixed32", [](auto path, auto* out) { out->push_back(7); return path.empty(); }},
+    {"optional_fixed64", [](auto path, auto* out) { out->push_back(8); return path.empty(); }},
+    {"optional_float", [](auto path, auto* out) { out->push_back(11); return path.empty(); }},
+    {"optional_foreign_enum", [](auto path, auto* out) { out->push_back(22); return path.empty(); }},
+    {"optional_foreign_message", [](auto path, auto* out) { out->push_back(19); return foreign_message_edition2023::convert_field_path_to_numbers(path, out); }},
+    {"optional_int32", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+    {"optional_int64", [](auto path, auto* out) { out->push_back(2); return path.empty(); }},
+    {"optional_nested_enum", [](auto path, auto* out) { out->push_back(21); return path.empty(); }},
+    {"optional_nested_message", [](auto path, auto* out) { out->push_back(18); return test_all_types_edition2023_nested_message::convert_field_path_to_numbers(path, out); }},
+    {"optional_sfixed32", [](auto path, auto* out) { out->push_back(9); return path.empty(); }},
+    {"optional_sfixed64", [](auto path, auto* out) { out->push_back(10); return path.empty(); }},
+    {"optional_sint32", [](auto path, auto* out) { out->push_back(5); return path.empty(); }},
+    {"optional_sint64", [](auto path, auto* out) { out->push_back(6); return path.empty(); }},
+    {"optional_string", [](auto path, auto* out) { out->push_back(14); return path.empty(); }},
+    {"optional_string_piece", [](auto path, auto* out) { out->push_back(24); return path.empty(); }},
+    {"optional_uint32", [](auto path, auto* out) { out->push_back(3); return path.empty(); }},
+    {"optional_uint64", [](auto path, auto* out) { out->push_back(4); return path.empty(); }},
+    {"packed_bool", [](auto path, auto* out) { out->push_back(87); return path.empty(); }},
+    {"packed_double", [](auto path, auto* out) { out->push_back(86); return path.empty(); }},
+    {"packed_fixed32", [](auto path, auto* out) { out->push_back(81); return path.empty(); }},
+    {"packed_fixed64", [](auto path, auto* out) { out->push_back(82); return path.empty(); }},
+    {"packed_float", [](auto path, auto* out) { out->push_back(85); return path.empty(); }},
+    {"packed_int32", [](auto path, auto* out) { out->push_back(75); return path.empty(); }},
+    {"packed_int64", [](auto path, auto* out) { out->push_back(76); return path.empty(); }},
+    {"packed_nested_enum", [](auto path, auto* out) { out->push_back(88); return path.empty(); }},
+    {"packed_sfixed32", [](auto path, auto* out) { out->push_back(83); return path.empty(); }},
+    {"packed_sfixed64", [](auto path, auto* out) { out->push_back(84); return path.empty(); }},
+    {"packed_sint32", [](auto path, auto* out) { out->push_back(79); return path.empty(); }},
+    {"packed_sint64", [](auto path, auto* out) { out->push_back(80); return path.empty(); }},
+    {"packed_uint32", [](auto path, auto* out) { out->push_back(77); return path.empty(); }},
+    {"packed_uint64", [](auto path, auto* out) { out->push_back(78); return path.empty(); }},
+    {"recursive_message", [](auto path, auto* out) { out->push_back(27); return test_all_types_edition2023::convert_field_path_to_numbers(path, out); }},
+    {"repeated_bool", [](auto path, auto* out) { out->push_back(43); return path.empty(); }},
+    {"repeated_bytes", [](auto path, auto* out) { out->push_back(45); return path.empty(); }},
+    {"repeated_cord", [](auto path, auto* out) { out->push_back(55); return path.empty(); }},
+    {"repeated_double", [](auto path, auto* out) { out->push_back(42); return path.empty(); }},
+    {"repeated_fixed32", [](auto path, auto* out) { out->push_back(37); return path.empty(); }},
+    {"repeated_fixed64", [](auto path, auto* out) { out->push_back(38); return path.empty(); }},
+    {"repeated_float", [](auto path, auto* out) { out->push_back(41); return path.empty(); }},
+    {"repeated_foreign_enum", [](auto path, auto* out) { out->push_back(52); return path.empty(); }},
+    {"repeated_foreign_message", [](auto path, auto* out) { out->push_back(49); return path.empty(); }},
+    {"repeated_int32", [](auto path, auto* out) { out->push_back(31); return path.empty(); }},
+    {"repeated_int64", [](auto path, auto* out) { out->push_back(32); return path.empty(); }},
+    {"repeated_nested_enum", [](auto path, auto* out) { out->push_back(51); return path.empty(); }},
+    {"repeated_nested_message", [](auto path, auto* out) { out->push_back(48); return path.empty(); }},
+    {"repeated_sfixed32", [](auto path, auto* out) { out->push_back(39); return path.empty(); }},
+    {"repeated_sfixed64", [](auto path, auto* out) { out->push_back(40); return path.empty(); }},
+    {"repeated_sint32", [](auto path, auto* out) { out->push_back(35); return path.empty(); }},
+    {"repeated_sint64", [](auto path, auto* out) { out->push_back(36); return path.empty(); }},
+    {"repeated_string", [](auto path, auto* out) { out->push_back(44); return path.empty(); }},
+    {"repeated_string_piece", [](auto path, auto* out) { out->push_back(54); return path.empty(); }},
+    {"repeated_uint32", [](auto path, auto* out) { out->push_back(33); return path.empty(); }},
+    {"repeated_uint64", [](auto path, auto* out) { out->push_back(34); return path.empty(); }},
+    {"unpacked_bool", [](auto path, auto* out) { out->push_back(101); return path.empty(); }},
+    {"unpacked_double", [](auto path, auto* out) { out->push_back(100); return path.empty(); }},
+    {"unpacked_fixed32", [](auto path, auto* out) { out->push_back(95); return path.empty(); }},
+    {"unpacked_fixed64", [](auto path, auto* out) { out->push_back(96); return path.empty(); }},
+    {"unpacked_float", [](auto path, auto* out) { out->push_back(99); return path.empty(); }},
+    {"unpacked_int32", [](auto path, auto* out) { out->push_back(89); return path.empty(); }},
+    {"unpacked_int64", [](auto path, auto* out) { out->push_back(90); return path.empty(); }},
+    {"unpacked_nested_enum", [](auto path, auto* out) { out->push_back(102); return path.empty(); }},
+    {"unpacked_sfixed32", [](auto path, auto* out) { out->push_back(97); return path.empty(); }},
+    {"unpacked_sfixed64", [](auto path, auto* out) { out->push_back(98); return path.empty(); }},
+    {"unpacked_sint32", [](auto path, auto* out) { out->push_back(93); return path.empty(); }},
+    {"unpacked_sint64", [](auto path, auto* out) { out->push_back(94); return path.empty(); }},
+    {"unpacked_uint32", [](auto path, auto* out) { out->push_back(91); return path.empty(); }},
+    {"unpacked_uint64", [](auto path, auto* out) { out->push_back(92); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> test_all_types_edition2023::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // optional_int32
+    found.value = get_optional_int32();
+    break;
+  }
+  case 2: { // optional_int64
+    found.value = get_optional_int64();
+    break;
+  }
+  case 3: { // optional_uint32
+    found.value = get_optional_uint32();
+    break;
+  }
+  case 4: { // optional_uint64
+    found.value = get_optional_uint64();
+    break;
+  }
+  case 5: { // optional_sint32
+    found.value = get_optional_sint32();
+    break;
+  }
+  case 6: { // optional_sint64
+    found.value = get_optional_sint64();
+    break;
+  }
+  case 7: { // optional_fixed32
+    found.value = get_optional_fixed32();
+    break;
+  }
+  case 8: { // optional_fixed64
+    found.value = get_optional_fixed64();
+    break;
+  }
+  case 9: { // optional_sfixed32
+    found.value = get_optional_sfixed32();
+    break;
+  }
+  case 10: { // optional_sfixed64
+    found.value = get_optional_sfixed64();
+    break;
+  }
+  case 11: { // optional_float
+    found.value = get_optional_float();
+    break;
+  }
+  case 12: { // optional_double
+    found.value = get_optional_double();
+    break;
+  }
+  case 13: { // optional_bool
+    found.value = get_optional_bool();
+    break;
+  }
+  case 14: { // optional_string
+    found.value = get_optional_string();
+    break;
+  }
+  case 15: { // optional_bytes
+    found.value = get_optional_bytes().share();
+    break;
+  }
+  case 18: { // optional_nested_message
+    found.value = &get_optional_nested_message();
+    break;
+  }
+  case 19: { // optional_foreign_message
+    if (!get_optional_foreign_message()) { set_optional_foreign_message(std::make_unique<foreign_message_edition2023>()); }
+    found.value = get_optional_foreign_message().get();
+    break;
+  }
+  case 21: { // optional_nested_enum
+    found.value = serde::pb::raw_enum_value{
+      .number = static_cast<int32_t>(get_optional_nested_enum()),
+      .name = enum_to_string(get_optional_nested_enum()),
+    };
+    break;
+  }
+  case 22: { // optional_foreign_enum
+    found.value = serde::pb::raw_enum_value{
+      .number = static_cast<int32_t>(get_optional_foreign_enum()),
+      .name = enum_to_string(get_optional_foreign_enum()),
+    };
+    break;
+  }
+  case 24: { // optional_string_piece
+    found.value = get_optional_string_piece();
+    break;
+  }
+  case 25: { // optional_cord
+    found.value = get_optional_cord();
+    break;
+  }
+  case 27: { // recursive_message
+    if (!get_recursive_message()) { set_recursive_message(std::make_unique<test_all_types_edition2023>()); }
+    found.value = get_recursive_message().get();
+    break;
+  }
+  case 31: { // repeated_int32
+    struct repeated_int32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<repeated_int32_field_value>();
+    value->value = &get_repeated_int32();
+    found.value = std::move(value);
+    break;
+  }
+  case 32: { // repeated_int64
+    struct repeated_int64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<repeated_int64_field_value>();
+    value->value = &get_repeated_int64();
+    found.value = std::move(value);
+    break;
+  }
+  case 33: { // repeated_uint32
+    struct repeated_uint32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint32_t>* value;
+    };
+    auto value = std::make_unique<repeated_uint32_field_value>();
+    value->value = &get_repeated_uint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 34: { // repeated_uint64
+    struct repeated_uint64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint64_t>* value;
+    };
+    auto value = std::make_unique<repeated_uint64_field_value>();
+    value->value = &get_repeated_uint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 35: { // repeated_sint32
+    struct repeated_sint32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<repeated_sint32_field_value>();
+    value->value = &get_repeated_sint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 36: { // repeated_sint64
+    struct repeated_sint64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<repeated_sint64_field_value>();
+    value->value = &get_repeated_sint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 37: { // repeated_fixed32
+    struct repeated_fixed32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint32_t>* value;
+    };
+    auto value = std::make_unique<repeated_fixed32_field_value>();
+    value->value = &get_repeated_fixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 38: { // repeated_fixed64
+    struct repeated_fixed64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint64_t>* value;
+    };
+    auto value = std::make_unique<repeated_fixed64_field_value>();
+    value->value = &get_repeated_fixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 39: { // repeated_sfixed32
+    struct repeated_sfixed32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<repeated_sfixed32_field_value>();
+    value->value = &get_repeated_sfixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 40: { // repeated_sfixed64
+    struct repeated_sfixed64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<repeated_sfixed64_field_value>();
+    value->value = &get_repeated_sfixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 41: { // repeated_float
+    struct repeated_float_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<float>* value;
+    };
+    auto value = std::make_unique<repeated_float_field_value>();
+    value->value = &get_repeated_float();
+    found.value = std::move(value);
+    break;
+  }
+  case 42: { // repeated_double
+    struct repeated_double_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<double>* value;
+    };
+    auto value = std::make_unique<repeated_double_field_value>();
+    value->value = &get_repeated_double();
+    found.value = std::move(value);
+    break;
+  }
+  case 43: { // repeated_bool
+    struct repeated_bool_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<bool>* value;
+    };
+    auto value = std::make_unique<repeated_bool_field_value>();
+    value->value = &get_repeated_bool();
+    found.value = std::move(value);
+    break;
+  }
+  case 44: { // repeated_string
+    struct repeated_string_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<ss::sstring>* value;
+    };
+    auto value = std::make_unique<repeated_string_field_value>();
+    value->value = &get_repeated_string();
+    found.value = std::move(value);
+    break;
+  }
+  case 45: { // repeated_bytes
+    struct repeated_bytes_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<iobuf>* value;
+    };
+    auto value = std::make_unique<repeated_bytes_field_value>();
+    value->value = &get_repeated_bytes();
+    found.value = std::move(value);
+    break;
+  }
+  case 48: { // repeated_nested_message
+    struct repeated_nested_message_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<test_all_types_edition2023_nested_message>* value;
+    };
+    auto value = std::make_unique<repeated_nested_message_field_value>();
+    value->value = &get_repeated_nested_message();
+    found.value = std::move(value);
+    break;
+  }
+  case 49: { // repeated_foreign_message
+    struct repeated_foreign_message_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<foreign_message_edition2023>* value;
+    };
+    auto value = std::make_unique<repeated_foreign_message_field_value>();
+    value->value = &get_repeated_foreign_message();
+    found.value = std::move(value);
+    break;
+  }
+  case 51: { // repeated_nested_enum
+    struct repeated_nested_enum_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<test_all_types_edition2023_nested_enum>* value;
+    };
+    auto value = std::make_unique<repeated_nested_enum_field_value>();
+    value->value = &get_repeated_nested_enum();
+    found.value = std::move(value);
+    break;
+  }
+  case 52: { // repeated_foreign_enum
+    struct repeated_foreign_enum_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<foreign_enum_edition2023>* value;
+    };
+    auto value = std::make_unique<repeated_foreign_enum_field_value>();
+    value->value = &get_repeated_foreign_enum();
+    found.value = std::move(value);
+    break;
+  }
+  case 54: { // repeated_string_piece
+    struct repeated_string_piece_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<ss::sstring>* value;
+    };
+    auto value = std::make_unique<repeated_string_piece_field_value>();
+    value->value = &get_repeated_string_piece();
+    found.value = std::move(value);
+    break;
+  }
+  case 55: { // repeated_cord
+    struct repeated_cord_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<ss::sstring>* value;
+    };
+    auto value = std::make_unique<repeated_cord_field_value>();
+    value->value = &get_repeated_cord();
+    found.value = std::move(value);
+    break;
+  }
+  case 75: { // packed_int32
+    struct packed_int32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<packed_int32_field_value>();
+    value->value = &get_packed_int32();
+    found.value = std::move(value);
+    break;
+  }
+  case 76: { // packed_int64
+    struct packed_int64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<packed_int64_field_value>();
+    value->value = &get_packed_int64();
+    found.value = std::move(value);
+    break;
+  }
+  case 77: { // packed_uint32
+    struct packed_uint32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint32_t>* value;
+    };
+    auto value = std::make_unique<packed_uint32_field_value>();
+    value->value = &get_packed_uint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 78: { // packed_uint64
+    struct packed_uint64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint64_t>* value;
+    };
+    auto value = std::make_unique<packed_uint64_field_value>();
+    value->value = &get_packed_uint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 79: { // packed_sint32
+    struct packed_sint32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<packed_sint32_field_value>();
+    value->value = &get_packed_sint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 80: { // packed_sint64
+    struct packed_sint64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<packed_sint64_field_value>();
+    value->value = &get_packed_sint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 81: { // packed_fixed32
+    struct packed_fixed32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint32_t>* value;
+    };
+    auto value = std::make_unique<packed_fixed32_field_value>();
+    value->value = &get_packed_fixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 82: { // packed_fixed64
+    struct packed_fixed64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint64_t>* value;
+    };
+    auto value = std::make_unique<packed_fixed64_field_value>();
+    value->value = &get_packed_fixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 83: { // packed_sfixed32
+    struct packed_sfixed32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<packed_sfixed32_field_value>();
+    value->value = &get_packed_sfixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 84: { // packed_sfixed64
+    struct packed_sfixed64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<packed_sfixed64_field_value>();
+    value->value = &get_packed_sfixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 85: { // packed_float
+    struct packed_float_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<float>* value;
+    };
+    auto value = std::make_unique<packed_float_field_value>();
+    value->value = &get_packed_float();
+    found.value = std::move(value);
+    break;
+  }
+  case 86: { // packed_double
+    struct packed_double_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<double>* value;
+    };
+    auto value = std::make_unique<packed_double_field_value>();
+    value->value = &get_packed_double();
+    found.value = std::move(value);
+    break;
+  }
+  case 87: { // packed_bool
+    struct packed_bool_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<bool>* value;
+    };
+    auto value = std::make_unique<packed_bool_field_value>();
+    value->value = &get_packed_bool();
+    found.value = std::move(value);
+    break;
+  }
+  case 88: { // packed_nested_enum
+    struct packed_nested_enum_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<test_all_types_edition2023_nested_enum>* value;
+    };
+    auto value = std::make_unique<packed_nested_enum_field_value>();
+    value->value = &get_packed_nested_enum();
+    found.value = std::move(value);
+    break;
+  }
+  case 89: { // unpacked_int32
+    struct unpacked_int32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<unpacked_int32_field_value>();
+    value->value = &get_unpacked_int32();
+    found.value = std::move(value);
+    break;
+  }
+  case 90: { // unpacked_int64
+    struct unpacked_int64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<unpacked_int64_field_value>();
+    value->value = &get_unpacked_int64();
+    found.value = std::move(value);
+    break;
+  }
+  case 91: { // unpacked_uint32
+    struct unpacked_uint32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint32_t>* value;
+    };
+    auto value = std::make_unique<unpacked_uint32_field_value>();
+    value->value = &get_unpacked_uint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 92: { // unpacked_uint64
+    struct unpacked_uint64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint64_t>* value;
+    };
+    auto value = std::make_unique<unpacked_uint64_field_value>();
+    value->value = &get_unpacked_uint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 93: { // unpacked_sint32
+    struct unpacked_sint32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<unpacked_sint32_field_value>();
+    value->value = &get_unpacked_sint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 94: { // unpacked_sint64
+    struct unpacked_sint64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<unpacked_sint64_field_value>();
+    value->value = &get_unpacked_sint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 95: { // unpacked_fixed32
+    struct unpacked_fixed32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint32_t>* value;
+    };
+    auto value = std::make_unique<unpacked_fixed32_field_value>();
+    value->value = &get_unpacked_fixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 96: { // unpacked_fixed64
+    struct unpacked_fixed64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<uint64_t>* value;
+    };
+    auto value = std::make_unique<unpacked_fixed64_field_value>();
+    value->value = &get_unpacked_fixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 97: { // unpacked_sfixed32
+    struct unpacked_sfixed32_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int32_t>* value;
+    };
+    auto value = std::make_unique<unpacked_sfixed32_field_value>();
+    value->value = &get_unpacked_sfixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 98: { // unpacked_sfixed64
+    struct unpacked_sfixed64_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<int64_t>* value;
+    };
+    auto value = std::make_unique<unpacked_sfixed64_field_value>();
+    value->value = &get_unpacked_sfixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 99: { // unpacked_float
+    struct unpacked_float_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<float>* value;
+    };
+    auto value = std::make_unique<unpacked_float_field_value>();
+    value->value = &get_unpacked_float();
+    found.value = std::move(value);
+    break;
+  }
+  case 100: { // unpacked_double
+    struct unpacked_double_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<double>* value;
+    };
+    auto value = std::make_unique<unpacked_double_field_value>();
+    value->value = &get_unpacked_double();
+    found.value = std::move(value);
+    break;
+  }
+  case 101: { // unpacked_bool
+    struct unpacked_bool_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<bool>* value;
+    };
+    auto value = std::make_unique<unpacked_bool_field_value>();
+    value->value = &get_unpacked_bool();
+    found.value = std::move(value);
+    break;
+  }
+  case 102: { // unpacked_nested_enum
+    struct unpacked_nested_enum_field_value : public serde::pb::field::repeated_value {
+      chunked_vector<test_all_types_edition2023_nested_enum>* value;
+    };
+    auto value = std::make_unique<unpacked_nested_enum_field_value>();
+    value->value = &get_unpacked_nested_enum();
+    found.value = std::move(value);
+    break;
+  }
+  case 56: { // map_int32_int32
+    struct map_int32_int32_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int32_t, int32_t>* value;
+    };
+    auto value = std::make_unique<map_int32_int32_field_value>();
+    value->value = &get_map_int32_int32();
+    found.value = std::move(value);
+    break;
+  }
+  case 57: { // map_int64_int64
+    struct map_int64_int64_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int64_t, int64_t>* value;
+    };
+    auto value = std::make_unique<map_int64_int64_field_value>();
+    value->value = &get_map_int64_int64();
+    found.value = std::move(value);
+    break;
+  }
+  case 58: { // map_uint32_uint32
+    struct map_uint32_uint32_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<uint32_t, uint32_t>* value;
+    };
+    auto value = std::make_unique<map_uint32_uint32_field_value>();
+    value->value = &get_map_uint32_uint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 59: { // map_uint64_uint64
+    struct map_uint64_uint64_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<uint64_t, uint64_t>* value;
+    };
+    auto value = std::make_unique<map_uint64_uint64_field_value>();
+    value->value = &get_map_uint64_uint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 60: { // map_sint32_sint32
+    struct map_sint32_sint32_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int32_t, int32_t>* value;
+    };
+    auto value = std::make_unique<map_sint32_sint32_field_value>();
+    value->value = &get_map_sint32_sint32();
+    found.value = std::move(value);
+    break;
+  }
+  case 61: { // map_sint64_sint64
+    struct map_sint64_sint64_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int64_t, int64_t>* value;
+    };
+    auto value = std::make_unique<map_sint64_sint64_field_value>();
+    value->value = &get_map_sint64_sint64();
+    found.value = std::move(value);
+    break;
+  }
+  case 62: { // map_fixed32_fixed32
+    struct map_fixed32_fixed32_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<uint32_t, uint32_t>* value;
+    };
+    auto value = std::make_unique<map_fixed32_fixed32_field_value>();
+    value->value = &get_map_fixed32_fixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 63: { // map_fixed64_fixed64
+    struct map_fixed64_fixed64_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<uint64_t, uint64_t>* value;
+    };
+    auto value = std::make_unique<map_fixed64_fixed64_field_value>();
+    value->value = &get_map_fixed64_fixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 64: { // map_sfixed32_sfixed32
+    struct map_sfixed32_sfixed32_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int32_t, int32_t>* value;
+    };
+    auto value = std::make_unique<map_sfixed32_sfixed32_field_value>();
+    value->value = &get_map_sfixed32_sfixed32();
+    found.value = std::move(value);
+    break;
+  }
+  case 65: { // map_sfixed64_sfixed64
+    struct map_sfixed64_sfixed64_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int64_t, int64_t>* value;
+    };
+    auto value = std::make_unique<map_sfixed64_sfixed64_field_value>();
+    value->value = &get_map_sfixed64_sfixed64();
+    found.value = std::move(value);
+    break;
+  }
+  case 66: { // map_int32_float
+    struct map_int32_float_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int32_t, float>* value;
+    };
+    auto value = std::make_unique<map_int32_float_field_value>();
+    value->value = &get_map_int32_float();
+    found.value = std::move(value);
+    break;
+  }
+  case 67: { // map_int32_double
+    struct map_int32_double_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<int32_t, double>* value;
+    };
+    auto value = std::make_unique<map_int32_double_field_value>();
+    value->value = &get_map_int32_double();
+    found.value = std::move(value);
+    break;
+  }
+  case 68: { // map_bool_bool
+    struct map_bool_bool_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<bool, bool>* value;
+    };
+    auto value = std::make_unique<map_bool_bool_field_value>();
+    value->value = &get_map_bool_bool();
+    found.value = std::move(value);
+    break;
+  }
+  case 69: { // map_string_string
+    struct map_string_string_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, ss::sstring>* value;
+    };
+    auto value = std::make_unique<map_string_string_field_value>();
+    value->value = &get_map_string_string();
+    found.value = std::move(value);
+    break;
+  }
+  case 70: { // map_string_bytes
+    struct map_string_bytes_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, iobuf>* value;
+    };
+    auto value = std::make_unique<map_string_bytes_field_value>();
+    value->value = &get_map_string_bytes();
+    found.value = std::move(value);
+    break;
+  }
+  case 71: { // map_string_nested_message
+    struct map_string_nested_message_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, test_all_types_edition2023_nested_message>* value;
+    };
+    auto value = std::make_unique<map_string_nested_message_field_value>();
+    value->value = &get_map_string_nested_message();
+    found.value = std::move(value);
+    break;
+  }
+  case 72: { // map_string_foreign_message
+    struct map_string_foreign_message_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, foreign_message_edition2023>* value;
+    };
+    auto value = std::make_unique<map_string_foreign_message_field_value>();
+    value->value = &get_map_string_foreign_message();
+    found.value = std::move(value);
+    break;
+  }
+  case 73: { // map_string_nested_enum
+    struct map_string_nested_enum_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, test_all_types_edition2023_nested_enum>* value;
+    };
+    auto value = std::make_unique<map_string_nested_enum_field_value>();
+    value->value = &get_map_string_nested_enum();
+    found.value = std::move(value);
+    break;
+  }
+  case 74: { // map_string_foreign_enum
+    struct map_string_foreign_enum_field_value : public serde::pb::field::map_value {
+      chunked_hash_map<ss::sstring, foreign_enum_edition2023>* value;
+    };
+    auto value = std::make_unique<map_string_foreign_enum_field_value>();
+    value->value = &get_map_string_foreign_enum();
+    found.value = std::move(value);
+    break;
+  }
+  case 111: { // oneof_uint32
+    if (!has_oneof_uint32()) {
+      set_oneof_uint32({});
+    }
+    found.value = get_oneof_uint32();
+    break;
+  }
+  case 112: { // oneof_nested_message
+    if (!has_oneof_nested_message()) {
+      set_oneof_nested_message({});
+    }
+    found.value = &get_oneof_nested_message();
+    break;
+  }
+  case 113: { // oneof_string
+    if (!has_oneof_string()) {
+      set_oneof_string({});
+    }
+    found.value = get_oneof_string();
+    break;
+  }
+  case 114: { // oneof_bytes
+    if (!has_oneof_bytes()) {
+      set_oneof_bytes({});
+    }
+    found.value = get_oneof_bytes().share();
+    break;
+  }
+  case 115: { // oneof_bool
+    if (!has_oneof_bool()) {
+      set_oneof_bool({});
+    }
+    found.value = get_oneof_bool();
+    break;
+  }
+  case 116: { // oneof_uint64
+    if (!has_oneof_uint64()) {
+      set_oneof_uint64({});
+    }
+    found.value = get_oneof_uint64();
+    break;
+  }
+  case 117: { // oneof_float
+    if (!has_oneof_float()) {
+      set_oneof_float({});
+    }
+    found.value = get_oneof_float();
+    break;
+  }
+  case 118: { // oneof_double
+    if (!has_oneof_double()) {
+      set_oneof_double({});
+    }
+    found.value = get_oneof_double();
+    break;
+  }
+  case 119: { // oneof_enum
+    if (!has_oneof_enum()) {
+      set_oneof_enum({});
+    }
+    found.value = serde::pb::raw_enum_value{
+      .number = static_cast<int32_t>(get_oneof_enum()),
+      .name = enum_to_string(get_oneof_enum()),
+    };
+    break;
+  }
+  case 201: { // groupliketype
+    found.value = &get_groupliketype();
+    break;
+  }
+  case 202: { // delimited_field
+    found.value = &get_delimited_field();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
+}
 
 foreign_message_edition2023::foreign_message_edition2023() noexcept = default;
 foreign_message_edition2023::foreign_message_edition2023(foreign_message_edition2023&&) noexcept = default;
@@ -5103,6 +6106,44 @@ void foreign_message_edition2023::apply_field_path_from(std::span<const ss::sstr
       return apply(path.subspan(1), this, update);
     }
   }
+}
+std::optional<std::vector<int32_t>> foreign_message_edition2023::convert_field_path_to_numbers(std::span<std::string_view> field_path) const {
+  std::vector<int32_t> numbers;
+  if (convert_field_path_to_numbers(field_path, &numbers)) { return numbers; }
+  return std::nullopt;
+}
+bool foreign_message_edition2023::convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out) {
+  if (field_path.empty()) {
+    return true;
+  }
+  constexpr static auto key_to_field_number = std::to_array<std::pair<std::string_view, bool(*)(decltype(field_path), decltype(out))>>({
+    {"c", [](auto path, auto* out) { out->push_back(1); return path.empty(); }},
+  });
+  auto fields = std::ranges::equal_range(key_to_field_number, field_path.front(), std::less<>(), [](const auto& pair) { return pair.first; });
+  if (fields.empty()) {
+    return false;
+  }
+  return fields.front().second(field_path.subspan(1), out);
+}
+std::optional<serde::pb::field> foreign_message_edition2023::lookup_field(std::span<int32_t> field_numbers) {
+
+  if (field_numbers.empty()) {
+    return serde::pb::field{.value = static_cast<serde::pb::base_message*>(this)};
+  }
+  serde::pb::field found;
+  switch (field_numbers.front()) {
+  case 1: { // c
+    found.value = get_c();
+    break;
+  }
+  default:
+    return std::nullopt;
+  }
+  if (field_numbers.size() > 1) {
+    if (!std::holds_alternative<serde::pb::base_message*>(found.value)) { return std::nullopt; }
+    return std::get<serde::pb::base_message*>(found.value)->lookup_field(field_numbers.subspan(1));
+  }
+  return found;
 }
 
 void enum_from_proto(iobuf_parser* p, test_all_types_edition2023_nested_enum* e) {

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
@@ -6,6 +6,7 @@
 #include "base/format_to.h"
 #include "bytes/iobuf.h"
 #include "serde/protobuf/base.h"
+#include "strings/static_str.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 
@@ -39,7 +40,7 @@ enum class test_all_types_edition2023_nested_enum : int8_t {
 void enum_to_proto(const test_all_types_edition2023_nested_enum&, iobuf*);
 void enum_from_proto(iobuf_parser*, test_all_types_edition2023_nested_enum*);
 // Returns the name of the enum value
-std::string_view enum_to_string(const test_all_types_edition2023_nested_enum&);
+static_str enum_to_string(const test_all_types_edition2023_nested_enum&);
 void enum_from_json(serde::pb::json::peekable_parser*, test_all_types_edition2023_nested_enum*);
 int32_t format_as(test_all_types_edition2023_nested_enum);
 
@@ -51,7 +52,7 @@ enum class foreign_enum_edition2023 : uint8_t {
 void enum_to_proto(const foreign_enum_edition2023&, iobuf*);
 void enum_from_proto(iobuf_parser*, foreign_enum_edition2023*);
 // Returns the name of the enum value
-std::string_view enum_to_string(const foreign_enum_edition2023&);
+static_str enum_to_string(const foreign_enum_edition2023&);
 void enum_from_json(serde::pb::json::peekable_parser*, foreign_enum_edition2023*);
 int32_t format_as(foreign_enum_edition2023);
 

--- a/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
+++ b/src/v/serde/protobuf/tests/goldens/test_messages_edition2023.proto.h
@@ -5,6 +5,7 @@
 
 #include "base/format_to.h"
 #include "bytes/iobuf.h"
+#include "serde/protobuf/base.h"
 #include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 
@@ -54,7 +55,7 @@ std::string_view enum_to_string(const foreign_enum_edition2023&);
 void enum_from_json(serde::pb::json::peekable_parser*, foreign_enum_edition2023*);
 int32_t format_as(foreign_enum_edition2023);
 
-class foreign_message_edition2023 {
+class foreign_message_edition2023 : public serde::pb::base_message {
 public:
   foreign_message_edition2023() noexcept;
   foreign_message_edition2023(const foreign_message_edition2023&) = delete;
@@ -84,6 +85,14 @@ public:
   int32_t get_c() const;
   void set_c(int32_t v);
 
+  std::string_view full_name() const override { return "protobuf_test_messages.editions.ForeignMessageEdition2023"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -94,7 +103,7 @@ private:
 };
 
 // groups
-class test_all_types_edition2023_group_like_type {
+class test_all_types_edition2023_group_like_type : public serde::pb::base_message {
 public:
   test_all_types_edition2023_group_like_type() noexcept;
   test_all_types_edition2023_group_like_type(const test_all_types_edition2023_group_like_type&) = delete;
@@ -126,6 +135,14 @@ public:
   uint32_t get_group_uint32() const;
   void set_group_uint32(uint32_t v);
 
+  std::string_view full_name() const override { return "protobuf_test_messages.editions.TestAllTypesEdition2023.GroupLikeType"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -136,7 +153,7 @@ private:
   uint32_t group_uint32_{};
 };
 
-class test_all_types_edition2023_nested_message {
+class test_all_types_edition2023_nested_message : public serde::pb::base_message {
 public:
   test_all_types_edition2023_nested_message() noexcept;
   test_all_types_edition2023_nested_message(const test_all_types_edition2023_nested_message&) = delete;
@@ -169,6 +186,14 @@ public:
   const std::unique_ptr<test_all_types_edition2023>& get_corecursive() const;
   void set_corecursive(std::unique_ptr<test_all_types_edition2023>&& v);
 
+  std::string_view full_name() const override { return "protobuf_test_messages.editions.TestAllTypesEdition2023.NestedMessage"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
+
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
@@ -179,7 +204,7 @@ private:
   std::unique_ptr<test_all_types_edition2023> corecursive_;
 };
 
-class test_all_types_edition2023 {
+class test_all_types_edition2023 : public serde::pb::base_message {
 public:
   test_all_types_edition2023() noexcept;
   test_all_types_edition2023(const test_all_types_edition2023&) = delete;
@@ -504,6 +529,14 @@ public:
   test_all_types_edition2023_group_like_type& get_delimited_field();
   const test_all_types_edition2023_group_like_type& get_delimited_field() const;
   void set_delimited_field(test_all_types_edition2023_group_like_type&& v);
+
+  std::string_view full_name() const override { return "protobuf_test_messages.editions.TestAllTypesEdition2023"; }
+  // Convert a field path into a path of field numbers.
+  static bool convert_field_path_to_numbers(std::span<std::string_view> field_path, std::vector<int32_t>* out);
+  // Convert a field path into a path of field numbers.
+  std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;
+  // Look up a field based on the field numbers.
+  std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;
 
   // NOTE: This is intended to be used by field_mask only. Do not use directly.
   static bool is_valid_field_path(std::span<const ss::sstring> path);

--- a/src/v/serde/protobuf/tests/reflection_test.cc
+++ b/src/v/serde/protobuf/tests/reflection_test.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+#include "src/v/serde/protobuf/tests/codegen_test.proto.h"
+#include "src/v/serde/protobuf/tests/test_messages_edition2023.proto.h"
+
+using namespace serde::pb;
+using testing::ElementsAre;
+using testing::Optional;
+
+TEST(ProtoReflection, CanConvertFieldPathToFieldNumbers) {
+    auto as_numbers = [](std::vector<std::string_view> path) {
+        protobuf_test_messages::editions::test_all_types_edition2023 proto;
+        return proto.convert_field_path_to_numbers(path);
+    };
+    EXPECT_THAT(as_numbers({"optional_int32"}), Optional(ElementsAre(1)));
+    EXPECT_EQ(as_numbers({"optional_foo"}), std::nullopt);
+    EXPECT_THAT(as_numbers({"optional_bytes"}), Optional(ElementsAre(15)));
+    EXPECT_THAT(
+      as_numbers({"optional_nested_message"}), Optional(ElementsAre(18)));
+    EXPECT_THAT(
+      as_numbers({"optional_nested_message", "a"}),
+      Optional(ElementsAre(18, 1)));
+    EXPECT_THAT(
+      as_numbers({
+        "optional_nested_message",
+        "corecursive",
+        "optional_nested_message",
+        "a",
+      }),
+      Optional(ElementsAre(18, 2, 18, 1)));
+    EXPECT_THAT(
+      as_numbers({
+        "optional_foreign_message",
+        "c",
+      }),
+      Optional(ElementsAre(19, 1)));
+    EXPECT_EQ(
+      as_numbers({
+        "optional_foreign_message",
+        "e",
+      }),
+      std::nullopt);
+    EXPECT_THAT(
+      as_numbers({
+        "repeated_nested_message",
+      }),
+      Optional(ElementsAre(48)));
+    EXPECT_EQ(
+      as_numbers({
+        "repeated_nested_message",
+        "a",
+      }),
+      std::nullopt);
+    EXPECT_THAT(
+      as_numbers({
+        "map_int32_int32",
+      }),
+      Optional(ElementsAre(56)));
+    EXPECT_EQ(
+      as_numbers({
+        "map_int32_int32",
+        "0",
+      }),
+      std::nullopt);
+    auto well_known = [](std::vector<std::string_view> path) {
+        proto::example::well_known_protos proto;
+        return proto.convert_field_path_to_numbers(path);
+    };
+    EXPECT_THAT(well_known({"single_timestamp"}), Optional(ElementsAre(7)));
+    EXPECT_THAT(well_known({"single_duration"}), Optional(ElementsAre(1)));
+    EXPECT_THAT(well_known({"single_field_mask"}), Optional(ElementsAre(4)));
+    EXPECT_EQ(well_known({"single_timestamp", "nanos"}), std::nullopt);
+    EXPECT_EQ(well_known({"single_field_mask", "paths"}), std::nullopt);
+    EXPECT_EQ(well_known({"single_duration", "seconds"}), std::nullopt);
+}
+
+namespace {
+template<typename T>
+auto FieldValue(const T& field_value) {
+    return Optional(
+      testing::Field(&field::value, testing::VariantWith<T>(field_value)));
+}
+template<typename T>
+auto FieldType() {
+    return Optional(
+      testing::Field(&field::value, testing::VariantWith<T>(testing::_)));
+}
+} // namespace
+
+TEST(ProtoReflection, FieldLookup_TestProto) {
+    protobuf_test_messages::editions::test_all_types_edition2023 proto;
+    auto lookup_field = [&proto](std::vector<std::string_view> path) {
+        return proto.lookup_field_by_path(path);
+    };
+    EXPECT_THAT(lookup_field({"optional_int32"}), FieldValue<int32_t>(0));
+    EXPECT_THAT(lookup_field({"optional_bool"}), FieldValue(false));
+    proto.set_optional_int32(42);
+    proto.set_optional_bool(true);
+    EXPECT_THAT(lookup_field({"optional_int32"}), FieldValue<int32_t>(42));
+    EXPECT_THAT(lookup_field({"optional_bool"}), FieldValue(true));
+    EXPECT_EQ(proto.get_recursive_message(), nullptr);
+    EXPECT_THAT(
+      lookup_field({"recursive_message"}), FieldType<base_message*>());
+    ASSERT_NE(proto.get_recursive_message(), nullptr);
+    EXPECT_THAT(
+      lookup_field({"recursive_message", "optional_sint32"}),
+      FieldValue<int32_t>(0));
+    proto.get_recursive_message()->set_optional_sint32(-9);
+    EXPECT_THAT(
+      lookup_field({"recursive_message", "optional_sint32"}),
+      FieldValue<int32_t>(-9));
+    proto = {};
+    EXPECT_EQ(proto.get_recursive_message(), nullptr);
+    EXPECT_THAT(
+      lookup_field({"recursive_message", "optional_sint32"}),
+      FieldValue<int32_t>(0));
+    ASSERT_NE(proto.get_recursive_message(), nullptr);
+    proto.get_recursive_message()->set_optional_sint32(-9);
+    EXPECT_THAT(
+      lookup_field({"recursive_message", "optional_sint32"}),
+      FieldValue<int32_t>(-9));
+    EXPECT_EQ(
+      lookup_field({"recursive_message", "does_not_exist"}), std::nullopt);
+    EXPECT_THAT(
+      lookup_field({"map_int64_int64"}),
+      FieldType<std::unique_ptr<field::map_value>>());
+    EXPECT_EQ(lookup_field({"map_int64_int64", "0"}), std::nullopt);
+    EXPECT_THAT(
+      lookup_field({"unpacked_float"}),
+      FieldType<std::unique_ptr<field::repeated_value>>());
+    EXPECT_EQ(lookup_field({"unpacked_float", "0"}), std::nullopt);
+    EXPECT_THAT(
+      lookup_field({"optional_nested_enum"}),
+      FieldValue(raw_enum_value{.number = 0, .name = "FOO"}));
+    proto.set_optional_nested_enum(
+      protobuf_test_messages::editions::test_all_types_edition2023_nested_enum::
+        baz);
+    EXPECT_THAT(
+      lookup_field({"optional_nested_enum"}),
+      FieldValue(raw_enum_value{.number = 2, .name = "BAZ"}));
+    EXPECT_FALSE(proto.has_oneof_uint32());
+    EXPECT_THAT(lookup_field({"oneof_uint32"}), FieldValue<uint32_t>(0));
+    EXPECT_TRUE(proto.has_oneof_uint32());
+    proto.set_oneof_string("foo");
+    EXPECT_THAT(lookup_field({"oneof_uint32"}), FieldValue<uint32_t>(0));
+    EXPECT_TRUE(proto.has_oneof_uint32());
+    proto.set_oneof_string("foo");
+    EXPECT_THAT(lookup_field({"oneof_string"}), FieldValue<ss::sstring>("foo"));
+    EXPECT_THAT(
+      lookup_field({"oneof_nested_message", "a"}), FieldValue<int32_t>(0));
+}


### PR DESCRIPTION
- **serde/pb: add base class for all generated protos**
- **bytes/iobuf: add full share method**
- **pbgen: implement base_message for all protobuf messages**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
