### PR TITLE
ct/l1: reader followups

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -212,6 +212,7 @@ domain_manager::get_first_offset_ge(rpc::get_first_offset_ge_request req) {
             .oid = obj.oid,
             .footer_pos = obj.footer_pos,
             .object_size = obj.object_size,
+            .last_offset = obj.last_offset,
         },
     };
 }
@@ -245,6 +246,7 @@ domain_manager::get_first_timestamp_ge(
             .oid = obj.oid,
             .footer_pos = obj.footer_pos,
             .object_size = obj.object_size,
+            .last_offset = obj.last_offset,
         },
     };
 }

--- a/src/v/cloud_topics/level_one/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/reader.cc
@@ -204,10 +204,10 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
     auto* abort_source = _config.abort_source
                            ? &_config.abort_source.value().get()
                            : &default_abort_source;
-    auto stream_fut = co_await ss::coroutine::as_future(
-      _io->read_object(extent, abort_source));
-    if (stream_fut.failed()) {
-        auto ex = stream_fut.get_exception();
+    auto read_fut = co_await ss::coroutine::as_future(
+      _io->read_object_as_iobuf(extent, abort_source));
+    if (read_fut.failed()) {
+        auto ex = read_fut.get_exception();
         vlog(
           cd_log.error,
           "Exception opening stream for footer from object {} (pos {} object "
@@ -218,40 +218,28 @@ ss::future<l1::footer> level_one_log_reader_impl::read_footer(
           ex);
         std::rethrow_exception(ex);
     }
-    auto stream_result = stream_fut.get();
-    if (!stream_result.has_value()) {
-        throw std::runtime_error(
-          fmt::format(
-            "Failed to open stream for footer from object {} (pos {} size {}): "
-            "{}",
-            oid,
-            extent.position,
-            object_size,
-            std::to_underlying(stream_result.error())));
-    }
 
-    auto& stream = stream_result.value();
-
-    auto footer_fut = co_await ss::coroutine::as_future(
-      read_iobuf_exactly(stream, footer_total_size));
-    if (footer_fut.failed()) {
-        auto ex = footer_fut.get_exception();
+    auto read_result = read_fut.get();
+    if (!read_result.has_value()) {
         vlog(
           cd_log.error,
-          "Exception reading footer from object {} (pos {} object size {}): {}",
+          "Failed to read footer from object {} (pos {} object size {}): {}",
           oid,
           extent.position,
           object_size,
-          ex);
-        co_await stream.close();
-        std::rethrow_exception(ex);
+          std::to_underlying(read_result.error()));
+        throw std::runtime_error(
+          fmt::format(
+            "Failed to read footer from object {} (pos {} size {}): {}",
+            oid,
+            extent.position,
+            object_size,
+            std::to_underlying(read_result.error())));
     }
 
-    iobuf footer_buf = footer_fut.get();
-    co_await stream.close();
-
     // Parse the footer - we have the complete footer so this should succeed.
-    auto footer_result = co_await l1::footer::read(std::move(footer_buf));
+    auto footer_result = co_await l1::footer::read(
+      std::move(read_result).value());
 
     if (!std::holds_alternative<l1::footer>(footer_result)) {
         vlog(

--- a/src/v/cloud_topics/level_one/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/reader.cc
@@ -186,7 +186,11 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
 
     auto footer = co_await read_footer(
       obj.oid, obj.footer_pos, obj.object_size);
-    _current_obj = current_object{.oid = obj.oid, .footer = std::move(footer)};
+    _current_obj = current_object{
+      .oid = obj.oid,
+      .footer = std::move(footer),
+      .last_offset = obj.last_offset,
+    };
     _state = state::ready;
 }
 
@@ -287,12 +291,7 @@ level_one_log_reader_impl::read_batches(l1::object_reader& reader) {
 
             // If we make it past all that, emit the batch.
             _batches.push_back(std::move(batch));
-        } else if (std::holds_alternative<model::topic_id_partition>(result)) {
-            // Partition marker. Done with this ntp's partition.
-            break;
-        } else if (
-          std::holds_alternative<l1::footer>(result)
-          || std::holds_alternative<l1::object_reader::eof>(result)) {
+        } else {
             // End of data.
             break;
         }
@@ -423,14 +422,13 @@ void level_one_log_reader_impl::consume_materialized_batches(
     // progress even if the offset range in the object is
     // smaller than the metastore's metadata about the offset
     // range covered by the object (because of, e.g. compaction).
-    // TODO: The metastore API should return the endpoint of the
-    // range covered by each object, which would be easier to
-    // understand than the increment here, and which would permit
-    // optimizations like read-ahead.
-    _next_offset = dest->empty()
-                     ? kafka::next_offset(_next_offset)
-                     : model::offset_cast(
-                         model::next_offset(dest->back().last_offset()));
+    auto last_offset = dest->empty()
+                         ? _current_obj
+                             .transform(
+                               [](const auto& obj) { return obj.last_offset; })
+                             .value_or(_next_offset)
+                         : model::offset_cast(dest->back().last_offset());
+    _next_offset = kafka::next_offset(last_offset);
 
     _current_obj.reset();
     _state = state::empty;

--- a/src/v/cloud_topics/level_one/frontend_reader/reader.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/reader.h
@@ -86,6 +86,7 @@ private:
     struct current_object {
         l1::object_id oid;
         l1::footer footer;
+        kafka::offset last_offset;
     };
 
     ss::future<> fetch_metadata(model::timeout_clock::time_point deadline);

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -78,6 +78,9 @@ public:
         object_id oid;
         size_t footer_pos;
         size_t object_size;
+        // The last offset available in the object (inclusive).
+        // This can be used to skip to the next offset.
+        kafka::offset last_offset;
     };
 
     // Interface to build object metadata for the L1 metastore. Meant to be

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -391,6 +391,7 @@ replicated_metastore::get_first_ge(
     resp.oid = reply.object.oid;
     resp.footer_pos = reply.object.footer_pos;
     resp.object_size = reply.object.object_size;
+    resp.last_offset = reply.object.last_offset;
     co_return resp;
 }
 
@@ -418,6 +419,7 @@ replicated_metastore::get_first_ge(
     resp.oid = reply.object.oid;
     resp.footer_pos = reply.object.footer_pos;
     resp.object_size = reply.object.object_size;
+    resp.last_offset = reply.object.last_offset;
     co_return resp;
 }
 

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -86,11 +86,16 @@ struct replace_objects_request
 struct object_metadata
   : serde::
       envelope<object_metadata, serde::version<0>, serde::compat_version<0>> {
-    auto serde_fields() { return std::tie(oid, footer_pos, object_size); }
+    auto serde_fields() {
+        return std::tie(oid, footer_pos, object_size, last_offset);
+    }
 
     object_id oid;
     size_t footer_pos;
     size_t object_size;
+
+    // The last offset (inclusive) that is within this object.
+    kafka::offset last_offset;
 };
 
 struct get_first_offset_ge_reply

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -247,6 +247,7 @@ simple_metastore::get_first_ge(
           .oid = it->oid,
           .footer_pos = footer_pos,
           .object_size = object_size,
+          .last_offset = it->last_offset,
         };
     }
     return std::unexpected(metastore::errc::out_of_range);
@@ -281,6 +282,7 @@ simple_metastore::get_first_ge(
               .oid = obj.oid,
               .footer_pos = footer_pos,
               .object_size = object_size,
+              .last_offset = obj.last_offset,
             };
         }
     }

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -177,6 +177,7 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
     ASSERT_EQ(get_res->oid, oid1);
     ASSERT_EQ(get_res->footer_pos, 200);
     ASSERT_EQ(get_res->object_size, 1200);
