### PR TITLE
Added trimming for consumer groups committed offsets while being mirrored

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -1255,4 +1255,40 @@ bool health_monitor_backend::does_raft0_have_leader() {
     return _raft0->get_leader_id().has_value();
 }
 
+ss::future<result<std::optional<kafka::offset>>>
+health_monitor_backend::get_partition_high_watermark(
+  model::topic_namespace_view tp_ns, model::partition_id p_id) {
+    auto ec = co_await maybe_refresh_cluster_health(
+      force_refresh::no,
+      model::timeout_clock::now()
+        + config::shard_local_cfg().health_monitor_max_metadata_age());
+    if (ec) {
+        co_return ec;
+    }
+    kafka::offset high_watermark;
+    model::revision_id current_revision;
+    for (const auto& [node_id, report] : *_reports) {
+        auto t_it = report->topics.find(tp_ns);
+        if (t_it == report->topics.end()) {
+            continue;
+        }
+        auto partition_it = t_it->second.find(p_id);
+        if (partition_it == t_it->second.end()) {
+            continue;
+        }
+        const auto& partition_status = partition_it->second;
+        if (partition_status.revision_id > current_revision) {
+            current_revision = partition_status.revision_id;
+            // reset offset, we are only interested in current revision
+            high_watermark = kafka::offset{};
+        }
+        high_watermark = std::max(
+          high_watermark, partition_status.high_watermark);
+    }
+
+    co_return high_watermark == kafka::offset{}
+      ? std::nullopt
+      : std::make_optional(high_watermark);
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -106,6 +106,20 @@ public:
     bool does_raft0_have_leader();
 
     bool contains_node_health_report(model::node_id) const;
+    /**
+     * Returns maximum high watermark for a given partition across the cluster.
+     * It returns the high watermark for the partition replica with highest
+     * revision.
+     *
+     * NOTE: why not returning the high watermark from the leader replica ?
+     *
+     * The leader replica high watermark may be stale if leader health report is
+     * older than followers one. High watermark is monotonically increasing
+     * therefore it is always safe to return the highest value.
+     */
+    ss::future<result<std::optional<kafka::offset>>>
+      get_partition_high_watermark(
+        model::topic_namespace_view, model::partition_id);
 
 private:
     /**

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -173,4 +173,13 @@ ss::future<> health_monitor_frontend::refresh_info() {
       });
 }
 
+ss::future<result<std::optional<kafka::offset>>>
+health_monitor_frontend::get_partition_high_watermark(
+  model::topic_namespace_view tp_ns, model::partition_id p_id) {
+    co_return co_await dispatch_to_backend(
+      [tp_ns, p_id](health_monitor_backend& be) {
+          return be.get_partition_high_watermark(tp_ns, p_id);
+      });
+}
+
 } // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -93,6 +93,13 @@ public:
      * optional if the node is not present in node status table.
      */
     std::optional<alive> is_alive(model::node_id) const;
+    /**
+     * Returns partition high watermark from the replica that reports the
+     * highest value within the cluster.
+     */
+    ss::future<result<std::optional<kafka::offset>>>
+      get_partition_high_watermark(
+        model::topic_namespace_view, model::partition_id);
 
 private:
     template<typename Func>

--- a/src/v/cluster_link/deps.h
+++ b/src/v/cluster_link/deps.h
@@ -129,4 +129,26 @@ public:
     virtual ss::future<bool> assure_topic_exists() = 0;
 };
 
+/**
+ * Cluster linking entry point for retrieving partition metadata information
+ */
+class partition_metadata_provider {
+public:
+    partition_metadata_provider() = default;
+    partition_metadata_provider(const partition_metadata_provider&) = delete;
+    partition_metadata_provider(partition_metadata_provider&&) = delete;
+    partition_metadata_provider& operator=(const partition_metadata_provider&)
+      = delete;
+    partition_metadata_provider& operator=(partition_metadata_provider&&)
+      = delete;
+    virtual ~partition_metadata_provider() = default;
+
+    /**
+     * Returns the high watermark for a given topic partition. If the
+     * information is missing or error occurs, returns std::nullopt.
+     */
+    virtual ss::future<std::optional<kafka::offset>>
+      get_partition_high_watermark(::model::topic_partition_view) = 0;
+};
+
 } // namespace cluster_link

