### PR TITLE
[Testing] Reproduce slow replicate on produce

### DIFF
--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -8,29 +8,29 @@
 # by the Apache License, Version 2.0
 import datetime
 import json
-import time
 import random
 import string
+import time
 from typing import NamedTuple, Optional
 
 from ducktape.utils.util import wait_until
-from rptest.clients.rpk import RpkTool
-from rptest.services.redpanda import (
-    MetricSample,
-    MetricSamples,
-    MetricsEndpoint,
-    ResourceSettings,
-    LoggingConfig,
-)
-from kafka import KafkaProducer, KafkaConsumer, TopicPartition
+from kafka import KafkaConsumer, KafkaProducer
+
 from rptest.clients.kcl import (
-    RawKCL,
-    KclCreateTopicsRequestTopic,
     KclCreatePartitionsRequestTopic,
+    KclCreateTopicsRequestTopic,
+    RawKCL,
 )
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import (
+    LoggingConfig,
+    MetricSample,
+    MetricsEndpoint,
+    ResourceSettings,
+)
+from rptest.tests.redpanda_test import RedpandaTest
 
 GB = 1_000_000_000
 
@@ -559,7 +559,7 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.check_producer_throttled(producer1, ignore_max_throttle=True)
 
         assert not self._throttling_enforced_broker_side(), (
-            f"On the first request, the throttling delay should not be enforced"
+            "On the first request, the throttling delay should not be enforced"
         )
 
         # Now check that another producer is throttled through throttle_ms but
@@ -568,7 +568,7 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.check_producer_throttled(producer2, ignore_max_throttle=True)
 
         assert not self._throttling_enforced_broker_side(), (
-            f"On the first request, the throttling delay should not be enforced"
+            "On the first request, the throttling delay should not be enforced"
         )
 
         # Also check that non-produce requests are not throttled either
@@ -576,13 +576,13 @@ class ClusterRateQuotaTest(RedpandaTest):
         self.check_consumer_not_throttled(consumer)
 
         assert not self._throttling_enforced_broker_side(), (
-            f"Non-produce requests should not be throttled either"
+            "Non-produce requests should not be throttled either"
         )
 
         # Wait for logs to propagate
         time.sleep(5)
         assert not self._throttling_enforced_broker_side(), (
-            f"No broker-side throttling should happen up until this point"
+            "No broker-side throttling should happen up until this point"
         )
 
         # Because the python client doesn't seem to enforce the quota

--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -170,12 +170,13 @@ class ClusterRateQuotaTest(RedpandaTest):
             *args,
             extra_rp_conf=additional_options,
             log_config=LoggingConfig(
-                "info",
+                "trace",
                 logger_levels={
                     "kafka": "trace",
                     "kafka_quotas": "trace",
                     "cluster": "trace",
                     "raft": "trace",
+                    "io": "debug",
                 },
             ),
             resource_settings=ResourceSettings(num_cpus=1),


### PR DESCRIPTION
Use PR to reproduce flakiness in cluster quota throttling tests where we see some produce requests hanging for around a second.

Relates to https://redpandadata.atlassian.net/browse/CORE-12789

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
