### PR TITLE
[CORE-13296] Align TLS configuration with policy

### DIFF
--- a/src/v/config/BUILD
+++ b/src/v/config/BUILD
@@ -47,6 +47,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cluster:topic_memory_per_partition_default",
         "//src/v/datalake:partition_spec_parser",
+        "//src/v/thirdparty/openssl",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -19,6 +19,7 @@
 #include "config/validators.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
+#include "net/tls.h"
 #include "security/config.h"
 #include "security/oidc_url_parser.h"
 #include "serde/rw/chrono.h"
@@ -3941,6 +3942,36 @@ configuration::configuration()
       "connections as client-initiated renegotiation was removed.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       false)
+  , tls_v1_2_cipher_suites(
+      *this,
+      "tls_v1_2_cipher_suites",
+      "Specifies the TLS 1.2 cipher suites available for external client "
+      "connections as a colon-separated OpenSSL-compatible list. Configure "
+      "this property to support legacy clients.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      ss::sstring{net::tls_v1_2_cipher_suites},
+      [](ss::sstring s) -> std::optional<ss::sstring> {
+          if (!validate_tls_v1_2_cipher_suites(s)) {
+              return ssx::sformat("Invalid cipher suites: {}", s);
+          }
+          return std::nullopt;
+      })
+  , tls_v1_3_cipher_suites(
+      *this,
+      "tls_v1_3_cipher_suites",
+      "Specifies the TLS 1.3 cipher suites available for external client "
+      "connections as a colon-separated OpenSSL-compatible list. Most "
+      "deployments don't need to modify this setting. Configure this property "
+      "only for specific organizational security policies.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      ss::sstring{net::tls_v1_3_cipher_suites},
+      [](ss::sstring s) -> std::optional<ss::sstring> {
+          if (!validate_tls_v1_3_cipher_suites(s)) {
+              return ssx::sformat("Invalid cipher suites: {}", s);
+          }
+          return std::nullopt;
+      })
+
   , iceberg_enabled(
       *this,
       true,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -730,6 +730,8 @@ struct configuration final : public config_store {
 
     enum_property<tls_version> tls_min_version;
     property<bool> tls_enable_renegotiation;
+    property<ss::sstring> tls_v1_2_cipher_suites;
+    property<ss::sstring> tls_v1_3_cipher_suites;
 
     // datalake configurations
     enterprise<property<bool>> iceberg_enabled;

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -79,6 +79,26 @@ void rjson_serialize_impl(
         w.Key("crl_file");
         w.String((*(v.get_crl_file())).c_str());
     }
+
+    if (v.get_tls_v1_2_cipher_suites()) {
+        w.Key("tls_v1_2_cipher_suites");
+        w.String(v.get_tls_v1_2_cipher_suites()->c_str());
+    }
+
+    if (v.get_tls_v1_3_cipher_suites()) {
+        w.Key("tls_v1_3_cipher_suites");
+        w.String(v.get_tls_v1_3_cipher_suites()->c_str());
+    }
+
+    if (v.get_min_tls_version()) {
+        w.Key("min_tls_version");
+        w.String(to_string_view(*v.get_min_tls_version()).data());
+    }
+
+    if (v.get_enable_renegotiation()) {
+        w.Key("enable_renegotiation");
+        w.Bool(*v.get_enable_renegotiation());
+    }
 }
 
 void rjson_serialize(

--- a/src/v/config/tests/tls_config_convert_test.cc
+++ b/src/v/config/tests/tls_config_convert_test.cc
@@ -30,6 +30,11 @@ SEASTAR_THREAD_TEST_CASE(test_decode_empty) {
     BOOST_TEST(!empty_cfg.get_key_cert_files());
     BOOST_TEST(!empty_cfg.get_truststore_file());
     BOOST_TEST(!empty_cfg.get_require_client_auth());
+    BOOST_TEST(!empty_cfg.get_crl_file());
+    BOOST_TEST(!empty_cfg.get_tls_v1_2_cipher_suites());
+    BOOST_TEST(!empty_cfg.get_tls_v1_3_cipher_suites());
+    BOOST_TEST(!empty_cfg.get_min_tls_version());
+    BOOST_TEST(!empty_cfg.get_enable_renegotiation());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_decode_full_abs_path) {
@@ -84,6 +89,10 @@ SEASTAR_THREAD_TEST_CASE(test_decode_default_config) {
     BOOST_TEST(!empty_cfg.get_truststore_file());
     BOOST_TEST(!empty_cfg.get_crl_file());
     BOOST_TEST(!empty_cfg.get_require_client_auth());
+    BOOST_TEST(!empty_cfg.get_tls_v1_2_cipher_suites());
+    BOOST_TEST(!empty_cfg.get_tls_v1_3_cipher_suites());
+    BOOST_TEST(!empty_cfg.get_min_tls_version());
+    BOOST_TEST(!empty_cfg.get_enable_renegotiation());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_decode_enabled_but_contains_empty_path) {
@@ -141,6 +150,35 @@ SEASTAR_THREAD_TEST_CASE(test_decode_p12_full_rel_path) {
     BOOST_TEST(*full_cfg.get_truststore_file() != "./truststore");
     BOOST_TEST(*full_cfg.get_crl_file() != "./crl");
     BOOST_TEST(full_cfg.get_require_client_auth());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_decode_cipher_suites) {
+    auto with_values
+      = "tls_config:\n"
+        "  enabled: true\n"
+        "  tls_v1_2_cipher_suites: ECDHE-ECDSA-AES256-GCM-SHA384\n"
+        "  tls_v1_3_cipher_suites: TLS_AES_256_GCM_SHA384\n";
+    auto full_cfg = read_from_yaml(with_values);
+    BOOST_TEST(
+      full_cfg.get_tls_v1_2_cipher_suites() == "ECDHE-ECDSA-AES256-GCM-SHA384");
+    BOOST_TEST(
+      full_cfg.get_tls_v1_3_cipher_suites() == "TLS_AES_256_GCM_SHA384");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_min_tls_version) {
+    auto with_values = "tls_config:\n"
+                       "  enabled: true\n"
+                       "  min_tls_version: v1.3\n";
+    auto full_cfg = read_from_yaml(with_values);
+    BOOST_TEST(full_cfg.get_min_tls_version() == config::tls_version::v1_3);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_enable_renegotiation) {
+    auto with_values = "tls_config:\n"
+                       "  enabled: true\n"
+                       "  enable_renegotiation: true\n";
+    auto full_cfg = read_from_yaml(with_values);
+    BOOST_TEST(full_cfg.get_enable_renegotiation());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_decode_p12_and_key_cert) {

--- a/src/v/config/tls_config.cc
+++ b/src/v/config/tls_config.cc
@@ -14,11 +14,14 @@
 #include "config/configuration.h"
 #include "config/convert.h"
 #include "net/tls.h"
+#include "thirdparty/openssl/err.h"
+#include "thirdparty/openssl/ssl.h"
 #include "utils/to_string.h"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/tls.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/variant_utils.hh>
 
 namespace config {
@@ -39,7 +42,24 @@ net::key_store create_key_store(const key_cert_container& container) {
           }};
       });
 }
+
+template<typename T, auto fn>
+struct ssl_deleter {
+    void operator()(T* ptr) { fn(ptr); }
+};
+
+template<typename T, auto fn>
+using ssl_handle = std::unique_ptr<T, ssl_deleter<T, fn>>;
+
+using ssl_ctx_ptr = ssl_handle<SSL_CTX, SSL_CTX_free>;
+
+bool ssl_clean_room(auto func) {
+    auto cleanup = ss::defer([] { ERR_clear_error(); });
+    ssl_ctx_ptr ctx{SSL_CTX_new(TLS_method())};
+    return ctx && func(ctx.get());
+}
 } // namespace
+
 ss::future<std::optional<ss::tls::credentials_builder>>
 tls_config::get_credentials_builder() const& {
     if (_enabled) {
@@ -107,6 +127,17 @@ std::ostream& operator<<(std::ostream& o, const config::tls_config& c) {
       << " }";
     return o;
 }
+
+bool validate_tls_v1_2_cipher_suites(const ss::sstring& s) {
+    return ssl_clean_room(
+      [&](auto ctx) { return SSL_CTX_set_cipher_list(ctx, s.data()) == 1; });
+}
+
+bool validate_tls_v1_3_cipher_suites(const ss::sstring& s) {
+    return ssl_clean_room(
+      [&](auto ctx) { return SSL_CTX_set_ciphersuites(ctx, s.data()) == 1; });
+}
+
 } // namespace config
 
 namespace YAML {

--- a/src/v/config/tls_config.cc
+++ b/src/v/config/tls_config.cc
@@ -186,6 +186,22 @@ Node convert<config::tls_config>::encode(const config::tls_config& rhs) {
         node["truststore_file"] = *rhs.get_truststore_file();
     }
 
+    if (rhs.get_tls_v1_2_cipher_suites()) {
+        node["tls_v1_2_cipher_suites"] = *rhs.get_tls_v1_2_cipher_suites();
+    }
+
+    if (rhs.get_tls_v1_3_cipher_suites()) {
+        node["tls_v1_3_cipher_suites"] = *rhs.get_tls_v1_3_cipher_suites();
+    }
+
+    if (rhs.get_min_tls_version()) {
+        node["min_tls_version"] = *rhs.get_min_tls_version();
+    }
+
+    if (rhs.get_enable_renegotiation()) {
+        node["enable_renegotiation"] = *rhs.get_enable_renegotiation();
+    }
+
     return node;
 }
 
@@ -241,8 +257,14 @@ bool convert<config::tls_config>::decode(
           container,
           to_absolute(read_optional(node, "truststore_file")),
           to_absolute(read_optional(node, "crl_file")),
-          node["require_client_auth"]
-            && node["require_client_auth"].as<bool>());
+          node["require_client_auth"] && node["require_client_auth"].as<bool>(),
+          read_optional(node, "tls_v1_2_cipher_suites"),
+          read_optional(node, "tls_v1_3_cipher_suites"),
+          node["min_tls_version"]
+            ? node["min_tls_version"].as<config::tls_version>()
+            : std::optional<config::tls_version>(),
+          node["enable_renegotiation"] ? node["enable_renegotiation"].as<bool>()
+                                       : std::optional<bool>());
     }
     return true;
 }

