### PR TITLE
Hold fetch semaphore units until response is sent

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -525,17 +525,18 @@ ss::future<> connection_context::handle_auth_v0(const size_t size) {
 
     sasl_authenticate_response response;
     {
+        auto sres = ss::make_lw_shared<session_resources>();
         auto ctx = request_context(
           shared_from_this(),
+          sres,
           request_header{
             .key = sasl_authenticate_api::key,
             .version = version,
           },
           std::move(request_buf),
           0s);
-        auto sres = session_resources{};
         auto resp = co_await kafka::process_request(
-                      std::move(ctx), _server.smp_group(), sres)
+                      std::move(ctx), _server.smp_group(), *sres)
                       .response;
         auto data = std::move(*resp).release();
         response.decode(std::move(data), version);
@@ -770,7 +771,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
     }
     auto self = shared_from_this();
     auto rctx = request_context(
-      self, std::move(hdr), std::move(buf), sres->backpressure_delay);
+      self, sres, std::move(hdr), std::move(buf), sres->backpressure_delay);
 
     /**
      * Not virtualized connection, simply forward to protocol state for request

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -125,6 +125,7 @@ struct session_resources {
     std::unique_ptr<handler_probe::hist_t::measurement> handler_latency;
     std::unique_ptr<request_tracker> tracker;
     request_data request_data;
+    ss::deleter response_resource_deleter;
 };
 using vcluster_connection_id
   = named_type<uint32_t, struct vcluster_connection_id_tag>;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1869,7 +1869,8 @@ ss::future<response_ptr> op_context::send_error_response(error_code ec) && {
 op_context::response_placeholder::response_placeholder(
   fetch_response::iterator it, op_context* ctx)
   : _it(it)
-  , _ctx(ctx) {}
+  , _ctx(ctx)
+  , _ktp(_it->partition->topic, _it->partition_response->partition_index) {}
 
 void op_context::response_placeholder::set(
   fetch_response::partition_response&& response) {

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -209,12 +209,12 @@ static ss::future<read_result> read_from_partition(
       std::move(aborted_transactions));
 }
 
-read_result::memory_units_t::memory_units_t(
+fetch_memory_units::fetch_memory_units(
   ssx::semaphore& memory_sem, ssx::semaphore& memory_fetch_sem) noexcept
   : kafka(ss::consume_units(memory_sem, 0))
   , fetch(ss::consume_units(memory_fetch_sem, 0)) {}
 
-read_result::memory_units_t::~memory_units_t() noexcept {
+fetch_memory_units::~fetch_memory_units() noexcept {
     if (shard == ss::this_shard_id() || !has_units()) {
         return;
     }
@@ -228,7 +228,7 @@ read_result::memory_units_t::~memory_units_t() noexcept {
     }
 }
 
-void read_result::memory_units_t::adopt(memory_units_t&& o) {
+void fetch_memory_units::adopt(fetch_memory_units&& o) {
     // Adopts assert internally that the units are from the same semaphore.
     // So there is no need to assert that they are from the same shard here.
     kafka.adopt(std::move(o.kafka));
@@ -247,12 +247,12 @@ void read_result::memory_units_t::adopt(memory_units_t&& o) {
  *   is assumed that a batch size has already been consumed from kafka
  *   memory semaphore for it.
  */
