### PR TITLE
Direct Consumer stale request filtering and fetcher simplification

### DIFF
--- a/src/v/kafka/client/direct_consumer/api_types.h
+++ b/src/v/kafka/client/direct_consumer/api_types.h
@@ -20,6 +20,9 @@
 
 #include <seastar/util/bool_class.hh>
 namespace kafka::client {
+
+using subscription_epoch = named_type<uint64_t, struct subscription_epoch_tag>;
+
 enum class offset_reset_policy : int8_t {
     // reset to the earliest offset
     earliest,
@@ -63,6 +66,8 @@ struct fetched_partition_data {
     chunked_vector<model::record_batch> data;
     kafka::error_code error = kafka::error_code::none;
     std::optional<chunked_vector<aborted_transaction>> aborted_transactions;
+    subscription_epoch subscription_epoch;
+    size_t size_bytes;
 };
 
 struct fetched_topic_data {

--- a/src/v/kafka/client/direct_consumer/direct_consumer.cc
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.cc
@@ -10,10 +10,13 @@
  */
 #include "kafka/client/direct_consumer/direct_consumer.h"
 
+#include "kafka/client/direct_consumer/api_types.h"
 #include "kafka/client/direct_consumer/data_queue.h"
 #include "kafka/client/direct_consumer/fetcher.h"
 #include "model/validation.h"
 #include "ssx/future-util.h"
+
+#include <algorithm>
 
 namespace kafka::client {
 
@@ -31,10 +34,65 @@ direct_consumer::fetch_next(std::chrono::milliseconds timeout) {
     }
     auto holder = _gate.hold();
     try {
-        co_return co_await _fetched_data_queue->pop(timeout);
+        auto maybe_response_to_filter = co_await _fetched_data_queue->pop(
+          timeout);
+        if (maybe_response_to_filter.has_error()) {
+            co_return maybe_response_to_filter;
+        }
+
+        // the remainder is synchronous, no lock is needed
+        auto& response_to_filter = maybe_response_to_filter.value();
+        filter_stale_subscriptions(response_to_filter);
+        co_return maybe_response_to_filter;
+
     } catch (ss::condition_variable_timed_out&) {
         co_return chunked_vector<fetched_topic_data>{};
     }
+}
+
+void direct_consumer::filter_stale_subscriptions(
+  chunked_vector<fetched_topic_data>& responses_to_filter) {
+    // for each topic, remove stale partitions
+    for (auto& topic_data : responses_to_filter) {
+        auto& partition_data = topic_data.partitions;
+
+        auto non_stale_subsegment = std::ranges::partition(
+          partition_data,
+          [this, &topic_data](const fetched_partition_data& data) mutable {
+              auto maybe_current_subscription_epoch = find_subscription_epoch(
+                topic_data.topic, data.partition_id);
+
+              vlog(
+                _cluster->logger().debug,
+                "current subscription epoch: {}, found request epoch: {}",
+                maybe_current_subscription_epoch,
+                data.subscription_epoch);
+
+              bool is_stale = data.subscription_epoch
+                              != maybe_current_subscription_epoch;
+              if (is_stale) {
+                  topic_data.total_bytes -= data.size_bytes;
+              }
+              // negate s.t. stale records accumulate at the back of the
+              // chunked_vector, allows for them to be removed with
+              // erase_to_end
+              return !is_stale;
+          });
+
+        auto erase_iterator = partition_data.end()
+                              - non_stale_subsegment.size();
+
+        partition_data.erase_to_end(erase_iterator);
+    }
+
+    // remove newly empty topics
+    auto non_empty_subsegment = std::ranges::partition(
+      responses_to_filter, [](const fetched_topic_data& topic_data) {
+          return !topic_data.partitions.empty();
+      });
+
+    responses_to_filter.erase_to_end(
+      responses_to_filter.end() - non_empty_subsegment.size());
 }
 
 void direct_consumer::update_configuration(configuration cfg) {
@@ -103,13 +161,17 @@ ss::future<> direct_consumer::update_fetchers(
                 sub.current_fetcher = *leader_id;
                 auto& new_fetcher = get_fetcher(*leader_id);
                 co_await new_fetcher.assign_partition(
-                  model::topic_partition_view(topic, p_id), sub.fetch_offset);
+                  model::topic_partition_view(topic, p_id),
+                  sub.fetch_offset,
+                  sub.subscription_epoch);
 
             } else if (sub.fetch_offset) {
                 // If the fetch offset is set, update it
                 auto& current = get_fetcher(*sub.current_fetcher);
                 co_await current.assign_partition(
-                  model::topic_partition_view(topic, p_id), sub.fetch_offset);
+                  model::topic_partition_view(topic, p_id),
+                  sub.fetch_offset,
+                  sub.subscription_epoch);
             }
             sub.fetch_offset.reset();
         }
@@ -148,6 +210,21 @@ fetcher& direct_consumer::get_fetcher(model::node_id id) {
     return *it->second;
 }
 
+std::optional<subscription_epoch> direct_consumer::find_subscription_epoch(
+  const model::topic& topic, model::partition_id partition_id) {
+    auto t_it = _subscriptions.find(topic);
+    if (t_it == _subscriptions.end()) {
+        return std::nullopt;
+    }
+
+    auto& p_map = t_it->second;
+    auto p_it = p_map.find(partition_id);
+    if (p_it == p_map.end()) {
+        return std::nullopt;
+    }
+    return p_it->second.subscription_epoch;
+}
+
 ss::future<> direct_consumer::start() {
     if (_started) {
         co_return;
@@ -182,14 +259,17 @@ direct_consumer::assign_partitions(chunked_vector<topic_assignment> topics) {
                 "Invalid topic name: {}, error: {}", t.topic, ec.message()));
         }
         for (auto& p : t.partitions) {
+            auto epoch_to_assign = ++epoch;
             vlog(
               _cluster->logger().trace,
-              "Assigning partition: {}/{} with offset: {}",
+              "Assigning partition: {}/{} with offset: {} and epoch {}",
               t.topic,
               p.partition_id,
-              p.next_offset);
-            auto& sub = _subscriptions[t.topic][p.partition_id];
-            sub.fetch_offset = p.next_offset;
+              p.next_offset,
+              epoch_to_assign);
+            _subscriptions[t.topic].insert_or_assign(
+              p.partition_id,
+              subscription{std::nullopt, p.next_offset, epoch_to_assign});
         }
     }
     co_await update_fetchers(std::move(lock_holder));
@@ -207,7 +287,7 @@ direct_consumer::unassign_topics(chunked_vector<model::topic> topics) {
         }
         removals[topic].reserve(state_it->second.size());
         for (const auto& [p_id, sub] : state_it->second) {
-            removals[topic][p_id] = sub;
+            removals[topic].insert_or_assign(p_id, sub);
         }
         _subscriptions.erase(topic);
     }