+    ASSERT_EQ(get_res->last_offset, 10_o);
 }
 
 TEST(SimpleMetastoreTest, TestAddWithGap) {
@@ -316,6 +317,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 10_o);
     }
     for (const auto& o : std::views::iota(11, 21)) {
         auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
@@ -323,6 +325,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 20_o);
     }
     for (const auto& o : std::views::iota(21, 31)) {
         auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
@@ -330,6 +333,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 30_o);
     }
 }
 
@@ -352,6 +356,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     ASSERT_EQ(get_res->oid, oid1);
     ASSERT_EQ(get_res->footer_pos, 100);
     ASSERT_EQ(get_res->object_size, 1100);
+    ASSERT_EQ(get_res->last_offset, 10_o);
 }
 
 TEST(SimpleMetastoreTest, TestAddGetOffsetOutOfRange) {
@@ -396,6 +401,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 10_o);
     }
     for (const auto& t : {2000_t, 2999_t}) {
         auto get_res = m.get_first_ge(tpr, t).get();
@@ -403,6 +409,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 20_o);
     }
     for (const auto& t : {3000_t, 3999_t}) {
         auto get_res = m.get_first_ge(tpr, t).get();
@@ -410,6 +417,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 30_o);
     }
 }
 
@@ -505,6 +513,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 20_o);
     }
     // Others should be served from oid1 or oid2.
     tpr = model::topic_id_partition::from(tid_b);
@@ -514,6 +523,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 10_o);
     }
     for (const auto& o : std::views::iota(11, 21)) {
         auto get_res = m.get_first_ge(tpr, kafka::offset{o}).get();
@@ -521,6 +531,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 20_o);
     }
     // Sanity check that replacement leaves us with expected offsets.
     for (const auto& tid : {tid_a, tid_b}) {
@@ -569,6 +580,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 20_o);
     }
     tpr = model::topic_id_partition::from(tid_b);
     for (const auto& o : std::views::iota(11, 21)) {
@@ -577,6 +589,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 20_o);
     }
     // Others should be served from oid1 or oid2.
     for (const auto& o : std::views::iota(0, 11)) {
@@ -585,6 +598,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->last_offset, 10_o);
     }
     // Sanity check that replacement leaves us with expected offsets.
     for (const auto& tid : {tid_a, tid_b}) {


### PR DESCRIPTION
- **ct/reconciler: use new method to simplify footer reading**
- **ct/l1: fix reader performance with compacted L1 data**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
