### PR TITLE
[v25.2.x] [CORE-12961] Add security report admin endpoint

### DIFF
--- a/src/v/config/broker_authn_endpoint.cc
+++ b/src/v/config/broker_authn_endpoint.cc
@@ -45,6 +45,11 @@ std::ostream& operator<<(std::ostream& os, const broker_authn_endpoint& ep) {
     return os;
 }
 
+bool kafka_authz_enabled() {
+    return config::shard_local_cfg().kafka_enable_authorization().value_or(
+      config::shard_local_cfg().enable_sasl());
+}
+
 broker_authn_method get_authn_method(std::string_view connection_name) {
     // If authn_method is set on the endpoint
     //    Use it

--- a/src/v/config/broker_authn_endpoint.cc
+++ b/src/v/config/broker_authn_endpoint.cc
@@ -9,8 +9,13 @@
 
 #include "config/broker_authn_endpoint.h"
 
+#include "config/configuration.h"
+#include "config/node_config.h"
 #include "model/metadata.h"
 #include "strings/string_switch.h"
+
+#include <algorithm>
+#include <string_view>
 
 namespace config {
 
@@ -38,6 +43,36 @@ from_string_view<broker_authn_method>(std::string_view sv) {
 std::ostream& operator<<(std::ostream& os, const broker_authn_endpoint& ep) {
     fmt::print(os, "{{{}:{}:{}}}", ep.name, ep.address, ep.authn_method);
     return os;
+}
+
+broker_authn_method get_authn_method(std::string_view connection_name) {
+    // If authn_method is set on the endpoint
+    //    Use it
+    // Else if kafka_enable_authorization is not set
+    //    Use sasl if enable_sasl
+    // Else if has mtls mapping rules
+    //    Use mtls_identity
+    // Else
+    //    Disable AuthN
+
+    std::optional<config::broker_authn_method> authn_method;
+    const auto& kafka_api = config::node().kafka_api.value();
+    auto ep_it = std::ranges::find(
+      kafka_api, connection_name, &broker_authn_endpoint::name);
+    if (ep_it != kafka_api.end()) {
+        authn_method = ep_it->authn_method;
+    }
+    if (authn_method.has_value()) {
+        return *authn_method;
+    }
+    const auto& config = config::shard_local_cfg();
+    // if kafka_enable_authorization is not set, use sasl iff enable_sasl
+    if (
+      !config.kafka_enable_authorization().has_value()
+      && config.enable_sasl()) {
+        return config::broker_authn_method::sasl;
+    }
+    return config::broker_authn_method::none;
 }
 
 } // namespace config

--- a/src/v/config/broker_authn_endpoint.h
+++ b/src/v/config/broker_authn_endpoint.h
@@ -61,6 +61,7 @@ consteval std::string_view property_type_name<broker_authn_endpoint>() {
 
 } // namespace detail
 
+bool kafka_authz_enabled();
 broker_authn_method get_authn_method(std::string_view connection_name);
 
 } // namespace config

--- a/src/v/config/broker_authn_endpoint.h
+++ b/src/v/config/broker_authn_endpoint.h
@@ -61,6 +61,8 @@ consteval std::string_view property_type_name<broker_authn_endpoint>() {
 
 } // namespace detail
 
+broker_authn_method get_authn_method(std::string_view connection_name);
+
 } // namespace config
 
 namespace YAML {

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -45,13 +45,11 @@ std::optional<sasl_configuration> create_sasl_configuration_from_client_cfg(
 ss::future<std::optional<kafka::client::sasl_configuration>>
 create_client_credentials(
   cluster::controller& controller,
-  const config::configuration& cluster_cfg,
   const kafka::client::configuration& client_cfg,
   security::acl_principal principal) {
     auto sasl_cfg = create_sasl_configuration_from_client_cfg(client_cfg);
     // If AuthZ is not enabled, don't create credentials.
-    if (!cluster_cfg.kafka_enable_authorization().value_or(
-          cluster_cfg.enable_sasl())) {
+    if (!config::kafka_authz_enabled()) {
         co_return sasl_cfg;
     }
 

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -29,10 +29,7 @@ namespace kafka::client {
 namespace {
 std::optional<sasl_configuration> create_sasl_configuration_from_client_cfg(
   const kafka::client::configuration& client_cfg) {
-    if (
-      client_cfg.scram_password.is_overriden()
-      || client_cfg.scram_username.is_overriden()
-      || client_cfg.sasl_mechanism.is_overriden()) {
+    if (is_scram_configured(client_cfg)) {
         return sasl_configuration{
           .mechanism = client_cfg.sasl_mechanism(),
           .username = client_cfg.scram_username(),
@@ -42,6 +39,13 @@ std::optional<sasl_configuration> create_sasl_configuration_from_client_cfg(
     return std::nullopt;
 }
 } // namespace
+
+bool is_scram_configured(const configuration& client_cfg) {
+    return client_cfg.scram_password.is_overriden()
+           || client_cfg.scram_username.is_overriden()
+           || client_cfg.sasl_mechanism.is_overriden();
+}
+
 ss::future<std::optional<kafka::client::sasl_configuration>>
 create_client_credentials(
   cluster::controller& controller,
@@ -54,10 +58,7 @@ create_client_credentials(
     }
 
     // If the configuration is overriden, use it.
-    if (
-      client_cfg.scram_password.is_overriden()
-      || client_cfg.scram_username.is_overriden()
-      || client_cfg.sasl_mechanism.is_overriden()) {
+    if (is_scram_configured(client_cfg)) {
         co_return sasl_cfg;
     }
 

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -25,6 +25,8 @@
 
 namespace kafka::client {
 
+bool is_scram_configured(const configuration& client_cfg);
+
 ss::future<std::optional<kafka::client::sasl_configuration>>
 create_client_credentials(
   cluster::controller& controller,

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -28,7 +28,6 @@ namespace kafka::client {
 ss::future<std::optional<kafka::client::sasl_configuration>>
 create_client_credentials(
   cluster::controller& controller,
-  const config::configuration& cluster_cfg,
   const kafka::client::configuration& client_cfg,
   security::acl_principal principal);
 

--- a/src/v/kafka/client/test/test_config_utils.cc
+++ b/src/v/kafka/client/test/test_config_utils.cc
@@ -80,7 +80,7 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
 
     const auto create_credentials = [&, this]() {
         return kafka::client::create_client_credentials(
-          *app.controller, cluster_cfg, client_cfg, principal);
+          *app.controller, client_cfg, principal);
     };
 
     // Default configuration, no authz - expect no changes

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -253,39 +253,6 @@ coordinator_ntp_mapper& server::coordinator_mapper() {
     return _group_router.local().coordinator_mapper().local();
 }
 
-config::broker_authn_method get_authn_method(const net::connection& conn) {
-    // If authn_method is set on the endpoint
-    //    Use it
-    // Else if kafka_enable_authorization is not set
-    //    Use sasl if enable_sasl
-    // Else if has mtls mapping rules
-    //    Use mtls_identity
-    // Else
-    //    Disable AuthN
-
-    std::optional<config::broker_authn_method> authn_method;
-    auto n = conn.name();
-    const auto& kafka_api = config::node().kafka_api.value();
-    auto ep_it = std::find_if(
-      kafka_api.begin(),
-      kafka_api.end(),
-      [&n](const config::broker_authn_endpoint& ep) { return ep.name == n; });
-    if (ep_it != kafka_api.end()) {
-        authn_method = ep_it->authn_method;
-    }
-    if (authn_method.has_value()) {
-        return *authn_method;
-    }
-    const auto& config = config::shard_local_cfg();
-    // if kafka_enable_authorization is not set, use sasl iff enable_sasl
-    if (
-      !config.kafka_enable_authorization().has_value()
-      && config.enable_sasl()) {
-        return config::broker_authn_method::sasl;
-    }
-    return config::broker_authn_method::none;
-}
-
 ss::future<security::tls::mtls_state> get_mtls_principal_state(
   const security::tls::principal_mapper& pm, net::connection& conn) {
     using namespace std::chrono_literals;
@@ -345,7 +312,7 @@ ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
     const bool authz_enabled
       = config::shard_local_cfg().kafka_enable_authorization().value_or(
         config::shard_local_cfg().enable_sasl());
-    const auto authn_method = get_authn_method(*conn);
+    const auto authn_method = config::get_authn_method(conn->name());
 
     const auto sasl_max_reauth
       = config::shard_local_cfg().kafka_sasl_max_reauth_ms();

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -309,9 +309,7 @@ ss::future<security::tls::mtls_state> get_mtls_principal_state(
 }
 
 ss::future<> server::apply(ss::lw_shared_ptr<net::connection> conn) {
-    const bool authz_enabled
-      = config::shard_local_cfg().kafka_enable_authorization().value_or(
-        config::shard_local_cfg().enable_sasl());
+    const bool authz_enabled = config::kafka_authz_enabled();
     const auto authn_method = config::get_authn_method(conn->name());
 
     const auto sasl_max_reauth

--- a/src/v/pandaproxy/rest/api.cc
+++ b/src/v/pandaproxy/rest/api.cc
@@ -78,6 +78,11 @@ ss::future<> api::set_config(ss::sstring name, std::any val) {
       });
 }
 
+const configuration& api::get_config() const { return _proxy.local().config(); }
+const kafka::client::configuration& api::get_client_config() const {
+    return _client_cfg;
+}
+
 ss::future<> api::set_client_config(ss::sstring name, std::any val) {
     return _proxy.invoke_on_all(
       [name{std::move(name)}, val{std::move(val)}](pandaproxy::rest::proxy& p) {

--- a/src/v/pandaproxy/rest/api.h
+++ b/src/v/pandaproxy/rest/api.h
@@ -43,6 +43,9 @@ public:
     ss::future<> set_config(ss::sstring name, std::any val);
     ss::future<> set_client_config(ss::sstring name, std::any val);
 
+    const configuration& get_config() const;
+    const kafka::client::configuration& get_client_config() const;
+
 private:
     ss::smp_service_group _sg;
     size_t _max_memory;

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/controller.h"
 #include "config/configuration.h"
+#include "kafka/client/config_utils.h"
 #include "kafka/client/configuration.h"
 #include "pandaproxy/api/api-doc/rest.json.hh"
 #include "pandaproxy/logger.h"
@@ -166,10 +167,7 @@ ss::future<> proxy::do_start() {
 
 ss::future<> proxy::configure() {
     std::optional<kafka::client::sasl_configuration> sasl_config;
-    if (
-      _client_cfg.scram_username.is_overriden()
-      || _client_cfg.scram_password.is_overriden()
-      || _client_cfg.sasl_mechanism.is_overriden()) {
+    if (is_scram_configured(_client_cfg)) {
         sasl_config = kafka::client::sasl_configuration{
           .mechanism = _client_cfg.sasl_mechanism(),
           .username = _client_cfg.scram_username(),

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -145,6 +145,7 @@ ss::future<> proxy::stop() {
 }
 
 configuration& proxy::config() { return _config; }
+const configuration& proxy::config() const { return _config; }
 
 ss::future<> proxy::do_start() {
     if (_is_started) {

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -42,6 +42,7 @@ public:
     ss::future<> stop();
 
     configuration& config();
+    const configuration& config() const;
     ss::sharded<kafka::client::client>& client() { return _client; }
     ss::sharded<kafka_client_cache>& client_cache() { return _client_cache; }
     ss::future<> mitigate_error(std::exception_ptr);

--- a/src/v/pandaproxy/schema_registry/api.cc
+++ b/src/v/pandaproxy/schema_registry/api.cc
@@ -94,4 +94,13 @@ ss::future<> api::restart() {
     co_await start();
 }
 
+const configuration& api::get_config() const { return _cfg; }
+
+const kafka::client::configuration& api::get_client_config() const {
+    return _client_cfg;
+}
+
+bool api::has_ephemeral_credentials() const {
+    return _service.local().has_ephemeral_credentials();
+}
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/api.h
+++ b/src/v/pandaproxy/schema_registry/api.h
@@ -49,6 +49,11 @@ public:
     ss::future<> stop();
     ss::future<> restart();
 
+    const configuration& get_config() const;
+    const kafka::client::configuration& get_client_config() const;
+
+    bool has_ephemeral_credentials() const;
+
 private:
     friend class schema_id_validator;
     friend class schema::registry;

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -404,10 +404,7 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
 
 ss::future<> service::configure() {
     auto sasl_config = co_await kafka::client::create_client_credentials(
-      *_controller,
-      config::shard_local_cfg(),
-      _client_config,
-      security::schema_registry_principal);
+      *_controller, _client_config, security::schema_registry_principal);
     co_await _client.invoke_on_all(
       [sasl_config = std::move(sasl_config)](kafka::client::client& c) {
           c.set_credentials(sasl_config);

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -65,6 +65,10 @@ public:
 
     std::unique_ptr<cluster::controller>& controller() { return _controller; }
 
+    bool has_ephemeral_credentials() const {
+        return _has_ephemeral_credentials;
+    }
+
 private:
     ss::future<> do_start();
     ss::future<> configure();

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -227,6 +227,7 @@ redpanda_cc_library(
         "//src/v/features:enterprise_features",
         "//src/v/finjector",
         "//src/v/json",
+        "//src/v/kafka/client",
         "//src/v/kafka/data:partition_proxy",
         "//src/v/kafka/server",
         "//src/v/metrics",

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -134,7 +134,8 @@
             "admin",
             "schema_registry",
             "schema_registry_client",
-            "pandaproxy"
+            "pandaproxy",
+            "audit_log_client"
           ]
         },
         "listener_name": {

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -150,7 +150,9 @@
             "NO_AUTHN",
             "NO_AUTHZ",
             "SASL_PLAIN",
-            "PP_CONFIGURED_CLIENT"
+            "PP_CONFIGURED_CLIENT",
+            "INSECURE_MIN_TLS_VERSION",
+            "TLS_RENEGOTIATION"
           ]
         },
         "description": {

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -131,7 +131,8 @@
           "enum": [
             "kafka",
             "rpc",
-            "admin"
+            "admin",
+            "pandaproxy"
           ]
         },
         "listener_name": {
@@ -145,7 +146,8 @@
             "NO_TLS",
             "NO_AUTHN",
             "NO_AUTHZ",
-            "SASL_PLAIN"
+            "SASL_PLAIN",
+            "PP_CONFIGURED_CLIENT"
           ]
         },
         "description": {
@@ -254,6 +256,54 @@
         },
         "authorization_enabled": {
             "type": "boolean"
+        }
+    }
+},
+"pandaproxy_interface_security_report": {
+    "description": "Security report for pandaproxy interfaces",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "int"
+        },
+        "advertised_host": {
+            "type": "string"
+        },
+        "advertised_port": {
+            "type": "int"
+        },
+        "tls_enabled": {
+            "type": "boolean"
+        },
+        "mutual_tls_enabled": {
+            "type": "boolean"
+        },
+        "authentication_methods": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "BASIC",
+                    "OIDC"
+                ]
+            }
+        },
+        "authorization_enabled": {
+            "type": "boolean"
+        },
+        "configured_authentication_method": {
+            "type": "string",
+            "enum": [
+                "None",
+                "SCRAM_Configured",
+                "SCRAM_Proxied"
+            ]
         }
     }
 }

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -129,7 +129,8 @@
         "affected_interface": {
           "type": "string",
           "enum": [
-            "kafka"
+            "kafka",
+            "rpc"
           ]
         },
         "listener_name": {
@@ -194,6 +195,30 @@
             "items": {
                 "type": "string"
             }
+        }
+    }
+},
+"rpc_interface_security_report": {
+    "description": "Security report for rpc interface",
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "int"
+        },
+        "advertised_host": {
+            "type": "string"
+        },
+        "advertised_port": {
+            "type": "int"
+        },
+        "tls_enabled": {
+            "type": "boolean"
+        },
+        "mutual_tls_enabled": {
+            "type": "boolean"
         }
     }
 }

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -132,6 +132,8 @@
             "kafka",
             "rpc",
             "admin",
+            "schema_registry",
+            "schema_registry_client",
             "pandaproxy"
           ]
         },
@@ -259,6 +261,40 @@
         }
     }
 },
+"schema_registry_interface_security_report": {
+    "description": "Security report for schema registry interfaces",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "int"
+        },
+        "tls_enabled": {
+            "type": "boolean"
+        },
+        "mutual_tls_enabled": {
+            "type": "boolean"
+        },
+        "authentication_methods": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "BASIC",
+                    "OIDC"
+                ]
+            }
+        },
+        "authorization_enabled": {
+            "type": "boolean"
+        }
+    }
+},
 "pandaproxy_interface_security_report": {
     "description": "Security report for pandaproxy interfaces",
     "type": "object",
@@ -303,6 +339,46 @@
                 "None",
                 "SCRAM_Configured",
                 "SCRAM_Proxied"
+            ]
+        }
+    }
+},
+"host_port": {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "int"
+        }
+    }
+},
+"client_security_report": {
+    "description": "Security report for kafka client interfaces",
+    "type": "object",
+    "properties": {
+        "kafka_listener_name": {
+            "type": "string"
+        },
+        "brokers": {
+            "type": "array",
+            "items": {
+                "$ref": "host_port"
+            }
+        },
+        "tls_enabled": {
+            "type": "boolean"
+        },
+        "mutual_tls_enabled": {
+            "type": "boolean"
+        },
+        "configured_authentication_method": {
+            "type": "string",
+            "enum": [
+                "None",
+                "SCRAM_Configured",
+                "SCRAM_Ephemeral"
             ]
         }
     }

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -130,7 +130,8 @@
           "type": "string",
           "enum": [
             "kafka",
-            "rpc"
+            "rpc",
+            "admin"
           ]
         },
         "listener_name": {
@@ -218,6 +219,40 @@
             "type": "boolean"
         },
         "mutual_tls_enabled": {
+            "type": "boolean"
+        }
+    }
+},
+"admin_interface_security_report": {
+    "description": "Security report for admin interfaces",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "int"
+        },
+        "tls_enabled": {
+            "type": "boolean"
+        },
+        "mutual_tls_enabled": {
+            "type": "boolean"
+        },
+        "authentication_methods": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "BASIC",
+                    "OIDC"
+                ]
+            }
+        },
+        "authorization_enabled": {
             "type": "boolean"
         }
     }

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -122,4 +122,78 @@
             "type": "int"
         }
     }
