### PR TITLE
ct: disable compaction for L0 metadata

### DIFF
--- a/src/v/cluster/archival/adjacent_segment_merger.cc
+++ b/src/v/cluster/archival/adjacent_segment_merger.cc
@@ -174,7 +174,7 @@ adjacent_segment_merger::run(run_quota_t quota) {
         co_return result;
     }
 
-    if (_archiver.ntp_config().is_compacted()) {
+    if (_archiver.ntp_config().is_locally_compacted()) {
         // This should never happen because we should not have been constructed
         // for a compacted topic: this is a double-check for safety.
         vlog(

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -674,7 +674,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
         }
 
         if (_local_segment_merger) {
-            auto is_compacted = _parent.log()->config().is_compacted();
+            auto is_compacted = _parent.log()->config().is_locally_compacted();
             if (!is_compacted) {
                 vlog(
                   _rtclog.debug,
@@ -1979,7 +1979,7 @@ ntp_archiver::schedule_uploads(model::offset max_offset_exclusive) {
 
     if (
       config::shard_local_cfg().cloud_storage_enable_compacted_topic_reupload()
-      && _parent.get_ntp_config().is_compacted()
+      && _parent.get_ntp_config().is_locally_compacted()
       && compacted_segments_upload_start < start_upload_offset) {
         params.push_back({
           .upload_kind = segment_upload_kind::compacted,

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1485,8 +1485,9 @@ ss::future<std::error_code> controller_backend::create_partition(
         }
 
         auto rtp = cfg.properties.remote_topic_properties;
-        const bool is_cloud_topic = ntp_config.is_archival_enabled()
-                                    || ntp_config.is_remote_fetch_enabled();
+        const bool is_tiered_storage_topic
+          = ntp_config.is_archival_enabled()
+            || ntp_config.is_remote_fetch_enabled();
         const bool is_internal = ntp.ns == model::kafka_internal_namespace;
         /**
          * Here we decide if a partition needs recovery from tiered storage, it
@@ -1495,7 +1496,7 @@ ss::future<std::error_code> controller_backend::create_partition(
          * from the tiered storage.
          */
         if (
-          is_force_reconfigured && is_cloud_topic && !is_internal
+          is_force_reconfigured && is_tiered_storage_topic && !is_internal
           && !ntp_config.get_overrides().recovery_enabled) {
             // topic being cloud enabled implies existence of overrides
             ntp_config.get_overrides().recovery_enabled

--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -91,12 +91,7 @@ ss::future<log_recovery_result> partition_recovery_manager::download_log(
   model::initial_revision_id remote_revision,
   int32_t remote_partition_count,
   cloud_storage::remote_path_provider& path_provider) {
-    if (!ntp_cfg.has_overrides()) {
-        vlog(
-          cst_log.debug, "No overrides for {} found, skipping", ntp_cfg.ntp());
-        co_return log_recovery_result{};
-    }
-    auto enabled = ntp_cfg.get_overrides().recovery_enabled;
+    auto enabled = ntp_cfg.recovery_enabled();
     if (!enabled) {
         vlog(
           cst_log.debug,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -200,7 +200,7 @@ disk_log_impl::disk_log_impl(
         config().ntp(),
         _manager.config().readers_cache_eviction_timeout,
         config::shard_local_cfg().readers_cache_target_max_size.bind()))
-  , _compaction_enabled(config().is_compacted()) {
+  , _compaction_enabled(config().is_locally_compacted()) {
     for (auto& s : _segs) {
         _probe->add_initial_segment(*s);
         if (_compaction_enabled) {
@@ -1340,7 +1340,7 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
      * Compaction. Could factor out into a public interface like gc/retention if
      * there is a need to run it separately.
      */
-    if (config().is_compacted() && !_segs.empty()) {
+    if (config().is_locally_compacted() && !_segs.empty()) {
         scoped_file_tracker::set_t leftovers;
         cfg.compact.files_to_cleanup = &leftovers;
         auto fut = co_await ss::coroutine::as_future(
@@ -2016,7 +2016,7 @@ ss::future<> disk_log_impl::new_segment(model::offset o, model::term_id t) {
           return remove_empty_segments().then(
             [this, h = std::move(handles)]() mutable {
                 vassert(!_closed, "cannot add log segment to closed log");
-                if (config().is_compacted()) {
+                if (config().is_locally_compacted()) {
                     h->mark_as_compacted_segment();
                 }
                 _segs.add(std::move(h));
@@ -2074,7 +2074,7 @@ size_t disk_log_impl::max_segment_size() const {
         result = *config().get_overrides().segment_size;
     } else {
         // no overrides use defaults
-        result = config().is_compacted()
+        result = config().is_locally_compacted()
                    ? _manager.config().compacted_segment_size()
                    : _manager.config().max_segment_size();
     }
@@ -2265,7 +2265,7 @@ ss::future<> disk_log_impl::apply_segment_ms() {
     // what Kafka does exactly.
     auto max_lag = config().max_compaction_lag_ms();
     if (
-      config().is_compacted()
+      config().is_locally_compacted()
       && max_lag != local_config.max_compaction_lag_ms.default_value()) {
         // Clamp for the same reasons.
         const auto clamped_max_lag = std::clamp(
@@ -3596,7 +3596,7 @@ ss::future<bool> disk_log_impl::update_start_offset(model::offset o) {
 }
 
 bool disk_log_impl::notify_compaction_update() {
-    bool new_compaction_enabled = config().is_compacted();
+    bool new_compaction_enabled = config().is_locally_compacted();
     bool result = (_compaction_enabled != new_compaction_enabled);
     _compaction_enabled = new_compaction_enabled;
 
@@ -3625,7 +3625,7 @@ void disk_log_impl::set_overrides(ntp_config::default_overrides o) {
  * perform full compaction.
  */
 int64_t disk_log_impl::compaction_backlog() {
-    if (!config().is_compacted() || _segs.empty()) {
+    if (!config().is_locally_compacted() || _segs.empty()) {
         return 0;
     }
 
@@ -3881,7 +3881,7 @@ disk_log_impl::disk_usage_target(gc_config cfg, usage usage) {
      * compacted topics are always stored whole on local storage such that local
      * retention settings do not come into play.
      */
-    if (config().is_compacted()) {
+    if (config().is_locally_compacted()) {
         /*
          * if there is no delete policy enabled for a compacted topic then its
          * local capacity requirement is limited only by compaction process and
@@ -4535,7 +4535,7 @@ disk_log_impl::earliest_dirty_segment_ts() const {
 
 std::optional<model::timestamp>
 disk_log_impl::earliest_removable_timestamp(model::offset o) const {
-    if (!config().is_compacted()) {
+    if (!config().is_locally_compacted()) {
         return std::nullopt;
     }
 

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -421,7 +421,7 @@ ss::future<> kvstore::recover() {
 
     auto segments = co_await recover_segments(
       partition_path(_ntpc),
-      _ntpc.is_compacted(),
+      _ntpc.is_locally_compacted(),
       [] { return std::nullopt; },
       _as,
       config::shard_local_cfg().storage_read_buffer_size(),

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -757,7 +757,7 @@ ss::future<ss::shared_ptr<log>> log_manager::do_manage(
 
     auto segments = co_await recover_segments(
       partition_path(cfg),
-      cfg.is_compacted(),
+      cfg.is_locally_compacted(),
       [this, cache_enabled] { return create_cache(cache_enabled); },
       _abort_source,
       config::shard_local_cfg().storage_read_buffer_size(),

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -153,14 +153,6 @@ public:
 
     bool has_overrides() const { return _overrides != nullptr; }
 
-    bool has_compacted_override() const {
-        auto cp_override = cleanup_policy_override();
-        if (!cp_override) {
-            return false;
-        }
-        return model::is_compaction_enabled(cp_override.value());
-    }
-
     bool is_compacted() const {
         return model::is_compaction_enabled(cleanup_policy());
     }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -149,6 +149,7 @@ public:
     ss::sstring& base_directory() { return _base_dir; }
 
     const default_overrides& get_overrides() const { return *_overrides; }
+
     default_overrides& get_overrides() { return *_overrides; }
 
     bool has_overrides() const { return _overrides != nullptr; }
@@ -222,6 +223,11 @@ public:
         }
 
         return config::shard_local_cfg().log_retention_ms();
+    }
+
+    topic_recovery_enabled recovery_enabled() const {
+        return _overrides != nullptr ? _overrides->recovery_enabled
+                                     : topic_recovery_enabled::no;
     }
 
     bool is_archival_enabled() const {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -153,8 +153,20 @@ public:
 
     bool has_overrides() const { return _overrides != nullptr; }
 
-    bool is_compacted() const {
+    // If compaction is enabled for local storage.
+    bool is_locally_compacted() const {
+        if (cloud_topic_enabled()) {
+            return false;
+        }
         return model::is_compaction_enabled(cleanup_policy());
+    }
+
+    // If compaction is enabled for remote storage.
+    //
+    // NOTE: currently this is only supported for cloud topics
+    bool is_remotely_compacted() const {
+        return cloud_topic_enabled()
+               && model::is_compaction_enabled(cleanup_policy());
     }
 
     bool is_collectable() const {

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -888,7 +888,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
       })
       .then([path, &ntpc, &resources, ntp_sanitizer_config](
               ss::lw_shared_ptr<segment> seg) mutable {
-          if (!ntpc.is_compacted()) {
+          if (!ntpc.is_locally_compacted()) {
               return ss::make_ready_future<ss::lw_shared_ptr<segment>>(seg);
           }
           return with_segment(


### PR DESCRIPTION
This patch series does some cleanup in `ntp_config` and also splits the current definition
of "compaction enabled" into "is local compaction enabled" and "is remote compaction enabled".
This will have to be reworked if/when tiered storage compaction is ever a thing, but for now
this represents the state of the world better in Redpanda.

TBH I quite like the idea of `ntp_config` to encode a single source of truth for the topic specific
behaviors we have in redpanda (ref: https://github.com/redpanda-data/redpanda/issues/15097).
So maybe it makes sense to pull in more checks and remove the `get_overrides` method so we don't have
a bunch of reaching into the `ntp_config` to access overrides directly (instead we can have additional
logic ontop).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
