### PR TITLE
[v25.2.x] kc/configuration: use system trust when no truststore is provided

### DIFF
--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -343,7 +343,10 @@ tls_configuration::build_credentials() const {
                 truststore_str, ss::tls::x509_crt_format::PEM);
               return ss::now();
           });
+    } else {
+        co_await builder.set_system_trust();
     }
+
     if (k_store) {
         co_await ss::visit(
           *k_store,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27471
