### PR TITLE
`ct`: log shutdown errors in `reconciler` at `DEBUG`

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -49,6 +49,7 @@ redpanda_cc_library(
         "//src/v/kafka/utils:txn_reader",
         "//src/v/model",
         "//src/v/random:generators",
+        "//src/v/ssx:future_util",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:node_hash_map",
         "@seastar",

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -180,6 +180,7 @@ ss::future<> reconciler::reconcile() {
                                          : ss::log_level::error,
           "Exception creating staging file: {}",
           ex);
+        co_return;
     }
     auto staging_file_result = staging_file_fut.get();
     if (!staging_file_result.has_value()) {

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -21,6 +21,7 @@
 #include "kafka/utils/txn_reader.h"
 #include "model/namespace.h"
 #include "random/generators.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/log.hh>
@@ -173,7 +174,12 @@ ss::future<> reconciler::reconcile() {
       _l1_io->create_tmp_file());
     if (staging_file_fut.failed()) {
         auto ex = staging_file_fut.get_exception();
-        vlog(lg.error, "Exception creating staging file: {}", ex);
+        vlogl(
+          lg,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                         : ss::log_level::error,
+          "Exception creating staging file: {}",
+          ex);
     }
     auto staging_file_result = staging_file_fut.get();
     if (!staging_file_result.has_value()) {
@@ -195,7 +201,12 @@ ss::future<> reconciler::reconcile() {
     co_await builder->close(); // Always.
     if (object_fut.failed()) {
         auto ex = object_fut.get_exception();
-        vlog(lg.error, "Exception building object: {}", ex);
+        vlogl(
+          lg,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                         : ss::log_level::error,
+          "Exception building object: {}",
+          ex);
         co_await staging_file->remove();
         co_return;
     }
@@ -219,7 +230,13 @@ ss::future<> reconciler::reconcile() {
     co_await staging_file->remove(); // Always.
     if (upload_fut.failed()) {
         auto ex = upload_fut.get_exception();
-        vlog(lg.error, "Exception uploading L1 object {}: {}", object_id, ex);
+        vlogl(
+          lg,
+          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
+                                         : ss::log_level::error,
+          "Exception uploading L1 object {}: {}",
+          object_id,
+          ex);
         co_return;
     }
     auto upload_result = upload_fut.get();


### PR DESCRIPTION
To prevent noisy failures in CI due to `ERROR` level logging. Non-shutdown errors are still logged at `ERROR` for real bug catching in early stages of cloud topics implementations.

Also, add early `co_return` in unhappy path for `staging_file_fut` to match the other unhappy paths.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
