### PR TITLE
ducktape: Add more detailed net tuner test

### DIFF
--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -57,7 +57,7 @@ class RpkRemoteTool:
         return self._execute([self._rpk_binary(), "cluster", "config", "lint"])
 
     def tune(self, tuner):
-        return self._execute([self._rpk_binary(), "redpanda", "tune", tuner])
+        return self._execute([self._rpk_binary(), "redpanda", "tune", tuner, "-v"])
 
     def mode_set(self, mode):
         return self._execute([self._rpk_binary(), "redpanda", "mode", mode])

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -21,7 +21,14 @@ class RpkRemoteTool:
         self._redpanda = redpanda
         self._node = node
 
-    def config_set(self, key, value, format=None, path=None, timeout=30):
+    def config_set(
+        self,
+        key: str,
+        value: str,
+        format: str | None = None,
+        path: str | None = None,
+        timeout: int = 30,
+    ) -> str:
         cmd = [
             "set",
             f"'{key}'",
@@ -56,7 +63,7 @@ class RpkRemoteTool:
     def cluster_config_lint(self):
         return self._execute([self._rpk_binary(), "cluster", "config", "lint"])
 
-    def tune(self, tuner):
+    def tune(self, tuner: str) -> str:
         return self._execute([self._rpk_binary(), "redpanda", "tune", tuner, "-v"])
 
     def mode_set(self, mode):

--- a/tests/rptest/tuner_integration_tests/__init__.py
+++ b/tests/rptest/tuner_integration_tests/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from ducktape.tests.test import TestContext
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk_remote import RpkRemoteTool
+
+
+class NetTunerTest(RedpandaTest):
+    def __init__(self, ctx: TestContext):
+        super().__init__(test_context=ctx)
+
+    @staticmethod
+    def parse_matching_interrupt_num_from_interrupt_file(
+        interrupt_file: str, matcher: str
+    ) -> list[int]:
+        ret: list[int] = []
+        for line in interrupt_file.split("\n"):
+            if matcher in line:
+                ret.append(int(line.split(":")[0]))
+
+        return ret
+
+    @cluster(num_nodes=1)
+    def test_tune_net(self):
+        # TODO: generalize, only works on 4 core AWS for now.
+
+        node = self.redpanda.nodes[0]
+        rpk = RpkRemoteTool(self.redpanda, node)
+        rpk.config_set("rpk.tune_network", "true")
+
+        rpk.tune("net")
+
+        # test irqbalance
+        irqbalance_output = node.account.ssh_output(
+            "systemctl status irqbalance"
+        ).decode("utf-8")
+        assert "--banirq" in irqbalance_output, (
+            f"irqbalance is not configured correctly, got {irqbalance_output}"
+        )
+
+        # test interrupts
+        interrupts_file = node.account.ssh_output("cat /proc/interrupts").decode(
+            "utf-8"
+        )
+        interrupt_ids = self.parse_matching_interrupt_num_from_interrupt_file(
+            interrupts_file, "ens5"
+        )
+        target_mq_setup = (
+            node.account.ssh_output(
+                "/opt/redpanda/bin/hwloc-distrib-redpanda 4 --single --restrict 0xf"
+            )
+            .decode("utf-8")
+            .strip()
+        )
+
+        for interrupt_id, target_mask in zip(interrupt_ids, target_mq_setup.split()):
+            cpu_affinity = (
+                node.account.ssh_output(f"cat /proc/irq/{interrupt_id}/smp_affinity")
+                .decode("utf-8")
+                .strip()
+            )
+            assert int(cpu_affinity, 16) == int(target_mask, 16), (
+                f"IRQ {interrupt_id} smp_affinity is not set correctly, got {cpu_affinity} expected {target_mask}"
+            )
+
+        # test RPS
+        for i in range(4):
+            rps_cpu = (
+                node.account.ssh_output(
+                    f"cat /sys/class/net/ens5/queues/rx-{i}/rps_cpus"
+                )
+                .decode("utf-8")
+                .strip()
+            )
+            assert rps_cpu == "f", (
+                f"rps_cpus for queue {i} is not set correctly, got {rps_cpu}"
+            )
+
+        # test RFS
+        targetRFSTableSize = 32768
+
+        total_rps_sock_flow_entries = int(
+            node.account.ssh_output("cat /proc/sys/net/core/rps_sock_flow_entries")
+            .decode("utf-8")
+            .strip()
+        )
+        assert total_rps_sock_flow_entries == targetRFSTableSize, (
+            f"rps_sock_flow_entries is not set correctly, got {total_rps_sock_flow_entries}"
+        )
+
+        for i in range(4):
+            rps_sock_flow_entries = int(
+                node.account.ssh_output(
+                    f"cat /sys/class/net/ens5/queues/rx-{i}/rps_flow_cnt"
+                )
+                .decode("utf-8")
+                .strip()
+            )
+            assert rps_sock_flow_entries / 4, (
+                f"rps_flow_cnt for queue {i} is not set correctly, got {rps_sock_flow_entries}"
+            )


### PR DESCRIPTION
While we do have some CDT tuner tests they only test very basic stuff
and mostly effectively just whether the tuner runs without failing.

Given various auto-detection logic in the tuner this is often not good
enough as the tuner might silently do nothing.

In this PR we add a new test for the net tuner which tests the expected
changes in more detail.

For now it's not very generic and only works on a AWS 4-core machine. In
a later patch I will make this more generic and/or verify it's running
on the expected hardware.

The test is not part of any suite. Later we will add a separate suite
and CI pipeline for this as well.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