--- a/src/v/config/tls_config.cc
+++ b/src/v/config/tls_config.cc
@@ -63,6 +63,7 @@ bool ssl_clean_room(auto func) {
 ss::future<std::optional<ss::tls::credentials_builder>>
 tls_config::get_credentials_builder() const& {
     if (_enabled) {
+        const auto& cfg = config::shard_local_cfg();
         auto builder = co_await net::get_credentials_builder({
           .truststore = _truststore_file.transform(
             [](auto& f) { return net::certificate(std::filesystem::path(f)); }),
@@ -70,10 +71,14 @@ tls_config::get_credentials_builder() const& {
           .crl = _crl_file.transform(
             [](auto& f) { return net::certificate(std::filesystem::path(f)); }),
           .min_tls_version = from_config(
-            config::shard_local_cfg().tls_min_version()),
-          .enable_renegotiation
-          = config::shard_local_cfg().tls_enable_renegotiation(),
+            _min_tls_version.value_or(cfg.tls_min_version())),
+          .enable_renegotiation = _enable_renegotiation.value_or(
+            cfg.tls_enable_renegotiation()),
           .require_client_auth = _require_client_auth,
+          .tls_v1_2_cipher_suites = _tls_v1_2_cipher_suites.value_or(
+            cfg.tls_v1_2_cipher_suites()),
+          .tls_v1_3_cipher_suites = _tls_v1_3_cipher_suites.value_or(
+            cfg.tls_v1_3_cipher_suites()),
         });
         co_return builder;
     }

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -116,6 +116,9 @@ private:
     bool _require_client_auth{false};
 };
 
+bool validate_tls_v1_2_cipher_suites(const ss::sstring& s);
+bool validate_tls_v1_3_cipher_suites(const ss::sstring& s);
+
 } // namespace config
 
 namespace YAML {

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -80,6 +80,26 @@ public:
       , _crl_file(std::move(crl))
       , _require_client_auth(require_client_auth) {}
 
+    tls_config(
+      bool enabled,
+      std::optional<key_cert_container> key_cert,
+      std::optional<ss::sstring> truststore,
+      std::optional<ss::sstring> crl,
+      bool require_client_auth,
+      std::optional<ss::sstring> tls_v1_2_cipher_suites,
+      std::optional<ss::sstring> tls_v1_3_cipher_suites,
+      std::optional<tls_version> min_tls_version,
+      std::optional<bool> enable_renegotiation)
+      : _enabled(enabled)
+      , _key_cert(std::move(key_cert))
+      , _truststore_file(std::move(truststore))
+      , _crl_file(std::move(crl))
+      , _require_client_auth(require_client_auth)
+      , _tls_v1_2_cipher_suites(std::move(tls_v1_2_cipher_suites))
+      , _tls_v1_3_cipher_suites(std::move(tls_v1_3_cipher_suites))
+      , _min_tls_version(min_tls_version)
+      , _enable_renegotiation(enable_renegotiation) {}
+
     bool is_enabled() const { return _enabled; }
 
     const std::optional<key_cert_container>& get_key_cert_files() const {
@@ -94,8 +114,23 @@ public:
 
     bool get_require_client_auth() const { return _require_client_auth; }
 
-    ss::future<std::optional<ss::tls::credentials_builder>>
+    const std::optional<ss::sstring>& get_tls_v1_2_cipher_suites() const {
+        return _tls_v1_2_cipher_suites;
+    }
 
+    const std::optional<ss::sstring>& get_tls_v1_3_cipher_suites() const {
+        return _tls_v1_3_cipher_suites;
+    }
+
+    const std::optional<tls_version>& get_min_tls_version() const {
+        return _min_tls_version;
+    }
+
+    const std::optional<bool>& get_enable_renegotiation() const {
+        return _enable_renegotiation;
+    }
+
+    ss::future<std::optional<ss::tls::credentials_builder>>
     get_credentials_builder() const&;
 
     ss::future<std::optional<ss::tls::credentials_builder>>
@@ -114,6 +149,10 @@ private:
     std::optional<ss::sstring> _truststore_file;
     std::optional<ss::sstring> _crl_file;
     bool _require_client_auth{false};
+    std::optional<ss::sstring> _tls_v1_2_cipher_suites{};
+    std::optional<ss::sstring> _tls_v1_3_cipher_suites{};
+    std::optional<tls_version> _min_tls_version{};
+    std::optional<bool> _enable_renegotiation{};
 };
 
 bool validate_tls_v1_2_cipher_suites(const ss::sstring& s);

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -41,28 +41,24 @@ ss::future<std::optional<ss::sstring>> find_ca_file() {
     }
     co_return std::nullopt;
 }
