### PR TITLE
fetch_plan_bench: non-random topic names

### DIFF
--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -849,6 +849,7 @@ redpanda_cc_bench(
         "//src/v/security",
         "//src/v/test_utils:fixture",
         "@boost//:test",
+        "@fmt",
         "@seastar//:benchmark",
     ],
 )

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -18,11 +18,14 @@
 #include "kafka/server/handlers/fetch.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
-#include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "security/acl.h"
 
 #include <seastar/testing/perf_tests.hh>
+
+#include <fmt/core.h>
+
+#include <string>
 
 static ss::logger fpt_logger("fpt_test");
 
@@ -100,12 +103,16 @@ struct fetch_plan : redpanda_thread_fixture {
 
         _state.emplace();
 
-        co_await ss::parallel_for_each(boost::irange(tcount), [&, this](int) {
-            auto name = model::topic(
-              random_generators::gen_alphanum_string(topic_name_length));
-            _state->topics.push_back(name);
+        co_await ss::parallel_for_each(boost::irange(tcount), [&, this](int i) {
+            constexpr auto topic_name_format = "topic-{:05}-";
+            auto name = fmt::format(topic_name_format, i);
+            vassert(name.size() <= topic_name_length, "cannot fit name");
+            name += std::string(topic_name_length - name.size(), 'x');
+            vassert(name.size() == topic_name_length, "huh");
+            model::topic topic{name};
+            _state->topics.push_back(topic);
             return add_topic(
-              model::topic_namespace_view(model::kafka_namespace, name),
+              model::topic_namespace_view(model::kafka_namespace, topic),
               pcount);
         });
 


### PR DESCRIPTION
This bench showed about a 1% variability, while other non-async benches show usually less than 0.1%, often around 0.01%.

Underlying cause seems to be random topic names: after using fixed topic names the variability drops to ~0.01%. This makes sense since the names used will affect hash map collisions and this test is sensitive to that.

Before this change, 10 runs looks like:

```
test                     iterations      median         mad         min         max      allocs       tasks        inst      cycles
fetch_plan.t1p1_no_auth     9000000   103.733ns     0.000ns   103.733ns   103.733ns       8.000       0.000      2267.1       498.2
fetch_plan.t1p1_no_auth     9000000   106.953ns     0.000ns   106.953ns   106.953ns       8.000       0.000      2286.1       513.2
fetch_plan.t1p1_no_auth     9000000   110.322ns     0.000ns   110.322ns   110.322ns       8.000       0.000      2267.7       516.5
fetch_plan.t1p1_no_auth     9000000   104.894ns     0.000ns   104.894ns   104.894ns       8.000       0.000      2267.6       496.6
fetch_plan.t1p1_no_auth     9000000   108.358ns     0.000ns   108.358ns   108.358ns       8.000       0.000      2286.4       499.1
fetch_plan.t1p1_no_auth     9000000   104.301ns     0.000ns   104.301ns   104.301ns       8.000       0.000      2267.5       495.3
fetch_plan.t1p1_no_auth     9000000   105.518ns     0.000ns   105.518ns   105.518ns       8.000       0.000      2267.2       496.3
fetch_plan.t1p1_no_auth     9000000   107.567ns     0.000ns   107.567ns   107.567ns       8.000       0.000      2267.3       495.9
fetch_plan.t1p1_no_auth     9000000   107.053ns     0.000ns   107.053ns   107.053ns       8.000       0.000      2267.6       496.6
fetch_plan.t1p1_no_auth     9000000   105.608ns     0.000ns   105.608ns   105.608ns       8.000       0.000      2286.6       498.1
```

while after it looks like (note `inst` column values):

```
test                     iterations      median         mad         min         max      allocs       tasks        inst      cycles
fetch_plan.t1p1_no_auth     9000000   106.189ns     0.000ns   106.189ns   106.189ns       8.000       0.000      2286.4       505.4
fetch_plan.t1p1_no_auth     9000000   108.027ns     0.000ns   108.027ns   108.027ns       8.000       0.000      2286.5       513.5
fetch_plan.t1p1_no_auth     9000000   106.684ns     0.000ns   106.684ns   106.684ns       8.000       0.000      2286.5       508.3
fetch_plan.t1p1_no_auth     9000000   106.632ns     0.000ns   106.632ns   106.632ns       8.000       0.000      2286.3       505.7
fetch_plan.t1p1_no_auth     9000000   109.501ns     0.000ns   109.501ns   109.501ns       8.000       0.000      2286.5       520.7
fetch_plan.t1p1_no_auth     9000000   106.641ns     0.000ns   106.641ns   106.641ns       8.000       0.000      2286.4       505.9
fetch_plan.t1p1_no_auth     9000000   106.281ns     0.000ns   106.281ns   106.281ns       8.000       0.000      2286.6       503.0
fetch_plan.t1p1_no_auth     9000000   107.354ns     0.000ns   107.354ns   107.354ns       8.000       0.000      2286.3       509.1
fetch_plan.t1p1_no_auth     8000000   111.425ns     0.000ns   111.425ns   111.425ns       8.000       0.000      2286.4       530.3
fetch_plan.t1p1_no_auth     9000000   106.893ns     0.000ns   106.893ns   106.893ns       8.000       0.000      2286.3       507.2
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

