### PR TITLE
Run some Shadow Linking test against Kafka cluster

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -214,7 +214,7 @@ ss::future<> remote_broker::initialize_versions() {
         vlog(
           _logger.warn,
           "Unable to initialize the API versions - {}",
-          std::current_exception());
+          response.data.error_code);
         throw broker_error(
           _node_id,
           response.data.error_code,

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -169,8 +169,14 @@ namespace {
 api_versions_request make_api_versions_request(api_version version) {
     api_versions_request req;
     if (version >= api_version(3)) {
+        /**
+         * In order to work with Kafka brokers this must match the following
+         * regex:
+         *
+         * [a-zA-Z0-9](?:[a-zA-Z0-9\\-.]*[a-zA-Z0-9])?
+         */
         req.data.client_software_name = "redpanda-client";
-        req.data.client_software_version = ss::sstring(redpanda_version());
+        req.data.client_software_version = ss::sstring(redpanda_git_version());
     }
     return req;
 }
@@ -192,33 +198,47 @@ ss::future<> remote_broker::initialize_versions() {
     api_versions_request request;
     request.data.client_software_name = "redpanda-client";
     request.data.client_software_version = ss::sstring(redpanda_version());
-    auto response = co_await _transport->dispatch(
+    auto response_buffer = co_await _transport->dispatch_request_raw_response(
       make_api_versions_request(api_versions_api::max_valid),
       api_versions_api::max_valid);
-
-    // TODO: handle the returned supported version here
-    if (response.data.error_code == error_code::unsupported_version) {
-        auto fallback_version = find_api_versions_request_version(
-          response.data.api_keys);
-        vlog(
-          _logger.info,
-          "Broker does not support API version request version {}, falling "
-          "back to version {}",
-          api_versions_api::max_valid,
-          fallback_version);
-        response = co_await _transport->dispatch(
-          make_api_versions_request(fallback_version), fallback_version);
-    }
-
-    if (response.data.error_code != error_code::none) {
-        vlog(
-          _logger.warn,
-          "Unable to initialize the API versions - {}",
-          response.data.error_code);
-        throw broker_error(
-          _node_id,
-          response.data.error_code,
-          "Failed to initialize API versions");
+    /**
+     * Peek for the API versions response error code.
+     */
+    protocol::decoder reader(response_buffer.share());
+    auto resp_ec = kafka::error_code(reader.read_int16());
+    /**
+     * If the broker does not support the requested version of the API versions
+     * request, it will respond with UNSUPPORTED_VERSION error code and the
+     * ApiVersionResponse version 0.
+     *
+     * For more details see: KIP-511
+     */
+    api_versions_response response;
+    if (resp_ec == error_code::none) {
+        response.decode(
+          std::move(response_buffer), api_versions_api::max_valid);
+    } else {
+        // TODO: handle the returned supported version here
+        if (resp_ec == error_code::unsupported_version) {
+            response.decode(std::move(response_buffer), api_version(0));
+            auto fallback_version = find_api_versions_request_version(
+              response.data.api_keys);
+            vlog(
+              _logger.info,
+              "Broker does not support API version request version {}, falling "
+              "back to version {}",
+              api_versions_api::max_valid,
+              fallback_version);
+            response = co_await _transport->dispatch(
+              make_api_versions_request(fallback_version), fallback_version);
+        } else {
+            vlog(
+              _logger.warn,
+              "Unable to initialize the API versions - {}",
+              resp_ec);
+            throw broker_error(
+              _node_id, resp_ec, "Failed to initialize API versions");
+        }
     }
 
     for (auto& api : response.data.api_keys) {

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -85,7 +85,7 @@ public:
       RequestT r,
       api_version version,
       std::optional<model::timeout_clock::duration> timeout = default_timeout) {
-        return do_send(std::move(r), version, timeout)
+        return do_send_and_decode(std::move(r), version, timeout)
           .then(
             [this](
               checked<typename RequestT::api_type::response_type, errc> res) {
@@ -117,7 +117,40 @@ public:
       RequestT r,
       api_version version,
       std::optional<model::timeout_clock::duration> timeout = default_timeout) {
-        return do_send(std::move(r), version, timeout);
+        return do_send_and_decode(std::move(r), version, timeout);
+    }
+    /**
+     * Dispatches the request to the broker and returns the raw response
+     * as an iobuf. This is useful for requests that have a non-standard
+     * decoding rules f.e. API version request
+     */
+    template<typename RequestT>
+    requires(KafkaApi<typename RequestT::api_type>)
+    ss::future<iobuf> dispatch_request_raw_response(
+      RequestT r,
+      api_version version,
+      std::optional<model::timeout_clock::duration> timeout = default_timeout) {
+        return do_send(std::move(r), version, timeout)
+          .then([this](checked<iobuf, errc> res) {
+              if (res.has_error()) {
+                  if (res.error() == errc::disconnected) {
+                      throw kafka_request_disconnected_exception(
+                        fmt::format(
+                          "Broker {}:{} transport disconnected",
+                          server_address().host(),
+                          server_address().port()));
+                  } else if (res.error() == errc::timeout) {
+                      throw kafka_request_disconnected_exception(
+                        fmt::format(
+                          "Broker {}:{} request of type {} timed out",
+                          server_address().host(),
+                          server_address().port(),
+                          RequestT::api_type::name));
+                  }
+              }
+
+              return std::move(res.value());
+          });
     }
 
     ss::future<> connect(
@@ -166,12 +199,11 @@ private:
     void on_timeout(correlation_id correlation);
 
     template<typename RequestT>
-    ss::future<checked<typename RequestT::api_type::response_type, errc>>
-    do_send(
+    ss::future<checked<iobuf, errc>> do_send(
       RequestT request,
       api_version version,
       std::optional<model::timeout_clock::duration> timeout) {
-        using ret_t = checked<typename RequestT::api_type::response_type, errc>;
+        using ret_t = checked<iobuf, errc>;
         // hold the mutex here before the message is written to the output
         // stream to ensure ordering or requests.
         auto u = co_await _dispatch_mutex.get_units();
@@ -221,15 +253,32 @@ private:
         // return all units to the semaphore before flushing the output
         u.return_all();
         co_await _out.flush();
-        typename RequestT::api_type::response_type resp;
         auto response_data = co_await std::move(response_future);
         if (response_data.has_error()) {
             co_return ret_t(response_data.error());
         }
-        resp.decode(std::move(response_data.value().data), version);
-        // TODO: If we need to handle tags, we can do it here.
-        co_return resp;
+
+        co_return std::move(response_data.value().data);
     }
+
+    template<typename RequestT>
+    ss::future<checked<typename RequestT::api_type::response_type, errc>>
+    do_send_and_decode(
+      RequestT request,
+      api_version version,
+      std::optional<model::timeout_clock::duration> timeout) {
+        using ret_t = checked<typename RequestT::api_type::response_type, errc>;
+        auto response_data = co_await do_send(
+          std::move(request), version, timeout);
+        if (response_data.has_error()) {
+            co_return ret_t(response_data.error());
+        }
+        typename RequestT::api_type::response_type resp;
+        resp.decode(std::move(response_data.value()), version);
+        // TODO: If we need to handle tags, we can do it here.
+        co_return ret_t(std::move(resp));
+    }
+
     mutex _dispatch_mutex{"kafka::client::transport::dispatch_mutex"};
     bool _needs_stop = false;
     correlation_id _correlation{0};

--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -24,6 +24,9 @@ class KafkaServiceAdapter(RedpandaServiceForClients):
     def brokers(self):
         return self._kafka_service.bootstrap_servers()
 
+    def brokers_list(self) -> list[str]:
+        return self._kafka_service.bootstrap_servers().split(",")
+
     def start(self):
         return self._kafka_service.start()
 

--- a/tests/rptest/services/multi_cluster_services.py
+++ b/tests/rptest/services/multi_cluster_services.py
@@ -18,6 +18,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.kafka import KafkaServiceAdapter
 from rptest.services.redpanda import RedpandaService
+from kafkatest.services.kafka import quorum
 
 KAFKA_VERSION = kafkatest.version.KafkaVersion("3.7.0")
 
@@ -31,6 +32,34 @@ Service = RedpandaService | KafkaServiceAdapter
 C = TypeVar("C", bound="Cluster")
 KC = TypeVar("KC", bound="KafkaCluster")
 RC = TypeVar("RC", bound="RedpandaCluster")
+
+
+class SecondaryClusterSpec(dict):
+    def __init__(
+        self,
+        cluster_type: ServiceType = ServiceType.REDPANDA,
+        kafka_version: str | None = None,
+        kafka_quorum: str | None = None,
+    ):
+        super().__init__(
+            cluster_type=cluster_type,
+        )
+        if kafka_version:
+            self["kafka_version"] = kafka_version
+        if kafka_quorum:
+            self["kafka_quorum"] = kafka_quorum
+
+    @property
+    def cluster_type(self) -> ServiceType:
+        return self["cluster_type"]
+
+    @property
+    def kafka_version(self) -> str | None:
+        return self.get("kafka_version", None)
+
+    @property
+    def kafka_quorum(self) -> str | None:
+        return self.get("kafka_quorum", None)
 
 
 class Cluster:
@@ -70,18 +99,29 @@ class Cluster:
 
 
 class KafkaCluster(Cluster):
-    _zk: ZookeeperService
+    _zk: ZookeeperService | None
 
-    def __init__(self, service: KafkaServiceAdapter, zk: ZookeeperService):
+    def __init__(self, service: KafkaServiceAdapter, zk: ZookeeperService | None):
         super().__init__(service)
         self._zk = zk
 
     @classmethod
-    def create(cls: Type[KC], test_ctx, num_brokers) -> KC:
-        zk = ZookeeperService(test_ctx, num_nodes=1, version=KAFKA_VERSION)
+    def create(cls: Type[KC], test_ctx, num_brokers, version, quorum_type) -> KC:
+        if quorum_type == quorum.zk:
+            zk = ZookeeperService(test_ctx, num_nodes=1)
+        else:
+            zk = None
         svc = KafkaServiceAdapter(
             test_ctx,
-            KafkaService(test_ctx, num_nodes=num_brokers, zk=zk, version=KAFKA_VERSION),
+            KafkaService(
+                test_ctx,
+                num_nodes=num_brokers,
+                zk=zk,
+                version=kafkatest.version.KafkaVersion(version),
+                quorum_info_provider=lambda kafka: quorum.ServiceQuorumInfo(
+                    quorum_type=quorum_type, kafka=kafka
+                ),
+            ),
         )
         return cls(svc, zk)
 
@@ -90,12 +130,14 @@ class KafkaCluster(Cluster):
         return True
 
     def start(self):
-        self._zk.start()
+        if self._zk:
+            self._zk.start()
         super().start()
 
     def stop(self):
         super().stop()
-        self._zk.stop()
+        if self._zk:
+            self._zk.stop()
 
     def __str__(self):
         return f"Kafka cluster of {len(self.service.nodes)} nodes"
@@ -139,14 +181,16 @@ class MultiClusterServices:
         test_ctx,
         logger,
         redpanda: RedpandaService,
-        secondary_type: ServiceType = ServiceType.REDPANDA,
+        secondary_spec: SecondaryClusterSpec = SecondaryClusterSpec(
+            ServiceType.REDPANDA
+        ),
         num_brokers=3,
         secondary_args: SecondaryClusterArgs = SecondaryClusterArgs(),
     ):
         self.test_ctx = test_ctx
         self.logger = logger
         self._clusters: list[Cluster] = [RedpandaCluster(redpanda)]
-        if secondary_type is ServiceType.REDPANDA:
+        if secondary_spec.cluster_type is ServiceType.REDPANDA:
             self._clusters.append(
                 RedpandaCluster.create(
                     self.test_ctx,
@@ -155,8 +199,19 @@ class MultiClusterServices:
                     **secondary_args.kwargs,
                 )
             )
-        elif secondary_type is ServiceType.KAFKA:
-            self._clusters.append(KafkaCluster.create(self.test_ctx, num_brokers))
+        elif secondary_spec.cluster_type is ServiceType.KAFKA:
+            self._clusters.append(
+                KafkaCluster.create(
+                    self.test_ctx,
+                    num_brokers,
+                    secondary_spec.kafka_version
+                    if secondary_spec.kafka_version
+                    else KAFKA_VERSION,
+                    secondary_spec.kafka_quorum
+                    if secondary_spec.kafka_quorum
+                    else "COMBINED_KRAFT",
+                )
+            )
         assert len(self._clusters) == 2, f"Expected two clusters, got {self._clusters=}"
 
     def setUp(self):

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -17,6 +17,7 @@ from contextlib import nullcontext
 
 from connectrpc.errors import ConnectError, ConnectErrorCode
 from ducktape.mark import matrix
+from ducktape.mark import ignore
 
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
     shadow_link_pb2,
@@ -32,6 +33,7 @@ from rptest.services.kgo_verifier_services import (
 from rptest.services.multi_cluster_services import (
     Cluster,
     MultiClusterServices,
+    SecondaryClusterSpec,
     ServiceType,
 )
 from rptest.tests.cluster_linking_test_base import (
@@ -136,13 +138,15 @@ class MultiClusterKafkaTest(MultiClusterTestBase):
         # MultiClusterServices will set itself up
         pass
 
-    @cluster(num_nodes=7)
+    @cluster(num_nodes=6)
     def test_basic_ops(self):
         with MultiClusterServices(
             self.test_context,
             self.logger,
             self.redpanda,
-            secondary_spec=SecondaryClusterSpec(ServiceType.REDPANDA),
+            secondary_spec=SecondaryClusterSpec(
+                ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+            ),
             num_brokers=3,
         ) as services:
             assert services.secondary.is_kafka, (
@@ -548,8 +552,16 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         return leadership_transfer_thread(redpanda, topic)
 
     @cluster(num_nodes=7)
-    @matrix(shuffle_leadership=[True, False])
-    def test_replication_basic(self, shuffle_leadership):
+    @matrix(
+        shuffle_leadership=[True, False],
+        source_cluster_spec=[
+            SecondaryClusterSpec(ServiceType.REDPANDA),
+            SecondaryClusterSpec(
+                ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+            ),
+        ],
+    )
+    def test_replication_basic(self, shuffle_leadership, source_cluster_spec):
         topic = TopicSpec(name="source-topic", partition_count=5, replication_factor=3)
 
         self.source_default_client().create_topic(topic)
@@ -606,7 +618,15 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
         )
 
     @cluster(num_nodes=7)
-    def test_consumer_groups_mirroring(self):
+    @matrix(
+        source_cluster_spec=[
+            SecondaryClusterSpec(ServiceType.REDPANDA),
+            SecondaryClusterSpec(
+                ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+            ),
+        ]
+    )
+    def test_consumer_groups_mirroring(self, source_cluster_spec):
         topic = TopicSpec(name="source-topic", partition_count=5, replication_factor=3)
 
         self.source_default_client().create_topic(topic)
@@ -659,8 +679,22 @@ class ShadowLinkConsumeGroupsMirroringTest(ShadowLinkTestBase):
             pass
 
     @cluster(num_nodes=7)
-    @matrix(with_failures=[True, False])
-    def test_continuous_group_sync(self, with_failures):
+    @ignore(
+        with_failures=True,
+        source_cluster_spec=SecondaryClusterSpec(
+            ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+        ),
+    )
+    @matrix(
+        with_failures=[True, False],
+        source_cluster_spec=[
+            SecondaryClusterSpec(ServiceType.REDPANDA),
+            SecondaryClusterSpec(
+                ServiceType.KAFKA, kafka_version="3.8.0", kafka_quorum="COMBINED_KRAFT"
+            ),
+        ],
+    )
+    def test_continuous_group_sync(self, with_failures, source_cluster_spec):
         partition_count = 120
         topic_count = 6
 

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -113,7 +113,7 @@ class MultiClusterRedpandaTest(MultiClusterTestBase):
             self.test_context,
             self.logger,
             self.redpanda,
-            secondary_type=ServiceType.REDPANDA,
+            secondary_spec=SecondaryClusterSpec(ServiceType.REDPANDA),
             num_brokers=3,
         ) as services:
             assert services.secondary.is_redpanda, (
@@ -142,7 +142,7 @@ class MultiClusterKafkaTest(MultiClusterTestBase):
             self.test_context,
             self.logger,
             self.redpanda,
-            secondary_type=ServiceType.KAFKA,
+            secondary_spec=SecondaryClusterSpec(ServiceType.REDPANDA),
             num_brokers=3,
         ) as services:
             assert services.secondary.is_kafka, (

--- a/tests/rptest/tests/cluster_linking_test_base.py
+++ b/tests/rptest/tests/cluster_linking_test_base.py
@@ -31,10 +31,17 @@ from rptest.services.multi_cluster_services import (
     RedpandaService,
     SecondaryClusterArgs,
     ServiceType,
+    SecondaryClusterSpec,
 )
 from rptest.services.redpanda import LoggingConfig
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.node_operations import FailureInjectorBackgroundThread
+
+
+SOURCE_CLUSTER_SPEC = "source_cluster_spec"
+
+
+DEFAULT_SOURCE_CLUSTER_SPEC = SecondaryClusterSpec(ServiceType.REDPANDA)
 
 
 class ShadowLinkTestBase(PreallocNodesTest):
@@ -82,13 +89,22 @@ class ShadowLinkTestBase(PreallocNodesTest):
         self.services: MultiClusterServices
         self.service_client: shadow_link_pb2_connect.ShadowLinkServiceClient
         self.secondary_cluster_args: SecondaryClusterArgs = secondary_cluster_args
+        self.source_cluster_spec: SecondaryClusterSpec = self.get_source_cluster_spec()
+
+    def get_source_cluster_spec(self) -> SecondaryClusterSpec:
+        if not self.test_context.injected_args:
+            return DEFAULT_SOURCE_CLUSTER_SPEC
+
+        return self.test_context.injected_args.get(
+            SOURCE_CLUSTER_SPEC, DEFAULT_SOURCE_CLUSTER_SPEC
+        )
 
     def setUp(self):
         self.services = MultiClusterServices(
             self.test_context,
             self.logger,
             self.redpanda,
-            secondary_type=ServiceType.REDPANDA,
+            secondary_spec=self.source_cluster_spec,
             num_brokers=3,
             secondary_args=self.secondary_cluster_args,
         )


### PR DESCRIPTION
Added a way to easily run Cluster Linking tests against Kafka cluster.

Now the test author can run test against Kafka cluster by simply providing the source cluster specification.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none