### PR TITLE
Fixed race condition when checking if group mirroring task should start.

### DIFF
--- a/src/v/cluster_link/group_mirroring_task.cc
+++ b/src/v/cluster_link/group_mirroring_task.cc
@@ -27,8 +27,8 @@ void group_mirroring_task::update_config(const model::metadata& link_metadata) {
 
 namespace {
 
-chunked_hash_set<::model::partition_id> coordinators_on_current_shard(
-  link& link, ss::shard_id current_shard, ::model::node_id self_id) {
+chunked_hash_set<::model::partition_id>
+coordinators_on_current_shard(link& link, ss::shard_id, ::model::node_id) {
     auto topic_cfg = link.topic_metadata_cache().find_topic_cfg(
       ::model::kafka_consumer_offsets_nt);
     chunked_hash_set<::model::partition_id> ret;
@@ -39,12 +39,9 @@ chunked_hash_set<::model::partition_id> coordinators_on_current_shard(
          p_id < ::model::partition_id(topic_cfg->partition_count);
          ++p_id) {
         ::model::ktp ktp(::model::kafka_consumer_offsets_topic, p_id);
-        const auto is_leader = link.partition_leader_cache().get_leader_node(
-                                 ktp.as_tn_view(), ktp.get_partition())
-                               == self_id;
-        const auto on_current_shard = link.partition_manager().shard_owner(ktp)
-                                      == current_shard;
-        if (is_leader && on_current_shard) {
+        const auto is_leader = link.partition_manager().is_current_shard_leader(
+          ktp);
+        if (is_leader) {
             ret.insert(p_id);
         }
     }

--- a/src/v/cluster_link/tests/deps.h
+++ b/src/v/cluster_link/tests/deps.h
@@ -250,6 +250,10 @@ public:
         _impl->remove_shard_owner(ntp);
     }
 
+    bool is_current_shard_leader(const ::model::ntp& ntp) const final {
+        return _impl->shard_owner(ntp) == ss::this_shard_id();
+    }
+
     ss::future<::result<::model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard_id,
       const ::model::ktp& ktp,

--- a/src/v/kafka/data/rpc/deps.cc
+++ b/src/v/kafka/data/rpc/deps.cc
@@ -84,6 +84,10 @@ public:
         return _proxy->shard_owner(ntp);
     };
 
+    bool is_current_shard_leader(const model::ntp& ntp) const final {
+        return _proxy->is_current_shard_leader(ntp);
+    }
+
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard,
       const model::ktp& ktp,
@@ -245,6 +249,21 @@ partition_manager_proxy::shard_owner(const model::ntp& ntp) {
 std::optional<ss::shard_id>
 partition_manager::shard_owner(const model::ktp& ktp) {
     return shard_owner(ktp.to_ntp());
+}
+
+bool partition_manager::is_current_shard_leader(const model::ktp& ktp) const {
+    return is_current_shard_leader(ktp.to_ntp());
+};
+
+bool partition_manager_proxy::is_current_shard_leader(const model::ntp& ntp) {
+    auto shard = shard_owner(ntp);
+    if (shard != ss::this_shard_id()) {
+        // not on this shard,
+        return false;
+    }
+
+    auto p = _manager->local().get(ntp);
+    return p && p->is_leader();
 }
 
 std::unique_ptr<topic_creator>

--- a/src/v/kafka/data/rpc/deps.h
+++ b/src/v/kafka/data/rpc/deps.h
@@ -150,6 +150,13 @@ public:
     virtual std::optional<ss::shard_id> shard_owner(const model::ntp&) = 0;
 
     /**
+     * Checks if current shard owns a given ntp and is the leader for it.
+     */
+    bool is_current_shard_leader(const model::ktp&) const;
+
+    virtual bool is_current_shard_leader(const model::ntp&) const = 0;
+
+    /**
      * Invoke a function on the ntp's leader shard.
      *
      * Will return cluster::errc::not_leader if the shard_id is incorrect for
@@ -231,6 +238,8 @@ public:
 
     std::optional<ss::shard_id> shard_owner(const model::ktp& ntp);
     std::optional<ss::shard_id> shard_owner(const model::ntp& ntp);
+
+    bool is_current_shard_leader(const model::ntp& ntp);
 
 private:
     ss::sharded<cluster::shard_table>* _table;

--- a/src/v/kafka/data/rpc/test/deps.h
+++ b/src/v/kafka/data/rpc/test/deps.h
@@ -445,6 +445,10 @@ public:
         co_return co_await fn(&pp);
     }
 
+    bool is_current_shard_leader(const model::ntp& ntp) {
+        return shard_owner(ntp) == ss::this_shard_id();
+    }
+
 private:
     int _errors_to_inject = 0;
     ss::chunked_fifo<produced_batch> _produced_batches;
@@ -499,6 +503,10 @@ public:
         result<partition_offsets, cluster::errc>>(kafka::partition_proxy*)> fn,
       require_leader) final {
         return _fake_proxy->invoke_on_shard_impl(shard_id, ktp, std::move(fn));
+    }
+
+    bool is_current_shard_leader(const model::ntp& ntp) const override {
+        return _fake_proxy->is_current_shard_leader(ntp);
     }
 
 private:

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -52,6 +52,10 @@ public:
         return _proxy->shard_owner(ntp);
     };
 
+    bool is_current_shard_leader(const model::ntp& ntp) const final {
+        return _proxy->is_current_shard_leader(ntp);
+    }
+
     ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
       ss::shard_id shard,
       const model::ktp& ktp,

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -164,6 +164,10 @@ public:
         return _fake_proxy->shard_owner(ntp);
     }
 
+    bool is_current_shard_leader(const model::ntp& ntp) const override {
+        return _fake_proxy->shard_owner(ntp) == ss::this_shard_id();
+    }
+
     void set_errors(int n) {
         // TODO(oren): could just reach down for this
         _errors_to_inject = n;


### PR DESCRIPTION
Previously the consumer group mirroring task relied on the partitions
leader table to check if current node is a partition leader and decide
if the task should run on the shard. This approach is prone to the race
condition as the notification may trigger task reconciliation first and
only then update partition leaders table.

In order to fix the race condition the method checking if the consumer
group mirroring should start was changed to check the partition
directly. This guarantees that the correct state is observed when
checking if task should run as the notification is fired after raft
protocol local state update.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none