### PR TITLE
bazel: Update OpenSSL

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -245,7 +245,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "+jSsiRDdAVIs8rK7sut79Hq8WO9ZvJvuMLIhoL/DvDM=",
+        "bzlTransitiveDigest": "ZNcszVIZUfAfu5eR6IGFRW/v0K090h3kmOVOuTzusgU=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -380,18 +380,18 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl.BUILD",
-              "sha256": "dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce",
-              "strip_prefix": "openssl-3.0.17",
-              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz"
+              "sha256": "c9489d2abcf943cdc8329a57092331c598a402938054dc3a22218aea8a8ec3bf",
+              "strip_prefix": "openssl-3.5.3",
+              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.5.3/openssl-3.5.3.tar.gz"
             }
           },
           "openssl-fips": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:openssl-fips.BUILD",
-              "sha256": "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90",
-              "strip_prefix": "openssl-3.0.9",
-              "url": "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/openssl-3.0.9.tar.gz"
+              "sha256": "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539",
+              "strip_prefix": "openssl-3.1.2",
+              "url": "https://github.com/openssl/openssl/releases/download/openssl-3.1.2/openssl-3.1.2.tar.gz"
             }
           },
           "rapidjson": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -130,17 +130,17 @@ def data_dependency():
     http_archive(
         name = "openssl",
         build_file = "//bazel/thirdparty:openssl.BUILD",
-        sha256 = "dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce",
-        strip_prefix = "openssl-3.0.17",
-        url = "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz",
+        sha256 = "c9489d2abcf943cdc8329a57092331c598a402938054dc3a22218aea8a8ec3bf",
+        strip_prefix = "openssl-3.5.3",
+        url = "https://github.com/openssl/openssl/releases/download/openssl-3.5.3/openssl-3.5.3.tar.gz",
     )
 
     http_archive(
         name = "openssl-fips",
         build_file = "//bazel/thirdparty:openssl-fips.BUILD",
-        sha256 = "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90",
-        strip_prefix = "openssl-3.0.9",
-        url = "https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies/openssl-3.0.9.tar.gz",
+        sha256 = "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539",
+        strip_prefix = "openssl-3.1.2",
+        url = "https://github.com/openssl/openssl/releases/download/openssl-3.1.2/openssl-3.1.2.tar.gz",
     )
 
     http_archive(

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -41,12 +41,13 @@ ss::future<std::optional<ss::sstring>> find_ca_file() {
     }
     co_return std::nullopt;
 }
-const std::string_view tls_v1_2_cipher_suites = "ECDHE-ECDSA-AES256-GCM-SHA384:"
-                                                "ECDHE-RSA-AES256-GCM-SHA384:"
-                                                "ECDHE-ECDSA-CHACHA20-POLY1305:"
-                                                "ECDHE-RSA-CHACHA20-POLY1305:"
-                                                "ECDHE-ECDSA-AES128-GCM-SHA256:"
-                                                "ECDHE-RSA-AES128-GCM-SHA256";
+const std::string_view tls_v1_2_cipher_suites
+  = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:"
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:"
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:"
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:"
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:"
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
 
 const std::string_view tls_v1_3_cipher_suites = "TLS_AES_256_GCM_SHA384:"
                                                 "TLS_CHACHA20_POLY1305_SHA256:"

--- a/tests/rptest/tests/tls_version_test.py
+++ b/tests/rptest/tests/tls_version_test.py
@@ -54,7 +54,7 @@ PERMITTED_ERROR_MESSAGE = [
     "seastar::tls::verification_error",
     "SSL routines::no shared cipher",
     "SSL routines::unsupported protocol",
-    "sslv3 alert handshake failure",
+    "ssl/tls alert handshake failure",
 ]
 
 


### PR DESCRIPTION
Quick experiment for updating OpenSSL to 3.5.3

## Backports Required

Maybe backport?

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Features

* Support for FIPS 140-3

### Improvements

* TLS 1.2 cipher suites can now be configured with IANA names
