### PR TITLE
CORE-13288 dt/simple_http_server: respond after valid request 

### DIFF
--- a/tests/rptest/remote_scripts/simple_http_server.py
+++ b/tests/rptest/remote_scripts/simple_http_server.py
@@ -1,7 +1,7 @@
 import http.server
-import socketserver
 import json
 import signal
+import socketserver
 
 
 class PrintingHandler(http.server.BaseHTTPRequestHandler):
@@ -25,19 +25,26 @@ class PrintingHandler(http.server.BaseHTTPRequestHandler):
         self._handle()
 
     def _handle(self):
+        # read and capture request content
+        req = {}
+        req["method"] = self.command
+        req["path"] = self.path
+        if "Content-Length" in self.headers:
+            req["content_length"] = int(self.headers.get("Content-Length"))
+            raw_body = self.rfile.read(req["content_length"])
+            if len(raw_body) != req["content_length"]:
+                # Ignore invalid requests and force a new request
+                self.connection.close()
+                return
+
+            req["body"] = raw_body.decode("ascii")
+
         # set reply
         self.send_response(200)
         self.send_header("Content-type", "application/json")
         self.end_headers()
 
         # print request content
-        req = {}
-        req["method"] = self.command
-        req["path"] = self.path
-        if "Content-Length" in self.headers:
-            req["content_length"] = int(self.headers.get("Content-Length"))
-            req["body"] = self.rfile.read(req["content_length"]).decode("ascii")
-
         print(json.dumps(req), flush=True)
 
 

--- a/tests/rptest/tests/crash_reporter_test.py
+++ b/tests/rptest/tests/crash_reporter_test.py
@@ -9,13 +9,13 @@
 
 import json
 
-from rptest.services.cluster import cluster
-from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest
-from rptest.tests.metrics_reporter_test import MetricsReporterServer
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.tests.crash_loop_checks_test import HOSTNAME_ERRORS
+from rptest.tests.metrics_reporter_test import MetricsReporterServer
+from rptest.tests.redpanda_test import RedpandaTest
 
 
 class CrashReporterServer(MetricsReporterServer):
@@ -61,8 +61,10 @@ class CrashReporterTest(RedpandaTest):
                 self.logger.info("No requests yet")
                 return False
 
-        self.logger.info("Waiting for crash report to be posted")
-        wait_until(_request_received, 20, backoff_sec=1)
+        # Crash report uploads can fail in CI due to aborted connections, so allow extra time for retries
+        timeout_s = 40
+        self.logger.info(f"Waiting {timeout_s}s for crash report to be posted")
+        wait_until(_request_received, timeout_s, backoff_sec=1)
         self.telemetry.stop()
 
         self.logger.info("Verifying the content of the crash report requests")


### PR DESCRIPTION
Only respond 200 after having read the request. Abort the connection if
the request body could not be read fully.

The broker (HTTP client) considers post requests successful once it has
received the response headers back. However, if the connection is broker
after the response headers have been sent back, but before the
simple_http_server reads the request body, the server could read a
malformed request body (0 bytes).

To handle these occasional connection aborts, this commit starts
validating the request body size, and forces a re-request by terminating
the connection if the request is invalid.

Fixes https://redpandadata.atlassian.net/browse/CORE-13288

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
