### PR TITLE
Deduplicate batches in direct consumer verifier

### DIFF
--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -190,7 +190,6 @@ private:
         std::optional<kafka::offset> fetch_offset;
         std::optional<kafka::offset> high_watermark;
         leader_epoch current_leader_epoch{kafka::invalid_leader_epoch};
-        intrusive_list_hook _hook;
         assignment_epoch assignment_epoch{0};
         bool incremental_include{false};
 
@@ -198,8 +197,7 @@ private:
             return fetch_offset.has_value();
         }
     };
-    using state_list
-      = intrusive_list<partition_fetch_state, &partition_fetch_state::_hook>;
+    using state_list = chunked_vector<partition_fetch_state>;
     struct partitions_to_process {
         model::topic topic;
         state_list to_include_in_fetch;

--- a/tests/rptest/direct_consumer_tests/direct_consumer_test.py
+++ b/tests/rptest/direct_consumer_tests/direct_consumer_test.py
@@ -182,8 +182,7 @@ class DirectConsumerVerifierTest(RedpandaTest):
             final_state = verifier.get_consumer_state(state_request)
 
             # assertions
-            # must have seen at least msg_count, duplicate offsets are legal but undesirable
-            assert final_state.total_consumed_messages >= msg_count, (
+            assert final_state.total_consumed_messages == msg_count, (
                 f"Expected {msg_count} messages, got {final_state.total_consumed_messages}"
             )
 


### PR DESCRIPTION
Fetcher allows for concurrent updates to its assignments
- assignments are held in
  chunked_hash_map<topic, chunked_hash_map<partition_id, fetcher_state>>
- assignments may be updated on any fiber by modifying this assignments
  map

Fetcher state is an intrusive list element

The fetcher runs in a loop fiber as follows:
- partitions = collect_partitions()
- request = make_request(partitions)
- fetch_response = dispatch_fetch(request)
- update_assignments(fetch_response)

Where collect partitions builds an intrusive list of partition
to include in the next fetch request from the assignments map
and make_request uses that intrusive list to serialize a request

Currently, this approach has two problems.
1. fetcher_state is an intrusive list element but has no custom move
   semantics.
   - naiive moves of intrusive list elements do not preserve their
     intrusive lists
   - removals from chunked_hash_map can move the contained elements
   - can surface as an unexpected reordering of the partitions to
     include list used by make_request
     - the symptom of this was that partitions would be missed in some
       fetch requests, thus failing to inform their broker of updated
       fetch offsets. This lead to duplicated fetched records
2. iterators to intrusive lists are invalidated by the destruction of
   their backing intrusive list element
   - this means that a sufficiently unlucky unassignment could destruct
     the element that the fetcher loop is currently iterating on causing
     a bad memory access

The resolution used in this commit is to stop using intrusive list for
the incremental state created by the fetcher loop fiber.

Instead, the incremental state is now held in a chunked_vector which
owns a copy of the fetcher state as it was at the beginning of the loop.

Now that the fetcher loop owns the memory on which it iterates, the
backing list can be more easily shown NOT to mutate while the fetcher
iterates.

This will prevent both of the above issues.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes

* deduplicates records fetched via direct_consumer

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
