### PR TITLE
cloud_topics: fix L0 reader when seek offsets do not align with batch boundaries

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -481,7 +481,8 @@ ss::future<> bg_upload_and_replicate(
                     for (const auto& b : inp) {
                         vlog(
                           cd_log.trace,
-                          "Putting batch to cache: {}, term: {}",
+                          "Putting batch for {} to cache: {}, term: {}",
+                          ntp,
                           b.base_offset(),
                           b.term());
                         api->cache_put(ntp, b);
@@ -567,7 +568,8 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         for (const auto& b : rb_copy) {
             vlog(
               cd_log.trace,
-              "Putting batch to cache: {}, term: {}",
+              "Putting batch for {} to cache: {}, term: {}",
+              ntp(),
               b.base_offset(),
               b.term());
             _data_plane->cache_put(ntp(), b);

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -33,11 +33,7 @@ level_zero_log_reader_impl::level_zero_log_reader_impl(
   data_plane_api* ct_api)
   : _config(cfg)
   , _underlying(std::move(underlying))
-  , _ct_api(ct_api) {
-    if (_config.max_bytes == 0) {
-        _current = state::end_of_stream_state;
-    }
-}
+  , _ct_api(ct_api) {}
 
 ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::do_load_slice(
@@ -84,9 +80,6 @@ level_zero_log_reader_impl::do_load_slice(
 
 std::optional<chunked_circular_buffer<model::record_batch>>
 level_zero_log_reader_impl::maybe_load_slices_from_cache() {
-    if (_config.skip_cache) {
-        return std::nullopt;
-    }
     chunked_circular_buffer<model::record_batch> ret;
     size_t materialized_bytes = 0;
     auto current = _config.start_offset;
@@ -105,7 +98,8 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
         }
         vlog(
           cd_log.trace,
-          "Loaded batch from cache: {}",
+          "Loaded batch from cache for {}: {} @ term {}",
+          current,
           batch.value().base_offset(),
           batch.value().term());
         vassert(

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -115,9 +115,12 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
             break;
         }
         vassert(
-          batch->base_offset() == kafka::offset_cast(current),
-          "Unexpected base offset {} vs {}",
+          batch->base_offset() <= kafka::offset_cast(current)
+            && kafka::offset_cast(current) <= batch->last_offset(),
+          "Unexpected batch for {}, got range: [{},{}] for offset {}",
+          _underlying->ntp(),
           batch->base_offset(),
+          batch->last_offset(),
           current);
         ret.push_back(std::move(batch.value()));
         materialized_bytes += batch_size;
@@ -368,6 +371,12 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                     batch.header());
                   // Propagate materialized batches to the record batch cache
                   if (cache_enabled()) {
+                      vlog(
+                        cd_log.trace,
+                        "Putting batch for {} to cache: {}, term: {}",
+                        _underlying->ntp(),
+                        batch.base_offset(),
+                        batch.term());
                       _ct_api->cache_put(_underlying->ntp(), batch.copy());
                   }
                   return batch;

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -10,22 +10,15 @@
 
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
-#include "config/configuration.h"
-#include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
-#include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "ssx/sformat.h"
-#include "storage/ntp_config.h"
-#include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
 
 #include <gtest/gtest.h>
-
-#include <iterator>
 
 using tests::kafka_consume_transport;
 using tests::kafka_produce_transport;
@@ -85,7 +78,7 @@ TEST_F(e2e_fixture, test_l0_path) {
     auto deferred_close = ss::defer([&producer] { producer.stop().get(); });
 
     size_t total_records = 100;
-    size_t records_per_batch = 1;
+    size_t records_per_batch = 5;
     std::vector<kv_t> records;
     for (size_t i = 0; i < total_records; i += records_per_batch) {
         std::vector<kv_t> batch;
@@ -101,17 +94,20 @@ TEST_F(e2e_fixture, test_l0_path) {
     kafka_consume_transport consumer(make_kafka_client().get());
     consumer.start().get();
     auto deferred_c_close = ss::defer([&consumer] { consumer.stop().get(); });
-    auto consumed_records = consumer
-                              .consume_from_partition(
-                                topic_name,
-                                model::partition_id(0),
-                                model::offset(0))
-                              .get();
-    BOOST_CHECK_EQUAL(records.size(), consumed_records.size());
-    for (size_t i = 0; i < records.size(); ++i) {
-        BOOST_CHECK_EQUAL(records[i].key, consumed_records[i].key);
-        BOOST_CHECK_EQUAL(records[i].val, consumed_records[i].val);
+    for (auto [seek_offset, start_offset] :
+         std::map<int, int>{{0, 0}, {1, 0}, {5, 5}, {6, 5}, {99, 95}}) {
+        auto consumed_records = consumer
+                                  .consume_from_partition(
+                                    topic_name,
+                                    model::partition_id(0),
+                                    model::offset(seek_offset))
+                                  .get();
+        ASSERT_EQ(consumed_records.size(), records.size() - start_offset);
+        for (const auto& [expected_offset, consumed] : std::views::zip(
+               std::views::iota(start_offset), consumed_records)) {
+            ASSERT_EQ(records[expected_offset].key, consumed.key);
+            ASSERT_EQ(records[expected_offset].val, consumed.val);
+        }
     }
-
-    ss::sleep(10s).get();
+    ss::sleep(1s).get();
 }

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -39,8 +39,6 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
 
-#include <chrono>
-#include <iterator>
 #include <optional>
 #include <system_error>
 
@@ -48,23 +46,37 @@ namespace {
 
 cloud_topics::cloud_topic_log_reader_config
 kafka_to_cloud_topic_log_reader_config(kafka::log_reader_config cfg) {
-    return cloud_topics::cloud_topic_log_reader_config(
-      /*start_offset=*/cfg.start_offset,
-      /*max_offset=*/cfg.max_offset,
-      /*min_bytes=*/cfg.min_bytes,
-      /*max_bytes=*/cfg.max_bytes,
-      /*type_filter=*/std::nullopt,
-      /*first_timestamp=*/cfg.first_timestamp,
-      /*abort_source=*/cfg.abort_source,
-      /*client_address=*/cfg.client_address,
-      /*strict_max_bytes=*/cfg.strict_max_bytes);
+    return {/*start_offset=*/cfg.start_offset,
+            /*max_offset=*/cfg.max_offset,
+            /*min_bytes=*/cfg.min_bytes,
+            /*max_bytes=*/cfg.max_bytes,
+            /*type_filter=*/std::nullopt,
+            /*time=*/cfg.first_timestamp,
+            /*as=*/cfg.abort_source,
+            /*client_addr=*/cfg.client_address,
+            /*strict_max_bytes=*/cfg.strict_max_bytes};
+}
+
+using frontend_errc = cloud_topics::frontend_errc;
+
+kafka::error_code map_errc(frontend_errc errc) {
+    switch (errc) {
+    case frontend_errc::offset_not_available:
+        return kafka::error_code::offset_not_available;
+    case frontend_errc::invalid_topic_exception:
+        return kafka::error_code::invalid_topic_exception;
+    case frontend_errc::not_leader_for_partition:
+        return kafka::error_code::not_leader_for_partition;
+    case frontend_errc::offset_out_of_range:
+        return kafka::error_code::offset_out_of_range;
+    default:
+        return kafka::error_code::unknown_server_error;
+    }
 }
 
 } // namespace
 
 namespace kafka {
-
-using frontend_errc = cloud_topics::frontend_errc;
 
 cloud_topic_partition::cloud_topic_partition(
   ss::lw_shared_ptr<cluster::partition> p,
@@ -86,18 +98,7 @@ ss::future<result<model::offset, error_code>>
 cloud_topic_partition::sync_effective_start(model::timeout_clock::duration d) {
     auto res = co_await _fe->sync_effective_start(d);
     if (!res.has_value()) {
-        switch (res.error()) {
-        case frontend_errc::offset_not_available:
-            co_return error_code::offset_not_available;
-        case frontend_errc::invalid_topic_exception:
-            co_return error_code::invalid_topic_exception;
-        case frontend_errc::not_leader_for_partition:
-            co_return error_code::not_leader_for_partition;
-        case frontend_errc::offset_out_of_range:
-            co_return error_code::offset_out_of_range;
-        default:
-            co_return error_code::unknown_server_error;
-        }
+        co_return map_errc(res.error());
     }
     co_return kafka::offset_cast(res.value());
 }
@@ -110,12 +111,7 @@ checked<model::offset, error_code>
 cloud_topic_partition::last_stable_offset() const {
     auto res = _fe->last_stable_offset();
     if (!res.has_value()) {
-        switch (res.error()) {
-        case frontend_errc::offset_not_available:
-            return error_code::offset_not_available;
-        default:
-            return error_code::unknown_server_error;
-        };
+        return map_errc(res.error());
     }
     return kafka::offset_cast(res.value());
 }
@@ -203,18 +199,7 @@ ss::future<error_code> cloud_topic_partition::validate_fetch_offset(
     auto res = co_await _fe->validate_fetch_offset(
       model::offset_cast(fetch_offset), reading_from_follower, deadline);
     if (!res.has_value()) {
-        switch (res.error()) {
-        case frontend_errc::offset_not_available:
-            co_return error_code::offset_not_available;
-        case frontend_errc::invalid_topic_exception:
-            co_return error_code::invalid_topic_exception;
-        case frontend_errc::not_leader_for_partition:
-            co_return error_code::not_leader_for_partition;
-        case frontend_errc::offset_out_of_range:
-            co_return error_code::offset_out_of_range;
-        default:
-            co_return error_code::unknown_server_error;
-        }
+        co_return map_errc(res.error());
     }
     co_return error_code::none;
 }
@@ -222,18 +207,7 @@ ss::future<error_code> cloud_topic_partition::validate_fetch_offset(
 result<partition_info> cloud_topic_partition::get_partition_info() const {
     auto res = _fe->get_partition_info();
     if (!res.has_value()) {
-        switch (res.error()) {
-        case frontend_errc::offset_not_available:
-            return error_code::offset_not_available;
-        case frontend_errc::invalid_topic_exception:
-            return error_code::invalid_topic_exception;
-        case frontend_errc::not_leader_for_partition:
-            return error_code::not_leader_for_partition;
-        case frontend_errc::offset_out_of_range:
-            return error_code::offset_out_of_range;
-        default:
-            return error_code::unknown_server_error;
-        }
+        return map_errc(res.error());
     }
     const auto& ct_info = res.value();
     partition_info info;
@@ -244,7 +218,7 @@ result<partition_info> cloud_topic_partition::get_partition_info() const {
         replica.high_watermark = kafka::offset_cast(ct_replica.high_watermark);
         replica.log_end_offset = kafka::offset_cast(ct_replica.log_end_offset);
         replica.is_alive = ct_replica.is_alive;
-        info.replicas.push_back(std::move(replica));
+        info.replicas.push_back(replica);
     }
     info.leader = ct_info.leader;
     return info;


### PR DESCRIPTION
- **kafka/data/ct: extract errc conversion to helper function**
- **ct/reader: remove eager end of stream check**
- **cloud_topics: loosen assertion when loading from cache**
- **cloud_topics: add test ensuring reads from batch boundaries are served**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
