### PR TITLE
ct: Implement inactive epoch estimation

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -96,6 +96,10 @@ ss::future<bool> ctp_stm::sync_in_term(ss::abort_source& as) {
     co_return true;
 }
 
+std::optional<cluster_epoch> ctp_stm::estimate_inactive_epoch() const noexcept {
+    return _state.estimate_min_epoch().transform(prev_cluster_epoch);
+}
+
 ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {
     // Consume the first epoch from the partition starting from
     // start offset if nothing was reconciled yet or from the last
@@ -176,7 +180,7 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
 
         auto placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
         auto id = placeholder.id;
-        _state.advance_epoch(id.epoch);
+        _state.advance_epoch(id.epoch, batch.header().base_offset);
 
     } else if (
       batch.header().type == model::record_batch_type::ctp_stm_command) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -67,6 +67,9 @@ public:
     /// alone can't cause data loss.
     ss::future<std::optional<cluster_epoch>> get_inactive_epoch();
 
+    /// Return inactive epoch of the CTP
+    std::optional<cluster_epoch> estimate_inactive_epoch() const noexcept;
+
     /// Sync with the STM
     ///
     /// \brief The method is syncing the STM  to minimize races.

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -109,6 +109,11 @@ ctp_stm_api::get_inactive_epoch() const {
     co_return res.get();
 }
 