+},
+"security_report_alert": {
+    "type": "object",
+    "properties": {
+        "affected_interface": {
+          "type": "string",
+          "enum": [
+            "kafka"
+          ]
+        },
+        "listener_name": {
+          "description": "The listener name of the affected interface, if provided.",
+          "type": "string"
+        },
+        "issue": {
+          "required": true,
+          "type": "string",
+          "enum": [
+            "NO_TLS",
+            "NO_AUTHN",
+            "NO_AUTHZ",
+            "SASL_PLAIN"
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of the alert",
+          "required": true,
+          "type": "string"
+        }
+      }
+},
+"kafka_interface_security_report": {
+    "description": "Security report for kafka interfaces",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "port": {
+            "type": "int"
+        },
+        "advertised_host": {
+            "type": "string"
+        },
+        "advertised_port": {
+            "type": "int"
+        },
+        "tls_enabled": {
+            "type": "boolean"
+        },
+        "mutual_tls_enabled": {
+            "type": "boolean"
+        },
+        "authentication_method": {
+            "type": "string",
+            "enum": [
+                "SASL",
+                "mTLS",
+                "None"
+            ]
+        },
+        "authorization_enabled": {
+            "type": "boolean"
+        },
+        "supported_sasl_mechanisms": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
 }

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -451,6 +451,9 @@
                                     "items": {
                                         "$ref": "#/definitions/pandaproxy_interface_security_report"
                                     }
+                                },
+                                "audit_log_client": {
+                                    "$ref": "#/definitions/client_security_report"
                                 }
                             }
                         },

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -436,6 +436,12 @@
                                     "items": {
                                         "$ref": "#/definitions/admin_interface_security_report"
                                     }
+                                },
+                                "pandaproxy": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/pandaproxy_interface_security_report"
+                                    }
                                 }
                             }
                         },

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -404,5 +404,41 @@
             }
         }
     }
+},
+"/v1/security/report": {
+    "get": {
+        "summary": "Get security report",
+        "operationId": "get_security_report",
+        "produces": [
+            "application/json"
+        ],
+        "responses": {
+            "200": {
+                "description": "OK",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "interfaces": {
+                            "type": "object",
+                            "properties": {
+                                "kafka": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/kafka_interface_security_report"
+                                    }
+                                }
+                            }
+                        },
+                        "alerts": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "security_report_alert"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -430,6 +430,12 @@
                                 "rpc": {
                                     "type": "object",
                                     "$ref": "#/definitions/rpc_interface_security_report"
+                                },
+                                "admin": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/admin_interface_security_report"
+                                    }
                                 }
                             }
                         },

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -437,6 +437,15 @@
                                         "$ref": "#/definitions/admin_interface_security_report"
                                     }
                                 },
+                                "schema_registry": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/schema_registry_interface_security_report"
+                                    }
+                                },
+                                "schema_registry_client": {
+                                    "$ref": "#/definitions/client_security_report"
+                                },
                                 "pandaproxy": {
                                     "type": "array",
                                     "items": {

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -426,6 +426,10 @@
                                     "items": {
                                         "$ref": "#/definitions/kafka_interface_security_report"
                                     }
+                                },
+                                "rpc": {
+                                    "type": "object",
+                                    "$ref": "#/definitions/rpc_interface_security_report"
                                 }
                             }
                         },

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -41,26 +41,35 @@
 namespace seastar::httpd::security_json {
 struct interfaces_report : public json::json_base {
     json::json_list<kafka_interface_security_report> kafka;
+    json::json_element<rpc_interface_security_report> rpc;
 
-    void register_params() { add(&kafka, "kafka"); }
+    void register_params() {
+        add(&kafka, "kafka");
+        add(&rpc, "rpc");
+    }
+
     interfaces_report() { register_params(); }
 
     interfaces_report(const interfaces_report& e) {
         register_params();
         kafka = e.kafka;
+        rpc = e.rpc;
     }
     template<class T>
     interfaces_report& operator=(const T& e) {
         kafka = e.kafka;
+        rpc = e.rpc;
         return *this;
     }
     interfaces_report& operator=(const interfaces_report& e) {
         kafka = e.kafka;
+        rpc = e.rpc;
         return *this;
     }
     template<class T>
     interfaces_report& update(T& e) {
         e.kafka = kafka;
+        e.rpc = rpc;
         return *this;
     }
 };
@@ -1124,6 +1133,31 @@ generate_kafka_interface_report(
 
     return reports;
 }
+
+ss::httpd::security_json::rpc_interface_security_report
+generate_rpc_interface_report(
+  std::vector<ss::httpd::security_json::security_report_alert>& alerts) {
+    ss::httpd::security_json::rpc_interface_security_report report;
+
+    const auto& rpc_server = config::node().rpc_server();
+    const auto& rpc_advertised = config::node().advertised_rpc_api();
+
+    report.host = rpc_server.host();
+    report.port = rpc_server.port();
+    report.advertised_host = rpc_advertised.host();
+    report.advertised_port = rpc_advertised.port();
+
+    report.tls_enabled = config::node().rpc_server_tls().is_enabled();
+    report.mutual_tls_enabled
+      = config::node().rpc_server_tls().get_require_client_auth();
+
+    if (!report.tls_enabled()) {
+        alerts.push_back(
+          make_interface_alert(affected_interface::rpc, alert_issue::NO_TLS));
+    }
+
+    return report;
+}
 } // namespace
 
 ss::future<ss::json::json_return_type>
