### PR TITLE
Adjust OAuth audit log test to allow for >1 record

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2301,7 +2301,7 @@ class AuditLogTestOauth(AuditLogTestBase):
         [ip_set.add(r["dst_endpoint"]["ip"]) for r in records]
 
         assert len(records) == len(ip_set), (
-            f"Expected one record but received {len(records)}"
+            f"Expected {len(ip_set)} record but received {len(records)}"
         )
 
         records = self.read_all_from_audit_log(
@@ -2315,7 +2315,10 @@ class AuditLogTestOauth(AuditLogTestBase):
             lambda records: self.aggregate_count(records) >= 1,
         )
 
-        assert 1 == len(records), f"Expected one record but received {len(records)}"
+        # The kafka client may have sent the metadata request to >1 node, so we may see >1 metadata record
+        assert len(records) >= 1, (
+            f"Expected at least one record but received {len(records)}"
+        )
 
     @skip_fips_mode
     @cluster(num_nodes=6)


### PR DESCRIPTION
Possibly tied with the updates to the kafka clients, it now appears that the Kafka client may send a metadata request to multiple brokers, rather than just one.  This results in >1 metadata audit record appearing in the log.  Adjust to the test to fail only if we receive 0 records.

Fixes: CORE-13324

Todo:
- [ ] Run audit log tests a bunch 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
