### PR TITLE
Use `RedpandaServiceForClients` in `KgoVerifierServices`

### DIFF
--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -1,3 +1,5 @@
+from logging import Logger
+from typing import Any, Callable
 from ducktape.utils.util import wait_until
 
 from rptest.services.redpanda_types import (
@@ -5,6 +7,7 @@ from rptest.services.redpanda_types import (
     KafkaClientSecurity,
     RedpandaServiceForClients,
 )
+from rptest.util import wait_until_with_progress_check
 
 
 class KafkaServiceAdapter(RedpandaServiceForClients):
@@ -46,6 +49,22 @@ class KafkaServiceAdapter(RedpandaServiceForClients):
     # they are plain text
     def kafka_client_security(self) -> KafkaClientSecurity:
         return PLAINTEXT_SECURITY
+
+    # Redpanda supports more clever version of this method that verifies if cluster is healthy and fail fast if it is not
+    # KafkaService does not have such checks, so we just call the original wait_until_with_progress_check function
+    def wait_until_with_progress_check(
+        self,
+        check: Callable[[], Any],
+        condition: Callable[[], Any],
+        timeout_sec: int,
+        progress_sec: int,
+        backoff_sec: int,
+        err_msg: str | None = None,
+        logger: Logger | None = None,
+    ):
+        return wait_until_with_progress_check(
+            check, condition, timeout_sec, progress_sec, backoff_sec, err_msg, logger
+        )
 
     # required for rpk
     def find_binary(self, name):

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -44,7 +44,7 @@ class KgoVerifierService(Service):
     def __init__(
         self,
         context,
-        redpanda,
+        redpanda: RedpandaServiceForClients,
         topic,
         msg_size,
         custom_node,
@@ -80,6 +80,7 @@ class KgoVerifierService(Service):
         self._username = username
         self._password = password
         self._enable_tls = enable_tls
+        self._status: ProduceStatus | ConsumerStatus
 
         # if testing redpanda cloud, override with default test super user/pass
         if hasattr(redpanda, "GLOBAL_CLOUD_CLUSTER_CONFIG"):
@@ -298,6 +299,11 @@ class KgoVerifierService(Service):
 
             raise
 
+    @property
+    def status_thread(self) -> StatusThread:
+        assert self._status_thread is not None
+        return self._status_thread
+
     def _do_wait_node(self, node, timeout_sec):
         """
         Wait for the remote process to gracefully finish: if it is a one-shot
@@ -324,16 +330,16 @@ class KgoVerifierService(Service):
             f"wait_node {self.who_am_i()}: waiting for worker to complete"
         )
         self._redpanda.wait_until(
-            lambda: self._status.active is False or self._status_thread.errored,
+            lambda: self._status.active is False or self.status_thread.errored,
             timeout_sec=timeout_sec,
             backoff_sec=5,
             err_msg=f"{self.who_am_i()} didn't complete in {timeout_sec} seconds",
         )
-        self._status_thread.raise_on_error()
+        self.status_thread.raise_on_error()
 
         # Read final status
         self.logger.debug(f"wait_node {self.who_am_i()}: reading final status")
-        self._status_thread.shutdown()
+        self.status_thread.shutdown()
         self._status_thread = None
 
         # Permit the subprocess to exit, and wait for it to do so
@@ -386,7 +392,7 @@ class KgoVerifierService(Service):
 class StatusThread(threading.Thread):
     INTERVAL = 5
 
-    def __init__(self, parent: Service, node, status_cls, *args, **kwargs):
+    def __init__(self, parent: KgoVerifierService, node, status_cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.daemon = True
 
@@ -430,8 +436,9 @@ class StatusThread(threading.Thread):
         for s in worker_statuses[1:]:
             reduced.merge(self._status_cls(**s))
 
-        if self._status_cls == ProduceStatus:
-            progress = worker_statuses[0]["sent"] / float(self._parent._msg_count)
+        if isinstance(self._parent, KgoVerifierProducer):
+            parent: KgoVerifierProducer = self._parent
+            progress = worker_statuses[0]["sent"] / float(parent._msg_count)
             self.logger.info(
                 f"Producer {self.who_am_i} progress: {progress * 100:.2f}% {reduced}"
             )
@@ -663,10 +670,11 @@ class KgoVerifierProducer(KgoVerifierService):
         self._client_name = client_name
 
     @property
-    def produce_status(self):
+    def produce_status(self) -> ProduceStatus:
+        assert self._status is not None and isinstance(self._status, ProduceStatus)
         return self._status
 
-    def wait_node(self, node, timeout_sec=None):
+    def wait_node(self, node, timeout_sec: int | None):
         if not self._status_thread:
             return True
 
@@ -674,9 +682,9 @@ class KgoVerifierProducer(KgoVerifierService):
         self.logger.debug(what)
         try:
             self._redpanda.wait_until(
-                lambda: self._status_thread.errored
-                or self._status.acked >= self._msg_count,
-                timeout_sec=timeout_sec,
+                lambda: self.status_thread.errored
+                or self.produce_status.acked >= self._msg_count,
+                timeout_sec=timeout_sec if timeout_sec is not None else 30,
                 backoff_sec=self._status_thread.INTERVAL,
                 err_msg=what,
             )
@@ -686,7 +694,7 @@ class KgoVerifierProducer(KgoVerifierService):
 
         self._status_thread.raise_on_error()
 
-        if self._status.bad_offsets != 0:
+        if self.produce_status.bad_offsets != 0:
             # This either means that the test sent multiple producers' traffic to
             # the same topic, or that Redpanda showed a buggy behavior with
             # idempotency: producer records should always land at the next offset
@@ -704,10 +712,10 @@ class KgoVerifierProducer(KgoVerifierService):
 
     def wait_for_acks(self, count, timeout_sec, backoff_sec, progress_sec=None):
         def acks():
-            return self._status.acked
+            return self.produce_status.acked
 
         def acks_at_count():
-            return self._status_thread.errored or acks() >= count
+            return self.status_thread.errored or acks() >= count
 
         if progress_sec is not None:
             self._redpanda.wait_until_with_progress_check(
@@ -722,17 +730,17 @@ class KgoVerifierProducer(KgoVerifierService):
             self._redpanda.wait_until(
                 acks_at_count, timeout_sec=timeout_sec, backoff_sec=backoff_sec
             )
-        self._status_thread.raise_on_error()
+        self.status_thread.raise_on_error()
 
     def _wait_for_file_on_nodes(self, file_name):
         self._redpanda.wait_until(
-            lambda: self._status_thread.errored
+            lambda: self.status_thread.errored
             or all(node.account.exists(file_name) for node in self.nodes),
             timeout_sec=15,
             backoff_sec=1,
             err_msg=f"Timed out waiting for {file_name} to be created",
         )
-        self._status_thread.raise_on_error()
+        self.status_thread.raise_on_error()
 
     def wait_for_offset_map(self):
         # Producer worker aims to checkpoint every 5 seconds, so we should see this promptly.
@@ -745,7 +753,7 @@ class KgoVerifierProducer(KgoVerifierService):
         self._wait_for_file_on_nodes(value_map_file_name)
 
     def is_complete(self):
-        return self._status.acked >= self._msg_count
+        return self.produce_status.acked >= self._msg_count
 
     def client_name(self):
         return self._client_name if self._client_name else self.who_am_i()
@@ -826,12 +834,12 @@ class AbstractConsumer(KgoVerifierService):
         self.logger.info("Waiting for total reads to reach %d", count)
 
         self._redpanda.wait_until(
-            lambda: self._status_thread.errored
+            lambda: self.status_thread.errored
             or self.consumer_status.validator.total_reads >= count,
             timeout_sec=timeout_sec,
             backoff_sec=backoff_sec,
         )
-        self._status_thread.raise_on_error()
+        self.status_thread.raise_on_error()
 
 
 class KgoVerifierSeqConsumer(AbstractConsumer):
@@ -913,17 +921,18 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
 
     def wait_node(self, node, timeout_sec=None):
         if self._producer:
+            producer: KgoVerifierProducer = self._producer
 
             def consumed_whole_log():
-                producer_done = self._producer._status.sent == self._producer._msg_count
+                producer_done = producer.produce_status.sent == producer._msg_count
                 if not producer_done:
                     self.logger.debug(
-                        f"Producer {self._producer.who_am_i()} hasn't finished yet"
+                        f"Producer {producer.who_am_i()} hasn't finished yet"
                     )
                     return False
 
                 consumed = self._status.validator.max_offsets_consumed
-                produced = self._producer._status.max_offsets_produced
+                produced = producer.produce_status.max_offsets_produced
                 if consumed != produced:
                     self.logger.debug(
                         f"Consumer {self.who_am_i()} hasn't read all produced data yet: {consumed=} {produced=}"
@@ -935,7 +944,7 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
                 consumed_whole_log,
                 timeout_sec=timeout_sec,
                 backoff_sec=2,
-                err_msg=f"Consumer hasn't read all produced data: consumed={self._status.validator.max_offsets_consumed} produced={self._producer._status.max_offsets_produced}",
+                err_msg=f"Consumer hasn't read all produced data: consumed={self._status.validator.max_offsets_consumed} produced={self._producer.produce_status.max_offsets_produced}",
             )
 
         return super().wait_node(node, timeout_sec=timeout_sec)

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -23,7 +23,7 @@ from ducktape.utils.util import wait_until
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda_types import RedpandaServiceForClients
 
 # Install location, specified by Dockerfile or AMI
 TESTS_DIR = os.path.join("/opt", "kgo-verifier")
@@ -70,7 +70,7 @@ class KgoVerifierService(Service):
             assert not self.nodes
             self.nodes = custom_node
 
-        self._redpanda: RedpandaService = redpanda
+        self._redpanda: RedpandaServiceForClients = redpanda
         self._topic = topic
         self._msg_size = msg_size
         self._pid = None
@@ -83,10 +83,11 @@ class KgoVerifierService(Service):
 
         # if testing redpanda cloud, override with default test super user/pass
         if hasattr(redpanda, "GLOBAL_CLOUD_CLUSTER_CONFIG"):
-            security_config = redpanda.security_config()
-            self._username = security_config.get("sasl_plain_username", None)
-            self._password = security_config.get("sasl_plain_password", None)
-            self._enable_tls = security_config.get("enable_tls", False)
+            security_config = redpanda.kafka_client_security()
+            if security_config.sasl_enabled:
+                self._username = security_config.username
+                self._password = security_config.password
+            self._enable_tls = security_config.tls_enabled
 
         for node in self.nodes:
             if not hasattr(node, "kgo_verifier_ports"):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1250,6 +1250,7 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
         timeout_sec: int,
         backoff_sec: int,
         err_msg: str | Callable[[], str] = "",
+        retry_on_exc: bool = False,
     ) -> None:
         """
         Cluster-aware variant of wait_until, which will fail out
@@ -1276,7 +1277,11 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
             return r
 
         wait_until(
-            wrapped, timeout_sec=timeout_sec, backoff_sec=backoff_sec, err_msg=err_msg
+            wrapped,
+            timeout_sec=timeout_sec,
+            backoff_sec=backoff_sec,
+            err_msg=err_msg,
+            retry_on_exc=retry_on_exc,
         )
 
     def wait_until_with_progress_check(
@@ -1982,6 +1987,9 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         if self._is_serverless_cluster:
             return self._cloud_cluster.get_serverless_broker_address()
         return self._cloud_cluster.get_broker_address()
+
+    def brokers_list(self) -> list[str]:
+        return self.brokers().split(",")
 
     def install_pack_version(self) -> str:
         if self._is_serverless_cluster:

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -3,7 +3,7 @@ from copy import copy
 from dataclasses import astuple, dataclass
 from enum import Enum, auto
 from logging import Logger
-from typing import Iterator, Protocol, Sequence
+from typing import Any, Callable, Iterator, Protocol, Sequence
 
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
 
@@ -287,3 +287,25 @@ class RedpandaServiceForClients(Protocol):
     def kafka_client_security(self) -> KafkaClientSecurity: ...
 
     def brokers(self) -> str: ...
+
+    def brokers_list(self) -> list[str]: ...
+
+    def wait_until(
+        self,
+        fn: Callable[[], Any],
+        timeout_sec: int,
+        backoff_sec: int,
+        err_msg: str | Callable[[], str] = "",
+        retry_on_exc: bool = False,
+    ): ...
+
+    def wait_until_with_progress_check(
+        self,
+        check: Callable[[], Any],
+        condition: Callable[[], Any],
+        timeout_sec: int,
+        progress_sec: int,
+        backoff_sec: int,
+        err_msg: str | None = None,
+        logger: Logger | None = None,
+    ): ...


### PR DESCRIPTION
RedpandaServiceForClients should be a default interface that client use
to interact with RedpandaService. This way it is easy to replace
Redpanda with Kafka service and verify the behavior of kafka under the same test
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none