### PR TITLE
cloud topics: use topic id revision for objects

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -528,4 +528,36 @@ object_reader::create(ss::file f, size_t offset, size_t length) {
     return create(ss::make_file_input_stream(std::move(f), offset, length));
 }
 
+fmt::iterator
+footer::partition::index_entry::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{file_position: {}, kafka_offset: {}, max_timestamp: {}}}",
+      file_position,
+      kafka_offset,
+      max_timestamp);
+}
+
+fmt::iterator footer::partition::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{file_position: {}, length: {}, first_offset: {}, last_offset: {}, "
+      "max_timestamp: {}, indexes: [{}]}}",
+      file_position,
+      length,
+      first_offset,
+      last_offset,
+      max_timestamp,
+      fmt::join(indexes, ", "));
+}
+
+fmt::iterator footer::format_to(fmt::iterator it) const {
+    auto out = fmt::format_to(it, "{{partitions: [");
+    for (const auto& [tidp, partition] : partitions) {
+        out = fmt::format_to(
+          out, "{{tidp: {}, partition: {}}}, ", tidp, partition);
+    }
+    return fmt::format_to(out, "]}}");
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -171,12 +171,11 @@ ss::future<> footer::serde_async_read(iobuf_parser& p, serde::header h) {
     using serde::read_nested;
     auto size = read_nested<size_t>(p, h._bytes_left_limit);
     for (size_t i = 0; i < size; ++i) {
-        auto ntp = co_await read_async_nested<model::ntp>(
+        auto tidp = co_await read_async_nested<model::topic_id_partition>(
           p, h._bytes_left_limit);
         auto partition = co_await read_async_nested<footer::partition>(
           p, h._bytes_left_limit);
-        partitions.emplace_hint(
-          partitions.end(), std::move(ntp), std::move(partition));
+        partitions.emplace_hint(partitions.end(), tidp, std::move(partition));
     }
 }
 
@@ -184,15 +183,15 @@ ss::future<> footer::serde_async_write(iobuf& buf) const {
     using serde::write;
     using serde::write_async;
     write(buf, partitions.size());
-    for (const auto& [ntp, p] : partitions) {
-        co_await write_async(buf, ntp);
+    for (const auto& [tidp, p] : partitions) {
+        co_await write_async(buf, tidp);
         co_await write_async(buf, p.copy());
     }
 }
 
 size_t footer::file_position_before_kafka_offset(
-  const model::ntp& ntp, kafka::offset target) {
-    auto [it, end] = partitions.equal_range(ntp);
+  const model::topic_id_partition& tidp, kafka::offset target) {
+    auto [it, end] = partitions.equal_range(tidp);
     auto min_partition_after_target = end;
     for (; it != end; ++it) {
         const auto& partition = it->second;
@@ -225,8 +224,8 @@ size_t footer::file_position_before_kafka_offset(
 }
 
 size_t footer::file_position_before_max_timestamp(
-  const model::ntp& ntp, model::timestamp target) {
-    auto [begin, end] = partitions.equal_range(ntp);
+  const model::topic_id_partition& tidp, model::timestamp target) {
+    auto [begin, end] = partitions.equal_range(tidp);
     auto filtered = std::views::filter(
       std::ranges::subrange{begin, end}, [&target](const auto& entry) {
           return target <= entry.second.max_timestamp;
@@ -259,8 +258,8 @@ size_t footer::file_position_before_max_timestamp(
 
 footer footer::copy() const {
     footer copy;
-    for (const auto& [ntp, p] : partitions) {
-        copy.partitions.emplace_hint(copy.partitions.end(), ntp, p.copy());
+    for (const auto& [tidp, p] : partitions) {
+        copy.partitions.emplace_hint(copy.partitions.end(), tidp, p.copy());
     }
     return copy;
 }
@@ -307,10 +306,10 @@ public:
       : _output(std::move(output))
       , _opts(opts) {}
 
-    ss::future<> start_partition(model::ntp ntp) final {
+    ss::future<> start_partition(model::topic_id_partition tidp) final {
         end_partition();
-        co_await serde_write_to_stream(data_type::partition_marker, ntp);
-        _current_ntp = ntp;
+        co_await serde_write_to_stream(data_type::partition_marker, tidp);
+        _current_tidp = tidp;
         _current_partition = {
           .file_position = _offset,
           .length = 0, // will be set when the partition is finished
@@ -327,7 +326,7 @@ public:
           "expected raft_data batches, got: {}",
           batch.header().type);
         dassert(
-          _current_ntp != model::ntp{},
+          _current_tidp != model::topic_id_partition{},
           "wrote a data batch without starting a partition");
         dassert(
           _current_partition.last_offset
@@ -378,12 +377,12 @@ public:
 
 private:
     void end_partition() {
-        if (_current_ntp == model::ntp{}) {
+        if (_current_tidp == model::topic_id_partition{}) {
             return;
         }
         _current_partition.length = _offset - _current_partition.file_position;
         _index.partitions.emplace(
-          std::exchange(_current_ntp, {}),
+          std::exchange(_current_tidp, {}),
           std::exchange(_current_partition, {}));
     }
 
@@ -412,7 +411,7 @@ private:
     size_t _offset = 0;
     ss::output_stream<char> _output;
     footer _index;
-    model::ntp _current_ntp;
+    model::topic_id_partition _current_tidp;
     footer::partition _current_partition;
     options _opts;
 };
@@ -454,7 +453,7 @@ public:
         case data_type::kafka_batch:
             co_return co_await read_next_batch();
         case data_type::partition_marker:
-            co_return co_await read_next_serde<model::ntp>();
+            co_return co_await read_next_serde<model::topic_id_partition>();
         case data_type::footer:
             _saw_footer = true;
             co_return co_await read_next_serde<footer>();

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "absl/container/btree_map.h"
+#include "base/format_to.h"
 #include "base/seastarx.h"
 #include "base/units.h"
 #include "container/chunked_vector.h"
@@ -100,6 +101,7 @@ struct footer
                 return std::tie(file_position, kafka_offset, max_timestamp);
             }
             bool operator==(const index_entry&) const = default;
+            fmt::iterator format_to(fmt::iterator) const;
         };
         // Index information for l1 data, this is a snapshot of the state at a
         // periodic interval within the partition data. For example, we can
@@ -123,6 +125,7 @@ struct footer
         ss::future<> serde_async_read(iobuf_parser&, serde::header);
         ss::future<> serde_async_write(iobuf&) const;
         bool operator==(const partition&) const = default;
+        fmt::iterator format_to(fmt::iterator) const;
 
         partition copy() const;
     };
@@ -142,6 +145,7 @@ struct footer
     ss::future<> serde_async_write(iobuf&) const;
 
     bool operator==(const footer&) const = default;
+    fmt::iterator format_to(fmt::iterator) const;
 
     // The value returned when an index search doesn't have contain matching
     // data.
@@ -346,57 +350,3 @@ public:
 };
 
 } // namespace cloud_topics::l1
-
-template<>
-struct fmt::formatter<cloud_topics::l1::footer::partition::index_entry> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    typename FormatContext::iterator format(
-      const cloud_topics::l1::footer::partition::index_entry& entry,
-      FormatContext& ctx) const {
-        return fmt::format_to(
-          ctx.out(),
-          "{{file_position: {}, kafka_offset: {}, max_timestamp: {}}}",
-          entry.file_position,
-          entry.kafka_offset,
-          entry.max_timestamp);
-    }
-};
-
-template<>
-struct fmt::formatter<cloud_topics::l1::footer::partition> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    typename FormatContext::iterator format(
-      const cloud_topics::l1::footer::partition& partition,
-      FormatContext& ctx) const {
-        return fmt::format_to(
-          ctx.out(),
-          "{{file_position: {}, length: {}, first_offset: {}, last_offset: {}, "
-          "max_timestamp: {}, indexes: [{}]}}",
-          partition.file_position,
-          partition.length,
-          partition.first_offset,
-          partition.last_offset,
-          partition.max_timestamp,
-          fmt::join(partition.indexes, ", "));
-    }
-};
-
-template<>
-struct fmt::formatter<cloud_topics::l1::footer> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    typename FormatContext::iterator
-    format(const cloud_topics::l1::footer& index, FormatContext& ctx) const {
-        auto out = fmt::format_to(ctx.out(), "{{partitions: [");
-        for (const auto& [tidp, partition] : index.partitions) {
-            out = fmt::format_to(
-              out, "{{tidp: {}, partition: {}}}, ", tidp, partition);
-        }
-        return fmt::format_to(out, "]}}");
-    }
-};

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -39,10 +39,10 @@ namespace cloud_topics::l1 {
 // [Partition 1 Marker][Partition 1 Data][Partition 2 Marker][Partition 2 Data]...[Footer][Footer Size]
 //
 // Components:
-// 1. Partition Marker: A data type delimiter (1 byte) + size (4 bytes) + serialized model::ntp
+// 1. Partition Marker: A data type delimiter (1 byte) + size (4 bytes) + serialized model::topic_id_partition
 //    - Delimiter: 0x01 (data_type::partition_marker)
-//    - Size: uint32_t size of the serialized ntp data
-//    - Data: Serialized model::ntp identifying the partition
+//    - Size: uint32_t size of the serialized topid id partition data
+//    - Data: Serialized model::topic_id_partition identifying the partition
 //
 // 2. Partition Data: Sequence of kafka record batches for the partition,
 //    with offsets strictly increasing within each partition
@@ -134,7 +134,7 @@ struct footer
     //
     // However in terms of offsets, there *must* not be overlapping ranges
     // within the same file.
-    absl::btree_multimap<model::ntp, partition> partitions;
+    absl::btree_multimap<model::topic_id_partition, partition> partitions;
 
     footer copy() const;
 
@@ -154,14 +154,15 @@ struct footer
     // Example:
     //
     // If the footer has the following offset ranges indexed for the given
-    // ntp:
+    // topic_id_partition:
     //
     // [[1, 10], [11, 20], [30, 40]]
     //
     // Searching for offset 5 would yield the position of the batch[0],
     // while a search for offsets 25 or 40 would yield batch[2]. Searching for
     // offset 50 would yield `npos`.
-    size_t file_position_before_kafka_offset(const model::ntp&, kafka::offset);
+    size_t file_position_before_kafka_offset(
+      const model::topic_id_partition&, kafka::offset);
 
     // Return the file position of the latest record batch that has a
     // max_timestamp at or before the given timestamp. If the timestamp is
@@ -170,7 +171,7 @@ struct footer
     // Example:
     //
     // If the footer has the following max timestamps indexed for the given
-    // ntp:
+    // topic_id_partition:
     //
     // 3, 10, 10, 10, 40
     //
@@ -178,8 +179,8 @@ struct footer
     // the timestamp 1 would yield the position of batch[0].
     // While a search for timestamp 25 or 40 would yield batch[4] and the
     // timestamp 50 would yield `npos`.
-    size_t
-    file_position_before_max_timestamp(const model::ntp&, model::timestamp);
+    size_t file_position_before_max_timestamp(
+      const model::topic_id_partition&, model::timestamp);
 
     // Read the footer using the suffix of an L1 object.
     //
@@ -224,9 +225,10 @@ struct footer
 // discarded. It's possible there is partially flushed data that would result
 // in an invalid file if resumed.
 //
-// NOTE: It's valid to call start_partition() with the same NTP multiple times
-// but the data *must* contain disjoint offset ranges. There is currently no
-// restriction that segments for the same NTP must be written in order.
+// NOTE: It's valid to call start_partition() with the same topic_id_partition
+// multiple times but the data *must* contain disjoint offset ranges. There is
+// currently no restriction that segments for the same topic_id_partition must
+// be written in order.
 class object_builder {
 public:
     object_builder() = default;
@@ -254,7 +256,7 @@ public:
     // This must be called before any add_batch() calls, and calling this
     // after calling start_partition() implicitly ends the current partition
     // and starts a new one.
-    virtual ss::future<> start_partition(model::ntp ntp) = 0;
+    virtual ss::future<> start_partition(model::topic_id_partition tidp) = 0;
 
     // Append a kafka batch to the object. The batch here is expected to be:
     //
@@ -287,8 +289,9 @@ public:
 // from object_builder.
 //
 // This represents an L1 object, which is just a stream of segments,where a
-// segment is a series of batches for a NTP. If used with a object_seeker, then
-// it can also represent the tail of an L1 object (see object_seeker for more).
+// segment is a series of batches for a topic_id_partition. If used with a
+// object_seeker, then it can also represent the tail of an L1 object (see
+// object_seeker for more).
 class object_reader {
 public:
     // A marker struct that indicates we've reached the end of the file.
@@ -327,12 +330,13 @@ public:
     // and we are about to start reading the next partition. If an footer
     // is returned, then we've reached the end of the file and the footer is
     // returned.
-    using result = std::variant<model::ntp, model::record_batch, footer, eof>;
+    using result = std::
+      variant<model::topic_id_partition, model::record_batch, footer, eof>;
 
     // Read the "next" item from the L1 object.
     //
-    // The next item can be either a partition marker (model::ntp) or a
-    // data batch (model::record_batch).
+    // The next item can be either a partition marker
+    // (model::topic_id_partition) or a data batch (model::record_batch).
     virtual ss::future<result> read_next() = 0;
 
     // Close the reader, releasing any resources it holds.
@@ -389,9 +393,9 @@ struct fmt::formatter<cloud_topics::l1::footer> {
     typename FormatContext::iterator
     format(const cloud_topics::l1::footer& index, FormatContext& ctx) const {
         auto out = fmt::format_to(ctx.out(), "{{partitions: [");
-        for (const auto& [ntp, partition] : index.partitions) {
+        for (const auto& [tidp, partition] : index.partitions) {
             out = fmt::format_to(
-              out, "{{ntp: {}, partition: {}}}, ", ntp, partition);
+              out, "{{tidp: {}, partition: {}}}, ", tidp, partition);
         }
         return fmt::format_to(out, "]}}");
     }

--- a/src/v/cloud_topics/level_one/common/tests/BUILD
+++ b/src/v/cloud_topics/level_one/common/tests/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/bytes:iostream",
         "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/cloud_topics/level_one/common/tests/object_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_test.cc
@@ -10,6 +10,7 @@
 
 #include "bytes/iostream.h"
 #include "cloud_topics/level_one/common/object.h"
+#include "model/fundamental.h"
 #include "model/tests/random_batch.h"
 
 #include <seastar/util/backtrace.hh>
@@ -49,20 +50,20 @@ make_batches(const std::vector<batch_spec>& specs) {
     return batches;
 }
 
-struct batches_by_ntp {
-    model::ntp ntp;
+struct batches_by_tidp {
+    model::topic_id_partition tidp;
     std::vector<batch_spec> batches;
 };
 
 std::pair<object_builder::object_info, iobuf> make_object(
-  const std::vector<batches_by_ntp>& specs_by_ntp,
+  const std::vector<batches_by_tidp>& specs_by_tidp,
   object_builder::options opts = {}) {
     iobuf output;
     auto builder = object_builder::create(
       make_iobuf_ref_output_stream(output), opts);
     auto _ = ss::defer([&builder] { builder->close().get(); });
-    for (const auto& [ntp, specs] : specs_by_ntp) {
-        builder->start_partition(ntp).get();
+    for (const auto& [tidp, specs] : specs_by_tidp) {
+        builder->start_partition(tidp).get();
         auto batches = make_batches(specs);
         for (auto& batch : batches) {
             builder->add_batch(std::move(batch)).get();
@@ -107,7 +108,7 @@ model::timestamp operator""_t(unsigned long long t) {
 TEST(L1ObjectsIndex, OffsetSearch) {
     footer index;
     index.partitions.emplace(
-      model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+      model::topic_id_partition{model::topic_id(uuid_t::create()), model::partition_id(0)},
       footer::partition{
         .file_position = 0,
         .indexes = {
@@ -138,7 +139,7 @@ TEST(L1ObjectsIndex, OffsetSearch) {
 TEST(L1ObjectsIndex, TimestampSearch) {
     footer index;
     index.partitions.emplace(
-       model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+      model::topic_id_partition{model::topic_id(uuid_t::create()), model::partition_id(0)},
     footer::partition{
       .file_position = 0,
       .indexes = {
@@ -179,9 +180,10 @@ TEST(L1ObjectsIndex, TimestampSearch) {
 }
 
 TEST(L1Objects, OffsetSearch) {
-    auto specs_by_ntp = std::vector<batches_by_ntp>{
+    auto test_topic_id = model::topic_id(uuid_t::create());
+    auto specs_by_tidp = std::vector<batches_by_tidp>{
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition{test_topic_id, model::partition_id(0)},
         .batches = {
           {.base_offset = 5_o, .last_offset = 9_o},
           {.base_offset = 10_o, .last_offset = 19_o},
@@ -189,7 +191,7 @@ TEST(L1Objects, OffsetSearch) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition{test_topic_id, model::partition_id(0)},
         .batches = {
           {.base_offset = 30_o, .last_offset = 39_o},
           {.base_offset = 40_o, .last_offset = 49_o},
@@ -197,7 +199,7 @@ TEST(L1Objects, OffsetSearch) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(1)},
+        .tidp = model::topic_id_partition{test_topic_id, model::partition_id(1)},
         .batches = {
           {.base_offset = 5_o, .last_offset = 9_o},
           {.base_offset = 10_o, .last_offset = 19_o},
@@ -207,7 +209,7 @@ TEST(L1Objects, OffsetSearch) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition{test_topic_id, model::partition_id(0)},
         .batches = {
           {.base_offset = 100_o, .last_offset = 109_o},
           {.base_offset = 110_o, .last_offset = 119_o},
@@ -217,9 +219,9 @@ TEST(L1Objects, OffsetSearch) {
     };
     // All batches end up being indexed this way.
     auto [index_one, object_one] = make_object(
-      specs_by_ntp, {.indexing_frequency = 1});
+      specs_by_tidp, {.indexing_frequency = 1});
 
-    model::ntp ntp{"test_ns", "test_topic", model::partition_id(0)};
+    model::topic_id_partition tidp{test_topic_id, model::partition_id(0)};
 
     std::unordered_map<kafka::offset, kafka::offset>
       offset_lookup_to_batch_start = {
@@ -233,25 +235,25 @@ TEST(L1Objects, OffsetSearch) {
 
     for (const auto& [seek, expected] : offset_lookup_to_batch_start) {
         size_t pos = index_one.index.file_position_before_kafka_offset(
-          ntp, seek);
+          tidp, seek);
         ASSERT_NE(pos, footer::npos) << "No position found for " << seek
-                                     << " in partition " << ntp.tp.partition;
+                                     << " in partition " << tidp.partition;
         auto result = read_one_at(object_one, pos);
         ASSERT_TRUE(std::holds_alternative<model::record_batch>(result));
         ASSERT_EQ(
           std::get<model::record_batch>(result).base_offset(),
           kafka::offset_cast(expected))
-          << "for offset " << seek << " in partition " << ntp.tp.partition;
+          << "for offset " << seek << " in partition " << tidp.partition;
     }
     EXPECT_EQ(
       footer::npos,
-      index_one.index.file_position_before_kafka_offset(ntp, 9999_o));
+      index_one.index.file_position_before_kafka_offset(tidp, 9999_o));
 
     // Index only the middle batches in partition 1
     auto [index_two, object_two] = make_object(
-      specs_by_ntp, {.indexing_frequency = 3_KiB});
+      specs_by_tidp, {.indexing_frequency = 3_KiB});
 
-    ntp.tp.partition = model::partition_id(1);
+    tidp.partition = model::partition_id(1);
 
     // 20 and 60 are indexed.
     offset_lookup_to_batch_start = {
@@ -270,7 +272,7 @@ TEST(L1Objects, OffsetSearch) {
     for (const auto& [seek, expected] : offset_lookup_to_batch_start) {
         auto result = read_one_at(
           object_two,
-          index_two.index.file_position_before_kafka_offset(ntp, seek));
+          index_two.index.file_position_before_kafka_offset(tidp, seek));
         ASSERT_TRUE(std::holds_alternative<model::record_batch>(result));
         ASSERT_EQ(
           std::get<model::record_batch>(result).base_offset(),
@@ -278,13 +280,14 @@ TEST(L1Objects, OffsetSearch) {
     }
     EXPECT_EQ(
       footer::npos,
-      index_two.index.file_position_before_kafka_offset(ntp, 80_o));
+      index_two.index.file_position_before_kafka_offset(tidp, 80_o));
 }
 
 TEST(L1Objects, TimestampSearch) {
-    std::vector<batches_by_ntp> specs_by_ntp = {
+    auto test_topic_id = model::topic_id(uuid_t::create());
+    std::vector<batches_by_tidp> specs_by_tidp = {
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(0)),
         .batches = {
           {.base_offset = 30_o, .last_offset = 39_o, .max_timestamp = 1500_t},
           {.base_offset = 40_o, .last_offset = 49_o, .max_timestamp = 2000_t},
@@ -292,7 +295,7 @@ TEST(L1Objects, TimestampSearch) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(1)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(1)),
         .batches = {
           {.base_offset = 0_o, .last_offset = 9_o, .max_timestamp = 1000_t},
           {.base_offset = 10_o, .last_offset = 19_o, .max_timestamp = 2000_t},
@@ -300,14 +303,14 @@ TEST(L1Objects, TimestampSearch) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(1)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(1)),
         .batches = {
           {.base_offset = 40_o, .last_offset = 49_o, .max_timestamp = 4000_t},
           {.base_offset = 50_o, .last_offset = 59_o, .max_timestamp = 5000_t},
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(0)),
         .batches = {
           {.base_offset = 0_o, .last_offset = 9_o, .max_timestamp = 1000_t},
           {.base_offset = 10_o, .last_offset = 19_o, .max_timestamp = 1500_t},
@@ -317,9 +320,10 @@ TEST(L1Objects, TimestampSearch) {
     };
     // Every batch is indexed, except the first.
     auto [index_one, object_one] = make_object(
-      specs_by_ntp, {.indexing_frequency = 1});
+      specs_by_tidp, {.indexing_frequency = 1});
 
-    model::ntp ntp{"test_ns", "test_topic", model::partition_id(0)};
+    auto tidp = model::topic_id_partition(
+      test_topic_id, model::partition_id(0));
 
     std::map<model::timestamp, kafka::offset> timequery_to_batch_start = {
       {900_t, 0_o},
@@ -333,63 +337,64 @@ TEST(L1Objects, TimestampSearch) {
 
     for (const auto& [seek, expected] : timequery_to_batch_start) {
         auto pos = index_one.index.file_position_before_max_timestamp(
-          ntp, seek);
+          tidp, seek);
         ASSERT_NE(pos, footer::npos) << "No position found for " << seek
-                                     << " in partition " << ntp.tp.partition;
+                                     << " in partition " << tidp.partition;
         auto result = read_one_at(object_one, pos);
         ASSERT_TRUE(std::holds_alternative<model::record_batch>(result));
         ASSERT_EQ(
           std::get<model::record_batch>(result).base_offset(),
           kafka::offset_cast(expected))
-          << " for timestamp " << seek << " in partition " << ntp.tp.partition;
+          << " for timestamp " << seek << " in partition " << tidp.partition;
     }
     EXPECT_EQ(
       footer::npos,
-      index_one.index.file_position_before_max_timestamp(ntp, 2501_t));
+      index_one.index.file_position_before_max_timestamp(tidp, 2501_t));
 
-    ntp.tp.partition = model::partition_id(1);
+    tidp.partition = model::partition_id(1);
 
     timequery_to_batch_start = {};
 
     for (const auto& [seek, expected] : timequery_to_batch_start) {
         auto pos = index_one.index.file_position_before_max_timestamp(
-          ntp, seek);
+          tidp, seek);
         ASSERT_NE(pos, footer::npos) << "No position found for " << seek
-                                     << " in partition " << ntp.tp.partition;
+                                     << " in partition " << tidp.partition;
         auto result = read_one_at(object_one, pos);
         ASSERT_TRUE(std::holds_alternative<model::record_batch>(result));
         ASSERT_EQ(
           std::get<model::record_batch>(result).base_offset(),
           kafka::offset_cast(expected))
-          << " for timestamp " << seek << " in partition " << ntp.tp.partition;
+          << " for timestamp " << seek << " in partition " << tidp.partition;
     }
     EXPECT_EQ(
       footer::npos,
-      index_one.index.file_position_before_max_timestamp(ntp, 5001_t));
+      index_one.index.file_position_before_max_timestamp(tidp, 5001_t));
 }
 
 namespace {
 
 testing::AssertionResult expect_read_results(
   std::unique_ptr<object_reader> reader,
-  const std::vector<batches_by_ntp>& expected,
+  const std::vector<batches_by_tidp>& expected,
   std::optional<std::reference_wrapper<footer>> object_footer,
   bool expect_ntp_markers = true) {
     auto _ = ss::defer([&reader] { reader->close().get(); });
-    for (const auto& [ntp, specs] : expected) {
+    for (const auto& [tidp, specs] : expected) {
         if (expect_ntp_markers) {
-            SCOPED_TRACE(fmt::format("reading: {}", ntp));
+            SCOPED_TRACE(fmt::format("reading: {}", tidp));
             object_reader::result partition;
             EXPECT_NO_THROW(partition = reader->read_next().get());
-            if (!std::holds_alternative<model::ntp>(partition)) {
+            if (!std::holds_alternative<model::topic_id_partition>(partition)) {
                 return testing::AssertionFailure()
-                       << "Expected partition for ntp: " << ntp << ", but got "
-                       << partition.index();
+                       << "Expected partition for tidp: " << tidp
+                       << ", but got " << partition.index();
             }
-            if (std::get<model::ntp>(partition) != ntp) {
+            if (std::get<model::topic_id_partition>(partition) != tidp) {
                 return testing::AssertionFailure()
-                       << "Expected partition for ntp: " << ntp
-                       << ", but got: " << std::get<model::ntp>(partition);
+                       << "Expected partition for tidp: " << tidp
+                       << ", but got: "
+                       << std::get<model::topic_id_partition>(partition);
             }
         }
         for (const auto& spec : specs) {
@@ -449,9 +454,10 @@ testing::AssertionResult expect_read_results(
 } // namespace
 
 TEST(L1Objects, FullScan) {
-    std::vector<batches_by_ntp> specs_by_ntp = {
+    auto test_topic_id = model::topic_id(uuid_t::create());
+    std::vector<batches_by_tidp> specs_by_tidp = {
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(0)),
         .batches = {
           {
             .base_offset = 0_o,
@@ -471,7 +477,7 @@ TEST(L1Objects, FullScan) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(1)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(1)),
         .batches = {
           {
             .base_offset = 99_o,
@@ -491,7 +497,7 @@ TEST(L1Objects, FullScan) {
         },
       },
     };
-    auto [info, object] = make_object(specs_by_ntp);
+    auto [info, object] = make_object(specs_by_tidp);
     EXPECT_EQ(info.size_bytes, object.size_bytes());
     std::variant<footer, size_t> read_footer_result;
     ASSERT_NO_THROW(
@@ -515,13 +521,14 @@ TEST(L1Objects, FullScan) {
           read_footer_result, testing::VariantWith<size_t>(missing_len));
     }
     EXPECT_TRUE(
-      expect_read_results(make_reader(object), specs_by_ntp, info.index));
+      expect_read_results(make_reader(object), specs_by_tidp, info.index));
 }
 
 TEST(L1Objects, PartialScan) {
-    std::vector<batches_by_ntp> specs_by_ntp = {
+    auto test_topic_id = model::topic_id(uuid_t::create());
+    std::vector<batches_by_tidp> specs_by_tidp = {
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(0)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(0)),
         .batches = {
           {
             .base_offset = 0_o,
@@ -541,7 +548,7 @@ TEST(L1Objects, PartialScan) {
         },
       },
       {
-        .ntp = model::ntp{"test_ns", "test_topic", model::partition_id(1)},
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(1)),
         .batches = {
           {
             .base_offset = 99_o,
@@ -561,9 +568,9 @@ TEST(L1Objects, PartialScan) {
         },
       },
     };
-    auto [info, object] = make_object(specs_by_ntp);
-    for (const auto& spec : specs_by_ntp) {
-        auto it = info.index.partitions.find(spec.ntp);
+    auto [info, object] = make_object(specs_by_tidp);
+    for (const auto& spec : specs_by_tidp) {
+        auto it = info.index.partitions.find(spec.tidp);
         ASSERT_NE(it, info.index.partitions.end());
         auto reader = object_reader::create(make_iobuf_input_stream(
           object.share(it->second.file_position, it->second.length)));

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -29,8 +29,8 @@ ss::future<> compaction_sink::maybe_flush_object_builder() {
     }
 
     auto builder = std::exchange(_builder, nullptr);
-    auto object_info = co_await builder->finish();
-    co_await builder->close();
+    auto object_info = co_await builder->finish().finally(
+      [&builder] { return builder->close(); });
 
     auto active_buf = std::exchange(_active_output_buf, std::nullopt).value();
     _closed_objs.emplace_back(std::move(object_info), std::move(active_buf));

--- a/src/v/cloud_topics/level_one/compaction/sink.cc
+++ b/src/v/cloud_topics/level_one/compaction/sink.cc
@@ -47,7 +47,7 @@ ss::future<> compaction_sink::maybe_roll() {
     _builder = object_builder::create(
       make_iobuf_ref_output_stream(_active_output_buf.value()), _opts);
 
-    co_await _builder->start_partition(_ntp);
+    co_await _builder->start_partition(_tidp);
 
     co_return;
 }

--- a/src/v/cloud_topics/level_one/compaction/sink.h
+++ b/src/v/cloud_topics/level_one/compaction/sink.h
@@ -13,6 +13,7 @@
 #include "cloud_topics/level_one/common/object.h"
 #include "compaction/reducer.h"
 #include "container/chunked_vector.h"
+#include "model/fundamental.h"
 
 namespace cloud_topics::l1 {
 
@@ -23,8 +24,9 @@ public:
         iobuf obj;
     };
 
-    compaction_sink(model::ntp ntp, object_builder::options opts = {})
-      : _ntp(std::move(ntp))
+    compaction_sink(
+      model::topic_id_partition tidp, object_builder::options opts = {})
+      : _tidp(tidp)
       , _opts(opts) {}
 
     ss::future<ss::stop_iteration>
@@ -42,7 +44,7 @@ private:
 
     ss::future<> maybe_roll();
 
-    model::ntp _ntp;
+    model::topic_id_partition _tidp;
     const object_builder::options _opts;
 
     std::optional<iobuf> _active_output_buf{std::nullopt};

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -25,6 +25,8 @@
 
 static const auto test_ntp = model::ntp(
   model::ns("kafka"), model::topic("tapioca"), model::partition_id(0));
+static const auto test_tidp = model::topic_id_partition(
+  model::topic_id(uuid_t::create()), test_ntp.tp.partition);
 
 TEST(ReducerTest, Batches) {
     namespace l1 = cloud_topics::l1;
@@ -36,7 +38,7 @@ TEST(ReducerTest, Batches) {
 
     auto src = std::make_unique<compaction::simple_source>(
       std::move(input_batches), test_ntp);
-    auto sink = std::make_unique<l1::compaction_sink>(test_ntp);
+    auto sink = std::make_unique<l1::compaction_sink>(test_tidp);
 
     chunked_vector<l1::compaction_sink::object_output_t> output_objs;
     sink->set_object_sink(&output_objs);


### PR DESCRIPTION
- **ct/l1/object: use topic_id_partition for objects**
- **ct/compaction: always close object builders**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
