### PR TITLE
Adding retry for topic describe

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -1454,11 +1454,26 @@ class ManyTopicsTest(RedpandaTest):
 
         # Topic hwm getter
         def _get_hwm(topic):
-            _hwm = 0
-            for partition in self.rpk.describe_topic(topic):
-                # Add currect high watermark for topic
-                _hwm += partition.high_watermark
-            return _hwm
+            max_retries = 3
+            delay = 5
+            for attempt in range(1, max_retries + 1):
+                try:
+                    _hwm = 0
+                    for partition in self.rpk.describe_topic(topic):
+                        # Add currect high watermark for topic
+                        _hwm += partition.high_watermark
+                    return _hwm
+                except Exception as e:
+                    self.logger.debug(
+                        f"describe_topic failed for {topic} on attempt {attempt}: {e}"
+                    )
+                    if attempt < max_retries:
+                        time.sleep(delay)
+                    else:
+                        self.logger.error(
+                            f"Giving up on topic {topic} after {max_retries} attempts due to: {e}"
+                        )
+                        return 0
 
         # Validate high watermark
         target_messages_per_node = profile.message_count * pnode_client_count


### PR DESCRIPTION
#DEVPROD-2432
Adding retry for topic describe and adding more logs

@ballard26 As we discussed, adding a retry on topic describe and some more logs to see why we get -11 error

## Backports Required
- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none


### Improvements
This might show more details on why we get error code -11 on long prk command