### PR TITLE
utils/s3fifo: reduce hook size by 33%

### DIFF
--- a/src/v/utils/s3_fifo.h
+++ b/src/v/utils/s3_fifo.h
@@ -16,7 +16,6 @@
 #include <fmt/format.h>
 
 #include <algorithm>
-#include <optional>
 
 /**
  * \defgroup cache Cache
@@ -314,10 +313,12 @@ private:
 
     friend class testing_details::cache_hook_accessor;
 
-    uint8_t freq_{0};
-    std::optional<uint64_t> ghost_insertion_time_;
-    location location_{};
     hook_type hook_;
+    // This is conceptually an optional, but that increases the struct size.
+    uint64_t ghost_insertion_time_{0};
+    bool has_ghost_insertion_time_{false};
+    uint8_t freq_{0};
+    location location_{};
 };
 
 /**
@@ -507,7 +508,7 @@ void cache<T, Hook, Evictor, Cost>::insert(T& entry) noexcept {
     auto& hook = entry.*Hook;
     if (ghost_queue_contains(entry)) {
         // evict from ghost queue
-        hook.ghost_insertion_time_.reset();
+        hook.has_ghost_insertion_time_ = false;
 
         main_fifo_.push_back(entry);
         hook.location_ = cache_hook::location::main;
@@ -586,8 +587,8 @@ bool cache<T, Hook, Evictor, Cost>::ghost_queue_contains(
      *   on_ghost = expires > now
      */
     const auto& hook = entry.*Hook;
-    if (hook.ghost_insertion_time_.has_value()) {
-        auto expires = *hook.ghost_insertion_time_ + max_main_queue_size_;
+    if (hook.has_ghost_insertion_time_) {
+        auto expires = hook.ghost_insertion_time_ + max_main_queue_size_;
         return expires > ghost_queue_age_;
     }
     return false;
@@ -630,6 +631,7 @@ bool cache<T, Hook, Evictor, Cost>::evict_small() noexcept {
 
             // insert into ghost queue
             hook.ghost_insertion_time_ = ghost_queue_age_;
+            hook.has_ghost_insertion_time_ = true;
             ghost_queue_age_ += cost;
             return true;
 

--- a/src/v/utils/tests/s3_fifo_test.cc
+++ b/src/v/utils/tests/s3_fifo_test.cc
@@ -18,12 +18,15 @@ class cache_hook_accessor {
 public:
     static std::optional<size_t>
     get_hook_insertion_time(const utils::s3_fifo::cache_hook& hook) {
-        return hook.ghost_insertion_time_;
+        return hook.has_ghost_insertion_time_
+                 ? std::make_optional(hook.ghost_insertion_time_)
+                 : std::nullopt;
     }
 
     static void set_hook_insertion_time(
       utils::s3_fifo::cache_hook& hook, std::optional<size_t> time) {
-        hook.ghost_insertion_time_ = time;
+        hook.ghost_insertion_time_ = time.value_or(0);
+        hook.has_ghost_insertion_time_ = time.has_value();
     }
 
     static uint8_t get_hook_freq(utils::s3_fifo::cache_hook& hook) {


### PR DESCRIPTION
Due to padding and alignment, the current struct is 48 bytes. With these
changes it's now 32 bytes.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
