### PR TITLE
tests: skip tests on FIPS

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -2979,6 +2979,7 @@ class AuditLogTestSchemaRegistryACLs(AuditLogTestSchemaRegistryBase):
             "authn attempt in sr",
         )
 
+    @skip_fips_mode
     @cluster(num_nodes=5)
     @matrix(
         endpoint_name=[e.name for e in PUBLIC_ENDPOINTS],
@@ -3232,6 +3233,7 @@ class AuditLogTestBypassBase(AuditLogTestBase):
     def setUp(self):
         super().setUp(wait_for_audit_log=self.expect_topic)
 
+    @skip_fips_mode
     @cluster(
         num_nodes=4,
         log_allow_list=[


### PR DESCRIPTION
These tests expect the `ocsf-server` dependency to be installed. However, this dependency is skipped on fips CDT builds. Thus, these tests should be skipped on FIPS

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

