### PR TITLE
rm_stm: cleanup variable/parameter naming

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -258,10 +258,7 @@ producer_state::producer_state(
         ready.set_value(kafka_result{req.last_offset});
         _requests._finished_requests.push_back(
           ss::make_lw_shared<request>(
-            req.first_sequence,
-            req.last_sequence,
-            req.last_term,
-            std::move(ready)));
+            req.first_sequence, req.last_sequence, req.term, std::move(ready)));
     }
 }
 

--- a/src/v/cluster/rm_stm_types.cc
+++ b/src/v/cluster/rm_stm_types.cc
@@ -317,7 +317,8 @@ tx_snapshot_v6::tx_snapshot_v6(tx_snapshot_v5 snap_v5, raft::group_id group)
             v6.finished_requests.emplace_back(
               request.first_sequence,
               request.last_sequence,
-              request.last_offset);
+              request.last_offset,
+              producer_state_snapshot::finished_request::unset_term);
         }
         producer_states.emplace(v6.id.get_id(), std::move(v6));
     }

--- a/src/v/cluster/rm_stm_types.h
+++ b/src/v/cluster/rm_stm_types.h
@@ -196,25 +196,25 @@ struct producer_state_snapshot
           finished_request,
           serde::version<1>,
           serde::compat_version<0>> {
+        static constexpr model::term_id unset_term{-1};
         finished_request() = default;
         finished_request(
           int32_t first,
           int32_t last,
           kafka::offset last_offset,
-          model::term_id term = model::term_id{-1})
+          model::term_id term)
           : first_sequence(first)
           , last_sequence(last)
           , last_offset(last_offset)
-          , last_term(term) {}
+          , term(term) {}
 
         int32_t first_sequence;
         int32_t last_sequence;
         kafka::offset last_offset;
-        model::term_id last_term{model::term_id{-1}};
+        model::term_id term{model::term_id{-1}};
 
         auto serde_fields() {
-            return std::tie(
-              first_sequence, last_sequence, last_offset, last_term);
+            return std::tie(first_sequence, last_sequence, last_offset, term);
         }
     };
 


### PR DESCRIPTION
Followups to https://github.com/redpanda-data/redpanda/pull/27587

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