-static read_result::memory_units_t reserve_memory_units(
+static fetch_memory_units reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,
   const bool obligatory_batch_read) {
-    read_result::memory_units_t memory_units;
+    fetch_memory_units memory_units;
     const size_t memory_kafka_now = memory_sem.current();
     const size_t memory_fetch = memory_fetch_sem.current();
     const size_t batch_size_estimate
@@ -309,7 +309,7 @@ static void adjust_semaphore_units(
 static void adjust_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
-  read_result::memory_units_t& memory_units,
+  fetch_memory_units& memory_units,
   const size_t read_bytes) {
     adjust_semaphore_units(memory_sem, memory_units.kafka, read_bytes);
     adjust_semaphore_units(memory_fetch_sem, memory_units.fetch, read_bytes);
@@ -330,7 +330,7 @@ static ss::future<read_result> do_read_from_ntp(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem) {
     // control available memory
-    read_result::memory_units_t memory_units(memory_sem, memory_fetch_sem);
+    fetch_memory_units memory_units(memory_sem, memory_fetch_sem);
     if (!ntp_config.cfg.skip_read) {
         memory_units = reserve_memory_units(
           memory_sem,
@@ -458,7 +458,7 @@ ss::future<read_result> read_from_ntp(
       memory_fetch_sem);
 }
 
-read_result::memory_units_t reserve_memory_units(
+fetch_memory_units reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,
@@ -490,7 +490,7 @@ static void fill_fetch_responses(
     }
 
     // Used to aggregate semaphore_units from results.
-    std::optional<read_result::memory_units_t> total_memory_units;
+    std::optional<fetch_memory_units> total_memory_units;
 
     for (auto idx : range) {
         auto& res = results[idx];

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -556,12 +556,16 @@ static void fill_fetch_responses(
           0, std::min({results.size(), responses.size()}));
     }
 
-    // Used to aggregate semaphore_units from results.
-    std::optional<fetch_memory_units> total_memory_units;
+    // Used to aggregate semaphore units together by the shard they originate
+    // from. All units aggregated will be released when this function exits.
+    // Aggregating them ensures there is at most one cross shard call to each
+    // shard.
+    memory_units_by_shard mem_units_to_delete;
 
     for (auto idx : range) {
         auto& res = results[idx];
         const auto& resp_it = responses[idx];
+        const auto& ktp = resp_it->ktp();
 
         fetch_response::partition_response resp;
         resp.partition_index = res.partition;
@@ -589,10 +593,7 @@ static void fill_fetch_responses(
          * Cache fetch metadata
          */
         octx.rctx.get_fetch_metadata_cache().insert_or_assign(
-          {resp_it->topic(), resp_it->partition_id()},
-          res.start_offset,
-          res.high_watermark,
-          res.last_stable_offset);
+          ktp, res.start_offset, res.high_watermark, res.last_stable_offset);
         /**
          * Over response budget, we will just waste this read, it will cause
          * data to be stored in the cache so next read is fast
@@ -601,27 +602,33 @@ static void fill_fetch_responses(
             resp.preferred_read_replica = *res.preferred_replica;
         }
 
-        // Aggregate memory_units from all results together to avoid
-        // making more than one cross-shard function call to free them.
-        //
-        // Only aggregate non-empty memory_units.
-        if (res.memory_units.has_units()) {
-            if (unlikely(!total_memory_units)) {
-                // Move the first set of semaphore_units to get a copy of the
-                // semaphore pointer and the shard results originates from.
-                total_memory_units = std::move(res.memory_units);
-            } else {
-                total_memory_units->adopt(std::move(res.memory_units));
-            }
+        if (record_latency) {
+            std::chrono::microseconds fetch_latency
+              = std::chrono::duration_cast<std::chrono::microseconds>(
+                op_context::latency_clock::now() - start_time);
+            octx.rctx.probe().record_fetch_latency(fetch_latency);
         }
+
+        if (!res.has_data()) {
+            // It's possible that data for this partition has already been
+            // written to the response, but is no longer in the partition due to
+            // truncation or otherwise. Hence we move any existing response
+            // units out of the op_context and into the deleter here.
+            mem_units_to_delete.add_units(
+              octx.response_memory_units.remove_units(ktp));
+            resp.records = batch_reader();
+            resp_it->set(std::move(resp));
+            continue;
+        }
+
+        auto current_response_size = resp_it->response_size();
+        auto bytes_left = octx.bytes_left - current_response_size;
 
         /**
          * According to KIP-74 we have to return first batch even if it would
          * violate max_bytes fetch parameter
          */
-        if (
-          res.has_data()
-          && (octx.bytes_left >= res.data_size_bytes() || octx.response_size == 0)) {
+        if (bytes_left >= res.data_size_bytes() || octx.response_size == 0) {
             /**
              * set aborted transactions if present
              */
@@ -639,19 +646,29 @@ static void fill_fetch_responses(
                   });
                 resp.aborted_transactions = std::move(aborted);
             }
+
+            // Move the units for the previously written response into the
+            // deleter and the new units into the op_context.
+            mem_units_to_delete.add_units(octx.response_memory_units.add_units(
+              ktp, std::move(res.memory_units)));
+
             resp.records = batch_reader(std::move(res).release_data());
+            resp_it->set(std::move(resp));
         } else {
+            // The newly read partition data is free'd when the function
+            // exits. Hence the memory units should be free'd as well.
+            mem_units_to_delete.add_units(std::move(res.memory_units));
+
             // TODO: add probe to measure how much of read data is discarded
-            resp.records = batch_reader();
-        }
 
-        resp_it->set(std::move(resp));
-
-        if (record_latency) {
-            std::chrono::microseconds fetch_latency
-              = std::chrono::duration_cast<std::chrono::microseconds>(
-                op_context::latency_clock::now() - start_time);
-            octx.rctx.probe().record_fetch_latency(fetch_latency);
+            // If there was a previously written response that fits within the
+            // bytes_left limit then try to preserve it. However, it there
+            // wasn't then at least write the metadata for the partition into
+            // the response.
+            if (current_response_size == 0) {
+                resp.records = batch_reader();
+                resp_it->set(std::move(resp));
+            }
         }
     }
 }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -236,6 +236,73 @@ void fetch_memory_units::adopt(fetch_memory_units&& o) {
 }
 
 /**
+ * Used to aggregate memory units by their originating shard.
+ * This allows for any amount of memory units to be released with at most 1
+ * cross-shard call per shard.
+ */
+class memory_units_by_shard {
+public:
+    void add_units(fetch_memory_units&& units) {
+        auto map_it = _memory_units.find(units.shard);
+        if (map_it == _memory_units.end()) {
+            // Move the first set of semaphore_units to get a copy of
+            // the semaphore pointer and the shard results originates
+            // from.
+            _memory_units.insert_or_assign(units.shard, std::move(units));
+        } else {
+            map_it->second.adopt(std::move(units));
+        }
+    }
+
+    void add_units(std::optional<fetch_memory_units> units) {
+        if (units) {
+            add_units(std::move(units.value()));
+        }
+    }
+
+private:
+    chunked_hash_map<ss::shard_id, fetch_memory_units> _memory_units;
+};
+
+std::optional<fetch_memory_units> memory_units_by_ktp::add_units(
+  const model::ktp_with_hash& ktp, fetch_memory_units&& units) {
+    auto map_it = _memory_units.find(ktp);
+    if (map_it == _memory_units.end()) {
+        _memory_units.insert_or_assign(ktp, std::move(units));
+        return {};
+    } else {
+        auto old_units = std::move(map_it->second);
+        map_it->second = std::move(units);
+        return old_units;
+    }
+}
+
+std::optional<fetch_memory_units>
+memory_units_by_ktp::remove_units(const model::ktp_with_hash& ktp) {
+    return _memory_units.extract(ktp).transform(
+      [](auto v) { return std::get<1>(std::move(v)); });
+}
+
+ss::deleter memory_units_by_ktp::into_deleter() && {
+    return ss::make_deleter([memory_units = std::move(_memory_units)] mutable {
+        // Aggregate units to ensure only one cross shard call to each shard at
+        // most.
+        memory_units_by_shard units_per_shard;
+        for (auto& [_, units] : memory_units) {
+            units_per_shard.add_units(std::move(units));
+        }
+    });
+}
+
+size_t memory_units_by_ktp::unit_count() {
+    size_t total_units = 0;
+    for (const auto& [_, units] : _memory_units) {
+        total_units += units.fetch.count();
+    }
+    return total_units;
+}
+
+/**
  * Consume proper amounts of units from memory semaphores and return them as
  * semaphore_units. Fetch semaphore units returned are the indication of
  * available resources: if none, there is no memory for the operation;
@@ -1631,6 +1698,9 @@ fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
           }
           octx.response.data.error_code = error_code::none;
           return do_fetch(octx).then([&octx] {
+              auto resp_units_deleter
+                = std::move(octx.response_memory_units).into_deleter();
+
               // NOTE: Audit call doesn't happen until _after_ the fetch
               // is done. This was done for the sake of simplicity and
               // because fetch doesn't alter the state of the broker
@@ -1638,6 +1708,9 @@ fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
                   return std::move(octx).send_error_response(
                     error_code::broker_not_available);
               }
+
+              octx.rctx.add_response_resource_deleter(
+                std::move(resp_units_deleter));
               return std::move(octx).send_response();
           });
       });

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -55,6 +55,8 @@ struct op_context {
             return _it->partition_response->partition_index;
         }
 
+        const model::ktp_with_hash& ktp() { return _ktp; }
+
         bool empty() { return _it->partition_response->records->empty(); }
         bool has_error() {
             return _it->partition_response->error_code != error_code::none;
@@ -69,6 +71,7 @@ struct op_context {
     private:
         fetch_response::iterator _it;
         op_context* _ctx;
+        const model::ktp_with_hash _ktp;
     };
 
     using iteration_order_t

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -217,6 +217,34 @@ struct ntp_fetch_config {
     }
 };
 
+/***
+ * Holds semaphore units from memory semaphores. Can be passed across
+ * shards, semaphore units will be released in the shard where the instance
+ * of this class has been created.
+ */
+struct fetch_memory_units {
+    ssx::semaphore_units kafka;
+    ssx::semaphore_units fetch;
+    ss::shard_id shard = ss::this_shard_id();
+
+    ~fetch_memory_units() noexcept;
+    fetch_memory_units() noexcept = default;
+    fetch_memory_units(fetch_memory_units&&) noexcept = default;
+    fetch_memory_units& operator=(fetch_memory_units&&) noexcept = default;
+    fetch_memory_units(const fetch_memory_units&) = delete;
+    fetch_memory_units& operator=(const fetch_memory_units&) = delete;
+    fetch_memory_units(
+      ssx::semaphore& memory_sem, ssx::semaphore& memory_fetch_sem) noexcept;
+
+    /*
+     * Adopts another fetch_memory_units. This requires that both
+     * fetch_memory_units are from the same shard.
+     */
+    void adopt(fetch_memory_units&& o);
+
+    bool has_units() const { return fetch.count() > 0 || kafka.count() > 0; }
+};
+
 /**
  * Simple type aggregating either data or an error
  */
@@ -224,35 +252,6 @@ struct read_result {
     using foreign_data_t = ss::foreign_ptr<std::unique_ptr<iobuf>>;
     using data_t = std::unique_ptr<iobuf>;
     using variant_t = std::variant<data_t, foreign_data_t>;
-
-    /// Holds semaphore units from memory semaphores. Can be passed across
-    /// shards, semaphore units will be released in the shard where the instance
-    /// of this class has been created.
-    struct memory_units_t {
-        ssx::semaphore_units kafka;
-        ssx::semaphore_units fetch;
-        ss::shard_id shard = ss::this_shard_id();
-
-        ~memory_units_t() noexcept;
-        memory_units_t() noexcept = default;
-        memory_units_t(memory_units_t&&) noexcept = default;
-        memory_units_t& operator=(memory_units_t&&) noexcept = default;
-        memory_units_t(const memory_units_t&) = delete;
-        memory_units_t& operator=(const memory_units_t&) = delete;
-        memory_units_t(
-          ssx::semaphore& memory_sem,
-          ssx::semaphore& memory_fetch_sem) noexcept;
-
-        /*
-         * Adopts another memory_units_t. This requires that both
-         * memory_units_t are from the same shard.
-         */
-        void adopt(memory_units_t&& o);
-
-        bool has_units() const {
-            return fetch.count() > 0 || kafka.count() > 0;
-        }
-    };
 
     explicit read_result(error_code e)
       : start_offset(-1)
@@ -345,7 +344,7 @@ struct read_result {
     error_code error;
     model::partition_id partition;
     std::vector<cluster::tx::tx_range> aborted_transactions;
-    memory_units_t memory_units;
+    fetch_memory_units memory_units;
 };
 // struct aggregating fetch requests and corresponding response iterators for
 // the same shard
@@ -445,7 +444,7 @@ ss::future<read_result> read_from_ntp(
  */
 kafka::fetch_plan make_simple_fetch_plan(op_context& octx);
 
-read_result::memory_units_t reserve_memory_units(
+fetch_memory_units reserve_memory_units(
   ssx::semaphore& memory_sem,
   ssx::semaphore& memory_fetch_sem,
   const size_t max_bytes,

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "cluster/rm_stm.h"
+#include "container/chunked_hash_map.h"
 #include "container/chunked_vector.h"
 #include "container/intrusive_list_helpers.h"
 #include "kafka/protocol/fetch.h"
@@ -36,6 +37,29 @@ using fetch_handler = single_stage_handler<
   13,
   default_estimate_adaptor,
   fetch_scheduling_group_provider>;
+
+struct fetch_memory_units;
+class memory_units_by_ktp {
+public:
+    /// Adds memory units for the provided ktp. Note that any existing memory
+    /// units for the ktp are returned.
+    [[nodiscard]]
+    std::optional<fetch_memory_units>
+    add_units(const model::ktp_with_hash&, fetch_memory_units&&);
+
+    /// Removes and returns all units for the provided ktp.
+    [[nodiscard]]
+    std::optional<fetch_memory_units> remove_units(const model::ktp_with_hash&);
+
+    /// Moves `response_memory_units` into a `ss::deleter`.
+    ss::deleter into_deleter() &&;
+
+    /// Returns the total number of units held by this class.
+    size_t unit_count();
+
+private:
+    chunked_hash_map<model::ktp_with_hash, fetch_memory_units> _memory_units;
+};
 
 /*
  * Fetch operation context
@@ -171,6 +195,12 @@ struct op_context {
     // for fetches that have preferred replica set we skip read, therefore we
     // need other indicator of finished fetch request.
     bool contains_preferred_replica = false;
+
+    // For tracking memory used by each ktp in the response. It is tracked
+    // per-ktp as the fetch path can re-read a ktp and have to release the
+    // current units for that ktp in order to fill the response with the newly
+    // read result.
+    memory_units_by_ktp response_memory_units;
 };
 
 struct fetch_config {

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -68,6 +68,12 @@ struct op_context {
         }
         intrusive_list_hook _hook;
 
+        size_t response_size() {
+            return _it->partition_response->records
+              .transform(&kafka::batch_reader::size_bytes)
+              .value_or(0);
+        }
+
     private:
         fetch_response::iterator _it;
         op_context* _ctx;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -86,10 +86,12 @@ class request_context {
 public:
     request_context(
       ss::lw_shared_ptr<connection_context> conn,
+      ss::lw_shared_ptr<session_resources> sres,
       request_header&& header,
       iobuf&& request,
       ss::lowres_clock::duration throttle_delay) noexcept
       : _conn(std::move(conn))
+      , _session_resources(std::move(sres))
       , _request_size(request.size_bytes())
       , _header(std::move(header))
       , _reader(std::move(request))
@@ -418,6 +420,12 @@ public:
         return _conn->server().container().local().is_cluster_link_active();
     }
 
+    void add_response_resource_deleter(ss::deleter&& res) {
+        _session_resources->response_resource_deleter = ss::make_object_deleter(
+          std::move(_session_resources->response_resource_deleter),
+          std::move(res));
+    }
+
 private:
     template<typename T>
     security::auth_result do_authorized(
@@ -502,6 +510,7 @@ private:
 
 private:
     ss::lw_shared_ptr<connection_context> _conn;
+    ss::lw_shared_ptr<session_resources> _session_resources;
     size_t _request_size;
     request_header _header;
     protocol::decoder _reader;

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -755,7 +755,9 @@ redpanda_cc_btest(
     ],
     cpu = 1,
     deps = [
+        "//src/v/base",
         "//src/v/cluster/tests:cluster_test_fixture",
+        "//src/v/container:chunked_vector",
         "//src/v/kafka/protocol",
         "//src/v/kafka/server",
         "//src/v/model",

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -7,7 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "base/units.h"
 #include "cluster/tests/cluster_test_fixture.h"
+#include "container/chunked_vector.h"
 #include "kafka/protocol/batch_consumer.h"
 #include "kafka/protocol/types.h"
 #include "kafka/server/handlers/fetch.h"
@@ -1131,4 +1133,80 @@ FIXTURE_TEST(fetch_offset_out_of_range, redpanda_thread_fixture) {
       resp.data.responses[0].partitions[0].high_watermark, hwm);
     BOOST_REQUIRE_EQUAL(
       resp.data.responses[0].partitions[0].last_stable_offset, hwm);
+}
+
+FIXTURE_TEST(fetch_response_bytes_eq_units, redpanda_thread_fixture) {
+    // create topic with single partition
+    model::topic topic("foo");
+    model::partition_id pid(0);
+    auto ntp = make_default_ntp(topic, pid);
+    wait_for_controller_leadership().get();
+    add_topic(model::topic_namespace_view(ntp)).get();
+
+    wait_for_partition_offset(ntp, model::offset(0)).get();
+
+    // append some data
+    auto shard = app.shard_table.local().shard_for(ntp);
+    app.partition_manager
+      .invoke_on(
+        *shard,
+        [ntp](cluster::partition_manager& mgr) {
+            return model::test::make_random_batches(model::offset(0), 20)
+              .then([ntp, &mgr](auto batches) {
+                  auto partition = mgr.get(ntp);
+                  return partition->raft()->replicate(
+                    chunked_vector<model::record_batch>(
+                      std::from_range,
+                      std::move(batches) | std::views::as_rvalue),
+                    raft::replicate_options(
+                      raft::consistency_level::quorum_ack));
+              });
+        })
+      .get();
+    wait_for_partition_offset(ntp, model::offset(20)).get();
+
+    auto conn_context = make_connection_context();
+    conn_context->start().get();
+
+    auto make_rctx = [&] {
+        auto fetch_topics = chunked_vector<kafka::fetch_topic>{};
+
+        fetch_topics.push_back(
+          kafka::fetch_topic{
+            .topic = topic,
+            .partitions = {kafka::fetch_partition{
+              .partition = pid,
+              .current_leader_epoch = kafka::leader_epoch(-1),
+              .fetch_offset = model::offset(0),
+              .log_start_offset = model::offset(-1),
+              .partition_max_bytes = 10 * MiB,
+            }}});
+
+        // create a request
+        kafka::fetch_request_data frq_data;
+        frq_data.replica_id = kafka::client::consumer_replica_id;
+        frq_data.max_wait_ms = 500ms;
+        frq_data.min_bytes = 1;
+        frq_data.max_bytes = 50_MiB;
+        frq_data.isolation_level = model::isolation_level::read_uncommitted;
+        frq_data.session_id = kafka::invalid_fetch_session_id;
+        frq_data.session_epoch = kafka::final_fetch_session_epoch;
+        frq_data.topics = std::move(fetch_topics);
+
+        auto request = kafka::fetch_request{.data = std::move(frq_data)};
+
+        kafka::request_header header{
+          .key = kafka::fetch_handler::api::key,
+          .version = kafka::api_version{12}};
+
+        return make_request_context(std::move(request), header, conn_context);
+    };
+
+    auto octx = kafka::op_context(make_rctx(), ss::default_smp_service_group());
+    kafka::testing::do_fetch(octx).get();
+    conn_context->stop().get();
+
+    BOOST_REQUIRE(octx.response_size > 0);
+    BOOST_REQUIRE(
+      octx.response_size == octx.response_memory_units.unit_count());
 }

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -834,9 +834,14 @@ kafka::request_context redpanda_thread_fixture::make_request_context_erased(
     iobuf buf;
     kafka::protocol::encoder writer(buf);
     encoder(writer);
+    auto sres = ss::make_lw_shared<kafka::session_resources>();
 
     return kafka::request_context(
-      conn, std::move(header), std::move(buf), std::chrono::milliseconds(0));
+      conn,
+      std::move(sres),
+      std::move(header),
+      std::move(buf),
+      std::chrono::milliseconds(0));
 }
 
 kafka::request_context redpanda_thread_fixture::make_fetch_request_context() {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR does the following:
- Adds a `ss::deleter` to `session_resources` that can be added to
  via `request_context`. This allows request handlers to free any resources
  related to the response after its been fully sent to the client.
- Adds `response_memory_units` to `op_context` to track memory units per 
  partition in the fetch response.
- Modifies `fill_fetch_responses` to ensures units in 
  `op_context::response_memory_units` accurately reflect data being used in 
  the fetch response.
- A few additional changes in `fill_fetch_responses` to make a more accurate
  `bytes_left` calculation and to avoid unnecessarily discarding data in the fetch response.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
