### PR TITLE
kc/configuration: use system trust when no truststore is provided

### DIFF
--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -364,7 +364,10 @@ tls_configuration::build_credentials() const {
                 truststore_str, ss::tls::x509_crt_format::PEM);
               return ss::now();
           });
+    } else {
+        co_await builder.set_system_trust();
     }
+
     if (k_store) {
         co_await ss::visit(
           *k_store,


### PR DESCRIPTION
When no trust store (CA certificate chain) is provided in kafka client configuration the logic should default to system embedded trust store. Previously the code path was missing forcing users to set the trust store manually.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- Fixes not setting system trust store when one is not provided