### PR TITLE
Add support topic ids kafka client

### DIFF
--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -85,7 +85,11 @@ validate_and_get_configs_from_response(
 // Validates the contents of the metadata cache from the source cluster.  If
 // partition count or replication count are invalid then will return
 // std::nullopt.  Otherwise returns the metadata information.
-std::optional<std::tuple<int32_t, int16_t, kafka::topic_authorized_operations>>
+std::optional<std::tuple<
+  int32_t,
+  int16_t,
+  kafka::topic_authorized_operations,
+  std::optional<::model::topic_id>>>
 validate_topic_cache_entry(
   prefix_logger& logger,
   const kafka::client::topic_cache& cache,
@@ -113,16 +117,23 @@ validate_topic_cache_entry(
         return std::nullopt;
     }
 
+    auto topic_id = it->second.topic_id;
+
     vlog(
       logger.trace,
-      "Topic {} has {} partitions, RF={} and authorized operations {:08x}",
+      "Topic {} has {} partitions, RF={} and authorized operations {:08x} and "
+      "topic_id {}",
       topic,
       partition_count,
       replication_factor,
-      it->second.authorized_operations);
+      it->second.authorized_operations,
+      topic_id);
 
     return std::make_tuple(
-      partition_count, replication_factor, it->second.authorized_operations);
+      partition_count,
+      replication_factor,
+      it->second.authorized_operations,
+      topic_id);
 }
 } // namespace
 
@@ -308,6 +319,7 @@ void source_topic_syncer::enqueue_create_mirror_topic_commands(
           model::add_mirror_topic_cmd{
             .topic = it->first,
             .metadata = model::mirror_topic_metadata{
+              .source_topic_id = it->second.topic_id,
               .source_topic_name = it->first,
               .partition_count = it->second.partition_count,
               .replication_factor = it->second.rf,
@@ -369,6 +381,23 @@ void source_topic_syncer::enqueue_update_mirror_topic_commands(
                 .topic = topic,
                 .state = model::mirror_topic_state::failed,
               });
+            continue;
+        }
+
+        if (
+          mirror_topic_cache.source_topic_id.has_value()
+          && metadata_cache.topic_id.has_value()
+          && mirror_topic_cache.source_topic_id != metadata_cache.topic_id) {
+            vlog(
+              logger().warn,
+              "Topic {} has changed its topic ID from {} -> {}.  Marking as "
+              "failed",
+              topic,
+              mirror_topic_cache.source_topic_id,
+              metadata_cache.topic_id);
+            commands.emplace_back(
+              model::update_mirror_topic_state_cmd{
+                .topic = topic, .state = model::mirror_topic_state::failed});
             continue;
         }
 
@@ -510,22 +539,25 @@ source_topic_syncer::find_candidate_topics_for_update(
             continue;
         }
 
-        auto [partition_count, rf, authorized_operations]
+        auto [partition_count, rf, authorized_operations, topic_id]
           = metadata_value.value();
 
         vlog(
           logger().trace,
-          "Emplacing topic {} with {} partitions, RF={} for update candidate",
+          "Emplacing topic {} with {} partitions, RF={}, topic_id={} for "
+          "update candidate",
           topic,
           partition_count,
-          rf);
+          rf,
+          topic_id);
         candidate_topics.emplace(
           std::move(topic),
           std::make_pair(
             topic_metadata{
               .partition_count = partition_count,
               // Only mirror source topic replication factor if configured to do
-              .rf = mirror_rf ? std::make_optional(rf) : std::nullopt},
+              .rf = mirror_rf ? std::make_optional(rf) : std::nullopt,
+              .topic_id = topic_id},
             std::move(mirror_metadata)));
     }
 
@@ -565,7 +597,7 @@ source_topic_syncer::find_candidate_topics_for_creation(
             continue;
         }
 
