### PR TITLE
ct: add first offset to get_first_ge

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -212,6 +212,7 @@ domain_manager::get_first_offset_ge(rpc::get_first_offset_ge_request req) {
             .oid = obj.oid,
             .footer_pos = obj.footer_pos,
             .object_size = obj.object_size,
+            .first_offset = obj.first_offset,
             .last_offset = obj.last_offset,
         },
     };
@@ -246,6 +247,7 @@ domain_manager::get_first_timestamp_ge(
             .oid = obj.oid,
             .footer_pos = obj.footer_pos,
             .object_size = obj.object_size,
+            .first_offset = obj.first_offset,
             .last_offset = obj.last_offset,
         },
     };

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -79,6 +79,8 @@ public:
         object_id oid;
         size_t footer_pos;
         size_t object_size;
+        // The first offset available in the object (inclusive).
+        kafka::offset first_offset;
         // The last offset available in the object (inclusive).
         // This can be used to skip to the next offset.
         kafka::offset last_offset;

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -391,6 +391,7 @@ replicated_metastore::get_first_ge(
     resp.oid = reply.object.oid;
     resp.footer_pos = reply.object.footer_pos;
     resp.object_size = reply.object.object_size;
+    resp.first_offset = reply.object.first_offset;
     resp.last_offset = reply.object.last_offset;
     co_return resp;
 }
@@ -419,6 +420,7 @@ replicated_metastore::get_first_ge(
     resp.oid = reply.object.oid;
     resp.footer_pos = reply.object.footer_pos;
     resp.object_size = reply.object.object_size;
+    resp.first_offset = reply.object.first_offset;
     resp.last_offset = reply.object.last_offset;
     co_return resp;
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -87,13 +87,16 @@ struct object_metadata
   : serde::
       envelope<object_metadata, serde::version<0>, serde::compat_version<0>> {
     auto serde_fields() {
-        return std::tie(oid, footer_pos, object_size, last_offset);
+        return std::tie(
+          oid, footer_pos, object_size, first_offset, last_offset);
     }
 
     object_id oid;
     size_t footer_pos;
     size_t object_size;
 
+    // The first offset (inclusive) that is within this object.
+    kafka::offset first_offset;
     // The last offset (inclusive) that is within this object.
     kafka::offset last_offset;
 };

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -249,6 +249,7 @@ simple_metastore::get_first_ge(
           .oid = it->oid,
           .footer_pos = footer_pos,
           .object_size = object_size,
+          .first_offset = it->base_offset,
           .last_offset = it->last_offset,
         };
     }
@@ -284,6 +285,7 @@ simple_metastore::get_first_ge(
               .oid = obj.oid,
               .footer_pos = footer_pos,
               .object_size = object_size,
+              .first_offset = obj.base_offset,
               .last_offset = obj.last_offset,
             };
         }

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -178,6 +178,7 @@ TEST(SimpleMetastoreTest, TestGetMissingPartition) {
     ASSERT_EQ(get_res->oid, oid1);
     ASSERT_EQ(get_res->footer_pos, 200);
     ASSERT_EQ(get_res->object_size, 1200);
+    ASSERT_EQ(get_res->first_offset, 0_o);
     ASSERT_EQ(get_res->last_offset, 10_o);
 }
 
@@ -318,6 +319,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 0_o);
         ASSERT_EQ(get_res->last_offset, 10_o);
     }
     for (const auto& o : std::views::iota(11, 21)) {
@@ -326,6 +328,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 11_o);
         ASSERT_EQ(get_res->last_offset, 20_o);
     }
     for (const auto& o : std::views::iota(21, 31)) {
@@ -334,6 +337,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBasic) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 21_o);
         ASSERT_EQ(get_res->last_offset, 30_o);
     }
 }
@@ -357,6 +361,7 @@ TEST(SimpleMetastoreTest, TestAddGetOffsetBelowStart) {
     ASSERT_EQ(get_res->oid, oid1);
     ASSERT_EQ(get_res->footer_pos, 100);
     ASSERT_EQ(get_res->object_size, 1100);
+    ASSERT_EQ(get_res->first_offset, 0_o);
     ASSERT_EQ(get_res->last_offset, 10_o);
 }
 
@@ -402,6 +407,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 0_o);
         ASSERT_EQ(get_res->last_offset, 10_o);
     }
     for (const auto& t : {2000_t, 2999_t}) {
@@ -410,6 +416,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 11_o);
         ASSERT_EQ(get_res->last_offset, 20_o);
     }
     for (const auto& t : {3000_t, 3999_t}) {
@@ -418,6 +425,7 @@ TEST(SimpleMetastoreTest, TestAddGetTimestampBasic) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 21_o);
         ASSERT_EQ(get_res->last_offset, 30_o);
     }
 }
@@ -514,6 +522,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 0_o);
         ASSERT_EQ(get_res->last_offset, 20_o);
     }
     // Others should be served from oid1 or oid2.
@@ -524,6 +533,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 0_o);
         ASSERT_EQ(get_res->last_offset, 10_o);
     }
     for (const auto& o : std::views::iota(11, 21)) {
@@ -532,6 +542,7 @@ TEST(StateUpdateTest, TestReplaceMultipleOnePartition) {
         ASSERT_EQ(get_res->oid, oid2);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 11_o);
         ASSERT_EQ(get_res->last_offset, 20_o);
     }
     // Sanity check that replacement leaves us with expected offsets.
@@ -581,6 +592,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 0_o);
         ASSERT_EQ(get_res->last_offset, 20_o);
     }
     tpr = model::topic_id_partition::from(tid_b);
@@ -590,6 +602,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_EQ(get_res->oid, oid3);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 11_o);
         ASSERT_EQ(get_res->last_offset, 20_o);
     }
     // Others should be served from oid1 or oid2.
@@ -599,6 +612,7 @@ TEST(StateUpdateTest, TestReplaceMultipleMultiplePartitions) {
         ASSERT_EQ(get_res->oid, oid1);
         ASSERT_EQ(get_res->footer_pos, 100);
         ASSERT_EQ(get_res->object_size, 1100);
+        ASSERT_EQ(get_res->first_offset, 0_o);
         ASSERT_EQ(get_res->last_offset, 10_o);
     }
     // Sanity check that replacement leaves us with expected offsets.


### PR DESCRIPTION
this first offset is needed for time based retention time queries.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
