### PR TITLE
Fix rptest namespace cleanup

### DIFF
--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -192,18 +192,10 @@ class RpCloudApiClient(object):
         # return it
         return _ret["clusters"]
 
-    def list_namespaces(self, include_deleted=False):
-        # Use local var to manupulate output
-        _ret = self._http_get(
+    def list_namespaces(self):
+        return self._http_get(
             self.namespace_endpoint(), base_url=self._config.public_api_url
         )["resource_groups"]
-        # Filter out deleted ones
-        if include_deleted:
-            _namespaces = _ret
-        else:
-            _namespaces = [n for n in _ret if not n["deleted"]]
-        # return it
-        return _namespaces
 
     def list_networks(self, ns_uuid=None):
         # get networks for a namespace


### PR DESCRIPTION
The rp_cloud_cleanup.py (cleanup_entrypoint) at the end of each test is failing due to a mismatch in expectations for the data returned from the control plane API for a resource group.

Example: https://buildkite.com/redpanda/vtools/builds/24274#0198a1b2-b6db-4eb3-a9d7-65d656c1934a

Exception:

```
_bk;t=1755108327819# Listing namespaces

_bk;t=1755108328308Traceback (most recent call last):

_bk;t=1755108328308  File "/home/ubuntu/tests/rp_cloud_cleanup.py", line 731, in <module>

_bk;t=1755108328308    cleanup_entrypoint()

_bk;t=1755108328308  File "/home/ubuntu/tests/rp_cloud_cleanup.py", line 714, in cleanup_entrypoint

_bk;t=1755108328308    cleaner.clean_namespaces(ns_name_prefix, 8)

_bk;t=1755108328308  File "/home/ubuntu/tests/rp_cloud_cleanup.py", line 277, in clean_namespaces

_bk;t=1755108328308    ns_list = self.cloudv2.list_namespaces()

_bk;t=1755108328308  File "/home/ubuntu/redpanda/tests/rptest/services/provider_clients/rpcloud_client.py", line 203, in list_namespaces

_bk;t=1755108328308    _namespaces = [n for n in _ret if not n['deleted']]

_bk;t=1755108328308  File "/home/ubuntu/redpanda/tests/rptest/services/provider_clients/rpcloud_client.py", line 203, in <listcomp>

_bk;t=1755108328308    _namespaces = [n for n in _ret if not n['deleted']]

_bk;t=1755108328308KeyError: 'deleted'

_bk;t=1755108328580~
```

From the documentation it is not possible to list deleted resource groups: https://docs.redpanda.com/api/doc/cloud-controlplane/operation/operation-resourcegroupservice_listresourcegroups

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
