### PR TITLE
rptest: remove RedpandaServiceBase

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -17,11 +17,9 @@ from typing import Optional, Any
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.cluster.node_container import NodeContainer
 
 from rptest.services.redpanda import (
     RedpandaService,
-    RedpandaServiceBase,
     RedpandaServiceCloud,
 )
 from rptest.services.utils import BadLogLines

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -30,7 +30,7 @@ import uuid
 import zipfile
 import pathlib
 import shlex
-from enum import Enum, IntEnum
+from enum import Enum
 from typing import (
     Callable,
     List,
@@ -61,11 +61,8 @@ from ducktape.cluster.cluster import ClusterNode
 from prometheus_client.parser import text_string_to_metric_families
 from prometheus_client.metrics_core import Metric
 from ducktape.errors import TimeoutError
-from ducktape.tests.test import TestContext
 from rptest.context.gcp import GCPContext
-from rptest.services.rpk_consumer import RpkConsumer
 
-from rptest.clients.helm import HelmTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kubectl import KubectlTool, is_redpanda_pod
 from rptest.clients.rpk import RpkTool
@@ -149,7 +146,7 @@ SaslCredentials = redpanda_types.SaslCredentials
 FileToChecksumSize = dict[str, Tuple[str, int]]
 
 # Map of node -> (path -> (arbitrary dictionary))
-NodeConfigOverridesT = dict[ClusterNode, dict]
+NodeConfigOverridesT = dict[ClusterNode, dict[str, Any]]
 
 # The endpoint info for the azurite (Azure ABS emulator )container that
 # is used when running tests in a docker environment.
@@ -216,7 +213,7 @@ CHAOS_LOG_ALLOW_LIST = [
     re.compile("cluster - .*Directory not empty"),
     re.compile("r/heartbeat - .*cannot find consensus group"),
     re.compile(
-        "cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
+        r"cluster - .*exception while executing partition operation:.*std::exception \(std::exception\)"
     ),
     # Failure to handle an internal RPC because the RPC server already handles connections but doesn't yet handle this method. This can happen while the node is still starting up/restarting.
     # e.g. "admin_api_server - server.cc:655 - [_anonymous] exception intercepted - url: [http://ip-172-31-9-208:9644/v1/brokers/7/decommission] http_return_status[500] reason - seastar::httpd::server_error_exception (Unexpected error: rpc::errc::method_not_found)"
@@ -291,7 +288,7 @@ class MetricSamples:
         self.samples = samples
 
     def label_filter(self, labels: Mapping[str, str]):
-        def f(sample):
+        def f(sample: MetricSample):
             for key, value in labels.items():
                 assert key in sample.labels
                 return sample.labels[key] == value
@@ -336,8 +333,9 @@ def get_cloud_provider() -> str:
 
 
 def get_cloud_storage_type(
-    applies_only_on: list[CloudStorageType] | None = None, docker_use_arbitrary=False
-):
+    applies_only_on: list[CloudStorageType] | None = None,
+    docker_use_arbitrary: bool = False,
+) -> list[CloudStorageType]:
     """
     Returns a list[CloudStorageType] based on the "CLOUD_PROVIDER"
     environment variable. For example:
@@ -396,10 +394,14 @@ def get_cloud_storage_type_and_url_style() -> List[CloudStorageTypeAndUrlStyle]:
                   [CloudStorageType.S3, 'path'],
                   [CloudStorageType.ABS, 'virtual_host']]
     """
+
+    def get_style(t: CloudStorageType) -> List[CloudStorageTypeAndUrlStyle]:
+        return [(t, us) for us in get_cloud_storage_url_style(t)]
+
     return [
         tus
         for tus_list in map(
-            lambda t: [[t, us] for us in get_cloud_storage_url_style(t)],
+            get_style,
             get_cloud_storage_type(),
         )
         for tus in tus_list
@@ -547,7 +549,7 @@ class SISettings:
 
     def __init__(
         self,
-        test_context,
+        test_context: TestContext,
         *,
         log_segment_size: int = 16 * 1000000,
         cloud_storage_cache_chunk_size: Optional[int] = None,
@@ -571,8 +573,8 @@ class SISettings:
         use_bucket_cleanup_policy: bool = True,
         cloud_storage_housekeeping_interval_ms: Optional[int] = None,
         cloud_storage_spillover_manifest_max_segments: Optional[int] = None,
-        fast_uploads=False,
-        retention_local_strict=True,
+        fast_uploads: bool = False,
+        retention_local_strict: bool = True,
         cloud_storage_max_throughput_per_shard: Optional[int] = None,
         cloud_storage_signature_version: str = "s3v4",
         before_call_headers: Optional[Callable[[], dict[str, str]]] = None,
@@ -709,7 +711,7 @@ class SISettings:
             # segment upload or download quickly so we can try again
             self.cloud_storage_segment_upload_timeout_ms = 15000
 
-        self._expected_damage_types = set()
+        self._expected_damage_types: set[str] = set()
 
     def get_use_fips_s3_endpoint(self) -> bool:
         use_fips_option = self._context.globals.get(
@@ -738,13 +740,13 @@ class SISettings:
             and (self.get_use_fips_s3_endpoint() or in_fips_environment())
         )
 
-    def load_context(self, logger, test_context):
+    def load_context(self, logger: Logger, test_context: TestContext):
         if self.cloud_storage_type == CloudStorageType.S3:
             self._load_s3_context(logger, test_context)
         elif self.cloud_storage_type == CloudStorageType.ABS:
             self._load_abs_context(logger, test_context)
 
-    def _load_abs_context(self, logger, test_context):
+    def _load_abs_context(self, logger: Logger, test_context: TestContext):
         storage_account = test_context.globals.get(
             self.GLOBAL_ABS_STORAGE_ACCOUNT, None
         )
@@ -764,7 +766,7 @@ class SISettings:
                 "Using Azurite defualt credentials."
             )
 
-    def _load_s3_context(self, logger, test_context):
+    def _load_s3_context(self, logger: Logger, test_context: TestContext):
         """
         Update based on the test context, to e.g. consume AWS access keys in
         the globals dictionary.
@@ -854,7 +856,7 @@ class SISettings:
             self._cloud_storage_azure_container = new_bucket_name
 
     # Call this to update the extra_rp_conf
-    def update_rp_conf(self, conf) -> dict[str, Any]:
+    def update_rp_conf(self, conf: dict[str, Any]) -> dict[str, Any]:
         if self.cloud_storage_type == CloudStorageType.S3:
             conf["cloud_storage_credentials_source"] = (
                 self.cloud_storage_credentials_source
@@ -1499,434 +1501,6 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
         return count
 
 
-class RedpandaServiceBase(RedpandaServiceABC, Service):
-    PERSISTENT_ROOT = "/var/lib/redpanda"
-    TRIM_LOGS_KEY = "trim_logs"
-    DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
-    NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
-    RPK_CONFIG_FILE = "/root/.config/rpk/rpk.yaml"
-    CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
-    TLS_SERVER_KEY_FILE = "/etc/redpanda/server.key"
-    TLS_SERVER_CRT_FILE = "/etc/redpanda/server.crt"
-    TLS_SERVER_P12_FILE = "/etc/redpanda/server.p12"
-    TLS_CA_CRT_FILE = "/etc/redpanda/ca.crt"
-    TLS_CA_CRL_FILE = "/etc/redpanda/ca.crl"
-    SYSTEM_TLS_CA_CRT_FILE = "/usr/local/share/ca-certificates/ca.crt"
-    STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda.log")
-    BACKTRACE_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda_backtrace.log")
-    COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda.profraw")
-    TEMP_OSSL_CONFIG_FILE = "/etc/openssl.cnf"
-    DEFAULT_NODE_READY_TIMEOUT_SEC = 40
-    NODE_READY_TIMEOUT_MIN_SEC_KEY = "node_ready_timeout_min_sec"
-    DEFAULT_CLOUD_STORAGE_SCRUB_TIMEOUT_SEC = 60
-    DEDICATED_NODE_KEY = "dedicated_nodes"
-    RAISE_ON_ERRORS_KEY = "raise_on_error"
-    LOG_LEVEL_KEY = "redpanda_log_level"
-    DEFAULT_LOG_LEVEL = "info"
-    COV_KEY = "enable_cov"
-    DEFAULT_COV_OPT = "OFF"
-
-    # Where we put a compressed binary if saving it after failure
-    EXECUTABLE_SAVE_PATH = "/tmp/redpanda.gz"
-
-    FAILURE_INJECTION_CONFIG_PATH = "/etc/redpanda/failure_injection_config.json"
-
-    OPENSSL_CONFIG_FILE_BASE = "openssl/openssl.cnf"
-    OPENSSL_MODULES_PATH_BASE = "lib/ossl-modules/"
-
-    # When configuring multiple listeners for testing, a secondary port to use
-    # instead of the default.
-    KAFKA_ALTERNATE_PORT = 9093
-    KAFKA_KERBEROS_PORT = 9094
-    ADMIN_ALTERNATE_PORT = 9647
-
-    GLOBAL_USE_STRESS_FIBER = "enable_stress_fiber"
-    GLOBAL_NUM_STRESS_FIBERS = "num_stress_fibers"
-    GLOBAL_STRESS_FIBER_MIN_MS = "stress_fiber_min_ms"
-    GLOBAL_STRESS_FIBER_MAX_MS = "stress_fiber_max_ms"
-    DEFAULT_USE_STRESS_FIBER = "OFF"
-    DEFAULT_NUM_STRESS_FIBERS = 1
-    DEFAULT_STRESS_FIBER_MIN_MS = 100
-    DEFAULT_STRESS_FIBER_MAX_MS = 200
-
-    CLUSTER_CONFIG_DEFAULTS = {
-        "join_retry_timeout_ms": 200,
-        "default_topic_partitions": 4,
-        "enable_metrics_reporter": False,
-        "superusers": [RedpandaServiceConstants.SUPERUSER_CREDENTIALS[0]],
-        # Disable segment size jitter to make tests more deterministic if they rely on
-        # inspecting storage internals (e.g. number of segments after writing a certain
-        # amount of data).
-        "log_segment_size_jitter_percent": 0,
-        # This is high enough not to interfere with the logic in any tests, while also
-        # providing some background coverage of the connection limit code (i.e. that it
-        # doesn't crash, it doesn't limit when it shouldn't)
-        "kafka_connections_max": 2048,
-        "kafka_connections_max_per_ip": 1024,
-        "kafka_connections_max_overrides": ["1.2.3.4:5"],
-        # configure shutdown watchdog timeout to 20 seconds to give it a chance
-        # to fire before Redpanda node that doesn't stopped is killed
-        "partition_manager_shutdown_watchdog_timeout": 20000,
-    }
-
-    logs = {
-        "redpanda_start_stdout_stderr": {
-            "path": STDOUT_STDERR_CAPTURE,
-            "collect_default": True,
-        },
-        "code_coverage_profraw_file": {
-            "path": COVERAGE_PROFRAW_CAPTURE,
-            "collect_default": True,
-        },
-        "executable": {"path": EXECUTABLE_SAVE_PATH, "collect_default": False},
-        "backtraces": {"path": BACKTRACE_CAPTURE, "collect_default": True},
-    }
-
-    # Thread name of shards to be used with redpanda_tid()
-    SHARD_0_THREAD_NAME = "redpanda"
-    SHARD_1_THREAD_NAME = "reactor-1"
-
-    class FIPSMode(Enum):
-        disabled = 0
-        permissive = 1
-        enabled = 2
-
-    def __init__(
-        self,
-        context: TestContext,
-        num_brokers: int,
-        *,
-        cluster_spec=None,
-        extra_rp_conf=None,
-        resource_settings: Optional[ResourceSettings] = None,
-        si_settings: Optional[SISettings] = None,
-        superuser: Optional[SaslCredentials] = None,
-        skip_if_no_redpanda_log: Optional[bool] = False,
-        disable_cloud_storage_diagnostics=True,
-    ):
-        super(RedpandaServiceBase, self).__init__(
-            context, num_nodes=num_brokers, cluster_spec=cluster_spec
-        )
-        self._context = context
-        self._extra_rp_conf = extra_rp_conf or dict()
-
-        if si_settings is not None:
-            self.set_si_settings(si_settings)
-        else:
-            self._si_settings = None
-
-        if superuser is None:
-            superuser = self.SUPERUSER_CREDENTIALS
-            self._skip_create_superuser = False
-        else:
-            # When we are passed explicit superuser credentials, presume that the caller
-            # is taking care of user creation themselves (e.g. when testing credential bootstrap)
-            self._skip_create_superuser = True
-
-        self._superuser = superuser
-
-        self._admin = Admin(
-            self, auth=(self._superuser.username, self._superuser.password)
-        )
-
-        if resource_settings is None:
-            resource_settings = ResourceSettings()
-        self._resource_settings = resource_settings
-
-        # Disable saving cloud storage diagnostics. This may be useful for
-        # tests that generate millions of objecst, as collecting diagnostics
-        # may take a significant amount of time.
-        self._disable_cloud_storage_diagnostics = disable_cloud_storage_diagnostics
-
-        self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
-
-        self._node_id_by_idx = {}
-        self._security_config: dict[str, str | int] = {}
-
-        self._skip_if_no_redpanda_log = skip_if_no_redpanda_log
-
-        self._dedicated_nodes: bool = self._context.globals.get(
-            self.DEDICATED_NODE_KEY, False
-        )
-
-        self.logger.info(f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
-
-    def restart_nodes(
-        self,
-        nodes,
-        override_cfg_params=None,
-        start_timeout=None,
-        stop_timeout=None,
-        auto_assign_node_id=False,
-        omit_seeds_on_idx_one=True,
-        extra_cli: list[str] = [],
-    ):
-        nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(nodes)) as executor:
-            # The list() wrapper is to cause futures to be evaluated here+now
-            # (including throwing any exceptions) and not just spawned in background.
-            list(executor.map(lambda n: self.stop_node(n, timeout=stop_timeout), nodes))
-            list(
-                executor.map(
-                    lambda n: self.start_node(
-                        n,
-                        override_cfg_params=override_cfg_params,
-                        timeout=start_timeout,
-                        auto_assign_node_id=auto_assign_node_id,
-                        omit_seeds_on_idx_one=omit_seeds_on_idx_one,
-                        extra_cli=extra_cli,
-                    ),
-                    nodes,
-                )
-            )
-
-    def set_extra_rp_conf(self, conf):
-        self._extra_rp_conf = conf
-        if self._si_settings is not None:
-            self._extra_rp_conf = self._si_settings.update_rp_conf(self._extra_rp_conf)
-
-    def set_si_settings(self, si_settings: SISettings):
-        si_settings.load_context(self.logger, self._context)
-        self._si_settings = si_settings
-        self._extra_rp_conf = self._si_settings.update_rp_conf(self._extra_rp_conf)
-
-    def use_stress_fiber(self) -> bool:
-        """Return true if the test should run with the stress fiber."""
-        use_stress_fiber = self._context.globals.get(
-            self.GLOBAL_USE_STRESS_FIBER, self.DEFAULT_USE_STRESS_FIBER
-        )
-        if use_stress_fiber == "ON":
-            return True
-        elif use_stress_fiber == "OFF":
-            return False
-
-        self.logger.warn(f"{self.GLOBAL_USE_STRESS_FIBER} should be 'ON', or 'OFF'")
-        return False
-
-    def get_stress_fiber_params(self) -> Tuple[int, int, int]:
-        fibers = int(
-            self._context.globals.get(
-                self.GLOBAL_NUM_STRESS_FIBERS, self.DEFAULT_NUM_STRESS_FIBERS
-            )
-        )
-        min_ms = int(
-            self._context.globals.get(
-                self.GLOBAL_STRESS_FIBER_MIN_MS, self.DEFAULT_STRESS_FIBER_MIN_MS
-            )
-        )
-        max_ms = int(
-            self._context.globals.get(
-                self.GLOBAL_STRESS_FIBER_MAX_MS, self.DEFAULT_STRESS_FIBER_MAX_MS
-            )
-        )
-        return (fibers, min_ms, max_ms)
-
-    def add_extra_rp_conf(self, conf):
-        self._extra_rp_conf = {**self._extra_rp_conf, **conf}
-
-    def metric_sum(
-        self,
-        metric_name: str,
-        metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
-        namespace: str | None = None,
-        topic: str | None = None,
-        nodes: Any = None,
-        expect_metric: bool = False,
-    ):
-        """
-        Pings the 'metrics_endpoint' of each node and returns the summed values
-        of the given metric, optionally filtering by namespace and topic.
-        """
-
-        if nodes is None:
-            nodes = self.nodes
-
-        return self._metric_sum(
-            metric_name,
-            nodes,
-            metrics_endpoint,
-            namespace,
-            topic,
-            expect_metric=expect_metric,
-        )
-
-    def healthy(self):
-        """
-        A primitive health check on all the nodes which returns True when all
-        nodes report that no under replicated partitions exist. This should
-        later be replaced by a proper / official start-up probe type check on
-        the health of a node after a restart.
-        """
-        counts: dict[int, int | None] = {self.idx(node): None for node in self.nodes}
-        for node in self.nodes:
-            try:
-                metrics = self.metrics(node)
-            except:
-                return False
-            idx = self.idx(node)
-            for family in metrics:
-                for sample in family.samples:
-                    if (
-                        sample.name
-                        == "vectorized_cluster_partition_under_replicated_replicas"
-                    ):
-                        counts[idx] = int(sample.value) + (counts[idx] or 0)
-        return all(map(lambda count: count == 0, counts.values()))
-
-    def rolling_restart_nodes(
-        self,
-        nodes,
-        override_cfg_params=None,
-        start_timeout=None,
-        stop_timeout=None,
-        use_maintenance_mode=True,
-        omit_seeds_on_idx_one=True,
-        auto_assign_node_id=False,
-    ):
-        nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
-        restarter = RollingRestarter(self)
-        restarter.restart_nodes(
-            nodes,
-            override_cfg_params=override_cfg_params,
-            start_timeout=start_timeout,
-            stop_timeout=stop_timeout,
-            use_maintenance_mode=use_maintenance_mode,
-            omit_seeds_on_idx_one=omit_seeds_on_idx_one,
-            auto_assign_node_id=auto_assign_node_id,
-        )
-
-    def set_resource_settings(self, rs):
-        self._resource_settings = rs
-
-    @property
-    def si_settings(self) -> SISettings:
-        """Return the SISettings object associated with this redpanda service,
-        containing the cloud storage associated settings. Throws if si settings
-        were not configured for this service."""
-        assert self._si_settings, (
-            "si_settings were None, probably because they were not specified during redpanda service creation"
-        )
-        return self._si_settings
-
-    def for_nodes(self, nodes, cb: Callable) -> list:
-        n_workers = len(nodes)
-        if n_workers > 0:
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=n_workers
-            ) as executor:
-                # The list() wrapper is to cause futures to be evaluated here+now
-                # (including throwing any exceptions) and not just spawned in background.
-                return list(executor.map(cb, nodes))
-        else:
-            return []
-
-    def trim_logs(self):
-        if not self._trim_logs:
-            return
-
-        # Excessive logging may cause disks to fill up quickly.
-        # Call this method to removes TRACE and DEBUG log lines from redpanda logs
-        # Ensure this is only done on tests that have passed
-        def prune(node):
-            node.account.ssh(
-                f"sed -i -E -e '/TRACE|DEBUG/d' {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
-            )
-
-        self.for_nodes(self.nodes, prune)
-
-    def node_id(self, node, force_refresh=False, timeout_sec=30):
-        """
-        Returns the node ID of a given node. Uses a cached value unless
-        'force_refresh' is set to True.
-
-        NOTE: this is not thread-safe.
-        """
-        idx = self.idx(node)
-        if not force_refresh:
-            if idx in self._node_id_by_idx:
-                return self._node_id_by_idx[idx]
-
-        def _try_get_node_id():
-            try:
-                node_cfg = self._admin.get_node_config(node)
-            except:
-                return (False, -1)
-            return (True, node_cfg["node_id"])
-
-        node_id = wait_until_result(
-            _try_get_node_id,
-            timeout_sec=timeout_sec,
-            err_msg=f"couldn't reach admin endpoint for {node.account.hostname}",
-        )
-        self.logger.info(f"Got node ID for {node.account.hostname}: {node_id}")
-        self._node_id_by_idx[idx] = node_id
-        return node_id
-
-    def kafka_client_security(self):
-        if self._security_config:
-
-            def get_str(key: str):
-                v = self._security_config[key]
-                assert isinstance(v, str)
-                return v
-
-            creds = SaslCredentials(
-                username=get_str("sasl_plain_username"),
-                password=get_str("sasl_plain_password"),
-                algorithm=get_str("sasl_mechanism"),
-            )
-        else:
-            creds = None
-
-        return KafkaClientSecurity(creds, tls_enabled=False)
-
-    def set_skip_if_no_redpanda_log(self, v: bool):
-        self._skip_if_no_redpanda_log = v
-
-    def raise_on_bad_logs(
-        self, allow_list: LogAllowList = (), test_start_time: float | None = None
-    ):
-        """
-        Raise a BadLogLines exception if any nodes' logs contain errors not
-        permitted by `allow_list`
-
-        :param allow_list: LogAllowList of additional lines to ignore (default
-            ignores are always included)
-        :return: None
-        """
-        allow_list = prepare_allow_list(allow_list)
-
-        _searchable_nodes = []
-        for node in self.nodes:
-            if self._skip_if_no_redpanda_log and not node.account.exists(
-                RedpandaServiceBase.STDOUT_STDERR_CAPTURE
-            ):
-                self.logger.info(
-                    f"{RedpandaServiceBase.STDOUT_STDERR_CAPTURE} not found on {node.account.hostname}. Skipping log scan."
-                )
-                continue
-            _searchable_nodes.append((self.get_version_if_not_head(node), node))
-
-        lsearcher = LogSearchLocal(
-            self._context,
-            allow_list,
-            self.logger,
-            RedpandaServiceBase.STDOUT_STDERR_CAPTURE,
-        )
-        lsearcher.search_logs(_searchable_nodes)
-
-    @property
-    def dedicated_nodes(self):
-        """
-        If true, the nodes are dedicated linux servers, e.g. EC2 instances.
-
-        If false, the nodes are containers that share CPUs and memory with
-        one another.
-        :return:
-        """
-        return self._dedicated_nodes
-
-
 class KubeServiceMixin:
     kubectl: KubectlTool
 
@@ -1942,11 +1516,11 @@ class KubeServiceMixin:
         return int(core_count_str.strip())
 
     def get_node_disk_free(self):
-        if self.kubectl.exists(RedpandaServiceBase.PERSISTENT_ROOT):
-            df_path = RedpandaServiceBase.PERSISTENT_ROOT
+        if self.kubectl.exists(RedpandaService.PERSISTENT_ROOT):
+            df_path = RedpandaService.PERSISTENT_ROOT
         else:
             # If dir doesn't exist yet, use the parent.
-            df_path = os.path.dirname(RedpandaServiceBase.PERSISTENT_ROOT)
+            df_path = os.path.dirname(RedpandaService.PERSISTENT_ROOT)
         df_out = self.kubectl.exec(f"df --output=avail {df_path}")
         avail_kb = int(df_out.strip().split("\n")[1].strip())
         return avail_kb * 1024
@@ -1998,7 +1572,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
         self.config_profile_name = config_profile_name
         self._min_brokers = min_brokers
-        self._superuser = RedpandaServiceBase.SUPERUSER_CREDENTIALS
+        self._superuser = RedpandaService.SUPERUSER_CREDENTIALS
 
         self._trim_logs = False
 
@@ -2759,8 +2333,99 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         return {}
 
 
-class RedpandaService(RedpandaServiceBase):
+class RedpandaService(RedpandaServiceABC, Service):
+    PERSISTENT_ROOT = "/var/lib/redpanda"
+    TRIM_LOGS_KEY = "trim_logs"
+    DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
+    NODE_CONFIG_FILE = "/etc/redpanda/redpanda.yaml"
+    RPK_CONFIG_FILE = "/root/.config/rpk/rpk.yaml"
+    CLUSTER_BOOTSTRAP_CONFIG_FILE = "/etc/redpanda/.bootstrap.yaml"
+    TLS_SERVER_KEY_FILE = "/etc/redpanda/server.key"
+    TLS_SERVER_CRT_FILE = "/etc/redpanda/server.crt"
+    TLS_SERVER_P12_FILE = "/etc/redpanda/server.p12"
+    TLS_CA_CRT_FILE = "/etc/redpanda/ca.crt"
+    TLS_CA_CRL_FILE = "/etc/redpanda/ca.crl"
+    SYSTEM_TLS_CA_CRT_FILE = "/usr/local/share/ca-certificates/ca.crt"
+    STDOUT_STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda.log")
+    BACKTRACE_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda_backtrace.log")
+    COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT, "redpanda.profraw")
+    TEMP_OSSL_CONFIG_FILE = "/etc/openssl.cnf"
+    DEFAULT_NODE_READY_TIMEOUT_SEC = 40
+    NODE_READY_TIMEOUT_MIN_SEC_KEY = "node_ready_timeout_min_sec"
+    DEFAULT_CLOUD_STORAGE_SCRUB_TIMEOUT_SEC = 60
+    DEDICATED_NODE_KEY = "dedicated_nodes"
+    RAISE_ON_ERRORS_KEY = "raise_on_error"
+    LOG_LEVEL_KEY = "redpanda_log_level"
+    DEFAULT_LOG_LEVEL = "info"
+    COV_KEY = "enable_cov"
+    DEFAULT_COV_OPT = "OFF"
+
     ENTERPRISE_LICENSE_NAG = "A Redpanda Enterprise Edition license is required"
+
+    # Where we put a compressed binary if saving it after failure
+    EXECUTABLE_SAVE_PATH = "/tmp/redpanda.gz"
+
+    FAILURE_INJECTION_CONFIG_PATH = "/etc/redpanda/failure_injection_config.json"
+
+    OPENSSL_CONFIG_FILE_BASE = "openssl/openssl.cnf"
+    OPENSSL_MODULES_PATH_BASE = "lib/ossl-modules/"
+
+    # When configuring multiple listeners for testing, a secondary port to use
+    # instead of the default.
+    KAFKA_ALTERNATE_PORT = 9093
+    KAFKA_KERBEROS_PORT = 9094
+    ADMIN_ALTERNATE_PORT = 9647
+
+    GLOBAL_USE_STRESS_FIBER = "enable_stress_fiber"
+    GLOBAL_NUM_STRESS_FIBERS = "num_stress_fibers"
+    GLOBAL_STRESS_FIBER_MIN_MS = "stress_fiber_min_ms"
+    GLOBAL_STRESS_FIBER_MAX_MS = "stress_fiber_max_ms"
+    DEFAULT_USE_STRESS_FIBER = "OFF"
+    DEFAULT_NUM_STRESS_FIBERS = 1
+    DEFAULT_STRESS_FIBER_MIN_MS = 100
+    DEFAULT_STRESS_FIBER_MAX_MS = 200
+
+    CLUSTER_CONFIG_DEFAULTS: dict[str, Any] = {
+        "join_retry_timeout_ms": 200,
+        "default_topic_partitions": 4,
+        "enable_metrics_reporter": False,
+        "superusers": [RedpandaServiceConstants.SUPERUSER_CREDENTIALS[0]],
+        # Disable segment size jitter to make tests more deterministic if they rely on
+        # inspecting storage internals (e.g. number of segments after writing a certain
+        # amount of data).
+        "log_segment_size_jitter_percent": 0,
+        # This is high enough not to interfere with the logic in any tests, while also
+        # providing some background coverage of the connection limit code (i.e. that it
+        # doesn't crash, it doesn't limit when it shouldn't)
+        "kafka_connections_max": 2048,
+        "kafka_connections_max_per_ip": 1024,
+        "kafka_connections_max_overrides": ["1.2.3.4:5"],
+        # configure shutdown watchdog timeout to 20 seconds to give it a chance
+        # to fire before Redpanda node that doesn't stopped is killed
+        "partition_manager_shutdown_watchdog_timeout": 20000,
+    }
+
+    logs = {
+        "redpanda_start_stdout_stderr": {
+            "path": STDOUT_STDERR_CAPTURE,
+            "collect_default": True,
+        },
+        "code_coverage_profraw_file": {
+            "path": COVERAGE_PROFRAW_CAPTURE,
+            "collect_default": True,
+        },
+        "executable": {"path": EXECUTABLE_SAVE_PATH, "collect_default": False},
+        "backtraces": {"path": BACKTRACE_CAPTURE, "collect_default": True},
+    }
+
+    # Thread name of shards to be used with redpanda_tid()
+    SHARD_0_THREAD_NAME = "redpanda"
+    SHARD_1_THREAD_NAME = "reactor-1"
+
+    class FIPSMode(Enum):
+        disabled = 0
+        permissive = 1
+        enabled = 2
 
     nodes: list[ClusterNode]
 
@@ -2769,6 +2434,7 @@ class RedpandaService(RedpandaServiceBase):
         context: TestContext,
         num_brokers: int,
         *,
+        cluster_spec=None,
         extra_rp_conf=None,
         extra_node_conf=None,
         resource_settings=None,
@@ -2787,16 +2453,69 @@ class RedpandaService(RedpandaServiceBase):
         cloud_storage_scrub_timeout_s=None,
         rpk_node_config: Optional[RpkNodeConfig] = None,
     ):
-        super(RedpandaService, self).__init__(
-            context,
-            num_brokers,
-            extra_rp_conf=extra_rp_conf,
-            resource_settings=resource_settings,
-            si_settings=si_settings,
-            superuser=superuser,
-            skip_if_no_redpanda_log=skip_if_no_redpanda_log,
-            disable_cloud_storage_diagnostics=disable_cloud_storage_diagnostics,
+        super().__init__(context, num_nodes=num_brokers, cluster_spec=cluster_spec)
+
+        # def __init__(
+        #     self,
+        #     context: TestContext,
+        #     num_brokers: int,
+        #     *,
+        #     cluster_spec=None,
+        #     extra_rp_conf=None,
+        #     resource_settings: Optional[ResourceSettings] = None,
+        #     si_settings: Optional[SISettings] = None,
+        #     superuser: Optional[SaslCredentials] = None,
+        #     skip_if_no_redpanda_log: Optional[bool] = False,
+        #     disable_cloud_storage_diagnostics=True,
+        # ):
+
+        # BEGIN
+
+        self._context = context
+        self._extra_rp_conf = extra_rp_conf or dict()
+
+        if si_settings is not None:
+            self.set_si_settings(si_settings)
+        else:
+            self._si_settings = None
+
+        if superuser is None:
+            superuser = self.SUPERUSER_CREDENTIALS
+            self._skip_create_superuser = False
+        else:
+            # When we are passed explicit superuser credentials, presume that the caller
+            # is taking care of user creation themselves (e.g. when testing credential bootstrap)
+            self._skip_create_superuser = True
+
+        self._superuser = superuser
+
+        self._admin = Admin(
+            self, auth=(self._superuser.username, self._superuser.password)
         )
+
+        if resource_settings is None:
+            resource_settings = ResourceSettings()
+        self._resource_settings = resource_settings
+
+        # Disable saving cloud storage diagnostics. This may be useful for
+        # tests that generate millions of objecst, as collecting diagnostics
+        # may take a significant amount of time.
+        self._disable_cloud_storage_diagnostics = disable_cloud_storage_diagnostics
+
+        self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
+
+        self._node_id_by_idx = {}
+        self._security_config: dict[str, str | int] = {}
+
+        self._skip_if_no_redpanda_log = skip_if_no_redpanda_log
+
+        self._dedicated_nodes: bool = self._context.globals.get(
+            self.DEDICATED_NODE_KEY, False
+        )
+
+        self.logger.info(f"ResourceSettings: dedicated_nodes={self._dedicated_nodes}")
+
+        # END
         self._security = security
         self._installer: RedpandaInstaller = RedpandaInstaller(self)
         self._pandaproxy_config = pandaproxy_config
@@ -2895,6 +2614,281 @@ class RedpandaService(RedpandaServiceBase):
         self._seed_servers = self.nodes
 
         self._expect_max_controller_records = 1000
+
+    def restart_nodes(
+        self,
+        nodes,
+        override_cfg_params=None,
+        start_timeout=None,
+        stop_timeout=None,
+        auto_assign_node_id=False,
+        omit_seeds_on_idx_one=True,
+        extra_cli: list[str] = [],
+    ):
+        nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(nodes)) as executor:
+            # The list() wrapper is to cause futures to be evaluated here+now
+            # (including throwing any exceptions) and not just spawned in background.
+            list(executor.map(lambda n: self.stop_node(n, timeout=stop_timeout), nodes))
+            list(
+                executor.map(
+                    lambda n: self.start_node(
+                        n,
+                        override_cfg_params=override_cfg_params,
+                        timeout=start_timeout,
+                        auto_assign_node_id=auto_assign_node_id,
+                        omit_seeds_on_idx_one=omit_seeds_on_idx_one,
+                        extra_cli=extra_cli,
+                    ),
+                    nodes,
+                )
+            )
+
+    def set_extra_rp_conf(self, conf: dict[str, Any]):
+        self._extra_rp_conf = conf
+        if self._si_settings is not None:
+            self._extra_rp_conf = self._si_settings.update_rp_conf(self._extra_rp_conf)
+
+    def set_si_settings(self, si_settings: SISettings):
+        si_settings.load_context(self.logger, self._context)
+        self._si_settings = si_settings
+        self._extra_rp_conf = self._si_settings.update_rp_conf(self._extra_rp_conf)
+
+    def use_stress_fiber(self) -> bool:
+        """Return true if the test should run with the stress fiber."""
+        use_stress_fiber = self._context.globals.get(
+            self.GLOBAL_USE_STRESS_FIBER, self.DEFAULT_USE_STRESS_FIBER
+        )
+        if use_stress_fiber == "ON":
+            return True
+        elif use_stress_fiber == "OFF":
+            return False
+
+        self.logger.warn(f"{self.GLOBAL_USE_STRESS_FIBER} should be 'ON', or 'OFF'")
+        return False
+
+    def get_stress_fiber_params(self) -> Tuple[int, int, int]:
+        fibers = int(
+            self._context.globals.get(
+                self.GLOBAL_NUM_STRESS_FIBERS, self.DEFAULT_NUM_STRESS_FIBERS
+            )
+        )
+        min_ms = int(
+            self._context.globals.get(
+                self.GLOBAL_STRESS_FIBER_MIN_MS, self.DEFAULT_STRESS_FIBER_MIN_MS
+            )
+        )
+        max_ms = int(
+            self._context.globals.get(
+                self.GLOBAL_STRESS_FIBER_MAX_MS, self.DEFAULT_STRESS_FIBER_MAX_MS
+            )
+        )
+        return (fibers, min_ms, max_ms)
+
+    def add_extra_rp_conf(self, conf):
+        self._extra_rp_conf = {**self._extra_rp_conf, **conf}
+
+    def metric_sum(
+        self,
+        metric_name: str,
+        metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
+        namespace: str | None = None,
+        topic: str | None = None,
+        nodes: Any = None,
+        expect_metric: bool = False,
+    ):
+        """
+        Pings the 'metrics_endpoint' of each node and returns the summed values
+        of the given metric, optionally filtering by namespace and topic.
+        """
+
+        if nodes is None:
+            nodes = self.nodes
+
+        return self._metric_sum(
+            metric_name,
+            nodes,
+            metrics_endpoint,
+            namespace,
+            topic,
+            expect_metric=expect_metric,
+        )
+
+    def healthy(self):
+        """
+        A primitive health check on all the nodes which returns True when all
+        nodes report that no under replicated partitions exist. This should
+        later be replaced by a proper / official start-up probe type check on
+        the health of a node after a restart.
+        """
+        counts: dict[int, int | None] = {self.idx(node): None for node in self.nodes}
+        for node in self.nodes:
+            try:
+                metrics = self.metrics(node)
+            except:
+                return False
+            idx = self.idx(node)
+            for family in metrics:
+                for sample in family.samples:
+                    if (
+                        sample.name
+                        == "vectorized_cluster_partition_under_replicated_replicas"
+                    ):
+                        counts[idx] = int(sample.value) + (counts[idx] or 0)
+        return all(map(lambda count: count == 0, counts.values()))
+
+    def rolling_restart_nodes(
+        self,
+        nodes,
+        override_cfg_params=None,
+        start_timeout=None,
+        stop_timeout=None,
+        use_maintenance_mode=True,
+        omit_seeds_on_idx_one=True,
+        auto_assign_node_id=False,
+    ):
+        nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
+        restarter = RollingRestarter(self)
+        restarter.restart_nodes(
+            nodes,
+            override_cfg_params=override_cfg_params,
+            start_timeout=start_timeout,
+            stop_timeout=stop_timeout,
+            use_maintenance_mode=use_maintenance_mode,
+            omit_seeds_on_idx_one=omit_seeds_on_idx_one,
+            auto_assign_node_id=auto_assign_node_id,
+        )
+
+    def set_resource_settings(self, rs):
+        self._resource_settings = rs
+
+    @property
+    def si_settings(self) -> SISettings:
+        """Return the SISettings object associated with this redpanda service,
+        containing the cloud storage associated settings. Throws if si settings
+        were not configured for this service."""
+        assert self._si_settings, (
+            "si_settings were None, probably because they were not specified during redpanda service creation"
+        )
+        return self._si_settings
+
+    def for_nodes(self, nodes, cb: Callable) -> list:
+        n_workers = len(nodes)
+        if n_workers > 0:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=n_workers
+            ) as executor:
+                # The list() wrapper is to cause futures to be evaluated here+now
+                # (including throwing any exceptions) and not just spawned in background.
+                return list(executor.map(cb, nodes))
+        else:
+            return []
+
+    def trim_logs(self):
+        if not self._trim_logs:
+            return
+
+        # Excessive logging may cause disks to fill up quickly.
+        # Call this method to removes TRACE and DEBUG log lines from redpanda logs
+        # Ensure this is only done on tests that have passed
+        def prune(node):
+            node.account.ssh(
+                f"sed -i -E -e '/TRACE|DEBUG/d' {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
+            )
+
+        self.for_nodes(self.nodes, prune)
+
+    def node_id(self, node, force_refresh=False, timeout_sec=30):
+        """
+        Returns the node ID of a given node. Uses a cached value unless
+        'force_refresh' is set to True.
+
+        NOTE: this is not thread-safe.
+        """
+        idx = self.idx(node)
+        if not force_refresh:
+            if idx in self._node_id_by_idx:
+                return self._node_id_by_idx[idx]
+
+        def _try_get_node_id():
+            try:
+                node_cfg = self._admin.get_node_config(node)
+            except:
+                return (False, -1)
+            return (True, node_cfg["node_id"])
+
+        node_id = wait_until_result(
+            _try_get_node_id,
+            timeout_sec=timeout_sec,
+            err_msg=f"couldn't reach admin endpoint for {node.account.hostname}",
+        )
+        self.logger.info(f"Got node ID for {node.account.hostname}: {node_id}")
+        self._node_id_by_idx[idx] = node_id
+        return node_id
+
+    def kafka_client_security(self):
+        if self._security_config:
+
+            def get_str(key: str):
+                v = self._security_config[key]
+                assert isinstance(v, str)
+                return v
+
+            creds = SaslCredentials(
+                username=get_str("sasl_plain_username"),
+                password=get_str("sasl_plain_password"),
+                algorithm=get_str("sasl_mechanism"),
+            )
+        else:
+            creds = None
+
+        return KafkaClientSecurity(creds, tls_enabled=False)
+
+    def set_skip_if_no_redpanda_log(self, v: bool):
+        self._skip_if_no_redpanda_log = v
+
+    def raise_on_bad_logs(
+        self, allow_list: LogAllowList = (), test_start_time: float | None = None
+    ):
+        """
+        Raise a BadLogLines exception if any nodes' logs contain errors not
+        permitted by `allow_list`
+
+        :param allow_list: LogAllowList of additional lines to ignore (default
+            ignores are always included)
+        """
+
+        allow_list = prepare_allow_list(allow_list)
+
+        _searchable_nodes = []
+        for node in self.nodes:
+            if self._skip_if_no_redpanda_log and not node.account.exists(
+                RedpandaService.STDOUT_STDERR_CAPTURE
+            ):
+                self.logger.info(
+                    f"{RedpandaService.STDOUT_STDERR_CAPTURE} not found on {node.account.hostname}. Skipping log scan."
+                )
+                continue
+            _searchable_nodes.append((self.get_version_if_not_head(node), node))
+
+        lsearcher = LogSearchLocal(
+            self._context,
+            allow_list,
+            self.logger,
+            RedpandaService.STDOUT_STDERR_CAPTURE,
+        )
+        lsearcher.search_logs(_searchable_nodes)
+
+    @property
+    def dedicated_nodes(self):
+        """
+        If true, the nodes are dedicated linux servers, e.g. EC2 instances.
+
+        If false, the nodes are containers that share CPUs and memory with
+        one another.
+        :return:
+        """
+        return self._dedicated_nodes
 
     def redpanda_env_preamble(self):
         # Pass environment variables via FOO=BAR shell expressions
@@ -3658,7 +3652,7 @@ class RedpandaService(RedpandaServiceBase):
         """
         self.logger.debug(f"Gathering logs to analyze from {node.name}...")
         expr = '"application.*Stopping"'
-        cmd = f"grep {expr} {RedpandaServiceBase.STDOUT_STDERR_CAPTURE} || true"
+        cmd = f"grep {expr} {RedpandaService.STDOUT_STDERR_CAPTURE} || true"
 
         other_stopping = []
         last_next_to_shutdown = None
@@ -6036,7 +6030,7 @@ class RedpandaService(RedpandaServiceBase):
 def make_redpanda_service(
     context: TestContext, num_brokers: int | None, *, extra_rp_conf=None, **kwargs
 ) -> RedpandaService:
-    """Factory function for instatiating the appropriate RedpandaServiceBase subclass."""
+    """Factory function for instatiating the appropriate RedpandaServiceABC subclass."""
 
     # https://github.com/redpanda-data/core-internal/issues/1002
     assert not is_redpanda_cloud(context), (

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -40,8 +40,7 @@ from rptest.services.redpanda import (
     LoggingConfig,
     MetricSamples,
     MetricsEndpoint,
-    PandaproxyConfig,
-    RedpandaServiceBase,
+    RedpandaService,
     SchemaRegistryConfig,
     SecurityConfig,
     TLSProvider,
@@ -1985,7 +1984,7 @@ class AuditLogTestInvalidConfigMTLS(AuditLogTestInvalidConfigBase):
         )
         self.admin_user_cert = self.tls.create_cert(
             socket.gethostname(),
-            common_name=RedpandaServiceBase.SUPERUSER_CREDENTIALS[0],
+            common_name=RedpandaService.SUPERUSER_CREDENTIALS[0],
             name="admin_client",
         )
         self._security_config = AuditLogTestSecurityConfig(
@@ -2041,7 +2040,7 @@ class AuditLogTestKafkaTlsApi(AuditLogTestBase):
         )
         self.admin_user_cert = self.tls.create_cert(
             socket.gethostname(),
-            common_name=RedpandaServiceBase.SUPERUSER_CREDENTIALS[0],
+            common_name=RedpandaService.SUPERUSER_CREDENTIALS[0],
             name="admin_client",
         )
 
@@ -2135,7 +2134,7 @@ class AuditLogTestOauth(AuditLogTestBase):
 
     def __init__(self, test_context):
         security = AuditLogTestSecurityConfig(
-            user_creds=RedpandaServiceBase.SUPERUSER_CREDENTIALS
+            user_creds=RedpandaService.SUPERUSER_CREDENTIALS
         )
         security.enable_sasl = True
         security.sasl_mechanisms = ["SCRAM"]

--- a/tests/rptest/tests/data_migrations_api_test.py
+++ b/tests/rptest/tests/data_migrations_api_test.py
@@ -36,7 +36,7 @@ from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
 )
 from rptest.services.redpanda import (
-    RedpandaServiceBase,
+    RedpandaService,
     SISettings,
     make_redpanda_service,
 )
@@ -60,7 +60,7 @@ def now():
 
 
 @bg_thread_cm
-def TransferLeadersBackgroundThread(redpanda: RedpandaServiceBase, topic: str):
+def TransferLeadersBackgroundThread(redpanda: RedpandaService, topic: str):
     logger = redpanda.logger
     admin = Admin(redpanda, retry_codes=[503, 504])
     while (yield):

--- a/tests/rptest/tests/redpanda_startup_test.py
+++ b/tests/rptest/tests/redpanda_startup_test.py
@@ -15,7 +15,7 @@ from ducktape.cluster.cluster import ClusterNode
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import MetricsEndpoint, MetricSamples, RedpandaServiceBase
+from rptest.services.redpanda import MetricsEndpoint, MetricSamples, RedpandaService
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.utils.log_utils import wait_until_nag_is_set
 from rptest.utils.mode_checks import in_fips_environment
@@ -38,12 +38,12 @@ class RedpandaStartupTest(RedpandaTest):
 
 class RedpandaFIPSStartupTestBase(RedpandaTest):
     @staticmethod
-    def fips_mode_to_str(fips_mode: RedpandaServiceBase.FIPSMode) -> str:
-        if fips_mode == RedpandaServiceBase.FIPSMode.disabled:
+    def fips_mode_to_str(fips_mode: RedpandaService.FIPSMode) -> str:
+        if fips_mode == RedpandaService.FIPSMode.disabled:
             return "disabled"
-        elif fips_mode == RedpandaServiceBase.FIPSMode.enabled:
+        elif fips_mode == RedpandaService.FIPSMode.enabled:
             return "enabled"
-        elif fips_mode == RedpandaServiceBase.FIPSMode.permissive:
+        elif fips_mode == RedpandaService.FIPSMode.permissive:
             return "permissive"
         else:
             assert False, f"Unknown FIPS Mode; {fips_mode}"
@@ -51,7 +51,7 @@ class RedpandaFIPSStartupTestBase(RedpandaTest):
     def __init__(
         self,
         test_context,
-        fips_mode: RedpandaServiceBase.FIPSMode = RedpandaServiceBase.FIPSMode.permissive,
+        fips_mode: RedpandaService.FIPSMode = RedpandaService.FIPSMode.permissive,
     ):
         super(RedpandaFIPSStartupTestBase, self).__init__(test_context=test_context)
 
@@ -103,7 +103,7 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
         def check_fips_mode_metric(
             metrics_name: str,
             metrics_endpoint: MetricsEndpoint,
-            expected_mode: RedpandaServiceBase.FIPSMode,
+            expected_mode: RedpandaService.FIPSMode,
         ):
             metrics = self.redpanda.metrics_sample(
                 sample_pattern=metrics_name, metrics_endpoint=metrics_endpoint
@@ -114,7 +114,7 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
             for n in self.redpanda.nodes:
                 samples = [sample for sample in metrics.samples if sample.node == n]
                 assert len(samples) == 1, f"Invalid number of samples: {len(samples)}"
-                fips_mode = RedpandaServiceBase.FIPSMode(int(samples[0].value))
+                fips_mode = RedpandaService.FIPSMode(int(samples[0].value))
                 assert fips_mode == expected_mode, (
                     f"Mismatch in mode: {fips_mode} != {expected_mode}"
                 )
@@ -122,12 +122,12 @@ class RedpandaFIPSStartupTest(RedpandaFIPSStartupTestBase):
         check_fips_mode_metric(
             metrics_name="vectorized_application_fips_mode",
             metrics_endpoint=MetricsEndpoint.METRICS,
-            expected_mode=RedpandaServiceBase.FIPSMode.permissive,
+            expected_mode=RedpandaService.FIPSMode.permissive,
         )
         check_fips_mode_metric(
             metrics_name="redpanda_application_fips_mode",
             metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
-            expected_mode=RedpandaServiceBase.FIPSMode.permissive,
+            expected_mode=RedpandaService.FIPSMode.permissive,
         )
 
     @ignore  # https://redpandadata.atlassian.net/browse/CORE-4283
@@ -257,7 +257,7 @@ class RedpandaFIPSStartupLicenseTest(RedpandaFIPSStartupTestBase):
 
     def __init__(self, test_context):
         super(RedpandaFIPSStartupLicenseTest, self).__init__(
-            test_context=test_context, fips_mode=RedpandaServiceBase.FIPSMode.disabled
+            test_context=test_context, fips_mode=RedpandaService.FIPSMode.disabled
         )
 
         self.redpanda.set_environment(
@@ -281,9 +281,9 @@ class RedpandaFIPSStartupLicenseTest(RedpandaFIPSStartupTestBase):
         )
 
         fips_mode = (
-            RedpandaServiceBase.FIPSMode.enabled
+            RedpandaService.FIPSMode.enabled
             if in_fips_environment()
-            else RedpandaServiceBase.FIPSMode.permissive
+            else RedpandaService.FIPSMode.permissive
         )
 
         fips_config = dict(

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -359,9 +359,9 @@ class BucketScrubSelfTest(RedpandaTest):
 
 class SimpleSelfTest(Test):
     """
-    Verify instantiation of a RedpandaServiceBase subclass through the factory method.
+    Verify instantiation of a RedpandaServiceABC subclass through the factory method.
 
-    Runs a few methods of RedpandaServiceBase.
+    Runs a few methods of RedpandaService.
     """
 
     def __init__(self, test_context):


### PR DESCRIPTION
This is a vestigial base class: it is not instantiated directly and has only one subclass, RedpandaService, which should be used directly.

The "true" base class of RedpandaService and RedpandaServiceCloud is RedpandaServiceABC.

This change merges all static attributes and methods of RS and RSB and combines their constructor. Some type fixes are made to redpanda.py as well.

RedpandaServiceBase still exists as an empty class to allow this to race with another change which removes more RSB use, but that will be removed soon.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