--- a/src/v/cluster_link/group_mirroring_task.cc
+++ b/src/v/cluster_link/group_mirroring_task.cc
@@ -375,8 +375,62 @@ void group_mirroring_task::handle_offset_commit_response(
 ss::future<chunked_vector<group_mirroring_task::group_offsets>>
 group_mirroring_task::trim_to_partition_highwatermark(
   chunked_vector<group_offsets> offsets) {
-    // TODO: add trimming implementation
-    co_return std::move(offsets);
+    auto& metadata_provider = get_link()->get_partition_metadata_provider();
+
+    chunked_vector<group_offsets> trimmed_offsets;
+    trimmed_offsets.reserve(offsets.size());
+
+    for (auto& g_offsets : offsets) {
+        group_offsets trimmed_g_offsets;
+        trimmed_g_offsets.group_id = std::move(g_offsets.group_id);
+        trimmed_g_offsets.topic_offsets.reserve(g_offsets.topic_offsets.size());
+        for (auto& t_offsets : g_offsets.topic_offsets) {
+            topic_offsets trimmed_t_offsets;
+            trimmed_t_offsets.topic = std::move(t_offsets.topic);
+            trimmed_t_offsets.partition_offsets.reserve(
+              t_offsets.partition_offsets.size());
+            for (auto& po : t_offsets.partition_offsets) {
+                auto maybe_hw
+                  = co_await metadata_provider.get_partition_high_watermark(
+                    ::model::topic_partition_view(
+                      trimmed_t_offsets.topic, po.partition));
+                vlog(
+                  logger().trace,
+                  "Offset trimming for group {}, partition: {}/{}, committed "
+                  "offset: {}, partition hwm: {}",
+                  trimmed_g_offsets.group_id,
+                  trimmed_t_offsets.topic,
+                  po.partition,
+                  po.committed_offset,
+                  maybe_hw);
+                if (!maybe_hw.has_value()) {
+                    vlog(
+                      logger().debug,
+                      "Group: {}, no high watermark for partition {}/{}, "
+                      "skipping offset commit",
+                      trimmed_g_offsets.group_id,
+                      trimmed_t_offsets.topic,
+                      po.partition);
+                    continue;
+                }
+                trimmed_t_offsets.partition_offsets.push_back(
+                  partition_committed_offset{
+                    .partition = po.partition,
+                    .committed_offset = std::min(
+                      *maybe_hw, po.committed_offset),
+                  });
+            }
+            if (!trimmed_t_offsets.partition_offsets.empty()) {
+                trimmed_g_offsets.topic_offsets.push_back(
+                  std::move(trimmed_t_offsets));
+            }
+        }
+        if (!trimmed_g_offsets.topic_offsets.empty()) {
+            trimmed_offsets.push_back(std::move(trimmed_g_offsets));
+        }
+    }
+
+    co_return std::move(trimmed_offsets);
 }
 
 ss::future<std::expected<

--- a/src/v/cluster_link/group_mirroring_task.cc
+++ b/src/v/cluster_link/group_mirroring_task.cc
@@ -375,8 +375,6 @@ void group_mirroring_task::handle_offset_commit_response(
 ss::future<chunked_vector<group_mirroring_task::group_offsets>>
 group_mirroring_task::trim_to_partition_highwatermark(
   chunked_vector<group_offsets> offsets) {
-    auto& metadata_provider = get_link()->get_partition_metadata_provider();
-
     chunked_vector<group_offsets> trimmed_offsets;
     trimmed_offsets.reserve(offsets.size());
 
@@ -390,10 +388,8 @@ group_mirroring_task::trim_to_partition_highwatermark(
             trimmed_t_offsets.partition_offsets.reserve(
               t_offsets.partition_offsets.size());
             for (auto& po : t_offsets.partition_offsets) {
-                auto maybe_hw
-                  = co_await metadata_provider.get_partition_high_watermark(
-                    ::model::topic_partition_view(
-                      trimmed_t_offsets.topic, po.partition));
+                auto maybe_hw = co_await get_partition_high_watermark(
+                  trimmed_t_offsets.topic, po.partition);
                 vlog(
                   logger().trace,
                   "Offset trimming for group {}, partition: {}/{}, committed "
@@ -432,7 +428,60 @@ group_mirroring_task::trim_to_partition_highwatermark(
 
     co_return std::move(trimmed_offsets);
 }
+ss::future<std::optional<kafka::offset>>
+group_mirroring_task::get_partition_high_watermark(
+  const ::model::topic& topic, ::model::partition_id p_id) {
+    auto& metadata_provider = get_link()->get_partition_metadata_provider();
+    auto hr_hwm = co_await metadata_provider.get_partition_high_watermark(
+      ::model::topic_partition_view(topic, p_id));
 
+    /**
+     * Check if the replica for partition is present on current node, if it is
+     * then query for its high watermark as it is most likely more up to date
+     * than the one from the health report.
+     */
+
+    auto& partition_manager = get_link()->partition_manager();
+    ::model::ktp ktp(topic, p_id);
+    auto owning_shard = partition_manager.shard_owner(
+      ktp); // ensure metadata is loaded
+    if (!owning_shard.has_value()) {
+        co_return hr_hwm;
+    }
+
+    if (owning_shard) {
+        vlog(
+          logger().trace,
+          "Fetching high watermark for partition {}/{} from replica on shard "
+          "{}",
+          topic,
+          p_id,
+          *owning_shard);
+        auto hw = co_await partition_manager.invoke_on_shard(
+          *owning_shard,
+          ktp,
+          [](kafka::partition_proxy* pp) {
+              return ssx::now<::result<::model::offset, cluster::errc>>(
+                pp->high_watermark());
+          },
+          kafka::data::rpc::require_leader::no);
+        if (hw) {
+            auto replica_hwm = ::model::offset_cast(hw.value());
+            if (hr_hwm) {
+                co_return std::max(replica_hwm, hr_hwm.value());
+            }
+            co_return replica_hwm;
+        }
+        vlog(
+          logger().info,
+          "Failed to get high watermark for partition {}/{} from replica - "
+          "{}",
+          topic,
+          p_id,
+          hw.error());
+    }
+    co_return hr_hwm;
+}
 ss::future<std::expected<
   chunked_vector<group_mirroring_task::group_offsets>,
   group_mirroring_task::error>>

--- a/src/v/cluster_link/group_mirroring_task.h
+++ b/src/v/cluster_link/group_mirroring_task.h
@@ -148,6 +148,9 @@ private:
     void make_unavailable(const error& err);
     void make_active();
 
+    ss::future<std::optional<kafka::offset>> get_partition_high_watermark(
+      const ::model::topic& topic, ::model::partition_id p_id);
+
     model::consumer_groups_mirroring_config _config;
     chunked_hash_map<kafka::group_id, group_metadata> _groups_to_mirror;
 

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -273,6 +273,10 @@ consumer_groups_router& link::get_group_router() {
     return _manager->get_group_router();
 }
 
+partition_metadata_provider& link::get_partition_metadata_provider() {
+    return _manager->get_partition_metadata_provider();
+}
+
 std::optional<chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
 link::get_mirror_topics_for_link() const {
     return _manager->get_mirror_topics_for_link(_link_id);

--- a/src/v/cluster_link/link.h
+++ b/src/v/cluster_link/link.h
@@ -103,6 +103,8 @@ public:
 
     consumer_groups_router& get_group_router();
 
+    partition_metadata_provider& get_partition_metadata_provider();
+
     std::optional<
       chunked_hash_map<::model::topic, model::mirror_topic_metadata>>
     get_mirror_topics_for_link() const;

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -81,6 +81,7 @@ manager::manager(
   std::unique_ptr<link_factory> link_factory,
   std::unique_ptr<cluster_factory> cluster_factory,
   std::unique_ptr<consumer_groups_router> group_router,
+  std::unique_ptr<partition_metadata_provider> partition_metadata_provider,
   ss::lowres_clock::duration task_reconciler_interval,
   config::binding<int16_t> default_topic_replication)
   : _self(self)
@@ -92,6 +93,7 @@ manager::manager(
   , _link_factory(std::move(link_factory))
   , _cluster_factory(std::move(cluster_factory))
   , _group_router(std::move(group_router))
+  , _partition_metadata_provider(std::move(partition_metadata_provider))
   , _queue(
       [](const std::exception_ptr& ex) {
           vlog(cllog.warn, "unexpected cluster link manager error: {}", ex);
@@ -524,5 +526,10 @@ ss::future<> manager::stop_topic_reconciler() {
 
 consumer_groups_router& manager::get_group_router() noexcept {
     return *_group_router;
+}
+
+partition_metadata_provider&
+manager::get_partition_metadata_provider() noexcept {
+    return *_partition_metadata_provider;
 }
 } // namespace cluster_link

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -47,6 +47,7 @@ public:
       std::unique_ptr<link_factory> link_factory,
       std::unique_ptr<cluster_factory> cluster_factory,
       std::unique_ptr<consumer_groups_router> group_router,
+      std::unique_ptr<partition_metadata_provider> partition_metadata_provider,
       ss::lowres_clock::duration task_reconciler_interval,
       config::binding<int16_t> default_topic_replication);
     manager(const manager&) = delete;
@@ -137,6 +138,8 @@ public:
 
     kafka::data::rpc::topic_creator& topic_creator() noexcept;
 
+    partition_metadata_provider& get_partition_metadata_provider() noexcept;
+
 private:
     /// Called periodically to reconcile registered tasks on created links
     ss::future<> link_task_reconciler();
@@ -156,6 +159,7 @@ private:
     std::unique_ptr<cluster_factory> _cluster_factory;
     std::unique_ptr<topic_reconciler> _topic_reconciler;
     std::unique_ptr<consumer_groups_router> _group_router;
+    std::unique_ptr<partition_metadata_provider> _partition_metadata_provider;
     ssx::work_queue _queue;
 
     chunked_vector<std::unique_ptr<task_factory>> _task_factories;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -12,6 +12,7 @@
 #include "cluster_link/service.h"
 
 #include "cluster/cluster_link/frontend.h"
+#include "cluster/health_monitor_frontend.h"
 #include "cluster/partition_manager.h"
 #include "cluster_link/group_mirroring_task.h"
 #include "cluster_link/link.h"
@@ -191,6 +192,28 @@ private:
     ss::sharded<kafka::group_router>* _router;
 };
 
+class health_monitor_based_partition_metadata_provider
+  : public partition_metadata_provider {
+public:
+    explicit health_monitor_based_partition_metadata_provider(
+      ss::sharded<cluster::health_monitor_frontend>* hm_frontend)
+      : _hm_frontend(hm_frontend) {}
+
+    ss::future<std::optional<kafka::offset>>
+    get_partition_high_watermark(::model::topic_partition_view tp) final {
+        auto hwm = co_await _hm_frontend->local().get_partition_high_watermark(
+          ::model::topic_namespace_view(::model::kafka_namespace, tp.topic),
+          tp.partition);
+        if (!hwm) {
+            vlog(cllog.warn, "Error getting high watermark for {}", tp);
+            co_return std::nullopt;
+        }
+        co_return hwm.value();
+    }
+
+    ss::sharded<cluster::health_monitor_frontend>* _hm_frontend;
+};
+
 service::service(
   ::model::node_id self,
   ss::sharded<frontend>* plf,
@@ -201,6 +224,7 @@ service::service(
   ss::sharded<cluster::metadata_cache>* metadata_cache,
   cluster::controller* controller,
   ss::sharded<kafka::group_router>* group_router,
+  ss::sharded<cluster::health_monitor_frontend>* hm_frontend,
   ss::smp_service_group smp_group)
   : _self(self)
   , _plf(plf)
@@ -211,6 +235,7 @@ service::service(
   , _metadata_cache(metadata_cache)
   , _controller(controller)
   , _group_router(group_router)
+  , _hm_frontend(hm_frontend)
   , _smp_group(smp_group) {}
 
 service::~service() = default;
@@ -228,6 +253,8 @@ ss::future<> service::start() {
       std::make_unique<default_link_factory>(_partition_manager),
       std::make_unique<cluster_factory>(),
       std::make_unique<kafka_consumer_groups_router>(_group_router),
+      std::make_unique<health_monitor_based_partition_metadata_provider>(
+        _hm_frontend),
       30s, // Temporary until we have a proper configuration for this
       config::shard_local_cfg().default_topic_replication.bind());
 

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -41,6 +41,7 @@ public:
       ss::sharded<cluster::metadata_cache>* metadata_cache,
       cluster::controller* controller,
       ss::sharded<kafka::group_router>* group_router,
+      ss::sharded<cluster::health_monitor_frontend>* hm_frontend,
       ss::smp_service_group smp_group);
 
     service(const service&) = delete;
@@ -89,6 +90,7 @@ private:
     ss::sharded<cluster::metadata_cache>* _metadata_cache;
     cluster::controller* _controller;
     ss::sharded<kafka::group_router>* _group_router;
+    ss::sharded<cluster::health_monitor_frontend>* _hm_frontend;
     ss::smp_service_group _smp_group;
     std::unique_ptr<manager> _manager;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -81,6 +81,11 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
           _consumer_group_router = router.get();
           return router;
       }),
+      ss::sharded_parameter([this]() {
+          auto provider = std::make_unique<test_partition_metadata_provider>();
+          _partition_metadata_provider = provider.get();
+          return provider;
+      }),
       1s,
       _default_topic_replication.bind());
 
@@ -241,4 +246,14 @@ test_consumer_group_router::offset_commit(kafka::offset_commit_request req) {
 
     co_return resp;
 }
+
+ss::future<std::optional<kafka::offset>>
+test_partition_metadata_provider::get_partition_high_watermark(
+  ::model::topic_partition_view tp) {
+    auto it = hwms.find(::model::topic_partition(tp));
+    if (it != hwms.end()) {
+        co_return it->second;
+    }
+    co_return std::nullopt;
+};
 } // namespace cluster_link::tests

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -193,7 +193,8 @@ public:
       ss::shard_id,
       const N&,
       ss::noncopyable_function<
-        ss::future<::result<R, cluster::errc>>(kafka::partition_proxy*)>) {
+        ss::future<::result<R, cluster::errc>>(kafka::partition_proxy*)>,
+      kafka::data::rpc::require_leader) {
         throw std::runtime_error("not implemented");
     }
 
@@ -225,18 +226,20 @@ public:
     ss::future<::result<::model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard_id,
       const ::model::ktp& ktp,
-      ss::noncopyable_function<
-        ss::future<::result<::model::offset, cluster::errc>>(
-          kafka::partition_proxy*)> fn) final {
-        return _impl->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+      ss::noncopyable_function<ss::future<
+        ::result<::model::offset, cluster::errc>>(kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader require_leader) final {
+        return _impl->invoke_on_shard_impl(
+          shard_id, ktp, std::move(fn), require_leader);
     }
     ss::future<::result<::model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard_id,
       const ::model::ntp& ntp,
-      ss::noncopyable_function<
-        ss::future<::result<::model::offset, cluster::errc>>(
-          kafka::partition_proxy*)> fn) final {
-        return _impl->invoke_on_shard_impl(shard_id, ntp, std::move(fn));
+      ss::noncopyable_function<ss::future<
+        ::result<::model::offset, cluster::errc>>(kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader require_leader) final {
+        return _impl->invoke_on_shard_impl(
+          shard_id, ntp, std::move(fn), require_leader);
     }
 
     ss::future<::result<kafka::data::rpc::partition_offsets, cluster::errc>>
@@ -245,8 +248,10 @@ public:
       const ::model::ktp& ktp,
       ss::noncopyable_function<ss::future<
         ::result<kafka::data::rpc::partition_offsets, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
-        return _impl->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+        kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader require_leader) final {
+        return _impl->invoke_on_shard_impl(
+          shard_id, ktp, std::move(fn), require_leader);
     }
 
 private:

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -406,6 +406,13 @@ struct test_consumer_group_router : public consumer_groups_router {
     int partition_count = 1;
 };
 
+struct test_partition_metadata_provider : public partition_metadata_provider {
+    ss::future<std::optional<kafka::offset>>
+      get_partition_high_watermark(::model::topic_partition_view) final;
+
+    chunked_hash_map<::model::topic_partition, kafka::offset> hwms;
+};
+
 class cluster_link_manager_test_fixture {
 public:
     explicit cluster_link_manager_test_fixture(::model::node_id self);
@@ -474,6 +481,10 @@ public:
         return _consumer_group_router;
     }
 
+    test_partition_metadata_provider* partition_metadata_provider() {
+        return _partition_metadata_provider;
+    }
+
     ss::future<bool> wait_for_report_to_match(
       ss::lowres_clock::duration timeout,
       ss::lowres_clock::duration backoff,
@@ -496,6 +507,7 @@ private:
     kafka::data::rpc::test::fake_topic_creator* _ftpc{nullptr};
     link_factory* _lf{nullptr};
     test_consumer_group_router* _consumer_group_router{nullptr};
+    test_partition_metadata_provider* _partition_metadata_provider{nullptr};
     ss::sharded<manager> _manager;
     config::mock_property<int16_t> _default_topic_replication{1};
 

--- a/src/v/cluster_link/tests/group_mirroring_task_test.cc
+++ b/src/v/cluster_link/tests/group_mirroring_task_test.cc
@@ -246,6 +246,20 @@ public:
         }
     }
 
+    void set_source_cluster_high_watermark(
+      std::unordered_map<ss::sstring, std::unordered_map<int, int64_t>>
+        offsets) {
+        auto p_md = fixture()->partition_metadata_provider();
+
+        for (auto& [topic, partitions] : offsets) {
+            for (auto& [p, offset] : partitions) {
+                p_md->hwms[::model::topic_partition(
+                  ::model::topic(topic), ::model::partition_id(p))]
+                  = kafka::offset(offset);
+            }
+        }
+    }
+
     ss::future<kafka::client::response_t> handle_list_groups_request(
       ::model::node_id id, kafka::client::request_t, kafka::api_version) {
         kafka::list_groups_response resp{};
@@ -380,6 +394,8 @@ TEST_F(group_mirroring_task_test, test_happy_path_offsets_mirroring) {
 
     set_source_cluster_group_offsets(
       test_group, {{"t-topic", {{0, 100}, {4, 312}}}});
+    set_source_cluster_high_watermark(
+      {{"t-topic", {{0, 1000}, {1, 1000}, {4, 1000}}}});
     /**
      * Verify if offset is mirrored
      */
@@ -406,6 +422,8 @@ TEST_F(group_mirroring_task_test, test_updating_source_cluster_coordinator) {
     metadata.group_id = test_group;
     metadata.coordinator_id = ::model::node_id(0);
     source_cluster_group[test_group] = std::move(metadata);
+    set_source_cluster_high_watermark(
+      {{"t-topic", {{0, 1000}, {1, 1000}, {4, 1025}, {12, 1000}}}});
 
     set_source_cluster_group_offsets(
       test_group, {{"t-topic", {{0, 100}, {4, 312}}}});
@@ -423,6 +441,47 @@ TEST_F(group_mirroring_task_test, test_updating_source_cluster_coordinator) {
      */
     wait_for_mirrored_offsets(
       test_group, {{"t-topic", {{0, 100}, {4, 1024}, {12, 10}}}})
+      .get();
+}
+
+TEST_F(group_mirroring_task_test, test_offsets_trimming_to_hwm) {
+    make_current_node_leader_for({0, 1, 2, 3});
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    bool is_active = wait_for_task_state(model::task_state::active).get();
+    ASSERT_TRUE(is_active);
+
+    // set consumer group offsets
+    kafka::group_id test_group("t-group");
+
+    consumer_group_metadata metadata;
+    metadata.group_id = test_group;
+    metadata.coordinator_id = ::model::node_id(0);
+    source_cluster_group[test_group] = std::move(metadata);
+
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 100}, {4, 312}}}});
+    set_source_cluster_high_watermark({{"t-topic", {{0, 80}}}});
+    /**
+     * Verify if offset is mirrored
+     */
+    wait_for_mirrored_offsets(test_group, {{"t-topic", {{0, 80}}}}).get();
+    // check that even after waiting for it, the offset for partition 0 is still
+    // below the high watermark
+    ASSERT_THROW(
+      wait_for_mirrored_offsets(test_group, {{"t-topic", {{0, 81}}}}).get(),
+      ss::timed_out_error);
+
+    auto& groups = fixture()->consumer_group_router()->groups;
+    auto it = groups.find(test_group);
+    // check that only one partition is present, there is no hwm for partition 4
+    // yet
+    ASSERT_EQ(it->second.offsets[::model::topic("t-topic")].size(), 1);
+
+    // update hwms
+    set_source_cluster_high_watermark({{"t-topic", {{0, 82}, {4, 500}}}});
+
+    wait_for_mirrored_offsets(test_group, {{"t-topic", {{0, 82}, {4, 312}}}})
       .get();
 }
 

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -185,6 +185,7 @@ public:
           std::make_unique<link_test_factory>(this, 1s),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
           std::make_unique<test_consumer_group_router>(),
