### PR TITLE
ct: Downgrade the assertion in ct/frontend

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -468,24 +468,32 @@ ss::future<> bg_upload_and_replicate(
                 if (res.has_error()) {
                     return res.error();
                 }
-                // We know that the data is replicated so it's safe to add
-                // the batch to the record batch cache before returning.
                 if (cache_enabled) {
-                    vassert(
-                      res.value().last_term != model::term_id{},
-                      "Term not set");
-                    update_batches(
-                      inp,
-                      kafka::offset_cast(res.value().last_offset),
-                      res.value().last_term);
-                    for (const auto& b : inp) {
+                    // The term_id is not guaranteed to be set if the request
+                    // was served from the list of finished requests. This might
+                    // happen if the request is coming from the snapshot (in
+                    // which case it's not stored) or from the log replay. The
+                    // simplest solution in this case is to skip caching.
+                    if (res.value().last_term >= model::term_id{0}) {
+                        update_batches(
+                          inp,
+                          kafka::offset_cast(res.value().last_offset),
+                          res.value().last_term);
+                        for (const auto& b : inp) {
+                            vlog(
+                              cd_log.trace,
+                              "Putting batch to cache: {}, term: {}",
+                              b.base_offset(),
+                              b.term());
+                            api->cache_put(ntp, b);
+                        }
+                    } else {
                         vlog(
-                          cd_log.trace,
-                          "Putting batch for {} to cache: {}, term: {}",
+                          cd_log.debug,
+                          "Skipping cache put for ntp {} at offset {} with "
+                          "unset term",
                           ntp,
-                          b.base_offset(),
-                          b.term());
-                        api->cache_put(ntp, b);
+                          res.value().last_offset);
                     }
                 }
                 return raft::replicate_result{

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -218,7 +218,7 @@ void requests::stm_apply(
     ready.set_value(kafka_result{.last_offset = offset});
     _finished_requests.emplace_back(
       ss::make_lw_shared<request>(
-        bid.first_seq, bid.last_seq, model::term_id{-1}, std::move(ready)));
+        bid.first_seq, bid.last_seq, term, std::move(ready)));
 
     while (_finished_requests.size() > requests_cached_max) {
         _finished_requests.pop_front();
@@ -260,7 +260,7 @@ producer_state::producer_state(
           ss::make_lw_shared<request>(
             req.first_sequence,
             req.last_sequence,
-            model::term_id{-1},
+            req.last_term,
             std::move(ready)));
     }
 }
@@ -529,7 +529,10 @@ producer_state::snapshot(kafka::offset log_start_offset) const {
         // offsets older than log start are no longer interesting.
         if (kafka_offset >= log_start_offset) {
             snapshot.finished_requests.emplace_back(
-              req->_first_sequence, req->_last_sequence, kafka_offset);
+              req->_first_sequence,
+              req->_last_sequence,
+              kafka_offset,
+              req->term());
         }
     }
     if (_transaction_state) {

--- a/src/v/cluster/rm_stm_types.h
+++ b/src/v/cluster/rm_stm_types.h
@@ -194,20 +194,27 @@ struct producer_state_snapshot
     struct finished_request
       : serde::envelope<
           finished_request,
-          serde::version<0>,
+          serde::version<1>,
           serde::compat_version<0>> {
         finished_request() = default;
-        finished_request(int32_t first, int32_t last, kafka::offset last_offset)
+        finished_request(
+          int32_t first,
+          int32_t last,
+          kafka::offset last_offset,
+          model::term_id term = model::term_id{-1})
           : first_sequence(first)
           , last_sequence(last)
-          , last_offset(last_offset) {}
+          , last_offset(last_offset)
+          , last_term(term) {}
 
         int32_t first_sequence;
         int32_t last_sequence;
         kafka::offset last_offset;
+        model::term_id last_term{model::term_id{-1}};
 
         auto serde_fields() {
-            return std::tie(first_sequence, last_sequence, last_offset);
+            return std::tie(
+              first_sequence, last_sequence, last_offset, last_term);
         }
     };
 


### PR DESCRIPTION
With the rm_stm in the write path the the frontend may see the replicated batch with term set to -1. This happens in case of idempotency viloation. The rm_stm uses the request from the list of finished requests and this request could potentially come from the snapshot which doesn't store term or from the log replay in which case the term is not propagated to the request.

This PR is a bug fix required for using CT in `RandomNodeOperationsTest`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none