### PR TITLE
Treat _schemas topic as a soft requirement for critical topics

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -882,18 +882,17 @@ class CloudCluster:
         _topics = self._query_panda_proxy("/topics")
         # For Azure, connect is in development
         if self.config.provider == PROVIDER_AZURE:
-            _critical = ["_schemas", "_redpanda_e2e_probe"]
-            required_critical_topic_count = 2
+            _critical = ["_redpanda_e2e_probe"]
+            required_critical_topic_count = 1
         else:
             _critical = [
-                "_schemas",
                 "__redpanda.connectors_logs",
                 "_internal_connectors_status",
                 "_internal_connectors_configs",
                 "_redpanda_e2e_probe",
                 "_internal_connectors_offsets",
             ]
-            required_critical_topic_count = 6
+            required_critical_topic_count = 5
 
         _intersect = list(set(_topics) & set(_critical))
         if len(_intersect) < required_critical_topic_count:


### PR DESCRIPTION
#DEVPROD-3342

Treat _schemas topic as a soft requirement for critical topics

As discussed with cloud and core, treating `_schemas` topic as a soft requirement during cluster health check. It is lazy created and might or might not be available during health check. More details are in DEVPROD-3342

## Backports Required

- [x ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
