### PR TITLE
Fix cluster linking replication factor sync

### DIFF
--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -501,7 +501,8 @@ TEST_F_CORO(frontend_validation_test, update_mirror_topic_mirrored_by_other) {
 TEST_F_CORO(frontend_validation_test, test_mirror_properties) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"segment.ms"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "segment.ms"};
     m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {
       {
         .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
@@ -523,7 +524,8 @@ TEST_F_CORO(frontend_validation_test, test_mirror_properties) {
 TEST_F_CORO(frontend_validation_test, test_mirror_properties_empty_pattern) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"segment.ms"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "segment.ms"};
     m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {
       {
         .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
@@ -545,7 +547,8 @@ TEST_F_CORO(frontend_validation_test, test_mirror_properties_empty_pattern) {
 TEST_F_CORO(frontend_validation_test, test_mirror_properties_invalid_wildcard) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"segment.ms"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "segment.ms"};
     m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
       .filter = ::cluster_link::model::filter_type::include,
@@ -560,7 +563,8 @@ TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_wildcard_in_prefix) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"segment.ms"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "segment.ms"};
     m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::prefix,
       .filter = ::cluster_link::model::filter_type::include,
@@ -576,7 +580,8 @@ TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_characters) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"segment.ms"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "segment.ms"};
     m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
       .filter = ::cluster_link::model::filter_type::include,
@@ -592,7 +597,8 @@ TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_topic_name) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"segment.ms"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "segment.ms"};
     m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
       .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
       .filter = ::cluster_link::model::filter_type::include,
@@ -608,7 +614,8 @@ TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_topic_property) {
     auto m1 = create_base_metadata();
     m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = absl::flat_hash_set<ss::sstring>{"redpanda.remote.readreplica"};
+      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
+        "redpanda.remote.readreplica"};
 
     EXPECT_EQ(
       co_await upsert_cluster_link(std::move(m1)),

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -81,7 +81,8 @@ manager::manager(
   std::unique_ptr<link_factory> link_factory,
   std::unique_ptr<cluster_factory> cluster_factory,
   std::unique_ptr<consumer_groups_router> group_router,
-  ss::lowres_clock::duration task_reconciler_interval)
+  ss::lowres_clock::duration task_reconciler_interval,
+  config::binding<int16_t> default_topic_replication)
   : _self(self)
   , _partition_leader_cache(std::move(partition_leader_cache))
   , _partition_manager(std::move(partition_manager))
@@ -96,7 +97,8 @@ manager::manager(
           vlog(cllog.warn, "unexpected cluster link manager error: {}", ex);
       },
       ssx::work_queue::is_paused_t::yes)
-  , _task_reconciler_interval(task_reconciler_interval) {}
+  , _task_reconciler_interval(task_reconciler_interval)
+  , _default_topic_replication(std::move(default_topic_replication)) {}
 
 ss::future<> manager::start() {
     vlog(cllog.info, "Starting cluster link manager");
@@ -486,7 +488,8 @@ ss::future<> manager::start_topic_reconciler() {
           _topic_creator.get(),
           _topic_metadata_cache.get(),
           _registry.get(),
-          topic_reconciler_interval);
+          topic_reconciler_interval,
+          _default_topic_replication);
     }
     try {
         co_await _topic_reconciler->start();

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -47,7 +47,8 @@ public:
       std::unique_ptr<link_factory> link_factory,
       std::unique_ptr<cluster_factory> cluster_factory,
       std::unique_ptr<consumer_groups_router> group_router,
-      ss::lowres_clock::duration task_reconciler_interval);
+      ss::lowres_clock::duration task_reconciler_interval,
+      config::binding<int16_t> default_topic_replication);
     manager(const manager&) = delete;
     manager(manager&&) = delete;
     manager& operator=(const manager&) = delete;
@@ -164,6 +165,7 @@ private:
     mutex _link_task_reconciler_mutex{
       "cluster_link::manager::link_task_reconciler"};
     ss::timer<ss::lowres_clock> _link_task_reconciler_timer;