@@ -1133,6 +1167,7 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
     std::vector<ss::httpd::security_json::security_report_alert> alerts;
 
     interfaces_report.kafka = generate_kafka_interface_report(alerts);
+    interfaces_report.rpc = generate_rpc_interface_report(alerts);
     report.interfaces = std::move(interfaces_report);
 
     report.alerts = std::move(alerts);

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -1499,6 +1499,27 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
       ephemeral_credentials::yes);
     report.interfaces = std::move(interfaces_report);
 
+    const auto min_secure_tls = config::tls_version::v1_2;
+    if (config::shard_local_cfg().tls_min_version < min_secure_tls) {
+        ss::httpd::security_json::security_report_alert alert;
+        alert.issue = alert_issue::INSECURE_MIN_TLS_VERSION;
+        alert.description = ssx::sformat(
+          "TLS minimum version is set to {} which is less than {}. This is "
+          "insecure and not recommended.",
+          config::shard_local_cfg().tls_min_version,
+          min_secure_tls);
+        alerts.push_back(std::move(alert));
+    }
+
+    if (config::shard_local_cfg().tls_enable_renegotiation()) {
+        ss::httpd::security_json::security_report_alert alert;
+        alert.issue = alert_issue::TLS_RENEGOTIATION;
+        alert.description = ssx::sformat(
+          "TLS renegotiation is enabled. This is insecure and not "
+          "recommended.");
+        alerts.push_back(std::move(alert));
+    }
+
     report.alerts = std::move(alerts);
 
     return ss::make_ready_future<ss::json::json_return_type>(std::move(report));

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -11,6 +11,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "cluster/controller.h"
 #include "cluster/security_frontend.h"
+#include "config/broker_authn_endpoint.h"
 #include "features/enterprise_feature_messages.h"
 #include "json/document.h"
 #include "json/json.h"
@@ -36,6 +37,66 @@
 
 #include <optional>
 #include <sstream>
+
+namespace seastar::httpd::security_json {
+struct interfaces_report : public json::json_base {
+    json::json_list<kafka_interface_security_report> kafka;
+
+    void register_params() { add(&kafka, "kafka"); }
+    interfaces_report() { register_params(); }
+
+    interfaces_report(const interfaces_report& e) {
+        register_params();
+        kafka = e.kafka;
+    }
+    template<class T>
+    interfaces_report& operator=(const T& e) {
+        kafka = e.kafka;
+        return *this;
+    }
+    interfaces_report& operator=(const interfaces_report& e) {
+        kafka = e.kafka;
+        return *this;
+    }
+    template<class T>
+    interfaces_report& update(T& e) {
+        e.kafka = kafka;
+        return *this;
+    }
+};
+struct security_report : public json::json_base {
+    json::json_element<interfaces_report> interfaces;
+    json::json_list<security_report_alert> alerts;
+
+    void register_params() {
+        add(&interfaces, "interfaces");
+        add(&alerts, "alerts");
+    }
+    security_report() { register_params(); }
+    security_report(const security_report& e) {
+        register_params();
+        interfaces = e.interfaces;
+        alerts = e.alerts;
+    }
+    template<class T>
+    security_report& operator=(const T& e) {
+        interfaces = e.interfaces;
+        alerts = e.alerts;
+        return *this;
+    }
+    security_report& operator=(const security_report& e) {
+        interfaces = e.interfaces;
+        alerts = e.alerts;
+        return *this;
+    }
+    template<class T>
+    security_report& update(T& e) {
+        e.interfaces = interfaces;
+        e.alerts = alerts;
+        return *this;
+    }
+};
+} // namespace seastar::httpd::security_json
 
 namespace {
 
@@ -438,6 +499,13 @@ void admin_server::register_security_routes() {
         -> ss::future<ss::json::json_return_type> {
           check_license(features::enterprise_error_message::acl_with_rbac());
           return update_role_members_handler(std::move(req));
+      });
+
+    register_route<superuser>(
+      ss::httpd::security_json::get_security_report,
+      [this](std::unique_ptr<ss::http::request> req)
+        -> ss::future<ss::json::json_return_type> {
+          return get_security_report(std::move(req));
       });
 }
 
@@ -891,4 +959,183 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::delete_role_handler(
       std::move(rep),
       ss::http::reply::status_type::no_content,
       seastar::json::json_void{});
