### PR TITLE
ct/l1: reconciler followups

### DIFF
--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -66,8 +66,12 @@ redpanda_cc_library(
     name = "abstract_io",
     srcs = ["abstract_io.cc"],
     hdrs = ["abstract_io.h"],
+    implementation_deps = [
+        "//src/v/bytes:iostream",
+    ],
     deps = [
         ":object_id",
+        "//src/v/bytes:iobuf",
         "//src/v/container:chunked_vector",
         "//src/v/utils:named_type",
         "@seastar",

--- a/src/v/cloud_topics/level_one/common/abstract_io.cc
+++ b/src/v/cloud_topics/level_one/common/abstract_io.cc
@@ -10,10 +10,23 @@
 
 #include "cloud_topics/level_one/common/abstract_io.h"
 
+#include "bytes/iostream.h"
+
 namespace cloud_topics::l1 {
 
 ss::future<ss::input_stream<char>> io::read_file(staging_file* file) {
     return file->input_stream();
+}
+
+ss::future<std::expected<iobuf, io::errc>>
+io::read_object_as_iobuf(object_extent extent, ss::abort_source* as) {
+    auto result = co_await this->read_object(extent, as);
+    if (!result) {
+        co_return std::unexpected(result.error());
+    }
+    auto& stream = result.value();
+    co_return co_await read_iobuf_exactly(stream, extent.size)
+      .finally([&stream] { return stream.close(); });
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/abstract_io.h
+++ b/src/v/cloud_topics/level_one/common/abstract_io.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "bytes/iobuf.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "container/chunked_vector.h"
 
@@ -85,6 +86,11 @@ public:
     // Behind the scenes, there may or may not be caching going on.
     virtual ss::future<std::expected<ss::input_stream<char>, errc>>
     read_object(object_extent, ss::abort_source*) = 0;
+
+    // The same as `read_object` except that instead of returning an input
+    // stream, the data is fully buffered into an `iobuf`.
+    virtual ss::future<std::expected<iobuf, errc>>
+    read_object_as_iobuf(object_extent, ss::abort_source*);
 
     // Delete the specified objects from object storage.
     virtual ss::future<std::expected<void, errc>>

--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -370,10 +370,13 @@ public:
           = std::bit_cast<std::array<char, sizeof(uint32_t)>, uint32_t>(
             _offset - footer_start);
         co_await _output.write(footer_size.data(), footer_size.size());
+        _offset += footer_size.size();
         co_return info;
     }
 
     ss::future<> close() final { return _output.close(); }
+
+    size_t file_size() const final { return _offset; }
 
 private:
     void end_partition() {

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -269,6 +269,12 @@ public:
     //    partition.
     virtual ss::future<> add_batch(model::record_batch) = 0;
 
+    // Return the size of file in bytes that has been built so far.
+    //
+    // After `finish` has been called, this will be the size of the fully
+    // constructed file.
+    virtual size_t file_size() const = 0;
+
     // Information about the finished object.
     struct object_info {
         footer index;

--- a/src/v/cloud_topics/level_one/common/tests/object_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_test.cc
@@ -30,22 +30,26 @@ struct batch_spec {
     model::timestamp max_timestamp;
 };
 
+model::record_batch make_batch(const batch_spec& spec) {
+    int count = static_cast<int>(spec.last_offset - spec.base_offset) + 1;
+    std::vector<size_t> record_sizes;
+    std::fill_n(std::back_inserter(record_sizes), count, 100);
+    return model::test::make_random_batch(
+      model::test::record_batch_spec{
+        .offset = kafka::offset_cast(spec.base_offset),
+        .count = count,
+        .record_sizes = record_sizes,
+        .timestamp = spec.max_timestamp,
+        .all_records_have_same_timestamp = true,
+      });
+}
+
 chunked_vector<model::record_batch>
 make_batches(const std::vector<batch_spec>& specs) {
     chunked_vector<model::record_batch> batches;
+    batches.reserve(specs.size());
     for (const auto& spec : specs) {
-        int count = static_cast<int>(spec.last_offset - spec.base_offset) + 1;
-        std::vector<size_t> record_sizes;
-        std::fill_n(std::back_inserter(record_sizes), count, 100);
-        batches.push_back(
-          model::test::make_random_batch(
-            model::test::record_batch_spec{
-              .offset = kafka::offset_cast(spec.base_offset),
-              .count = count,
-              .record_sizes = record_sizes,
-              .timestamp = spec.max_timestamp,
-              .all_records_have_same_timestamp = true,
-            }));
+        batches.push_back(make_batch(spec));
     }
     return batches;
 }
@@ -581,4 +585,29 @@ TEST(L1Objects, PartialScan) {
           std::nullopt,
           /*expect_ntp_markers=*/false));
     }
+}
+
+TEST(L1Objects, BuilderSize) {
+    auto test_topic_id = model::topic_id(uuid_t::create());
+    iobuf output;
+    auto builder = object_builder::create(
+      make_iobuf_ref_output_stream(output), {});
+    auto _ = ss::defer([&builder] { builder->close().get(); });
+    EXPECT_EQ(builder->file_size(), 0);
+    builder->start_partition({test_topic_id, model::partition_id{0}}).get();
+    auto after_partition_size = builder->file_size();
+    EXPECT_GT(after_partition_size, 0);
+    builder
+      ->add_batch(make_batch({
+        .base_offset = 10_o,
+        .last_offset = 15_o,
+        .max_timestamp = 100_t,
+      }))
+      .get();
+    auto after_batch_size = builder->file_size();
+    EXPECT_GT(after_batch_size, after_partition_size);
+    auto finished = builder->finish().get();
+    auto final_size = builder->file_size();
+    EXPECT_GT(final_size, after_batch_size);
+    EXPECT_EQ(final_size, finished.size_bytes);
 }


### PR DESCRIPTION
Add some small helpers to L1 io layer that would have been helpful in https://github.com/redpanda-data/redpanda/pull/27318

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