+    config::binding<int16_t> _default_topic_replication;
     ss::condition_variable _link_created_cv;
     ss::abort_source _as;
     ss::gate _g;

--- a/src/v/cluster_link/model/BUILD
+++ b/src/v/cluster_link/model/BUILD
@@ -20,6 +20,7 @@ redpanda_cc_library(
         "//src/v/model",
         "//src/v/serde",
         "//src/v/serde:variant",
+        "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:named_type",
         "//src/v/utils:unresolved_address",
         "//src/v/utils:uuid",

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -17,6 +17,7 @@
 #include "model/metadata.h"
 #include "serde/envelope.h"
 #include "serde/rw/variant.h"
+#include "utils/absl_sstring_hash.h"
 #include "utils/named_type.h"
 #include "utils/unresolved_address.h"
 #include "utils/uuid.h"
@@ -316,8 +317,10 @@ struct topic_metadata_mirroring_config
 
     /// Filters
     chunked_vector<resource_name_filter_pattern> topic_name_filters;
+    using properties_set
+      = absl::flat_hash_set<ss::sstring, sstring_hash, sstring_eq>;
     /// List of topic properties to mirror
-    absl::flat_hash_set<ss::sstring> topic_properties_to_mirror;
+    properties_set topic_properties_to_mirror;
 
     ss::lowres_clock::duration get_task_interval() const {
         return task_interval.value_or(task_interval_default);

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -228,8 +228,9 @@ struct mirror_topic_metadata
     ::model::topic_id destination_topic_id;
     /// The number of partitions on the source topic
     int32_t partition_count;
-    /// The replication factor
-    int16_t replication_factor;
+    /// The replication factor - if not provided, is using
+    /// `default_topic_replication` cluster config
+    std::optional<int16_t> replication_factor;
     /// The configuration for the topic
     chunked_hash_map<ss::sstring, ss::sstring> topic_configs;
 
@@ -500,7 +501,7 @@ struct update_mirror_topic_properties_cmd
     /// Name of the topic
     ::model::topic topic;
     int32_t partition_count;
-    int16_t replication_factor;
+    std::optional<int16_t> replication_factor;
     chunked_hash_map<ss::sstring, ss::sstring> topic_configs;
 
     friend bool operator==(

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -224,7 +224,8 @@ ss::future<> service::start() {
       std::make_unique<default_link_factory>(_partition_manager),
       std::make_unique<cluster_factory>(),
       std::make_unique<kafka_consumer_groups_router>(_group_router),
-      30s); // Temporary until we have a proper configuration for this
+      30s, // Temporary until we have a proper configuration for this
+      config::shard_local_cfg().default_topic_replication.bind());
 
     co_await _manager->register_task_factory<source_topic_syncer_factory>();
     co_await _manager->register_task_factory<group_mirroring_task_factory>();

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -20,6 +20,8 @@
 
 namespace cluster_link {
 
+using properties_set = model::topic_metadata_mirroring_config::properties_set;
+
 namespace {
 const absl::flat_hash_set<ss::sstring> required_topic_properties{
   ss::sstring{kafka::topic_property_max_message_bytes},
@@ -619,8 +621,8 @@ source_topic_syncer::describe_topics(
   ::model::node_id controller_id,
   kafka::api_version describe_configs_version,
   const chunked_vector<::model::topic>& topics,
-  const absl::flat_hash_set<ss::sstring>& configs) {
-    absl::flat_hash_set<ss::sstring> requested_configs_set = configs;
+  const properties_set& configs) {
+    properties_set requested_configs_set = configs;
     requested_configs_set.insert(
       required_topic_properties.begin(), required_topic_properties.end());
     chunked_vector<ss::sstring> requested_configs(

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -482,6 +482,10 @@ source_topic_syncer::find_candidate_topics_for_update(
           "Cluster link table reporting that link does not exist!");
         return {};
     }
+
+    auto mirror_rf = _config.topic_properties_to_mirror.contains(
+      kafka::topic_property_replication_factor);
+
     candidate_update_map candidate_topics;
     candidate_topics.reserve(mirror_topics->size());
 
@@ -518,7 +522,10 @@ source_topic_syncer::find_candidate_topics_for_update(
         candidate_topics.emplace(
           std::move(topic),
           std::make_pair(
-            topic_metadata{.partition_count = partition_count, .rf = rf},
+            topic_metadata{
+              .partition_count = partition_count,
+              // Only mirror source topic replication factor if configured to do
+              .rf = mirror_rf ? std::make_optional(rf) : std::nullopt},
             std::move(mirror_metadata)));
     }
 
@@ -534,6 +541,9 @@ source_topic_syncer::find_candidate_topics_for_creation(
     /// Map of topics with partition count
     candidate_create_map candidate_topics;
     candidate_topics.reserve(topics.size());
+
+    auto mirror_rf = _config.topic_properties_to_mirror.contains(
+      kafka::topic_property_replication_factor);
 
     for (const auto& topic : topics) {
         vlog(logger().trace, "Checking topic: {}", topic);
@@ -609,7 +619,12 @@ source_topic_syncer::find_candidate_topics_for_creation(
 
         vlog(logger().debug, "Topic {} is candidate for mirroring", topic);
         candidate_topics.emplace(
-          topic, topic_metadata{.partition_count = partition_count, .rf = rf});
+          topic,
+          topic_metadata{
+            .partition_count = partition_count,
+            // Only mirror source topic replication factor if configured to do
+            // so
+            .rf = mirror_rf ? std::make_optional(rf) : std::nullopt});
     }
 
     return candidate_topics;

--- a/src/v/cluster_link/source_topic_syncer.h
+++ b/src/v/cluster_link/source_topic_syncer.h
@@ -87,7 +87,7 @@ private:
       ::model::node_id controller_id,
       kafka::api_version describe_configs_version,
       const chunked_vector<::model::topic>& topics,
-      const absl::flat_hash_set<ss::sstring>& configs);
+      const model::topic_metadata_mirroring_config::properties_set& configs);
 
 private:
     model::topic_metadata_mirroring_config _config;

--- a/src/v/cluster_link/source_topic_syncer.h
+++ b/src/v/cluster_link/source_topic_syncer.h
@@ -47,7 +47,7 @@ protected:
 private:
     struct topic_metadata {
         int32_t partition_count;
-        int16_t rf;
+        std::optional<int16_t> rf;
     };
 
     using reconciler_commands = std::variant<

--- a/src/v/cluster_link/tests/BUILD
+++ b/src/v/cluster_link/tests/BUILD
@@ -15,6 +15,7 @@ redpanda_test_cc_library(
         "//src/v/cluster_link:impl",
         "//src/v/cluster_link:utils",
         "//src/v/cluster_link/replication/tests:deps_test_impl",
+        "//src/v/config",
         "//src/v/kafka/client/test:cluster_mock",
         "//src/v/kafka/data/rpc",
         "//src/v/kafka/data/rpc/test:test_deps",
@@ -126,6 +127,7 @@ redpanda_cc_gtest(
     deps = [
         ":test_deps",
         "//src/v/cluster_link:impl",
+        "//src/v/config",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
     ],

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -80,7 +80,8 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
           _consumer_group_router = router.get();
           return router;
       }),
-      1s);
+      1s,
+      _default_topic_replication.bind());
 
     auto notif_id = _table.local().register_for_updates(
       [this](model::id_t id) { _manager.local().on_link_change(id); });

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -49,7 +49,8 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
         int32_t partition_count,
         ::model::node_id leader) {
           return update_partition_count(tp_ns, partition_count, leader);
-      });
+      },
+      _default_topic_replication.bind());
     _ftpc = ftpc.get();
 
     _lf = lf.get();

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -495,7 +495,7 @@ private:
     link_factory* _lf{nullptr};
     test_consumer_group_router* _consumer_group_router{nullptr};
     ss::sharded<manager> _manager;