+}
+
+namespace {
+
+using kafka_authn_method
+  = ss::httpd::security_json::kafka_interface_security_report::
+    kafka_interface_security_report_authentication_method;
+
+using affected_interface = ss::httpd::security_json::security_report_alert::
+  security_report_alert_affected_interface;
+
+using alert_issue = ss::httpd::security_json::security_report_alert::
+  security_report_alert_issue;
+kafka_authn_method to_report_type(config::broker_authn_method m) {
+    switch (m) {
+    case config::broker_authn_method::none:
+        return kafka_authn_method::None;
+    case config::broker_authn_method::sasl:
+        return kafka_authn_method::SASL;
+    case config::broker_authn_method::mtls_identity:
+        return kafka_authn_method::mTLS;
+    }
+
+    __builtin_unreachable();
+}
+
+ss::sstring get_listener_name(ss::sstring name) {
+    static const ss::sstring unnamed_interface = "{{unnamed}}";
+    if (name.empty()) {
+        return unnamed_interface;
+    }
+    return name;
+}
+
+ss::httpd::security_json::security_report_alert make_interface_alert(
+  const affected_interface interface_type,
+  const alert_issue issue,
+  std::optional<ss::sstring> listener_name = std::nullopt) {
+    listener_name = std::move(listener_name).transform(get_listener_name);
+
+    ss::httpd::security_json::security_report_alert alert;
+    alert.affected_interface = interface_type;
+    if (listener_name.has_value()) {
+        alert.listener_name = listener_name.value();
+    }
+    alert.issue = issue;
+
+    const auto make_description = [&alert,
+                                   &listener_name](std::string_view msg) {
+        return ssx::sformat(
+          "{} interface{}{}. This is insecure and not recommended.",
+          alert.affected_interface().to_json(),
+          listener_name.has_value()
+            ? ss::format(" \"{}\"", listener_name.value())
+            : "",
+          msg);
+    };
+
+    switch (issue) {
+    case alert_issue::NO_TLS:
+        alert.description = make_description(" is not using TLS");
+        break;
+    case alert_issue::NO_AUTHN:
+        alert.description = make_description(" is not using authentication");
+        break;
+    case alert_issue::NO_AUTHZ:
+        alert.description = make_description(" is not using authorization");
+        break;
+    case alert_issue::SASL_PLAIN:
+        alert.description = make_description(" is using SASL/PLAIN");
+        break;
+    default:
+        vassert(
+          false, "make_interface_alert should not be called on this value");
+    }
+
+    return alert;
+}
+
+template<typename Report, typename Endpoint>
+void set_report_advertised(
+  Report& report,
+  const ss::sstring& name,
+  const std::vector<Endpoint>& advertised_api) {
+    auto it = std::ranges::find(advertised_api, name, &Endpoint::name);
+    if (it != advertised_api.end()) {
+        report.advertised_host = it->address.host();
+        report.advertised_port = it->address.port();
+    } else {
+        report.advertised_host = report.host;
+        report.advertised_port = report.port;
+    }
+}
+
+template<typename Report, typename TlsConfig>
+void set_report_tls(
+  Report& report,
+  const ss::sstring& name,
+  const std::vector<TlsConfig>& tls_interfaces) {
+    auto it = std::ranges::find(tls_interfaces, name, &TlsConfig::name);
+    if (it != tls_interfaces.end()) {
+        report.tls_enabled = it->config.is_enabled();
+        report.mutual_tls_enabled = it->config.get_require_client_auth();
+    } else {
+        report.tls_enabled = false;
+        report.mutual_tls_enabled = false;
+    }
+}
+
+std::vector<ss::httpd::security_json::kafka_interface_security_report>
+generate_kafka_interface_report(
+  std::vector<ss::httpd::security_json::security_report_alert>& alerts) {
+    std::vector<ss::httpd::security_json::kafka_interface_security_report>
+      reports;
+    const auto& kafka_interfaces = config::node().kafka_api();
+
+    reports.reserve(kafka_interfaces.size());
+
+    for (const auto& kface : kafka_interfaces) {
+        ss::httpd::security_json::kafka_interface_security_report report;
+        report.name = kface.name;
+        report.host = kface.address.host();
+        report.port = kface.address.port();
+
+        set_report_advertised(
+          report, kface.name, config::node().advertised_kafka_api_property()());
+
+        set_report_tls(report, kface.name, config::node().kafka_api_tls());
+        if (!report.tls_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::kafka, alert_issue::NO_TLS, kface.name));
+        }
+
+        auto authn_method = config::get_authn_method(kface.name);
+        report.authentication_method = to_report_type(authn_method);
+        if (report.authentication_method().v == kafka_authn_method::None) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::kafka, alert_issue::NO_AUTHN, kface.name));
+        }
+
+        if (authn_method == config::broker_authn_method::sasl) {
+            std::vector<ss::sstring> sasl_mechs{
+              config::shard_local_cfg().sasl_mechanisms()};
+
+            if (std::ranges::contains(sasl_mechs, "PLAIN")) {
+                alerts.push_back(make_interface_alert(
+                  affected_interface::kafka,
+                  alert_issue::SASL_PLAIN,
+                  kface.name));
+            }
+
+            report.supported_sasl_mechanisms = std::move(sasl_mechs);
+        }
+
+        report.authorization_enabled = config::kafka_authz_enabled();
+        if (!report.authorization_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::kafka, alert_issue::NO_AUTHZ, kface.name));
+        }
+
+        reports.emplace_back(std::move(report));
+    }
+
+    return reports;
+}
+} // namespace
+
+ss::future<ss::json::json_return_type>
+admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
+    ss::httpd::security_json::security_report report;
+    ss::httpd::security_json::interfaces_report interfaces_report;
+    std::vector<ss::httpd::security_json::security_report_alert> alerts;
+
+    interfaces_report.kafka = generate_kafka_interface_report(alerts);
+    report.interfaces = std::move(interfaces_report);
+
+    report.alerts = std::move(alerts);
+
+    return ss::make_ready_future<ss::json::json_return_type>(std::move(report));
 }

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -52,6 +52,7 @@ struct interfaces_report : public json::json_base {
     json::json_list<schema_registry_interface_security_report> schema_registry;
     json::json_element<client_security_report> schema_registry_client;
     json::json_list<pandaproxy_interface_security_report> pandaproxy;
+    json::json_element<client_security_report> audit_log_client;
 
     void register_params() {
         add(&kafka, "kafka");
@@ -60,6 +61,7 @@ struct interfaces_report : public json::json_base {
         add(&schema_registry, "schema_registry");
         add(&schema_registry_client, "schema_registry_client");
         add(&pandaproxy, "pandaproxy");
+        add(&audit_log_client, "audit_log_client");
     }
 
     interfaces_report() { register_params(); }
@@ -72,6 +74,7 @@ struct interfaces_report : public json::json_base {
         schema_registry = e.schema_registry;
         schema_registry_client = e.schema_registry_client;
         pandaproxy = e.pandaproxy;
+        audit_log_client = e.audit_log_client;
     }
     template<class T>
     interfaces_report& operator=(const T& e) {
@@ -81,6 +84,7 @@ struct interfaces_report : public json::json_base {
         schema_registry = e.schema_registry;
         schema_registry_client = e.schema_registry_client;
         pandaproxy = e.pandaproxy;
+        audit_log_client = e.audit_log_client;
         return *this;
     }
     interfaces_report& operator=(const interfaces_report& e) {
@@ -90,6 +94,7 @@ struct interfaces_report : public json::json_base {
         schema_registry = e.schema_registry;
         schema_registry_client = e.schema_registry_client;
         pandaproxy = e.pandaproxy;
+        audit_log_client = e.audit_log_client;
         return *this;
     }
     template<class T>
@@ -100,6 +105,7 @@ struct interfaces_report : public json::json_base {
         e.schema_registry = schema_registry;
         e.schema_registry_client = schema_registry_client;
         e.pandaproxy = pandaproxy;
+        e.audit_log_client = audit_log_client;
         return *this;
     }
 };
@@ -1486,6 +1492,11 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
             ephemeral_credentials{
               _schema_registry->has_ephemeral_credentials()});
     }
+    interfaces_report.audit_log_client = generate_kafka_client_interface_report(
+      alerts,
+      affected_interface::audit_log_client,
+      _audit_mgr.local().get_client_config(),
+      ephemeral_credentials::yes);
     report.interfaces = std::move(interfaces_report);
 
     report.alerts = std::move(alerts);

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -21,6 +21,8 @@
 #include "kafka/server/server.h"
 #include "pandaproxy/rest/api.h"
 #include "pandaproxy/rest/configuration.h"
+#include "pandaproxy/schema_registry/api.h"
+#include "pandaproxy/schema_registry/configuration.h"
 #include "redpanda/admin/api-doc/security.json.hh"
 #include "redpanda/admin/server.h"
 #include "security/credential_store.h"
@@ -47,12 +49,16 @@ struct interfaces_report : public json::json_base {
     json::json_list<kafka_interface_security_report> kafka;
     json::json_element<rpc_interface_security_report> rpc;
     json::json_list<admin_interface_security_report> admin;
+    json::json_list<schema_registry_interface_security_report> schema_registry;
+    json::json_element<client_security_report> schema_registry_client;
     json::json_list<pandaproxy_interface_security_report> pandaproxy;
 
     void register_params() {
         add(&kafka, "kafka");
         add(&rpc, "rpc");
         add(&admin, "admin");
+        add(&schema_registry, "schema_registry");
+        add(&schema_registry_client, "schema_registry_client");
         add(&pandaproxy, "pandaproxy");
     }
 
@@ -63,6 +69,8 @@ struct interfaces_report : public json::json_base {
         kafka = e.kafka;
         rpc = e.rpc;
         admin = e.admin;
+        schema_registry = e.schema_registry;
+        schema_registry_client = e.schema_registry_client;
         pandaproxy = e.pandaproxy;
     }
     template<class T>
@@ -70,6 +78,8 @@ struct interfaces_report : public json::json_base {
         kafka = e.kafka;
         rpc = e.rpc;
         admin = e.admin;
+        schema_registry = e.schema_registry;
+        schema_registry_client = e.schema_registry_client;
         pandaproxy = e.pandaproxy;
         return *this;
     }
@@ -77,6 +87,8 @@ struct interfaces_report : public json::json_base {
         kafka = e.kafka;
         rpc = e.rpc;
         admin = e.admin;
+        schema_registry = e.schema_registry;
+        schema_registry_client = e.schema_registry_client;
         pandaproxy = e.pandaproxy;
         return *this;
     }
@@ -85,6 +97,8 @@ struct interfaces_report : public json::json_base {
         e.kafka = kafka;
         e.rpc = rpc;
         e.admin = admin;
+        e.schema_registry = schema_registry;
+        e.schema_registry_client = schema_registry_client;
         e.pandaproxy = pandaproxy;
         return *this;
     }
@@ -1002,6 +1016,9 @@ using pp_authn_method
   = ss::httpd::security_json::pandaproxy_interface_security_report::
     pandaproxy_interface_security_report_configured_authentication_method;
 
+using client_authn_method = ss::httpd::security_json::client_security_report::
+  client_security_report_configured_authentication_method;
+
 kafka_authn_method to_report_type(config::broker_authn_method m) {
     switch (m) {
     case config::broker_authn_method::none:
@@ -1277,7 +1294,7 @@ generate_pandaproxy_interface_report(
         const auto authn = iface.authn_method.value_or(
           config::rest_authn_method::none);
         // If rest_authn_method is not none, then the actual authentication
-        // method is being red from http_authentication cluster config
+        // method is being read from http_authentication cluster config
         const bool is_authn_enabled = authn
                                       == config::rest_authn_method::http_basic;
 
@@ -1326,6 +1343,122 @@ generate_pandaproxy_interface_report(
     return reports;
 }
 
+std::vector<ss::httpd::security_json::schema_registry_interface_security_report>
+generate_schema_registry_interface_report(
+  std::vector<ss::httpd::security_json::security_report_alert>& alerts,
+  const pandaproxy::schema_registry::configuration& config) {
+    std::vector<
+      ss::httpd::security_json::schema_registry_interface_security_report>
+      reports;
+    const auto& sr_interfaces = config.schema_registry_api();
+
+    reports.reserve(sr_interfaces.size());
+
+    for (const auto& iface : sr_interfaces) {
+        ss::httpd::security_json::schema_registry_interface_security_report
+          report;
+        report.name = iface.name;
+        report.host = iface.address.host();
+        report.port = iface.address.port();
+
+        set_report_tls(report, iface.name, config.schema_registry_api_tls());
+        if (!report.tls_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::schema_registry,
+              alert_issue::NO_TLS,
+              iface.name));
+        }
+
+        const auto authn = iface.authn_method.value_or(
+          config::rest_authn_method::none);
+        // If rest_authn_method is not none, then the actual authentication
+        // method is being red from http_authentication cluster config
+        const bool is_authn_enabled = authn
+                                      == config::rest_authn_method::http_basic;
+
+        report.authorization_enabled
+          = config::shard_local_cfg().schema_registry_enable_authorization()
+            && is_authn_enabled;
+        if (!report.authorization_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::schema_registry,
+              alert_issue::NO_AUTHZ,
+              iface.name));
+        }
+
+        set_report_http_authentication(report, is_authn_enabled);
+        if (report.authentication_methods._elements.empty()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::schema_registry,
+              alert_issue::NO_AUTHN,
+              iface.name));
+        }
+
+        reports.emplace_back(std::move(report));
+    }
+
+    return reports;
+}
+
+using ephemeral_credentials = ss::bool_class<struct ephemeral_credentials_tag>;
+
+client_authn_method get_kclient_auth(
+  const kafka::client::configuration& config, ephemeral_credentials ephemeral) {
+    if (ephemeral) {
+        return client_authn_method::SCRAM_Ephemeral;
+    }
+    if (is_scram_configured(config)) {
+        return client_authn_method::SCRAM_Configured;
+    }
+    return client_authn_method::None;
+}
+
+ss::httpd::security_json::client_security_report
+generate_kafka_client_interface_report(
+  std::vector<ss::httpd::security_json::security_report_alert>& alerts,
+  const affected_interface interface,
+  const kafka::client::configuration& config,
+  ephemeral_credentials ephemeral = ephemeral_credentials::no) {
+    ss::httpd::security_json::client_security_report report;
+
+    const ss::sstring name = config.client_identifier().value_or("");
+    report.kafka_listener_name = name;
+
+    const auto& brokers = config.brokers();
+
+    std::vector<ss::httpd::security_json::host_port> json_brokers;
+    json_brokers.reserve(brokers.size());
+    for (const auto& broker : brokers) {
+        ss::httpd::security_json::host_port hp;
+        hp.host = broker.host();
+        hp.port = broker.port();
+        json_brokers.push_back(std::move(hp));
+    }
+    report.brokers = json_brokers;
+
+    const auto& broker_tls = config.broker_tls();
+    report.tls_enabled = broker_tls.is_enabled();
+    report.mutual_tls_enabled = broker_tls.get_require_client_auth();
+
+    if (!report.tls_enabled()) {
+        alerts.push_back(
+          make_interface_alert(interface, alert_issue::NO_TLS, name));
+    }
+
+    report.configured_authentication_method = get_kclient_auth(
+      config, ephemeral);
+
+    if (
+      report.configured_authentication_method().v
+      == ss::httpd::security_json::client_security_report::
+        client_security_report_configured_authentication_method::None) {
+        alerts.push_back(
+          make_interface_alert(interface, alert_issue::NO_AUTHN, name));
+    }
+
+    return report;
+}
+
 } // namespace
 
 ss::future<ss::json::json_return_type>
@@ -1340,6 +1473,18 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
     if (_http_proxy) {
         interfaces_report.pandaproxy = generate_pandaproxy_interface_report(
           alerts, _http_proxy->get_config(), _http_proxy->get_client_config());
+    }
+    if (_schema_registry) {
+        interfaces_report.schema_registry
+          = generate_schema_registry_interface_report(
+            alerts, _schema_registry->get_config());
+        interfaces_report.schema_registry_client
+          = generate_kafka_client_interface_report(
+            alerts,
+            affected_interface::schema_registry_client,
+            _schema_registry->get_client_config(),
+            ephemeral_credentials{
+              _schema_registry->has_ephemeral_credentials()});
     }
     report.interfaces = std::move(interfaces_report);
 

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -42,10 +42,12 @@ namespace seastar::httpd::security_json {
 struct interfaces_report : public json::json_base {
     json::json_list<kafka_interface_security_report> kafka;
     json::json_element<rpc_interface_security_report> rpc;
+    json::json_list<admin_interface_security_report> admin;
 
     void register_params() {
         add(&kafka, "kafka");
         add(&rpc, "rpc");
+        add(&admin, "admin");
     }
 
     interfaces_report() { register_params(); }
@@ -54,22 +56,26 @@ struct interfaces_report : public json::json_base {
         register_params();
         kafka = e.kafka;
         rpc = e.rpc;
+        admin = e.admin;
     }
     template<class T>
     interfaces_report& operator=(const T& e) {
         kafka = e.kafka;
         rpc = e.rpc;
+        admin = e.admin;
         return *this;
     }
     interfaces_report& operator=(const interfaces_report& e) {
         kafka = e.kafka;
         rpc = e.rpc;
+        admin = e.admin;
         return *this;
     }
     template<class T>
     interfaces_report& update(T& e) {
         e.kafka = kafka;
         e.rpc = rpc;
+        e.admin = admin;
         return *this;
     }
 };
@@ -1047,6 +1053,13 @@ ss::httpd::security_json::security_report_alert make_interface_alert(
     return alert;
 }
 
+// Empty lists are normally ignored by ss::json. By setting the _set variable
+// they will be serialized even if empty.
+template<typename T>
+void force_list(seastar::json::json_list<T>& jlist) {
+    jlist._set = true;
+}
+
 template<typename Report, typename Endpoint>
 void set_report_advertised(
   Report& report,
@@ -1074,6 +1087,20 @@ void set_report_tls(
     } else {
         report.tls_enabled = false;
         report.mutual_tls_enabled = false;
+    }
+}
+
+template<typename Report>
+void set_report_http_authentication(
+  Report& report, const bool& is_authn_enabled) {
+    force_list(report.authentication_methods);
+
+    if (!is_authn_enabled) {
+        return;
+    }
+
+    for (auto& meth : config::shard_local_cfg().http_authentication()) {
+        report.authentication_methods.push(meth);
     }
 }
 
@@ -1158,6 +1185,48 @@ generate_rpc_interface_report(
 
     return report;
 }
+
+std::vector<ss::httpd::security_json::admin_interface_security_report>
+generate_admin_interface_report(
+  std::vector<ss::httpd::security_json::security_report_alert>& alerts) {
+    std::vector<ss::httpd::security_json::admin_interface_security_report>
+      reports;
+    const auto& admin_interfaces = config::node().admin();
+
+    reports.reserve(admin_interfaces.size());
+
+    for (const auto& iface : admin_interfaces) {
+        ss::httpd::security_json::admin_interface_security_report report;
+        report.name = iface.name;
+        report.host = iface.address.host();
+        report.port = iface.address.port();
+
+        set_report_tls(report, iface.name, config::node().admin_api_tls());
+        if (!report.tls_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::admin, alert_issue::NO_TLS, iface.name));
+        }
+
+        const auto require_auth
+          = config::shard_local_cfg().admin_api_require_auth();
+
+        report.authorization_enabled = require_auth;
+        if (!report.authorization_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::admin, alert_issue::NO_AUTHZ, iface.name));
+        }
+
+        set_report_http_authentication(report, require_auth);
+        if (report.authentication_methods._elements.empty()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::admin, alert_issue::NO_AUTHN, iface.name));
+        }
+
+        reports.emplace_back(std::move(report));
+    }
+
+    return reports;
+}
 } // namespace
 
 ss::future<ss::json::json_return_type>
