### PR TITLE
kafka/server: only disable strict max bytes for obligatory batch reads

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -578,16 +578,22 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
             ntp_cfg.cfg.skip_read = true;
         }
 
+        // In Kafka first non-empty partition in a request or session
+        // is considered the `obligatory` batch read.
+        const bool obligatory_batch_read = total_read_size == 0;
+
+        // If it's the obligatory batch read then we need to allow for the
+        // configured max bytes to exceeded if the next batch in the partition
+        // is larger. This is needed to conform with KIP-74.
+        ntp_cfg.cfg.strict_max_bytes = !obligatory_batch_read;
+
         auto&& res = co_await do_read_from_ntp(
           cluster_pm,
           replica_selector,
           ntp_cfg,
           foreign_read,
           deadline,
-          // In Kafka first non-empty partition in a request or session
-          // is considered the `obligatory` batch read. The logic below
-          // is designed to approximate this behavior.
-          total_read_size == 0,
+          obligatory_batch_read,
           memory_sem,
           memory_fetch_sem);
 
@@ -1446,7 +1452,7 @@ class simple_fetch_planner final : public fetch_planner::impl {
                       .timeout = octx.deadline.value_or(model::no_timeout),
                       .current_leader_epoch = fp.current_leader_epoch,
                       .isolation_level = octx.request.data.isolation_level,
-                      .strict_max_bytes = octx.response_size > 0,
+                      .strict_max_bytes = true,
                       .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
                       .read_from_follower = octx.request.has_rack_id(),
                       .consumer_rack_id = octx.request.has_rack_id()


### PR DESCRIPTION
Prior to this PR all partitions in the initial call to `fetch_ntps` were allowed to exceed the max bytes configured in the log reader if it was needed to read a single batch. Beyond not being required by the Kafka protocol this also results in memory safety concerns. The fetch path only reserves memory up to the configured max bytes. So every byte read beyond that limit increases the likelihood of an OOM.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