-    config::mock_property<int16_t> _default_topic_replication{3};
+    config::mock_property<int16_t> _default_topic_replication{1};
 
     ::model::node_id _self;
     model::id_t _next_link_id{0};

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -16,6 +16,7 @@
 #include "cluster_link/manager.h"
 #include "cluster_link/replication/tests/deps_test_impl.h"
 #include "cluster_link/utils.h"
+#include "config/mock_property.h"
 #include "kafka/client/test/cluster_mock.h"
 #include "kafka/data/rpc/deps.h"
 #include "kafka/data/rpc/test/deps.h"
@@ -494,6 +495,7 @@ private:
     link_factory* _lf{nullptr};
     test_consumer_group_router* _consumer_group_router{nullptr};
     ss::sharded<manager> _manager;
+    config::mock_property<int16_t> _default_topic_replication{3};
 
     ::model::node_id _self;
     model::id_t _next_link_id{0};

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -143,6 +143,7 @@ protected:
     ss::sharded<table> _table;
 
     std::unique_ptr<manager> _manager;
+    config::mock_property<int16_t> _default_topic_replication{3};
 
     absl::flat_hash_map<notification_id, ss::noncopyable_function<void(uuid_t)>>
       _callbacks;
@@ -183,7 +184,8 @@ public:
           std::make_unique<link_test_factory>(this, 1s),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
           std::make_unique<test_consumer_group_router>(),