@@ -1168,6 +1237,7 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
 
     interfaces_report.kafka = generate_kafka_interface_report(alerts);
     interfaces_report.rpc = generate_rpc_interface_report(alerts);
+    interfaces_report.admin = generate_admin_interface_report(alerts);
     report.interfaces = std::move(interfaces_report);
 
     report.alerts = std::move(alerts);

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -16,7 +16,11 @@
 #include "json/document.h"
 #include "json/json.h"
 #include "json/stringbuffer.h"
+#include "kafka/client/config_utils.h"
+#include "kafka/client/configuration.h"
 #include "kafka/server/server.h"
+#include "pandaproxy/rest/api.h"
+#include "pandaproxy/rest/configuration.h"
 #include "redpanda/admin/api-doc/security.json.hh"
 #include "redpanda/admin/server.h"
 #include "security/credential_store.h"
@@ -43,11 +47,13 @@ struct interfaces_report : public json::json_base {
     json::json_list<kafka_interface_security_report> kafka;
     json::json_element<rpc_interface_security_report> rpc;
     json::json_list<admin_interface_security_report> admin;
+    json::json_list<pandaproxy_interface_security_report> pandaproxy;
 
     void register_params() {
         add(&kafka, "kafka");
         add(&rpc, "rpc");
         add(&admin, "admin");
+        add(&pandaproxy, "pandaproxy");
     }
 
     interfaces_report() { register_params(); }
@@ -57,18 +63,21 @@ struct interfaces_report : public json::json_base {
         kafka = e.kafka;
         rpc = e.rpc;
         admin = e.admin;
+        pandaproxy = e.pandaproxy;
     }
     template<class T>
     interfaces_report& operator=(const T& e) {
         kafka = e.kafka;
         rpc = e.rpc;
         admin = e.admin;
+        pandaproxy = e.pandaproxy;
         return *this;
     }
     interfaces_report& operator=(const interfaces_report& e) {
         kafka = e.kafka;
         rpc = e.rpc;
         admin = e.admin;
+        pandaproxy = e.pandaproxy;
         return *this;
     }
     template<class T>
@@ -76,6 +85,7 @@ struct interfaces_report : public json::json_base {
         e.kafka = kafka;
         e.rpc = rpc;
         e.admin = admin;
+        e.pandaproxy = pandaproxy;
         return *this;
     }
 };
@@ -987,6 +997,11 @@ using affected_interface = ss::httpd::security_json::security_report_alert::
 
 using alert_issue = ss::httpd::security_json::security_report_alert::
   security_report_alert_issue;
+
+using pp_authn_method
+  = ss::httpd::security_json::pandaproxy_interface_security_report::
+    pandaproxy_interface_security_report_configured_authentication_method;
+
 kafka_authn_method to_report_type(config::broker_authn_method m) {
     switch (m) {
     case config::broker_authn_method::none:
@@ -1044,6 +1059,11 @@ ss::httpd::security_json::security_report_alert make_interface_alert(
         break;
     case alert_issue::SASL_PLAIN:
         alert.description = make_description(" is using SASL/PLAIN");
+        break;
+    case alert_issue::PP_CONFIGURED_CLIENT:
+        alert.description = make_description(
+          ", authorization is not enabled and the pandaproxy client has scram "
+          "credentials");
         break;
     default:
         vassert(
@@ -1227,6 +1247,85 @@ generate_admin_interface_report(
 
     return reports;
 }
+
+std::vector<ss::httpd::security_json::pandaproxy_interface_security_report>
+generate_pandaproxy_interface_report(
+  std::vector<ss::httpd::security_json::security_report_alert>& alerts,
+  const pandaproxy::rest::configuration& config,
+  const kafka::client::configuration& client_config) {
+    std::vector<ss::httpd::security_json::pandaproxy_interface_security_report>
+      reports;
+    const auto& pp_interfaces = config.pandaproxy_api();
+
+    reports.reserve(pp_interfaces.size());
+
+    for (const auto& iface : pp_interfaces) {
+        ss::httpd::security_json::pandaproxy_interface_security_report report;
+        report.name = iface.name;
+        report.host = iface.address.host();
+        report.port = iface.address.port();
+
+        set_report_advertised(
+          report, iface.name, config.advertised_pandaproxy_api());
+
+        set_report_tls(report, iface.name, config.pandaproxy_api_tls());
+        if (!report.tls_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::pandaproxy, alert_issue::NO_TLS, iface.name));
+        }
+
+        const auto authn = iface.authn_method.value_or(
+          config::rest_authn_method::none);
+        // If rest_authn_method is not none, then the actual authentication
+        // method is being red from http_authentication cluster config
+        const bool is_authn_enabled = authn
+                                      == config::rest_authn_method::http_basic;
+
+        const auto get_pp_auth_method = [is_authn_enabled, &client_config]() {
+            if (is_authn_enabled) {
+                return pp_authn_method::SCRAM_Proxied;
+            }
+
+            const auto kclient_configured = is_scram_configured(client_config);
+            if (kclient_configured) {
+                return pp_authn_method::SCRAM_Configured;
+            }
+
+            return pp_authn_method::None;
+        };
+        const auto config_authn_method = get_pp_auth_method();
+        report.configured_authentication_method = config_authn_method;
+
+        // For pp, authn kinda implies authz as well.
+        report.authorization_enabled = is_authn_enabled;
+        if (!report.authorization_enabled()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::pandaproxy,
+              alert_issue::NO_AUTHZ,
+              iface.name));
+        }
+
+        if (config_authn_method == pp_authn_method::SCRAM_Configured) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::pandaproxy,
+              alert_issue::PP_CONFIGURED_CLIENT,
+              iface.name));
+        }
+
+        set_report_http_authentication(report, is_authn_enabled);
+        if (report.authentication_methods._elements.empty()) {
+            alerts.push_back(make_interface_alert(
+              affected_interface::pandaproxy,
+              alert_issue::NO_AUTHN,
+              iface.name));
+        }
+
+        reports.emplace_back(std::move(report));
+    }
+
+    return reports;
+}
+
 } // namespace
 
 ss::future<ss::json::json_return_type>
@@ -1238,6 +1337,10 @@ admin_server::get_security_report(std::unique_ptr<ss::http::request>) {
     interfaces_report.kafka = generate_kafka_interface_report(alerts);
     interfaces_report.rpc = generate_rpc_interface_report(alerts);
     interfaces_report.admin = generate_admin_interface_report(alerts);
+    if (_http_proxy) {
+        interfaces_report.pandaproxy = generate_pandaproxy_interface_report(
+          alerts, _http_proxy->get_config(), _http_proxy->get_client_config());
+    }
     report.interfaces = std::move(interfaces_report);
 
     report.alerts = std::move(alerts);

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -483,6 +483,9 @@ private:
     ss::future<ss::json::json_return_type>
     update_role_members_handler(std::unique_ptr<ss::http::request> req);
 
+    ss::future<ss::json::json_return_type>
+    get_security_report(std::unique_ptr<ss::http::request> req);
+
     /// Kafka routes
     ss::future<ss::json::json_return_type>
       kafka_transfer_leadership_handler(std::unique_ptr<ss::http::request>);

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -264,6 +264,10 @@ public:
 
     bool report_redpanda_app_event(is_started);
 
+    const kafka::client::configuration& get_client_config() const {
+        return _config;
+    }
+
 private:
     using ignore_enabled_events
       = ss::bool_class<struct ignore_enabled_events_tag>;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1360,6 +1360,9 @@ class Admin:
             json=dict(add=to_add, remove=to_remove),
         )
 
+    def security_report(self):
+        return self._request("get", "security/report")
+
     def list_role_members(self, role: str):
         return self._request("get", f"security/roles/{role}/members")
 

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -9,13 +9,19 @@
 
 from dataclasses import dataclass, fields
 
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, matrix
 
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.scram_test import SaslPlainTLSProvider
-from rptest.services.redpanda import SecurityConfig, RedpandaService, SaslCredentials
+from rptest.tests.pandaproxy_test import PandaProxyMTLSBase
+from rptest.services.redpanda import (
+    SecurityConfig,
+    RedpandaService,
+    SaslCredentials,
+    PandaproxyConfig,
+)
 from rptest.services.tls import TLSCertManager
 
 
@@ -123,6 +129,43 @@ class AdminInterface:
         )
 
 
+PANDAPROXY_INTERFACE_KEYS = [
+    "name",
+    "host",
+    "port",
+    "advertised_host",
+    "advertised_port",
+    "tls_enabled",
+    "mutual_tls_enabled",
+    "authentication_methods",
+    "authorization_enabled",
+    "configured_authentication_method",
+]
+
+
+@dataclass
+class PandaproxyInterface:
+    tls_enabled: bool
+    mutual_tls_enabled: bool
+    authorization_enabled: bool
+    authentication_methods: list[str]
+    configured_authentication_method: str
+
+    @staticmethod
+    def expected_keys() -> list[str]:
+        return PANDAPROXY_INTERFACE_KEYS
+
+    @staticmethod
+    def default():
+        return PandaproxyInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_methods=[],
+            configured_authentication_method="None",
+        )
+
+
 @dataclass
 class SecurityAlert:
     affected_interface: str | None
