### PR TITLE
utils/uuid: have default initialization for uuid_t

### DIFF
--- a/src/v/utils/uuid.h
+++ b/src/v/utils/uuid.h
@@ -46,7 +46,7 @@ public:
     friend bool operator==(const uuid_t& u, const uuid_t& v) = default;
     friend std::strong_ordering operator<=>(const uuid_t& u, const uuid_t& v);
 
-    operator ss::sstring() const;
+    operator ss::sstring() const; // NOLINT(*explicit*)
 
     template<typename H>
     friend H AbslHashValue(H h, const uuid_t& u) {
@@ -64,7 +64,7 @@ private:
     explicit uuid_t(const underlying_t& uuid)
       : _uuid(uuid) {}
 
-    underlying_t _uuid;
+    underlying_t _uuid{};
 };
 
 bool operator<(const uuid_t& l, const uuid_t& r);


### PR DESCRIPTION
See: https://github.com/redpanda-data/redpanda/pull/27483#discussion_r2334383384

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