+          std::make_unique<test_partition_metadata_provider>(),
           task_reconciler_interval,
           _default_topic_replication.bind());
     }
@@ -420,6 +421,7 @@ public:
           std::move(elf),
           std::make_unique<cluster_mock_factory>(&_cluster_mock),
           std::make_unique<test_consumer_group_router>(),
+          std::make_unique<test_partition_metadata_provider>(),
           task_reconciler_interval,
           _default_topic_replication.bind());
         co_await _manager->start();

--- a/src/v/kafka/data/rpc/deps.cc
+++ b/src/v/kafka/data/rpc/deps.cc
@@ -88,25 +88,30 @@ public:
       ss::shard_id shard,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
-        return _proxy->invoke_on_shard_impl(shard, ktp, std::move(fn));
+        kafka::partition_proxy*)> fn,
+      require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard, ktp, std::move(fn), require_leader);
     }
 
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard,
       const model::ntp& ntp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
-        return _proxy->invoke_on_shard_impl(shard, ntp, std::move(fn));
+        kafka::partition_proxy*)> fn,
+      require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard, ntp, std::move(fn), require_leader);
     }
 
     ss::future<result<partition_offsets, cluster::errc>> get_offsets_from_shard(
       ss::shard_id shard_id,
       const model::ktp& ktp,
-      ss::noncopyable_function<
-        ss::future<result<partition_offsets, cluster::errc>>(
-          kafka::partition_proxy*)> fn) final {
-        return _proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+      ss::noncopyable_function<ss::future<
+        result<partition_offsets, cluster::errc>>(kafka::partition_proxy*)> fn,
+      require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard_id, ktp, std::move(fn), require_leader);
     }
 
 private:

