### PR TITLE
datalake: properly determine client timestamp

### DIFF
--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -23,6 +23,7 @@
 #include "model/batch_compression.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "model/timestamp.h"
 
 #include <seastar/core/loop.hh>
 
@@ -128,7 +129,10 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
       raw_size_bytes,
       decompressed_size_bytes);
 
+    auto is_broker_time = batch.header().attrs.timestamp_type()
+                          == model::timestamp_type::append_time;
     auto first_timestamp = batch.header().first_timestamp.value();
+    auto max_timestamp = batch.header().max_timestamp;
     auto it = model::record_batch_iterator::create(batch);
     while (it.has_next()) {
         if (as.abort_requested()) {
@@ -138,8 +142,10 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
         auto record = it.next();
         auto key = record.share_key_opt();
         auto val = record.share_value_opt();
-        auto timestamp = model::timestamp{
-          first_timestamp + record.timestamp_delta()};
+        auto timestamp = is_broker_time
+                           ? max_timestamp
+                           : model::timestamp{
+                               first_timestamp + record.timestamp_delta()};
         kafka::offset offset{batch.base_offset()() + record.offset_delta()};
         if (offset < start_offset) {
             continue;

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -20,11 +20,13 @@
 #include "datalake/tests/test_utils.h"
 #include "datalake/translation/translation_probe.h"
 #include "features/feature_table.h"
+#include "gmock/gmock.h"
 #include "iceberg/filesystem_catalog.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
 #include "model/timeout_clock.h"
+#include "model/timestamp.h"
 #include "random/generators.h"
 #include "storage/record_batch_builder.h"
 
@@ -539,4 +541,58 @@ TEST_F(RecordMultiplexerTest, TestMultiplexingFromMiddleOfBatch) {
     EXPECT_FALSE(result.has_error()) << result.error();
     EXPECT_EQ(result.value().start_offset(), start_offset);
     EXPECT_EQ(result.value().last_offset(), last_offset);
+}
+
+TEST_F(RecordMultiplexerTest, TestRecordTimestamp) {
+    // Make sure we respect client vs broker timestamps.
+    binary_type_resolver kv_resolver; // This test doesn't need schemas
+    direct_table_creator table_creator(kv_resolver, schema_mgr);
+    key_value_translator kv_translator;
+    auto mux = record_multiplexer(
+      ntp,
+      topic_rev,
+      std::make_unique<test_data_writer_factory>(false),
+      schema_mgr,
+      kv_resolver,
+      kv_translator,
+      table_creator,
+      model::iceberg_invalid_record_action::dlq_table,
+      location_provider(scoped_remote->remote.local().provider(), bucket_name),
+      *get_or_create_probe(ntp),
+      &features);
+    auto batches = model::test::make_random_batches(
+                     {
+                       .offset = model::offset{0},
+                       .count = 2,
+                       .records = 100,
+                       // Use a timestamp from 1 year ago
+                       .timestamp = model::timestamp{1726262280000},
+                     })
+                     .get();
+    // Simulate the second batch is using the broker append time, which is a
+    // current timestamp
+    batches.back().set_max_timestamp(
+      model::timestamp_type::append_time, model::timestamp{1757884680000});
+    auto start_offset = batches.front().base_offset();
+    auto reader = model::make_memory_record_batch_reader(std::move(batches));
+    mux
+      .multiplex(
+        std::move(reader), kafka::offset{start_offset}, model::no_timeout, as)
+      .get();
+    auto result = std::move(mux).finish().get();
+    ASSERT_FALSE(result.has_error());
+    // We should get a partition between the two batches because the different
+    // timestamps
+    ASSERT_EQ(result.value().data_files.size(), 2);
+    // We don't require the order of the data files.
+    EXPECT_THAT(
+      result.value().data_files,
+      testing::UnorderedElementsAre(
+        testing::Field(
+          &partitioning_writer::partitioned_file::partition_key_path,
+          remote_path("redpanda.timestamp_hour=2024-09-13-21")),
+        testing::Field(
+          &partitioning_writer::partitioned_file::partition_key_path,
+          remote_path("redpanda.timestamp_hour=2025-09-14-21"))));
+    EXPECT_EQ(result.value().dlq_files.size(), 0);
 }


### PR DESCRIPTION
If the broker time is used for the batch, we must use the max timestamp,
not the first + delta. This mirrors the logic in clients (we also do
this correctly in Wasm, see transform_module.cc).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Use the correct timestamp for Iceberg translated data when the record is configured to use the broker append time as its timestamp
