### PR TITLE
ct: assert epoch order of placeholders in ctp stm

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -172,15 +172,12 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
     } else if (
       batch.header().type == model::record_batch_type::ctp_stm_command) {
         // Decode the command and apply it to the state.
-        kafka::offset lro;
-        batch.for_each_record([&lro](model::record&& r) {
+        batch.for_each_record([this](model::record&& r) {
             auto key = serde::from_iobuf<uint8_t>(r.release_key());
             auto cmd_key = static_cast<ctp_stm_key>(key);
             switch (cmd_key) {
             case ctp_stm_key::advance_reconciled_offset: {
-                auto cmd = serde::from_iobuf<advance_reconciled_offset_cmd>(
-                  r.release_value());
-                lro = cmd.last_reconciled_offset;
+                apply_advance_reconciled_offset(std::move(r));
                 break;
             }
             default:
@@ -191,13 +188,19 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
             }
             return ss::stop_iteration::no;
         });
-        vlog(_log.debug, "New LRO value is {}", lro);
-        // LRO is expected to be within the translation range
-        auto lro_log = _raft->log()->to_log_offset(kafka::offset_cast(lro));
-        _state.advance_last_reconciled_offset(lro, lro_log);
     }
 
     co_return;
+}
+
+void ctp_stm::apply_advance_reconciled_offset(model::record record) {
+    auto cmd = serde::from_iobuf<advance_reconciled_offset_cmd>(
+      record.release_value());
+    auto lro = cmd.last_reconciled_offset;
+    vlog(_log.debug, "New LRO value is {}", lro);
+    // LRO is expected to be within the translation range
+    auto lro_log = _raft->log()->to_log_offset(kafka::offset_cast(lro));
+    _state.advance_last_reconciled_offset(lro, lro_log);
 }
 
 void ctp_stm::apply_placeholder(const model::record_batch& batch) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -219,6 +219,15 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
     });
     auto placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
     auto id = placeholder.id;
+    // this assertion is made here rather than inside the state object itself
+    // because the assertion is about the physical content of the log rather
+    // than the computed state.
+    vassert(
+      id.epoch >= _last_seen_epoch,
+      "Observed a non-monotonic epoch sequence {} < {}",
+      id.epoch,
+      _last_seen_epoch);
+    _last_seen_epoch = id.epoch;
     _state.advance_epoch(id.epoch, batch.header().base_offset);
 }
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -168,20 +168,7 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
     vlog(_log.debug, "Applying record batch: {}", batch.header());
 
     if (batch.header().type == model::record_batch_type::dl_placeholder) {
-        // Cherry-pick the placeholder from the record batch
-        vassert(
-          batch.record_count() > 0,
-          "Record batch must have at least one record");
-        iobuf value;
-        batch.for_each_record([&value](model::record&& r) {
-            value = std::move(r).release_value();
-            return ss::stop_iteration::yes;
-        });
-
-        auto placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
-        auto id = placeholder.id;
-        _state.advance_epoch(id.epoch, batch.header().base_offset);
-
+        apply_placeholder(batch);
     } else if (
       batch.header().type == model::record_batch_type::ctp_stm_command) {
         // Decode the command and apply it to the state.
@@ -211,6 +198,19 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
     }
 
     co_return;
+}
+
+void ctp_stm::apply_placeholder(const model::record_batch& batch) {
+    vassert(
+      batch.record_count() > 0, "Record batch must have at least one record");
+    iobuf value;
+    batch.for_each_record([&value](model::record&& r) {
+        value = std::move(r).release_value();
+        return ss::stop_iteration::yes;
+    });
+    auto placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
+    auto id = placeholder.id;
+    _state.advance_epoch(id.epoch, batch.header().base_offset);
 }
 
 ss::future<raft::local_snapshot_applied>

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -167,30 +167,36 @@ ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
     }
     vlog(_log.debug, "Applying record batch: {}", batch.header());
 
-    if (batch.header().type == model::record_batch_type::dl_placeholder) {
+    switch (batch.header().type) {
+    case model::record_batch_type::dl_placeholder:
         apply_placeholder(batch);
-    } else if (
-      batch.header().type == model::record_batch_type::ctp_stm_command) {
+        break;
+
+    case model::record_batch_type::ctp_stm_command:
         // Decode the command and apply it to the state.
         batch.for_each_record([this](model::record&& r) {
             auto key = serde::from_iobuf<uint8_t>(r.release_key());
             auto cmd_key = static_cast<ctp_stm_key>(key);
+
             switch (cmd_key) {
-            case ctp_stm_key::advance_reconciled_offset: {
+            case ctp_stm_key::advance_reconciled_offset:
                 apply_advance_reconciled_offset(std::move(r));
                 break;
-            }
+
             default:
                 throw std::runtime_error(fmt_with_ctx(
                   fmt::format,
                   "Unknown ctp_stm_key({})",
                   static_cast<int>(key)));
             }
+
             return ss::stop_iteration::no;
         });
-    }
+        break;
 
-    co_return;
+    default:
+        break;
+    }
 }
 
 void ctp_stm::apply_advance_reconciled_offset(model::record record) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -16,10 +16,6 @@
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/types.h"
 #include "raft/consensus.h"
-#include "serde/rw/map.h"
-#include "serde/rw/uuid.h"
-#include "serde/rw/vector.h"
-#include "storage/offset_translator_state.h"
 
 #include <seastar/core/abort_source.hh>
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -78,7 +78,8 @@ public:
     ss::future<bool> sync_in_term(ss::abort_source& as);
 
 private:
-    ss::future<> do_apply(const model::record_batch& batch) override;
+    ss::future<> do_apply(const model::record_batch&) override;
+    void apply_placeholder(const model::record_batch&);
 
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -80,6 +80,7 @@ public:
 private:
     ss::future<> do_apply(const model::record_batch&) override;
     void apply_placeholder(const model::record_batch&);
+    void apply_advance_reconciled_offset(model::record);
 
     ss::future<raft::local_snapshot_applied>
     apply_local_snapshot(raft::stm_snapshot_header, iobuf&&) override;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -98,6 +98,10 @@ private:
     ss::rwlock _lock;
     /// Current in-memory state of the STM
     ctp_stm_state _state;
+
+    // The last observed epoch to be applied to the state machine. This value is
+    // used to check for violations of monotonicity in epoch order.
+    cluster_epoch _last_seen_epoch{};
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -13,11 +13,8 @@
 #include "cloud_topics/level_zero/stm/ctp_stm_state.h"
 #include "cloud_topics/level_zero/stm/types.h"
 #include "raft/persisted_stm.h"
-#include "raft/replicate.h"
 
 #include <seastar/core/rwlock.hh>
-
-#include <expected>
 
 namespace cloud_topics {
 


### PR DESCRIPTION
* Some cosmetic changes to ctp stm
* Assert that ctp stm processes placeholders in epoch order

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
