### PR TITLE
cloud_topics: don't log shutdown errors at error level

### DIFF
--- a/src/v/cloud_topics/level_zero/throttler/throttler.cc
+++ b/src/v/cloud_topics/level_zero/throttler/throttler.cc
@@ -155,8 +155,11 @@ ss::future<> throttler<Clock>::bg_throttle_write_pipeline() {
         } else {
             auto res = fut.get();
             if (res.has_error()) {
-                vlog(
-                  cd_log.error, "Pipeline throttling error: {}", res.error());
+                auto level = res.error() == errc::shutting_down
+                               ? ss::log_level::debug
+                               : ss::log_level::error;
+                vlogl(
+                  cd_log, level, "Pipeline throttling error: {}", res.error());
             } else {
                 total_bytes = res.value();
             }


### PR DESCRIPTION
```
<BadLogLines
nodes=docker-rp-1(2),docker-rp-2(2),docker-rp-3(2),docker-rp-4(2),docker-rp-5(2) example="ERROR 2025-09-10 02:44:23,593 [shard 0:main] cloud_topics -
throttler.cc:159 - Pipeline throttling error: cloud_topics:errc:4">
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