@@ -227,7 +307,7 @@ ss::future<> direct_consumer::unassign_partitions(
         auto p_it = state_it->second.find(tp.partition);
 
         if (p_it != state_it->second.end()) {
-            removals[tp.topic][tp.partition] = p_it->second;
+            removals[tp.topic].insert_or_assign(tp.partition, p_it->second);
             state_it->second.erase(p_it);
         }
         if (state_it->second.empty()) {

--- a/src/v/kafka/client/direct_consumer/direct_consumer.h
+++ b/src/v/kafka/client/direct_consumer/direct_consumer.h
@@ -13,6 +13,7 @@
 #include "container/chunked_hash_map.h"
 #include "kafka/client/cluster.h"
 #include "kafka/client/direct_consumer/api_types.h"
+#include "model/fundamental.h"
 
 namespace kafka {
 struct metadata_response_data;
@@ -125,8 +126,17 @@ public:
 
 private:
     struct subscription {
+        subscription(
+          std::optional<model::node_id> current_fetcher,
+          std::optional<kafka::offset> fetch_offset,
+          subscription_epoch subscription_epoch) noexcept
+          : current_fetcher{current_fetcher}
+          , fetch_offset{fetch_offset}
+          , subscription_epoch{subscription_epoch} {}
+
         std::optional<model::node_id> current_fetcher;
         std::optional<kafka::offset> fetch_offset;
+        subscription_epoch subscription_epoch;
     };
     friend class fetcher;
     void on_metadata_update(const metadata_response_data&);
@@ -137,6 +147,12 @@ private:
       topic_partition_map<subscription> removals = {});
 
     fetcher& get_fetcher(model::node_id id);
+
+    std::optional<subscription_epoch> find_subscription_epoch(
+      const model::topic& topic, model::partition_id partition_id);
+
+    void filter_stale_subscriptions(
+      chunked_vector<fetched_topic_data>& responses_to_filter);
 
     cluster* _cluster;
 
@@ -151,6 +167,16 @@ private:
     chunked_hash_map<model::node_id, std::unique_ptr<fetcher>> _broker_fetchers;
     std::unique_ptr<data_queue> _fetched_data_queue;
     ss::condition_variable _data_available;
+
+    /**
+     * Versions subscriptions; inc'd and assigned to all new subs. A sub's
+     * subscription_epoch tags along for the lifecycles of fetch requests to
+     * responses. On fetch_next, a fetch_response's subscription_epoch will get
+     * be compared against the current sub's subscription_epoch. A difference
+     * indicates a stale fetch.
+     * Stale fetches need to be dropped.
+     */
+    subscription_epoch epoch{0};
 
     cluster::callback_id _metadata_callback_id;
     bool _started = false;

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -809,10 +809,27 @@ ss::future<> fetcher::assign_partition(
     auto lock = co_await _state_lock.get_units();
     vlog(
       logger().debug,
-      "[broker: {}] Assigned partition: {} with offset: {}",
+      "[broker: {}] Assigned partition: {} with offset: {} subscription_epoch: "
+      "{}",
       _id,
       tp,
-      offset);
+      offset,
+      subscription_epoch);
+
+    auto maybe_existing_assignment = find_fetcher_state(tp.topic, tp.partition);
+    if (maybe_existing_assignment) {
+        auto& existing_assignment = maybe_existing_assignment->get();
+        vlog(
+          logger().warn,
+          "[broker: {}] "
+          "overwriting existing fetcher partition assignment "
+          "tp: {}, fetch_offset: {}, fetcher_epoch: {}, subscription epoch: {}",
+          _id,
+          tp,
+          existing_assignment.fetch_offset,
+          existing_assignment.fetcher_epoch,
+          existing_assignment.subscription_epoch);
+    }
 
     _partitions[tp.topic].insert_or_assign(
       tp.partition,
@@ -854,7 +871,11 @@ fetcher::unassign_partition(model::topic_partition_view tp_v) {
     auto& partitions = it->second;
     auto p_it = partitions.find(tp_v.partition);
     if (p_it == partitions.end()) {
-        // partition not found, nothing to unassign
+        vlog(
+          logger().warn,
+          "[broker: {}] Unassign called on tp: {} which is not owned",
+          _id,
+          tp_v);
         co_return std::nullopt;
     }
     vlog(

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -505,6 +505,15 @@ fetcher::process_fetch_response(
             part_data.error = part_response.error_code;
             part_data.partition_id = part_response.partition_index;
 
+            auto snapshotted_epochs
+              = find_epoch_set(
+                  topic_data.topic, part_response.partition_index, epochs)
+                  .value_or(
+                    epoch_set{fetcher_epoch(-1), subscription_epoch(-1)});
+
+            part_data.subscription_epoch
+              = snapshotted_epochs.subscription_epoch;
+
             if (part_response.error_code != kafka::error_code::none) {
                 if (
                   part_response.error_code

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -12,6 +12,7 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "base/format_to.h"
+#include "kafka/client/direct_consumer/api_types.h"
 #include "kafka/client/direct_consumer/data_queue.h"
 #include "kafka/client/direct_consumer/direct_consumer.h"
 #include "kafka/client/errors.h"
@@ -887,11 +888,10 @@ ss::future<> fetcher::assign_partition(
       tp,
       offset);
 
-    _partitions[tp.topic][tp.partition] = partition_fetch_state{
-      .partition_id = tp.partition,
-      .fetch_offset = offset,
-      .assignment_epoch = next_epoch(),
-      .incremental_include = true};
+    _partitions[tp.topic].insert_or_assign(
+      tp.partition,
+      partition_fetch_state(
+        tp.partition, offset, next_epoch(), subscription_epoch(-1)));
 
     // in the case of fast leadership transfers, we may have a partition both
     // being added and forgotten, in which case, make sure that it is only being

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -1009,6 +1009,46 @@ fetcher::do_list_offsets(list_offsets_request req) {
     }
 }
 
+std::optional<std::reference_wrapper<fetcher::partition_fetch_state>>
+fetcher::find_fetcher_state(
+  const model::topic& topic, model::partition_id partition) {
+    auto t_it = _partitions.find(topic);
+    if (t_it == _partitions.end()) {
+        return std::nullopt;
+    }
+
+    auto& partition_assignments = t_it->second;
+    auto p_it = partition_assignments.find(partition);
+    if (p_it == partition_assignments.end()) {
+        return std::nullopt;
+    }
+
+    return p_it->second;
+}
+
+bool fetcher::is_consistent_fetcher_epoch(
+  const model::topic& topic,
+  model::partition_id partition_id,
+  const topic_partition_map<epoch_set>& epochs) {
+    // not found in epochs -> inconsistent
+    // not found in assignments -> inconsistent
+    // epochs fetcher epoch != assignments fetcher epoch -> inconsistent
+    // epochs fetcher epoch == assignments fetch epoch -> consistent
+
+    auto maybe_epoch_set = find_epoch_set(topic, partition_id, epochs);
+    if (!maybe_epoch_set) {
+        return false;
+    }
+    auto epoch_set = *maybe_epoch_set;
+
+    auto maybe_fetch_state = find_fetcher_state(topic, partition_id);
+    if (!maybe_fetch_state) {
+        return false;
+    }
+    auto& fetch_state = maybe_fetch_state->get();
+    return fetch_state.fetcher_epoch == epoch_set.fetcher_epoch;
+}
+
 fmt::iterator fetch_session_state::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -892,7 +892,9 @@ ss::future<api_version> fetcher::get_list_offsets_request_version() const {
 }
 
 ss::future<> fetcher::assign_partition(
-  model::topic_partition_view tp, std::optional<kafka::offset> offset) {
+  model::topic_partition_view tp,
+  std::optional<kafka::offset> offset,
+  subscription_epoch subscription_epoch) {
     auto lock = co_await _state_lock.get_units();
     vlog(
       logger().debug,
@@ -904,7 +906,7 @@ ss::future<> fetcher::assign_partition(
     _partitions[tp.topic].insert_or_assign(
       tp.partition,
       partition_fetch_state(
-        tp.partition, offset, next_epoch(), subscription_epoch(-1)));
+        tp.partition, offset, next_epoch(), subscription_epoch));
 
     // in the case of fast leadership transfers, we may have a partition both
     // being added and forgotten, in which case, make sure that it is only

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -150,8 +150,10 @@ ss::future<fetcher::partitions_with_epoch> fetcher::collect_partitions() {
           partitions,
           [&to_process, &ret, inc = _session_state.incremental()](auto& p_fs) {
               partition_fetch_state& fetch_state = p_fs.second;
-              ret.fetcher_epochs[to_process.topic][fetch_state.partition_id]
-                = fetch_state.fetcher_epoch;
+              ret.epochs[to_process.topic].insert_or_assign(
+                fetch_state.partition_id,
+                epoch_set(
+                  fetch_state.fetcher_epoch, fetch_state.subscription_epoch));
               if (!fetch_state.fetch_offset.has_value()) {
                   to_process.to_list_offsets.push_back(fetch_state);
                   return;
@@ -348,10 +350,10 @@ ss::future<> fetcher::do_fetch() {
          * request.
          */
         auto partitions_with_epochs = co_await collect_partitions();
-        auto fetcher_epochs = std::move(partitions_with_epochs.fetcher_epochs);
+        auto epochs = std::move(partitions_with_epochs.epochs);
 
         auto list_offsets_err = co_await maybe_initialise_fetch_offsets(
-          partitions_with_epochs.partitions, fetcher_epochs);
+          partitions_with_epochs.partitions, epochs);
         /**
          */
         if (list_offsets_err != kafka::error_code::none) {
@@ -381,9 +383,7 @@ ss::future<> fetcher::do_fetch() {
         auto response = co_await _parent->_cluster->dispatch_to(
           _id, std::move(req), version);
         auto fetch_result = co_await process_fetch_response(
-          std::move(response),
-          fetcher_epochs,
-          partitions_with_epochs.partitions);
+          std::move(response), epochs, partitions_with_epochs.partitions);
 
         if (fetch_result.has_error()) {
             auto ec = fetch_result.error();
@@ -441,7 +441,7 @@ ss::future<> fetcher::do_fetch() {
 std::optional<fetcher::fetcher_epoch> fetcher::find_fetcher_epoch(
   const model::topic& topic,
   model::partition_id partition,
-  const topic_partition_map<fetcher_epoch>& epochs) {
+  const topic_partition_map<epoch_set>& epochs) {
     auto topic_iterator = epochs.find(topic);
 
     if (topic_iterator == epochs.end()) {
@@ -455,13 +455,13 @@ std::optional<fetcher::fetcher_epoch> fetcher::find_fetcher_epoch(
         return std::nullopt;
     }
 
-    return partition_iterator->second;
+    return partition_iterator->second.fetcher_epoch;
 }
 
 ss::future<kafka_result<fetcher::fetch_response_content>>
 fetcher::process_fetch_response(
   fetch_response resp,
-  const topic_partition_map<fetcher_epoch>& epochs,
+  const topic_partition_map<epoch_set>& epochs,
   const chunked_vector<partitions_to_process>& partitions) {
     if (resp.data.error_code != kafka::error_code::none) {
         co_return resp.data.error_code;
@@ -730,7 +730,7 @@ model::timestamp timestamp_for_offset_reset_policy(offset_reset_policy policy) {
 
 ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
   const chunked_vector<partitions_to_process>& partitions,
-  const topic_partition_map<fetcher_epoch>& epochs) {
+  const topic_partition_map<epoch_set>& epochs) {
     const auto timestamp = timestamp_for_offset_reset_policy(
       _parent->_config.reset_policy);
 

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -150,8 +150,8 @@ ss::future<fetcher::partitions_with_epoch> fetcher::collect_partitions() {
           partitions,
           [&to_process, &ret, inc = _session_state.incremental()](auto& p_fs) {
               partition_fetch_state& fetch_state = p_fs.second;
-              ret.assignment_epochs[to_process.topic][fetch_state.partition_id]
-                = fetch_state.assignment_epoch;
+              ret.fetcher_epochs[to_process.topic][fetch_state.partition_id]
+                = fetch_state.fetcher_epoch;
               if (!fetch_state.fetch_offset.has_value()) {
                   to_process.to_list_offsets.push_back(fetch_state);
                   return;
@@ -276,7 +276,7 @@ bool fetcher::maybe_update_fetch_offset(
   model::partition_id partition_id,
   kafka::offset last_received,
   kafka::offset high_watermark,
-  std::optional<assignment_epoch> maybe_response_epoch) {
+  std::optional<fetcher_epoch> maybe_response_epoch) {
     auto t_it = _partitions.find(topic);
     if (t_it == _partitions.end()) {
         return false;
@@ -300,22 +300,22 @@ bool fetcher::maybe_update_fetch_offset(
           _id,
           topic,
           partition_id,
-          p_it->second.assignment_epoch);
+          p_it->second.fetcher_epoch);
         return false;
     }
 
     const auto response_epoch = maybe_response_epoch.value();
 
-    if (p_it->second.assignment_epoch != response_epoch) {
+    if (p_it->second.fetcher_epoch != response_epoch) {
         vlog(
           logger().trace,
-          "[broker: {}] Ignoring {}/{} reply, assignment epoch changed, "
+          "[broker: {}] Ignoring {}/{} reply, fetcher epoch changed, "
           "request epoch: {}, current epoch: {}",
           _id,
           topic,
           partition_id,
           response_epoch,
-          p_it->second.assignment_epoch);
+          p_it->second.fetcher_epoch);
         return false;
     }
 
@@ -348,11 +348,10 @@ ss::future<> fetcher::do_fetch() {
          * request.
          */
         auto partitions_with_epochs = co_await collect_partitions();
-        auto assignment_epochs = std::move(
-          partitions_with_epochs.assignment_epochs);
+        auto fetcher_epochs = std::move(partitions_with_epochs.fetcher_epochs);
 
         auto list_offsets_err = co_await maybe_initialise_fetch_offsets(
-          partitions_with_epochs.partitions, assignment_epochs);
+          partitions_with_epochs.partitions, fetcher_epochs);
         /**
          */
         if (list_offsets_err != kafka::error_code::none) {
@@ -383,7 +382,7 @@ ss::future<> fetcher::do_fetch() {
           _id, std::move(req), version);
         auto fetch_result = co_await process_fetch_response(
           std::move(response),
-          assignment_epochs,
+          fetcher_epochs,
           partitions_with_epochs.partitions);
 
         if (fetch_result.has_error()) {
@@ -439,10 +438,10 @@ ss::future<> fetcher::do_fetch() {
     }
 }
 
-std::optional<fetcher::assignment_epoch> fetcher::find_assignment_epoch(
+std::optional<fetcher::fetcher_epoch> fetcher::find_fetcher_epoch(
   const model::topic& topic,
   model::partition_id partition,
-  const topic_partition_map<assignment_epoch>& epochs) {
+  const topic_partition_map<fetcher_epoch>& epochs) {
     auto topic_iterator = epochs.find(topic);
 
     if (topic_iterator == epochs.end()) {
@@ -462,7 +461,7 @@ std::optional<fetcher::assignment_epoch> fetcher::find_assignment_epoch(
 ss::future<kafka_result<fetcher::fetch_response_content>>
 fetcher::process_fetch_response(
   fetch_response resp,
-  const topic_partition_map<assignment_epoch>& epochs,
+  const topic_partition_map<fetcher_epoch>& epochs,
   const chunked_vector<partitions_to_process>& partitions) {
     if (resp.data.error_code != kafka::error_code::none) {
         co_return resp.data.error_code;
@@ -579,7 +578,7 @@ fetcher::process_fetch_response(
                 part_data.data = co_await reader_to_chunked_vector(
                   std::move(part_response.records.value()));
 
-                auto maybe_response_epoch = find_assignment_epoch(
+                auto maybe_response_epoch = find_fetcher_epoch(
                   topic_data.topic, part_data.partition_id, epochs);
 
                 bool updated_offset = maybe_update_fetch_offset(
@@ -591,7 +590,7 @@ fetcher::process_fetch_response(
                 if (!updated_offset) {
                     // case when partition is either
                     // 1. partition is not assigned to this fetcher
-                    // 2. assignment epoch changed
+                    // 2. fetcher epoch changed
                     // for either skip
                     continue;
                 }
@@ -646,9 +645,9 @@ fetcher::process_fetch_response(
                   partition_iterator != partition_map.end() && !partition_err) {
                     // compare the epochs before we make an edit
                     const auto assigned_epoch
-                      = partition_iterator->second.assignment_epoch;
+                      = partition_iterator->second.fetcher_epoch;
 
-                    auto maybe_request_epoch = find_assignment_epoch(
+                    auto maybe_request_epoch = find_fetcher_epoch(
                       topic, p.partition_id, epochs);
 
                     if (!maybe_request_epoch) {
@@ -715,7 +714,7 @@ void fetcher::reset_partition_offset(model::topic_partition_view tp) {
         return;
     }
     p_it->second.fetch_offset = std::nullopt;
-    p_it->second.assignment_epoch = next_epoch();
+    p_it->second.fetcher_epoch = next_epoch();
 }
 
 namespace {
@@ -731,7 +730,7 @@ model::timestamp timestamp_for_offset_reset_policy(offset_reset_policy policy) {
 
 ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
   const chunked_vector<partitions_to_process>& partitions,
-  const topic_partition_map<assignment_epoch>& epochs) {
+  const topic_partition_map<fetcher_epoch>& epochs) {
     const auto timestamp = timestamp_for_offset_reset_policy(
       _parent->_config.reset_policy);
 
@@ -811,9 +810,9 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
                 continue;
             }
 
-            const auto assigned_epoch = p_it->second.assignment_epoch;
+            const auto assigned_epoch = p_it->second.fetcher_epoch;
 
-            auto maybe_response_epoch = find_assignment_epoch(
+            auto maybe_response_epoch = find_fetcher_epoch(
               response_topic.topic, response_partition.partition_id, epochs);
 
             if (!maybe_response_epoch) {
@@ -833,14 +832,14 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
                 vlog(
                   logger().trace,
                   "[broker: {}] Skipping partition {}/{} list offset response "
-                  "as assignment epoch has changed. request_epoch: {}, "
+                  "as fetcher epoch has changed. request_epoch: {}, "
                   "current_epoch: {}",
                   _id,
                   response_topic.topic,
                   response_partition.partition_id,
                   response_partition.offset,
                   request_epoch,
-                  p_it->second.assignment_epoch);
+                  p_it->second.fetcher_epoch);
                 continue;
             }
             vlog(

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -473,6 +473,22 @@ fetcher::process_fetch_response(
 
     auto lock = co_await _state_lock.get_units();
 
+    // we allow for assignment updates to occur while a fetch is ongoing s.t.
+    // assignment updates are not blocked by a longstanding fetch. At this
+    // point, all inconsistent fetch responses should be discarded
+    for (auto& topic_response : resp.data.responses) {
+        auto consistent_subrange = std::ranges::partition(
+          topic_response.partitions,
+          [this, &topic_response, &epochs](partition_data& partition_response) {
+              return is_consistent_fetcher_epoch(
+                topic_response.topic,
+                partition_response.partition_index,
+                epochs);
+          });
+        topic_response.partitions.erase_to_end(
+          topic_response.partitions.end() - consistent_subrange.size());
+    } // all responses now belong to consistent tps
+
     // For fetch session maintenance, the goal is to omit partitions from each
     // fetch request whenever possible. The incremental_include flag controls
     // whether a certain partition appears in the next fetch request, after

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -572,7 +572,10 @@ fetcher::process_fetch_response(
                   || part_response.records->is_end_of_stream()) {
                     continue;
                 }
-                topic_data.total_bytes += part_response.records->size_bytes();
+                auto partition_response_size
+                  = part_response.records->size_bytes();
+                part_data.size_bytes = partition_response_size;
+                topic_data.total_bytes += partition_response_size;
                 part_data.data = co_await reader_to_chunked_vector(
                   std::move(part_response.records.value()));
 

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -277,65 +277,27 @@ bool fetcher::maybe_update_fetch_offset(
   const model::topic& topic,
   model::partition_id partition_id,
   kafka::offset last_received,
-  kafka::offset high_watermark,
-  std::optional<epoch_set> maybe_response_epochs) {
-    auto t_it = _partitions.find(topic);
-    if (t_it == _partitions.end()) {
-        return false;
-    }
-    auto p_it = t_it->second.find(partition_id);
-    if (p_it == t_it->second.end()) {
+  kafka::offset high_watermark) {
+    auto maybe_fetch_state = find_fetcher_state(topic, partition_id);
+    if (!maybe_fetch_state) {
         return false;
     }
 
-    // possible in a tight race
-    // 1. unassign from A
-    // 2. begin fetch
-    // 3. assign to A
-    // 4. broker receives update
-    // 5. the fetch will receive a response for which it did not have an epoch
-    // this is logically the same as epoch mismatch
-    if (!maybe_response_epochs) {
-        vlog(
-          logger().info,
-          "[broker: {}] Ignoring unbidden {}/{} current epoch: {}",
-          _id,
-          topic,
-          partition_id,
-          p_it->second.fetcher_epoch);
-        return false;
-    }
-
-    const auto response_fetcher_epoch
-      = maybe_response_epochs.value().fetcher_epoch;
-
-    if (p_it->second.fetcher_epoch != response_fetcher_epoch) {
-        vlog(
-          logger().trace,
-          "[broker: {}] Ignoring {}/{} reply, fetcher epoch changed, "
-          "request epoch: {}, current epoch: {}",
-          _id,
-          topic,
-          partition_id,
-          response_fetcher_epoch,
-          p_it->second.fetcher_epoch);
-        return false;
-    }
-
+    auto& fetch_state = maybe_fetch_state->get();
     vlog(
       logger().trace,
       "[broker: {}] Updating {}/{} fetch offset from {} to {} {{hwm: {}}}",
       _id,
       topic,
       partition_id,
-      p_it->second.fetch_offset,
+      fetch_state.fetch_offset,
       kafka::next_offset(last_received),
       high_watermark);
-    p_it->second.high_watermark = high_watermark;
-    p_it->second.fetch_offset = kafka::next_offset(last_received);
+    fetch_state.high_watermark = high_watermark;
+    fetch_state.fetch_offset = kafka::next_offset(last_received);
     // we updated the fetch offset, so we should sync to with the broker's
     // fetch session on the next request
-    p_it->second.incremental_include = true;
+    fetch_state.incremental_include = true;
 
     return true;
 }
@@ -604,20 +566,12 @@ fetcher::process_fetch_response(
                 part_data.data = co_await reader_to_chunked_vector(
                   std::move(part_response.records.value()));
 
-                auto maybe_response_epoch = find_epoch_set(
-                  topic_data.topic, part_data.partition_id, epochs);
-
                 bool updated_offset = maybe_update_fetch_offset(
                   topic_data.topic,
                   part_data.partition_id,
                   model::offset_cast(part_data.data.back().last_offset()),
-                  part_data.high_watermark,
-                  maybe_response_epoch);
+                  part_data.high_watermark);
                 if (!updated_offset) {
-                    // case when partition is either
-                    // 1. partition is not assigned to this fetcher
-                    // 2. fetcher epoch changed
-                    // for either skip
                     continue;
                 }
                 dirty_partitions[topic_data.topic].insert(

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -750,48 +750,20 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
                 continue;
             }
 
-            // global state may have changed, we're not locked
-            auto t_it = _partitions.find(response_topic.topic);
-            if (t_it == _partitions.end()) {
-                continue;
-            }
-            auto p_it = t_it->second.find(response_partition.partition_id);
-            if (p_it == t_it->second.end()) {
-                continue;
-            }
-
-            const auto assigned_fetcher_epoch = p_it->second.fetcher_epoch;
-
-            auto maybe_request_epochs = find_epoch_set(
-              response_topic.topic, response_partition.partition_id, epochs);
-
-            if (!maybe_request_epochs) {
-                vlog(
-                  logger().warn,
-                  "[broker: {} received a list topics response which was not "
-                  "requested on ntp: {}/{}",
-                  _id,
-                  response_topic.topic,
-                  response_partition.partition_id);
-                continue;
-            }
-
-            const auto request_epochs = maybe_request_epochs.value();
-
-            if (request_epochs.fetcher_epoch != assigned_fetcher_epoch) {
-                vlog(
-                  logger().trace,
-                  "[broker: {}] Skipping partition {}/{} list offset response "
-                  "as fetcher epoch has changed. request_epoch: {}, "
-                  "current_epoch: {}",
-                  _id,
+            if (!is_consistent_fetcher_epoch(
                   response_topic.topic,
                   response_partition.partition_id,
-                  response_partition.offset,
-                  request_epochs.fetcher_epoch,
-                  assigned_fetcher_epoch);
+                  epochs)) {
                 continue;
             }
+
+            auto maybe_fetch_state = find_fetcher_state(
+              response_topic.topic, response_partition.partition_id);
+            vassert(
+              maybe_fetch_state.has_value(),
+              "fetch state should be found if the tp is consistent");
+            auto& fetch_state = maybe_fetch_state->get();
+
             vlog(
               logger().info,
               "[broker: {}] Resetting partition {}/{} fetch offset to: {}",
@@ -799,9 +771,9 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
               response_topic.topic,
               response_partition.partition_id,
               response_partition.offset);
-            p_it->second.fetch_offset = response_partition.offset;
-            p_it->second.high_watermark.reset();
-            p_it->second.incremental_include = true;
+            fetch_state.fetch_offset = response_partition.offset;
+            fetch_state.high_watermark.reset();
+            fetch_state.incremental_include = true;
         }
     }
 

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -278,7 +278,7 @@ bool fetcher::maybe_update_fetch_offset(
   model::partition_id partition_id,
   kafka::offset last_received,
   kafka::offset high_watermark,
-  std::optional<fetcher_epoch> maybe_response_epoch) {
+  std::optional<epoch_set> maybe_response_epochs) {
     auto t_it = _partitions.find(topic);
     if (t_it == _partitions.end()) {
         return false;
@@ -295,7 +295,7 @@ bool fetcher::maybe_update_fetch_offset(
     // 4. broker receives update
     // 5. the fetch will receive a response for which it did not have an epoch
     // this is logically the same as epoch mismatch
-    if (!maybe_response_epoch) {
+    if (!maybe_response_epochs) {
         vlog(
           logger().info,
           "[broker: {}] Ignoring unbidden {}/{} current epoch: {}",
@@ -306,9 +306,10 @@ bool fetcher::maybe_update_fetch_offset(
         return false;
     }
 
-    const auto response_epoch = maybe_response_epoch.value();
+    const auto response_fetcher_epoch
+      = maybe_response_epochs.value().fetcher_epoch;
 
-    if (p_it->second.fetcher_epoch != response_epoch) {
+    if (p_it->second.fetcher_epoch != response_fetcher_epoch) {
         vlog(
           logger().trace,
           "[broker: {}] Ignoring {}/{} reply, fetcher epoch changed, "
@@ -316,7 +317,7 @@ bool fetcher::maybe_update_fetch_offset(
           _id,
           topic,
           partition_id,
-          response_epoch,
+          response_fetcher_epoch,
           p_it->second.fetcher_epoch);
         return false;
     }
@@ -438,7 +439,7 @@ ss::future<> fetcher::do_fetch() {
     }
 }
 
-std::optional<fetcher::fetcher_epoch> fetcher::find_fetcher_epoch(
+std::optional<fetcher::epoch_set> fetcher::find_epoch_set(
   const model::topic& topic,
   model::partition_id partition,
   const topic_partition_map<epoch_set>& epochs) {
@@ -455,7 +456,7 @@ std::optional<fetcher::fetcher_epoch> fetcher::find_fetcher_epoch(
         return std::nullopt;
     }
 
-    return partition_iterator->second.fetcher_epoch;
+    return partition_iterator->second;
 }
 
 ss::future<kafka_result<fetcher::fetch_response_content>>
@@ -578,7 +579,7 @@ fetcher::process_fetch_response(
                 part_data.data = co_await reader_to_chunked_vector(
                   std::move(part_response.records.value()));
 
-                auto maybe_response_epoch = find_fetcher_epoch(
+                auto maybe_response_epoch = find_epoch_set(
                   topic_data.topic, part_data.partition_id, epochs);
 
                 bool updated_offset = maybe_update_fetch_offset(
@@ -644,13 +645,13 @@ fetcher::process_fetch_response(
                 if (
                   partition_iterator != partition_map.end() && !partition_err) {
                     // compare the epochs before we make an edit
-                    const auto assigned_epoch
+                    const auto assigned_fetcher_epoch
                       = partition_iterator->second.fetcher_epoch;
 
-                    auto maybe_request_epoch = find_fetcher_epoch(
+                    auto maybe_request_epochs = find_epoch_set(
                       topic, p.partition_id, epochs);
 
-                    if (!maybe_request_epoch) {
+                    if (!maybe_request_epochs) {
                         // see maybe_update_fetch_offset for explanation
                         vlog(
                           logger().info,
@@ -660,9 +661,10 @@ fetcher::process_fetch_response(
                         continue;
                     }
 
-                    const auto request_epoch = maybe_request_epoch.value();
+                    const auto request_epochs = maybe_request_epochs.value();
 
-                    if (assigned_epoch == request_epoch) {
+                    if (
+                      assigned_fetcher_epoch == request_epochs.fetcher_epoch) {
                         partition_iterator->second.incremental_include = false;
                     } else {
                         vlog(
@@ -671,8 +673,8 @@ fetcher::process_fetch_response(
                           "fetched_epoch, {}, current_epoch: {}",
                           topic,
                           p.partition_id,
-                          request_epoch,
-                          assigned_epoch);
+                          request_epochs.fetcher_epoch,
+                          assigned_fetcher_epoch);
                     }
                 }
             }
@@ -810,12 +812,12 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
                 continue;
             }
 
-            const auto assigned_epoch = p_it->second.fetcher_epoch;
+            const auto assigned_fetcher_epoch = p_it->second.fetcher_epoch;
 
-            auto maybe_response_epoch = find_fetcher_epoch(
+            auto maybe_request_epochs = find_epoch_set(
               response_topic.topic, response_partition.partition_id, epochs);
 
-            if (!maybe_response_epoch) {
+            if (!maybe_request_epochs) {
                 vlog(
                   logger().warn,
                   "[broker: {} received a list topics response which was not "
@@ -826,9 +828,9 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
                 continue;
             }
 
-            const auto request_epoch = maybe_response_epoch.value();
+            const auto request_epochs = maybe_request_epochs.value();
 
-            if (request_epoch != assigned_epoch) {
+            if (request_epochs.fetcher_epoch != assigned_fetcher_epoch) {
                 vlog(
                   logger().trace,
                   "[broker: {}] Skipping partition {}/{} list offset response "
@@ -838,8 +840,8 @@ ss::future<kafka::error_code> fetcher::maybe_initialise_fetch_offsets(
                   response_topic.topic,
                   response_partition.partition_id,
                   response_partition.offset,
-                  request_epoch,
-                  p_it->second.fetcher_epoch);
+                  request_epochs.fetcher_epoch,
+                  assigned_fetcher_epoch);
                 continue;
             }
             vlog(
@@ -896,8 +898,8 @@ ss::future<> fetcher::assign_partition(
         tp.partition, offset, next_epoch(), subscription_epoch(-1)));
 
     // in the case of fast leadership transfers, we may have a partition both
-    // being added and forgotten, in which case, make sure that it is only being
-    // added
+    // being added and forgotten, in which case, make sure that it is only
+    // being added
     auto forget_topic_iterator = _partitions_to_forget.find(tp.topic);
     if (forget_topic_iterator != _partitions_to_forget.end()) {
         // topic is in the 'to forget map', now is the partition in the topic's

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -483,14 +483,14 @@ fetcher::process_fetch_response(
             part_data.error = part_response.error_code;
             part_data.partition_id = part_response.partition_index;
 
-            auto snapshotted_epochs
-              = find_epoch_set(
-                  topic_data.topic, part_response.partition_index, epochs)
-                  .value_or(
-                    epoch_set{fetcher_epoch(-1), subscription_epoch(-1)});
-
+            auto maybe_epoch_set = find_epoch_set(
+              topic_data.topic, part_response.partition_index, epochs);
+            vassert(
+              maybe_epoch_set.has_value(),
+              "tp should be found in snapshotted epochs if the response is "
+              "epoch consistent");
             part_data.subscription_epoch
-              = snapshotted_epochs.subscription_epoch;
+              = maybe_epoch_set.value().subscription_epoch;
 
             if (part_response.error_code != kafka::error_code::none) {
                 if (

--- a/src/v/kafka/client/direct_consumer/fetcher.cc
+++ b/src/v/kafka/client/direct_consumer/fetcher.cc
@@ -649,59 +649,28 @@ fetcher::process_fetch_response(
           "partitions, not both");
 
         if (!included.empty()) {
-            // _partitions maps topic -> parition map
-            // partition map maps partition -> subscription info
-            // get an iterator to the topic map
-            auto topic_iterator = _partitions.find(topic);
-            if (topic_iterator == _partitions.end()) {
-                continue;
-            }
-
             auto errs_it = dirty_partitions.find(topic);
             bool topic_err = errs_it != dirty_partitions.end();
-
-            auto& partition_map = topic_iterator->second;
 
             for (const auto& p : included) {
                 bool partition_err = topic_err
                                      && errs_it->second.contains(
                                        p.partition_id);
-                auto partition_iterator = partition_map.find(p.partition_id);
-                if (
-                  partition_iterator != partition_map.end() && !partition_err) {
-                    // compare the epochs before we make an edit
-                    const auto assigned_fetcher_epoch
-                      = partition_iterator->second.fetcher_epoch;
 
-                    auto maybe_request_epochs = find_epoch_set(
-                      topic, p.partition_id, epochs);
-
-                    if (!maybe_request_epochs) {
-                        // see maybe_update_fetch_offset for explanation
-                        vlog(
-                          logger().info,
-                          "unbidden response on ntp: {}/{}",
-                          topic,
-                          p.partition_id);
-                        continue;
-                    }
-
-                    const auto request_epochs = maybe_request_epochs.value();
-
-                    if (
-                      assigned_fetcher_epoch == request_epochs.fetcher_epoch) {
-                        partition_iterator->second.incremental_include = false;
-                    } else {
-                        vlog(
-                          logger().trace,
-                          "disclusion epoch mismatch on ntp: {}, "
-                          "fetched_epoch, {}, current_epoch: {}",
-                          topic,
-                          p.partition_id,
-                          request_epochs.fetcher_epoch,
-                          assigned_fetcher_epoch);
-                    }
+                // if errored, keep it in the next fetch
+                if (partition_err) {
+                    continue;
                 }
+
+                if (!is_consistent_fetcher_epoch(
+                      topic, p.partition_id, epochs)) {
+                    continue;
+                }
+
+                auto& fetcher_state
+                  = find_fetcher_state(topic, p.partition_id)->get();
+
+                fetcher_state.incremental_include = false;
             }
         }
 

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -265,6 +265,24 @@ private:
       model::partition_id partition,
       const topic_partition_map<epoch_set>& epochs);
 
+    /**
+     * finds a fetcher_state within the map of assigned partitions
+     * returns a reference to its fetch state if found, nullopt otherwise
+     */
+    std::optional<std::reference_wrapper<partition_fetch_state>>
+    find_fetcher_state(
+      const model::topic& topic, model::partition_id partition);
+
+    /**
+     * given a tp and an epoch map compares the current fetcher epoch against
+     * that from the provided map. If either epoch is missing, or the epochs
+     * disagree, the tp is inconsistent.
+     */
+    bool is_consistent_fetcher_epoch(
+      const model::topic& topic,
+      model::partition_id partition_id,
+      const topic_partition_map<epoch_set>& epochs);
+
     ss::future<api_version> get_fetch_request_version() const;
     ss::future<api_version> get_list_offsets_request_version() const;
     ss::future<> do_fetch();

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -140,8 +140,8 @@ private:
  *
  * Fetcher locks the assignment state while changing assignments, preparing the
  * fetch request and processing the response. Every time the partition
- * assignment is updated its corresponding assignment epoch is incremented.
- * Partition fetch responses with stale assignment epoch are ignored. This
+ * assignment is updated its corresponding fetcher epoch is incremented.
+ * Partition fetch responses with stale fetcher epoch are ignored. This
  * concurrency control mechanism guarantees that the fetcher will not update its
  * subscriptions with the stale information from the request when it was changed
  * more than once while it was waiting for the response.
@@ -185,7 +185,7 @@ public:
     void toggle_sessions(fetch_sessions_enabled);
 
 private:
-    using assignment_epoch = named_type<uint64_t, struct fetcher_epoch_tag>;
+    using fetcher_epoch = named_type<uint64_t, struct fetcher_epoch_tag>;
     /**
      * Fields required s.t. they are harder to forget.
      * Defaults:
@@ -198,13 +198,13 @@ private:
         partition_fetch_state(
           model::partition_id partition_id,
           std::optional<kafka::offset> fetch_offset,
-          assignment_epoch fetcher_epoch,
+          fetcher_epoch fetcher_epoch,
           subscription_epoch subscription_epoch) noexcept
           : partition_id{partition_id}
           , fetch_offset{fetch_offset}
           , high_watermark{std::nullopt}
           , current_leader_epoch{kafka::invalid_leader_epoch}
-          , assignment_epoch{fetcher_epoch}
+          , fetcher_epoch{fetcher_epoch}
           , incremental_include{true}
           , subscription_epoch{subscription_epoch} {}
 
@@ -212,7 +212,7 @@ private:
         std::optional<kafka::offset> fetch_offset;
         std::optional<kafka::offset> high_watermark;
         leader_epoch current_leader_epoch;
-        assignment_epoch assignment_epoch;
+        fetcher_epoch fetcher_epoch;
         bool incremental_include;
         subscription_epoch subscription_epoch;
 
@@ -238,17 +238,17 @@ private:
     // filter stale fetch responses
     struct epoch_set {
         epoch_set(
-          assignment_epoch fetcher_epoch,
+          fetcher_epoch fetcher_epoch,
           subscription_epoch subscription_epoch) noexcept
           : fetcher_epoch{fetcher_epoch}
           , subscription_epoch{subscription_epoch} {}
 
-        assignment_epoch fetcher_epoch;
+        fetcher_epoch fetcher_epoch;
         subscription_epoch subscription_epoch;
     };
 
     struct partitions_with_epoch {
-        topic_partition_map<assignment_epoch> assignment_epochs;
+        topic_partition_map<fetcher_epoch> fetcher_epochs;
         chunked_vector<partitions_to_process> partitions;
     };
     struct fetch_response_content {
@@ -258,10 +258,10 @@ private:
         kafka::fetch_session_id session_id{0};
     };
 
-    static std::optional<assignment_epoch> find_assignment_epoch(
+    static std::optional<fetcher_epoch> find_fetcher_epoch(
       const model::topic& topic,
       model::partition_id partition,
-      const topic_partition_map<assignment_epoch>& epochs);
+      const topic_partition_map<fetcher_epoch>& epochs);
 
     ss::future<api_version> get_fetch_request_version() const;
     ss::future<api_version> get_list_offsets_request_version() const;
@@ -269,14 +269,14 @@ private:
     ss::future<partitions_with_epoch> collect_partitions();
     ss::future<kafka::error_code> maybe_initialise_fetch_offsets(
       const chunked_vector<partitions_to_process>&,
-      const topic_partition_map<assignment_epoch>& epochs);
+      const topic_partition_map<fetcher_epoch>& epochs);
 
     ss::future<fetch_request>
     make_fetch_request(const chunked_vector<partitions_to_process>&);
 
     ss::future<kafka_result<fetch_response_content>> process_fetch_response(
       fetch_response resp,
-      const topic_partition_map<assignment_epoch>& epochs,
+      const topic_partition_map<fetcher_epoch>& epochs,
       const chunked_vector<partitions_to_process>& partitions);
     /**
      * Returns false if the partition was not found or the fetch offset was
@@ -288,14 +288,14 @@ private:
       model::partition_id,
       kafka::offset,
       kafka::offset,
-      std::optional<assignment_epoch>);
+      std::optional<fetcher_epoch>);
 
     ss::future<kafka_result<chunked_vector<topic_partition_offsets>>>
       do_list_offsets(list_offsets_request);
 
     data_queue& queue();
     prefix_logger& logger();
-    assignment_epoch next_epoch() { return ++_epoch; }
+    fetcher_epoch next_epoch() { return ++_epoch; }
 
     void reset_partition_offset(model::topic_partition_view);
 
@@ -307,7 +307,16 @@ private:
     ss::condition_variable _partitions_updated;
     ss::gate _gate;
     mutex _state_lock;
-    assignment_epoch _epoch{0};
+    /**
+     * A fetcher epoch will be incremented and assigned to every assigned
+     * partition. This allows for different assignment instances of a tp to be
+     * differentiated, e.g. a tp is assigned to a fetcher, unassigned, and
+     * reassigned with a lower fetch offset. Any response from the first
+     * instance of assignment should
+     * 1. not be placed on the output queue and
+     * 2. not be used to update the fetch offset of the second assignment
+     */
+    fetcher_epoch _epoch{0};
     ss::abort_source _as;
 };
 } // namespace kafka::client

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -186,13 +186,35 @@ public:
 
 private:
     using assignment_epoch = named_type<uint64_t, struct fetcher_epoch_tag>;
+    /**
+     * Fields required s.t. they are harder to forget.
+     * Defaults:
+     *  - high_watermark: nullopt, not known at instantiation
+     *  - current_leader_epoch: nullopt, not known at instantiation
+     *  - incremental_include: true, new assignments should always be included
+     *    in the next fetch
+     */
     struct partition_fetch_state {
+        partition_fetch_state(
+          model::partition_id partition_id,
+          std::optional<kafka::offset> fetch_offset,
+          assignment_epoch fetcher_epoch,
+          subscription_epoch subscription_epoch) noexcept
+          : partition_id{partition_id}
+          , fetch_offset{fetch_offset}
+          , high_watermark{std::nullopt}
+          , current_leader_epoch{kafka::invalid_leader_epoch}
+          , assignment_epoch{fetcher_epoch}
+          , incremental_include{true}
+          , subscription_epoch{subscription_epoch} {}
+
         model::partition_id partition_id;
         std::optional<kafka::offset> fetch_offset;
         std::optional<kafka::offset> high_watermark;
-        leader_epoch current_leader_epoch{kafka::invalid_leader_epoch};
-        assignment_epoch assignment_epoch{0};
-        bool incremental_include{false};
+        leader_epoch current_leader_epoch;
+        assignment_epoch assignment_epoch;
+        bool incremental_include;
+        subscription_epoch subscription_epoch;
 
         bool include_in_fetch_request() const {
             return fetch_offset.has_value();

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -232,6 +232,21 @@ private:
                    && to_forget.empty();
         }
     };
+
+    // consistency tracking, fetcher_epoch will be used to detect fetcher
+    // assignment updates, subscription epoch will be used in direct_consumer to
+    // filter stale fetch responses
+    struct epoch_set {
+        epoch_set(
+          assignment_epoch fetcher_epoch,
+          subscription_epoch subscription_epoch) noexcept
+          : fetcher_epoch{fetcher_epoch}
+          , subscription_epoch{subscription_epoch} {}
+
+        assignment_epoch fetcher_epoch;
+        subscription_epoch subscription_epoch;
+    };
+
     struct partitions_with_epoch {
         topic_partition_map<assignment_epoch> assignment_epochs;
         chunked_vector<partitions_to_process> partitions;

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -248,7 +248,7 @@ private:
     };
 
     struct partitions_with_epoch {
-        topic_partition_map<fetcher_epoch> fetcher_epochs;
+        topic_partition_map<epoch_set> epochs;
         chunked_vector<partitions_to_process> partitions;
     };
     struct fetch_response_content {
@@ -261,7 +261,7 @@ private:
     static std::optional<fetcher_epoch> find_fetcher_epoch(
       const model::topic& topic,
       model::partition_id partition,
-      const topic_partition_map<fetcher_epoch>& epochs);
+      const topic_partition_map<epoch_set>& epochs);
 
     ss::future<api_version> get_fetch_request_version() const;
     ss::future<api_version> get_list_offsets_request_version() const;
@@ -269,14 +269,14 @@ private:
     ss::future<partitions_with_epoch> collect_partitions();
     ss::future<kafka::error_code> maybe_initialise_fetch_offsets(
       const chunked_vector<partitions_to_process>&,
-      const topic_partition_map<fetcher_epoch>& epochs);
+      const topic_partition_map<epoch_set>& epochs);
 
     ss::future<fetch_request>
     make_fetch_request(const chunked_vector<partitions_to_process>&);
 
     ss::future<kafka_result<fetch_response_content>> process_fetch_response(
       fetch_response resp,
-      const topic_partition_map<fetcher_epoch>& epochs,
+      const topic_partition_map<epoch_set>& epochs,
       const chunked_vector<partitions_to_process>& partitions);
     /**
      * Returns false if the partition was not found or the fetch offset was

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -165,7 +165,9 @@ public:
      * update the fetch offsets for the already assigned partitions.
      */
     ss::future<> assign_partition(
-      model::topic_partition_view, std::optional<kafka::offset>);
+      model::topic_partition_view,
+      std::optional<kafka::offset>,
+      subscription_epoch);
     /**
      * Unassign partition from the fetcher, it will stop fetching data for the
      * partition and remove it from the fetcher state. After the unassignment

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -258,7 +258,7 @@ private:
         kafka::fetch_session_id session_id{0};
     };
 
-    static std::optional<fetcher_epoch> find_fetcher_epoch(
+    static std::optional<epoch_set> find_epoch_set(
       const model::topic& topic,
       model::partition_id partition,
       const topic_partition_map<epoch_set>& epochs);
@@ -288,7 +288,7 @@ private:
       model::partition_id,
       kafka::offset,
       kafka::offset,
-      std::optional<fetcher_epoch>);
+      std::optional<epoch_set>);
 
     ss::future<kafka_result<chunked_vector<topic_partition_offsets>>>
       do_list_offsets(list_offsets_request);

--- a/src/v/kafka/client/direct_consumer/fetcher.h
+++ b/src/v/kafka/client/direct_consumer/fetcher.h
@@ -304,11 +304,7 @@ private:
      * This indicates that the fetch response should be ignored.
      */
     bool maybe_update_fetch_offset(
-      const model::topic&,
-      model::partition_id,
-      kafka::offset,
-      kafka::offset,
-      std::optional<epoch_set>);
+      const model::topic&, model::partition_id, kafka::offset, kafka::offset);
 
     ss::future<kafka_result<chunked_vector<topic_partition_offsets>>>
       do_list_offsets(list_offsets_request);

--- a/src/v/kafka/client/direct_consumer/tests/BUILD
+++ b/src/v/kafka/client/direct_consumer/tests/BUILD
@@ -28,6 +28,7 @@ redpanda_cc_gtest(
         "//src/v/kafka/client/direct_consumer",
         "//src/v/kafka/client/test:cluster_mock",
         "//src/v/kafka/protocol",
+        "//src/v/model",
         "//src/v/model/tests:random",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/kafka/client/direct_consumer/tests/direct_consumer_test.cc
+++ b/src/v/kafka/client/direct_consumer/tests/direct_consumer_test.cc
@@ -15,6 +15,7 @@
 #include "kafka/client/test/cluster_mock.h"
 #include "kafka/client/types.h"
 #include "kafka/protocol/types.h"
+#include "model/fundamental.h"
 #include "model/tests/random_batch.h"
 #include "test_utils/async.h"
 #include "test_utils/test.h"
@@ -466,6 +467,130 @@ TEST_F(consumer_test_mock, TestLeadershipChange) {
             return all_batches[test_topic][model::partition_id(0)].size() == 33;
         });
     });
+}
+
+namespace {
+// types and functions specific to subscription epoch filtering
+namespace epoch_filtering_ns {
+
+enum reassign_direction : uint8_t { backward, same, forward };
+
+std::pair<kafka::offset, kafka::offset>
+init_offsets(reassign_direction direction) {
+    switch (direction) {
+    case backward:
+        return {kafka::offset{20}, kafka::offset{10}};
+    case same:
+        return {kafka::offset{10}, kafka::offset{10}};
+    case forward:
+        return {kafka::offset{10}, kafka::offset{20}};
+    }
+}
+
+/**
+ * Checks stale subscription filtering.
+ * 1. replicate batches of 10, offset 0 -> 49
+ * 2. assign ntp to direct_consumer with assignment_offset
+ * 3. let dc fetch data
+ * 4. unassign ntp
+ * 5. reassign ntp with reassignment_offset
+ * 6. check the first call to fetch_next is a empty fetch (was filtered out)
+ * 7. drain all fetches, check we see only 50 - reassignment offset
+ */
+void epoch_filtering_test(
+  consumer_test_mock* self, reassign_direction direction) {
+    self->prepare_cluster();
+    model::topic test_topic("panda-test");
+    self->cluster_mock.add_topic(test_topic, 1, 3);
+    topic_partition_map<chunked_vector<model::record_batch>> all_batches;
+
+    static constexpr auto batch_count{5};
+    static constexpr auto batch_size{10};
+
+    // 1. replicate [0,9], [10,19], [20,29]... [40,49]
+    for (auto index{0}; index < batch_count; ++index) {
+        std::ignore = index;
+        self->make_data_available(test_topic, 0, batch_size);
+    }
+
+    auto client_cluster = self->create_client_cluster();
+    client_cluster.start().get();
+    direct_consumer consumer(client_cluster, direct_consumer::configuration{});
+    consumer.start().get();
+    auto deferred_stop = ss::defer([&] {
+        consumer.stop().get();
+        client_cluster.stop().get();
+    });
+
+    auto [assignment_offset, reassignment_offset] = init_offsets(direction);
+
+    auto get_assignment = [test_topic](kafka::offset begin) {
+        chunked_vector<topic_assignment> assignment;
+        assignment.push_back({
+          .topic = test_topic,
+        });
+        // only partition 0 is assigned
+        assignment.back().partitions.push_back(
+          partition_assignment{
+            .partition_id = model::partition_id(0),
+            .next_offset = kafka::offset(begin),
+          });
+        return assignment;
+    };
+
+    // 2. assign ntp at assignment_offset to direct_consumer
+    consumer.assign_partitions(get_assignment(assignment_offset)).get();
+
+    // 3. let dc fetch data
+    // TODO we need a way to force iterations to occur
+    ss::sleep(2s).get();
+
+    // 4&5. unassign & reassign with offset reassignment_offset instead
+    consumer.unassign_topics({test_topic}).get();
+    consumer.assign_partitions(get_assignment(reassignment_offset)).get();
+
+    // 6. check the first call to fetch_next is an empty fetch (was filtered)
+    auto filtered_fetch_result = consumer.fetch_next(5s).get();
+    ASSERT_TRUE(filtered_fetch_result.has_value());
+    auto filtered_fetch = std::move(filtered_fetch_result).value();
+    int found_partition_count{0};
+
+    for (auto& topic_data : filtered_fetch) {
+        for (auto& partition_data : topic_data.partitions) {
+            std::ignore = partition_data;
+            ++found_partition_count;
+            ASSERT_EQ(topic_data.total_bytes, 0);
+        }
+    }
+    ASSERT_EQ(found_partition_count, 0);
+
+    const size_t expected_size = (batch_count * batch_size)
+                                 - static_cast<int64_t>(reassignment_offset);
+    const model::offset final_offset{batch_count * batch_size - 1};
+
+    // 7. drain all fetches, check we see only 50 - reassignment_offset
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        return self->fetch_and_append_to_map(all_batches, consumer).then([&] {
+            auto& ntp_batches = all_batches[test_topic][model::partition_id(0)];
+            return ntp_batches.size() == expected_size
+                   && ntp_batches.back().last_offset() == final_offset;
+        });
+    });
+}
+} // namespace epoch_filtering_ns
+} // namespace
+
+TEST_F(consumer_test_mock, TestEpochFilteringBackward) {
+    epoch_filtering_ns::epoch_filtering_test(
+      this, epoch_filtering_ns::backward);
+}
+
+TEST_F(consumer_test_mock, TestEpochFilteringSame) {
+    epoch_filtering_ns::epoch_filtering_test(this, epoch_filtering_ns::same);
+}
+
+TEST_F(consumer_test_mock, TestEpochFilteringForward) {
+    epoch_filtering_ns::epoch_filtering_test(this, epoch_filtering_ns::forward);
 }
 
 TEST_F(consumer_test_mock, TestOffsetResetPolicy) {


### PR DESCRIPTION
This PR does two things.
1. It adds stale fetch filtering to direct_consumer
2. It adds utility methods to diff the epochs used in a fetch request against the epochs found when the request ends
  a. This allows for substantial code simplification.

Direct consumer now tracks its subscriptions with a subscription_epoch. This field functions analogously to assignment_epoch within direct_consumer's fetchers. All fetches will bear the subscription_epoch from the point in time that they were fetched, and on calling fetch_next, the subscription epochs are diff'd against the current subscription epochs to identify and remove stale fetches.

For fetcher cleanup, this PR adds
```cpp
    bool is_consistent_fetcher_epoch(
      const model::topic& topic,
      model::partition_id partition_id,
      const topic_partition_map<epoch_set>& epochs);
```

When a fetch request is started, we snapshot the epochs of all partitions involved in the fetch request. When a fetch response is being handled, the assignment for a given partitions may have been removed, or updated.

This function true iff both the current epoch, and the epoch snapshotted for the request exist and are equal.

This allows for
1. all inconsistent responses to be removed when a fetch_response is handled
2. for a substantially smaller code footprint in the many cases where epoch drift needs to be detected

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Improvements

* Removes stale fetches from direct_consumer output when an ntp has been unassigned and reassigned
* direct_consumer/fetcher code simplification

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