+std::optional<cluster_epoch>
+ctp_stm_api::estimate_inactive_epoch() const noexcept {
+    return _stm->estimate_inactive_epoch();
+}
+
 ss::future<bool> ctp_stm_api::sync_in_term(ss::abort_source& as) {
     vlog(_rtclog.debug, "Syncing ctp_stm in term {}", _stm->_raft->term());
     co_return co_await _stm->sync_in_term(as);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -55,9 +55,17 @@ public:
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     advance_reconciled_offset(kafka::offset last_reconciled_offset);
 
-    /// Return the smallest epoch referenced by this ctp_stm.
+    /// Return the inactive epoch which is no longer referenced by this ctp_stm.
+    /// This method is guaranteed to return precise value but it creates
+    // a reader and scans the log for the minimum epoch.
+    /// \note This method could return std::nullopt if the partition is empty
     ss::future<std::expected<std::optional<cluster_epoch>, ctp_stm_api_errc>>
     get_inactive_epoch() const;
+
+    /// Return the inactive epoch which is no longer referenced by this ctp_stm.
+    /// This method can return stale value but is guaranteed to eventually
+    /// make forward progress.
+    std::optional<cluster_epoch> estimate_inactive_epoch() const noexcept;
 
     /// Sync STM state with the log.
     ///

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.cc
@@ -29,20 +29,40 @@ ctp_stm_state::get_last_reconciled_log_offset() const noexcept {
     return _last_reconciled_log_offset;
 }
 
-void ctp_stm_state::advance_epoch(cluster_epoch epoch) {
+std::optional<cluster_epoch>
+ctp_stm_state::estimate_min_epoch() const noexcept {
+    return _min_epoch_lower_bound;
+}
+
+void ctp_stm_state::advance_epoch(cluster_epoch epoch, model::offset offset) {
     // The STM works on both leader and followers, on a leader the
     // max_seen_epoch epoch is updated by the fencing mechanism.
     // On the follower the max_seen_epoch epoch has to follow the max epoch.
     _max_seen_epoch = std::max(
       _max_seen_epoch.value_or(cluster_epoch{}), epoch);
     // Register new epoch
-    _max_applied_epoch = std::max(
-      epoch, _max_applied_epoch.value_or(cluster_epoch{}));
+    if (_max_applied_epoch.value_or(cluster_epoch{}) != epoch) {
+        _max_applied_epoch = std::max(
+          epoch, _max_applied_epoch.value_or(cluster_epoch{}));
+        _max_applied_epoch_offset = offset;
+        if (!_min_epoch_lower_bound.has_value()) {
+            // First epoch applied to the STM
+            _min_epoch_lower_bound = _max_applied_epoch;
+        }
+    }
 }
 
 void ctp_stm_state::advance_last_reconciled_offset(
   kafka::offset new_last_reconciled_offset,
   model::offset new_last_reconciled_log_offset) noexcept {
+    if (
+      _max_applied_epoch_offset.value_or(model::offset{})
+      <= new_last_reconciled_log_offset) {
+        // We advanced LRO past the offset at which we saw the current
+        // max_applied_epoch value so we can use max_applied_epoch as
+        // the new min_applied_epoch
+        _min_epoch_lower_bound = _max_applied_epoch;
+    }
     _last_reconciled_offset = std::max(
       _last_reconciled_offset.value_or(kafka::offset{}),
       new_last_reconciled_offset);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_state.h
@@ -43,7 +43,7 @@ public:
     /// insync_offset greater or equal to the snapshot offset. All log records
     /// can be applied to the state again without changing the state because of
     /// the idempotency.
-    void advance_epoch(cluster_epoch epoch);
+    void advance_epoch(cluster_epoch epoch, model::offset offset);
 
     /// This is invoked in the write path before the batch with new
     /// epoch value is even replicated.
@@ -65,6 +65,10 @@ public:
     /// \return max_seen_epoch epoch.
     std::optional<cluster_epoch> get_max_seen_epoch() const noexcept;
 
+    /// Estimate the minimum epoch referenced by this ctp_stm.
+    /// \note This value might be stale.
+    std::optional<cluster_epoch> estimate_min_epoch() const noexcept;
+
     /// Advance LRO and it's translated log offset counterpart.
     void advance_last_reconciled_offset(
       kafka::offset new_last_reconciled_offset,
@@ -79,7 +83,9 @@ public:
         return std::tie(
           _max_applied_epoch,
           _last_reconciled_offset,
-          _last_reconciled_log_offset);
+          _last_reconciled_log_offset,
+          _max_applied_epoch_offset,
+          _min_epoch_lower_bound);
     }
 
     /// Max collectible offset is defined by the LRO.
@@ -107,6 +113,16 @@ private:
     ///
     /// We enforce no epochs applied or replicated are less than this value.
     std::optional<cluster_epoch> _max_applied_epoch;
+
+    /// The offset at which the max_applied_epoch was recorded first.
+    std::optional<model::offset> _max_applied_epoch_offset;
+
+    /// The epoch which is less or equal to the epoch referenced
+    /// by the first record batch after the last reconciled offset.
+    /// This epoch is not guaranteed to be "active" (from the point of
+    /// view of the partition) but it's guaranteed that all epochs before
+    /// this epoch are "inactive".
+    std::optional<cluster_epoch> _min_epoch_lower_bound;
 
     /// The last offset that was uploaded to L1. This value may lag behind
     /// the value stored in the L1 metastore, but should never be ahead of

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_state_test.cc
@@ -53,16 +53,16 @@ TEST(ctp_stm_state_test, advance_epoch) {
     ct::cluster_epoch epoch2(25);
     ct::cluster_epoch epoch3(10);
 
-    state.advance_epoch(epoch1);
+    state.advance_epoch(epoch1, model::offset(1));
     EXPECT_EQ(state.get_max_epoch().value(), epoch1);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch1);
 
-    state.advance_epoch(epoch2);
+    state.advance_epoch(epoch2, model::offset(2));
     EXPECT_EQ(state.get_max_epoch().value(), epoch2);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
 
     // Should not go backwards
-    state.advance_epoch(epoch3);
+    state.advance_epoch(epoch3, model::offset(3));
     EXPECT_EQ(state.get_max_epoch().value(), epoch2);
     EXPECT_EQ(state.get_max_seen_epoch().value(), epoch2);
 }
@@ -72,7 +72,7 @@ TEST(ctp_stm_state_test, advance_epoch_on_a_follower) {
     ct::ctp_stm_state state;
     ct::cluster_epoch advance_epoch(20);
 
-    state.advance_epoch(advance_epoch);
+    state.advance_epoch(advance_epoch, model::offset(1));
 
     EXPECT_EQ(state.get_max_seen_epoch().value(), advance_epoch);
     EXPECT_EQ(state.get_max_epoch().value(), advance_epoch);
@@ -104,6 +104,30 @@ TEST(ctp_stm_state_test, get_max_collectible_offset) {
     model::offset log_offset(500);
     state.advance_last_reconciled_offset(kafka::offset(300), log_offset);
     EXPECT_EQ(state.get_max_collectible_offset(), log_offset);
+}
+
+TEST(ctp_stm_state_test, advance_lro_updates_min_epoch) {
+    ct::ctp_stm_state state;
+    ct::cluster_epoch epoch1(10);
+    ct::cluster_epoch epoch2(20);
+
+    // Initially min epoch is not set
+    EXPECT_FALSE(state.estimate_min_epoch().has_value());
+
+    state.advance_epoch(epoch1, model::offset(1));
+    EXPECT_TRUE(state.estimate_min_epoch().has_value());
+    EXPECT_EQ(state.estimate_min_epoch().value(), epoch1);
+
+    state.advance_epoch(epoch2, model::offset(5));
+    EXPECT_EQ(state.estimate_min_epoch().value(), epoch1);
+
+    // Advance LRO past the offset of epoch1
+    state.advance_last_reconciled_offset(kafka::offset(100), model::offset(2));
+    EXPECT_EQ(state.estimate_min_epoch().value(), epoch1);
+
+    // Advance LRO past the offset of epoch2
+    state.advance_last_reconciled_offset(kafka::offset(200), model::offset(6));
+    EXPECT_EQ(state.estimate_min_epoch().value(), epoch2);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
The ctp_stm implements get_inactive_epoch method which creates a log reader and scans the partition to compute inactive epoch. This commit adds an alternative lightweight mechanism that can be used to estimate the value of the inactive epoch. The estimated value is guaranteed to never overestimate the inactive epoch.

The algorithm is tracking `min_epoch_lower_bound` value. The inactive epoch can be estimated based on this value as `min_epoch_lower_bound - 1`.
The algorithm records the log offset at which it first encountered the current largest epoch value. When eventually the LRO is propagated forward past the `max_applied_epoch_offset` the `min_epoch_lower_bound` value is set to `max_applied_epoch`. 

The algorithm can be formally described as a "divide and conquer" algorithm. At any point in time the log is divided into two parts. The part that contains `min_epoch_lower_bound` and the part that contains `max_applied_epoch`. For `max_applied_epoch` we're tracking the offset at which `max_applied_epoch` starts (`max_applied_epoch_offset`). When the LRO is updated (which means that the partition is soft-truncated) the LRO is compared to the offset at which `max_applied_epoch` starts. If these offsets match or the LRO overshoots we know that the log (excl. soft-truncated part below LSO) contains only one epoch and this epoch is `max_applied_epoch`. 

```
                                                  
         ┌──────────────────┬──────────────────┐  
  min    │                  │max               │  
  epoch  │                  │epoch             │  
         └──────────────────┴──────────────────┘  
                      ▲     ▲                     
                      │     │                     
                     LRO   max epoch              
                           offset                 
                                                  
```

The observation here is that the placeholder batches in the L0 log are constantly reconciled and LRO is propagated. This process guarantees liveness (if reconciler is not running we can't run GC). The epoch is not changed frequently so we can assume that most of the time the log will contain only one epoch.

The corner case: when the partition is updated less frequently than the cluster epoch is, every new record batch will have a different epoch. This is the worst case for the algorithm because in this case it may livelock if the reconciler only ever reconciles data in the partition partially. In other words, if after reconciliation the LRO never reaches the offset at which the `max_epoch` was added. But the partition that receives such infrequent updates will be tiny and will be reconciled fully.  We can also replicate a sentinel batch periodically to avoid this problem. 

It's guaranteed that the `inactive_epoch` will make forward progress if the reconciler reconciles partition fully (all data that L0 has goes to L1). The method that computes the `inactive_epoch` precisely using the log reader interface is not removed and can be used as a source of truth. 

There is a section in the RFC that describes the alg. in detail (`L0 operation/CTP STM`).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none