-namespace {
-inline constexpr std::string_view tlsv1_2_cipher_string
+const std::string_view tls_v1_2_cipher_suites
   = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-"
     "SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:AES256-"
     "GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-CHACHA20-POLY1305:"
     "ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:AES128-SHA:AES128-CCM:ECDHE-"
     "RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES256-SHA:AES256-CCM";
 
-inline constexpr std::string_view tlsv1_3_ciphersuites
+const std::string_view tls_v1_3_cipher_suites
   = "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_"
     "SHA256:TLS_AES_128_CCM_SHA256";
-} // namespace
 
 ss::future<ss::tls::credentials_builder>
 get_credentials_builder(credentials_configuration cfg) {
     ss::tls::credentials_builder builder;
 
     builder.enable_server_precedence();
-    builder.set_cipher_string(
-      {tlsv1_2_cipher_string.data(), tlsv1_2_cipher_string.size()});
-    builder.set_ciphersuites(
-      {tlsv1_3_ciphersuites.data(), tlsv1_3_ciphersuites.size()});
+    builder.set_cipher_string(ss::sstring{tls_v1_2_cipher_suites});
+    builder.set_ciphersuites({ss::sstring{tls_v1_3_cipher_suites}});
     builder.set_minimum_tls_version(cfg.min_tls_version);
     builder.set_dh_level(ss::tls::dh_params::level::MEDIUM);
 

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -41,16 +41,23 @@ ss::future<std::optional<ss::sstring>> find_ca_file() {
     }
     co_return std::nullopt;
 }
