### PR TITLE
ct/l1: add length of partition data to seek results

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -189,7 +189,7 @@ ss::future<> footer::serde_async_write(iobuf& buf) const {
     }
 }
 
-size_t footer::file_position_before_kafka_offset(
+footer::seek_result footer::file_position_before_kafka_offset(
   const model::topic_id_partition& tidp, kafka::offset target) {
     auto [it, end] = partitions.equal_range(tidp);
     auto min_partition_after_target = end;
@@ -213,17 +213,28 @@ size_t footer::file_position_before_kafka_offset(
               return entry.kafka_offset;
           });
         if (index_it == rev.end()) {
-            return partition.file_position;
+            return {
+              .file_position = partition.file_position,
+              .length = partition.length,
+            };
         }
-        return index_it->file_position;
+        auto delta = index_it->file_position - partition.file_position;
+        return {
+          .file_position = index_it->file_position,
+          .length = partition.length - delta,
+        };
     }
     if (min_partition_after_target != end) {
-        return min_partition_after_target->second.file_position;
+        const auto& partition = min_partition_after_target->second;
+        return {
+          .file_position = partition.file_position,
+          .length = partition.length,
+        };
     }
     return npos;
 }
 
-size_t footer::file_position_before_max_timestamp(
+footer::seek_result footer::file_position_before_max_timestamp(
   const model::topic_id_partition& tidp, model::timestamp target) {
     auto [begin, end] = partitions.equal_range(tidp);
     auto filtered = std::views::filter(
@@ -237,7 +248,8 @@ size_t footer::file_position_before_max_timestamp(
     if (min_it == filtered.end()) {
         return npos;
     }
-    const auto& index = min_it->second.indexes;
+    const auto& partition = min_it->second;
+    const auto& index = partition.indexes;
     auto it = std::ranges::lower_bound(
       index, target, std::less<>{}, [](const auto& entry) {
           return entry.max_timestamp;
@@ -246,14 +258,21 @@ size_t footer::file_position_before_max_timestamp(
     // bounds, the best we can do is start at the last well known offset (the
     // last index entry).
     if (it == index.end()) {
-        return min_it->second.indexes.back().file_position;
+        --it;
     }
     // If at the first entry, we must start at the file beginning, because the
     // the max is inclusive of those entries.
     if (it == index.begin()) {
-        return min_it->second.file_position;
+        return {
+          .file_position = partition.file_position,
+          .length = partition.length,
+        };
     }
-    return it->file_position;
+    auto delta = it->file_position - partition.file_position;
+    return {
+      .file_position = it->file_position,
+      .length = partition.length - delta,
+    };
 }
 
 footer footer::copy() const {
@@ -558,6 +577,11 @@ fmt::iterator footer::format_to(fmt::iterator it) const {
           out, "{{tidp: {}, partition: {}}}, ", tidp, partition);
     }
     return fmt::format_to(out, "]}}");
+}
+
+fmt::iterator footer::seek_result::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it, "{{file_position:{},length:{}}}", file_position, length);
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -147,9 +147,23 @@ struct footer
     bool operator==(const footer&) const = default;
     fmt::iterator format_to(fmt::iterator) const;
 
+    // seek result is the result of asking the index where to start reading some
+    // data based on an offset or time query. Returned is the position or offset
+    // within the file to start reading from, as well as the remaining length of
+    // the partition data within that chunk.
+    struct seek_result {
+        size_t file_position = 0;
+        size_t length = 0;
+
+        bool operator==(const seek_result&) const = default;
+        fmt::iterator format_to(fmt::iterator) const;
+    };
     // The value returned when an index search doesn't have contain matching
     // data.
-    constexpr static size_t npos = std::numeric_limits<size_t>::max();
+    constexpr static seek_result npos = {
+      .file_position = std::numeric_limits<size_t>::max(),
+      .length = 0,
+    };
 
     // Return the file position of the latest record batch that has the offset
     // at or before the given offset. If the offset is not in this file then
@@ -165,7 +179,7 @@ struct footer
     // Searching for offset 5 would yield the position of the batch[0],
     // while a search for offsets 25 or 40 would yield batch[2]. Searching for
     // offset 50 would yield `npos`.
-    size_t file_position_before_kafka_offset(
+    seek_result file_position_before_kafka_offset(
       const model::topic_id_partition&, kafka::offset);
 
     // Return the file position of the latest record batch that has a
@@ -183,7 +197,7 @@ struct footer
     // the timestamp 1 would yield the position of batch[0].
     // While a search for timestamp 25 or 40 would yield batch[4] and the
     // timestamp 50 would yield `npos`.
-    size_t file_position_before_max_timestamp(
+    seek_result file_position_before_max_timestamp(
       const model::topic_id_partition&, model::timestamp);
 
     // Read the footer using the suffix of an L1 object.

--- a/src/v/cloud_topics/level_one/common/tests/object_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_test.cc
@@ -78,19 +78,19 @@ std::unique_ptr<object_reader> make_reader(iobuf& buf) {
       make_iobuf_input_stream(buf.share(0, buf.size_bytes())));
 }
 
-object_reader::result read_one_at(iobuf& buf, size_t offset) {
-    if (offset == footer::npos) {
+object_reader::result read_one_at(iobuf& buf, footer::seek_result result) {
+    if (result == footer::npos) {
         ss::throw_with_backtrace<std::runtime_error>(
           "Cannot read at npos offset, this is an invalid offset.");
     }
-    if (offset >= buf.size_bytes()) {
+    if (result.file_position >= buf.size_bytes()) {
         ss::throw_with_backtrace<std::out_of_range>(fmt::format(
-          "Offset {} is out of range for buffer size {}",
-          offset,
+          "result {} is out of range for buffer size {}",
+          result,
           buf.size_bytes()));
     }
     auto reader = object_reader::create(
-      make_iobuf_input_stream(buf.share(offset, buf.size_bytes() - offset)));
+      make_iobuf_input_stream(buf.share(result.file_position, result.length)));
     auto _ = ss::defer([&reader] { reader->close().get(); });
     return reader->read_next().get();
 }
@@ -111,6 +111,7 @@ TEST(L1ObjectsIndex, OffsetSearch) {
       model::topic_id_partition{model::topic_id(uuid_t::create()), model::partition_id(0)},
       footer::partition{
         .file_position = 0,
+        .length = 600,
         .indexes = {
           {.file_position = 100, .kafka_offset = 5_o},
           {.file_position = 200, .kafka_offset = 20_o},
@@ -121,18 +122,31 @@ TEST(L1ObjectsIndex, OffsetSearch) {
         .first_offset = 3_o,
         .last_offset = 65_o,
       });
-    std::map<kafka::offset, size_t> offset_to_filepos = {
-      {2_o, 0},    {3_o, 0},    {4_o, 0},    {5_o, 100},           {6_o, 100},
-      {19_o, 100}, {20_o, 200}, {21_o, 200}, {29_o, 200},          {30_o, 300},
-      {31_o, 300}, {49_o, 300}, {50_o, 400}, {51_o, 400},          {59_o, 400},
-      {60_o, 500}, {61_o, 500}, {65_o, 500}, {66_o, footer::npos},
+    std::map<kafka::offset, footer::seek_result> offset_to_filepos = {
+      {2_o, {.file_position = 0, .length = 600}},
+      {3_o, {.file_position = 0, .length = 600}},
+      {4_o, {.file_position = 0, .length = 600}},
+      {5_o, {.file_position = 100, .length = 500}},
+      {6_o, {.file_position = 100, .length = 500}},
+      {19_o, {.file_position = 100, .length = 500}},
+      {20_o, {.file_position = 200, .length = 400}},
+      {21_o, {.file_position = 200, .length = 400}},
+      {29_o, {.file_position = 200, .length = 400}},
+      {30_o, {.file_position = 300, .length = 300}},
+      {31_o, {.file_position = 300, .length = 300}},
+      {49_o, {.file_position = 300, .length = 300}},
+      {50_o, {.file_position = 400, .length = 200}},
+      {51_o, {.file_position = 400, .length = 200}},
+      {59_o, {.file_position = 400, .length = 200}},
+      {60_o, {.file_position = 500, .length = 100}},
+      {61_o, {.file_position = 500, .length = 100}},
+      {65_o, {.file_position = 500, .length = 100}},
+      {66_o, footer::npos},
     };
     for (const auto& [seek, expected] : offset_to_filepos) {
-        EXPECT_EQ(
-          index.file_position_before_kafka_offset(
-            index.partitions.begin()->first, seek),
-          expected)
-          << " for offset " << seek;
+        auto seek_result = index.file_position_before_kafka_offset(
+          index.partitions.begin()->first, seek);
+        EXPECT_EQ(seek_result, expected) << " for offset " << seek;
     }
 }
 
@@ -142,6 +156,7 @@ TEST(L1ObjectsIndex, TimestampSearch) {
       model::topic_id_partition{model::topic_id(uuid_t::create()), model::partition_id(0)},
     footer::partition{
       .file_position = 0,
+      .length = 600,
       .indexes = {
         {.file_position = 100, .kafka_offset = 5_o, .max_timestamp = 1000_t},
         {.file_position = 200, .kafka_offset = 20_o, .max_timestamp = 1500_t},
@@ -153,29 +168,28 @@ TEST(L1ObjectsIndex, TimestampSearch) {
       .last_offset = 65_o,
       .max_timestamp = 3000_t,
     });
-    std::map<model::timestamp, size_t> timequery_to_file_position = {
-      {999_t, 0},
-      {1000_t, 0},
-      {1001_t, 200},
-      {1499_t, 200},
-      {1500_t, 200},
-      {1501_t, 300},
-      {1999_t, 300},
-      {2000_t, 300},
-      {2001_t, 400},
-      {2499_t, 400},
-      {2500_t, 400},
-      {2501_t, 500},
-      {2999_t, 500},
-      {3000_t, 500},
-      {3001_t, footer::npos},
-    };
+    std::map<model::timestamp, footer::seek_result> timequery_to_file_position
+      = {
+        {999_t, {.file_position = 0, .length = 600}},
+        {1000_t, {.file_position = 0, .length = 600}},
+        {1001_t, {.file_position = 200, .length = 400}},
+        {1499_t, {.file_position = 200, .length = 400}},
+        {1500_t, {.file_position = 200, .length = 400}},
+        {1501_t, {.file_position = 300, .length = 300}},
+        {1999_t, {.file_position = 300, .length = 300}},
+        {2000_t, {.file_position = 300, .length = 300}},
+        {2001_t, {.file_position = 400, .length = 200}},
+        {2499_t, {.file_position = 400, .length = 200}},
+        {2500_t, {.file_position = 400, .length = 200}},
+        {2501_t, {.file_position = 500, .length = 100}},
+        {2999_t, {.file_position = 500, .length = 100}},
+        {3000_t, {.file_position = 500, .length = 100}},
+        {3001_t, footer::npos},
+      };
     for (const auto& [seek, expected] : timequery_to_file_position) {
-        EXPECT_EQ(
-          index.file_position_before_max_timestamp(
-            index.partitions.begin()->first, seek),
-          expected)
-          << " for timestamp " << seek;
+        auto seek_result = index.file_position_before_max_timestamp(
+          index.partitions.begin()->first, seek);
+        EXPECT_EQ(seek_result, expected) << " for timestamp " << seek;
     }
 }
 
@@ -234,7 +248,7 @@ TEST(L1Objects, OffsetSearch) {
       };
 
     for (const auto& [seek, expected] : offset_lookup_to_batch_start) {
-        size_t pos = index_one.index.file_position_before_kafka_offset(
+        auto pos = index_one.index.file_position_before_kafka_offset(
           tidp, seek);
         ASSERT_NE(pos, footer::npos) << "No position found for " << seek
                                      << " in partition " << tidp.partition;


### PR DESCRIPTION
Previously, it was assumed we'd read the whole object, and just needed
the seek offset, now we return the length of the rest of the partition
data.

Thinking a bit more about this, I'm not actually sure this is what we
want due to caching and L1 objects. Right now the IO abstraction
transparently caches behind the scenes, but if we provide many different
lengths we'll cache a bunch of different ranges of the same object. We
probably need to change the IO abstraction so we can do a better job
caching.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
