### PR TITLE
`ct/l1`: add `offset_interval_set::covers()`

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/offset_interval_set.cc
+++ b/src/v/cloud_topics/level_one/metastore/offset_interval_set.cc
@@ -45,6 +45,15 @@ bool offset_interval_set::contains(kafka::offset o) const {
     return iset_.find(o()) != iset_.end();
 }
 
+bool offset_interval_set::covers(kafka::offset start, kafka::offset end) const {
+    auto it = iset_.find(start());
+    if (it == iset_.end()) {
+        return false;
+    }
+
+    return (it->first <= start && it->second > end);
+}
+
 offset_interval_set::stream offset_interval_set::make_stream() const {
     return stream(iset_);
 }

--- a/src/v/cloud_topics/level_one/metastore/offset_interval_set.h
+++ b/src/v/cloud_topics/level_one/metastore/offset_interval_set.h
@@ -51,6 +51,7 @@ public:
     bool empty() const;
     bool insert(kafka::offset base, kafka::offset last);
     bool contains(kafka::offset offset) const;
+    bool covers(kafka::offset start, kafka::offset end) const;
     stream make_stream() const;
     chunked_vector<interval> to_vec() const;
     void truncate_with_new_start_offset(kafka::offset);

--- a/src/v/cloud_topics/level_one/metastore/tests/offset_interval_set_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/offset_interval_set_test.cc
@@ -117,3 +117,37 @@ TEST(OffsetIntervalSetTest, TestTruncate) {
     s.truncate_with_new_start_offset(o{6});
     EXPECT_THAT(s.to_vec(), testing::ElementsAre());
 }
+
+TEST(OffsetIntervalSetTest, TestCovers) {
+    offset_interval_set s;
+    ASSERT_TRUE(s.empty());
+
+    ASSERT_TRUE(s.insert(o{1}, o{5}));
+    ASSERT_TRUE(s.covers(o{1}, o{5}));
+    ASSERT_FALSE(s.covers(o{0}, o{5}));
+    ASSERT_FALSE(s.covers(o{1}, o{6}));
+    ASSERT_FALSE(s.covers(o{6}, o{10}));
+
+    ASSERT_TRUE(s.insert(o{0}, o{10}));
+    ASSERT_TRUE(s.covers(o{0}, o{5}));
+    ASSERT_TRUE(s.covers(o{1}, o{6}));
+    ASSERT_TRUE(s.covers(o{0}, o{10}));
+    ASSERT_FALSE(s.covers(o{0}, o{11}));
+    ASSERT_FALSE(s.covers(o{11}, o{100}));
+}
+
+TEST(OffsetIntervalSetTest, TestCoversDisjointIntervals) {
+    offset_interval_set s;
+    ASSERT_TRUE(s.empty());
+
+    ASSERT_TRUE(s.insert(o{0}, o{5}));
+    ASSERT_TRUE(s.insert(o{10}, o{20}));
+
+    ASSERT_TRUE(s.covers(o{0}, o{5}));
+    ASSERT_FALSE(s.covers(o{4}, o{10}));
+    ASSERT_FALSE(s.covers(o{5}, o{10}));
+    ASSERT_FALSE(s.covers(o{4}, o{11}));
+    ASSERT_TRUE(s.covers(o{10}, o{20}));
+
+    ASSERT_FALSE(s.covers(o{0}, o{20}));
+}


### PR DESCRIPTION
For determining if an input interval is covered by an interval present in the `interval_offset_map`.

This will be used in the future for determining which `extent`s in a partition are cleanly compacted or not. For example, computing the dirty ratio of a log could be written (using this function) as:

```cpp
double get_dirty_ratio(const partition_state& state){
    size_t total_size{0};
    size_t dirty_size{0};
    const auto& cleaned_ranges = state.compaction_state->cleaned_ranges;
    for (const auto& extent : state.extents) {
        total_size += extent.len;
        auto b = extent.base_offset;
        auto e = extent.last_offset;
        if (!cleaned_ranges.covers(b, e)) {
            dirty_size += extent.len;
        }
    }
    return total_size == 0 ? 0.0
                           : static_cast<double>(dirty_size)
                               / static_cast<double>(total_size);
}
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
