### PR TITLE
ct/ducktape: Ignore the cloud topics test

### DIFF
--- a/tests/rptest/tests/cloud_topics_test.py
+++ b/tests/rptest/tests/cloud_topics_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
-from ducktape.mark import matrix
+from ducktape.mark import ignore, matrix
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import SISettings, get_cloud_storage_type
@@ -46,6 +46,8 @@ class CloudTopicsTest(RedpandaTest):
                 config={"redpanda.cloud_topic.enabled": "true"},
             )
 
+    # Ignored because it's flaky but the test is still useful locally.
+    @ignore
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_reconciler_uploads(self, cloud_storage_type):


### PR DESCRIPTION
The cloud topics test is flaky and it doesn't really test anything given the current state of cloud topics. Ignore it (but don't remove it) because it's still useful for local development.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
