### PR TITLE
`compaction`: move legacy `enhance_key()` code back to `storage`

### DIFF
--- a/src/v/compaction/BUILD
+++ b/src/v/compaction/BUILD
@@ -10,9 +10,6 @@ redpanda_cc_library(
 
 redpanda_cc_library(
     name = "key",
-    srcs = [
-        "key.cc",
-    ],
     hdrs = [
         "key.h",
     ],

--- a/src/v/compaction/key.h
+++ b/src/v/compaction/key.h
@@ -24,7 +24,8 @@ struct compaction_key : bytes {
 
 // Adds additional context (batch type & whether the owning batch is a control
 // batch) to a key represented by `bytes_view`, and returns the result as a
-// `compaction_key`.
+// `compaction_key`. Should only be used in the context of local storage
+// compaction.
 compaction_key enhance_key(
   model::record_batch_type type, bool is_control_batch, bytes_view key);
 

--- a/src/v/compaction/tests/reducer_test.cc
+++ b/src/v/compaction/tests/reducer_test.cc
@@ -25,7 +25,7 @@ TEST(CompactionReducerTest, SimpleReducer) {
     int num_batches = 10;
     auto gen = linear_int_kv_batch_generator();
     auto spec = model::test::record_batch_spec{
-      .allow_compression = false, .count = 1};
+      .allow_compression = false, .count = 10};
     auto input_batches = gen(spec, num_batches);
     chunked_circular_buffer<model::record_batch> output_batches;
 

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -70,9 +70,8 @@ ss::future<bool> is_latest_record_for_key(
   const model::record_batch& b,
   const model::record& r) {
     const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
-    auto key_view = compaction_key{iobuf_to_bytes(r.key())};
-    auto key = enhance_key(
-      b.header().type, b.header().attrs.is_control(), key_view);
+    auto key = compaction_key{iobuf_to_bytes(r.key())};
+
     auto latest_offset_indexed = co_await map.get(key);
     // If the map hasn't indexed the given key, we should keep the
     // key.

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -324,6 +324,7 @@ redpanda_cc_library(
     deps = [
         ":batch_cache",
         ":chunk_cache",
+        ":compaction_key",
         ":disk",
         ":file_sanitizer_types",
         ":index_state",
@@ -480,6 +481,23 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "//src/v/serde",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "compaction_key",
+    srcs = [
+        "compaction_key.cc",
+    ],
+    hdrs = [
+        "compaction_key.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/bytes",
+        "//src/v/compaction:key",
+        "//src/v/model",
         "@seastar",
     ],
 )

--- a/src/v/storage/compaction_key.cc
+++ b/src/v/storage/compaction_key.cc
@@ -7,16 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "compaction/key.h"
+#include "storage/compaction_key.h"
 
 #include "model/record_batch_types.h"
 
 #include <algorithm>
 #include <type_traits>
 
-namespace compaction {
+namespace storage {
 
-compaction_key enhance_key(
+compaction::compaction_key enhance_key(
   model::record_batch_type type, bool is_control_batch, bytes_view key) {
     auto bt_le = ss::cpu_to_le(
       static_cast<std::underlying_type_t<model::record_batch_type>>(type));
@@ -29,7 +29,7 @@ compaction_key enhance_key(
     out = std::copy_n(
       reinterpret_cast<const char*>(&ctrl_le), sizeof(ctrl_le), out);
     std::copy_n(key.begin(), key.size(), out);
-    return compaction_key(std::move(enriched_key));
+    return compaction::compaction_key(std::move(enriched_key));
 }
 
-} // namespace compaction
+} // namespace storage

--- a/src/v/storage/compaction_key.h
+++ b/src/v/storage/compaction_key.h
@@ -10,16 +10,15 @@
 #pragma once
 
 #include "bytes/bytes.h"
+#include "compaction/key.h"
 #include "model/record_batch_types.h"
 
-namespace compaction {
+namespace storage {
 
-/**
- * Type representing a record key prefixed with batch_type
- */
-struct compaction_key : bytes {
-    explicit compaction_key(bytes b)
-      : bytes(std::move(b)) {}
-};
+// Adds additional context (batch type & whether the owning batch is a control
+// batch) to a key represented by `bytes_view`, and returns the result as a
+// `compaction_key`.
+compaction::compaction_key enhance_key(
+  model::record_batch_type type, bool is_control_batch, bytes_view key);
 
-} // namespace compaction
+} // namespace storage

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -18,6 +18,7 @@
 #include "model/record_utils.h"
 #include "random/generators.h"
 #include "storage/compacted_index.h"
+#include "storage/compaction_key.h"
 #include "storage/index_state.h"
 #include "storage/logger.h"
 #include "storage/record_batch_utils.h"
@@ -456,7 +457,7 @@ ss::future<ss::stop_iteration> map_building_reducer::maybe_index_record_in_map(
     }
 
     auto key_view = iobuf_to_bytes(r.key());
-    auto key = compaction::enhance_key(type, is_control, key_view);
+    auto key = enhance_key(type, is_control, key_view);
     bool success = co_await _map->put(key, offset);
 
     if (success) {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -49,6 +49,26 @@ ss::future<ss::stop_iteration> put_entry(
     co_return ss::stop_iteration::yes;
 }
 
+ss::future<bool> is_latest_record_for_enhanced_key(
+  const compaction::key_offset_map& map,
+  const model::record_batch& b,
+  const model::record& r) {
+    const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
+    auto key_view = compaction::compaction_key{iobuf_to_bytes(r.key())};
+    auto key = compaction::enhance_key(
+      b.header().type, b.header().attrs.is_control(), key_view);
+
+    auto latest_offset_indexed = co_await map.get(key);
+    // If the map hasn't indexed the given key, we should keep the
+    // key.
+    if (!latest_offset_indexed.has_value()) {
+        co_return true;
+    }
+    // We should only keep the record if its offset is equal or higher than
+    // that indexed.
+    co_return o >= latest_offset_indexed.value();
+}
+
 } // anonymous namespace
 
 ss::future<bool> build_offset_map_for_segment(
@@ -189,7 +209,7 @@ ss::future<index_state> deduplicate_segment(
     auto is_latest_record = [&map](
                               const model::record_batch& b,
                               const model::record& r) -> ss::future<bool> {
-        return compaction::is_latest_record_for_key(map, b, r);
+        return is_latest_record_for_enhanced_key(map, b, r);
     };
 
     const auto& ntp = seg->path().get_ntp();

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -15,6 +15,7 @@
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/compaction_key.h"
 #include "storage/compaction_reducers.h"
 #include "storage/exceptions.h"
 #include "storage/index_state.h"
@@ -55,7 +56,7 @@ ss::future<bool> is_latest_record_for_enhanced_key(
   const model::record& r) {
     const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
     auto key_view = compaction::compaction_key{iobuf_to_bytes(r.key())};
-    auto key = compaction::enhance_key(
+    auto key = enhance_key(
       b.header().type, b.header().attrs.is_control(), key_view);
 
     auto latest_offset_indexed = co_await map.get(key);

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -17,6 +17,7 @@
 #include "ssx/async_algorithm.h"
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/compaction_key.h"
 #include "storage/logger.h"
 #include "storage/segment_utils.h"
 #include "utils/vint.h"
@@ -202,7 +203,7 @@ ss::future<> spill_key_index::index(
        b = std::move(b),
        base_offset,
        delta]() {
-          auto key = compaction::enhance_key(batch_type, is_control_batch, b);
+          auto key = enhance_key(batch_type, is_control_batch, b);
           if (auto it = _midx.find(key); it != _midx.end()) {
               auto& pair = it->second;
               // must use both base+delta, since we only want to keep the


### PR DESCRIPTION
The use of `compaction::enhance_key()` should be limited to local storage compaction for indexing of a compaction map & de-duplication since the data present in existing `.compaction_index`s is of this format.

However, this functionality has no real benefit for new compaction implementations, since the extra bits encoded by `enhance_key()` are not going to be used anywhere (and aren't even used in local storage anymore) and are ultimately wasted space.

Duplicate the code in `compaction::is_latest_record_for_key()` back into a function within an anonymous namespace in `storage/segment_deduplication_utils.cc`, and remove the call to `enhance_key()` within the `compaction` namespace.

This code is left duplicated to avoid an extra `co_await` call to a generic `compaction::` function in the hot path.

Also, fix the `SimpleReducer` test, which was subject to a bug in which the non-enhanced key was being indexed but compared against the enhanced key during de-duplication- because of the number of records produced with the `linear_int_kv_batch_generator()`, this test was passing by accident.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
