### PR TITLE
tests: use mirrored deps for test image

### DIFF
--- a/tests/docker/ducktape-deps/kafka-tools
+++ b/tests/docker/ducktape-deps/kafka-tools
@@ -7,7 +7,7 @@ for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0" "3.8.0" "3.9.0"; do
   odir=/opt/kafka-${ver}
   mkdir -p "$odir"
   chmod a+rw "$odir"
-  DL_STRIP=1 download_extract "https://archive.apache.org/dist/kafka/${ver}/kafka_2.12-${ver}.tgz" "$odir"
+  DL_STRIP=1 download_extract "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/kafka_2.12-${ver}.tgz" "$odir"
 done
 ln -s /opt/kafka-3.9.0/ /opt/kafka-dev
 


### PR DESCRIPTION
Some archive.apache.org dependencies often experience performance issues leading to slow downloads. Now that https://github.com/redpanda-data/vtools/pull/3887 mirrored the dependencies, the test image should use these ones to not depend on the upstream

jira: [DEVPROD-3332]

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [X] v24.3.x

## Release Notes

* none


[DEVPROD-3332]: https://redpandadata.atlassian.net/browse/DEVPROD-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