--- a/src/v/kafka/data/rpc/deps.h
+++ b/src/v/kafka/data/rpc/deps.h
@@ -125,6 +125,7 @@ public:
       update_topic(cluster::topic_properties_update) = 0;
 };
 
+using require_leader = ss::bool_class<struct on_leader_only_tag>;
 /**
  * Handles routing for shard local partitions.
  */
@@ -158,13 +159,15 @@ public:
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn)
+        kafka::partition_proxy*)>,
+      require_leader req_leader = require_leader::yes)
       = 0;
     virtual ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id,
       const model::ntp&,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)>)
+        kafka::partition_proxy*)>,
+      require_leader req_leader = require_leader::yes)
       = 0;
 
     virtual ss::future<result<partition_offsets, cluster::errc>>
@@ -172,7 +175,8 @@ public:
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<
-        result<partition_offsets, cluster::errc>>(kafka::partition_proxy*)>)
+        result<partition_offsets, cluster::errc>>(kafka::partition_proxy*)>,
+      require_leader req_leader = require_leader::yes)
       = 0;
 };
 
@@ -194,13 +198,18 @@ public:
       ss::shard_id shard,
       const NTP& ntp,
       ss::noncopyable_function<
-        ss::future<result<R, cluster::errc>>(kafka::partition_proxy*)> func) {
+        ss::future<result<R, cluster::errc>>(kafka::partition_proxy*)> func,
+      require_leader req_leader = require_leader::yes) {
         return invoke_func_on_shard_impl(
           shard,
-          [ntp,
-           func = std::move(func)](cluster::partition_manager& mgr) mutable {
+          [ntp, func = std::move(func), req_leader](
+            cluster::partition_manager& mgr) mutable {
               auto pp = kafka::make_partition_proxy(ntp, mgr);
-              if (!pp || !pp->is_leader()) {
+              if (!pp) {
+                  return ss::make_ready_future<result<R, cluster::errc>>(
+                    cluster::errc::not_leader);
+              }
+              if (req_leader && !pp->is_leader()) {
                   return ss::make_ready_future<result<R, cluster::errc>>(
                     cluster::errc::not_leader);
               }

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -430,7 +430,8 @@ public:
       ss::shard_id shard_id,
       const N& ntp,
       ss::noncopyable_function<
-        ss::future<result<R, cluster::errc>>(kafka::partition_proxy*)> fn) {
+        ss::future<result<R, cluster::errc>>(kafka::partition_proxy*)> fn,
+      require_leader = require_leader::yes) {
         auto owner = shard_owner(ntp);
         if (!owner || shard_id != *owner) {
             co_return cluster::errc::not_leader;
@@ -478,23 +479,25 @@ public:
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
+        kafka::partition_proxy*)> fn,
+      require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
     }
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard_id,
       const model::ntp& ntp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
+        kafka::partition_proxy*)> fn,
+      require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ntp, std::move(fn));
     }
 
     ss::future<result<partition_offsets, cluster::errc>> get_offsets_from_shard(
       ss::shard_id shard_id,
       const model::ktp& ktp,
-      ss::noncopyable_function<
-        ss::future<result<partition_offsets, cluster::errc>>(
-          kafka::partition_proxy*)> fn) final {
+      ss::noncopyable_function<ss::future<
+        result<partition_offsets, cluster::errc>>(kafka::partition_proxy*)> fn,
+      require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1532,6 +1532,7 @@ void application::wire_up_runtime_services(
       &metadata_cache,
       controller.get(),
       &group_router,
+      &controller->get_health_monitor(),
       smp_service_groups.cluster_link_smp_sg())
       .get();
 

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -56,8 +56,10 @@ public:
       ss::shard_id shard,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
-        return _proxy->invoke_on_shard_impl(shard, ktp, std::move(fn));
+        kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard, ktp, std::move(fn), require_leader);
     }
 
     ss::future<result<kafka::data::rpc::partition_offsets, cluster::errc>>
