### PR TITLE
kafka fetch: make planning hierarchical

### DIFF
--- a/src/v/kafka/server/fetch_metadata_cache.h
+++ b/src/v/kafka/server/fetch_metadata_cache.h
@@ -56,14 +56,14 @@ public:
     }
 
     void insert_or_assign(
-      model::ktp ktp,
+      model::ktp_with_hash ktp,
       model::offset start_offset,
       model::offset hw,
       model::offset lso) {
         _cache.insert_or_assign(std::move(ktp), entry(start_offset, hw, lso));
     }
 
-    std::optional<partition_metadata> get(const model::ktp& ktp) {
+    std::optional<partition_metadata> get(const model::ktp_with_hash& ktp) {
         auto it = _cache.find(ktp);
         return it != _cache.end()
                  ? std::make_optional<partition_metadata>(it->second.md)
@@ -98,7 +98,7 @@ private:
 
     constexpr static std::chrono::seconds eviction_timeout{60};
     bool _stopped = false;
-    absl::node_hash_map<model::ktp, entry> _cache;
+    absl::node_hash_map<model::ktp_with_hash, entry> _cache;
     ss::timer<> _eviction_timer;
 };
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -414,7 +414,7 @@ ss::future<read_result> read_from_ntp(
     return do_read_from_ntp(
       cluster_pm,
       replica_selector,
-      {ktp, std::move(config)},
+      {{ktp.get_topic(), ktp.get_partition()}, std::move(config)},
       foreign_read,
       deadline,
       obligatory_batch_read,
@@ -1282,8 +1282,13 @@ size_t op_context::fetch_partition_count() const {
     }
 }
 
+namespace {
+
+// Calls f for each topic in the request, passing the associated partitions.
+// This exists to adapt the sessionfull and sessionless fetch cases to a
+// consistent iteration interface.
 template<typename Func>
-void op_context::for_each_fetch_partition(Func&& f) const {
+void for_each_fetch_partition(const op_context& octx, const Func& f) {
     /**
      * Iterate over original request only if it is sessionless or initial
      * full fetch request. For not initial full fetch requests we may
@@ -1291,23 +1296,37 @@ void op_context::for_each_fetch_partition(Func&& f) const {
      * during initial pass. Using session stored partitions will account for
      * the partitions already read and move to the end of iteration order
      */
+    auto& session_ctx = octx.session_ctx;
+
     if (
       session_ctx.is_sessionless()
-      || (session_ctx.is_full_fetch() && initial_fetch)) {
-        std::for_each(
-          request.cbegin(),
-          request.cend(),
-          [f = std::forward<Func>(f)](
-            const fetch_request::const_iterator::value_type& p) {
-              f(fetch_session_partition(p.topic->topic, *p.partition));
-          });
+      || (session_ctx.is_full_fetch() && octx.initial_fetch)) {
+        for (auto& topic : octx.request.data.topics) {
+            f(topic.topic,
+              topic.partitions | std::views::transform([&](const auto& p) {
+                  return fetch_session_partition{topic.topic, p};
+              }));
+        }
     } else {
-        std::for_each(
-          session_ctx.session()->partitions().cbegin_insertion_order(),
-          session_ctx.session()->partitions().cend_insertion_order(),
-          std::forward<Func>(f));
+        auto& sparts = session_ctx.session()->partitions();
+        // iterate over partitions, collecting all partitions with the same
+        // topic and passing them to f together
+        auto it = sparts.cbegin_insertion_order();
+        auto end = sparts.cend_insertion_order();
+        while (it != end) {
+            // from the current position, find the range of partitions which
+            // have the same topic, and pass that to the callback
+            const model::topic& current_topic = it->topic_partition.get_topic();
+            auto same_topic_end = std::find_if(
+              it, end, [&](const kafka::fetch_session_partition& part) {
+                  return part.topic_partition.get_topic() != current_topic;
+              });
+            f(current_topic, std::ranges::subrange(it, same_topic_end));
+            it = same_topic_end;
+        }
     }
 }
+} // namespace
 
 class simple_fetch_planner final : public fetch_planner::impl {
     fetch_plan create_plan(op_context& octx) final {
@@ -1322,46 +1341,45 @@ class simple_fetch_planner final : public fetch_planner::impl {
         /**
          * group fetch requests by shard
          */
-        octx.for_each_fetch_partition(
+        for_each_fetch_partition(
+          octx,
           [&resp_it, &octx, &plan, &bytes_left_in_plan, &client_address](
-            const fetch_session_partition& fp) {
-              // if this is not an initial fetch we are allowed to skip
-              // partions that aleready have an error or we have enough data
-              if (!octx.initial_fetch) {
-                  bool has_enough_data = !resp_it->empty()
-                                         && octx.over_min_bytes();
+            const model::topic& topic, const auto& partitions) {
+              // First, we check all the failure conditions which depend only on
+              // the topic, and not the partition.
 
-                  if (resp_it->has_error() || has_enough_data) {
+              const bool over_min_bytes = octx.over_min_bytes();
+              const auto& metadata_cache = octx.rctx.metadata_cache();
+              model::topic_namespace_view tn_view{
+                model::kafka_namespace, topic};
+
+              auto fail_all_partitions = [&](error_code ec) {
+                  for (const auto& fp : partitions) {
+                      resp_it->set(make_partition_response_error(
+                        fp.topic_partition.get_partition(), ec));
                       ++resp_it;
-                      return;
                   }
-              }
-
-              // We audit successful messages only on the initial fetch
-              audit_on_success audit{octx.initial_fetch};
+              };
 
               /**
-               * if not authorized do not include into a plan
+               * If not authorized do not include into a plan.
+               * We audit successful messages only on the initial fetch.
                */
-              if (!octx.rctx.authorized(
+              if (unlikely(!octx.rctx.authorized(
                     security::acl_operation::read,
-                    fp.topic_partition.get_topic(),
-                    audit)) {
-                  resp_it->set(make_partition_response_error(
-                    fp.topic_partition.get_partition(),
-                    error_code::topic_authorization_failed));
-                  ++resp_it;
-                  return;
+                    topic,
+                    audit_on_success{octx.initial_fetch}))) {
+                  return fail_all_partitions(
+                    error_code::topic_authorization_failed);
               }
 
               /**
-               * in sanction mode (without an enterprise license), the audit log
-               * topic is not consumable
+               * in sanction mode (without an enterprise license), the audit
+               * log topic is not consumable
                */
               if (unlikely(
-                    octx.rctx.feature_table().local().should_sanction()
-                    && fp.topic_partition.get_topic()
-                         == model::kafka_audit_logging_topic)) {
+                    topic == model::kafka_audit_logging_topic
+                    && octx.rctx.feature_table().local().should_sanction())) {
                   thread_local static ss::logger::rate_limit rate(1s);
                   vloglr(
                     klog,
@@ -1369,83 +1387,91 @@ class simple_fetch_planner final : public fetch_planner::impl {
                     rate,
                     "{}",
                     features::enterprise_error_message::audit_log_fetch());
-                  resp_it->set(make_partition_response_error(
-                    fp.topic_partition.get_partition(),
-                    error_code::unknown_server_error));
-                  ++resp_it;
-                  return;
-              }
-
-              auto& tp = fp.topic_partition;
-              auto tn_view = tp.as_tn_view();
-              const auto& metadata_cache = octx.rctx.metadata_cache();
-              auto partition_id = tp.get_partition();
-
-              if (unlikely(metadata_cache.is_disabled(tn_view, partition_id))) {
-                  resp_it->set(make_partition_response_error(
-                    partition_id, error_code::replica_not_available));
-                  ++resp_it;
-                  return;
+                  return fail_all_partitions(error_code::unknown_server_error);
               }
 
               if (unlikely(metadata_cache.should_reject_reads(tn_view))) {
-                  resp_it->set(make_partition_response_error(
-                    partition_id, error_code::invalid_topic_exception));
-                  ++resp_it;
-                  return;
+                  return fail_all_partitions(
+                    error_code::invalid_topic_exception);
               }
 
-              auto shard = octx.rctx.shards().shard_for(tp);
-              if (unlikely(!shard)) {
-                  // there is given partition in topic metadata, return
-                  // unknown_topic_or_partition error
+              for (const kafka::fetch_session_partition& fp : partitions) {
+                  // if this is not an initial fetch we are allowed to skip
+                  // partitions that already have an error or we have enough
+                  // data
+                  if (!octx.initial_fetch) {
+                      if (
+                        resp_it->has_error()
+                        || (over_min_bytes && !resp_it->empty())) {
+                          ++resp_it;
+                          continue;
+                      }
+                  }
 
+                  auto& tp = fp.topic_partition;
+                  auto partition_id = tp.get_partition();
+
+                  if (unlikely(
+                        metadata_cache.is_disabled(tn_view, partition_id))) {
+                      resp_it->set(make_partition_response_error(
+                        partition_id, error_code::replica_not_available));
+                      ++resp_it;
+                      continue;
+                  }
+
+                  auto shard = octx.rctx.shards().shard_for(tp);
+                  if (unlikely(!shard)) {
+                      // there is given partition in topic metadata, return
+                      // unknown_topic_or_partition error
+
+                      /**
+                       * no shard is found on current node, but topic exists in
+                       * cluster metadata, this mean that the partition was
+                       * moved but consumer has not updated its metadata yet. we
+                       * return not_leader_for_partition error to force metadata
+                       * update.
+                       */
+                      auto ec = metadata_cache.contains(tp.to_ntp())
+                                  ? error_code::not_leader_for_partition
+                                  : error_code::unknown_topic_or_partition;
+                      resp_it->set(
+                        make_partition_response_error(partition_id, ec));
+                      ++resp_it;
+                      continue;
+                  }
+
+                  auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(tp);
+                  auto max_bytes = std::min(
+                    bytes_left_in_plan, size_t(fp.max_bytes));
                   /**
-                   * no shard is found on current node, but topic exists in
-                   * cluster metadata, this mean that the partition was
-                   * moved but consumer has not updated its metadata yet. we
-                   * return not_leader_for_partition error to force metadata
-                   * update.
+                   * If offset is greater, assume that fetch will read max_bytes
                    */
-                  auto ec = metadata_cache.contains(tp.to_ntp())
-                              ? error_code::not_leader_for_partition
-                              : error_code::unknown_topic_or_partition;
-                  resp_it->set(make_partition_response_error(partition_id, ec));
+                  if (fetch_md && fetch_md->high_watermark > fp.fetch_offset) {
+                      bytes_left_in_plan -= max_bytes;
+                  }
+
+                  plan.fetches_per_shard[*shard].push_back(
+                    tp,
+                    fetch_config{
+                      .start_offset = fp.fetch_offset,
+                      .max_offset = model::model_limits<model::offset>::max(),
+                      .max_bytes = max_bytes,
+                      .timeout = octx.deadline.value_or(model::no_timeout),
+                      .current_leader_epoch = fp.current_leader_epoch,
+                      .isolation_level = octx.request.data.isolation_level,
+                      .strict_max_bytes = octx.response_size > 0,
+                      .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
+                      .read_from_follower = octx.request.has_rack_id(),
+                      .consumer_rack_id = octx.request.has_rack_id()
+                                            ? std::make_optional(
+                                                octx.request.data.rack_id)
+                                            : std::nullopt,
+                      .abort_source = octx.rctx.abort_source(),
+                      .client_address = model::client_address_t{client_address},
+                    },
+                    &(*resp_it));
                   ++resp_it;
-                  return;
               }
-
-              auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(tp);
-              auto max_bytes = std::min(
-                bytes_left_in_plan, size_t(fp.max_bytes));
-              /**
-               * If offset is greater, assume that fetch will read max_bytes
-               */
-              if (fetch_md && fetch_md->high_watermark > fp.fetch_offset) {
-                  bytes_left_in_plan -= max_bytes;
-              }
-
-              fetch_config config{
-                .start_offset = fp.fetch_offset,
-                .max_offset = model::model_limits<model::offset>::max(),
-                .max_bytes = max_bytes,
-                .timeout = octx.deadline.value_or(model::no_timeout),
-                .current_leader_epoch = fp.current_leader_epoch,
-                .isolation_level = octx.request.data.isolation_level,
-                .strict_max_bytes = octx.response_size > 0,
-                .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
-                .read_from_follower = octx.request.has_rack_id(),
-                .consumer_rack_id = octx.request.has_rack_id()
-                                      ? std::make_optional(
-                                          octx.request.data.rack_id)
-                                      : std::nullopt,
-                .abort_source = octx.rctx.abort_source(),
-                .client_address = model::client_address_t{client_address},
-              };
-
-              plan.fetches_per_shard[*shard].push_back(
-                {tp, std::move(config)}, &(*resp_it));
-              ++resp_it;
           });
         return plan;
     }

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -142,9 +142,6 @@ struct op_context {
      */
     size_t fetch_partition_count() const;
 
-    template<typename Func>
-    void for_each_fetch_partition(Func&& f) const;
-
     request_context rctx;
     ss::smp_service_group ssg;
     fetch_request request;
@@ -205,10 +202,10 @@ struct fetch_config {
 };
 
 struct ntp_fetch_config {
-    ntp_fetch_config(model::ktp ktp, fetch_config cfg)
+    ntp_fetch_config(model::ktp_with_hash&& ktp, fetch_config&& cfg)
       : _ktp(std::move(ktp))
-      , cfg(cfg) {}
-    model::ktp _ktp;
+      , cfg(std::move(cfg)) {}
+    model::ktp_with_hash _ktp;
     fetch_config cfg;
 
     const model::ktp& ktp() const { return _ktp; }
@@ -351,10 +348,13 @@ struct shard_fetch {
       , start_time{start_time} {}
 
     void push_back(
-      ntp_fetch_config config, op_context::response_placeholder_ptr r_ph) {
-        requests.push_back(std::move(config));
+      model::ktp_with_hash ktp,
+      kafka::fetch_config&& config,
+      op_context::response_placeholder_ptr r_ph) {
+        requests.emplace_back(std::move(ktp), std::move(config));
         responses.push_back(r_ph);
     }
+
     bool empty() const;
 
     void reserve(size_t n) {

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -48,11 +48,6 @@ struct fixture {
 };
 
 static constexpr size_t topic_name_length = 30;
-#ifdef SEASTAR_DEFAULT_ALLOCATOR
-static constexpr size_t max_partition_count = 100;
-#else
-static constexpr size_t max_partition_count = 1000;
-#endif
 
 struct test_args {
     size_t topic_count;
@@ -272,10 +267,3 @@ PERF_TEST_F(fetch_plan, t1p100_no_auth) { return run_bench(1, 100, false); }
 PERF_TEST_F(fetch_plan, t1p100_yes_auth) { return run_bench(1, 100, true); }
 PERF_TEST_F(fetch_plan, t100p1_no_auth) { return run_bench(100, 1, false); }
 PERF_TEST_F(fetch_plan, t100p1_yes_auth) { return run_bench(100, 1, true); }
-
-PERF_TEST_F(fetch_plan, max_no_auth) {
-    return run_bench(1, max_partition_count, false);
-}
-PERF_TEST_F(fetch_plan, max_yes_auth) {
-    return run_bench(1, max_partition_count, true);
-}


### PR DESCRIPTION
Current fetch planning iterates over all partitions in the fetch request (or fetch session, if sessions are used) in a "flat" manner, i.e., {"topic1", 0}, {"topic1", 1}, {"topic2", 0} for 3 partitions spread across two topics. Many of the checks in the planning loop are topic-specific, i.e,. they depend on only the topic, not the partition.

In the current flat approach, these checks are repeatedly executed for the same topic in the case of wide reads with multiple partitions in the same topic (the most common case for wide reads).

In this series we change the processing to be "hierarchical" instead, i.e., nested loops with topic on the outside, partition in the inside. When processing a request directly (i.e., not fetch session) the input is already hierarchical in this way. When iterating over a fetch session, it is not, so we re-group the flat list by topic at iteration time. In the session case, a topic could still appear more than once since we do an "in order" grouping and there is no guarantee that partitions for a given topic are all consecutive in session partition order.

Here are results after this change. Each benchmark is shown twice on adjacent rows, the top if before, the bottom is after:

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          1
random seed:              3634090417

test                        iterations      median         mad         min         max      allocs       tasks        inst      cycles
fetch_plan.t1p1_no_auth        6000000   153.806ns     0.528ns   153.178ns   155.895ns       8.000       0.000      2410.3       613.1
fetch_plan.t1p1_no_auth        8000000   126.400ns     0.068ns   126.229ns   127.735ns       8.000       0.000      2267.2       502.9

fetch_plan.t1p1_yes_auth       4000000   227.133ns     0.531ns   226.602ns   232.960ns      10.000       0.000      3643.2       910.1
fetch_plan.t1p1_yes_auth       5000000   206.990ns     0.041ns   206.949ns   207.346ns      10.000       0.000      3500.5       823.6

fetch_plan.t1p100_no_auth        70000    12.674us    22.706ns    12.642us    12.697us     206.015       0.000    148548.9     50410.7
fetch_plan.t1p100_no_auth       200000     4.287us     4.676ns     4.276us     4.292us     107.014       0.000     69652.6     17046.4

fetch_plan.t1p100_yes_auth       50000    18.894us    31.669ns    18.852us    18.943us     406.017       0.000    270601.3     75144.9
fetch_plan.t1p100_yes_auth      200000     4.358us     8.503ns     4.350us     4.379us     109.014       0.000     69865.8     17352.5

fetch_plan.t100p1_no_auth        70000    12.780us    32.438ns    12.747us    12.964us     206.015       0.000    149836.0     50910.7
fetch_plan.t100p1_no_auth        90000     9.422us    17.340ns     9.404us     9.452us     206.015       0.000    135139.2     37504.4

fetch_plan.t100p1_yes_auth       50000    19.165us     8.438ns    19.156us    19.203us     406.017       0.000    272598.6     76264.5
fetch_plan.t100p1_yes_auth       60000    15.737us    15.321ns    15.722us    15.834us     406.018       0.000    258006.5     62602.6
```

A benchmark named `tNpM` means N topics with M partitions each.

The results make sense: the most improved benchmark is `t1p100` which is a typical "wide" read: a read of many partitions from the same topic. A lot of work is saved since we only do per-topic work once.

t1p1 has only a single partition, so no work is saved: the improvement is only related to the other tweaks in this change, not the hierarchy one (with hierarchy alone, the result is slightly worse (a few %) than existing).

t100p1 also doesn't show speedup from the hierarchy change, since although it is a type o "wide read" each partition is in a unique topic, so we need to do the per-topic work every time. This style of wide read is probably quite rare but is included for completeness.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Fetch CPU performance with wide reads (many partitions assigned to a single consumer) is improved.