-const std::string_view tls_v1_2_cipher_suites
-  = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-"
-    "SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:AES256-"
-    "GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-CHACHA20-POLY1305:"
-    "ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:AES128-SHA:AES128-CCM:ECDHE-"
-    "RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES256-SHA:AES256-CCM";
+const std::string_view tls_v1_2_cipher_suites = "ECDHE-ECDSA-AES256-GCM-SHA384:"
+                                                "ECDHE-RSA-AES256-GCM-SHA384:"
+                                                "ECDHE-ECDSA-CHACHA20-POLY1305:"
+                                                "ECDHE-RSA-CHACHA20-POLY1305:"
+                                                "ECDHE-ECDSA-AES128-GCM-SHA256:"
+                                                "ECDHE-RSA-AES128-GCM-SHA256";
 
-const std::string_view tls_v1_3_cipher_suites
-  = "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_"
-    "SHA256:TLS_AES_128_CCM_SHA256";
+const std::string_view tls_v1_3_cipher_suites = "TLS_AES_256_GCM_SHA384:"
+                                                "TLS_CHACHA20_POLY1305_SHA256:"
+                                                "TLS_AES_128_GCM_SHA256:"
+                                                "TLS_AES_128_CCM_8_SHA256:"
+                                                "TLS_AES_128_CCM_SHA256";
+
+const std::string_view tls_v1_3_cipher_suites_strict
+  = "TLS_AES_256_GCM_SHA384:"
+    "TLS_CHACHA20_POLY1305_SHA256:"
+    "TLS_AES_128_GCM_SHA256";
 
 ss::future<ss::tls::credentials_builder>
 get_credentials_builder(credentials_configuration cfg) {

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -57,8 +57,10 @@ get_credentials_builder(credentials_configuration cfg) {
     ss::tls::credentials_builder builder;
 
     builder.enable_server_precedence();
-    builder.set_cipher_string(ss::sstring{tls_v1_2_cipher_suites});
-    builder.set_ciphersuites({ss::sstring{tls_v1_3_cipher_suites}});
+    builder.set_cipher_string(
+      cfg.tls_v1_2_cipher_suites.value_or(ss::sstring{tls_v1_2_cipher_suites}));
+    builder.set_ciphersuites(
+      cfg.tls_v1_3_cipher_suites.value_or(ss::sstring{tls_v1_3_cipher_suites}));
     builder.set_minimum_tls_version(cfg.min_tls_version);
     builder.set_dh_level(ss::tls::dh_params::level::MEDIUM);
 

--- a/src/v/net/tls.h
+++ b/src/v/net/tls.h
@@ -18,6 +18,7 @@ namespace net {
 
 extern const std::string_view tls_v1_2_cipher_suites;
 extern const std::string_view tls_v1_3_cipher_suites;
+extern const std::string_view tls_v1_3_cipher_suites_strict;
 
 /**
  * Either a path to certificate file or the certificate content itself

--- a/src/v/net/tls.h
+++ b/src/v/net/tls.h
@@ -16,6 +16,9 @@
 #include <seastar/net/tls.hh>
 namespace net {
 
+extern const std::string_view tls_v1_2_cipher_suites;
+extern const std::string_view tls_v1_3_cipher_suites;
+
 /**
  * Either a path to certificate file or the certificate content itself
  * in PEM format.

--- a/src/v/net/tls.h
+++ b/src/v/net/tls.h
@@ -68,6 +68,8 @@ struct credentials_configuration {
     ss::tls::tls_version min_tls_version;
     bool enable_renegotiation = false;
     bool require_client_auth = false;
+    std::optional<ss::sstring> tls_v1_2_cipher_suites;
+    std::optional<ss::sstring> tls_v1_3_cipher_suites;
     fmt::iterator format_to(fmt::iterator it) const;
 };
 

--- a/src/v/redpanda/BUILD
+++ b/src/v/redpanda/BUILD
@@ -61,6 +61,7 @@ redpanda_cc_library(
         "//src/v/migrations",
         "//src/v/model",
         "//src/v/net",
+        "//src/v/net:tls",
         "//src/v/pandaproxy:core",
         "//src/v/pandaproxy/schema_registry:server",
         "//src/v/pandaproxy/rest:server",

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -91,6 +91,7 @@
 #include "config/node_config.h"
 #include "config/property.h"
 #include "config/seed_server.h"
+#include "config/tls_config.h"
 #include "config/types.h"
 #include "crash_tracker/signals.h"
 #include "crypto/ossl_context_service.h"
@@ -2710,9 +2711,29 @@ void application::wire_up_bootstrap_services() {
                 = config::shard_local_cfg().rpc_server_tcp_recv_buf;
               c.tcp_send_buf
                 = config::shard_local_cfg().rpc_server_tcp_send_buf;
+              config::tls_config tls_config{
+                config::node().rpc_server_tls().is_enabled(),
+                config::node().rpc_server_tls().get_key_cert_files(),
+                config::node().rpc_server_tls().get_truststore_file(),
+                config::node().rpc_server_tls().get_crl_file(),
+                config::node().rpc_server_tls().get_require_client_auth(),
+                config::node()
+                  .rpc_server_tls()
+                  .get_tls_v1_2_cipher_suites()
+                  .value_or(ss::sstring{}),
+                config::node()
+                  .rpc_server_tls()
+                  .get_tls_v1_3_cipher_suites()
+                  .value_or(ss::sstring{net::tls_v1_3_cipher_suites_strict}),
+                config::node().rpc_server_tls().get_min_tls_version().value_or(
+                  config::tls_version::v1_3),
+                config::node()
+                  .rpc_server_tls()
+                  .get_enable_renegotiation()
+                  .value_or(false)};
               auto credentials
                 = net::build_reloadable_server_credentials_with_probe(
-                    config::node().rpc_server_tls(),
+                    tls_config,
                     "rpc",
                     "",
                     [this](

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -755,6 +755,44 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Do this instead.
                 valid_value = 10000
 
+            if name == "tls_v1_2_cipher_suites":
+                valid_value = ":".join(
+                    random.sample(
+                        [
+                            "ECDHE-RSA-AES128-GCM-SHA256",
+                            "ECDHE-ECDSA-AES128-GCM-SHA256",
+                            "AES128-GCM-SHA256",
+                            "ECDHE-RSA-AES256-GCM-SHA384",
+                            "ECDHE-ECDSA-AES256-GCM-SHA384",
+                            "AES256-GCM-SHA384",
+                            "ECDHE-RSA-CHACHA20-POLY1305",
+                            "ECDHE-ECDSA-CHACHA20-POLY1305",
+                            "ECDHE-RSA-AES128-SHA",
+                            "ECDHE-ECDSA-AES128-SHA",
+                            "AES128-SHA",
+                            "AES128-CCM",
+                            "ECDHE-RSA-AES256-SHA",
+                            "ECDHE-ECDSA-AES256-SHA",
+                            "AES256-SHA",
+                            "AES256-CCM",
+                        ],
+                        random.randint(3, 8),
+                    )
+                )
+            if name == "tls_v1_3_cipher_suites":
+                valid_value = ":".join(
+                    random.sample(
+                        [
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_CHACHA20_POLY1305_SHA256",
+                            "TLS_AES_128_GCM_SHA256",
+                            "TLS_AES_128_CCM_8_SHA256",
+                            "TLS_AES_128_CCM_SHA256",
+                        ],
+                        random.randint(1, 3),
+                    )
+                )
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates, remove=[])

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -17,7 +17,13 @@ from ducktape.services.service import Service
 
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SecurityConfig, TLSProvider
+from rptest.services.redpanda import (
+    PandaproxyConfig,
+    RedpandaService,
+    SchemaRegistryConfig,
+    SecurityConfig,
+    TLSProvider,
+)
 from rptest.services.tls import (
     Certificate,
     CertificateAuthority,
@@ -92,6 +98,7 @@ class TLSVersionTestBase(RedpandaTest):
         super(TLSVersionTestBase, self).__init__(test_context=test_context)
         self.security = SecurityConfig()
         self.tls = TLSCertManager(self.logger, key_type=key_type)
+        self.key_type = key_type
         self.admin = Admin(self.redpanda)
         self.installer = self.redpanda._installer
 
@@ -99,7 +106,36 @@ class TLSVersionTestBase(RedpandaTest):
         self.security.tls_provider = TLSVersionTestProvider(tls=self.tls)
         self.redpanda.set_security_settings(self.security)
 
-        super().setUp()
+        self.schema_registry_config = SchemaRegistryConfig()
+        self.schema_registry_config.require_client_auth = True
+        self.redpanda.set_schema_registry_settings(self.schema_registry_config)
+
+        self.pandaproxy_config = PandaproxyConfig()
+        self.pandaproxy_config.require_client_auth = True
+        self.redpanda.set_pandaproxy_settings(self.pandaproxy_config)
+
+        tls = dict(
+            enabled=True,
+            require_client_auth=True,
+            key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+            cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+            truststore_file=RedpandaService.TLS_CA_CRT_FILE,
+        )
+        admin_api_tls = tls.copy()
+        admin_api_tls.update(
+            name="iplistener",
+        )
+
+        cfg_overrides = {}
+
+        def set_cfg(node):
+            cfg_overrides[node] = dict(
+                admin_api_tls=admin_api_tls, rpc_server_tls=admin_api_tls
+            )
+
+        self.redpanda.for_nodes(self.redpanda.nodes, set_cfg)
+
+        self.redpanda.start(node_config_overrides=cfg_overrides)
 
     def _output_good(self, output: str) -> bool:
         return "Verify return code: 0" in output or "Verify return code: 19" in output
@@ -111,18 +147,25 @@ class TLSVersionTestBase(RedpandaTest):
         )
 
     def verify_tls_version(
-        self, node: ClusterNode, tls_version: TLSVersion, expect_fail: bool
+        self,
+        node: ClusterNode,
+        tls_version: TLSVersion,
+        expect_fail: bool,
+        port: int = 9092,
+        cipher: str = None,
     ):
         tls_version_str = tls_version_to_openssl(tls_version)
+        cipher_arg = "ciphersuites" if tls_version == TLSVersion.v1_3 else "cipher"
+        cipher_opt = f"-{cipher_arg} {cipher}" if cipher else ""
         try:
-            cmd = f"openssl s_client {tls_version_str} -CAfile {self.tls.ca.crt} -connect {node.name}:9092"
+            cmd = f"openssl s_client {tls_version_str} {cipher_opt} -CAfile {self.tls.ca.crt} -connect {node.name}:{port}"
             self.logger.debug(f"Running: {cmd}")
             _ = subprocess.check_output(
                 cmd.split(), stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL
             )
             if expect_fail:
                 assert False, (
-                    f"Expected openssl s_client to fail with TLS version string {tls_version_str}"
+                    f"Expected openssl s_client to fail with TLS version string {tls_version_str}, cipher {cipher}, port {port}"
                 )
         except subprocess.CalledProcessError as e:
             if not expect_fail:

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -10,7 +10,7 @@
 import socket
 import subprocess
 from enum import IntEnum
-from typing import Optional
+from typing import List, Optional
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.mark import matrix
@@ -52,6 +52,7 @@ class TLSVersionTestProvider(TLSProvider):
 
 PERMITTED_ERROR_MESSAGE = [
     "seastar::tls::verification_error",
+    "SSL routines::no shared cipher",
     "SSL routines::unsupported protocol",
     "sslv3 alert handshake failure",
 ]
@@ -145,6 +146,8 @@ class TLSVersionTestBase(RedpandaTest):
         return (
             "no protocols available" in output
             or "tlsv1 alert protocol version" in output
+            or "handshake failure" in output
+            or "wrong version number" in output
         )
 
     def verify_tls_version(
@@ -177,6 +180,130 @@ class TLSVersionTestBase(RedpandaTest):
                 assert self._output_error(e.output.decode()), (
                     f"Output not expected for failure: {e.output.decode()}"
                 )
+
+    # Default ciphersuites for TLS 1.2 and 1.3
+    TLSV1_2_CIPHERS = [
+        "ECDHE-ECDSA-AES256-GCM-SHA384",
+        "ECDHE-RSA-AES256-GCM-SHA384",
+        "ECDHE-ECDSA-CHACHA20-POLY1305",
+        "ECDHE-RSA-CHACHA20-POLY1305",
+        "ECDHE-ECDSA-AES128-GCM-SHA256",
+        "ECDHE-RSA-AES128-GCM-SHA256",
+    ]
+    TLSV1_2_CIPHERS_WEAK = TLSV1_2_CIPHERS + [
+        "AES256-GCM-SHA384",
+        "DHE-RSA-AES256-GCM-SHA384",
+        "DHE-RSA-AES128-GCM-SHA256",
+        "DHE-RSA-CHACHA20-POLY1305",
+    ]
+    TLSV1_3_CIPHERS = [
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_128_CCM_8_SHA256",
+        "TLS_AES_128_CCM_SHA256",
+    ]
+
+    TLSV1_3_CIPHERS_STRICT = [
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_AES_128_GCM_SHA256",
+    ]
+
+    def _filter_by_key_type(self, key_type: TLSKeyType, ciphers: List) -> List:
+        if key_type == TLSKeyType.RSA:
+            # DHE-RSA and ECDHE-RSA require an RSA certificate
+            return [
+                c
+                for c in ciphers
+                if c.startswith("DHE-RSA") or c.startswith("ECDHE-RSA")
+            ]
+        elif key_type == TLSKeyType.ECDSA:
+            return [c for c in ciphers if c.startswith("ECDHE-ECDSA")]
+        else:
+            raise ValueError(f"Unsupported key type: {key_type}")
+
+    def _get_openssl_ciphers(self, key_type: TLSKeyType) -> List:
+        # Get the list of ciphers supported by the installed version of OpenSSL
+        tls_version_str = tls_version_to_openssl(TLSVersion.v1_2)
+        process = subprocess.run(
+            ["openssl", "ciphers", "-s", tls_version_str],
+            text=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        self.logger.debug(f"stdout: {process.stdout}")
+        tls1_2_ciphers = [
+            (TLSVersion.v1_2, c)
+            for c in self._filter_by_key_type(
+                key_type=self.key_type, ciphers=process.stdout.strip().split(":")
+            )
+        ]
+
+        return tls1_2_ciphers + [(TLSVersion.v1_3, c) for c in self.TLSV1_3_CIPHERS]
+
+    def _get_default_ciphers(self, key_type: TLSKeyType, strict: bool) -> List:
+        # TLS 1.2 ciphers (only if not strict)
+        tls12_ciphers = []
+        if not strict:
+            tls12_ciphers = [
+                (TLSVersion.v1_2, c)
+                for c in self._filter_by_key_type(key_type, self.TLSV1_2_CIPHERS)
+            ]
+
+        # TLS 1.3 ciphers (strict or normal)
+        tls13_ciphers = [
+            (TLSVersion.v1_3, c)
+            for c in (self.TLSV1_3_CIPHERS_STRICT if strict else self.TLSV1_3_CIPHERS)
+        ]
+
+        ciphers = tls12_ciphers + tls13_ciphers
+        assert ciphers, f"No ciphers found for key type {key_type} strict {strict}"
+
+        return ciphers
+
+    @cluster(num_nodes=1, log_allow_list=PERMITTED_ERROR_MESSAGE)
+    def test_ciphersuite_support(self):
+        """
+        Test all ciphers for TLS 1.2+ across all interfaces filtered by key_type.
+        """
+        interfaces = [
+            (9092, False),
+            (9644, False),
+            (8082, False),
+            (8081, False),
+            (33145, True),
+        ]
+
+        openssl_ciphers = self._get_openssl_ciphers(key_type=self.key_type)
+
+        def check_ciphers(expected_ciphers):
+            for port, strict in interfaces:
+                expected = expected_ciphers(strict)
+                valid_test = len(expected) < len(openssl_ciphers) and len(expected) > 0
+                assert valid_test, (
+                    f"Expecting some expected failures and expected successes for port {port} strict {strict}"
+                )
+                for v, c in openssl_ciphers:
+                    expect_fail = (v, c) not in expected
+                    self.logger.info(
+                        f"Testing port: {port} tls: {v} cipher: {c}, cert: {self.key_type}, expect_fail: {expect_fail}"
+                    )
+
+                    self.verify_tls_version(
+                        node=self.redpanda.nodes[0],
+                        tls_version=v,
+                        expect_fail=expect_fail,
+                        port=port,
+                        cipher=c,
+                    )
+
+        # Check default ciphers
+        def default_ciphers(strict: bool):
+            return self._get_default_ciphers(key_type=self.key_type, strict=strict)
+
+        check_ciphers(default_ciphers)
 
     @cluster(num_nodes=3, log_allow_list=PERMITTED_ERROR_MESSAGE)
     @matrix(version=[0, 1, 2, 3])

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -325,6 +325,18 @@ class TLSVersionTestBase(RedpandaTest):
 
         check_ciphers(expected_ciphers)
 
+        self.redpanda.set_cluster_config(
+            values={
+                "tls_min_version": "v1.3",
+            },
+            expect_restart=True,
+        )
+
+        def expected_ciphers_tls1_3(strict: bool):
+            return [(TLSVersion.v1_3, c) for c in self.TLSV1_3_CIPHERS_STRICT]
+
+        check_ciphers(expected_ciphers_tls1_3)
+
     @cluster(num_nodes=3, log_allow_list=PERMITTED_ERROR_MESSAGE)
     @matrix(version=[0, 1, 2, 3])
     def test_change_version(self, version: int):

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -148,6 +148,7 @@ class TLSVersionTestBase(RedpandaTest):
             or "tlsv1 alert protocol version" in output
             or "handshake failure" in output
             or "wrong version number" in output
+            or ("CONNECTED(" in output and "unexpected eof while reading" in output)
         )
 
     def verify_tls_version(
@@ -304,6 +305,25 @@ class TLSVersionTestBase(RedpandaTest):
             return self._get_default_ciphers(key_type=self.key_type, strict=strict)
 
         check_ciphers(default_ciphers)
+
+        # Change ciphers
+        self.redpanda.set_cluster_config(
+            values={
+                "tls_v1_2_cipher_suites": ":".join(self.TLSV1_2_CIPHERS_WEAK),
+                "tls_v1_3_cipher_suites": ":".join(self.TLSV1_3_CIPHERS_STRICT),
+            },
+            expect_restart=True,
+        )
+
+        def expected_ciphers(strict: bool):
+            return [(TLSVersion.v1_3, c) for c in self.TLSV1_3_CIPHERS_STRICT] + [
+                (TLSVersion.v1_2, c)
+                for c in self._filter_by_key_type(
+                    self.key_type, (self.TLSV1_2_CIPHERS_WEAK if not strict else [])
+                )
+            ]
+
+        check_ciphers(expected_ciphers)
 
     @cluster(num_nodes=3, log_allow_list=PERMITTED_ERROR_MESSAGE)
     @matrix(version=[0, 1, 2, 3])

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -10,6 +10,7 @@
 import socket
 import subprocess
 from enum import IntEnum
+from typing import Optional
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.mark import matrix
@@ -152,7 +153,7 @@ class TLSVersionTestBase(RedpandaTest):
         tls_version: TLSVersion,
         expect_fail: bool,
         port: int = 9092,
-        cipher: str = None,
+        cipher: Optional[str] = None,
     ):
         tls_version_str = tls_version_to_openssl(tls_version)
         cipher_arg = "ciphersuites" if tls_version == TLSVersion.v1_3 else "cipher"


### PR DESCRIPTION
## Documentation
### Update

See https://github.com/redpanda-data/redpanda/pull/27835 - the change to the defaults will be deferred until v26.1

### Breaking Changes ###
As of Redpanda v26.1.1 the set of ciphers supported over TLSv1.2 and TLSv1.3 will be reduced and reordered for improved security and performance. The new defaults are all AEAD suites, providing strong authentication, key exchange, forward secrecy, and encryption of at least 128 bits. This applies to all external connections, both incoming and outgoing.

TLS v1.3 should be negotiated for clients running Java 11 or newer (from around Kafka 3.0), or using librdkafka 1.5 (July 2020) or newer, built with OpenSSL 1.0.2 or newer. This should cover the vast majority of use cases.

**Note: Connections between Redpanda brokers are always TLSv1.3, the following configuration options do not affect that.**

To enable support for older clients (such as pre-2018 Java 8), you may set:
```shell
rpk cluster config set \
 tls_v1_2_cipher_suites "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384" 
```

To revert to the old behaviour (not recommended):
```shell
rpk cluster config set \
 tls_v1_2_cipher_suites "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:AES128-SHA:AES128-CCM:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES256-SHA:AES256-CCM" \
 tls_v1_3_cipher_suites "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_CCM_SHA256"
```


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Improved default TLS Configuration
