### PR TITLE
[CORE-13246] kafka/handlers: modify delete_topic to return authZ failure when protected

### DIFF
--- a/src/v/kafka/server/handlers/delete_records.cc
+++ b/src/v/kafka/server/handlers/delete_records.cc
@@ -84,7 +84,11 @@ validate_at_topic_level(request_context& ctx, const delete_records_topic& t) {
     } else if (!is_deletable(*cfg)) {
         return make_partition_errors(t, error_code::policy_violation);
     } else if (is_nodelete_topic(t)) {
-        return make_partition_errors(t, error_code::invalid_topic_exception);
+        vlog(
+          klog.warn,
+          "Topic {} is protected by 'kafka_nodelete_topics'",
+          t.name);
+        return make_partition_errors(t, error_code::topic_authorization_failed);
     }
     return {};
 }

--- a/src/v/kafka/server/handlers/details/alter_config_utils.h
+++ b/src/v/kafka/server/handlers/details/alter_config_utils.h
@@ -122,7 +122,6 @@ chunked_vector<R> authorize_alter_config_resources(
       to_authorize.topic_changes.end(),
       [&ctx, &kafka_nodelete_topics, &kafka_noproduce_topics](const T& res) {
           auto topic = model::topic(res.resource_name);
-
           auto is_nodelete_topic = std::find(
                                      kafka_nodelete_topics.cbegin(),
                                      kafka_nodelete_topics.cend(),
@@ -150,7 +149,11 @@ chunked_vector<R> authorize_alter_config_resources(
       std::back_inserter(not_authorized),
       [](T& res) {
           return make_error_alter_config_resource_response<R>(
-            res, error_code::topic_authorization_failed);
+            res,
+            error_code::topic_authorization_failed,
+            "Not authorized to alter_configs or topic is protected by "
+            "'kafka_nodelete_topics' or "
+            "'kafka_noproduce_topics'");
       });
 
     to_authorize.topic_changes.erase_to_end(unauthorized_it);

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1369,11 +1369,15 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
                 resp.data.responses.push_back(
                   {.name = name,
                    .topic_id = id,
-                   .error_code = error_code::topic_authorization_failed});
+                   .error_code = error_code::topic_authorization_failed,
+                   .error_message = "Authorized to describe but not allowed to "
+                                    "delete this topic ID."});
             } else {
                 resp.data.responses.push_back(
                   {.topic_id = id,
-                   .error_code = error_code::topic_authorization_failed});
+                   .error_code = error_code::topic_authorization_failed,
+                   .error_message
+                   = "Not authorized to describe or delete this topic ID."});
             }
             id_to_name.erase(it);
         }
@@ -1388,7 +1392,8 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
         if (!ctx.authorized(security::acl_operation::describe, name)) {
             resp.data.responses.push_back(
               {.name = name,
-               .error_code = error_code::topic_authorization_failed});
+               .error_code = error_code::topic_authorization_failed,
+               .error_message = "Not authorized to describe this topic."});
         } else if (!id) {
             resp.data.responses.push_back(
               {.name = name,
@@ -1411,7 +1416,9 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
         } else {
             resp.data.responses.push_back(
               {.name = name,
-               .error_code = error_code::topic_authorization_failed});
+               .error_code = error_code::topic_authorization_failed,
+               .error_message = "Authorized to describe but not allowed to "
+                                "delete this topic."});
         }
     }
     provided_names.clear();
@@ -1502,7 +1509,7 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
         resp.data.responses.push_back(
           {.name = std::move(topic),
            .error_code = ec,
-           .error_message = "Too many partition mutations requested"});
+           .error_message = "Too many partition mutations requested."});
     }
 
     for (auto& topic : nodelete_topics) {
@@ -1510,7 +1517,7 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
           deletable_topic_result{
             .name = std::move(topic),
             .error_code = error_code::topic_authorization_failed,
-            .error_message = "Topic is protected by 'kafka_nodelete_topics'",
+            .error_message = "Topic is protected by 'kafka_nodelete_topics'.",
           });
     }
 

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1505,6 +1505,15 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
            .error_message = "Too many partition mutations requested"});
     }
 
+    for (auto& topic : nodelete_topics) {
+        resp.data.responses.push_back(
+          deletable_topic_result{
+            .name = std::move(topic),
+            .error_code = error_code::topic_authorization_failed,
+            .error_message = "Topic is protected by 'kafka_nodelete_topics'",
+          });
+    }
+
     std::vector<cluster::topic_result> do_delete_res;
     if (!valid_topic_names.empty()) {
         // construct namespaced topic set from request

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -1017,10 +1017,10 @@ class DataTransformsLoggingTest(BaseDataTransformsLoggingTest):
         self.setup_identity_xform(self.topics[0], self.topics[1])
 
         self.logger.debug(
-            f"{self.logs_topic.name}: delete topic should fail (empty response table)"
+            f"{self.logs_topic.name}: delete topic should fail (protected by 'kafka_nodelete_topics')"
         )
         with expect_exception(
-            RpkException, lambda e: "expected one row; found 0" in str(e)
+            RpkException, lambda e: "TOPIC_AUTHORIZATION_FAILED" in str(e)
         ):
             self._rpk.delete_topic(self.logs_topic.name)
 


### PR DESCRIPTION
Relevant discussion, https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1756777217698519

I am proposing to make a change to the delete_topic command to return `topic_authorization_failed` when the topic is protected by `kafka_nodelete_topics`. alter_config handles it in this way.

Current behavior (the protected topic is just skipped):
```
$ rpk topic delete __consumer_offsets
TOPIC  STATUS
```

New behavior (the protected topic will return the authZ failure):
```
$ rpk topic delete __consumer_offsets
TOPIC               STATUS
__consumer_offsets  TOPIC_AUTHORIZATION_FAILED: Topic is protected by 'kafka_nodelete_topics'
```

I've made a change to the delete_records handler to return the same error code but it doesn't support returning error message so far, https://kafka.apache.org/31/protocol.html#The_Messages_DeleteRecords, so that I just added a server side warn logging.

  Fixes CORE-13246

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* `delete_topics` returns TOPIC_AUTHORIZATION_FAILED for `kafka_nodelete_topics`. Also we'll see a warning message in the server log when `delete_records` is protected by `kafka_nodelete_topics`