### PR TITLE
Intrusive list safety

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -617,7 +617,6 @@ remote::subscribe(remote::event_filter& filter) {
     _as.check();
     auto holder = _gate.hold();
     vassert(filter._hook.is_linked() == false, "Filter is already in use");
-    filter._hook = {};
     _filters.push_back(filter);
     filter._promise.emplace();
     return filter._promise->get_future().then(

--- a/src/v/cluster/tests/namespaced_cache_test.cc
+++ b/src/v/cluster/tests/namespaced_cache_test.cc
@@ -24,6 +24,29 @@ struct fixture : public seastar_test {};
 struct entry {
     explicit entry(ss::sstring k)
       : key(std::move(k)) {}
+
+    // typically elements with intrusive lists should not have copy
+    // constructors, fine here because this is simply used to populate a
+    // vector with n copies of an entry
+    entry(const entry& other) noexcept
+      : pinned{other.pinned}
+      , key{other.key} {}
+
+    entry(entry&& other) noexcept
+      : pinned{other.pinned}
+      , key{std::move(other.key)} {
+        _hook.swap_nodes(other._hook);
+    }
+
+    entry& operator=(const entry&) = delete;
+
+    entry& operator=(entry&& other) noexcept {
+        pinned = other.pinned;
+        key = std::move(other.key);
+        _hook.swap_nodes(other._hook);
+        return *this;
+    }
+    ~entry() = default;
     bool pinned = false;
     ss::sstring key;
     safe_intrusive_list_hook _hook;
@@ -461,6 +484,16 @@ struct entry_with_ts {
     clock_type::time_point get_last_update_timestamp() const {
         return last_update_ts;
     }
+
+    entry_with_ts() = default;
+    entry_with_ts& operator=(const entry_with_ts& other) {
+        if (this != &other) {
+            last_update_ts = other.last_update_ts;
+        }
+        return *this;
+    }
+
+    entry_with_ts(const entry_with_ts& other) { *this = other; }
 
     void touch() { last_update_ts = clock_type::now(); }
 

--- a/src/v/container/intrusive_list_helpers.h
+++ b/src/v/container/intrusive_list_helpers.h
@@ -19,10 +19,44 @@
 #include <boost/intrusive/list.hpp>
 
 /**
- * An auto-unlink intrusive list hook.
+ * list_member_hook was written before move semantics.
+ *
+ * copy construction of a list_member_hook initializes the constructed hook to
+ * unlinked
+ * copy assignment is a noop does nothing.
+ *
+ * When an object which contains a list_member_hook is moved, the copy semantics
+ * for list_member_hook are invoked.
+ *
+ * Move can be implemented with swap_nodes to maintain the integrity and order
+ * of the intrusive list, but swap_nodes invalidates any iterators which point
+ * to the swapped nodes.
+ *
+ * Destruction of an intrusive list element in auto_unlink mode also invalidates
+ * any iterator to the pointed-to node.
+ *
+ * Given the above, intrusive list iterators should not be used without proper
+ * concurrency controls on both the intrusive list itself and the memory owner
+ * of the intrusive list elements.
+ *
+ * Avoid asynchronous loops over unlocked intrusive lists.
+ *
  */
-using intrusive_list_hook = boost::intrusive::list_member_hook<
-  boost::intrusive::link_mode<boost::intrusive::auto_unlink>>;
+template<boost::intrusive::link_mode_type LinkModeType>
+struct base_intrusive_list_hook
+  : public boost::intrusive::list_member_hook<
+      boost::intrusive::link_mode<LinkModeType>> {
+    base_intrusive_list_hook() = default;
+    base_intrusive_list_hook(const base_intrusive_list_hook&) = delete;
+    base_intrusive_list_hook& operator=(const base_intrusive_list_hook&)
+      = delete;
+    base_intrusive_list_hook(base_intrusive_list_hook&&) = delete;
+    base_intrusive_list_hook& operator=(base_intrusive_list_hook&&) = delete;
+    ~base_intrusive_list_hook() = default;
+};
+
+using intrusive_list_hook
+  = base_intrusive_list_hook<boost::intrusive::link_mode_type::auto_unlink>;
 
 /**
  * An intrusive list.
@@ -63,8 +97,8 @@ using intrusive_list = boost::intrusive::list<
 /**
  * A safe-link intrusive list hook.
  */
-using safe_intrusive_list_hook = boost::intrusive::list_member_hook<
-  boost::intrusive::link_mode<boost::intrusive::safe_link>>;
+using safe_intrusive_list_hook
+  = base_intrusive_list_hook<boost::intrusive::safe_link>;
 
 /**
  * An intrusive list with const-time size() method.

--- a/src/v/utils/tracking_allocator.h
+++ b/src/v/utils/tracking_allocator.h
@@ -29,7 +29,7 @@ public:
     explicit mem_tracker(ss::sstring label)
       : _label(std::move(label)) {}
     mem_tracker(mem_tracker&) = delete;
-    mem_tracker(mem_tracker&&) = default;
+    mem_tracker(mem_tracker&&) = delete;
     mem_tracker& operator=(mem_tracker&) = delete;
     mem_tracker& operator=(mem_tracker&&) = delete;
     ~mem_tracker() = default;


### PR DESCRIPTION
This PR deletes the copy and move semantics of intrusive_list_hook and safe_intrusive_list_hook by default to prevent subtle bugs which arise from using copy and move semantics on intrusive list elements concurrently with iterators on their derived intrusive lists.

Intrusive lists have subtle behavior when copied or moved.

As of writing, list_base_hook has copy semantics where copy construction default initializes the new list hooks, and copy assignment is a noop.

list_base_hook has deleted move semantics.

Given these and an object which contains an intrusive_list_hook, the containing object's default move constructor will move its contained data as normal, but invoke the above copy semantics for intrusive list hook.

A user might expect that moving an intrusive list element would also move its linkages to the moved-into-object, but this does not occur.

This can be a problem in any container which does not offer pointer stability (including chunked_vector and chunked_hash_map). If one of these collections owns the memory of intrusive list elements, then updates to these containers while concurrently iterating over a derived intrusive list can lead to dangling pointers, iterator invalidation, or reordering of intrusive list elements.

This pr answers this by deleting copy and move semantics by default such that intrusive list hooks may not be used naively with containers for which this could be a problem.

Note: this does not answer iterator invalidation and its corresponding dangling reference issues, which occurs when an intrusive list element is destructed while an intrusive list iterator currently points to that element.

See https://godbolt.org/z/7hGxsTzYv for a demonstration of reordering and iterator invalidation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Improvements

* Increases safety on our intrusive list wrappers

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