@@ -66,16 +68,20 @@ public:
       const model::ktp& ktp,
       ss::noncopyable_function<
         ss::future<result<kafka::data::rpc::partition_offsets, cluster::errc>>(
-          kafka::partition_proxy*)> fn) final {
-        return _proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+          kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard_id, ktp, std::move(fn), require_leader);
     }
 
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard,
       const model::ntp& ntp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
-        return _proxy->invoke_on_shard_impl(shard, ntp, std::move(fn));
+        kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader require_leader) final {
+        return _proxy->invoke_on_shard_impl(
+          shard, ntp, std::move(fn), require_leader);
     }
 
     ss::future<result<model::wasm_binary_iobuf, cluster::errc>> invoke_on_shard(

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -98,13 +98,17 @@ public:
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) override
+        kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader
+      = kafka::data::rpc::require_leader::yes) override
       = 0;
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id,
       const model::ntp&,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)>) override
+        kafka::partition_proxy*)>,
+      kafka::data::rpc::require_leader
+      = kafka::data::rpc::require_leader::yes) override
       = 0;
 
     ss::future<result<kafka::data::rpc::partition_offsets, cluster::errc>>
@@ -113,7 +117,9 @@ public:
       const model::ktp& ktp,
       ss::noncopyable_function<
         ss::future<result<kafka::data::rpc::partition_offsets, cluster::errc>>(
-          kafka::partition_proxy*)>) override
+          kafka::partition_proxy*)>,
+      kafka::data::rpc::require_leader
+      = kafka::data::rpc::require_leader::yes) override
       = 0;
 
     virtual ss::future<result<model::wasm_binary_iobuf, cluster::errc>>

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -185,14 +185,16 @@ public:
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
+        kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
     }
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard_id,
       const model::ntp& ntp,
       ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
+        kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ntp, std::move(fn));
     }
 
@@ -202,7 +204,8 @@ public:
       const model::ktp& ktp,
       ss::noncopyable_function<
         ss::future<result<kafka::data::rpc::partition_offsets, cluster::errc>>(
-          kafka::partition_proxy*)> fn) final {
+          kafka::partition_proxy*)> fn,
+      kafka::data::rpc::require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
     }
 


### PR DESCRIPTION
Consumer group mirroring task replicates committed offsets from source cluster consumer groups to target one. Consumer offsets mirroring is not synchronised with partition data mirroring therefore it may happen that the offset committed while replicating consumer group is greater than partition high watermark. If it is allowed then the consumer will receive offset of range errors and will be force to rewind their fetch offsets.

This PR introduces eager committed offsets trimming. The trimming is a simple operation that clamps the offset to be committed with current partition high watermark. 

The high watermark is currently queried from the health report.

### Optimisation

If partition replica is colocated with the task that executes the consumer group mirroring it is relatively cheap to query the partition replica directly and retrieve the high watermark. The high watermark queried directly from the partition has a high change of possibility to be more up to date than the one coming from the health report.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none