### PR TITLE
[CORE-8342] dt: fix flaky alter topic config test

### DIFF
--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -553,9 +553,7 @@ class AlterConfigMixedNodeTest(EndToEndTest):
                 {"redpanda.remote.read": "true", "redpanda.remote.write": "false"},
             ]
             for props in props_list:
-                kcl.alter_topic_config(
-                    props, incremental_update, topic, node=self.redpanda.controller()
-                )
+                kcl.alter_topic_config(props, incremental_update, topic)
                 wait_until(
                     lambda: func(props) == True,
                     timeout_sec=10,


### PR DESCRIPTION
Fixes: [CORE-8342](https://redpandadata.atlassian.net/browse/CORE-8342)

By not specifing a single node as the controller, the client request is sent with all brokers available. This allows it to handle the request gracefully even if the controller is in the process of changing.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none



[CORE-8342]: https://redpandadata.atlassian.net/browse/CORE-8342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