-          task_reconciler_interval);
+          task_reconciler_interval,
+          _default_topic_replication.bind());
     }
 
     virtual ss::future<> TearDownAsync() override {
@@ -416,7 +418,8 @@ public:
           std::move(elf),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
           std::make_unique<test_consumer_group_router>(),
-          task_reconciler_interval);
+          task_reconciler_interval,
+          _default_topic_replication.bind());
         co_await _manager->start();
     }
 

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -179,7 +179,8 @@ public:
             [](const ::model::ntp&, ::model::node_id) {},
             [](::model::topic_namespace_view, int32_t, ::model::node_id) {
                 return cluster::errc::success;
-            }),
+            },
+            _default_topic_replication.bind()),
           std::make_unique<test_link_registry>(&_table.local()),
           std::make_unique<link_test_factory>(this, 1s),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
@@ -413,7 +414,8 @@ public:
             [](const ::model::ntp&, ::model::node_id) {},
             [](::model::topic_namespace_view, int32_t, ::model::node_id) {
                 return cluster::errc::success;
-            }),
+            },
+            _default_topic_replication.bind()),
           std::make_unique<test_link_registry>(&_table.local()),
           std::move(elf),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -152,7 +152,7 @@ TEST_F_CORO(source_topic_syncer_test, select_all_filter) {
     EXPECT_EQ(
       mirror_topic_it->second.source_topic_name, ::model::topic("test_topic"));
     EXPECT_EQ(mirror_topic_it->second.partition_count, 3);
-    EXPECT_EQ(mirror_topic_it->second.replication_factor, 3);
+    EXPECT_FALSE(mirror_topic_it->second.replication_factor.has_value());
     const auto& configs = mirror_topic_it->second.topic_configs;
     EXPECT_NE(configs.find("max.message.bytes"), configs.end());
     EXPECT_NE(configs.find("message.timestamp.type"), configs.end());

--- a/src/v/cluster_link/tests/topic_properties_syncer_test.cc
+++ b/src/v/cluster_link/tests/topic_properties_syncer_test.cc
@@ -38,7 +38,7 @@ model::metadata get_default_metadata() {
       model::mirror_topic_metadata{
         .source_topic_name = test_topic,
         .partition_count = 1,
-        .replication_factor = 1,
+        .replication_factor = std::nullopt,
         .topic_configs = {
           {"max.message.bytes", "1048576"},
           {"cleanup.policy", "delete"},
@@ -101,7 +101,7 @@ TEST_F_CORO(topic_properties_syncer_test, topic_properties_sync) {
         if (mirror_topic_it != mirror_topics.end()) {
             const auto& topic_metadata = mirror_topic_it->second;
             return topic_metadata.partition_count == 3
-                   && topic_metadata.replication_factor == 3
+                   && !topic_metadata.replication_factor.has_value()
                    && topic_metadata.topic_configs.at("max.message.bytes")
                         == "1024";
         }
@@ -134,6 +134,57 @@ TEST_F_CORO(topic_properties_syncer_test, topic_properties_sync) {
     ASSERT_NE_CORO(mirror_topic_it, mirror_topics.end());
     EXPECT_EQ(mirror_topic_it->second.partition_count, 3);
     EXPECT_EQ(mirror_topic_it->second.state, model::mirror_topic_state::failed);
+}
+
+TEST_F_CORO(topic_properties_syncer_test, sync_rf) {
+    auto md = get_default_metadata();
+    md.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+      .emplace("replication.factor");
+
+    co_await fixture()->upsert_link(std::move(md));
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 1
+                   && topic_metadata.replication_factor == 1;
+        }
+        return false;
+    });
+
+    fixture()->get_cluster_mock().set_topic_replication_factor(test_topic, 3);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(test_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 1
+                   && topic_metadata.replication_factor == 3;
+        }
+        return false;
+    });
+
+    // Now add a new topic and ensure it gets the RF set correctly
+    const ::model::topic new_topic{"new_topic"};
+    fixture()->get_cluster_mock().add_topic(
+      new_topic, 1, 3, kafka::topic_authorized_operations(0x508));
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, new_topic] {
+        auto link = fixture()->find_link_by_name(test_link_name);
+        const auto& mirror_topics = link->get().state.mirror_topics;
+        auto mirror_topic_it = mirror_topics.find(new_topic);
+        if (mirror_topic_it != mirror_topics.end()) {
+            const auto& topic_metadata = mirror_topic_it->second;
+            return topic_metadata.partition_count == 1
+                   && topic_metadata.replication_factor == 3;
+        }
+        return false;
+    });
 }
 
 class update_properties_invalid_describe_configs_test

