### PR TITLE
kgo-verifier: add an option to commit offsets right after fetch

### DIFF
--- a/tests/go/kgo-verifier/cmd/kgo-verifier/main.go
+++ b/tests/go/kgo-verifier/cmd/kgo-verifier/main.go
@@ -50,6 +50,7 @@ var (
 	batchMaxBytes       = flag.Int("batch_max_bytes", 1048576, "the maximum batch size to allow per-partition (must be less than Kafka's max.message.bytes, producing)")
 	cgReaders           = flag.Int("consumer_group_readers", 0, "Number of parallel readers in the consumer group")
 	cgName              = flag.String("consumer_group_name", "", "The name of the consumer group. Generated randomly if not set.")
+	cgMaxUncommitted    = flag.Int("max-uncommitted", -1, "Negative means rely on auto-commit. For positive, commit consumer group offsets after fetching this many records. Limits discrepancy between read statistics and committed offsets.")
 	linger              = flag.Duration("linger", 0, "if non-zero, linger to use when producing")
 	maxBufferedRecords  = flag.Uint("max-buffered-records", 1024, "Producer buffer size: the default of 1 is makes roughly one event per batch, useful for measurement.  Set to something higher to make it easier to max out bandwidth.")
 	remote              = flag.Bool("remote", false, "Remote control mode, driven by HTTP calls, for use in automated tests")
@@ -376,7 +377,7 @@ func main() {
 		grw := verifier.NewGroupReadWorker(
 			verifier.NewGroupReadConfig(
 				makeWorkerConfig(), *cgName, nPartitions, *cgReaders,
-				*seqConsumeCount, (*consumeTputMb)*1024*1024), verifier.NewValidatorStatus(*compacted, *validateLatestValues, *topic, nPartitions))
+				*seqConsumeCount, (*consumeTputMb)*1024*1024, *cgMaxUncommitted), verifier.NewValidatorStatus(*compacted, *validateLatestValues, *topic, nPartitions))
 		workers.Add(&grw)
 		workers.SetReady()
 
@@ -385,6 +386,8 @@ func main() {
 			waitErr := grw.Wait(ctx)
 			util.Chk(waitErr, "Consumer error: %v", err)
 		}
+	} else {
+		util.Die("No valid operation specified (use one of -produce_msgs, -rand_read_msgs , -seq_read, -consumer_group_readers)")
 	}
 
 	if *remote {

--- a/tests/go/kgo-verifier/pkg/worker/verifier/group_read_worker.go
+++ b/tests/go/kgo-verifier/pkg/worker/verifier/group_read_worker.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/redpanda-data/redpanda/tests/go/kgo-verifier/pkg/util"
 	worker "github.com/redpanda-data/redpanda/tests/go/kgo-verifier/pkg/worker"
 	log "github.com/sirupsen/logrus"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -21,11 +22,12 @@ type GroupReadConfig struct {
 	nReaders       int
 	maxReadCount   int
 	rateLimitBytes int
+	maxUncommitted int
 }
 
 func NewGroupReadConfig(
 	wc worker.WorkerConfig, name string, nPartitions int32, nReaders int,
-	maxReadCount int, rateLimitBytes int) GroupReadConfig {
+	maxReadCount int, rateLimitBytes int, maxUncommitted int) GroupReadConfig {
 	return GroupReadConfig{
 		workerCfg:      wc,
 		groupName:      name,
@@ -33,6 +35,7 @@ func NewGroupReadConfig(
 		nReaders:       nReaders,
 		maxReadCount:   maxReadCount,
 		rateLimitBytes: rateLimitBytes,
+		maxUncommitted: maxUncommitted,
 	}
 }
 
@@ -246,7 +249,11 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 	}
 
 	for {
-		fetches := client.PollFetches(ctx)
+		if grw.config.maxUncommitted == 0 {
+			// for users to be aware that immediate commits are not supported
+			util.Die("max-uncommitted must be non-zero")
+		}
+		fetches := client.PollRecords(ctx, grw.config.maxUncommitted)
 		if ctx.Err() == context.Canceled {
 			break
 		} else if ctx.Err() != nil {
@@ -284,7 +291,14 @@ func (grw *GroupReadWorker) consumerGroupReadInner(
 			cgOffsets.AddRecord(ctx, r)
 		})
 
-		// Offsets will be committed on the next PollFetches invocation
+		// Otherwise offsets will be enqueued for commit on the next PollFetches invocation
+		// and the actual commit will happen in background respecting `kgo.AutoCommitInterval` (default: 5s).
+		if grw.config.maxUncommitted > 0 {
+			if err := client.CommitUncommittedOffsets(ctx); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -1011,6 +1011,7 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
         continuous=False,
         tolerate_data_loss=False,
         group_name=None,
+        max_uncommitted=None,  # None means rely on auto commit
         use_transactions=False,
         compacted=False,
         validate_latest_values=False,
@@ -1033,6 +1034,10 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
         self._max_msgs = max_msgs
         self._max_throughput_mb = max_throughput_mb
         self._group_name = group_name
+        assert max_uncommitted is None or max_uncommitted > 0, (
+            "max_uncommitted must be positive or None"
+        )
+        self._max_uncommitted = max_uncommitted
         self._continuous = continuous
         self._tolerate_data_loss = tolerate_data_loss
         self._use_transactions = use_transactions
@@ -1062,6 +1067,8 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
             cmd += " --tolerate-data-loss"
         if self._group_name is not None:
             cmd += f" --consumer_group_name {self._group_name}"
+        if self._max_uncommitted is not None:
+            cmd += f" --max-uncommitted {self._max_uncommitted}"
         if self._use_transactions:
             cmd += " --use-transactions"
         if self._compacted:


### PR DESCRIPTION
For kgo-verifier status thread to minimize the number of uncommitted messages reported as valid reads to the status thread.
Based on https://github.com/redpanda-data/kgo-verifier/pull/54.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
