### PR TITLE
[CORE-13296] security/oidc_service: Set TLS from cluster_config

### DIFF
--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -353,11 +353,13 @@ struct service::impl {
         if (is_https) {
             tls_host.emplace(url.host);
             if (!_creds) {
+                const auto& cfg = config::shard_local_cfg();
                 ss::tls::credentials_builder builder;
                 builder.set_client_auth(ss::tls::client_auth::NONE);
                 builder.set_minimum_tls_version(
-                  config::from_config(
-                    config::shard_local_cfg().tls_min_version()));
+                  config::from_config(cfg.tls_min_version()));
+                builder.set_cipher_string(cfg.tls_v1_2_cipher_suites);
+                builder.set_ciphersuites(cfg.tls_v1_3_cipher_suites);
                 co_await builder.set_system_trust();
                 _creds = co_await net::build_reloadable_credentials_with_probe<
                   ss::tls::certificate_credentials>(


### PR DESCRIPTION
Allows configuration of TLS to the Identity Provider from cluster configuration.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
