### PR TITLE
cloud_roles: simplify aws sigv4

### DIFF
--- a/src/v/cloud_roles/apply_aws_credentials.cc
+++ b/src/v/cloud_roles/apply_aws_credentials.cc
@@ -78,16 +78,13 @@ apply_aws_credentials::add_auth(http::client::request_header& header) const {
     }
 
     auto existing_hash = header[aws_header_names::x_amz_content_sha256];
-    std::string_view sha256;
     if (existing_hash.empty()) {
-        sha256 = sha_for_verb(header.method());
+        std::string_view sha256 = sha_for_verb(header.method());
         header.insert(
           aws_header_names::x_amz_content_sha256,
           {sha256.data(), sha256.size()});
-    } else {
-        sha256 = existing_hash;
     }
-    return _signature.sign_header(header, sha256);
+    return _signature.sign_header(header);
 }
 
 void apply_aws_credentials::reset_creds(credentials creds) {

--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -302,9 +302,10 @@ get_canonical_headers(const http::client::request_header& request) {
 /// <SignedHeaders>\n
 /// <HashedPayload>
 inline result<ss::sstring> create_canonical_request(
-  const canonical_headers& hdr,
-  const http::client::request_header& header,
-  std::string_view hashed_payload) {
+  const canonical_headers& hdr, const http::client::request_header& header) {
+    static constexpr boost::beast::string_view x_amz_content_sha256
+      = "x-amz-content-sha256";
+
     auto method = std::string(header.method_string());
     auto target = std::string(header.target());
     if (target.empty() || target.at(0) != '/') {
@@ -326,7 +327,7 @@ inline result<ss::sstring> create_canonical_request(
       canonical_query,
       hdr.canonical_headers,
       hdr.signed_headers,
-      hashed_payload);
+      header.at(x_amz_content_sha256));
 }
 
 /// Genertes string-to-sign (in spec terms), example:
@@ -383,8 +384,8 @@ ss::sstring redact_headers_from_string(const std::string_view original) {
     return absl::StrJoin(result, "\n");
 }
 
-std::error_code signature_v4::sign_header(
-  http::client::request_header& header, std::string_view sha256) const {
+std::error_code
+signature_v4::sign_header(http::client::request_header& header) const {
     ss::sstring date_str = _sig_time.format_date();
     auto sign_key = gen_sig_key(
       _private_key(), date_str, _region(), _service());
@@ -393,13 +394,12 @@ std::error_code signature_v4::sign_header(
     vlog(clrl_log.trace, "Credentials updated:\n[scope]\n{}\n", cred_scope);
     auto amz_date = _sig_time.format_datetime();
     header.set("x-amz-date", {amz_date.data(), amz_date.size()});
-    header.set("x-amz-content-sha256", {sha256.data(), sha256.size()});
     auto canonical_headers = get_canonical_headers(header);
     if (!canonical_headers) {
         return canonical_headers.error();
     }
     auto canonical_req = create_canonical_request(
-      canonical_headers.value(), header, sha256);
+      canonical_headers.value(), header);
     if (!canonical_req) {
         return canonical_req.error();
     }

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -101,10 +101,7 @@ public:
     /// header.
     ///
     /// \param header is an in/out parameter that contains request headers
-    /// \param sha256 is a hash of the payload if payload is signed or default
-    /// value otherwise
-    std::error_code sign_header(
-      http::client::request_header& header, std::string_view sha256) const;
+    std::error_code sign_header(http::client::request_header& header) const;
 
     static ss::sstring gen_sig_key(
       std::string_view key,

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -77,6 +77,23 @@ BOOST_AUTO_TEST_CASE(test_aws_headers) {
           h.at("x-amz-content-sha256"),
           "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
     }
+
+    // Test with existing x-amz-content-sha256 header.
+    // Datalake auth manager does this.
+    {
+        bh::request_header<> h{};
+        h.method(bh::verb::get);
+        h.set(
+          "x-amz-content-sha256",
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        BOOST_REQUIRE_EQUAL(applier.add_auth(h), std::error_code{});
+        fmt::print("{}", h);
+        BOOST_REQUIRE_EQUAL(h.at("x-amz-security-token"), "tok2");
+        // get request contains empty signature
+        BOOST_REQUIRE_EQUAL(
+          h.at("x-amz-content-sha256"),
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(test_credentials_print) {

--- a/src/v/cloud_roles/tests/signature_test.cc
+++ b/src/v/cloud_roles/tests/signature_test.cc
@@ -21,6 +21,9 @@
 #include <chrono>
 #include <sstream>
 
+static constexpr boost::beast::string_view x_amz_content_sha256
+  = "x-amz-content-sha256";
+
 std::chrono::time_point<std::chrono::system_clock>
 parse_time(const std::string& timestr) {
     std::tm tm = {};
@@ -51,8 +54,9 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_1) {
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::range, "bytes=0-9");
+    header.insert(x_amz_content_sha256, sha256);
 
-    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -89,8 +93,9 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_2) {
     header.insert(boost::beast::http::field::host, host);
     header.insert(
       boost::beast::http::field::date, "Fri, 24 May 2013 00:00:00 GMT");
+    header.insert(x_amz_content_sha256, sha256);
 
-    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -125,8 +130,9 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_3) {
     header.method(boost::beast::http::verb::get);
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
+    header.insert(x_amz_content_sha256, sha256);
 
-    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -159,8 +165,9 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_4) {
     header.method(boost::beast::http::verb::get);
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
+    header.insert(x_amz_content_sha256, sha256);
 
-    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -195,8 +202,9 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_non_s3) {
     header.method(boost::beast::http::verb::get);
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
+    header.insert(x_amz_content_sha256, sha256);
 
-    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "


### PR DESCRIPTION
This PR simplifies the AWS SigV4 signature implementation by removing the explicit sha256 parameter from the sign_header method. Instead of passing the SHA256 hash as a separate parameter, the method now expects the hash to be pre-populated in the x-amz-content-sha256 header field.

All the existing callers already did this anyway. It made no sense to reset the header. Update the method interface and tests to use the same flows.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