--- a/src/v/cluster_link/tests/topic_reconciler_test.cc
+++ b/src/v/cluster_link/tests/topic_reconciler_test.cc
@@ -46,7 +46,8 @@ public:
             ::model::node_id) {
               _ftmc->set_partition_count(tp_ns, partition_count);
               return cluster::errc::success;
-          });
+          },
+          _default_topic_replication.bind());
 
         _reconciler = std::make_unique<topic_reconciler>(
           _ftc.get(),

--- a/src/v/cluster_link/tests/topic_reconciler_test.cc
+++ b/src/v/cluster_link/tests/topic_reconciler_test.cc
@@ -11,6 +11,7 @@
 
 #include "cluster_link/tests/deps.h"
 #include "cluster_link/topic_reconciler.h"
+#include "config/mock_property.h"
 #include "test_utils/async.h"
 #include "test_utils/test.h"
 
@@ -48,7 +49,11 @@ public:
           });
 
         _reconciler = std::make_unique<topic_reconciler>(
-          _ftc.get(), _ftmc.get(), _link_registry.get(), 1s);
+          _ftc.get(),
+          _ftmc.get(),
+          _link_registry.get(),
+          1s,
+          _default_topic_replication.bind());
         co_await _reconciler->start();
 
         set_required_topic_properties(
@@ -168,6 +173,8 @@ private:
     model::id_t _created_link_id;
 
     model::id_t _next_link_id{1};
+
+    config::mock_property<int16_t> _default_topic_replication{3};
 };
 
 TEST_F_CORO(topic_reconciler_test, test_topic_creation_and_property_updates) {

--- a/src/v/cluster_link/tests/topic_reconciler_test.cc
+++ b/src/v/cluster_link/tests/topic_reconciler_test.cc
@@ -118,7 +118,7 @@ public:
       model::id_t id,
       ::model::topic topic,
       int32_t partition_count,
-      int16_t replication_factor,
+      std::optional<int16_t> replication_factor,
       chunked_hash_map<ss::sstring, ss::sstring> topic_configs = {}) {
         topic_configs.insert(
           _required_topic_properties.begin(), _required_topic_properties.end());
@@ -162,6 +162,10 @@ public:
     topic_reconciler* reconciler() const { return _reconciler.get(); }
 
     link_registry* link_registry() const { return _link_registry.get(); }
+
+    config::mock_property<int16_t>& default_topic_replication() {
+        return _default_topic_replication;
+    }
 
 private:
     ss::sharded<cluster::cluster_link::table> _table;
@@ -282,5 +286,40 @@ TEST_F_CORO(topic_reconciler_test, test_topic_failure) {
     const auto topic_cfg = metadata_cache()->find_topic_cfg(topic);
     ASSERT_TRUE_CORO(topic_cfg.has_value());
     EXPECT_EQ(topic_cfg->replication_factor, 1);
+}
+
+TEST_F_CORO(topic_reconciler_test, test_no_rf_set) {
+    ::model::topic_namespace topic{
+      ::model::kafka_namespace, ::model::topic{"test_topic"}};
+    ::model::topic_namespace topic2{
+      ::model::kafka_namespace, ::model::topic{"test_topic2"}};
+
+    default_topic_replication().update(1);
+
+    co_await add_mirror_topic(get_link_id(), topic.tp, 1, std::nullopt);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      10s, [this, topic = ::model::topic_namespace_view{topic}] {
+          return metadata_cache()->find_topic_cfg(topic).has_value();
+      });
+
+    const auto topic_cfg = metadata_cache()->find_topic_cfg(topic).value();
+    EXPECT_EQ(topic_cfg.tp_ns, topic);
+    EXPECT_EQ(topic_cfg.partition_count, 1);
+    EXPECT_EQ(topic_cfg.replication_factor, 1);
+
+    default_topic_replication().update(3);
+
+    co_await add_mirror_topic(get_link_id(), topic2.tp, 1, std::nullopt);
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(
+      10s, [this, topic = ::model::topic_namespace_view{topic2}] {
+          return metadata_cache()->find_topic_cfg(topic).has_value();
+      });
+
+    const auto topic_cfg2 = metadata_cache()->find_topic_cfg(topic2).value();
+    EXPECT_EQ(topic_cfg2.tp_ns, topic2);
+    EXPECT_EQ(topic_cfg2.partition_count, 1);
+    EXPECT_EQ(topic_cfg2.replication_factor, 3);
 }
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/topic_reconciler.cc
+++ b/src/v/cluster_link/topic_reconciler.cc
@@ -248,7 +248,8 @@ ss::future<> topic_reconciler::maybe_create_mirror_topic(
       ::model::kafka_namespace,
       topic,
       mirror_topic_config.partition_count,
-      mirror_topic_config.replication_factor,
+      mirror_topic_config.replication_factor.value_or(
+        _default_topic_replication()),
       topic_configs);
 
     auto res = co_await _topic_creator->create_topic(
@@ -274,8 +275,9 @@ topic_reconciler::maybe_create_update_mirror_topic(
       {::model::kafka_namespace, topic_name});
 
     if (
-      mirror_topic_config.replication_factor
-      != local_topic_config.replication_factor) {
+      mirror_topic_config.replication_factor.has_value()
+      && *mirror_topic_config.replication_factor
+           != local_topic_config.replication_factor) {
         vlog(
           cllog.debug,
           "Updating replication factor for topic {} from {} to {}",
@@ -285,7 +287,8 @@ topic_reconciler::maybe_create_update_mirror_topic(
         update.custom_properties.replication_factor.op
           = cluster::incremental_update_operation::set;
         update.custom_properties.replication_factor.value
-          = cluster::replication_factor(mirror_topic_config.replication_factor);
+          = cluster::replication_factor(
+            mirror_topic_config.replication_factor.value());
         config_updated = true;
     }
 

--- a/src/v/cluster_link/topic_reconciler.cc
+++ b/src/v/cluster_link/topic_reconciler.cc
@@ -27,11 +27,13 @@ topic_reconciler::topic_reconciler(
   kafka::data::rpc::topic_creator* topic_creator,
   kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
   link_registry* link_registry,
-  ss::lowres_clock::duration run_interval)
+  ss::lowres_clock::duration run_interval,
+  config::binding<int16_t> default_topic_replication)
   : _topic_creator(topic_creator)
   , _topic_metadata_cache(topic_metadata_cache)
   , _link_registry(link_registry)
-  , _run_interval(run_interval) {}
+  , _run_interval(run_interval)
+  , _default_topic_replication(std::move(default_topic_replication)) {}
 
 ss::future<> topic_reconciler::start() {
     vlog(cllog.info, "Starting topic reconciler");

--- a/src/v/cluster_link/topic_reconciler.h
+++ b/src/v/cluster_link/topic_reconciler.h
@@ -27,7 +27,8 @@ public:
       kafka::data::rpc::topic_creator* topic_creator,
       kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
       link_registry* link_registry,
-      ss::lowres_clock::duration run_interval);
+      ss::lowres_clock::duration run_interval,
+      config::binding<int16_t> default_topic_replication);
     topic_reconciler(const topic_reconciler&) = delete;
     topic_reconciler(topic_reconciler&&) = delete;
     topic_reconciler& operator=(const topic_reconciler&) = delete;
@@ -77,6 +78,7 @@ private:
     mutex _reconciler_mutex{"cluster_link::task_reconciler"};
     ss::timer<ss::lowres_clock> _reconciler_timer;
     ss::lowres_clock::duration _run_interval;
+    config::binding<int16_t> _default_topic_replication;
     ss::abort_source _as;
     ss::gate _gate;
 };

