### PR TITLE
Support describe cluster in kafka client

### DIFF
--- a/src/v/kafka/client/BUILD
+++ b/src/v/kafka/client/BUILD
@@ -164,13 +164,19 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "types",
-    srcs = [],
+    srcs = ["types.cc"],
     hdrs = ["types.h"],
+    implementation_deps = [
+        "//src/v/utils:to_string",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/protocol:metadata",
         "//src/v/model",
+        "@fmt",
     ],
 )
 

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -58,9 +58,9 @@ ss::future<> brokers::do_erase(model::node_id node_id) {
 }
 
 ss::future<> brokers::apply(
-  const chunked_vector<metadata_response::broker>& brokers_metadata) {
+  const chunked_vector<metadata_update::broker>& brokers_metadata) {
     auto u = co_await _state_mutex.get_units();
-    chunked_vector<metadata_response::broker> brokers_to_add;
+    chunked_vector<metadata_update::broker> brokers_to_add;
     chunked_vector<model::node_id> brokers_to_remove;
 
     for (auto& broker : brokers_metadata) {

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -17,6 +17,7 @@
 #include "container/chunked_vector.h"
 #include "kafka/client/broker.h"
 #include "kafka/client/configuration.h"
+#include "kafka/client/types.h"
 #include "kafka/protocol/metadata.h"
 #include "model/fundamental.h"
 
@@ -61,8 +62,7 @@ public:
      * Applies the metadata response to the brokers. This method will throw if
      * any of the brokers can not be connected to.
      */
-    ss::future<>
-    apply(const chunked_vector<metadata_response::broker>& brokers);
+    ss::future<> apply(const chunked_vector<metadata_update::broker>& brokers);
 
     /// \brief Returns true if there are no connected brokers
     bool empty() const;

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -66,7 +66,7 @@ client::client(
       _logger,
       [this](std::exception_ptr ex) { return mitigate_error(std::move(ex)); }) {
     _metadata_callback_id = _cluster->register_metadata_cb(
-      [this](const metadata_response_data& res) { on_metadata_update(res); });
+      [this](const metadata_update& res) { on_metadata_update(res); });
 }
 
 ss::future<> client::connect() {
@@ -106,7 +106,7 @@ ss::future<> client::stop() noexcept {
     co_await catch_and_log(_logger, [this]() { return _cluster->stop(); });
 }
 
-void client::on_metadata_update(const metadata_response_data& res) {
+void client::on_metadata_update(const metadata_update& res) {
     _partitioners.apply_metadata(res);
 }
 

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -213,7 +213,7 @@ private:
       chunked_vector<model::topic> topics,
       std::optional<chunked_vector<ss::sstring>> configuration_keys);
 
-    void on_metadata_update(const metadata_response_data& res);
+    void on_metadata_update(const metadata_update& res);
 
     /// \brief Connect and update metdata.
     ss::future<> do_connect(net::unresolved_address addr);

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -215,7 +215,8 @@ ss::future<> cluster::initialize_metadata_with_seed() {
 }
 
 ss::future<> cluster::dispatch_metadata_request(
-  std::optional<chunked_vector<model::topic>> topics_request_list) {
+  std::optional<chunked_vector<model::topic>> topics_request_list,
+  std::optional<api_version> requested_version) {
     auto h = _gate.hold();
     vlog(_logger.debug, "Dispatching metadata request");
     shared_broker_t broker;
@@ -245,13 +246,17 @@ ss::future<> cluster::dispatch_metadata_request(
 
         auto request_version = co_await get_metadata_request_version(
           broker, _as);
+        auto metadata_version
+          = requested_version.has_value()
+              ? std::min(requested_version.value(), request_version)
+              : request_version;
         // TODO: support topic subscription
         auto reply = co_await broker->dispatch(
           metadata_request{.data{
             .topics = std::move(topics_to_request),
             .allow_auto_topic_creation = false,
             .include_topic_authorized_operations = true}},
-          request_version);
+          metadata_version);
         vassert(
           std::holds_alternative<kafka::metadata_response>(reply),
           "Metadata response is required to be returned as a result of "

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -18,6 +18,33 @@
 #include <seastar/coroutine/as_future.hh>
 namespace kafka::client {
 
+namespace {
+using topic_metadata_included_t
+  = ss::bool_class<struct topic_metadata_included_tag>;
+metadata_update to_metadata_update(
+  metadata_response r, topic_metadata_included_t topic_metadata_included) {
+    metadata_update update;
+    update.brokers.reserve(r.data.brokers.size());
+    for (auto& b : r.data.brokers) {
+        update.brokers.push_back(
+          metadata_update::broker{
+            .node_id = b.node_id,
+            .host = std::move(b.host),
+            .port = b.port,
+            .rack = std::move(b.rack)});
+    }
+    update.cluster_id = std::move(r.data.cluster_id);
+    update.controller_id = r.data.controller_id;
+    if (topic_metadata_included) {
+        update.topics = std::move(r.data.topics);
+    }
+    // cluster_authorized_operations field was deprecated in v11
+    update.cluster_authorized_operations = r.data.cluster_authorized_operations;
+
+    return update;
+}
+} // namespace
+
 using namespace std::chrono_literals;
 cluster::cluster(connection_configuration config)
   : _config(std::move(config))
@@ -149,11 +176,12 @@ ss::future<> cluster::initialize_metadata_with_seed() {
             co_await broker->stop();
             continue;
         }
+        auto metadata_version = request_version_f.get();
         auto reply_f = co_await ss::coroutine::as_future(broker->dispatch(
           // use empty topic list not to request all topics, we are only
           // interested in brokers list
           metadata_request{.data = metadata_request_data{.topics = {}}},
-          request_version_f.get()));
+          metadata_version));
         /**
          * stop the broker after the request is done to ensure that
          * the broker is not left in a connected state. This is important
@@ -162,8 +190,8 @@ ss::future<> cluster::initialize_metadata_with_seed() {
          */
         co_await broker->stop();
         if (!reply_f.failed()) {
-            co_await apply_metadata(
-              std::get<metadata_response>(std::move(reply_f.get())));
+            co_await apply_metadata(to_metadata_update(
+              std::get<metadata_response>(std::move(reply_f.get()))));
             co_return;
         }
         auto ex = reply_f.get_exception();
@@ -210,8 +238,8 @@ ss::future<> cluster::dispatch_metadata_request() {
           "Metadata response is required to be returned as a result of "
           "metadata request");
 
-        co_await apply_metadata(
-          std::get<kafka::metadata_response>(std::move(reply)));
+        co_await apply_metadata(to_metadata_update(
+          std::get<kafka::metadata_response>(std::move(reply))));
     } catch (const broker_error& e) {
         vlog(
           _logger.warn, "Failed to dispatch metadata request - {}", e.what());
@@ -223,7 +251,7 @@ void cluster::set_sasl_configuration(std::optional<sasl_configuration> creds) {
     _config.sasl_cfg = std::move(creds);
 }
 
-ss::future<> cluster::apply_metadata(metadata_response reply) {
+ss::future<> cluster::apply_metadata(metadata_update reply) {
     /**
      * this is the only place where the cluster brokers are updated. It happens
      * under the metadata update lock.
@@ -233,22 +261,27 @@ ss::future<> cluster::apply_metadata(metadata_response reply) {
       _logger.debug,
       "Applying metadata response with {{ cluster_id: {}, "
       "controller_id: {}, brokers: {} and {} topics }}",
-      reply.data.cluster_id,
-      reply.data.controller_id,
-      reply.data.brokers,
-      reply.data.topics.size());
+      reply.cluster_id,
+      reply.controller_id,
+      reply.brokers,
+      reply.topics.has_value() ? reply.topics->size() : 0);
 
-    _cluster_id = reply.data.cluster_id;
-    if (reply.data.controller_id == unknown_node_id) {
+    _cluster_id = reply.cluster_id;
+    if (reply.controller_id == unknown_node_id) {
         _controller_id.reset();
     } else {
-        _controller_id = reply.data.controller_id;
+        _controller_id = reply.controller_id;
     }
-    _topic_cache.apply(reply.data.topics);
-    co_await _brokers.apply(reply.data.brokers);
+
+    if (reply.topics.has_value()) {
+        // Only apply topics if the response contains any, an empty list may be
+        // because none were requested
+        _topic_cache.apply(reply.topics.value());
+    }
+    co_await _brokers.apply(reply.brokers);
     _last_update_time = ss::lowres_clock::now();
     // trigger notification last, after the metadata is applied
-    _notifications.notify(reply.data);
+    _notifications.notify(reply);
 }
 
 ss::future<std::optional<api_version_range>> cluster::supported_api_versions(

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -108,7 +108,30 @@ ss::future<> cluster::update_metadata(
     if (_last_update_time >= request_time) {
         co_return;
     }
-    co_await dispatch_metadata_request(std::move(topics_request_list));
+    co_await dispatch_and_apply_metadata_updates(
+      std::move(topics_request_list));
+}
+
+ss::future<> cluster::dispatch_and_apply_metadata_updates(
+  std::optional<chunked_vector<model::topic>> topics_request_list) {
+    auto h = _gate.hold();
+
+    vlog(_logger.debug, "Starting cluster metadata dispatch and update");
+
+    if (_brokers.empty()) {
+        // If there are no brokers, connect to one of the seeds
+        co_await initialize_metadata_with_seed();
+    }
+
+    try {
+        auto broker = _brokers.any();
+        auto metadata_resp = co_await dispatch_metadata_request(
+          broker, std::move(topics_request_list));
+        co_await apply_metadata(to_metadata_update(std::move(metadata_resp)));
+    } catch (const broker_error& e) {
+        vlog(
+          _logger.warn, "Failed to dispatch metadata request - {}", e.what());
+    }
 }
 
 ss::future<> cluster::request_metadata_update(
@@ -214,17 +237,12 @@ ss::future<> cluster::initialize_metadata_with_seed() {
     }
 }
 
-ss::future<> cluster::dispatch_metadata_request(
+ss::future<metadata_response> cluster::dispatch_metadata_request(
+  shared_broker_t broker,
   std::optional<chunked_vector<model::topic>> topics_request_list,
   std::optional<api_version> requested_version) {
     auto h = _gate.hold();
     vlog(_logger.debug, "Dispatching metadata request");
-    shared_broker_t broker;
-
-    if (_brokers.empty()) {
-        // If there are no brokers, connect to one of the seeds
-        co_await initialize_metadata_with_seed();
-    }
 
     std::optional<chunked_vector<metadata_request_topic>> topics_to_request
       = std::nullopt;
@@ -239,35 +257,22 @@ ss::future<> cluster::dispatch_metadata_request(
           });
     }
 
-    try {
-        auto broker = _brokers.any();
-        // Initialize the broker if it is not connected, this is required to
-        // make sure the broker has up to date API version information.
+    auto request_version = co_await get_metadata_request_version(broker, _as);
+    auto metadata_version = std::min(
+      requested_version.value_or(request_version), request_version);
+    // TODO: support topic subscription
+    auto reply = co_await broker->dispatch(
+      metadata_request{.data{
+        .topics = std::move(topics_to_request),
+        .allow_auto_topic_creation = false,
+        .include_topic_authorized_operations = true}},
+      metadata_version);
+    vassert(
+      std::holds_alternative<kafka::metadata_response>(reply),
+      "Metadata response is required to be returned as a result of "
+      "metadata request");
 
-        auto request_version = co_await get_metadata_request_version(
-          broker, _as);
-        auto metadata_version
-          = requested_version.has_value()
-              ? std::min(requested_version.value(), request_version)
-              : request_version;
-        // TODO: support topic subscription
-        auto reply = co_await broker->dispatch(
-          metadata_request{.data{
-            .topics = std::move(topics_to_request),
-            .allow_auto_topic_creation = false,
-            .include_topic_authorized_operations = true}},
-          metadata_version);
-        vassert(
-          std::holds_alternative<kafka::metadata_response>(reply),
-          "Metadata response is required to be returned as a result of "
-          "metadata request");
-
-        co_await apply_metadata(to_metadata_update(
-          std::get<kafka::metadata_response>(std::move(reply))));
-    } catch (const broker_error& e) {
-        vlog(
-          _logger.warn, "Failed to dispatch metadata request - {}", e.what());
-    }
+    co_return std::get<metadata_response>(std::move(reply));
 }
 
 void cluster::set_sasl_configuration(std::optional<sasl_configuration> creds) {

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -90,24 +90,35 @@ ss::future<> cluster::request_metadata_update() {
 }
 
 namespace {
-ss::future<api_version> get_metadata_request_version(
-  const shared_broker_t& broker,
-  std::optional<std::reference_wrapper<ss::abort_source>> as) {
-    auto supported_version = co_await broker->get_supported_versions(
-      metadata_api::key, as);
-    // Currently we require at least version 1 of the metadata API. (The api
-    // where NULL topic list represents request to list all topics)
-    if (!supported_version || supported_version->max < api_version(1)) {
+
+template<KafkaApi Api>
+ss::future<api_version> get_required_api_version(
+  shared_broker_t broker,
+  std::optional<std::reference_wrapper<ss::abort_source>> as,
+  api_version min_required) {
+    auto supported_versions = co_await broker->get_supported_versions(
+      Api::key, as);
+    if (!supported_versions || supported_versions->max < min_required) {
         throw broker_error(
           broker->id(),
           error_code::unsupported_version,
           fmt::format(
-            "Broker {} at {}:{} does not support metadata API",
+            "Broker {} at {}:{} does not support {} API with required "
+            "version >= {}",
             broker->id(),
             broker->get_address().host(),
-            broker->get_address().port()));
+            broker->get_address().port(),
+            Api::name,
+            min_required));
     }
-    co_return std::min(supported_version->max, kafka::metadata_api::max_valid);
+    co_return std::min(supported_versions->max, Api::max_valid);
+}
+
+ss::future<api_version> get_metadata_request_version(
+  shared_broker_t broker,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    return get_required_api_version<metadata_api>(
+      std::move(broker), as, api_version(1));
 }
 } // namespace
 ss::future<> cluster::initialize_metadata_with_seed() {

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -99,7 +99,8 @@ ss::future<> cluster::stop() {
     co_await _brokers.stop();
 }
 
-ss::future<> cluster::update_metadata() {
+ss::future<> cluster::update_metadata(
+  std::optional<chunked_vector<model::topic>> topics_request_list) {
     auto request_time = ss::lowres_clock::now();
 
     _as.check();
@@ -107,13 +108,14 @@ ss::future<> cluster::update_metadata() {
     if (_last_update_time >= request_time) {
         co_return;
     }
-    co_await dispatch_metadata_request();
+    co_await dispatch_metadata_request(std::move(topics_request_list));
 }
 
-ss::future<> cluster::request_metadata_update() {
+ss::future<> cluster::request_metadata_update(
+  std::optional<chunked_vector<model::topic>> topics_request_list) {
     vlog(_logger.debug, "Requesting metadata update");
     auto h = _gate.hold();
-    co_await update_metadata();
+    co_await update_metadata(std::move(topics_request_list));
 }
 
 namespace {
@@ -212,7 +214,8 @@ ss::future<> cluster::initialize_metadata_with_seed() {
     }
 }
 
-ss::future<> cluster::dispatch_metadata_request() {
+ss::future<> cluster::dispatch_metadata_request(
+  std::optional<chunked_vector<model::topic>> topics_request_list) {
     auto h = _gate.hold();
     vlog(_logger.debug, "Dispatching metadata request");
     shared_broker_t broker;
@@ -220,6 +223,19 @@ ss::future<> cluster::dispatch_metadata_request() {
     if (_brokers.empty()) {
         // If there are no brokers, connect to one of the seeds
         co_await initialize_metadata_with_seed();
+    }
+
+    std::optional<chunked_vector<metadata_request_topic>> topics_to_request
+      = std::nullopt;
+    if (topics_request_list.has_value()) {
+        topics_to_request.emplace();
+        topics_to_request->reserve(topics_request_list->size());
+        std::ranges::transform(
+          std::move(topics_request_list.value()),
+          std::back_inserter(*topics_to_request),
+          [](model::topic& t) {
+              return metadata_request_topic{.name = std::move(t)};
+          });
     }
 
     try {
@@ -231,7 +247,10 @@ ss::future<> cluster::dispatch_metadata_request() {
           broker, _as);
         // TODO: support topic subscription
         auto reply = co_await broker->dispatch(
-          metadata_request{.data{.include_topic_authorized_operations = true}},
+          metadata_request{.data{
+            .topics = std::move(topics_to_request),
+            .allow_auto_topic_creation = false,
+            .include_topic_authorized_operations = true}},
           request_version);
         vassert(
           std::holds_alternative<kafka::metadata_response>(reply),

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -43,6 +43,22 @@ metadata_update to_metadata_update(
 
     return update;
 }
+metadata_update to_metadata_update(describe_cluster_response r) {
+    metadata_update update;
+    update.brokers.reserve(r.data.brokers.size());
+    for (auto& b : r.data.brokers) {
+        update.brokers.push_back(
+          metadata_update::broker{
+            .node_id = b.broker_id,
+            .host = std::move(b.host),
+            .port = b.port,
+            .rack = std::move(b.rack)});
+    }
+    update.cluster_id = std::move(r.data.cluster_id);
+    update.controller_id = r.data.controller_id;
+    update.cluster_authorized_operations = r.data.cluster_authorized_operations;
+    return update;
+}
 } // namespace
 
 using namespace std::chrono_literals;
@@ -125,9 +141,32 @@ ss::future<> cluster::dispatch_and_apply_metadata_updates(
 
     try {
         auto broker = _brokers.any();
-        auto metadata_resp = co_await dispatch_metadata_request(
-          broker, std::move(topics_request_list));
-        co_await apply_metadata(to_metadata_update(std::move(metadata_resp)));
+        auto describe_cluster_version = co_await broker->get_supported_versions(
+          describe_cluster_api::key, _as);
+        metadata_update mu;
+        if (describe_cluster_version) {
+            auto describe_cluster_resp
+              = co_await dispatch_describe_cluster_request(broker);
+            mu = to_metadata_update(std::move(describe_cluster_resp));
+        } else {
+            // If describe cluster isn't supported, then dispatch a metadata
+            // request with no topics at API version 10 in order to get the
+            // cluster level authorized operations
+            auto metadata_resp = co_await dispatch_metadata_request(
+              broker, {}, api_version(10));
+            mu = to_metadata_update(
+              std::move(metadata_resp), topic_metadata_included_t::no);
+        }
+
+        if (!topics_request_list.has_value() || !topics_request_list->empty()) {
+            // If there are topics to request, then do another metadata request
+            // with the most up-to-date version
+            auto metadata_resp = co_await dispatch_metadata_request(
+              broker, std::move(topics_request_list));
+            mu.topics = std::move(metadata_resp.data.topics);
+        }
+
+        co_await apply_metadata(std::move(mu));
     } catch (const broker_error& e) {
         vlog(
           _logger.warn, "Failed to dispatch metadata request - {}", e.what());
@@ -172,6 +211,13 @@ ss::future<api_version> get_metadata_request_version(
     return get_required_api_version<metadata_api>(
       std::move(broker), as, api_version(1));
 }
+
+ss::future<api_version> get_describe_cluster_request_version(
+  shared_broker_t broker,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    return get_required_api_version<describe_cluster_api>(
+      std::move(broker), as, api_version(0));
+}
 } // namespace
 ss::future<> cluster::initialize_metadata_with_seed() {
     vlog(
@@ -184,29 +230,31 @@ ss::future<> cluster::initialize_metadata_with_seed() {
         _next_seed = (_next_seed + 1) % _config.initial_brokers.size();
         const auto& address = _config.initial_brokers[_next_seed];
         auto broker = co_await _brokers.create_broker(unknown_node_id, address);
-        // explicitly connect to the broker to initialize connection before
-        // requesting metadata
 
-        auto request_version_f = co_await ss::coroutine::as_future(
-          get_metadata_request_version(broker, _as));
-        if (request_version_f.failed()) {
-            auto ex = request_version_f.get_exception();
+        auto describe_cluster_version_f = co_await ss::coroutine::as_future(
+          broker->get_supported_versions(describe_cluster_api::key, _as));
+        if (describe_cluster_version_f.failed()) {
+            error = describe_cluster_version_f.get_exception();
             vlog(
               _logger.warn,
-              "Failed to get supported metadata version {}:{} - {}",
+              "Failed to get supported describe cluster version {}:{} - {}",
               address.host(),
               address.port(),
-              ex);
-            error = ex;
+              error);
             co_await broker->stop();
             continue;
         }
-        auto metadata_version = request_version_f.get();
-        auto reply_f = co_await ss::coroutine::as_future(broker->dispatch(
-          // use empty topic list not to request all topics, we are only
-          // interested in brokers list
-          metadata_request{.data = metadata_request_data{.topics = {}}},
-          metadata_version));
+
+        auto describe_cluster_version = describe_cluster_version_f.get();
+        ss::future<> f = ss::now();
+        if (describe_cluster_version.has_value()) {
+            f = co_await ss::coroutine::as_future(
+              initialize_with_describe_cluster(broker));
+        } else {
+            f = co_await ss::coroutine::as_future(
+              initialize_with_metadata(broker));
+        }
+
         /**
          * stop the broker after the request is done to ensure that
          * the broker is not left in a connected state. This is important
@@ -214,19 +262,22 @@ ss::future<> cluster::initialize_metadata_with_seed() {
          * want to keep it connected.
          */
         co_await broker->stop();
-        if (!reply_f.failed()) {
-            co_await apply_metadata(to_metadata_update(
-              std::get<metadata_response>(std::move(reply_f.get()))));
-            co_return;
+
+        if (f.failed()) {
+            error = f.get_exception();
+            vlog(
+              _logger.warn,
+              "Failed to initialize metadata using {} with seed broker {}:{} - "
+              "{}",
+              describe_cluster_version ? "describe_cluster" : "metadata",
+              address.host(),
+              address.port(),
+              error);
+            continue;
         }
-        auto ex = reply_f.get_exception();
-        vlog(
-          _logger.warn,
-          "Failed to initialize metadata with seed broker {}:{} - {}",
-          address.host(),
-          address.port(),
-          ex);
-        error = ex;
+
+        // If we are successful in connecting to the broker, then we can stop
+        co_return;
     }
     if (error) {
         vlog(
@@ -235,6 +286,19 @@ ss::future<> cluster::initialize_metadata_with_seed() {
           error);
         std::rethrow_exception(error);
     }
+}
+
+ss::future<> cluster::initialize_with_describe_cluster(shared_broker_t broker) {
+    vlog(_logger.debug, "Initializing cluster with describe_cluster request");
+    auto resp = co_await dispatch_describe_cluster_request(std::move(broker));
+    co_await apply_metadata(to_metadata_update(std::move(resp)));
+}
+
+ss::future<> cluster::initialize_with_metadata(shared_broker_t broker) {
+    vlog(_logger.debug, "Initializing cluster with metadata request");
+    auto resp = co_await dispatch_metadata_request(std::move(broker), {});
+    co_await apply_metadata(
+      to_metadata_update(std::move(resp), topic_metadata_included_t::no));
 }
 
 ss::future<metadata_response> cluster::dispatch_metadata_request(
@@ -274,6 +338,25 @@ ss::future<metadata_response> cluster::dispatch_metadata_request(
       "metadata request");
 
     co_return std::get<metadata_response>(std::move(reply));
+}
+
+ss::future<describe_cluster_response>
+cluster::dispatch_describe_cluster_request(shared_broker_t broker) {
+    auto h = _gate.hold();
+    vlog(_logger.debug, "Dispatching describe cluster request");
+
+    auto request_version = co_await get_describe_cluster_request_version(
+      broker, _as);
+    auto reply = co_await broker->dispatch(
+      describe_cluster_request{
+        .data{.include_cluster_authorized_operations = true}},
+      request_version);
+    vassert(
+      std::holds_alternative<kafka::describe_cluster_response>(reply),
+      "Describe cluster response is required to be returned as a result of "
+      "describe cluster request");
+
+    co_return std::get<describe_cluster_response>(std::move(reply));
 }
 
 void cluster::set_sasl_configuration(std::optional<sasl_configuration> creds) {

--- a/src/v/kafka/client/cluster.cc
+++ b/src/v/kafka/client/cluster.cc
@@ -265,6 +265,7 @@ ss::future<metadata_response> cluster::dispatch_metadata_request(
       metadata_request{.data{
         .topics = std::move(topics_to_request),
         .allow_auto_topic_creation = false,
+        .include_cluster_authorized_operations = true,
         .include_topic_authorized_operations = true}},
       metadata_version);
     vassert(
@@ -296,6 +297,7 @@ ss::future<> cluster::apply_metadata(metadata_update reply) {
       reply.topics.has_value() ? reply.topics->size() : 0);
 
     _cluster_id = reply.cluster_id;
+    _cluster_authorized_operations = reply.cluster_authorized_operations;
     if (reply.controller_id == unknown_node_id) {
         _controller_id.reset();
     } else {

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -12,6 +12,7 @@
 #include "base/seastarx.h"
 #include "kafka/client/brokers.h"
 #include "kafka/client/topic_cache.h"
+#include "kafka/client/types.h"
 #include "utils/notification_list.h"
 #include "utils/prefix_logger.h"
 namespace kafka::client {
@@ -24,7 +25,7 @@ class cluster {
 public:
     using callback_id = named_type<int16_t, struct callback_id_tag>;
     using metadata_callback
-      = ss::noncopyable_function<void(const metadata_response_data&)>;
+      = ss::noncopyable_function<void(const metadata_update&)>;
 
     explicit cluster(connection_configuration config);
 
@@ -165,7 +166,7 @@ private:
     ss::future<> dispatch_metadata_request();
     ss::future<> initialize_metadata_with_seed();
     void update_timer_callback();
-    ss::future<> apply_metadata(metadata_response reply);
+    ss::future<> apply_metadata(metadata_update reply);
 
     connection_configuration _config;
     prefix_logger _logger;

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -173,7 +173,8 @@ private:
       = std::nullopt);
     ss::future<> dispatch_metadata_request(
       std::optional<chunked_vector<model::topic>> topics_request_list
-      = std::nullopt);
+      = std::nullopt,
+      std::optional<api_version> requested_version = std::nullopt);
     ss::future<> initialize_metadata_with_seed();
     void update_timer_callback();
     ss::future<> apply_metadata(metadata_update reply);

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -171,7 +171,11 @@ private:
     ss::future<> update_metadata(
       std::optional<chunked_vector<model::topic>> topics_request_list
       = std::nullopt);
-    ss::future<> dispatch_metadata_request(
+    ss::future<> dispatch_and_apply_metadata_updates(
+      std::optional<chunked_vector<model::topic>> topics_request_list
+      = std::nullopt);
+    ss::future<metadata_response> dispatch_metadata_request(
+      shared_broker_t broker,
       std::optional<chunked_vector<model::topic>> topics_request_list
       = std::nullopt,
       std::optional<api_version> requested_version = std::nullopt);

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -106,8 +106,14 @@ public:
      * This method propages the exception to the caller, that may change
      * in the future but now it is needed because of the way how PandaProxy and
      * SchemaRegistry works with ephemeral credentials.
+     *
+     * \param topics_request_list optional list of topics to request metadata
+     * on.  If `std::nullopt`, then request update on all topics, or only the
+     * topics in the list.  Any empty list means no topics to request update on
      */
-    ss::future<> request_metadata_update();
+    ss::future<> request_metadata_update(
+      std::optional<chunked_vector<model::topic>> topics_request_list
+      = std::nullopt);
 
     std::optional<model::node_id> get_controller_id() const {
         return _controller_id;
@@ -162,8 +168,12 @@ public:
     auto get_broker_ids() const { return _brokers.get_broker_ids(); }
 
 private:
-    ss::future<> update_metadata();
-    ss::future<> dispatch_metadata_request();
+    ss::future<> update_metadata(
+      std::optional<chunked_vector<model::topic>> topics_request_list
+      = std::nullopt);
+    ss::future<> dispatch_metadata_request(
+      std::optional<chunked_vector<model::topic>> topics_request_list
+      = std::nullopt);
     ss::future<> initialize_metadata_with_seed();
     void update_timer_callback();
     ss::future<> apply_metadata(metadata_update reply);

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -167,6 +167,10 @@ public:
 
     auto get_broker_ids() const { return _brokers.get_broker_ids(); }
 
+    cluster_authorized_operations get_cluster_authorized_operations() const {
+        return _cluster_authorized_operations;
+    }
+
 private:
     ss::future<> update_metadata(
       std::optional<chunked_vector<model::topic>> topics_request_list
@@ -191,6 +195,8 @@ private:
 
     std::optional<model::node_id> _controller_id;
     std::optional<ss::sstring> _cluster_id;
+    cluster_authorized_operations _cluster_authorized_operations{
+      cluster_authorized_operations_not_set};
 
     ss::timer<> _metadata_update_timer;
     mutex _update_lock{"kc/metadata_update_lock"};

--- a/src/v/kafka/client/cluster.h
+++ b/src/v/kafka/client/cluster.h
@@ -183,7 +183,11 @@ private:
       std::optional<chunked_vector<model::topic>> topics_request_list
       = std::nullopt,
       std::optional<api_version> requested_version = std::nullopt);
+    ss::future<describe_cluster_response>
+    dispatch_describe_cluster_request(shared_broker_t broker);
     ss::future<> initialize_metadata_with_seed();
+    ss::future<> initialize_with_describe_cluster(shared_broker_t);
+    ss::future<> initialize_with_metadata(shared_broker_t);
     void update_timer_callback();
     ss::future<> apply_metadata(metadata_update reply);
 

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -153,7 +153,7 @@ ss::future<> direct_consumer::start() {
         co_return;
     }
     _metadata_callback_id = _cluster->register_metadata_cb(
-      [this](const metadata_response_data& d) { on_metadata_update(d); });
+      [this](const metadata_update& d) { on_metadata_update(d); });
     _started = true;
 
     auto lock_holder = co_await _subscriptions_lock.get_units();
@@ -242,7 +242,7 @@ ss::future<> direct_consumer::handle_metadata_update() {
     co_await update_fetchers(std::move(lock_holder));
 }
 
-void direct_consumer::on_metadata_update(const metadata_response_data&) {
+void direct_consumer::on_metadata_update(const metadata_update&) {
     ssx::spawn_with_gate(_gate, [this] { return handle_metadata_update(); });
 }
 

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -129,7 +129,7 @@ private:
         std::optional<kafka::offset> fetch_offset;
     };
     friend class fetcher;
-    void on_metadata_update(const metadata_response_data&);
+    void on_metadata_update(const metadata_update&);
 
     ss::future<> handle_metadata_update();
     ss::future<> update_fetchers(

--- a/src/v/kafka/client/partitioners.cc
+++ b/src/v/kafka/client/partitioners.cc
@@ -111,9 +111,13 @@ partitioner default_partitioner(model::partition_id initial) {
       detail::roundrobin_partitioner{initial})};
 }
 
-void partitioners_cache::apply_metadata(const metadata_response_data& data) {
+void partitioners_cache::apply_metadata(const metadata_update& data) {
+    if (!data.topics.has_value()) {
+        // No topics in metadata update, nothing to do
+        return;
+    }
     chunked_hash_set<model::topic> metadata_topics;
-    for (const auto& t : data.topics) {
+    for (const auto& t : *data.topics) {
         static_assert(
           api_version_for(metadata_request::api_type::key) < api_version(12),
           "topic::name is nullable in v12+");

--- a/src/v/kafka/client/partitioners.h
+++ b/src/v/kafka/client/partitioners.h
@@ -67,7 +67,7 @@ partitioner default_partitioner(model::partition_id initial);
 
 class partitioners_cache {
 public:
-    void apply_metadata(const metadata_response_data& data);
+    void apply_metadata(const metadata_update& data);
 
     model::partition_id
     partition_for(model::topic_view tv, const record_essence& rec);

--- a/src/v/kafka/client/test/cluster_mock.cc
+++ b/src/v/kafka/client/test/cluster_mock.cc
@@ -236,6 +236,10 @@ ss::future<response_t> cluster_mock::handle_metadata_request(
     }
 
     r_data.controller_id = _controller_id.value_or(_brokers.begin()->first);
+    r_data.cluster_authorized_operations
+      = md_req.data.include_cluster_authorized_operations
+          ? _cluster_authorized_operations
+          : kafka::cluster_authorized_operations_not_set;
 
     co_return metadata_response{.data = std::move(r_data)};
 }

--- a/src/v/kafka/client/test/cluster_mock.h
+++ b/src/v/kafka/client/test/cluster_mock.h
@@ -143,6 +143,10 @@ public:
 
     config::configuration& mock_config() { return _mock_config; }
 
+    void set_cluster_authorized_operations(cluster_authorized_operations ops) {
+        _cluster_authorized_operations = ops;
+    }
+
 public:
     supported_versions default_supported_versions;
 
@@ -187,6 +191,8 @@ private:
 
     // If unset, will use the node_id of the first broker in _brokers
     std::optional<model::node_id> _controller_id;
+    cluster_authorized_operations _cluster_authorized_operations{
+      cluster_authorized_operations_not_set};
     prefix_logger _logger;
 };
 

--- a/src/v/kafka/client/test/cluster_test_with_mock.cc
+++ b/src/v/kafka/client/test/cluster_test_with_mock.cc
@@ -71,7 +71,7 @@ TEST_F(cluster_mock_fixture, TestMetadataCallback) {
       model::node_id(1), net::unresolved_address{"localhost", 9092});
     cluster.start().get();
     auto cid = cluster.register_metadata_cb(
-      [&](const kafka::metadata_response_data&) { callback_invocations++; });
+      [&](const kafka::client::metadata_update&) { callback_invocations++; });
     RPTEST_REQUIRE_EVENTUALLY(30s, [&]() { return callback_invocations >= 5; });
     cluster.unregister_metadata_cb(cid);
 }

--- a/src/v/kafka/client/test/cluster_test_with_mock.cc
+++ b/src/v/kafka/client/test/cluster_test_with_mock.cc
@@ -136,7 +136,9 @@ TEST_F(cluster_mock_fixture, TestApiVersionDiscovery) {
 }
 
 TEST_F(cluster_mock_fixture, TestTopicMetadata) {
+    auto cluster_authorized_ops = kafka::cluster_authorized_operations{0x101};
     cluster_mock.register_default_handlers();
+    cluster_mock.set_cluster_authorized_operations(cluster_authorized_ops);
     auto cluster = create_client_cluster();
 
     cluster_mock.add_broker(
@@ -160,4 +162,6 @@ TEST_F(cluster_mock_fixture, TestTopicMetadata) {
     auto auth_ops = topics.authorized_operations_for_topic(
       model::topic_view{"test-topic"});
     EXPECT_EQ(auth_ops.value(), 0x508);
+    EXPECT_EQ(
+      cluster.get_cluster_authorized_operations(), cluster_authorized_ops);
 }

--- a/src/v/kafka/client/types.cc
+++ b/src/v/kafka/client/types.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/types.h"
+
+#include "utils/to_string.h"
+
+namespace kafka::client {
+fmt::iterator metadata_update::broker::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{node_id: {}, host: {}, port: {}, rack: {}}}",
+      node_id,
+      host,
+      port,
+      rack);
+}
+
+fmt::iterator metadata_update::format_to(fmt::iterator it) const {
+    return fmt::format_to(
+      it,
+      "{{brokers: {}, cluster_id: {}, controller_id: {}, topics: {}, "
+      "cluster_authorized_operations: {}}}",
+      brokers,
+      cluster_id,
+      controller_id,
+      topics,
+      cluster_authorized_operations);
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/types.h
+++ b/src/v/kafka/client/types.h
@@ -11,7 +11,10 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "kafka/protocol/metadata.h"
 #include "model/record.h"
 
 #include <optional>
@@ -30,4 +33,26 @@ inline constexpr model::node_id consumer_replica_id{-1};
 /// \brief during connection, the node_id isn't known.
 inline constexpr model::node_id unknown_node_id{-1};
 
+/// \brief Structure used to report metadata updates
+/// Both describe cluster and metadata use very similar fields but are typed
+/// differently
+struct metadata_update {
+    struct broker {
+        model::node_id node_id{};
+        ss::sstring host{};
+        int32_t port{};
+        std::optional<ss::sstring> rack{};
+
+        fmt::iterator format_to(fmt::iterator it) const;
+    };
+
+    chunked_vector<broker> brokers;
+    std::optional<ss::sstring> cluster_id;
+    model::node_id controller_id{-1};
+    std::optional<chunked_vector<metadata_response_topic>> topics;
+    kafka::cluster_authorized_operations cluster_authorized_operations{
+      kafka::cluster_authorized_operations_not_set};
+
+    fmt::iterator format_to(fmt::iterator it) const;
+};
 } // namespace kafka::client

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -274,6 +274,12 @@ path_type_map = {
             "int32",
         ),
     },
+    "DescribeClusterResponseData": {
+        "ClusterAuthorizedOperations": (
+            "kafka::cluster_authorized_operations",
+            "int32",
+        ),
+    },
     "FetchRequestData": {
         "MaxWaitMs": ("std::chrono::milliseconds", "int32"),
         "IsolationLevel": ("model::isolation_level", "int8"),


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

With Topic ID support added, the metadata API handler was updated to v12.  v11 dropped support for the cluster_authorized_operations and moved that to the new DescribeCluster API.  This PR now uses that API to fetch that information and broker information and only relies on the Metadata API for topic information.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
