### PR TITLE
Remove AVG_THROUGHPUT_MBPS expectations for serverless

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/serverless_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/serverless_validation_test.py
@@ -208,13 +208,7 @@ class ServerlessValidationTest(RedpandaCloudTest):
         total_producers = self._producer_count(self._tier_limits.max_ingress)
         total_consumers = self._consumer_count(self._tier_limits.max_egress)
 
-        validator = self.base_validator(self._cloud_provider) | {
-            OMBSampleConfigurations.AVG_THROUGHPUT_MBPS: [
-                OMBSampleConfigurations.gte(
-                    self._mb_to_mib(self._tier_limits.max_ingress // (1 * MB))
-                ),
-            ],
-        }
+        validator = self.base_validator(self._cloud_provider) | {}
 
         workload = {
             "topics": 1,


### PR DESCRIPTION
For serverless we are starting by gathering data, we don't yet want to set any expectations.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none