@@ -136,6 +179,7 @@ def validate_report(
     kafka_expected={},
     rpc_expected=RpcInterface.default(),
     admin_expected={},
+    pandaproxy_expected=None,
     expected_alerts=[],
 ):
     assert response.status_code == 200, (
@@ -177,6 +221,14 @@ def validate_report(
         name = admin_json.get("name", "")
         expected_interface = admin_expected.get(name, AdminInterface.default())
         assert_interface(admin_json, expected_interface, AdminInterface)
+
+    if pandaproxy_expected is not None:
+        for pp_json in get_key("pandaproxy", interfaces):
+            name = pp_json.get("name", "")
+            expected_interface = pandaproxy_expected.get(
+                name, PandaproxyInterface.default()
+            )
+            assert_interface(pp_json, expected_interface, PandaproxyInterface)
 
     alerts_json = get_key("alerts", report_json)
     alerts = [make_from_dict(SecurityAlert, a) for a in alerts_json]
@@ -504,4 +556,158 @@ class AdminSecurityReportTest(RedpandaTest):
                 "": no_tls_interface,
                 "iplistener": with_tls_inteface,
             },
+        )
+
+
+class PandaproxyNoSecurityReportTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, pandaproxy_config=PandaproxyConfig(), **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        expected_alerts = [
+            SecurityAlert(
+                affected_interface="pandaproxy",
+                listener_name="{{unnamed}}",
+                issue="NO_TLS",
+                description='"pandaproxy" interface "{{unnamed}}" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="pandaproxy",
+                listener_name="{{unnamed}}",
+                issue="NO_AUTHN",
+                description='"pandaproxy" interface "{{unnamed}}" is not using authentication.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="pandaproxy",
+                listener_name="{{unnamed}}",
+                issue="NO_AUTHZ",
+                description='"pandaproxy" interface "{{unnamed}}" is not using authorization.'
+                " This is insecure and not recommended.",
+            ),
+        ]
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(report, pandaproxy_expected={}, expected_alerts=expected_alerts)
+
+
+class PandaproxyMTLSSecurityReportTest(PandaProxyMTLSBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.setup_cluster()
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        kafka_tls_interface = KafkaInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=False,
+            authentication_method="mTLS",
+            supported_sasl_mechanisms=None,
+        )
+
+        kafka_no_tls_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+        pp_interface = PandaproxyInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=False,
+            authentication_methods=[],
+            configured_authentication_method="None",
+        )
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": kafka_tls_interface,
+                "iplistener": kafka_tls_interface,
+                "kerberoslistener": kafka_no_tls_interface,
+            },
+            pandaproxy_expected={"": pp_interface},
+        )
+
+
+class PandaproxyAuthSecurityReportTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        pass
+
+    def _cluster_setup(self, auto_auth, enable_auth):
+        security = SecurityConfig()
+        security.http_authentication = ["BASIC", "OIDC"]
+        security.enable_sasl = True
+        security.auto_auth = auto_auth
+        pandaproxy_config = PandaproxyConfig()
+        pandaproxy_config.authn_method = "http_basic" if enable_auth else "none"
+
+        self.redpanda.set_security_settings(security)
+        self.redpanda.set_pandaproxy_settings(pandaproxy_config)
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    @matrix(auto_auth=[True, False], enable_auth=[True, False])
+    def test_security_report(self, auto_auth, enable_auth):
+        self._cluster_setup(auto_auth, enable_auth)
+
+        kafka_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=True,
+            authentication_method="SASL",
+            supported_sasl_mechanisms=sasl_default_mechs,
+        )
+
+        if enable_auth:
+            config_authn_method = "SCRAM_Proxied"
+        elif not auto_auth:
+            config_authn_method = "SCRAM_Configured"
+        else:
+            config_authn_method = "None"
+
+        pp_interface = PandaproxyInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=enable_auth,
+            authentication_methods=["BASIC", "OIDC"] if enable_auth else [],
+            configured_authentication_method=config_authn_method,
+        )
+
+        expected_alerts = []
+        if config_authn_method == "SCRAM_Configured":
+            expected_alerts.append(
+                SecurityAlert(
+                    affected_interface="pandaproxy",
+                    listener_name="{{unnamed}}",
+                    issue="PP_CONFIGURED_CLIENT",
+                    description='"pandaproxy" interface "{{unnamed}}", authorization is not enabled and the pandaproxy client has scram credentials.'
+                    " This is insecure and not recommended.",
+                )
+            )
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": kafka_interface,
+                "iplistener": kafka_interface,
+                "kerberoslistener": kafka_interface,
+            },
+            pandaproxy_expected={"": pp_interface},
+            expected_alerts=expected_alerts,
         )

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -244,6 +244,11 @@ def validate_report(
     pandaproxy_expected=None,
     schema_registry_expected=None,
     schema_registry_client_expected=KafkaClientInterface.default(),
+    audit_log_expected=KafkaClientInterface(
+        tls_enabled=False,
+        mutual_tls_enabled=False,
+        configured_authentication_method="SCRAM_Ephemeral",
+    ),
     expected_alerts=[],
 ):
     assert response.status_code == 200, (
@@ -306,6 +311,9 @@ def validate_report(
         assert_interface(
             src_json, schema_registry_client_expected, KafkaClientInterface
         )
+
+    alc_json = get_key("audit_log_client", interfaces)
+    assert_interface(alc_json, audit_log_expected, KafkaClientInterface)
 
     alerts_json = get_key("alerts", report_json)
     alerts = [make_from_dict(SecurityAlert, a) for a in alerts_json]
@@ -378,6 +386,13 @@ class NoSecurityReportTest(RedpandaTest):
                 description='"admin" interface "iplistener" is not using authorization.'
                 " This is insecure and not recommended.",
             ),
+            SecurityAlert(
+                affected_interface="audit_log_client",
+                listener_name="audit_log_client",
+                issue="NO_TLS",
+                description='"audit_log_client" interface "audit_log_client" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
         ]
 
         validate_report(report, expected_alerts=expected_alerts)
@@ -434,6 +449,12 @@ class KafkaSecurityReportTest(RedpandaTest):
             supported_sasl_mechanisms=sasl_mechs,
         )
 
+        audit_log_interface = KafkaClientInterface(
+            tls_enabled=enable_tls,
+            mutual_tls_enabled=enable_tls,
+            configured_authentication_method="SCRAM_Ephemeral",
+        )
+
         expected_alerts = []
         if authz_enabled:
             expected_alerts.extend(
@@ -470,6 +491,7 @@ class KafkaSecurityReportTest(RedpandaTest):
                 "iplistener": maybe_tls_interface,
                 "kerberoslistener": no_tls_interface,
             },
+            audit_log_expected=audit_log_interface,
             expected_alerts=expected_alerts,
         )
 
@@ -523,6 +545,12 @@ class RpcTLSSecurityReportTest(RedpandaTest):
 
         rpc_inteface = RpcInterface(tls_enabled=True, mutual_tls_enabled=True)
 
+        audit_log_interface = KafkaClientInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            configured_authentication_method="SCRAM_Ephemeral",
+        )
+
         report = Admin(self.redpanda).security_report()
         validate_report(
             report,
@@ -532,6 +560,7 @@ class RpcTLSSecurityReportTest(RedpandaTest):
                 "kerberoslistener": kafka_no_tls_interface,
             },
             rpc_expected=rpc_inteface,
+            audit_log_expected=audit_log_interface,
         )
 
 
@@ -618,6 +647,12 @@ class AdminSecurityReportTest(RedpandaTest):
             authentication_methods=["BASIC", "OIDC"],
         )
 
+        audit_log_interface = KafkaClientInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            configured_authentication_method="SCRAM_Ephemeral",
+        )
+
         admin = Admin(
             self.redpanda, auth=(self.BOOTSTRAP_USERNAME, self.BOOTSTRAP_PASSWORD)
         )
@@ -633,6 +668,7 @@ class AdminSecurityReportTest(RedpandaTest):
                 "": no_tls_interface,
                 "iplistener": with_tls_inteface,
             },
+            audit_log_expected=audit_log_interface,
         )
 
 
@@ -706,6 +742,12 @@ class PandaproxyMTLSSecurityReportTest(PandaProxyMTLSBase):
             configured_authentication_method="None",
         )
 
+        audit_log_interface = KafkaClientInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            configured_authentication_method="SCRAM_Ephemeral",
+        )
+
         report = Admin(self.redpanda).security_report()
         validate_report(
             report,
@@ -715,6 +757,7 @@ class PandaproxyMTLSSecurityReportTest(PandaProxyMTLSBase):
                 "kerberoslistener": kafka_no_tls_interface,
             },
             pandaproxy_expected={"": pp_interface},
+            audit_log_expected=audit_log_interface,
         )
 
 
@@ -881,6 +924,12 @@ class SchemaRegistryMTLSSecurityReportTest(SchemaRegistryMTLSBase):
             configured_authentication_method="None",
         )
 
+        audit_log_interface = KafkaClientInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            configured_authentication_method="SCRAM_Ephemeral",
+        )
+
         report = Admin(self.redpanda).security_report()
         validate_report(
             report,
@@ -891,6 +940,7 @@ class SchemaRegistryMTLSSecurityReportTest(SchemaRegistryMTLSBase):
             },
             schema_registry_expected={"": sr_interface},
             schema_registry_client_expected=src_interface,
+            audit_log_expected=audit_log_interface,
         )
 
 

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -327,7 +327,14 @@ def validate_report(
 
 class NoSecurityReportTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            *args,
+            extra_rp_conf={
+                "tls_min_version": "v1.0",
+                "tls_enable_renegotiation": "true",
+            },
+            **kwargs,
+        )
 
     def setUp(self):
         super().setUp()
@@ -391,6 +398,20 @@ class NoSecurityReportTest(RedpandaTest):
                 listener_name="audit_log_client",
                 issue="NO_TLS",
                 description='"audit_log_client" interface "audit_log_client" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface=None,
