### PR TITLE
tests: use mirrored spark dep for test image

### DIFF
--- a/tests/docker/ducktape-deps/spark
+++ b/tests/docker/ducktape-deps/spark
@@ -5,9 +5,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/download-utils" # import download-utils
 
 mkdir /opt/spark
 
-SPARK_VERSION=3.5.4
+SPARK_VERSION=3.5.6
 SPARK_FILE=spark-$SPARK_VERSION-bin-hadoop3.tgz
-SPARK_URL=https://archive.apache.org/dist/spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop3.tgz
+SPARK_URL=https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/spark-$SPARK_VERSION-bin-hadoop3.tgz
 
 DL_STRIP=1 download_extract ${SPARK_URL} /opt/spark
 


### PR DESCRIPTION
Follow-up for #27488

Some archive.apache.org dependencies often experience performance issues leading to slow downloads. Now that redpanda-data/vtools#3890 mirrored the spark dependency, the test image should use that to not depend on the upstream.

jira: [DEVPROD-3332]

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [X] v24.3.x

## Release Notes

* none



[DEVPROD-3332]: https://redpandadata.atlassian.net/browse/DEVPROD-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