### PR TITLE
direct_consumer: locking and no leader fixes

### DIFF
--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -50,14 +50,14 @@ void direct_consumer::update_configuration(configuration cfg) {
     });
 }
 
-ss::future<>
-direct_consumer::update_fetchers(topic_partition_map<subscription> removals) {
+ss::future<> direct_consumer::update_fetchers(
+  [[maybe_unused]] mutex::units lock_holder,
+  topic_partition_map<subscription> removals) {
     // do not update fetchers before the consumer is started
     if (!_started) {
         co_return;
     }
     auto holder = _gate.hold();
-    auto subscription_lock_holder = co_await _subscriptions_lock.get_units();
     /**
      * Unassign partitions from fetchers that are no longer needed.
      */
@@ -126,6 +126,8 @@ direct_consumer::update_fetchers(topic_partition_map<subscription> removals) {
         ssx::spawn_with_gate(
           _gate, [this] { return _cluster->request_metadata_update(); });
     }
+
+    co_return;
 }
 
 fetcher& direct_consumer::get_fetcher(model::node_id id) {
@@ -146,10 +148,15 @@ fetcher& direct_consumer::get_fetcher(model::node_id id) {
 }
 
 ss::future<> direct_consumer::start() {
+    if (_started) {
+        co_return;
+    }
     _metadata_callback_id = _cluster->register_metadata_cb(
       [this](const metadata_response_data& d) { on_metadata_update(d); });
     _started = true;
-    co_await update_fetchers();
+
+    auto lock_holder = co_await _subscriptions_lock.get_units();
+    co_await update_fetchers(std::move(lock_holder));
 }
 
 ss::future<> direct_consumer::stop() {
@@ -165,6 +172,7 @@ ss::future<> direct_consumer::stop() {
 
 ss::future<>
 direct_consumer::assign_partitions(chunked_vector<topic_assignment> topics) {
+    auto lock_holder = co_await _subscriptions_lock.get_units();
     for (auto& t : topics) {
         auto ec = model::validate_kafka_topic_name(t.topic);
         if (ec) {
@@ -183,11 +191,12 @@ direct_consumer::assign_partitions(chunked_vector<topic_assignment> topics) {
             sub.fetch_offset = p.next_offset;
         }
     }
-    co_await update_fetchers();
+    co_await update_fetchers(std::move(lock_holder));
 }
 
 ss::future<>
 direct_consumer::unassign_topics(chunked_vector<model::topic> topics) {
+    auto lock_holder = co_await _subscriptions_lock.get_units();
     topic_partition_map<subscription> removals;
     for (const auto& topic : topics) {
         vlog(_cluster->logger().trace, "Unassigning topic: {}", topic);
@@ -201,11 +210,12 @@ direct_consumer::unassign_topics(chunked_vector<model::topic> topics) {
         }
         _subscriptions.erase(topic);
     }
-    co_await update_fetchers(std::move(removals));
+    co_await update_fetchers(std::move(lock_holder), std::move(removals));
 }
 
 ss::future<> direct_consumer::unassign_partitions(
   chunked_vector<model::topic_partition> partitions) {
+    auto lock_holder = co_await _subscriptions_lock.get_units();
     topic_partition_map<subscription> removals;
     for (const auto& tp : partitions) {
         vlog(_cluster->logger().trace, "Unassigning partition: {}", tp);
@@ -223,11 +233,12 @@ ss::future<> direct_consumer::unassign_partitions(
             _subscriptions.erase(state_it);
         }
     }
-    co_await update_fetchers(std::move(removals));
+    co_await update_fetchers(std::move(lock_holder), std::move(removals));
 }
 
 ss::future<> direct_consumer::handle_metadata_update() {
-    co_await update_fetchers();
+    auto lock_holder = co_await _subscriptions_lock.get_units();
+    co_await update_fetchers(std::move(lock_holder));
 }
 
 void direct_consumer::on_metadata_update(const metadata_response_data&) {

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -85,6 +85,7 @@ ss::future<> direct_consumer::update_fetchers(
                       model::topic_partition_view(topic, p_id));
                     // preserve the fetch offset for the next fetcher to use
                     sub.fetch_offset = offset;
+                    sub.current_fetcher = std::nullopt;
                 }
                 continue;
             }

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -132,8 +132,9 @@ private:
     void on_metadata_update(const metadata_response_data&);
 
     ss::future<> handle_metadata_update();
-    ss::future<>
-    update_fetchers(topic_partition_map<subscription> removals = {});
+    ss::future<> update_fetchers(
+      mutex::units lock_holder,
+      topic_partition_map<subscription> removals = {});
 
     fetcher& get_fetcher(model::node_id id);
 


### PR DESCRIPTION
Direct consumer previously locked update_fetchers, but this lock was not guarding against concurrent modification of its _subscriptions map.

This commit changes update_fetchers to demand lock units from all callers, and return those lock units on completion. All updating apis now aquire a lock before modifying the underlying _subscriptions map.

Additionally adds proper leader assignment for when no leader is found. Previously the leader would not get reset to 'nullopt', which lead to the assigned fetch offset being overwritten with nullopt which inappropriately reset the fetch offset to the result of list_offsets

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Bug Fixes

* stronger locking guarantees on direct_consumer assignments, prevent iterator invalidation

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
