### PR TITLE
Introduce serverless_validation_test

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -688,6 +688,12 @@ def cleanup_entrypoint():
     # Init the cleaner class
     cleaner = CloudCleanup()
 
+    if cleaner.config.type == "serverless":
+        # Serverless clusters are created outside the scope of the test and will be cleaned up
+        # outside the scope of the test
+        print("Skipping cleanup during serverless tests")
+        sys.exit(0)
+
     # Arguments parsing. Quick and head on. No fancy argparse needed
     clean_namespaces = False
     clean_buckets = False

--- a/tests/rptest/redpanda_cloud_tests/serverless_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/serverless_validation_test.py
@@ -37,19 +37,8 @@ class ServerlessValidationTest(RedpandaCloudTest):
     # any less than that.
     CLUSTER_NODES = 10
 
-    GCP_EXPECTED_MAX_LATENCIES = {
-        OMBSampleConfigurations.E2E_LATENCY_50PCT: 200.0,
-        OMBSampleConfigurations.E2E_LATENCY_75PCT: 15000.0,
-        OMBSampleConfigurations.E2E_LATENCY_99PCT: 100000.0,
-        OMBSampleConfigurations.E2E_LATENCY_999PCT: 200000.0,
-    }
-
-    AWS_EXPECTED_MAX_LATENCIES = {
-        OMBSampleConfigurations.E2E_LATENCY_50PCT: 20.0,
-        OMBSampleConfigurations.E2E_LATENCY_75PCT: 25.0,
-        OMBSampleConfigurations.E2E_LATENCY_99PCT: 60.0,
-        OMBSampleConfigurations.E2E_LATENCY_999PCT: 100.0,
-    }
+    # no expectations at this time, we are simply measuring for now so we have historical data
+    EXPECTED_MAX_LATENCIES = {}
 
     # Mapping of result keys from specific series to their expected max latencies
     # Key is a series (Ex: endToEndLatency999pct and value is mapped to OMBSampleConfigurations.E2E_LATENCY_999PCT)
@@ -130,14 +119,7 @@ class ServerlessValidationTest(RedpandaCloudTest):
             self.logger.info(f"{key}: [{series_values}]")
 
     def expected_max_latencies(self):
