### PR TITLE
[v25.1.x] tests: use mirrored deps for test image

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN /java-verifiers && \
 
 FROM base AS kafka-tools
 
-ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
+ENV KAFKA_MIRROR="https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies"
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/kafka-tools /
 RUN /kafka-tools && \
     rm /kafka-tools


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27488

jira: [DEVPROD-3332]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x


[DEVPROD-3332]: https://redpandadata.atlassian.net/browse/DEVPROD-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