### PR TITLE
rptest: add a pyrefly configuration file

### DIFF
--- a/tests/pyrefly.toml
+++ b/tests/pyrefly.toml
@@ -1,0 +1,13 @@
+# A typechecker and LSP from Meta written in Rust and very fast.
+# Docs: https://pyrefly.org/
+# It's still alpha, but I'm giving it a go and finding it quite capable so far
+# We should switch to a pyproject.yaml file and then we can embed these settings
+# into there... Our settings are the defaults, but we add `typings` to our search
+# path to pick up our ducktape typings.
+project-includes = ["**/*"]
+project-excludes = [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/*venv/**/*",
+]
+search-path = ["./typings"]


### PR DESCRIPTION
I'm giving https://pyrefly.org/blog/introducing-pyrefly/ a go, it seems
pretty good so far (way better than basedpyright which is what I was
using for LSP), and very fast. We should eventually convert this into a
pyproject.toml file, but for now just using a pyrefly.toml directly.

NOTE: I did give `ty` from astral a go, and it's not nearly as far a
long interms of an LSP server compared to pyrefly, although I generally
do like the tooling the astral team puts out.

Fun reading for the curious: https://blog.edward-li.com/tech/comparing-pyrefly-vs-ty/

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
