### PR TITLE
`compaction`: rename `{backward/forward}_iteration()`

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/source.cc
+++ b/src/v/cloud_topics/level_one/compaction/source.cc
@@ -18,11 +18,11 @@ namespace cloud_topics::l1 {
 
 ss::future<> compaction_source::initialize() { co_return; }
 
-ss::future<ss::stop_iteration> compaction_source::backward_pass_iteration() {
+ss::future<ss::stop_iteration> compaction_source::map_building_iteration() {
     co_return ss::stop_iteration::yes;
 }
 
-ss::future<ss::stop_iteration> compaction_source::forward_pass_iteration(
+ss::future<ss::stop_iteration> compaction_source::deduplication_iteration(
   compaction::sliding_window_reducer::sink&) {
     co_return ss::stop_iteration::yes;
 }

--- a/src/v/cloud_topics/level_one/compaction/source.h
+++ b/src/v/cloud_topics/level_one/compaction/source.h
@@ -17,9 +17,9 @@ namespace cloud_topics::l1 {
 class compaction_source : public compaction::sliding_window_reducer::source {
 public:
     ss::future<> initialize() final;
-    ss::future<ss::stop_iteration> backward_pass_iteration() final;
+    ss::future<ss::stop_iteration> map_building_iteration() final;
     ss::future<ss::stop_iteration>
-    forward_pass_iteration(compaction::sliding_window_reducer::sink&) final;
+    deduplication_iteration(compaction::sliding_window_reducer::sink&) final;
 
 private:
 };

--- a/src/v/compaction/reducer.cc
+++ b/src/v/compaction/reducer.cc
@@ -17,12 +17,12 @@ ss::future<> compaction::sliding_window_reducer::run() && {
     // Step 0: Initialize source
     co_await _src->initialize();
 
-    // Step 1: Perform backward pass
-    co_await ss::repeat([this]() { return _src->backward_pass_iteration(); });
+    // Step 1: Perform map building pass.
+    co_await ss::repeat([this]() { return _src->map_building_iteration(); });
 
-    // Step 2: Perform forward pass.
+    // Step 2: Perform de-duplication pass.
     co_await ss::repeat(
-      [this]() { return _src->forward_pass_iteration(*_sink); });
+      [this]() { return _src->deduplication_iteration(*_sink); });
 
     // Done!
     co_await _sink->finalize();

--- a/src/v/compaction/reducer.h
+++ b/src/v/compaction/reducer.h
@@ -72,15 +72,15 @@ public:
     // example, the local storage source may need to collect the set of
     // `segment`s eligible for compaction, and perform self compaction on them
     // before proceeding to the sliding window algorithm.
-    // 2. `backward_pass_iteration()`: This is the pass that reads from the
-    // data source from head to tail, and indexes the latest key-offset pair in
-    // the contained map within the provided `compaction_config` object.This
-    // should ideally be a light-weight read over a portion of the log that
-    // avoids de-compression or e.g. uncached reads from cloud storage.
-    // 3. `forward_pass_iteration(sink)`: This is the pass that reads from
-    // the data source from tail to head, and provides the data to be written
-    // (determined by the contents of the key-offset map and other configured
-    // parameters within `cfg`) for this round of compaction to the sink object.
+    // 2. `map_building_iteration()`: This is the pass that reads from the
+    // data source and indexes the latest key-offset pair in the contained map
+    // within the provided `compaction_config` object. This should ideally be a
+    // light-weight read over a portion of the log that avoids de-compression or
+    // e.g. uncached reads from cloud storage.
+    // 3. `deduplication_iteration(sink)`: This is the pass that reads from
+    // the data source and provides the data to be written (determined by the
+    // contents of the key-offset map and other configured parameters within
+    // `cfg`) for this round of compaction to the sink object.
     class source {
     public:
         source() noexcept = default;
@@ -92,9 +92,9 @@ public:
 
     public:
         virtual ss::future<> initialize() = 0;
-        virtual ss::future<ss::stop_iteration> backward_pass_iteration() = 0;
+        virtual ss::future<ss::stop_iteration> map_building_iteration() = 0;
         virtual ss::future<ss::stop_iteration>
-        forward_pass_iteration(sink&) = 0;
+        deduplication_iteration(sink&) = 0;
     };
 
 public:

--- a/src/v/compaction/tests/simple_reducer.h
+++ b/src/v/compaction/tests/simple_reducer.h
@@ -99,7 +99,7 @@ public:
         co_return;
     }
 
-    ss::future<ss::stop_iteration> backward_pass_iteration() final {
+    ss::future<ss::stop_iteration> map_building_iteration() final {
         if (_b_it == _batches.rend()) {
             co_return ss::stop_iteration::yes;
         }
@@ -117,7 +117,7 @@ public:
     }
 
     ss::future<ss::stop_iteration>
-    forward_pass_iteration(sliding_window_reducer::sink& s) final {
+    deduplication_iteration(sliding_window_reducer::sink& s) final {
         if (_f_it == _batches.end()) {
             co_return ss::stop_iteration::yes;
         }


### PR DESCRIPTION
These function names were a poor choice, as they describe implementation details (which may not necessarily be true) and not the actual purpose of the functions.

Rename them to `map_building_iteration()` and `deduplication_iteration()` respectively to be more descriptive about their functionality (and not perscribe any requirements to their implementation).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
