### PR TITLE
ct: Add combined L0 and L1 reader

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -174,6 +174,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/v/cloud_topics/level_one/common:file_io",
     ],
 )
 

--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -52,6 +52,7 @@ redpanda_cc_library(
     visibility = [
         "//src/v/cloud_topics/frontend:__pkg__",
         "//src/v/cloud_topics/frontend/tests:__pkg__",
+        "//src/v/cloud_topics/frontend_reader:__pkg__",
         "//src/v/cloud_topics/level_one/frontend_reader:__pkg__",
         "//src/v/cloud_topics/level_one/frontend_reader/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/frontend_reader:__pkg__",

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -49,8 +49,6 @@ ss::future<> app::construct(
       storage,
       &controller->get_cluster_epoch_generator());
 
-    co_await construct_service(state, data_plane.get());
-
     // Touch the L1 staging directory before L1 i/o starts.
     co_await ss::recursive_touch_directory(
       config::node().l1_staging_path().string());
@@ -80,6 +78,14 @@ ss::future<> app::construct(
       shard_table,
       connection_cache,
       &domain_supervisor);
+
+    co_await construct_service(
+      state,
+      data_plane.get(),
+      ss::sharded_parameter([this] { return &l1_metastore_fe.local(); }),
+      ss::sharded_parameter([this] { return &l1_io.local(); }),
+      ss::sharded_parameter(
+        [&metadata_cache] { return &metadata_cache->local(); }));
 
     co_await construct_service(
       manager,

--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -25,6 +25,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cloud_storage:types",
         "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:state_accessors",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm",
         "//src/v/cloud_topics/level_zero/stm:placeholder",
         "//src/v/cluster",
@@ -36,6 +37,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cloud_topics:data_plane_api",
         "//src/v/cloud_topics:log_reader_config",
+        "//src/v/cloud_topics/frontend_reader",
         "//src/v/cloud_topics/level_zero/common:extent_meta",
         "//src/v/cloud_topics/level_zero/frontend_reader",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -12,15 +12,19 @@
 #include "cloud_storage/types.h"
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/errc.h"
+#include "cloud_topics/frontend_reader/reader.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/level_zero/frontend_reader/reader.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
+#include "cloud_topics/state_accessors.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "cluster/rm_stm_types.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/record_batch_types.h"
@@ -285,10 +289,34 @@ ss::future<storage::translating_reader> frontend::make_reader(
 
     auto ot_state = _partition->get_offset_translator_state();
 
-    // TODO: depending on the 'cfg' construct level zero or level one
-    // reader impl.
-    auto impl = std::make_unique<level_zero_log_reader_impl>(
-      cfg, _partition, _data_plane);
+    auto ct_state = _partition->get_cloud_topics_state();
+    vassert(ct_state != nullptr, "cloud topics state not initialized");
+
+    auto l1_frontend = ct_state->local().get_l1_metastore_frontend();
+    auto l1_io = ct_state->local().get_l1_io();
+    auto metadata_cache = ct_state->local().get_metadata_cache();
+
+    model::topic_namespace_view topic_ns_view(_partition->ntp());
+    auto topic_cfg = metadata_cache->get_topic_cfg(topic_ns_view);
+    if (!topic_cfg.has_value() || !topic_cfg->tp_id.has_value()) {
+        // Cloud topics must have a topic id.
+        throw std::runtime_error(
+          fmt::format(
+            "Topic ID not found for cloud topic {}", _partition->ntp()));
+    }
+
+    auto tidp = model::topic_id_partition{
+      *topic_cfg->tp_id, _partition->get_ntp_config().ntp().tp.partition};
+
+    auto impl = std::make_unique<cloud_topics_log_reader_impl>(
+      cfg,
+      _partition->ntp(),
+      tidp,
+      _partition,
+      l1_frontend,
+      l1_io,
+      _data_plane,
+      _ctp_stm_api.get());
 
     co_return storage::translating_reader{
       model::record_batch_reader(std::move(impl)), std::move(ot_state)};

--- a/src/v/cloud_topics/frontend_reader/BUILD
+++ b/src/v/cloud_topics/frontend_reader/BUILD
@@ -1,0 +1,22 @@
+load("//bazel:build.bzl", "redpanda_cc_library")
+
+redpanda_cc_library(
+    name = "frontend_reader",
+    srcs = ["reader.cc"],
+    hdrs = ["reader.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics:log_reader_config",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/level_one/common:abstract_io",
+        "//src/v/cloud_topics/level_one/frontend_reader:reader",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
+        "//src/v/cloud_topics/level_zero/frontend_reader",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
+        "//src/v/cluster",
+        "//src/v/model",
+    ],
+)

--- a/src/v/cloud_topics/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/frontend_reader/reader.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/frontend_reader/reader.h"
+
+#include "cloud_topics/level_one/frontend_reader/reader.h"
+#include "cloud_topics/level_one/metastore/replicated_metastore.h"
+#include "cloud_topics/level_zero/frontend_reader/reader.h"
+#include "cloud_topics/logger.h"
+#include "cluster/partition.h"
+#include "model/fundamental.h"
+
+namespace cloud_topics {
+
+cloud_topics_log_reader_impl::cloud_topics_log_reader_impl(
+  cloud_topic_log_reader_config& cfg,
+  model::ntp ntp,
+  model::topic_id_partition tidp,
+  ss::lw_shared_ptr<cluster::partition> partition,
+  l1::frontend* l1_frontend,
+  l1::io* io_interface,
+  data_plane_api* data_plane_api,
+  ctp_stm_api* stm_api)
+  : _config(cfg)
+  , _ntp(std::move(ntp))
+  , _tidp(tidp)
+  , _partition(std::move(partition))
+  , _metastore(std::make_unique<l1::replicated_metastore>(*l1_frontend))
+  , _io(io_interface)
+  , _data_plane_api(data_plane_api)
+  , _stm_api(stm_api) {}
+
+bool cloud_topics_log_reader_impl::is_end_of_stream() const {
+    return _state == state::end_of_stream;
+}
+
+ss::future<model::record_batch_reader::storage_t>
+cloud_topics_log_reader_impl::do_load_slice(
+  model::timeout_clock::time_point deadline) {
+    // This simple loop and switch doesn't attempt to stitch L1 and L0 batches
+    // together. When reaching the end of L1, the reader will return whatever
+    // it gets and read from L0 on the next call to do_load_slice.
+    while (true) {
+        switch (_state) {
+        case state::end_of_stream:
+            co_return model::record_batch_reader::storage_t{};
+        case state::uninitialized:
+            co_await initialize_reader(deadline);
+            vassert(
+              _state != state::uninitialized, "reader should be initialized");
+            break;
+        case state::reading_l1:
+            co_return co_await read_l1(deadline);
+        case state::reading_l0:
+            co_return co_await read_l0(deadline);
+        }
+    }
+}
+
+void cloud_topics_log_reader_impl::print(std::ostream& o) {
+    o << "cloud_topics_log_reader";
+}
+
+ss::future<> cloud_topics_log_reader_impl::initialize_reader(
+  model::timeout_clock::time_point /*deadline*/) {
+    _lro = _stm_api->get_last_reconciled_offset();
+    _original_max_offset = _config.max_offset;
+
+    if (_config.start_offset <= _lro) {
+        vlog(
+          cd_log.debug,
+          "Initializing reader in L1 for {} with start_offset {} and LRO {}",
+          _ntp,
+          _config.start_offset,
+          _lro);
+
+        _config.max_offset = std::min(_config.max_offset, _lro);
+
+        _l1_reader = std::make_unique<level_one_log_reader_impl>(
+          _config, _ntp, _tidp, _metastore.get(), _io);
+        _state = state::reading_l1;
+        co_return;
+    }
+
+    vlog(
+      cd_log.debug,
+      "Initializing reader in L0 for {} with start_offset {} and LRO {}",
+      _ntp,
+      _config.start_offset,
+      _lro);
+
+    _l0_reader = std::make_unique<level_zero_log_reader_impl>(
+      _config, _partition, _data_plane_api);
+    _state = state::reading_l0;
+}
+
+bool cloud_topics_log_reader_impl::should_transition_to_l0() const {
+    if (_lro >= _original_max_offset) {
+        return false;
+    }
+
+    if (
+      (_config.strict_max_bytes || _config.bytes_consumed > 0)
+      && _config.bytes_consumed >= _config.max_bytes) {
+        return false;
+    }
+
+    return true;
+}
+
+ss::future<model::record_batch_reader::storage_t>
+cloud_topics_log_reader_impl::read_l1(
+  model::timeout_clock::time_point deadline) {
+    vassert(_state == state::reading_l1, "reading L1 state mismatch");
+    vassert(_l1_reader, "L1 reader should be initialized");
+    vassert(!_l0_reader, "L0 reader should not be initialized");
+
+    auto result = co_await _l1_reader->do_load_slice(deadline);
+
+    if (_l1_reader->is_end_of_stream()) {
+        if (should_transition_to_l0()) {
+            _config.start_offset = kafka::next_offset(_lro);
+            _config.max_offset = _original_max_offset;
+
+            vlog(
+              cd_log.debug,
+              "Transitioning from L1 to L0 at offset {}",
+              _config.start_offset);
+
+            _l0_reader = std::make_unique<level_zero_log_reader_impl>(
+              _config, _partition, _data_plane_api);
+            _l1_reader.reset();
+            _state = state::reading_l0;
+
+            co_return result;
+        }
+        _state = state::end_of_stream;
+    }
+
+    co_return result;
+}
+
+ss::future<model::record_batch_reader::storage_t>
+cloud_topics_log_reader_impl::read_l0(
+  model::timeout_clock::time_point deadline) {
+    vassert(_state == state::reading_l0, "reading L0 state mismatch");
+    vassert(_l0_reader, "L0 reader should be initialized");
+    vassert(!_l1_reader, "L1 reader should not be initialized");
+
+    auto result = co_await _l0_reader->do_load_slice(deadline);
+
+    if (_l0_reader->is_end_of_stream()) {
+        _state = state::end_of_stream;
+    }
+
+    co_return result;
+}
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/frontend_reader/reader.h
+++ b/src/v/cloud_topics/frontend_reader/reader.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/common/abstract_io.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/level_zero/stm/ctp_stm_api.h"
+#include "cloud_topics/log_reader_config.h"
+#include "model/record_batch_reader.h"
+
+namespace cluster {
+class partition;
+}
+
+namespace cloud_topics {
+class data_plane_api;
+
+namespace l1 {
+class frontend;
+}
+
+/*
+ * This class implements a reader for a cloud topic. It reads from both L0 and
+ * L1.
+ *
+ * The reader determines at initialization whether to start reading from L1 or
+ * L0 based on the LRO, and if the L1 reader is exhausted but the reader expects
+ * more batches, the reader transitions to reading from L0.
+ */
+class cloud_topics_log_reader_impl : public model::record_batch_reader::impl {
+public:
+    cloud_topics_log_reader_impl(
+      cloud_topic_log_reader_config& cfg,
+      model::ntp ntp,
+      model::topic_id_partition tidp,
+      ss::lw_shared_ptr<cluster::partition> partition,
+      l1::frontend* l1_frontend,
+      l1::io* io_interface,
+      data_plane_api* data_plane_api,
+      ctp_stm_api* stm_api);
+
+    bool is_end_of_stream() const final;
+
+    ss::future<model::record_batch_reader::storage_t>
+      do_load_slice(model::timeout_clock::time_point) final;
+
+    void print(std::ostream& o) final;
+
+private:
+    enum class state { uninitialized, reading_l1, reading_l0, end_of_stream };
+
+    // Initialize the appropriate reader based on the LRO and min offset.
+    ss::future<> initialize_reader(model::timeout_clock::time_point deadline);
+
+    // Should the reader transition to L0, given that it has reached the end of
+    // the L1 stream?
+    bool should_transition_to_l0() const;
+
+    ss::future<model::record_batch_reader::storage_t>
+    read_l1(model::timeout_clock::time_point deadline);
+
+    ss::future<model::record_batch_reader::storage_t>
+    read_l0(model::timeout_clock::time_point deadline);
+
+    state _state{state::uninitialized};
+
+    // The last reconciled offset, determined at initialization.
+    // Used as the boundary between L1 and L0.
+    kafka::offset _lro{kafka::offset(-1)};
+
+    // Original max_offset from the config, preserved for L0.
+    kafka::offset _original_max_offset;
+
+    std::unique_ptr<model::record_batch_reader::impl> _l1_reader;
+    std::unique_ptr<model::record_batch_reader::impl> _l0_reader;
+
+    cloud_topic_log_reader_config _config;
+    model::ntp _ntp;
+    model::topic_id_partition _tidp;
+    ss::lw_shared_ptr<cluster::partition> _partition;
+    std::unique_ptr<l1::metastore> _metastore;
+    l1::io* _io;
+    data_plane_api* _data_plane_api;
+    ctp_stm_api* _stm_api;
+};
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_one/common/BUILD
+++ b/src/v/cloud_topics/level_one/common/BUILD
@@ -1,6 +1,7 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 package(default_visibility = [
+    "//src/v/cloud_topics/frontend_reader:__subpackages__",
     "//src/v/cloud_topics/level_one:__subpackages__",
     "//src/v/cloud_topics/reconciler:__subpackages__",
 ])

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -50,6 +50,8 @@ namespace cloud_topics::l1 {
 // side effects. As such, callers can think of this interface as thread safe.
 class metastore {
 public:
+    virtual ~metastore() = default;
+
     enum class errc {
         missing_ntp,
         invalid_request,

--- a/src/v/cloud_topics/state_accessors.h
+++ b/src/v/cloud_topics/state_accessors.h
@@ -9,9 +9,23 @@
  */
 #pragma once
 
+#include "cloud_topics/level_one/common/file_io.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <memory>
+
+namespace cluster {
+class metadata_cache;
+}
+
 namespace cloud_topics {
 
 class data_plane_api;
+
+namespace l1 {
+class frontend;
+} // namespace l1
 
 // Encapsulates the required bits to access topic state from cloud topics,
 // with minimal dependencies. This allows it to be passed around through
@@ -19,12 +33,28 @@ class data_plane_api;
 //
 class state_accessors {
 public:
-    explicit state_accessors(data_plane_api* data_plane)
-      : data_plane(data_plane) {}
+    explicit state_accessors(
+      data_plane_api* data_plane,
+      l1::frontend* l1_metastore_fe,
+      l1::file_io* l1_io,
+      cluster::metadata_cache* metadata_cache)
+      : data_plane(data_plane)
+      , l1_metastore_fe(l1_metastore_fe)
+      , l1_io(l1_io)
+      , metadata_cache(metadata_cache) {}
 
     data_plane_api* get_data_plane() { return data_plane; }
 
+    l1::frontend* get_l1_metastore_frontend() { return l1_metastore_fe; }
+
+    l1::file_io* get_l1_io() { return l1_io; }
+
+    cluster::metadata_cache* get_metadata_cache() { return metadata_cache; }
+
 private:
     data_plane_api* data_plane;
+    l1::frontend* l1_metastore_fe;
+    l1::file_io* l1_io;
+    cluster::metadata_cache* metadata_cache;
 };
 } // namespace cloud_topics


### PR DESCRIPTION
This adds a simple cloud topics reader that combines L0 and L1 readers. It is very lightly tested by the existing end-to-end test, which reads from L0. I think we should merge this along with #27578, and then it becomes much easier to write meaningful cloud topics tests (both unit and ducktape tests).

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