+                listener_name=None,
+                issue="INSECURE_MIN_TLS_VERSION",
+                description="TLS minimum version is set to v1.0 which is less than v1.2."
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface=None,
+                listener_name=None,
+                issue="TLS_RENEGOTIATION",
+                description="TLS renegotiation is enabled."
                 " This is insecure and not recommended.",
             ),
         ]

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from dataclasses import dataclass, fields
+
+from ducktape.mark import parametrize
+
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.scram_test import SaslPlainTLSProvider
+from rptest.services.redpanda import SecurityConfig
+from rptest.services.tls import TLSCertManager
+
+
+def make_from_dict(class_name, values):
+    fields_set = {f.name for f in fields(class_name) if f.init}
+    # Drop all values not in class_name
+    filtered = {k: v for k, v in values.items() if k in fields_set}
+    # Set all fields that don't have a value to None
+    field_values = {k: filtered[k] if k in filtered else None for k in fields_set}
+    return class_name(**field_values)
+
+
+KAFKA_INTERFACE_KEYS = [
+    "name",
+    "host",
+    "port",
+    "advertised_host",
+    "advertised_port",
+    "tls_enabled",
+    "mutual_tls_enabled",
+    "authentication_method",
+    "authorization_enabled",
+]
+
+sasl_default_mechs = ["SCRAM"]
+sasl_plain_mechs = ["SCRAM", "PLAIN"]
+
+
+@dataclass
+class KafkaInterface:
+    tls_enabled: bool
+    mutual_tls_enabled: bool
+    authorization_enabled: bool
+    authentication_method: str
+    supported_sasl_mechanisms: list | None
+
+    @staticmethod
+    def expected_keys() -> list[str]:
+        return KAFKA_INTERFACE_KEYS
+
+    @staticmethod
+    def default():
+        return KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+
+@dataclass
+class SecurityAlert:
+    affected_interface: str | None
+    listener_name: str | None
+    issue: str
+    description: str
+
+
+def validate_report(response, kafka_expected={}, expected_alerts=[]):
+    assert response.status_code == 200, (
+        f"Expected status code {200} but got {response.status_code}, instead.\n"
+        f"Content: {response.content}"
+    )
+
+    def assert_key(key, data):
+        assert key in data, f"Expected '{key}' key in '{data}'"
+
+    def get_key(key, data):
+        assert_key(key, data)
+        return data[key]
+
+    report_json = response.json()
+    interfaces = get_key("interfaces", report_json)
+
+    def assert_interface(json_data, expected_interface, interface_type):
+        for key in interface_type.expected_keys():
+            assert_key(key, json_data)
+
+        interface = make_from_dict(interface_type, json_data)
+        assert interface == expected_interface, (
+            f"Generated interface doesn't match expected:\n"
+            f"Report  : {interface}\n"
+            f"Expected: {expected_interface}\n"
+            f"In object: {json_data}\n"
+        )
+
+    for kafka_json in get_key("kafka", interfaces):
+        name = kafka_json.get("name", "")
+        expected_interface = kafka_expected.get(name, KafkaInterface.default())
+        assert_interface(kafka_json, expected_interface, KafkaInterface)
+
+    alerts_json = get_key("alerts", report_json)
+    alerts = [make_from_dict(SecurityAlert, a) for a in alerts_json]
+    alerts_str = "\n".join(str(a) for a in alerts)
+
+    for expected_alert in expected_alerts:
+        assert expected_alert in alerts, (
+            f"Expected alert:\n{expected_alert}\nnot found in alerts:\n{alerts_str}"
+        )
+
+
+class NoSecurityReportTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        report = Admin(self.redpanda).security_report()
+
+        expected_alerts = [
+            SecurityAlert(
+                affected_interface="kafka",
+                listener_name="dnslistener",
+                issue="NO_TLS",
+                description='"kafka" interface "dnslistener" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="kafka",
+                listener_name="dnslistener",
+                issue="NO_AUTHN",
+                description='"kafka" interface "dnslistener" is not using authentication.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="kafka",
+                listener_name="dnslistener",
+                issue="NO_AUTHZ",
+                description='"kafka" interface "dnslistener" is not using authorization.'
+                " This is insecure and not recommended.",
+            ),
+        ]
+
+        validate_report(report, expected_alerts=expected_alerts)
+
+
+class KafkaSecurityReportTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(KafkaSecurityReportTest, self).__init__(
+            test_context, num_brokers=3, extra_node_conf={"developer_mode": True}
+        )
+        self.tls = TLSCertManager(self.logger)
+
+    def setUp(self):
+        pass
+
+    def _start_cluster(self, enable_tls: bool, authn: str):
+        self.security = SecurityConfig()
+        enable_sasl = authn == "SASL"
+        self.security.enable_sasl = enable_sasl
+        if enable_sasl:
+            # Set to SASL/PLAIN to test alert for PLAIN
+            self.security.sasl_mechanisms = ["SCRAM", "PLAIN"]
+        if enable_tls:
+            self.security.tls_provider = SaslPlainTLSProvider(tls=self.tls)
+            if authn == "mTLS":
+                self.security.endpoint_authn_method = "mtls_identity"
+        self.redpanda.set_security_settings(self.security)
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    @parametrize(config={"enable_tls": False, "authn": "SASL"})
+    @parametrize(config={"enable_tls": True, "authn": "SASL"})
+    @parametrize(config={"enable_tls": True, "authn": "mTLS"})
+    def test_security_report(self, config):
+        enable_tls = config["enable_tls"]
+        authn = config["authn"]
+        self._start_cluster(enable_tls, authn)
+
+        authz_enabled = authn == "SASL"
+        sasl_mechs = sasl_plain_mechs if authz_enabled else None
+
+        maybe_tls_interface = KafkaInterface(
+            tls_enabled=enable_tls,
+            mutual_tls_enabled=enable_tls,
+            authorization_enabled=authz_enabled,
+            authentication_method=authn,
+            supported_sasl_mechanisms=sasl_mechs,
+        )
+        no_tls_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=authz_enabled,
+            authentication_method=authn if authz_enabled else "None",
+            supported_sasl_mechanisms=sasl_mechs,
+        )
+
+        expected_alerts = []
+        if authz_enabled:
+            expected_alerts.extend(
+                [
+                    SecurityAlert(
+                        affected_interface="kafka",
+                        listener_name="dnslistener",
+                        issue="SASL_PLAIN",
+                        description='"kafka" interface "dnslistener" is using SASL/PLAIN.'
+                        " This is insecure and not recommended.",
+                    ),
+                    SecurityAlert(
+                        affected_interface="kafka",
+                        listener_name="iplistener",
+                        issue="SASL_PLAIN",
+                        description='"kafka" interface "iplistener" is using SASL/PLAIN.'
+                        " This is insecure and not recommended.",
+                    ),
+                    SecurityAlert(
+                        affected_interface="kafka",
+                        listener_name="kerberoslistener",
+                        issue="SASL_PLAIN",
+                        description='"kafka" interface "kerberoslistener" is using SASL/PLAIN.'
+                        " This is insecure and not recommended.",
+                    ),
+                ]
+            )
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": maybe_tls_interface,
+                "iplistener": maybe_tls_interface,
+                "kerberoslistener": no_tls_interface,
+            },
+            expected_alerts=expected_alerts,
+        )

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -16,11 +16,13 @@ from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.scram_test import SaslPlainTLSProvider
 from rptest.tests.pandaproxy_test import PandaProxyMTLSBase
+from rptest.tests.schema_registry_test import SchemaRegistryMTLSBase
 from rptest.services.redpanda import (
     SecurityConfig,
     RedpandaService,
     SaslCredentials,
     PandaproxyConfig,
+    SchemaRegistryConfig,
 )
 from rptest.services.tls import TLSCertManager
 
@@ -166,6 +168,66 @@ class PandaproxyInterface:
         )
 
 
+SCHEMA_REGISTRY_INTERFACE_KEYS = [
+    "name",
+    "host",
+    "port",
+    "tls_enabled",
+    "mutual_tls_enabled",
+    "authentication_methods",
+    "authorization_enabled",
+]
+
+
+@dataclass
+class SchemaRegistryInterface:
+    tls_enabled: bool
+    mutual_tls_enabled: bool
+    authorization_enabled: bool
+    authentication_methods: list[str]
+
+    @staticmethod
+    def expected_keys() -> list[str]:
+        return SCHEMA_REGISTRY_INTERFACE_KEYS
+
+    @staticmethod
+    def default():
+        return SchemaRegistryInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_methods=[],
+        )
+
+
+KAFKA_CLIENT_INTERFACE_KEYS = [
+    "kafka_listener_name",
+    "brokers",
+    "tls_enabled",
+    "mutual_tls_enabled",
+    "configured_authentication_method",
+]
+
+
+@dataclass
+class KafkaClientInterface:
+    tls_enabled: bool
+    mutual_tls_enabled: bool
+    configured_authentication_method: str
+
+    @staticmethod
+    def expected_keys() -> list[str]:
+        return KAFKA_CLIENT_INTERFACE_KEYS
+
+    @staticmethod
+    def default():
+        return KafkaClientInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            configured_authentication_method="None",
+        )
+
+
 @dataclass
 class SecurityAlert:
     affected_interface: str | None
@@ -180,6 +242,8 @@ def validate_report(
     rpc_expected=RpcInterface.default(),
     admin_expected={},
     pandaproxy_expected=None,
+    schema_registry_expected=None,
+    schema_registry_client_expected=KafkaClientInterface.default(),
     expected_alerts=[],
 ):
     assert response.status_code == 200, (
@@ -229,6 +293,19 @@ def validate_report(
                 name, PandaproxyInterface.default()
             )
             assert_interface(pp_json, expected_interface, PandaproxyInterface)
+
+    if schema_registry_expected is not None:
+        for sr_json in get_key("schema_registry", interfaces):
+            name = sr_json.get("name", "")
+            expected_interface = schema_registry_expected.get(
+                name, SchemaRegistryInterface.default()
+            )
+            assert_interface(sr_json, expected_interface, SchemaRegistryInterface)
+
+        src_json = get_key("schema_registry_client", interfaces)
+        assert_interface(
+            src_json, schema_registry_client_expected, KafkaClientInterface
+        )
 
     alerts_json = get_key("alerts", report_json)
     alerts = [make_from_dict(SecurityAlert, a) for a in alerts_json]
@@ -711,3 +788,186 @@ class PandaproxyAuthSecurityReportTest(RedpandaTest):
             pandaproxy_expected={"": pp_interface},
             expected_alerts=expected_alerts,
         )
+
+
+class SchemaRegistryNoSecurityReportTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, schema_registry_config=SchemaRegistryConfig(), **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        expected_alerts = [
+            SecurityAlert(
+                affected_interface="schema_registry",
+                listener_name="{{unnamed}}",
+                issue="NO_TLS",
+                description='"schema_registry" interface "{{unnamed}}" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="schema_registry",
+                listener_name="{{unnamed}}",
+                issue="NO_AUTHN",
+                description='"schema_registry" interface "{{unnamed}}" is not using authentication.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="schema_registry",
+                listener_name="{{unnamed}}",
+                issue="NO_AUTHZ",
+                description='"schema_registry" interface "{{unnamed}}" is not using authorization.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="schema_registry_client",
+                listener_name="schema_registry_client",
+                issue="NO_TLS",
+                description='"schema_registry_client" interface "schema_registry_client" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="schema_registry_client",
+                listener_name="schema_registry_client",
+                issue="NO_AUTHN",
+                description='"schema_registry_client" interface "schema_registry_client" is not using authentication.'
+                " This is insecure and not recommended.",
+            ),
+        ]
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report, schema_registry_expected={}, expected_alerts=expected_alerts
+        )
+
+
+class SchemaRegistryMTLSSecurityReportTest(SchemaRegistryMTLSBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.setup_cluster()
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        kafka_tls_interface = KafkaInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=False,
+            authentication_method="mTLS",
+            supported_sasl_mechanisms=None,
+        )
+
+        kafka_no_tls_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+        sr_interface = SchemaRegistryInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=False,
+            authentication_methods=[],
+        )
+
+        src_interface = KafkaClientInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            configured_authentication_method="None",
+        )
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": kafka_tls_interface,
+                "iplistener": kafka_tls_interface,
+                "kerberoslistener": kafka_no_tls_interface,
+            },
+            schema_registry_expected={"": sr_interface},
+            schema_registry_client_expected=src_interface,
+        )
+
+
+class SchemaRegistryAuthSecurityReportTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            extra_rp_conf={
+                "schema_registry_enable_authorization": True,
+            },
+            **kwargs,
+        )
+
+    def setUp(self):
+        pass
+
+    def _cluster_setup(self, auto_auth):
+        security = SecurityConfig()
+        security.http_authentication = ["BASIC", "OIDC"]
+        security.enable_sasl = True
+        security.auto_auth = auto_auth
+        schema_registry_config = SchemaRegistryConfig()
+        schema_registry_config.authn_method = "http_basic"
+
+        self.redpanda.set_security_settings(security)
+        self.redpanda.set_schema_registry_settings(schema_registry_config)
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    @matrix(auto_auth=[True, False])
+    def test_security_report(self, auto_auth):
+        self._cluster_setup(auto_auth)
+
+        kafka_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=True,
+            authentication_method="SASL",
+            supported_sasl_mechanisms=sasl_default_mechs,
+        )
+
+        sr_interface = SchemaRegistryInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=True,
+            authentication_methods=["BASIC", "OIDC"],
+        )
+
+        src_interface = KafkaClientInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            configured_authentication_method="SCRAM_Ephemeral"
+            if auto_auth
+            else "SCRAM_Configured",
+        )
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": kafka_interface,
+                "iplistener": kafka_interface,
+                "kerberoslistener": kafka_interface,
+            },
+            schema_registry_expected={"": sr_interface},
+            schema_registry_client_expected=src_interface,
+        )
+
+
+class SchemaRegistryClientSecurityReportTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, schema_registry_config=SchemaRegistryConfig(), **kwargs)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        report = Admin(self.redpanda).security_report()
+        validate_report(report, schema_registry_expected={})

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -15,7 +15,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.scram_test import SaslPlainTLSProvider
-from rptest.services.redpanda import SecurityConfig
+from rptest.services.redpanda import SecurityConfig, RedpandaService
 from rptest.services.tls import TLSCertManager
 
 
