### PR TITLE
cloud topics: prep for retention work

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -2682,7 +2682,7 @@ ss::future<> ntp_archiver::apply_archive_retention() {
     }
 
     const auto& ntp_conf = _parent.get_ntp_config();
-    if (!ntp_conf.is_collectable()) {
+    if (!ntp_conf.is_remotely_collectable()) {
         vlog(_rtclog.trace, "NTP is not collectable");
         co_return;
     }

--- a/src/v/cluster/archival/retention_calculator.cc
+++ b/src/v/cluster/archival/retention_calculator.cc
@@ -79,7 +79,7 @@ std::optional<retention_calculator> retention_calculator::factory(
   const cloud_storage::partition_manifest& manifest,
   const storage::ntp_config& ntp_config,
   std::optional<kafka::offset> pinned_offset) {
-    if (!ntp_config.is_collectable()) {
+    if (!ntp_config.is_remotely_collectable()) {
         vlog(
           archival_log.trace, "{} Partition not collectible", ntp_config.ntp());
         return std::nullopt;

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -468,6 +468,9 @@ log_eviction_stm_factory::log_eviction_stm_factory(storage::kvstore& kvstore)
 
 bool log_eviction_stm_factory::is_applicable_for(
   const storage::ntp_config& cfg) const {
+    if (cfg.cloud_topic_enabled()) {
+        return false;
+    }
     return !storage::deletion_exempt(cfg.ntp());
 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -113,7 +113,7 @@ ss::future<std::error_code> partition::prefix_truncate(
   model::offset rp_start_offset,
   kafka::offset kafka_start_offset,
   ss::lowres_clock::time_point deadline) {
-    if (!_log_eviction_stm || !_raft->log_config().is_collectable()) {
+    if (!_log_eviction_stm || !_raft->log_config().is_locally_collectable()) {
         vlog(
           clusterlog.info,
           "Cannot prefix-truncate topic/partition {} retention settings not "

--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -255,7 +255,7 @@ std::ostream& operator<<(std::ostream& o, const retention& r) {
 }
 
 static retention get_retention_policy(const storage::ntp_config& prop) {
-    if (prop.is_collectable()) {
+    if (prop.is_remotely_collectable()) {
         // If a space constraint is set on the topic, use that: otherwise
         // use time based constraint if present.  If total retention setting
         // is less than local retention setting, take the smallest.
@@ -265,7 +265,7 @@ static retention get_retention_policy(const storage::ntp_config& prop) {
         //
         // This will also drop the compact settings and replace it with
         // delete.
-        auto overrides = prop.get_overrides();
+        const auto& overrides = prop.get_overrides();
         if (overrides.retention_local_target_bytes.has_optional_value()) {
             auto v = overrides.retention_local_target_bytes.value();
 

--- a/src/v/kafka/server/handlers/delete_records.cc
+++ b/src/v/kafka/server/handlers/delete_records.cc
@@ -58,7 +58,7 @@ validate_at_topic_level(request_context& ctx, const delete_records_topic& t) {
         if (cfg.is_read_replica()) {
             return false;
         }
-        /// Immitates the logic in ntp_config::is_collectable
+        /// Immitates the logic in ntp_config::is_*_collectable
         if (
           !cfg.properties.has_overrides()
           || !cfg.properties.cleanup_policy_bitflags) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1756,7 +1756,7 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
         co_return request_eviction_until_offset(offset);
     }
 
-    if (!config().is_collectable()) {
+    if (!config().is_locally_collectable()) {
         co_return std::nullopt;
     }
 
@@ -2987,7 +2987,7 @@ disk_log_impl::max_eligible_for_compacted_reupload_offset(
             // perfectly compacted data that truncation leaves us with
             // uncompacted data in cloud storage. so in this case, a single
             // round of windowed compaction is 'enough'.
-            if (config().is_collectable()) {
+            if (config().is_locally_collectable()) {
                 return seg->finished_windowed_compaction();
             }
 
@@ -3711,7 +3711,7 @@ ss::shared_ptr<log> make_disk_backed_log(
 ss::future<std::pair<usage, reclaim_size_limits>>
 disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
     std::optional<model::offset> max_offset;
-    if (config().is_collectable()) {
+    if (config().is_locally_collectable()) {
         auto cfg = apply_overrides(input_cfg);
         max_offset = retention_offset(cfg);
     }
@@ -3889,7 +3889,9 @@ disk_log_impl::disk_usage_target(gc_config cfg, usage usage) {
          * report space wanted as `factor * current capacity` to reflect that we
          * want space for continued growth.
          */
-        if (!config().is_collectable() || deletion_exempt(config().ntp())) {
+        if (
+          !config().is_locally_collectable()
+          || deletion_exempt(config().ntp())) {
             target.min_capacity_wanted = usage.total() * 2;
             co_return target;
         }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -237,23 +237,35 @@ public:
     }
 
     topic_recovery_enabled recovery_enabled() const {
+        if (cloud_topic_enabled()) {
+            return topic_recovery_enabled::no;
+        }
         return _overrides != nullptr ? _overrides->recovery_enabled
                                      : topic_recovery_enabled::no;
     }
 
     bool is_archival_enabled() const {
+        if (cloud_topic_enabled()) {
+            return false;
+        }
         return _overrides != nullptr && _overrides->shadow_indexing_mode
                && model::is_archival_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
 
     bool is_remote_fetch_enabled() const {
+        if (cloud_topic_enabled()) {
+            return false;
+        }
         return _overrides != nullptr && _overrides->shadow_indexing_mode
                && model::is_fetch_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
 
     bool is_read_replica_mode_enabled() const {
+        if (cloud_topic_enabled()) {
+            return false;
+        }
         return _overrides != nullptr && _overrides->read_replica
                && _overrides->read_replica.value();
     }
@@ -272,6 +284,9 @@ public:
      * both reads and writes to S3, and is not a read replica.
      */
     bool is_tiered_storage() const {
+        if (cloud_topic_enabled()) {
+            return false;
+        }
         return _overrides != nullptr
                && !_overrides->read_replica.value_or(false)
                && _overrides->shadow_indexing_mode
@@ -307,7 +322,7 @@ public:
     }
 
     bool write_caching() const {
-        if (!model::is_user_topic(_ntp)) {
+        if (!model::is_user_topic(_ntp) || cloud_topic_enabled()) {
             return false;
         }
         auto cluster_default
@@ -400,6 +415,10 @@ public:
     }
 
     model::iceberg_mode iceberg_mode() const {
+        // TODO(cloud_topics): support iceberg
+        if (cloud_topic_enabled()) {
+            return model::iceberg_mode::disabled;
+        }
         if (!config::shard_local_cfg().iceberg_enabled) {
             return model::iceberg_mode::disabled;
         }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -170,7 +170,18 @@ public:
                && model::is_compaction_enabled(cleanup_policy());
     }
 
-    bool is_collectable() const {
+    // If time/bytes based retention is enabled for local storage.
+    bool is_locally_collectable() const {
+        if (cloud_topic_enabled()) {
+            // Cloud topics always manually retains the log based
+            // on what has been written to L1.
+            return false;
+        }
+        return model::is_deletion_enabled(cleanup_policy());
+    }
+
+    // If time/bytes based retention is enabled for remote storage.
+    bool is_remotely_collectable() const {
         return model::is_deletion_enabled(cleanup_policy());
     }
 

--- a/src/v/storage/tests/log_retention_test.cc
+++ b/src/v/storage/tests/log_retention_test.cc
@@ -459,7 +459,7 @@ TEST_F(gc_fixture, non_collectible_disk_usage_test) {
         offset += model::offset(num_records);
     }
 
-    ASSERT_EQ(builder.get_disk_log_impl().config().is_collectable(), false);
+    ASSERT_FALSE(builder.get_disk_log_impl().config().is_locally_collectable());
 
     EXPECT_EQ(
       builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention,


### PR DESCRIPTION
- **storage: split the concept of locally vs remotely collectable.**
- **cluster: disable log_eviction_stm for cloud topics**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