--- a/src/v/kafka/data/rpc/test/BUILD
+++ b/src/v/kafka/data/rpc/test/BUILD
@@ -10,6 +10,7 @@ redpanda_test_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/config",
         "//src/v/kafka/data/rpc",
         "//src/v/model",
         "//src/v/model/tests:random",

--- a/src/v/kafka/data/rpc/test/deps.cc
+++ b/src/v/kafka/data/rpc/test/deps.cc
@@ -54,7 +54,8 @@ void kafka_data_test_fixture::wire_up_and_start() {
         int32_t partition_count,
         model::node_id leader) {
           return update_partition_count(tp_ns, partition_count, leader);
-      });
+      },
+      _default_topic_replication.bind());
     _ftpc = ftpc.get();
 
     _client

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "config/mock_property.h"
 #include "kafka/data/rpc/client.h"
 #include "kafka/data/rpc/deps.h"
 #include "kafka/data/rpc/service.h"
@@ -327,11 +328,13 @@ public:
         new_ntp_cb,
       ss::noncopyable_function<
         cluster::errc(model::topic_namespace_view, int32_t, model::node_id)>
-        new_partition_count_cb)
+        new_partition_count_cb,
+      config::binding<int16_t> default_topic_replication)
       : _new_topic_cb(std::move(new_topic_cb))
       , _update_topic_cb(std::move(update_topic_cb))
       , _new_ntp_cb(std::move(new_ntp_cb))