@@ -67,6 +67,30 @@ class KafkaInterface:
         )
 
 
+RPC_INTERFACE_KEYS = [
+    "host",
+    "port",
+    "advertised_host",
+    "advertised_port",
+    "tls_enabled",
+    "mutual_tls_enabled",
+]
+
+
+@dataclass
+class RpcInterface:
+    tls_enabled: bool
+    mutual_tls_enabled: bool
+
+    @staticmethod
+    def expected_keys() -> list[str]:
+        return RPC_INTERFACE_KEYS
+
+    @staticmethod
+    def default():
+        return RpcInterface(tls_enabled=False, mutual_tls_enabled=False)
+
+
 @dataclass
 class SecurityAlert:
     affected_interface: str | None
@@ -75,7 +99,9 @@ class SecurityAlert:
     description: str
 
 
-def validate_report(response, kafka_expected={}, expected_alerts=[]):
+def validate_report(
+    response, kafka_expected={}, rpc_expected=RpcInterface.default(), expected_alerts=[]
+):
     assert response.status_code == 200, (
         f"Expected status code {200} but got {response.status_code}, instead.\n"
         f"Content: {response.content}"
@@ -107,6 +133,9 @@ def validate_report(response, kafka_expected={}, expected_alerts=[]):
         name = kafka_json.get("name", "")
         expected_interface = kafka_expected.get(name, KafkaInterface.default())
         assert_interface(kafka_json, expected_interface, KafkaInterface)
+
+    rpc_json = get_key("rpc", interfaces)
+    assert_interface(rpc_json, rpc_expected, RpcInterface)
 
     alerts_json = get_key("alerts", report_json)
     alerts = [make_from_dict(SecurityAlert, a) for a in alerts_json]
@@ -149,6 +178,13 @@ class NoSecurityReportTest(RedpandaTest):
                 listener_name="dnslistener",
                 issue="NO_AUTHZ",
                 description='"kafka" interface "dnslistener" is not using authorization.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="rpc",
+                listener_name=None,
+                issue="NO_TLS",
+                description='"rpc" interface is not using TLS.'
                 " This is insecure and not recommended.",
             ),
         ]
@@ -244,4 +280,65 @@ class KafkaSecurityReportTest(RedpandaTest):
                 "kerberoslistener": no_tls_interface,
             },
             expected_alerts=expected_alerts,
+        )
+
+
+RPC_TLS_CONFIG = dict(
+    enabled=True,
+    require_client_auth=True,
+    key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+    cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+    truststore_file=RedpandaService.TLS_CA_CRT_FILE,
+    crl_file=RedpandaService.TLS_CA_CRL_FILE,
+)
+
+
+class RpcTLSSecurityReportTest(RedpandaTest):
+    def __init__(self, test_context):
+        super().__init__(test_context)
+        self.tls = TLSCertManager(self.logger)
+        self.security = SecurityConfig()
+        self.security.tls_provider = SaslPlainTLSProvider(tls=self.tls)
+        self.redpanda.set_security_settings(self.security)
+
+    def setUp(self):
+        # Set up TLS for RPC
+        cfg_overrides = {}
+
+        def set_cfg(node):
+            cfg_overrides[node] = dict(rpc_server_tls=RPC_TLS_CONFIG)
+
+        self.redpanda.for_nodes(self.redpanda.nodes, set_cfg)
+
+        self.redpanda.start(node_config_overrides=cfg_overrides)
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        kafka_tls_interface = KafkaInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+        kafka_no_tls_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+        rpc_inteface = RpcInterface(tls_enabled=True, mutual_tls_enabled=True)
+
+        report = Admin(self.redpanda).security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": kafka_tls_interface,
+                "iplistener": kafka_tls_interface,
+                "kerberoslistener": kafka_no_tls_interface,
+            },
+            rpc_expected=rpc_inteface,
         )

--- a/tests/rptest/tests/security_report_test.py
+++ b/tests/rptest/tests/security_report_test.py
@@ -15,7 +15,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.scram_test import SaslPlainTLSProvider
-from rptest.services.redpanda import SecurityConfig, RedpandaService
+from rptest.services.redpanda import SecurityConfig, RedpandaService, SaslCredentials
 from rptest.services.tls import TLSCertManager
 
 
@@ -91,6 +91,38 @@ class RpcInterface:
         return RpcInterface(tls_enabled=False, mutual_tls_enabled=False)
 
 
+ADMIN_INTERFACE_KEYS = [
+    "name",
+    "host",
+    "port",
+    "tls_enabled",
+    "mutual_tls_enabled",
+    "authentication_methods",
+    "authorization_enabled",
+]
+
+
+@dataclass
+class AdminInterface:
+    tls_enabled: bool
+    mutual_tls_enabled: bool
+    authorization_enabled: bool
+    authentication_methods: list[str]
+
+    @staticmethod
+    def expected_keys() -> list[str]:
+        return ADMIN_INTERFACE_KEYS
+
+    @staticmethod
+    def default():
+        return AdminInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_methods=[],
+        )
+
+
 @dataclass
 class SecurityAlert:
     affected_interface: str | None
@@ -100,7 +132,11 @@ class SecurityAlert:
 
 
 def validate_report(
-    response, kafka_expected={}, rpc_expected=RpcInterface.default(), expected_alerts=[]
+    response,
+    kafka_expected={},
+    rpc_expected=RpcInterface.default(),
+    admin_expected={},
+    expected_alerts=[],
 ):
     assert response.status_code == 200, (
         f"Expected status code {200} but got {response.status_code}, instead.\n"
@@ -136,6 +172,11 @@ def validate_report(
 
     rpc_json = get_key("rpc", interfaces)
     assert_interface(rpc_json, rpc_expected, RpcInterface)
+
+    for admin_json in get_key("admin", interfaces):
+        name = admin_json.get("name", "")
+        expected_interface = admin_expected.get(name, AdminInterface.default())
+        assert_interface(admin_json, expected_interface, AdminInterface)
 
     alerts_json = get_key("alerts", report_json)
     alerts = [make_from_dict(SecurityAlert, a) for a in alerts_json]
@@ -185,6 +226,27 @@ class NoSecurityReportTest(RedpandaTest):
                 listener_name=None,
                 issue="NO_TLS",
                 description='"rpc" interface is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="admin",
+                listener_name="iplistener",
+                issue="NO_TLS",
+                description='"admin" interface "iplistener" is not using TLS.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="admin",
+                listener_name="iplistener",
+                issue="NO_AUTHN",
+                description='"admin" interface "iplistener" is not using authentication.'
+                " This is insecure and not recommended.",
+            ),
+            SecurityAlert(
+                affected_interface="admin",
+                listener_name="iplistener",
+                issue="NO_AUTHZ",
+                description='"admin" interface "iplistener" is not using authorization.'
                 " This is insecure and not recommended.",
             ),
         ]
@@ -341,4 +403,105 @@ class RpcTLSSecurityReportTest(RedpandaTest):
                 "kerberoslistener": kafka_no_tls_interface,
             },
             rpc_expected=rpc_inteface,
+        )
+
+
+ADMIN_TLS_CONFIG = dict(
+    name="iplistener",
+    enabled=True,
+    require_client_auth=True,
+    key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+    cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+    truststore_file=RedpandaService.TLS_CA_CRT_FILE,
+    crl_file=RedpandaService.TLS_CA_CRL_FILE,
+)
+
+
+class AdminSecurityReportTest(RedpandaTest):
+    BOOTSTRAP_USERNAME = "bob"
+    BOOTSTRAP_PASSWORD = "sekrit"
+    BOOTSTRAP_MECHANISM = "SCRAM-SHA-512"
+
+    def __init__(self, test_context, *args, **kwargs):
+        # Configure the cluster as a user might configure it for secure
+        # bootstrap: i.e. all auth turned on from moment of creation.
+
+        super().__init__(
+            test_context,
+            *args,
+            environment={
+                "RP_BOOTSTRAP_USER": f"{self.BOOTSTRAP_USERNAME}:{self.BOOTSTRAP_PASSWORD}:{self.BOOTSTRAP_MECHANISM}"
+            },
+            extra_rp_conf={"admin_api_require_auth": True, "superusers": ["bob"]},
+            superuser=SaslCredentials(
+                self.BOOTSTRAP_USERNAME,
+                self.BOOTSTRAP_PASSWORD,
+                self.BOOTSTRAP_MECHANISM,
+            ),
+            **kwargs,
+        )
+        self.tls = TLSCertManager(self.logger)
+        self.security = SecurityConfig()
+        self.security.http_authentication = ["BASIC", "OIDC"]
+        self.security.tls_provider = SaslPlainTLSProvider(tls=self.tls)
+        self.redpanda.set_security_settings(self.security)
+
+    def setUp(self):
+        # Set up TLS for Admin
+        cfg_overrides = {}
+
+        def set_cfg(node):
+            cfg_overrides[node] = dict(admin_api_tls=ADMIN_TLS_CONFIG)
+
+        self.redpanda.for_nodes(self.redpanda.nodes, set_cfg)
+
+        self.redpanda.start(node_config_overrides=cfg_overrides)
+
+    @cluster(num_nodes=3)
+    def test_security_report(self):
+        kafka_tls_interface = KafkaInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+        kafka_no_tls_interface = KafkaInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=False,
+            authentication_method="None",
+            supported_sasl_mechanisms=None,
+        )
+
+        with_tls_inteface = AdminInterface(
+            tls_enabled=True,
+            mutual_tls_enabled=True,
+            authorization_enabled=True,
+            authentication_methods=["BASIC", "OIDC"],
+        )
+
+        no_tls_interface = AdminInterface(
+            tls_enabled=False,
+            mutual_tls_enabled=False,
+            authorization_enabled=True,
+            authentication_methods=["BASIC", "OIDC"],
+        )
+
+        admin = Admin(
+            self.redpanda, auth=(self.BOOTSTRAP_USERNAME, self.BOOTSTRAP_PASSWORD)
+        )
+        report = admin.security_report()
+        validate_report(
+            report,
+            kafka_expected={
+                "dnslistener": kafka_tls_interface,
+                "iplistener": kafka_tls_interface,
+                "kerberoslistener": kafka_no_tls_interface,
+            },
+            admin_expected={
+                "": no_tls_interface,
+                "iplistener": with_tls_inteface,
+            },
         )


### PR DESCRIPTION
backport of #27173 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Features

* Introduces GET /v1/security/report (Admin API)