### PR TITLE
admin: handle log level requests on shard 0

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -866,6 +866,10 @@ void admin_server::log_exception(
 }
 
 void admin_server::rearm_log_level_timer() {
+    vassert(
+      ss::this_shard_id() == ss::shard_id{0},
+      "Log levels should only be managed on shard 0");
+
     _log_level_timer.cancel();
 
     if (_log_level_resets.empty()) {
@@ -883,6 +887,9 @@ void admin_server::rearm_log_level_timer() {
 }
 
 void admin_server::log_level_timer_handler() {
+    vassert(
+      ss::this_shard_id() == ss::shard_id{0},
+      "Log levels should only be managed on shard 0");
     std::ranges::for_each(_log_level_resets, [](auto& pr) {
         auto& [name, lr] = pr;
         if (lr.expires.has_value() && lr.expires <= ss::timer<>::clock::now()) {
@@ -1576,179 +1583,192 @@ void admin_server::register_config_routes() {
     register_route<superuser>(
       ss::httpd::config_json::get_log_level,
       [this](std::unique_ptr<ss::http::request> req) {
-          ss::httpd::config_json::get_log_level_response rsp{};
-          ss::sstring name = req->get_path_param("name");
-          if (name == "") {
-              throw ss::httpd::bad_param_exception(
-                fmt::format(
-                  "Invalid parameter 'name' got {{{}}}",
-                  req->get_path_param("name")));
-          }
-          validate_no_control(name, string_conversion_exception{"name"});
+          return container().invoke_on(
+            ss::shard_id{0}, [req = std::move(req)](const admin_server& as) {
+                ss::httpd::config_json::get_log_level_response rsp{};
+                ss::sstring name = req->get_path_param("name");
+                if (name == "") {
+                    throw ss::httpd::bad_param_exception(
+                      fmt::format(
+                        "Invalid parameter 'name' got {{{}}}",
+                        req->get_path_param("name")));
+                }
+                validate_no_control(name, string_conversion_exception{"name"});
 
-          ss::log_level cur_level;
-          try {
-              cur_level = ss::global_logger_registry().get_logger_level(name);
-          } catch (const std::out_of_range&) {
-              throw ss::httpd::bad_param_exception(
-                fmt::format(
-                  "Cannot set log level: unknown logger {{{}}}", name));
-          }
+                ss::log_level cur_level;
+                try {
+                    cur_level = ss::global_logger_registry().get_logger_level(
+                      name);
+                } catch (const std::out_of_range&) {
+                    throw ss::httpd::bad_param_exception(
+                      fmt::format(
+                        "Cannot set log level: unknown logger {{{}}}", name));
+                }
 
-          rsp.name = name;
-          rsp.level = ss::to_sstring(cur_level);
+                rsp.name = name;
+                rsp.level = ss::to_sstring(cur_level);
 
-          auto find_iter = _log_level_resets.find(name);
-          if (
-            find_iter == _log_level_resets.end()
-            || !find_iter->second.expires.has_value()) {
-              rsp.expiration = 0;
-          } else {
-              auto remaining_dur = find_iter->second.expires.value()
-                                   - ss::timer<>::clock::now();
-              rsp.expiration = std::chrono::duration_cast<std::chrono::seconds>(
-                                 remaining_dur)
-                                 .count();
-          }
+                auto find_iter = as._log_level_resets.find(name);
+                if (
+                  find_iter == as._log_level_resets.end()
+                  || !find_iter->second.expires.has_value()) {
+                    rsp.expiration = 0;
+                } else {
+                    auto remaining_dur = find_iter->second.expires.value()
+                                         - ss::timer<>::clock::now();
+                    rsp.expiration
+                      = std::chrono::duration_cast<std::chrono::seconds>(
+                          remaining_dur)
+                          .count();
+                }
 
-          return ss::make_ready_future<ss::json::json_return_type>(rsp);
+                return ss::make_ready_future<ss::json::json_return_type>(rsp);
+            });
       });
 
     register_route<superuser>(
       ss::httpd::config_json::set_log_level,
       [this](std::unique_ptr<ss::http::request> req) {
-          using namespace std::chrono_literals;
-          ss::httpd::config_json::set_log_level_response rsp{};
-          ss::sstring name = req->get_path_param("name");
-          if (name == "") {
-              throw ss::httpd::bad_param_exception(
-                fmt::format(
-                  "Invalid parameter 'name' got {{{}}}",
-                  req->get_path_param("name")));
-          }
-          validate_no_control(name, string_conversion_exception{"name"});
+          return container().invoke_on(
+            ss::shard_id{0}, [req = std::move(req)](admin_server& as) {
+                using namespace std::chrono_literals;
+                ss::httpd::config_json::set_log_level_response rsp{};
+                ss::sstring name = req->get_path_param("name");
+                if (name == "") {
+                    throw ss::httpd::bad_param_exception(
+                      fmt::format(
+                        "Invalid parameter 'name' got {{{}}}",
+                        req->get_path_param("name")));
+                }
+                validate_no_control(name, string_conversion_exception{"name"});
 
-          // current level: will be used revert after a timeout (optional)
-          ss::log_level cur_level;
-          try {
-              cur_level = ss::global_logger_registry().get_logger_level(name);
-          } catch (const std::out_of_range&) {
-              throw ss::httpd::bad_param_exception(
-                fmt::format(
-                  "Cannot set log level: unknown logger {{{}}}", name));
-          }
+                // current level: will be used revert after a timeout (optional)
+                ss::log_level cur_level;
+                try {
+                    cur_level = ss::global_logger_registry().get_logger_level(
+                      name);
+                } catch (const std::out_of_range&) {
+                    throw ss::httpd::bad_param_exception(
+                      fmt::format(
+                        "Cannot set log level: unknown logger {{{}}}", name));
+                }
 
-          rsp.name = name;
-          rsp.previous_level = ss::to_sstring(cur_level);
+                rsp.name = name;
+                rsp.previous_level = ss::to_sstring(cur_level);
 
-          // decode new level
-          ss::log_level new_level;
-          try {
-              new_level = boost::lexical_cast<ss::log_level>(
-                req->get_query_param("level"));
-          } catch (const boost::bad_lexical_cast& e) {
-              throw ss::httpd::bad_param_exception(
-                fmt::format(
-                  "Cannot set log level for {{{}}}: unknown level {{{}}}",
+                // decode new level
+                ss::log_level new_level;
+                try {
+                    new_level = boost::lexical_cast<ss::log_level>(
+                      req->get_query_param("level"));
+                } catch (const boost::bad_lexical_cast& e) {
+                    throw ss::httpd::bad_param_exception(
+                      fmt::format(
+                        "Cannot set log level for {{{}}}: unknown level {{{}}}",
+                        name,
+                        req->get_query_param("level")));
+                }
+
+                rsp.new_level = ss::to_sstring(new_level);
+
+                // how long should the new log level be active
+                std::optional<std::chrono::seconds> expires;
+                if (auto e = req->get_query_param("expires"); !e.empty()) {
+                    try {
+                        expires = std::chrono::seconds(
+                          boost::lexical_cast<unsigned int>(e));
+                    } catch (const boost::bad_lexical_cast& e) {
+                        throw ss::httpd::bad_param_exception(
+                          fmt::format(
+                            "Cannot set log level for {{{}}}: invalid expires "
+                            "value "
+                            "{{{}}}",
+                            name,
+                            e));
+                    }
+                }
+
+                // Should we force the supplied expiration over the configured
+                // max?
+                auto force = false;
+                if (auto f = req->get_query_param("force"); !f.empty()) {
+                    force = str_to_bool(f);
+                }
+
+                auto is_verbose = [](auto new_level) {
+                    static std::unordered_set verbose_levels{
+                      ss::log_level::debug, ss::log_level::trace};
+                    return verbose_levels.contains(new_level);
+                };
+
+                auto clamp_expiry = [&is_verbose](
+                                      auto& expires, auto level, auto force) {
+                    // if no expiration was given, then use some reasonable
+                    // default that will prevent the system from remaining in a
+                    // non-optimal state (e.g. trace logging) indefinitely.
+                    auto exp = expires.value_or(600s);
+
+                    auto verbose = is_verbose(level);
+
+                    // subject to a node-config'ed max value, overrideable by
+                    // `force` query param
+                    auto max_exp
+                      = (!verbose || force)
+                          ? std::nullopt
+                          : config::node().verbose_logging_timeout_sec_max();
+
+                    // don't allow indefinite trace logging if we have a max
+                    // configured
+                    if (max_exp.has_value() && exp / 1s == 0) {
+                        return max_exp.value();
+                    }
+
+                    return std::min(
+                      exp, max_exp.value_or(std::chrono::seconds::max()));
+                };
+
+                // Maybe clamp expiration to node config
+                auto expires_v = clamp_expiry(expires, new_level, force);
+
+                vlog(
+                  adminlog.info,
+                  "Set log level for {{{}}}: {} -> {} (expiring {})",
                   name,
-                  req->get_query_param("level")));
-          }
+                  cur_level,
+                  new_level,
+                  expires_v / 1s > 0
+                    ? fmt::format(
+                        "{}s",
+                        std::chrono::duration_cast<std::chrono::seconds>(
+                          expires_v)
+                          .count())
+                    : "NEVER");
 
-          rsp.new_level = ss::to_sstring(new_level);
+                ss::global_logger_registry().set_logger_level(name, new_level);
 
-          // how long should the new log level be active
-          std::optional<std::chrono::seconds> expires;
-          if (auto e = req->get_query_param("expires"); !e.empty()) {
-              try {
-                  expires = std::chrono::seconds(
-                    boost::lexical_cast<unsigned int>(e));
-              } catch (const boost::bad_lexical_cast& e) {
-                  throw ss::httpd::bad_param_exception(
-                    fmt::format(
-                      "Cannot set log level for {{{}}}: invalid expires value "
-                      "{{{}}}",
-                      name,
-                      e));
-              }
-          }
+                auto when = [&]() -> std::optional<level_reset::time_point> {
+                    // expires=0 is same as not specifying it at all
+                    if (expires_v / 1s > 0) {
+                        return ss::timer<>::clock::now() + expires_v;
+                    } else {
+                        // new log level never expires, but we still want an
+                        // entry in the resets map as a record of the default
+                        return std::nullopt;
+                    }
+                }();
 
-          // Should we force the supplied expiration over the configured max?
-          auto force = false;
-          if (auto f = req->get_query_param("force"); !f.empty()) {
-              force = str_to_bool(f);
-          }
+                auto res = as._log_level_resets.try_emplace(
+                  name, cur_level, when);
+                if (!res.second) {
+                    res.first->second.expires = when;
+                }
 
-          auto is_verbose = [](auto new_level) {
-              static std::unordered_set verbose_levels{
-                ss::log_level::debug, ss::log_level::trace};
-              return verbose_levels.contains(new_level);
-          };
+                rsp.expiration = expires_v / 1s;
 
-          auto clamp_expiry = [&is_verbose](
-                                auto& expires, auto level, auto force) {
-              // if no expiration was given, then use some reasonable
-              // default that will prevent the system from remaining in a
-              // non-optimal state (e.g. trace logging) indefinitely.
-              auto exp = expires.value_or(600s);
+                as.rearm_log_level_timer();
 
-              auto verbose = is_verbose(level);
-
-              // subject to a node-config'ed max value, overrideable by
-              // `force` query param
-              auto max_exp
-                = (!verbose || force)
-                    ? std::nullopt
-                    : config::node().verbose_logging_timeout_sec_max();
-
-              // don't allow indefinite trace logging if we have a max
-              // configured
-              if (max_exp.has_value() && exp / 1s == 0) {
-                  return max_exp.value();
-              }
-
-              return std::min(
-                exp, max_exp.value_or(std::chrono::seconds::max()));
-          };
-
-          // Maybe clamp expiration to node config
-          auto expires_v = clamp_expiry(expires, new_level, force);
-
-          vlog(
-            adminlog.info,
-            "Set log level for {{{}}}: {} -> {} (expiring {})",
-            name,
-            cur_level,
-            new_level,
-            expires_v / 1s > 0
-              ? fmt::format(
-                  "{}s",
-                  std::chrono::duration_cast<std::chrono::seconds>(expires_v)
-                    .count())
-              : "NEVER");
-
-          ss::global_logger_registry().set_logger_level(name, new_level);
-
-          auto when = [&]() -> std::optional<level_reset::time_point> {
-              // expires=0 is same as not specifying it at all
-              if (expires_v / 1s > 0) {
-                  return ss::timer<>::clock::now() + expires_v;
-              } else {
-                  // new log level never expires, but we still want an entry in
-                  // the resets map as a record of the default
-                  return std::nullopt;
-              }
-          }();
-
-          auto res = _log_level_resets.try_emplace(name, cur_level, when);
-          if (!res.second) {
-              res.first->second.expires = when;
-          }
-
-          rsp.expiration = expires_v / 1s;
-
-          rearm_log_level_timer();
-
-          return ss::make_ready_future<ss::json::json_return_type>(rsp);
+                return ss::make_ready_future<ss::json::json_return_type>(rsp);
+            });
       });
 }
 

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -68,7 +68,7 @@ struct topic_recovery_service;
 
 extern ss::logger adminlog;
 
-class admin_server {
+class admin_server : public ss::peering_sharded_service<admin_server> {
 public:
     explicit admin_server(
       admin_server_cfg,


### PR DESCRIPTION
This fixes a bug where two concurrent log level setting requests that arrived on different shards could cause the logger to "expire" to the incorrect log level.

```
INFO  2025-09-04 21:57:13,500 [shard  7:admi] admin_api_server - server.cc:1509 - Set log level for {kafka-cg}: info -> trace (expiring 120s)
INFO  2025-09-04 21:57:18,659 [shard  1:admi] admin_api_server - server.cc:1509 - Set log level for {kafka-cg}: trace -> trace (expiring 120s)
INFO  2025-09-04 21:59:13,500 [shard  7:main] admin_api_server - server.cc:710 - Expiring log level for {kafka-cg} to info
INFO  2025-09-04 21:59:18,659 [shard  1:main] admin_api_server - server.cc:710 - Expiring log level for {kafka-cg} to trace
```

This commit routes all log level changing requests to shard 0, so that the existing deduplication logic can handle them correctly.

It is difficult to hit this scenario, because log level setting requests are rarely concurrent and also tend to arrive on the same shard (at least that has been my experience while trying to reproduce this locally).

I could reproduce the issue locally using two concurrent terminals sending a high volume of log setting requests and confirmed that this PR fixes the issue:
```
watch -n 0.001 'rpk redpanda admin config log-level set kafka --level=trace -e 10 --host=localhost:9644'
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
### Bug Fixes

* Fixes a bug where concurrent log level setting requests could lead to a situation where the logger ended up expiring to the incorrect log level.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