-        if self._cloud_provider == "gcp":
-            expected = self.GCP_EXPECTED_MAX_LATENCIES
-        elif self._cloud_provider == "aws":
-            expected = self.AWS_EXPECTED_MAX_LATENCIES
-        else:
-            raise ValueError(
-                f"Unsupported or unspecified cloud provider: {self._cloud_provider}"
-            )
+        expected = self.EXPECTED_MAX_LATENCIES
         return {
             series_key: expected[config_key]
             for series_key, config_key in ServerlessValidationTest.LATENCY_SERIES_AND_MAX.items()
@@ -191,14 +173,7 @@ class ServerlessValidationTest(RedpandaCloudTest):
         latencies in cases we know this is reasonable (e.g., a system running at
         its maximum partition count."""
 
-        if cloud_provider == "gcp":
-            latency_limits = ServerlessValidationTest.GCP_EXPECTED_MAX_LATENCIES
-        elif cloud_provider == "aws":
-            latency_limits = ServerlessValidationTest.AWS_EXPECTED_MAX_LATENCIES
-        else:
-            raise ValueError(
-                f"Unsupported or unspecified cloud provider: {cloud_provider}"
-            )
+        latency_limits = ServerlessValidationTest.EXPECTED_MAX_LATENCIES
 
         # use dict comprehension to generate dict of latencies to list of validation functions
         # e.g. { 'aggregatedEndToEndLatency50pct': [OMBSampleConfigurations.lte(20.0 * multiplier)] }

--- a/tests/rptest/redpanda_cloud_tests/serverless_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/serverless_validation_test.py
@@ -1,0 +1,289 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import math
+from typing import Any, TypeVar
+
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import get_cloud_provider
+from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
+from ducktape.tests.test import TestContext
+from rptest.services.producer_swarm import ProducerSwarm
+from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda_cloud import ThroughputTierInfo
+from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
+from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
+from rptest.services.machinetype import get_machine_info
+from rptest.utils.type_utils import rcast
+from rptest.tests.write_caching_test import WriteCachingMode
+
+# pyright: strict
+
+KiB = 1024
+MiB = KiB * KiB
+KB = 10**3
+MB = 10**6
+
+
+class ServerlessValidationTest(RedpandaCloudTest):
+    # The numbers of nodes we expect to run with - this value (10) is the default
+    # for duck.py so these tests should just work with that default, but not necessarily
+    # any less than that.
+    CLUSTER_NODES = 10
+
+    GCP_EXPECTED_MAX_LATENCIES = {
+        OMBSampleConfigurations.E2E_LATENCY_50PCT: 200.0,
+        OMBSampleConfigurations.E2E_LATENCY_75PCT: 15000.0,
+        OMBSampleConfigurations.E2E_LATENCY_99PCT: 100000.0,
+        OMBSampleConfigurations.E2E_LATENCY_999PCT: 200000.0,
+    }
+
+    AWS_EXPECTED_MAX_LATENCIES = {
+        OMBSampleConfigurations.E2E_LATENCY_50PCT: 20.0,
+        OMBSampleConfigurations.E2E_LATENCY_75PCT: 25.0,
+        OMBSampleConfigurations.E2E_LATENCY_99PCT: 60.0,
+        OMBSampleConfigurations.E2E_LATENCY_999PCT: 100.0,
+    }
+
+    # Mapping of result keys from specific series to their expected max latencies
+    # Key is a series (Ex: endToEndLatency999pct and value is mapped to OMBSampleConfigurations.E2E_LATENCY_999PCT)
+    LATENCY_SERIES_AND_MAX = {
+        "endToEndLatency50pct": OMBSampleConfigurations.E2E_LATENCY_50PCT,
+        "endToEndLatency75pct": OMBSampleConfigurations.E2E_LATENCY_75PCT,
+        "endToEndLatency99pct": OMBSampleConfigurations.E2E_LATENCY_99PCT,
+        "endToEndLatency999pct": OMBSampleConfigurations.E2E_LATENCY_999PCT,
+    }
+
+    def run_benchmark_with_retries(
+        self, benchmark: OpenMessagingBenchmark, max_retries: int
+    ):
+        for try_count in range(1, max_retries + 1):
+            self.logger.info(f"Starting benchmark attempt {try_count}/{max_retries}.")
+            benchmark.start()
+            benchmark_time_min = benchmark.benchmark_time_mins() + 5
+            benchmark.wait(timeout_sec=benchmark_time_min * 60)
+
+            res = benchmark.check_succeed(raise_exceptions=False)
+            assert res  # help type checker
+            is_valid, validation_results = res
+            if is_valid:
+                self.logger.info("Benchmark passed without significant latency issues.")
+                return True
+            else:
+                self.handle_failed_attempt(
+                    try_count, max_retries, benchmark, validation_results
+                )
+
+        return False
+
+    def handle_failed_attempt(
+        self,
+        try_count: int,
+        max_retries: int,
+        benchmark: OpenMessagingBenchmark,
+        validation_results: list[str],
+    ):
+        self.logger.info(f"Benchmark test attempt {try_count} failed.")
+        for result in validation_results:
+            self.logger.info(f"Result is: {result}")
+
+        self.logger.info("Checking test results for possible latency spikes.")
+        latency_metrics = self.extract_latency_metrics(benchmark)
+        spikes_detected = benchmark.detect_spikes_by_percentile(
+            latency_metrics, expected_max_latencies=self.expected_max_latencies()
+        )
+
+        if spikes_detected and try_count < max_retries:
+            self.logger.info(
+                f"Latency spikes detected. Preparing for attempt {try_count + 1}/{max_retries}."
+            )
+            self.logger.info("Stopping and freeing worker nodes and retrying.")
+            benchmark.stop()
+            benchmark.clean()
+            assert benchmark.workers  # help type checker
+            benchmark.workers.free()
+        else:
+            self.logger.info(
+                "Persistent high latency detected or maximum retries reached. No further retries."
+            )
+            benchmark.check_succeed()
+
+    def extract_latency_metrics(self, benchmark: OpenMessagingBenchmark):
+        latency_metrics = {
+            key: benchmark.metrics[key]
+            for key in self.LATENCY_SERIES_AND_MAX
+            if key in benchmark.metrics
+        }
+        self.log_latency_metrics(latency_metrics)
+        return latency_metrics
+
+    def log_latency_metrics(self, latency_metrics: dict[str, Any]):
+        self.logger.info("Latency metrics for spikes detection:")
+        for key, value in latency_metrics.items():
+            series_values = ", ".join(str(v) for v in value)
+            self.logger.info(f"{key}: [{series_values}]")
+
+    def expected_max_latencies(self):
+        if self._cloud_provider == "gcp":
+            expected = self.GCP_EXPECTED_MAX_LATENCIES
+        elif self._cloud_provider == "aws":
+            expected = self.AWS_EXPECTED_MAX_LATENCIES
+        else:
+            raise ValueError(
+                f"Unsupported or unspecified cloud provider: {self._cloud_provider}"
+            )
+        return {
+            series_key: expected[config_key]
+            for series_key, config_key in ServerlessValidationTest.LATENCY_SERIES_AND_MAX.items()
+        }
+
+    def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
+        self._ctx = test_ctx
+
+        self._cloud_provider = self._ctx.globals.get("cloud_provider")
+
+        if self._cloud_provider == "gcp":
+            self.tier_machine_info = get_machine_info("n2d-standard-4")
+            self.num_brokers = 6
+            # tier-3-gcp-v2-x86 / GCP / integration & preprod
+            self._tier_limits = ThroughputTierInfo(
+                max_ingress=100000000,
+                max_egress=200000000,
+                max_connections_count=45000,
+                max_partition_count=11200,
+            )
+        elif self._cloud_provider == "aws":
+            self.tier_machine_info = get_machine_info("m7gd.large")
+            self.num_brokers = 3
+            # tier-1-aws-v3-arm / AWS / integration & preprod
+            self._tier_limits = ThroughputTierInfo(
+                max_ingress=20000000,
+                max_egress=60000000,
+                max_connections_count=9000,
+                max_partition_count=2000,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported or unspecified cloud provider: {self._cloud_provider}"
+            )
+
+        super().__init__(test_ctx, *args, **kwargs)
+
+    def setup(self):
+        super().setup()
+        self.redpanda.clean_cluster()
+
+    def tearDown(self):
+        super().tearDown()
+        self.redpanda.clean_cluster()
+
+    @staticmethod
+    def base_validator(cloud_provider: str, multiplier: float = 1) -> dict[str, Any]:
+        """Return a validator object with reasonable latency targets for
+        healthy systems. Optionally accepts a multiplier value which will multiply
+        all the latencies by the given value, which could be used to accept higher
+        latencies in cases we know this is reasonable (e.g., a system running at
+        its maximum partition count."""
+
+        if cloud_provider == "gcp":
+            latency_limits = ServerlessValidationTest.GCP_EXPECTED_MAX_LATENCIES
+        elif cloud_provider == "aws":
+            latency_limits = ServerlessValidationTest.AWS_EXPECTED_MAX_LATENCIES
+        else:
+            raise ValueError(
+                f"Unsupported or unspecified cloud provider: {cloud_provider}"
+            )
+
+        # use dict comprehension to generate dict of latencies to list of validation functions
+        # e.g. { 'aggregatedEndToEndLatency50pct': [OMBSampleConfigurations.lte(20.0 * multiplier)] }
+        return {
+            k: [OMBSampleConfigurations.lte(v * multiplier)]
+            for k, v in latency_limits.items()
+        }
+
+    def _partition_count(self) -> int:
+        machine_config = self.tier_machine_info
+        return 5 * self.num_brokers * machine_config.num_shards
+
+    def _producer_count(self, ingress_rate: int) -> int:
+        """Determine the number of producers based on the ingress rate (in bytes).
+        We assume that each producer is capable of 5 MB/s."""
+        return max(ingress_rate // (5 * MB), 1)
+
+    def _consumer_count(self, egress_rate: int) -> int:
+        """Determine the number of consumers based on the egress rate (in bytes).
+        We assume that each consumer is capable of 5 MB/s."""
+        return max(egress_rate // (5 * MB), 1)
+
+    def _mb_to_mib(self, mb: float | int):
+        return math.floor(0.9537 * mb)
+
+    @cluster(num_nodes=CLUSTER_NODES)
+    def test_serverless_workload(self):
+        subscriptions = max(
+            self._tier_limits.max_egress // self._tier_limits.max_ingress, 1
+        )
+        partitions = self._partition_count()
+        total_producers = self._producer_count(self._tier_limits.max_ingress)
+        total_consumers = self._consumer_count(self._tier_limits.max_egress)
+
+        validator = self.base_validator(self._cloud_provider) | {
+            OMBSampleConfigurations.AVG_THROUGHPUT_MBPS: [
+                OMBSampleConfigurations.gte(
+                    self._mb_to_mib(self._tier_limits.max_ingress // (1 * MB))
+                ),
+            ],
+        }
+
+        workload = {
+            "topics": 1,
+            "message_size": 1 * KiB,
+            "payload_file": "payload/payload-1Kb.data",
+            "consumer_backlog_size_GB": 0,
+            "test_duration_minutes": 1,
+            "warmup_duration_minutes": 1,
+            "name": "ServerlessTestWorkload",
+            "partitions_per_topic": partitions,
+            "subscriptions_per_topic": subscriptions,
+            "consumer_per_subscription": max(total_consumers // subscriptions, 1),
+            "producers_per_topic": total_producers,
+            "producer_rate": self._tier_limits.max_ingress // (1 * KiB),
+        }
+
+        driver = {
+            "name": "ServerlessTestDriver",
+            "reset": "true",
+            "replication_factor": 3,
+            "request_timeout": 400000,
+            "producer_config": {
+                "enable.idempotence": "true",
+                "acks": "all",
+                "linger.ms": 1,
+                "max.in.flight.requests.per.connection": 5,
+            },
+            "consumer_config": {
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": "false",
+            },
+            "topic_config": {
+                "write.caching": "false",
+            },
+        }
+
+        benchmark = OpenMessagingBenchmark(
+            self._ctx,
+            self.redpanda,
+            driver,
+            (workload, validator),
+            num_workers=self.CLUSTER_NODES - 1,
+            topology="ensemble",
+        )
+        # Latency spikes detection and retry
+        max_retries = 1
+        self.run_benchmark_with_retries(benchmark, max_retries)

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -149,6 +149,13 @@ class RpCloudApiClient(object):
             _e += f"/{id}"
         return _e
 
+    @staticmethod
+    def serverless_cluster_endpoint(id=None):
+        _e = "/v1/serverless/clusters"
+        if id:
+            _e += f"/{id}"
+        return _e
+
     # delete for DEVPROD-2525
     @staticmethod
     def legacy_cluster_endpoint(id=None):
@@ -219,6 +226,13 @@ class RpCloudApiClient(object):
             self.cluster_endpoint(id=cluster_id), base_url=self._config.public_api_url
         )
         return _cluster["cluster"]
+
+    def get_serverless_cluster(self, cluster_id: str):
+        _cluster = self._http_get(
+            self.serverless_cluster_endpoint(id=cluster_id),
+            base_url=self._config.public_api_url,
+        )
+        return _cluster["serverless_cluster"]
 
     # delete for DEVPROD-2525
     def get_legacy_cluster(self, cluster_id: str):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1622,8 +1622,18 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             "ResourceSettings: setting dedicated_nodes=True because serving from redpanda cloud"
         )
 
-        cluster_id = self._cloud_cluster.create(superuser=self._superuser)
+        self._is_serverless_cluster = False
+        if self._cc_config["type"] == "serverless":
+            self._is_serverless_cluster = True
+        cluster_id = self._cloud_cluster.create(
+            superuser=self._superuser, is_serverless_cluster=self._is_serverless_cluster
+        )
         remote_uri = f"redpanda@{cluster_id}-agent"
+        if self._is_serverless_cluster:
+            # if cluster is a serverless cluster it will be treated as a black box, there will be no kubectl or
+            # checking of pods
+            return
+
         self.__kubectl = KubectlTool(
             self,
             remote_uri=remote_uri,
@@ -1965,9 +1975,14 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             )
 
     def brokers(self) -> str:
+        if self._is_serverless_cluster:
+            return self._cloud_cluster.get_serverless_broker_address()
         return self._cloud_cluster.get_broker_address()
 
     def install_pack_version(self) -> str:
+        if self._is_serverless_cluster:
+            # if serverless cluster we do not have an install pack version
+            return "unknown_version"
         return self._cloud_cluster.get_install_pack_version()
 
     def sockets_clear(self, node: RemoteClusterNode):
@@ -2170,6 +2185,10 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             # Shortcut to getting restart counter
             return p["containerStatuses"][0]["restartCount"]
 
+        if self._is_serverless_cluster:
+            # if serverless cluster test treats it like a black box, no checking of pods
+            return
+
         # Not checking active count vs expected nodes
         active, _, _ = self.get_redpanda_pods_presorted()
         for pod in active:
@@ -2244,6 +2263,10 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         :param allow_list: list of compiled regexes, or None for default
         :return: None
         """
+        if self._is_serverless_cluster:
+            # if serverless cluster test treats it as a black box, no checking of logs
+            return
+
         allow_list = prepare_allow_list(allow_list)
 
         lsearcher = LogSearchCloud(
@@ -2301,6 +2324,10 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             except Exception as e:
                 self.logger.warning(f"Error getting logs for {pod.name}: {e}")
             return pod.name
+
+        if self._is_serverless_cluster:
+            # if serverless cluster test treats it as a black box, no checking of pods
+            return {}
 
         # Safeguard if CloudService not created
         if self.pods is None or self._cloud_cluster is None:

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -465,6 +465,9 @@ class CloudCluster:
         return _cluster["state"] == state
 
     def _get_cluster_console_url(self):
+        if self.config.type == "SERVERLESS":
+            cluster = self.rpcloud.get_serverless_cluster(self.current.cluster_id)
+            return cluster["console_url"]
         cluster = self.rpcloud.get_cluster(self.current.cluster_id)
         return cluster["redpanda_console"]["url"]
 
@@ -570,10 +573,14 @@ class CloudCluster:
             "zones": self.current.zones,
         }
 
-    def _get_cluster(self, _id: str) -> dict[str, Any]:
+    def _get_cluster(
+        self, _id: str, is_serverless_cluster: bool = False
+    ) -> dict[str, Any]:
         """
         Calls public API to get cluster info
         """
+        if is_serverless_cluster:
+            return self.rpcloud.get_serverless_cluster(_id)
         return self.rpcloud.get_cluster(_id)
 
     def _get_legacy_cluster(self, _id: str) -> dict[str, Any]:
@@ -822,7 +829,7 @@ class CloudCluster:
         """Get the list of brokers from the pandaproxy API."""
         return self._query_panda_proxy("/brokers")["brokers"]
 
-    def _ensure_cluster_health(self) -> str | None:
+    def _ensure_cluster_health(self, is_serverless_cluster=False) -> str | None:
         """
         Check if current cluster is healthy
           - check connectivity
@@ -840,7 +847,9 @@ class CloudCluster:
         # Get cluster details
         try:
             self._logger.info("Getting cluster specs")
-            cluster = self._get_cluster(self.current.cluster_id)
+            cluster = self._get_cluster(
+                self.current.cluster_id, is_serverless_cluster=is_serverless_cluster
+            )
         except Exception as e:
             return warn_and_return(
                 f"# Failed to get info for cluster with Id: '{self.current.cluster_id}'"
@@ -850,6 +859,10 @@ class CloudCluster:
         self._logger.info(
             f"Cluster '{self.current.cluster_id}': state = '{cluster['state']}'"
         )
+
+        if is_serverless_cluster:
+            # if serverless cluster, assume healthy, we have no other state and we can't talk to the brokers directly
+            return None
 
         # Check if panda-proxy is available
         if not "url" in cluster["http_proxy"]:
@@ -947,7 +960,7 @@ class CloudCluster:
             # if there is still no id, just copy what globals.json had
             return self.config.id
 
-    def create(self, superuser: SaslCredentials) -> str:
+    def create(self, superuser: SaslCredentials, is_serverless_cluster=False) -> str:
         """Create a cloud cluster and a new namespace; block until cluster is finished creating.
 
         :param config_profile_name: config profile name, default 'tier-1-aws'
@@ -976,7 +989,9 @@ class CloudCluster:
                 self.current.consoleUrl = self._get_cluster_console_url()
                 self.update_cluster_acls(superuser)
                 # Do the health check
-                unhealthy_reason: str | None = self._ensure_cluster_health()
+                unhealthy_reason: str | None = self._ensure_cluster_health(
+                    is_serverless_cluster=is_serverless_cluster
+                )
             except Exception as e:
                 if fail_on_unhealthy:
                     raise
@@ -1004,7 +1019,9 @@ class CloudCluster:
                 self.rm_cluster_id_file()
                 # Create new cluster
                 self._create_new_cluster()
-            else:
+            elif not is_serverless_cluster:
+                # if serverless cluster we cannot ask about config profiles and such, the test will make assumptions
+                # about the supported capacity of serverless vclusters
                 # Just load needed info to create peering
                 self._logger.warning(
                     "will not create cluster; already have "
@@ -1142,6 +1159,10 @@ class CloudCluster:
 
     def get_broker_address(self):
         cluster = self.rpcloud.get_cluster(self.current.cluster_id)
+        return cluster["kafka_api"]["seed_brokers"][0]
+
+    def get_serverless_broker_address(self):
+        cluster = self.rpcloud.get_serverless_cluster(self.current.cluster_id)
         return cluster["kafka_api"]["seed_brokers"][0]
 
     def get_install_pack_version(self):


### PR DESCRIPTION
Performs a basic OMB test against a serverless cluster. Modeled after test_common_workload, but adapted for serverless.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none