### PR TITLE
k/metadata: fixed returning incorrect leader epoch

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2502,8 +2502,10 @@ struct leader_term {
       : leader(leader)
       , term(term) {}
 
+    explicit leader_term(std::optional<model::node_id> leader)
+      : leader(leader) {}
     std::optional<model::node_id> leader;
-    model::term_id term;
+    std::optional<model::term_id> term;
     friend auto operator<=>(const leader_term&, const leader_term&) = default;
     friend std::ostream& operator<<(std::ostream&, const leader_term&);
 };

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -182,13 +182,18 @@ std::ostream& operator<<(std::ostream& os, describe_configs_source s);
  * batch encoding utility in protocol/wire.h can remove the dependency on this,
  * for example by having the caller in the server perform this conversion.
  */
-inline kafka::leader_epoch leader_epoch_from_term(model::term_id term) {
-    try {
-        return kafka::leader_epoch(
-          boost::numeric_cast<kafka::leader_epoch::type>(term()));
-    } catch (const boost::bad_numeric_cast&) {
-        return kafka::invalid_leader_epoch;
-    }
+inline kafka::leader_epoch
+leader_epoch_from_term(std::optional<model::term_id> term) {
+    return term
+      .and_then([](auto&& term) {
+          try {
+              return std::make_optional<kafka::leader_epoch>(
+                boost::numeric_cast<kafka::leader_epoch::type>(term()));
+          } catch (const boost::bad_numeric_cast&) {
+              return std::optional<kafka::leader_epoch>{};
+          }
+      })
+      .value_or(kafka::invalid_leader_epoch);
 }
 
 /// Kafka API request correlation.

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -93,7 +93,7 @@ std::optional<cluster::leader_term> get_leader_term(
      * cluster::topic_dispatcher before)
      */
     if (!leader_term) {
-        leader_term.emplace(replicas[0], model::term_id(0));
+        leader_term.emplace(replicas[0]);
         return leader_term;
     }
     if (!leader_term->leader.has_value()) {


### PR DESCRIPTION
Since version 9 the `MetadataResponse` contains an information about partition leader epoch. If present the epoch value is considered by the clients as valid i.e. they use the leader epoch value to fence stale metadata updates. In some rare cases f.e. when some nodes are in recovery mode while other are not Redpanda leaders table may not yet contain the leader epoch information. In this case `MetadataResponse` should return an invalid leader epoch. This way the clients will not use the epoch to fence the partition update.

Together with implementation of TopicIDs support we upgraded max handled `MetadataRequest` version from `8` to `12`. This way clients started to rely on the leader epoch information included in `MetadataResponse`.

Previously when no leader epoch was present in partition leaders cache the metadata request handler always returned first replica as a leader and `0` as a value of leader epoch. This was incorrect as it forced clients to fence the partition metadata update. As a result of the update fencing the partition was not included in the consecutive fetch requests leading to a situation in which consumers were stuck for time required to refresh metadata again.

Described issue caused some of the tests (the one using Java based Kafka clients) to fail intermittently.

Fixes: #CORE-9955

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none