### PR TITLE
[v25.2.x] r/buffered_proto: removed status log line

### DIFF
--- a/src/v/raft/buffered_protocol.cc
+++ b/src/v/raft/buffered_protocol.cc
@@ -211,7 +211,6 @@ void buffered_protocol::garbage_collect_unused_queues() {
     for (auto it = _append_entries_queues.begin(),
               last = _append_entries_queues.end();
          it != last;) {
-        it->second->log_status();
         if (it->second->is_idle()) {
             std::unique_ptr<internal::append_entries_queue> queue;
             queue.swap(it->second);
@@ -355,15 +354,6 @@ ss::future<> append_entries_queue::stop() {
     _internal_metrics.clear();
     return _gate.close().finally(
       [this] { vlog(_logger.debug, "stopped queue"); });
-}
-
-void append_entries_queue::log_status() const {
-    vlog(
-      _logger.info,
-      "inflight requests: {}, buffered requests: {}, buffered_bytes: {}",
-      inflight_requests(),
-      _requests.size(),
-      _buffered_bytes);
 }
 
 void append_entries_queue::setup_internal_metrics() {

--- a/src/v/raft/buffered_protocol.h
+++ b/src/v/raft/buffered_protocol.h
@@ -53,8 +53,8 @@ public:
         return _current_max_inflight_requests
                - _inflight_requests_sem.available_units();
     };
+
     bool is_idle() const;
-    void log_status() const;
 
 private:
     ss::future<> dispatch_loop();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27420