-        auto [partition_count, rf, authorized_operations]
+        auto [partition_count, rf, authorized_operations, topic_id]
           = metadata_value.value();
 
         if (get_link()
@@ -624,7 +656,8 @@ source_topic_syncer::find_candidate_topics_for_creation(
             .partition_count = partition_count,
             // Only mirror source topic replication factor if configured to do
             // so
-            .rf = mirror_rf ? std::make_optional(rf) : std::nullopt});
+            .rf = mirror_rf ? std::make_optional(rf) : std::nullopt,
+            .topic_id = topic_id});
     }
 
     return candidate_topics;

--- a/src/v/cluster_link/source_topic_syncer.h
+++ b/src/v/cluster_link/source_topic_syncer.h
@@ -48,6 +48,7 @@ private:
     struct topic_metadata {
         int32_t partition_count;
         std::optional<int16_t> rf;
+        std::optional<::model::topic_id> topic_id;
     };
 
     using reconciler_commands = std::variant<

--- a/src/v/cluster_link/tests/source_topic_syncer_test.cc
+++ b/src/v/cluster_link/tests/source_topic_syncer_test.cc
@@ -318,6 +318,43 @@ TEST_F_CORO(source_topic_syncer_test, topic_with_no_partitions) {
     EXPECT_TRUE(mirror_topics.empty());
 }
 
