### PR TITLE
ct/l1: support combining L1 objects

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -20,6 +20,7 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <fmt/format.h>
@@ -27,6 +28,7 @@
 #include <algorithm>
 #include <bit>
 #include <cstring>
+#include <exception>
 #include <ranges>
 #include <type_traits>
 #include <utility>
@@ -385,9 +387,7 @@ public:
           .footer_offset = footer_start,
           .size_bytes = _offset + sizeof(uint32_t),
         };
-        auto footer_size
-          = std::bit_cast<std::array<char, sizeof(uint32_t)>, uint32_t>(
-            _offset - footer_start);
+        auto footer_size = as_bytes<uint32_t>(_offset - footer_start);
         co_await _output.write(footer_size.data(), footer_size.size());
         _offset += footer_size.size();
         co_return info;
@@ -396,6 +396,20 @@ public:
     ss::future<> close() final { return _output.close(); }
 
     size_t file_size() const final { return _offset; }
+
+    template<typename T>
+    static ss::future<size_t> serde_write_to_stream(
+      data_type dt, T data, ss::output_stream<char>* output) {
+        iobuf b;
+        b.append(as_bytes(dt));
+        iobuf serialized;
+        co_await serde::write_async(serialized, std::move(data));
+        b.append(as_bytes<uint32_t>(serialized.size_bytes()));
+        b.append(std::move(serialized));
+        auto size = b.size_bytes();
+        co_await write_iobuf_to_output_stream(std::move(b), *output);
+        co_return size;
+    }
 
 private:
     void end_partition() {
@@ -410,14 +424,8 @@ private:
 
     template<typename T>
     ss::future<> serde_write_to_stream(data_type dt, T data) {
-        iobuf b;
-        b.append(as_bytes(dt));
-        iobuf serialized;
-        co_await serde::write_async(serialized, std::move(data));
-        b.append(as_bytes<uint32_t>(serialized.size_bytes()));
-        b.append(std::move(serialized));
-        _offset += b.size_bytes();
-        co_await write_iobuf_to_output_stream(std::move(b), _output);
+        _offset += co_await object_builder_impl::serde_write_to_stream(
+          dt, std::move(data), &_output);
     }
 
     ss::future<> write_batch_to_stream(model::record_batch batch) {
@@ -548,6 +556,105 @@ object_reader::create(std::filesystem::path p, size_t offset, size_t length) {
 std::unique_ptr<object_reader>
 object_reader::create(ss::file f, size_t offset, size_t length) {
     return create(ss::make_file_input_stream(std::move(f), offset, length));
+}
+
+namespace {
+
+// Copy upto N bytes to the output stream from the input stream
+ss::future<> copy_n(
+  ss::input_stream<char>* input, ss::output_stream<char>* output, size_t n) {
+    struct limited_copier {
+        size_t n = 0;
+        ss::output_stream<char>* os;
+
+        ss::future<ss::consumption_result<char>>
+        operator()(ss::temporary_buffer<char> data) {
+            if (data.empty() || n == 0) {
+                co_return ss::stop_consuming<char>(std::move(data));
+            }
+            size_t amt = std::min(data.size(), n);
+            data.trim(amt);
+            co_await os->write(std::move(data));
+            n -= amt;
+            co_return ss::continue_consuming();
+        }
+    };
+    limited_copier copier{.n = n, .os = output};
+    co_await input->consume(copier);
+}
+
+ss::future<>
+close_all_streams(combine_objects_parameters parameters, bool quiet) {
+    std::exception_ptr ex;
+    for (auto& input : parameters.inputs) {
+        auto fut = co_await ss::coroutine::as_future(input.stream.close());
+        if (fut.failed()) {
+            ex = fut.get_exception();
+        }
+    }
+    auto fut = co_await ss::coroutine::as_future(parameters.output.close());
+    if (fut.failed()) {
+        ex = fut.get_exception();
+    }
+    if (ex && !quiet) {
+        std::rethrow_exception(ex);
+    }
+    std::ignore = ex;
+}
+
+} // namespace
+
+ss::future<object_builder::object_info>
+combine_objects(combine_objects_parameters parameters) {
+    footer index;
+    size_t written = 0;
+    for (auto& input : parameters.inputs) {
+        for (const auto& [tidp, part] : input.info.index.partitions) {
+            // As we copy over our partition and index entries, we also
+            // need to update the offsets.
+            footer::partition updated = part.copy();
+            updated.file_position += written;
+            for (auto& index_entry : updated.indexes) {
+                index_entry.file_position += written;
+            }
+            index.partitions.emplace(tidp, std::move(updated));
+        }
+        auto n = input.info.footer_offset;
+        auto fut = co_await ss::coroutine::as_future(
+          copy_n(&input.stream, &parameters.output, n));
+        if (fut.failed()) {
+            auto ex = fut.get_exception();
+            co_await close_all_streams(
+              std::move(parameters),
+              /*quiet=*/true);
+            std::rethrow_exception(ex);
+        }
+        written += n;
+    }
+    auto footer_offset = written;
+    auto footer_write_fut = co_await ss::coroutine::as_future(
+      object_builder_impl::serde_write_to_stream(
+        data_type::footer, index.copy(), &parameters.output));
+    if (footer_write_fut.failed()) {
+        auto ex = footer_write_fut.get_exception();
+        co_await close_all_streams(std::move(parameters), /*quiet=*/true);
+        std::rethrow_exception(ex);
+    }
+    auto footer_size = footer_write_fut.get();
+    auto footer_size_data = as_bytes<uint32_t>(footer_size);
+    auto fut = co_await ss::coroutine::as_future(parameters.output.write(
+      footer_size_data.data(), footer_size_data.size()));
+    if (fut.failed()) {
+        auto ex = fut.get_exception();
+        co_await close_all_streams(std::move(parameters), /*quiet=*/true);
+        std::rethrow_exception(ex);
+    }
+    co_await close_all_streams(std::move(parameters), /*quiet=*/false);
+    co_return object_builder::object_info{
+      .index = std::move(index),
+      .footer_offset = footer_offset,
+      .size_bytes = footer_offset + footer_size + sizeof(uint32_t),
+    };
 }
 
 fmt::iterator

--- a/src/v/cloud_topics/level_one/common/object.h
+++ b/src/v/cloud_topics/level_one/common/object.h
@@ -369,4 +369,36 @@ public:
     virtual ss::future<> close() = 0;
 };
 
+// The parameters to combine multiple L1 objects into a single L1 object.
+struct combine_objects_parameters {
+    // The input object that will be combined.
+    struct input_object {
+        // A stream for the full object that was built using an
+        // `object_builder`.
+        //
+        // Since this takes ownership of the stream it will also close the
+        // stream.
+        ss::input_stream<char> stream;
+        // The output from `object_builder::finish` containing metadata from the
+        // constructed object.
+        object_builder::object_info info;
+    };
+    // Mechanically, the objects to combine into a single object. The resulting
+    // object will contain data in the order of these input objects.
+    chunked_vector<input_object> inputs;
+    // The stream to write the output to.
+    //
+    // Since this takes ownership of the output stream it will also be
+    // responsible for closing it.
+    ss::output_stream<char> output;
+};
+
+// Combine multiple L1 objects into a single object, and write it to the output
+// stream.
+//
+// The new object metadata is returned after the merging of files is
+// successful.
+ss::future<object_builder::object_info>
+  combine_objects(combine_objects_parameters);
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/common/tests/object_test.cc
+++ b/src/v/cloud_topics/level_one/common/tests/object_test.cc
@@ -625,3 +625,105 @@ TEST(L1Objects, BuilderSize) {
     EXPECT_GT(final_size, after_batch_size);
     EXPECT_EQ(final_size, finished.size_bytes);
 }
+
+namespace {
+
+std::pair<object_builder::object_info, iobuf>
+combine_objects_via_reader(std::span<iobuf> objects) {
+    iobuf output_iobuf;
+    auto builder = object_builder::create(
+      make_iobuf_ref_output_stream(output_iobuf), {});
+    for (const auto& obj : objects) {
+        auto reader = object_reader::create(
+          make_iobuf_input_stream(obj.copy()));
+        while (true) {
+            auto stop = ss::visit(
+              reader->read_next().get(),
+              [&builder](model::topic_id_partition tidp) {
+                  builder->start_partition(tidp).get();
+                  return false;
+              },
+              [&builder](model::record_batch batch) {
+                  builder->add_batch(std::move(batch)).get();
+                  return false;
+              },
+              [](const auto&) { return true; });
+            if (stop) {
+                break;
+            }
+        }
+        reader->close().get();
+    }
+    auto info = builder->finish().get();
+    builder->close().get();
+    return std::make_pair(std::move(info), std::move(output_iobuf));
+}
+
+} // namespace
+
+TEST(L1Objects, CanCombineObjects) {
+    auto test_topic_id = model::topic_id(uuid_t::create());
+    std::vector<batches_by_tidp> specs_by_tidp = {
+      {
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(0)),
+        .batches = {
+          {.base_offset = 0_o, .last_offset = 10_o, .max_timestamp = model::timestamp{1000}},
+          {.base_offset = 11_o, .last_offset = 20_o, .max_timestamp = model::timestamp{2000}},
+          {.base_offset = 21_o, .last_offset = 30_o, .max_timestamp = model::timestamp{3000}},
+        },
+      },
+      {
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(1)),
+        .batches = {
+          {.base_offset = 0_o, .last_offset = 10_o, .max_timestamp = model::timestamp{2000}},
+          {.base_offset = 15_o, .last_offset = 20_o, .max_timestamp = model::timestamp{3000}},
+          {.base_offset = 21_o, .last_offset = 30_o, .max_timestamp = model::timestamp{3000}},
+        },
+      },
+      {
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(2)),
+        .batches = {
+          {.base_offset = 0_o, .last_offset = 10_o, .max_timestamp = model::timestamp{2000}},
+          {.base_offset = 11_o, .last_offset = 30_o, .max_timestamp = model::timestamp{5000}},
+        },
+      },
+      {
+        .tidp = model::topic_id_partition(test_topic_id, model::partition_id(3)),
+        .batches = {
+          {.base_offset = 0_o, .last_offset = 5_o, .max_timestamp = model::timestamp{1050}},
+          {.base_offset = 6_o, .last_offset = 20_o, .max_timestamp = model::timestamp{2050}},
+          {.base_offset = 21_o, .last_offset = 30_o, .max_timestamp = model::timestamp{3050}},
+        },
+      },
+    };
+    auto [info1, object1] = make_object({specs_by_tidp.front()});
+    auto [info2, object2] = make_object(
+      {specs_by_tidp.at(1), specs_by_tidp.at(2)});
+    auto [info3, object3] = make_object({specs_by_tidp.back()});
+    auto all_objects = std::to_array({
+      object1.copy(),
+      object2.copy(),
+      object3.copy(),
+    });
+    auto [info_all, object_all] = combine_objects_via_reader(all_objects);
+    chunked_vector<combine_objects_parameters::input_object> inputs;
+    inputs.emplace_back(
+      make_iobuf_input_stream(std::move(object1)), std::move(info1));
+    inputs.emplace_back(
+      make_iobuf_input_stream(std::move(object2)), std::move(info2));
+    inputs.emplace_back(
+      make_iobuf_input_stream(std::move(object3)), std::move(info3));
+    iobuf output;
+    auto combined_info = combine_objects(
+                           {
+                             .inputs = std::move(inputs),
+                             .output = make_iobuf_ref_output_stream(output),
+                           })
+                           .get();
+    EXPECT_EQ(info_all.size_bytes, combined_info.size_bytes);
+    EXPECT_EQ(info_all.footer_offset, combined_info.footer_offset);
+    EXPECT_EQ(output.size_bytes(), combined_info.size_bytes);
+    EXPECT_EQ(info_all.index, combined_info.index);
+    // Look ma, byte for byte the same!
+    EXPECT_EQ(object_all, output);
+}

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -30,6 +30,7 @@
 namespace model::test {
 using namespace tests; // NOLINT
 
+namespace {
 std::vector<model::record_header> make_headers(int n = 2) {
     std::vector<model::record_header> ret;
     ret.reserve(n);
@@ -37,32 +38,37 @@ std::vector<model::record_header> make_headers(int n = 2) {
         int key_len = get_int(i, 10);
         int val_len = get_int(i, 10);
         ret.emplace_back(
-          model::record_header(
-            key_len, random_iobuf(key_len), val_len, random_iobuf(val_len)));
+          key_len, random_iobuf(key_len), val_len, random_iobuf(val_len));
     }
     return ret;
 }
 
-static model::record _make_random_record(
-  int index,
-  std::optional<iobuf> key,
-  std::optional<size_t> rec_size = std::nullopt) {
+struct record_spec {
+    int index;
+    std::optional<iobuf> key;
+    std::optional<size_t> record_size;
+    int num_headers = 2;
+};
+
+model::record make_random_record(record_spec spec) {
     iobuf k;
-    vassert(!key || !rec_size, "Cannot specify both key and record size.");
-    if (key) {
-        k = std::move(*key);
-    } else if (rec_size) {
-        k = random_iobuf(*rec_size);
+    vassert(
+      !spec.key || !spec.record_size,
+      "Cannot specify both key and record size.");
+    if (spec.key) {
+        k = std::move(*spec.key);
+    } else if (spec.record_size) {
+        k = random_iobuf(*spec.record_size);
     } else {
         k = random_iobuf();
     }
     auto k_z = k.size_bytes();
     auto v = random_iobuf();
     auto v_z = v.size_bytes();
-    auto headers = make_headers();
+    auto headers = make_headers(spec.num_headers);
     auto size = sizeof(model::record_attributes::type) // attributes
-                + vint::vint_size(index)               // timestamp delta
-                + vint::vint_size(index)               // offset delta
+                + vint::vint_size(spec.index)          // timestamp delta
+                + vint::vint_size(spec.index)          // offset delta
                 + vint::vint_size(k_z)                 // size of key-len
                 + k.size_bytes()                       // size of key
                 + vint::vint_size(v_z)                 // size of value
@@ -72,25 +78,21 @@ static model::record _make_random_record(
         size += vint::vint_size(h.key_size()) + h.key().size_bytes()
                 + vint::vint_size(h.value_size()) + h.value().size_bytes();
     }
-    return model::record(
-      size,
+    return {
+      static_cast<int32_t>(size),
       model::record_attributes(0),
-      index,
-      index,
-      k_z,
+      spec.index,
+      spec.index,
+      static_cast<int32_t>(k_z),
       std::move(k),
-      v_z,
+      static_cast<int32_t>(v_z),
       std::move(v),
-      std::move(headers));
+      std::move(headers)};
 }
+} // namespace
 
 model::record make_random_record(int index, iobuf key) {
-    return _make_random_record(
-      index, std::make_optional<iobuf>(std::move(key)));
-}
-
-static model::record make_random_record(int index, std::optional<size_t> size) {
-    return _make_random_record(index, std::nullopt, size);
+    return make_random_record({.index = index, .key = std::move(key)});
 }
 
 model::record_batch make_random_batch(
@@ -159,9 +161,17 @@ model::record_batch make_random_batch(record_batch_spec spec) {
         if (spec.max_key_cardinality) {
             auto keystr = gen_alphanum_max_distinct(*spec.max_key_cardinality);
             auto key = iobuf::from(keystr.c_str());
-            rs.emplace_back(make_random_record(i, std::move(key)));
+            rs.emplace_back(make_random_record({
+              .index = i,
+              .key = std::move(key),
+              .num_headers = spec.headers_per_record,
+            }));
         } else {
-            rs.emplace_back(make_random_record(i, sz));
+            rs.emplace_back(make_random_record({
+              .index = i,
+              .record_size = sz,
+              .num_headers = spec.headers_per_record,
+            }));
         }
     }
     iobuf body;

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -26,6 +26,7 @@ struct record_batch_spec {
     int count{0};
     std::optional<int> records{std::nullopt};
     std::optional<int> max_key_cardinality{std::nullopt};
+    int headers_per_record = 2;
 
     model::record_batch_type bt{model::record_batch_type::raft_data};
     bool enable_idempotence{false};


### PR DESCRIPTION
- **model/tests: allow specifying the number of headers in each record**
- **ct/l1: support combining objects**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
