### PR TITLE
Fixed missing notification in cluster linking subsystem

### DIFF
--- a/src/v/cluster/utils/partition_change_notifier.h
+++ b/src/v/cluster/utils/partition_change_notifier.h
@@ -24,6 +24,8 @@ namespace cluster {
 // Supports notifications for partitions with replicas on the current shard.
 class partition_change_notifier {
 public:
+    using notify_current_state
+      = ss::bool_class<struct notify_current_state_tag>;
     enum class notification_type : int8_t {
         // Notification for leadership change of a partition.
         // Notified on assuming leadership or losing leadership.
@@ -68,8 +70,8 @@ public:
 
     virtual ~partition_change_notifier() = default;
 
-    virtual notification_id_type
-      register_partition_notifications(notification_cb_t)
+    virtual notification_id_type register_partition_notifications(
+      notification_cb_t, notify_current_state = notify_current_state::no)
       = 0;
 
     virtual void unregister_partition_notifications(notification_id_type) = 0;

--- a/src/v/cluster/utils/partition_change_notifier_impl.cc
+++ b/src/v/cluster/utils/partition_change_notifier_impl.cc
@@ -49,7 +49,7 @@ void partition_change_notifier_impl::do_notify_call_back(
 
 notification_id_type
 partition_change_notifier_impl::register_partition_notifications(
-  notification_cb_t cb) {
+  notification_cb_t cb, notify_current_state notify_current) {
     notification_state nstate;
     auto id = _notification_id++;
     auto exceptional_cleanup = ss::defer(
@@ -134,6 +134,22 @@ partition_change_notifier_impl::register_partition_notifications(
       });
     exceptional_cleanup.cancel();
     nstate.cb = std::move(cb);
+    if (notify_current) {
+        // notify about all current partitions
+        for (const auto& partition :
+             _partition_mgr.local().partitions() | std::views::values) {
+            partition_state state{
+              partition->term(),
+              partition->is_leader(),
+              _topic_table.local().get_topic_cfg(
+                model::topic_namespace_view{partition->ntp()})};
+
+            nstate.cb(
+              notification_type::partition_replica_assigned,
+              partition->ntp(),
+              std::move(state));
+        }
+    }
     _notification_ids.emplace(id, std::move(nstate));
     return id;
 }

--- a/src/v/cluster/utils/partition_change_notifier_impl.h
+++ b/src/v/cluster/utils/partition_change_notifier_impl.h
@@ -27,8 +27,8 @@ public:
       ss::sharded<cluster::partition_manager>&,
       ss::sharded<cluster::topic_table>&);
 
-    notification_id_type
-      register_partition_notifications(notification_cb_t) final;
+    notification_id_type register_partition_notifications(
+      notification_cb_t, notify_current_state) final;
 
     void unregister_partition_notifications(notification_id_type) final;
 

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -291,7 +291,8 @@ void service::register_notifications() {
                 // TODO: once we have partition properties
                 break;
             }
-        });
+        },
+        cluster::partition_change_notifier::notify_current_state::yes);
     _notification_cleanups.emplace_back([this, partition_notifications_id] {
         _notifications->unregister_partition_notifications(
           partition_notifications_id);

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -244,3 +244,45 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         assert target_cluster_group.state == "Empty", (
             "Group test_group state expected to be empty on target cluster"
         )
+
+    @cluster(num_nodes=6)
+    def test_topic_creation_in_target_cluster(self):
+        topics = []
+        for i in range(10):
+            cleanup_policy = "delete" if i % 2 == 0 else "compact"
+            topic = TopicSpec(
+                name=f"source-topic-{i}",
+                partition_count=i + 3,
+                replication_factor=3,
+                cleanup_policy=cleanup_policy,
+            )
+            self.source_default_client().create_topic(topic)
+            topics.append(topic)
+
+        self.create_link("test-link")
+
+        def _topics_are_present_in_target_cluster():
+            target_rpk = RpkTool(self.target_cluster.service)
+            topics_in_target = {t for t in target_rpk.list_topics()}
+            self.logger.info(f"Topics in target cluster: {topics_in_target}")
+            if len(topics_in_target) < len(topics):
+                return False
+            for t in topics:
+                if t.name not in topics_in_target:
+                    return False
+
+            return True
+
+        wait_until(
+            lambda: _topics_are_present_in_target_cluster(),
+            timeout_sec=20,
+            err_msg="Failed to find topics in the target cluster",
+        )
+        target_rpk = RpkTool(self.target_cluster.service)
+        for t in topics:
+            target_configs = target_rpk.describe_topic_configs(t.name)
+            self.logger.info(f"Target topic {t.name} configs: {target_configs}")
+            assert target_configs["cleanup.policy"][0] == t.cleanup_policy, (
+                f"Expected cleanup policy {t.cleanup_policy} for topic {t.name}, "
+                f"got {target_configs['cleanup.policy']}"
+            )


### PR DESCRIPTION
When controller leadership notification was missed the topic reconciler failed to start leading to situation in which topics were not created in the target cluster.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none