### PR TITLE
`ct/l1`: add `meta` and `logger` [CT - Compaction #1]

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -61,3 +61,22 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "meta",
+    hdrs = [
+        "meta.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/container:intrusive",
+        "//src/v/model",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -3,6 +3,20 @@ load("//bazel:build.bzl", "redpanda_cc_library")
 package(default_visibility = ["//src/v/cloud_topics/level_one:__subpackages__"])
 
 redpanda_cc_library(
+    name = "logger",
+    hdrs = [
+        "logger.h",
+    ],
+    visibility = [
+        "//src/v/cloud_topics/level_one:__subpackages__",
+    ],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "source",
     srcs = [
         "source.cc",

--- a/src/v/cloud_topics/level_one/compaction/filter.cc
+++ b/src/v/cloud_topics/level_one/compaction/filter.cc
@@ -21,6 +21,13 @@
 
 namespace cloud_topics::l1 {
 
+compaction_filter::compaction_filter(
+  compaction::sliding_window_reducer::sink& sink,
+  const compaction::key_offset_map& map,
+  model::ntp ntp)
+  : filter(sink, std::move(ntp))
+  , _map(map) {}
+
 ss::future<> compaction_filter::maybe_index_offset_delta(
   const model::record_batch& b,
   const model::record& r,

--- a/src/v/cloud_topics/level_one/compaction/filter.h
+++ b/src/v/cloud_topics/level_one/compaction/filter.h
@@ -18,25 +18,24 @@ namespace cloud_topics::l1 {
 class compaction_filter : public compaction::filter {
 public:
     compaction_filter(
-      compaction::sliding_window_reducer::sink& sink,
-      const compaction::key_offset_map& map,
-      model::ntp ntp)
-      : filter(sink, std::move(ntp))
-      , _map(map) {}
+      compaction::sliding_window_reducer::sink&,
+      const compaction::key_offset_map&,
+      model::ntp);
 
 private:
     ss::future<> maybe_index_offset_delta(
-      const model::record_batch& b,
-      const model::record& r,
-      std::vector<int32_t>& offset_deltas) const;
+      const model::record_batch&,
+      const model::record&,
+      std::vector<int32_t>&) const;
 
     ss::future<std::vector<int32_t>>
-    compute_offset_deltas_to_keep(const model::record_batch& b) const final;
+    compute_offset_deltas_to_keep(const model::record_batch&) const final;
 
     ss::future<std::optional<model::record_batch>>
-    filter_batch_with_offset_deltas(
-      model::record_batch b, std::vector<int32_t> offset_deltas) const final;
+      filter_batch_with_offset_deltas(
+        model::record_batch, std::vector<int32_t>) const final;
 
+private:
     const compaction::key_offset_map& _map;
 };
 

--- a/src/v/cloud_topics/level_one/compaction/logger.h
+++ b/src/v/cloud_topics/level_one/compaction/logger.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace cloud_topics::l1 {
+
+inline ss::logger compaction_log("cloud_topics::compaction");
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/common/object.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/level_one/metastore/offset_interval_set.h"
+#include "container/chunked_hash_map.h"
+#include "container/intrusive_list_helpers.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/gate.hh>
+
+#include <memory>
+
+namespace cloud_topics::l1 {
+
+struct log_compaction_meta {
+    log_compaction_meta(model::topic_id_partition tid_p, model::ntp ntp)
+      : tid_p(std::move(tid_p))
+      , ntp(std::move(ntp)) {}
+
+    model::topic_id_partition tid_p;
+    model::ntp ntp;
+    ss::gate gate;
+    intrusive_list_hook link;
+};
+
+using log_compaction_meta_ptr = std::unique_ptr<log_compaction_meta>;
+
+struct log_compaction_meta_hash {
+    using is_transparent = void;
+
+    size_t
+    operator()(const cloud_topics::l1::log_compaction_meta_ptr& m) const {
+        return std::hash<model::ntp>{}(m->ntp);
+    }
+
+    size_t operator()(const model::ntp& ntp) const {
+        return std::hash<model::ntp>{}(ntp);
+    }
+};
+
+struct log_compaction_meta_eq {
+    using is_transparent = void;
+
+    bool operator()(
+      const cloud_topics::l1::log_compaction_meta_ptr& lhs,
+      const cloud_topics::l1::log_compaction_meta_ptr& rhs) const {
+        return lhs->ntp == rhs->ntp;
+    }
+
+    bool operator()(
+      const cloud_topics::l1::log_compaction_meta_ptr& lhs,
+      const model::ntp& rhs) const noexcept {
+        return lhs->ntp == rhs;
+    }
+
+    bool operator()(
+      const model::ntp& lhs,
+      const cloud_topics::l1::log_compaction_meta_ptr& rhs) const {
+        return lhs == rhs->ntp;
+    }
+};
+
+using logs_type_t = chunked_hash_set<
+  log_compaction_meta_ptr,
+  log_compaction_meta_hash,
+  log_compaction_meta_eq>;
+
+using log_list_t
+  = intrusive_list<log_compaction_meta, &log_compaction_meta::link>;
+
+struct log_info_and_meta {
+    metastore::compaction_info_response info;
+    log_compaction_meta* meta;
+};
+
+// Represents the output from a compaction job over a cloud topic partition.
+// Highly subject to change in the future.
+struct object_output_t {
+    metastore::object_metadata::ntp_metadata ntp_md;
+    object_builder::object_info info;
+    std::unique_ptr<staging_file> staging_file;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -110,6 +110,8 @@ redpanda_cc_library(
         ":state",
         "//src/v/base",
         "//src/v/cloud_topics/level_one/common:object_id",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -17,6 +17,7 @@
 #include "model/fundamental.h"
 #include "model/timestamp.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
 #include <expected>
@@ -229,7 +230,7 @@ public:
         // been removed.
         offset_interval_set removed_tombstones_ranges;
 
-        // Timsetamp at which the compaction operation happened.
+        // Timestamp at which the compaction operation happened.
         model::timestamp cleaned_at;
     };
     using compaction_map_t
@@ -294,6 +295,47 @@ public:
       const model::topic_id_partition&,
       model::timestamp tombstone_removal_upper_bound_ts)
       = 0;
+
+    // All the information required to query a `compaction_info_response` from
+    // the metastore. Parameters are used for call to
+    // `get_compaction_offsets()`.
+    struct sample_spec {
+        model::topic_id_partition tid_p;
+        model::timestamp tombstone_removal_upper_bound_ts;
+    };
+
+    struct compaction_info_response {
+        // The dirty ratio of the log/partition.
+        double dirty_ratio;
+        // The earliest dirty timestamp in the log. `std::nullopt` if there is
+        // no such timestamp.
+        std::optional<model::timestamp> earliest_dirty_ts;
+        // Compaction offsets returned by call to `get_compaction_offsets()`
+        // (see above).
+        compaction_offsets_response offsets_response;
+    };
+
+    // Obtains compaction state for a provided `sample_spec` on the basis of a
+    // single partition. Provides information relevant to determining if a
+    // partition requires compaction - e.g dirty ratio and earliest dirty
+    // timestamp, as well as compaction offsets (see `get_compaction_offsets()`
+    // above).
+    virtual ss::future<std::expected<compaction_info_response, errc>>
+    get_compaction_info(const sample_spec&) = 0;
+
+    // Vectorized RPC for obtaining compaction state for a number of partitions.
+    // Ensures `compaction_info_response`s for partitions are returned in the
+    // same order as requested in `to_sample`.
+    virtual ss::future<
+      chunked_vector<std::expected<compaction_info_response, errc>>>
+    get_compaction_infos(const chunked_vector<sample_spec>& to_sample) {
+        chunked_vector<std::expected<compaction_info_response, errc>> ret;
+        ret.reserve(to_sample.size());
+        for (const auto& log : to_sample) {
+            ret.push_back(co_await get_compaction_info(log));
+        }
+        co_return ret;
+    }
 };
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -559,4 +559,10 @@ replicated_metastore::get_compaction_offsets(
     co_return resp;
 }
 
+ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
+replicated_metastore::get_compaction_info(
+  [[maybe_unused]] const sample_spec& log) {
+    co_return compaction_info_response{};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -59,6 +59,9 @@ public:
     get_compaction_offsets(
       const model::topic_id_partition&, model::timestamp) override;
 
+    ss::future<std::expected<compaction_info_response, errc>>
+    get_compaction_info(const sample_spec&) override;
+
 private:
     frontend& fe_;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -13,6 +13,8 @@
 #include "cloud_topics/level_one/metastore/state.h"
 #include "cloud_topics/level_one/metastore/state_update.h"
 #include "cloud_topics/logger.h"
+#include "container/chunked_vector.h"
+#include "model/fundamental.h"
 
 #include <seastar/core/coroutine.hh>
 
@@ -479,6 +481,104 @@ simple_metastore::get_compaction_offsets(
         }
     }
     return resp;
+}
+
+std::expected<double, metastore::errc> simple_metastore::get_dirty_ratio(
+  const state& state, const model::topic_id_partition& tp) {
+    auto prt_ref = state.partition_state(tp);
+
+    if (!prt_ref.has_value()) {
+        return std::unexpected(errc::missing_ntp);
+    }
+
+    const auto& prt = prt_ref->get();
+
+    const auto& compaction_state = prt.compaction_state;
+
+    if (!compaction_state.has_value()) {
+        return 1.0;
+    }
+
+    // Compute
+    size_t total_size{0};
+    size_t dirty_size{0};
+    const auto& cleaned_ranges = compaction_state->cleaned_ranges;
+    for (const auto& extent : prt.extents) {
+        total_size += extent.len;
+        auto b = extent.base_offset;
+        auto e = extent.last_offset;
+        if (!cleaned_ranges.covers(b, e)) {
+            dirty_size += extent.len;
+        }
+    }
+
+    return total_size == 0 ? 0.0
+                           : static_cast<double>(dirty_size)
+                               / static_cast<double>(total_size);
+}
+
+std::expected<std::optional<model::timestamp>, metastore::errc>
+simple_metastore::get_earliest_dirty_ts(
+  const state& state, const model::topic_id_partition& tp) {
+    auto prt_ref = state.partition_state(tp);
+
+    if (!prt_ref.has_value()) {
+        return std::unexpected(errc::missing_ntp);
+    }
+
+    const auto& prt = prt_ref->get();
+
+    const auto& compaction_state = prt.compaction_state;
+
+    // Start search for first dirty offset from the start offset of the log
+    // (which may not be 0 for a `compact,delete` topic). If compaction hasn't
+    // yet been run for this partition, this value is already the first dirty
+    // offset.
+    kafka::offset first_dirty_offset{prt.start_offset};
+    if (compaction_state.has_value()) {
+        const auto& clean_ranges = compaction_state->cleaned_ranges;
+        auto clean_ranges_strm = clean_ranges.make_stream();
+        while (clean_ranges_strm.has_next()) {
+            auto clean_interval = clean_ranges_strm.next();
+            if (first_dirty_offset < clean_interval.base_offset) {
+                break;
+            }
+
+            first_dirty_offset = kafka::next_offset(clean_interval.last_offset);
+        }
+    }
+
+    auto it = std::ranges::lower_bound(
+      prt.extents, first_dirty_offset, std::less<>{}, &extent::last_offset);
+    if (it != prt.extents.end()) {
+        return it->max_timestamp;
+    }
+
+    return std::nullopt;
+}
+
+ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
+simple_metastore::get_compaction_info(const sample_spec& log) {
+    auto dirty_ratio = get_dirty_ratio(state_, log.tid_p);
+    if (!dirty_ratio.has_value()) {
+        co_return std::unexpected(dirty_ratio.error());
+    }
+
+    auto earliest_dirty_ts = get_earliest_dirty_ts(state_, log.tid_p);
+    if (!earliest_dirty_ts.has_value()) {
+        co_return std::unexpected(earliest_dirty_ts.error());
+    }
+
+    auto offsets = get_compaction_offsets(
+      state_, log.tid_p, log.tombstone_removal_upper_bound_ts);
+    if (!offsets.has_value()) {
+        co_return std::unexpected(offsets.error());
+    }
+
+    co_return compaction_info_response{
+      .dirty_ratio = dirty_ratio.value(),
+      .earliest_dirty_ts = earliest_dirty_ts.value(),
+      .offsets_response = std::move(offsets).value()};
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -12,6 +12,7 @@
 #include "base/seastarx.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/level_one/metastore/state.h"
+#include "model/timestamp.h"
 
 #include <seastar/core/future.hh>
 
@@ -90,6 +91,9 @@ public:
     get_compaction_offsets(
       const model::topic_id_partition&, model::timestamp) override;
 
+    ss::future<std::expected<compaction_info_response, errc>>
+    get_compaction_info(const sample_spec&) override;
+
 private:
     friend class domain_manager;
     static std::expected<offsets_response, errc>
@@ -101,6 +105,10 @@ private:
     static std::expected<compaction_offsets_response, errc>
     get_compaction_offsets(
       const state&, const model::topic_id_partition&, model::timestamp);
+    static std::expected<double, errc>
+    get_dirty_ratio(const state&, const model::topic_id_partition&);
+    static std::expected<std::optional<model::timestamp>, errc>
+    get_earliest_dirty_ts(const state&, const model::topic_id_partition&);
     static std::expected<kafka::offset, errc> get_end_offset_for_term(
       const state&, const model::topic_id_partition&, model::term_id);
     static std::expected<model::term_id, errc> get_term_for_offset(

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -22,6 +22,7 @@ const object_id oid1 = l1::create_object_id();
 const object_id oid2 = l1::create_object_id();
 const object_id oid3 = l1::create_object_id();
 const object_id oid4 = l1::create_object_id();
+const object_id oid5 = l1::create_object_id();
 
 const std::string_view tid_a = "deadbeef-aaaa-0000-0000-000000000000/0";
 const std::string_view tid_b = "deadbeef-bbbb-0000-0000-000000000000/0";
@@ -1454,4 +1455,70 @@ TEST(SimpleMetastoreTest, TestSetStartWithCompactionState) {
     EXPECT_THAT(
       cmp_after->removable_tombstone_ranges.to_vec(),
       testing::ElementsAre(MatchesRange(10_o, 15_o)));
+}
+
+TEST(SimpleMetastoreTest, TestDirtyRatio) {
+    simple_metastore m;
+    om_list_t os;
+    auto tp = model::topic_id_partition::from(tid_a);
+    os.emplace_back(
+      om_builder(oid1, 100, 10).add(tid_a, 0_o, 9_o, 1000_t, 0, 99).build());
+    os.emplace_back(
+      om_builder(oid2, 100, 10).add(tid_a, 10_o, 19_o, 2000_t, 0, 99).build());
+    auto add_res
+      = m.add_objects(os, terms_builder().add(tid_a, 0_tm, 0_o).build()).get();
+    ASSERT_TRUE(add_res.has_value());
+
+    // Clean range is [0, 5]. Both extents still have dirty offsets.
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid3, 100, 10)
+                              .add(tid_a, 0_o, 9_o, 1000_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 0_o, 5_o, 3000_t);
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    auto to_sample = metastore::sample_spec{
+      .tid_p = tp, .tombstone_removal_upper_bound_ts = 3000_t};
+    auto compaction_info = m.get_compaction_info(to_sample).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 1.0);
+
+    // Clean range is now [0, 9]. Only one extent still has dirty offsets.
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid4, 100, 10)
+                              .add(tid_a, 0_o, 9_o, 1000_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 6_o, 9_o, 3000_t);
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    compaction_info = m.get_compaction_info(to_sample).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.5);
+
+    // Clean range is now [0, 19], the entire log is clean.
+    {
+        om_list_t new_os;
+        new_os.emplace_back(om_builder(oid5, 100, 10)
+                              .add(tid_a, 0_o, 19_o, 1000_t, 0, 99)
+                              .build());
+
+        auto cmb = cm_builder();
+        cmb.clean(tid_a, 10_o, 19_o, 3000_t);
+        auto compact_res = m.compact_objects(new_os, cmb.build()).get();
+        ASSERT_TRUE(compact_res.has_value());
+    }
+
+    compaction_info = m.get_compaction_info(to_sample).get();
+    ASSERT_TRUE(compaction_info.has_value());
+    ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.0);
 }

--- a/src/v/compaction/reducer.h
+++ b/src/v/compaction/reducer.h
@@ -62,7 +62,7 @@ public:
 
     public:
         virtual ss::future<ss::stop_iteration>
-        operator()(model::record_batch b, model::compression c) = 0;
+        operator()(model::record_batch, model::compression) = 0;
         virtual ss::future<> finalize() = 0;
     };
 


### PR DESCRIPTION
Some preliminary definitions to be used later in `cloud_topics` compaction.

For a view of the entire landscape of `cloud_topics` compaction, please look at: https://github.com/redpanda-data/redpanda/pull/27592.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
