### PR TITLE
config: do not allow to unset cluster_id

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -589,7 +589,7 @@ configuration::configuration()
       "Cluster identifier.",
       {.needs_restart = needs_restart::no, .gets_restored = gets_restored::no},
       std::nullopt,
-      &validate_non_empty_string_opt)
+      &validate_non_empty_string_non_empty_opt)
   , disable_metrics(
       *this,
       "disable_metrics",

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -162,6 +162,17 @@ validate_non_empty_string_opt(const std::optional<ss::sstring>& os) {
 }
 
 std::optional<ss::sstring>
+validate_non_empty_string_non_empty_opt(const std::optional<ss::sstring>& os) {
+    if (!os.has_value()) {
+        return "Value must be set";
+    } else if (os.value().empty()) {
+        return "Empty string is not valid";
+    } else {
+        return std::nullopt;
+    }
+}
+
+std::optional<ss::sstring>
 validate_audit_event_types(const std::vector<ss::sstring>& vs) {
     /// TODO: Should match stringified enums in kafka/types.h
     static const absl::flat_hash_set<ss::sstring> audit_event_types{

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -46,6 +46,9 @@ std::optional<ss::sstring>
 validate_non_empty_string_opt(const std::optional<ss::sstring>&);
 
 std::optional<ss::sstring>
+validate_non_empty_string_non_empty_opt(const std::optional<ss::sstring>&);
+
+std::optional<ss::sstring>
 validate_audit_event_types(const std::vector<ss::sstring>& vs);
 
 std::optional<ss::sstring>


### PR DESCRIPTION
We want to use this value in Whole Cluster Recovery. It is much easier to reason about it if once we waited for it to be initialized we can be sure it won't get unset at runtime.

Changing is fine. We just need a value to work with.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