+TEST_F_CORO(source_topic_syncer_test, topic_id_changes) {
+    auto topic_name = ::model::topic("test_topic");
+    fixture()->get_cluster_mock().add_topic(
+      topic_name, 3, 3, kafka::topic_authorized_operations(0x508));
+
+    co_await fixture()->upsert_link(get_default_metadata());
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, topic_name] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        if (!link_metadata.has_value()) {
+            return false;
+        }
+        auto& mirror_topics = link_metadata->get().state.mirror_topics;
+        return mirror_topics.contains(topic_name);
+    });
+
+    fixture()->get_cluster_mock().remove_topic(topic_name);
+    // Re-create the topic which should change the topic ID
+    fixture()->get_cluster_mock().add_topic(
+      topic_name, 3, 3, kafka::topic_authorized_operations(0x508));
+
+    RPTEST_REQUIRE_EVENTUALLY_CORO(5s, [this, topic_name] {
+        auto link_metadata = fixture()->find_link_by_name(
+          model::name_t("test_link"));
+        if (!link_metadata.has_value()) {
+            return false;
+        }
+        auto& mirror_topics = link_metadata->get().state.mirror_topics;
+        auto it = mirror_topics.find(topic_name);
+        if (it == mirror_topics.end()) {
+            return false;
+        }
+        return it->second.state == model::mirror_topic_state::failed;
+    });
+}
+
 TEST_F_CORO(source_topic_syncer_test, topic_with_no_replicas) {
     fixture()->get_cluster_mock().add_topic(
       ::model::topic("test_topic"),

--- a/src/v/kafka/client/test/cluster_mock.cc
+++ b/src/v/kafka/client/test/cluster_mock.cc
@@ -201,7 +201,8 @@ void cluster_mock::register_broker_handler(
 }
 
 ss::future<response_t> cluster_mock::handle_metadata_request(
-  model::node_id, request_t req, api_version) {
+  model::node_id, request_t req, api_version v) {
+    static const auto topic_id_support_version = api_version(10);
     auto md_req = std::get<metadata_request>(std::move(req));
     metadata_response_data r_data;
     for (auto& b : _brokers) {
@@ -216,8 +217,10 @@ ss::future<response_t> cluster_mock::handle_metadata_request(
 
     for (const auto& [topic, md] : _topics) {
         metadata_response::topic md_topic;
-        // TODO - Update when supporting topic IDs on RP
         md_topic.name = topic;
+        if (v >= topic_id_support_version) {
+            md_topic.topic_id = md.topic_id;
+        }
 
         md_topic.topic_authorized_operations
           = md_req.data.include_topic_authorized_operations
@@ -372,7 +375,8 @@ void cluster_mock::add_topic(
   model::topic topic_name,
   size_t partition_count,
   size_t replication_factor,
-  kafka::topic_authorized_operations authorized_operations) {
+  kafka::topic_authorized_operations authorized_operations,
+  std::optional<model::topic_id> topic_id) {
     if (_topics.contains(topic_name)) {
         // Topic already exists, do not overwrite
         throw std::invalid_argument(
@@ -390,6 +394,7 @@ void cluster_mock::add_topic(
 
     topic_metadata md;
     md.authorized_operations = authorized_operations;
+    md.topic_id = topic_id.value_or(model::topic_id{uuid_t::create()});
 
     for (auto p_id : std::views::iota(size_t(0), partition_count)) {
         partition_metadata p_md{

--- a/src/v/kafka/client/test/cluster_mock.h
+++ b/src/v/kafka/client/test/cluster_mock.h
@@ -121,7 +121,8 @@ public:
       size_t partition_count,
       size_t replication_factor,
       kafka::topic_authorized_operations authorized_operations
-      = kafka::topic_authorized_operations_not_set);
+      = kafka::topic_authorized_operations_not_set,
+      std::optional<model::topic_id> topic_id = std::nullopt);
     void remove_topic(model::topic_view topic_name);
 
     void set_topic_partition_count(

--- a/src/v/kafka/client/test/cluster_test_with_mock.cc
+++ b/src/v/kafka/client/test/cluster_test_with_mock.cc
@@ -145,11 +145,13 @@ TEST_F(cluster_mock_fixture, TestTopicMetadata) {
       model::node_id(1), net::unresolved_address{"localhost", 9092});
     cluster.start().get();
     auto deferred_stop = ss::defer([&cluster] { cluster.stop().get(); });
+    auto topic_id = model::topic_id{uuid_t::create()};
     cluster_mock.add_topic(
       model::topic{"test-topic"},
       3,
       1,
-      kafka::topic_authorized_operations{0x508});
+      kafka::topic_authorized_operations{0x508},
+      topic_id);
     EXPECT_NO_THROW(cluster.request_metadata_update().get())
       << "request_metadata_update threw";
     RPTEST_REQUIRE_EVENTUALLY(30s, [&] {
@@ -164,4 +166,5 @@ TEST_F(cluster_mock_fixture, TestTopicMetadata) {
     EXPECT_EQ(auth_ops.value(), 0x508);
     EXPECT_EQ(
       cluster.get_cluster_authorized_operations(), cluster_authorized_ops);
+    EXPECT_EQ(topics.topic_id_for_name(model::topic{"test-topic"}), topic_id);
 }

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -28,6 +28,9 @@ void topic_cache::apply(
           "topic::name is nullable in v12+");
         auto& cache_t = new_cache.emplace(*t.name, topic_data{}).first->second;
         cache_t.authorized_operations = t.topic_authorized_operations;
+        if (t.topic_id != model::topic_id{}) {
+            cache_t.topic_id = t.topic_id;
+        }
         if (!t.partitions.empty()) {
             cache_t.replication_factor = t.partitions[0].replica_nodes.size();
         }
@@ -81,6 +84,15 @@ topic_cache::leader_epoch(model::topic_partition_view tp) const {
     }
 
     return p_data.leader_epoch;
+}
+
+std::optional<model::topic_id>
+topic_cache::topic_id_for_name(model::topic_view tp) const {
+    auto topic_it = _topics.find(tp);
+    if (topic_it == _topics.end()) {
+        return std::nullopt;
+    }
+    return topic_it->second.topic_id;
 }
 
 std::optional<kafka::topic_authorized_operations>

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -32,6 +32,7 @@ class topic_cache {
         kafka::topic_authorized_operations authorized_operations
           = kafka::topic_authorized_operations_not_set;
         int16_t replication_factor;
+        std::optional<model::topic_id> topic_id;
     };
 
     using topics_t = chunked_hash_map<model::topic, topic_data>;
@@ -52,7 +53,10 @@ public:
     std::optional<kafka::leader_epoch>
       leader_epoch(model::topic_partition_view) const;
 
+    /// \brief A view of all known topics
     auto topics() const { return std::views::keys(_topics); }
+
+    std::optional<model::topic_id> topic_id_for_name(model::topic_view) const;
 
     std::optional<kafka::topic_authorized_operations>
     authorized_operations_for_topic(model::topic_view tp) const;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Add support for handling Topic IDs in the kafka client and applying them to the cluster link table mirror topic list.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
