### PR TITLE
[CORE-13253] cloud_topics: collect ctp inactive epoch into health report for L0 GC

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -85,10 +85,9 @@ ss::future<> app::construct(
       manager,
       ss::sharded_parameter([&] { return &remote->local(); }),
       bucket,
-      ss::sharded_parameter(
-        [&] { return &controller->get_partition_manager().local(); }),
-      ss::sharded_parameter(
-        [&] { return &controller->get_raft_manager().local(); }));
+      &controller->get_partition_manager(),
+      &controller->get_raft_manager(),
+      &controller->get_health_monitor());
 }
 
 ss::future<> app::start() {

--- a/src/v/cloud_topics/level_zero/gc/BUILD
+++ b/src/v/cloud_topics/level_zero/gc/BUILD
@@ -13,6 +13,7 @@ redpanda_cc_library(
         "//src/v/cloud_io:remote",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics:object_utils",
+        "//src/v/cluster",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -13,6 +13,7 @@
 #include "cloud_io/remote.h"
 #include "cloud_topics/logger.h"
 #include "cloud_topics/object_utils.h"
+#include "cluster/health_monitor_frontend.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
@@ -69,6 +70,10 @@ private:
 
 class epoch_source_cluster_impl : public level_zero_gc::epoch_source {
 public:
+    explicit epoch_source_cluster_impl(
+      seastar::sharded<cluster::health_monitor_frontend>* health_monitor)
+      : health_monitor_(health_monitor) {}
+
     seastar::future<std::expected<std::optional<cluster_epoch>, std::string>>
     max_gc_eligible_epoch(seastar::abort_source*) override {
         /*
@@ -77,6 +82,10 @@ public:
          */
         co_return std::nullopt;
     }
+
+private:
+    [[maybe_unused]] seastar::sharded<cluster::health_monitor_frontend>*
+      health_monitor_;
 };
 
 level_zero_gc::level_zero_gc(
@@ -93,11 +102,12 @@ level_zero_gc::level_zero_gc(
 level_zero_gc::level_zero_gc(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
+  seastar::sharded<cluster::health_monitor_frontend>* health_monitor,
   level_zero_gc_config config)
   : level_zero_gc(
       config,
       std::make_unique<object_storage_remote_impl>(remote, std::move(bucket)),
-      std::make_unique<epoch_source_cluster_impl>()) {}
+      std::make_unique<epoch_source_cluster_impl>(health_monitor)) {}
 
 void level_zero_gc::start() {
     vlog(cd_log.info, "Starting cloud topics L0 GC worker");

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.h
@@ -15,6 +15,7 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
 
 #include <expected>
 
@@ -22,6 +23,10 @@ using namespace std::chrono_literals;
 
 namespace cloud_io {
 class remote;
+}
+
+namespace cluster {
+class health_monitor_frontend;
 }
 
 namespace cloud_topics {
@@ -207,6 +212,7 @@ public:
     level_zero_gc(
       cloud_io::remote*,
       cloud_storage_clients::bucket_name,
+      seastar::sharded<cluster::health_monitor_frontend>*,
       level_zero_gc_config = {});
 
     /*

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.cc
@@ -13,7 +13,7 @@
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/logger.h"
 
-namespace cloud_topics {
+namespace cloud_topics::l0 {
 
 bool ctp_stm_factory::is_applicable_for(
   const storage::ntp_config& ntp_cfg) const {
@@ -29,4 +29,4 @@ void ctp_stm_factory::create(
     raft->log()->stm_manager()->add_stm(stm);
 }
 
-} // namespace cloud_topics
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_factory.h
@@ -12,7 +12,7 @@
 
 #include "cluster/state_machine_registry.h"
 
-namespace cloud_topics {
+namespace cloud_topics::l0 {
 
 class ctp_stm_factory : public cluster::state_machine_factory {
 public:
@@ -24,4 +24,4 @@ public:
       const cluster::stm_instance_config& cfg) final;
 };
 
-} // namespace cloud_topics
+} // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -52,7 +52,7 @@ public:
 
             raft::state_machine_manager_builder builder;
 
-            cloud_topics::ctp_stm_factory stm_factory;
+            cloud_topics::l0::ctp_stm_factory stm_factory;
             stm_factory.create(
               builder, &*node->raft(), cluster::stm_instance_config{nullptr});
 

--- a/src/v/cloud_topics/manager/manager.cc
+++ b/src/v/cloud_topics/manager/manager.cc
@@ -21,13 +21,15 @@ namespace cloud_topics {
 cloud_topics_manager::cloud_topics_manager(
   cloud_io::remote* remote,
   cloud_storage_clients::bucket_name bucket,
-  cluster::partition_manager* partition_manager,
-  raft::group_manager* group_manager)
+  ss::sharded<cluster::partition_manager>* partition_manager,
+  ss::sharded<raft::group_manager>* group_manager,
+  ss::sharded<cluster::health_monitor_frontend>* health_monitor)
   : remote_(remote)
   , bucket_(std::move(bucket))
   , partition_manager_(partition_manager)
   , group_manager_(group_manager)
-  , level_zero_gc_(remote_, bucket_) {}
+  , health_monitor_(health_monitor)
+  , level_zero_gc_(remote_, bucket_, health_monitor_) {}
 
 seastar::future<> cloud_topics_manager::start() {
     vlog(cd_log.info, "Cloud topics manager starting");
@@ -37,17 +39,18 @@ seastar::future<> cloud_topics_manager::start() {
       model::l1_metastore_topic,
       model::partition_id(0));
 
-    manage_notifications_ = partition_manager_->register_manage_notification(
-      manager_ntp.ns,
-      manager_ntp.tp.topic,
-      [this, manager_ntp](const auto& partition) {
-          if (partition->ntp() == manager_ntp) {
-              start_managing(*partition);
-          }
-      });
+    manage_notifications_
+      = partition_manager_->local().register_manage_notification(
+        manager_ntp.ns,
+        manager_ntp.tp.topic,
+        [this, manager_ntp](const auto& partition) {
+            if (partition->ntp() == manager_ntp) {
+                start_managing(*partition);
+            }
+        });
 
     unmanage_notifications_
-      = partition_manager_->register_unmanage_notification(
+      = partition_manager_->local().register_unmanage_notification(
         manager_ntp.ns, manager_ntp.tp.topic, [this, manager_ntp](auto tp) {
             if (tp.partition == manager_ntp.tp.partition) {
                 stop_managing(manager_ntp);
@@ -55,12 +58,12 @@ seastar::future<> cloud_topics_manager::start() {
         });
 
     leadership_notifications_
-      = group_manager_->register_leadership_notification(
+      = group_manager_->local().register_leadership_notification(
         [this, manager_ntp](
           raft::group_id group,
           model::term_id,
           std::optional<model::node_id> leader_id) {
-            auto partition = partition_manager_->partition_for(group);
+            auto partition = partition_manager_->local().partition_for(group);
             if (partition && partition->ntp() == manager_ntp) {
                 notify_leadership(partition, leader_id);
             }
@@ -75,17 +78,17 @@ seastar::future<> cloud_topics_manager::stop() {
     vlog(cd_log.info, "Cloud topics manager stopping");
 
     if (manage_notifications_) {
-        partition_manager_->unregister_manage_notification(
+        partition_manager_->local().unregister_manage_notification(
           *manage_notifications_);
     }
 
     if (unmanage_notifications_) {
-        partition_manager_->unregister_unmanage_notification(
+        partition_manager_->local().unregister_unmanage_notification(
           *unmanage_notifications_);
     }
 
     if (leadership_notifications_) {
-        group_manager_->unregister_leadership_notification(
+        group_manager_->local().unregister_leadership_notification(
           *leadership_notifications_);
     }
 

--- a/src/v/cloud_topics/manager/manager.h
+++ b/src/v/cloud_topics/manager/manager.h
@@ -15,10 +15,12 @@
 #include "raft/notification.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
 
 namespace cluster {
 class partition;
 class partition_manager;
+class health_monitor_frontend;
 } // namespace cluster
 
 namespace cloud_io {
@@ -49,8 +51,9 @@ public:
     cloud_topics_manager(
       cloud_io::remote* remote,
       cloud_storage_clients::bucket_name bucket,
-      cluster::partition_manager*,
-      raft::group_manager*);
+      seastar::sharded<cluster::partition_manager>*,
+      seastar::sharded<raft::group_manager>*,
+      seastar::sharded<cluster::health_monitor_frontend>*);
 
     seastar::future<> start();
     seastar::future<> stop();
@@ -58,8 +61,9 @@ public:
 private:
     cloud_io::remote* remote_;
     cloud_storage_clients::bucket_name bucket_;
-    cluster::partition_manager* partition_manager_;
-    raft::group_manager* group_manager_;
+    seastar::sharded<cluster::partition_manager>* partition_manager_;
+    seastar::sharded<raft::group_manager>* group_manager_;
+    seastar::sharded<cluster::health_monitor_frontend>* health_monitor_;
 
     std::optional<cluster::notification_id_type> manage_notifications_;
     std::optional<cluster::notification_id_type> unmanage_notifications_;

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -946,6 +946,8 @@ partition_status build_partition_status(const partition& p) {
     status.revision_id = p.get_revision_id();
     status.size_bytes = p.size_bytes() + p.non_log_disk_size_bytes();
     status.reclaimable_size_bytes = p.reclaimable_size_bytes();
+    status.cloud_topic_max_gc_eligible_epoch
+      = p.cloud_topic_max_gc_eligible_epoch();
     status.shard = ss::this_shard_id();
 
     if (p.ntp().ns == model::kafka_namespace) {

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -213,7 +213,7 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
       o,
       "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
       "reclaimable_size_bytes: {}, under_replicated: {}, shard: {}, "
-      "followers_stats: {}, kafka_highwatermark: {}}}",
+      "followers_stats: {}, kafka_highwatermark: {}, ct_max_gc_epoch: {}}}",
       ps.id,
       ps.term,
       ps.leader_id,
@@ -223,7 +223,8 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
       ps.under_replicated_replicas,
       ps.shard,
       ps.followers_stats,
-      ps.high_watermark);
+      ps.high_watermark,
+      ps.cloud_topic_max_gc_eligible_epoch);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -104,7 +104,7 @@ struct followers_stats
 };
 struct partition_status
   : serde::
-      envelope<partition_status, serde::version<5>, serde::compat_version<0>> {
+      envelope<partition_status, serde::version<6>, serde::compat_version<0>> {
     static constexpr size_t invalid_size_bytes = size_t(-1);
     static constexpr uint32_t invalid_shard_id = uint32_t(-1);
 
@@ -143,6 +143,15 @@ struct partition_status
      */
     kafka::offset high_watermark;
 
+    /*
+     * If the partition is a cloud topics partition, then this field records the
+     * maximum epoch (inclusive) that is eligible for garbage collection. When
+     * reducing (applying `min`) this value across node reports, ignore
+     * std::nullopt. If the reduced value is std::nullopt then the partition
+     * should be treated as if it contains no GC eligible data.
+     */
+    std::optional<int64_t> cloud_topic_max_gc_eligible_epoch;
+
     auto serde_fields() {
         return std::tie(
           id,
@@ -154,7 +163,8 @@ struct partition_status
           reclaimable_size_bytes,
           shard,
           followers_stats,
-          high_watermark);
+          high_watermark,
+          cloud_topic_max_gc_eligible_epoch);
     }
 
     friend std::ostream& operator<<(std::ostream&, const partition_status&);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -473,6 +473,12 @@ ss::future<> partition::start(
     // store partition properties stm offset for fast access
     _partition_properties_stm
       = _raft->stm_manager()->get<cluster::partition_properties_stm>();
+
+    // the cloud topics stm provides access to garbage collection metadata. this
+    // metadata is collected into cluster health reports as a way to disseminate
+    // this information to the garbage collection process.
+    _ctp_stm = _raft->stm_manager()->get<cloud_topics::ctp_stm>();
+
     // Start the probe after the partition is fully initialised
     _probe.setup_metrics(ntp);
 
@@ -1836,6 +1842,13 @@ ss::future<result<ss::rwlock::holder>> partition::hold_writes_enabled() {
     }
 
     co_return *std::move(maybe_units);
+}
+
+std::optional<int64_t> partition::cloud_topic_max_gc_eligible_epoch() const {
+    if (_ctp_stm) {
+        return _ctp_stm->estimate_inactive_epoch();
+    }
+    return std::nullopt;
 }
 
 ss::sharded<cloud_topics::state_accessors>*

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cloud_storage/fwd.h"
+#include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cluster/archival/archival_metadata_stm.h"
 #include "cluster/archival/fwd.h"
 #include "cluster/fwd.h"
@@ -402,6 +403,10 @@ public:
     ss::sharded<cloud_topics::state_accessors>*
     get_cloud_topics_state() noexcept;
 
+    // If this is a cloud topics partition then the max GC eligible epoch (if
+    // any) is returned.
+    std::optional<int64_t> cloud_topic_max_gc_eligible_epoch() const;
+
 private:
     ss::future<>
     replicate_unsafe_reset(cloud_storage::partition_manifest manifest);
@@ -428,6 +433,7 @@ private:
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<partition_properties_stm> _partition_properties_stm;
     ss::sharded<cloud_topics::state_accessors>* _cloud_topics_state;
+    ss::shared_ptr<cloud_topics::ctp_stm> _ctp_stm;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<features::feature_table>& _feature_table;

--- a/src/v/cluster/tests/health_monitor_bench.cc
+++ b/src/v/cluster/tests/health_monitor_bench.cc
@@ -21,6 +21,7 @@ cluster::topic_status make_topic_status(size_t id, size_t num_partitions) {
         part_status.id = model::partition_id(i);
         part_status.leader_id = model::node_id(1);
         part_status.reclaimable_size_bytes = 100;
+        part_status.cloud_topic_max_gc_eligible_epoch = 101;
         part_status.revision_id = model::revision_id(1);
         part_status.term = model::term_id(1);
         if (i % 3 == 0) { // leaders

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -3154,7 +3154,7 @@ void application::start_runtime_services(
           pm.register_factory<datalake::translation::stm_factory>(
             config::shard_local_cfg().iceberg_enabled());
           if (config::shard_local_cfg().development_enable_cloud_topics()) {
-              pm.register_factory<cloud_topics::ctp_stm_factory>();
+              pm.register_factory<cloud_topics::l0::ctp_stm_factory>();
               pm.register_factory<cloud_topics::l1::stm_factory>();
           }
           pm.register_factory<kafka::write_at_offset_stm_factory>(


### PR DESCRIPTION
Collects CTP inactive epoch into cluster health report for use by the L0 GC manager.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
