### PR TITLE
ct/l1: Fix object builder uninitialized state

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -411,7 +411,7 @@ private:
     size_t _offset = 0;
     ss::output_stream<char> _output;
     footer _index;
-    model::topic_id_partition _current_tidp;
+    model::topic_id_partition _current_tidp{};
     footer::partition _current_partition;
     options _opts;
 };

--- a/src/v/cloud_topics/level_one/common/tests/object_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_test.cc
@@ -498,6 +498,7 @@ TEST(L1Objects, FullScan) {
       },
     };
     auto [info, object] = make_object(specs_by_tidp);
+    EXPECT_EQ(info.index.partitions.size(), 2);
     EXPECT_EQ(info.size_bytes, object.size_bytes());
     std::variant<footer, size_t> read_footer_result;
     ASSERT_NO_THROW(


### PR DESCRIPTION
The object builder was tracking partition state with _current_tidp, which was uninitialized. This caused a garbage partitions to be added to the object index when end_partition() was called before any partition was started. I changed _current_tidp to std::optional to fix it.

I found this bug rebasing the reconciler object building change on the conversion of object builder to use topic id partition. That change contains a regression test for this issue.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