-      , _new_partition_count_cb(std::move(new_partition_count_cb)) {}
+      , _new_partition_count_cb(std::move(new_partition_count_cb))
+      , _default_topic_replication(std::move(default_topic_replication)) {}
 
     ss::future<cluster::errc> create_topic(
       model::topic_namespace_view tp_ns,
@@ -342,7 +345,7 @@ public:
           tp_ns.ns,
           tp_ns.tp,
           partition_count,
-          replication_factor.value_or(1),
+          replication_factor.value_or(_default_topic_replication()),
         };
         tcfg.properties = properties;
         _new_topic_cb(tcfg);
@@ -383,6 +386,7 @@ private:
     ss::noncopyable_function<cluster::errc(
       model::topic_namespace_view, int32_t, model::node_id)>
       _new_partition_count_cb;
+    config::binding<int16_t> _default_topic_replication;
 };
 
 class fake_partition_manager_proxy {
@@ -555,6 +559,7 @@ private:
     ss::sharded<local_service> _local_services;
     ss::sharded<local_service> _remote_services;
     ss::sharded<kafka::data::rpc::client> _client;
+    config::mock_property<int16_t> _default_topic_replication{1};
 
     model::node_id self_node;
     ss::sharded<::rpc::connection_cache>* _conn_cache;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Originally, the RF of the source topic was being replicated regardless of the `topic_properties_sync` config.  Now we will only replicate the source topic RF is `replication.factor` is in that set.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
