### PR TITLE
[CORE-13410] cloud_storage: fix large allocation when listing objects

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -1049,7 +1049,7 @@ ss::future<list_result> remote::list_objects(
           item_filter);
 
         if (res) {
-            auto list_result = res.value();
+            auto list_result = std::move(res.value());
             // Successful call, prepare for future calls by getting
             // continuation_token if result was truncated
             items_remaining = list_result.is_truncated;
@@ -1126,7 +1126,7 @@ ss::future<list_result> remote::list_objects(
           bucket,
           result->error());
     }
-    co_return *result;
+    co_return std::move(*result);
 }
 
 ss::future<upload_result> remote::upload_object(upload_request upload_request) {

--- a/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
@@ -81,11 +81,11 @@ TEST(FindLatestReport, NonDatePathsIgnored) {
     ss::abort_source as;
     retry_chain_node parent{as};
 
-    const auto dates = cl::client::list_bucket_result{
+    auto dates = cl::client::list_bucket_result{
       .common_prefixes = {"1215-06/", "133701Z/"}};
 
     csi::MockRemote remote;
-    setup_and_validate_list_call(remote, parent, dates);
+    setup_and_validate_list_call(remote, parent, std::move(dates));
 
     csi::aws_ops ops{bucket, id, prefix};
     const auto result = ops.fetch_latest_report_metadata(remote, parent).get();
@@ -114,7 +114,7 @@ void run_test(csi::MockRemote& remote, retry_chain_node& parent, T... ts) {
     // We expect the following prefixes to be checked, in order from latest to
     // earliest.
     // The scanning will stop once the first manifest checksum is found
-    auto common_prefixes = std::vector<ss::sstring>{
+    auto common_prefixes = chunked_vector<ss::sstring>{
       "1215-06-15T01-02Z/",
       latest_date_which_has_report,
       latest_date,
@@ -122,10 +122,10 @@ void run_test(csi::MockRemote& remote, retry_chain_node& parent, T... ts) {
     for (auto& p : common_prefixes) {
         p = fmt::format("{}{}", list_prefix, p);
     }
-    const auto dates = cl::client::list_bucket_result{
-      .common_prefixes = common_prefixes};
+    auto dates = cl::client::list_bucket_result{
+      .common_prefixes = std::move(common_prefixes)};
 
-    setup_and_validate_list_call(remote, parent, dates);
+    setup_and_validate_list_call(remote, parent, std::move(dates));
 
     // The latest date does not have a manifest checksum, so it will be checked
     // and then discarded

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -755,7 +755,7 @@ TEST_P(all_types_remote_fixture, test_list_bucket_with_prefix) {
                       cloud_storage_clients::object_key{url_base() + "x/"})
                     .get();
     ASSERT_TRUE(result.has_value());
-    auto items = result.value().contents;
+    const auto& items = result.value().contents;
     ASSERT_EQ(items.size(), 2);
     ASSERT_EQ(items[0].key, url_base() + "x/a");
     ASSERT_EQ(items[1].key, url_base() + "x/b");
@@ -790,7 +790,7 @@ TEST_P(all_types_remote_fixture, test_list_bucket_with_filter) {
                       })
                     .get();
     ASSERT_TRUE(result.has_value());
-    auto items = result.value().contents;
+    const auto& items = result.value().contents;
     ASSERT_EQ(items.size(), 1);
     ASSERT_EQ(items[0].key, path_with_prefix);
 }

--- a/src/v/cloud_storage/topic_manifest_downloader.cc
+++ b/src/v/cloud_storage/topic_manifest_downloader.cc
@@ -188,7 +188,7 @@ topic_manifest_downloader::download_manifest(
 
 namespace {
 using list_outcome_t
-  = std::vector<cloud_storage_clients::client::list_bucket_item>;
+  = chunked_vector<cloud_storage_clients::client::list_bucket_item>;
 ss::future<result<list_outcome_t, error_outcome>> find_prefixed_manifest_paths(
   remote& remote,
   cloud_storage_clients::bucket_name bucket,
@@ -214,7 +214,7 @@ ss::future<result<list_outcome_t, error_outcome>> find_prefixed_manifest_paths(
           prefixed_list_res.error());
         co_return error_outcome::manifest_download_error;
     }
-    co_return prefixed_list_res.value().contents;
+    co_return std::move(prefixed_list_res.value().contents);
 }
 } // namespace
 

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -874,26 +874,8 @@ ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
         throw parse_rest_error_response(content_type, status, std::move(buf));
     }
 
-    co_return co_await ss::do_with(
-      response_stream->as_input_stream(),
-      xml_sax_parser{},
-      [pred = std::move(collect_item_if)](
-        ss::input_stream<char>& stream, xml_sax_parser& p) mutable {
-          p.start_parse(std::make_unique<abs_parse_impl>(std::move(pred)));
-          return ss::do_until(
-                   [&stream] { return stream.eof(); },
-                   [&stream, &p] {
-                       return stream.read().then(
-                         [&p](ss::temporary_buffer<char>&& chunk) {
-                             p.parse_chunk(std::move(chunk));
-                         });
-                   })
-            .then([&stream] { return stream.close(); })
-            .then([&p] {
-                p.end_parse();
-                return p.result();
-            });
-      });
+    co_return co_await parse_from_stream<abs_parse_impl>(
+      response_stream->as_input_stream(), std::move(collect_item_if));
 }
 
 ss::future<result<abs_client::storage_account_info, error_outcome>>

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -108,8 +108,8 @@ public:
         bool is_truncated = false;
         ss::sstring prefix;
         ss::sstring next_continuation_token;
-        std::vector<list_bucket_item> contents;
-        std::vector<ss::sstring> common_prefixes;
+        chunked_vector<list_bucket_item> contents;
+        chunked_vector<ss::sstring> common_prefixes;
     };
 
     /// A predicate to allow list_objects to collect items selectively, saving

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -1022,27 +1022,8 @@ ss::future<s3_client::list_bucket_result> s3_client::do_list_objects_v2(
                       });
                 }
 
-                return ss::do_with(
-                  resp->as_input_stream(),
-                  xml_sax_parser{},
-                  [pred = std::move(gather_item_if)](
-                    ss::input_stream<char>& stream, xml_sax_parser& p) mutable {
-                      p.start_parse(
-                        std::make_unique<aws_parse_impl>(std::move(pred)));
-                      return ss::do_until(
-                               [&stream] { return stream.eof(); },
-                               [&stream, &p] {
-                                   return stream.read().then(
-                                     [&p](ss::temporary_buffer<char>&& chunk) {
-                                         p.parse_chunk(std::move(chunk));
-                                     });
-                               })
-                        .then([&stream] { return stream.close(); })
-                        .then([&p] {
-                            p.end_parse();
-                            return p.result();
-                        });
-                  });
+                return parse_from_stream<aws_parse_impl>(
+                  resp->as_input_stream(), std::move(gather_item_if));
             });
       });
 }

--- a/src/v/cloud_storage_clients/tests/xml_sax_parser_test.cc
+++ b/src/v/cloud_storage_clients/tests/xml_sax_parser_test.cc
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(test_parse_payload) {
     p.start_parse(std::make_unique<cloud_storage_clients::aws_parse_impl>());
     p.parse_chunk(std::move(buffer));
     p.end_parse();
-    auto result = p.result();
+    auto result = std::move(p).result();
     BOOST_REQUIRE_EQUAL(result.contents.size(), 2);
     BOOST_REQUIRE_EQUAL(result.contents[0].key, "test-key1");
     BOOST_REQUIRE_EQUAL(result.contents[0].size_bytes, 111);
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(test_parse_abs) {
     p.parse_chunk(std::move(buffer));
     p.end_parse();
 
-    auto result = p.result();
+    auto result = std::move(p).result();
     BOOST_REQUIRE_EQUAL(result.contents.size(), 1);
     BOOST_REQUIRE_EQUAL(result.contents[0].key, "blob-name");
     BOOST_REQUIRE_EQUAL(result.contents[0].size_bytes, 1112);
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(test_parse_abs_with_continuation) {
     p.parse_chunk(std::move(buffer));
     p.end_parse();
 
-    auto result = p.result();
+    auto result = std::move(p).result();
     BOOST_REQUIRE_EQUAL(result.is_truncated, true);
     BOOST_REQUIRE_EQUAL(result.next_continuation_token, "nnn");
 }
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(test_parse_abs_with_blob_prefix) {
     p.parse_chunk(std::move(buffer));
     p.end_parse();
 
-    auto result = p.result();
+    auto result = std::move(p).result();
     BOOST_REQUIRE(result.contents.empty());
     BOOST_REQUIRE_EQUAL(result.common_prefixes.size(), 1);
     BOOST_REQUIRE_EQUAL(

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -295,8 +295,8 @@ void abs_parse_impl::handle_characters(std::string_view characters) {
     }
 }
 
-client::list_bucket_result parser_state::impl::parsed_items() const {
-    return _items;
+client::list_bucket_result parser_state::impl::parsed_items() && {
+    return std::move(_items);
 }
 
 xml_sax_parser::xml_sax_parser(xml_sax_parser&& other) noexcept {
@@ -348,8 +348,9 @@ void xml_sax_parser::end_parse() {
     }
 }
 
-client::list_bucket_result xml_sax_parser::result() const {
-    return _state->parsed_items();
+client::list_bucket_result xml_sax_parser::result() && {
+    auto state = std::exchange(_state, {});
+    return std::move(*state).parsed_items();
 }
 
 void xml_sax_parser::start_element(
@@ -406,7 +407,7 @@ seastar::future<client::list_bucket_result> parse_from_stream(
             .then([&stream] { return stream.close(); })
             .then([&p] {
                 p.end_parse();
-                return p.result();
+                return std::move(p).result();
             });
       });
 }

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -372,4 +372,37 @@ void xml_sax_parser::characters(
       {reinterpret_cast<const char*>(data), static_cast<size_t>(size)});
 }
 
+template<typename Impl>
+seastar::future<client::list_bucket_result> parse_from_stream(
+  seastar::input_stream<char> stream, std::optional<client::item_filter> pred) {
+    return ss::do_with(
+      std::move(stream),
+      xml_sax_parser{},
+      [pred = std::move(pred)](
+        ss::input_stream<char>& stream, xml_sax_parser& p) mutable {
+          p.start_parse(std::make_unique<Impl>(std::move(pred)));
+          return ss::do_until(
+                   [&stream] { return stream.eof(); },
+                   [&stream, &p] {
+                       return stream.read().then(
+                         [&p](ss::temporary_buffer<char>&& chunk) {
+                             p.parse_chunk(std::move(chunk));
+                         });
+                   })
+            .then([&stream] { return stream.close(); })
+            .then([&p] {
+                p.end_parse();
+                return p.result();
+            });
+      });
+}
+
+template seastar::future<client::list_bucket_result>
+parse_from_stream<aws_parse_impl>(
+  seastar::input_stream<char> stream, std::optional<client::item_filter> pred);
+
+template seastar::future<client::list_bucket_result>
+parse_from_stream<abs_parse_impl>(
+  seastar::input_stream<char> stream, std::optional<client::item_filter> pred);
+
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/xml_sax_parser.cc
+++ b/src/v/cloud_storage_clients/xml_sax_parser.cc
@@ -385,8 +385,22 @@ seastar::future<client::list_bucket_result> parse_from_stream(
                    [&stream] { return stream.eof(); },
                    [&stream, &p] {
                        return stream.read().then(
-                         [&p](ss::temporary_buffer<char>&& chunk) {
-                             p.parse_chunk(std::move(chunk));
+                         [&p](ss::temporary_buffer<char> chunk) {
+                             /*
+                              * Seastar may return chunks of 128KB which is very
+                              * close to our max allocation limit. But when this
+                              * is handed off to to libxml the data may be
+                              * incorporated into a buffer that needs resizing
+                              * and exceed the max allocation limit. So break
+                              * this up into smaller chunks for processing.
+                              */
+                             constexpr auto max_part_size = 16_KiB;
+                             while (!chunk.empty()) {
+                                 auto part_size = std::min(
+                                   max_part_size, chunk.size());
+                                 p.parse_chunk(chunk.share(0, part_size));
+                                 chunk.trim_front(part_size);
+                             }
                          });
                    })
             .then([&stream] { return stream.close(); })

--- a/src/v/cloud_storage_clients/xml_sax_parser.h
+++ b/src/v/cloud_storage_clients/xml_sax_parser.h
@@ -54,7 +54,7 @@ struct parser_state {
         virtual void handle_start_element(std::string_view element_name) = 0;
         virtual void handle_end_element(std::string_view element_name) = 0;
         virtual void handle_characters(std::string_view characters) = 0;
-        client::list_bucket_result parsed_items() const;
+        client::list_bucket_result parsed_items() &&;
 
         virtual ~impl() = default;
 
@@ -81,8 +81,9 @@ struct parser_state {
         _impl->handle_characters(characters);
     }
 
-    client::list_bucket_result parsed_items() const {
-        return _impl->parsed_items();
+    client::list_bucket_result parsed_items() && {
+        auto impl = std::exchange(_impl, {});
+        return std::move(*impl).parsed_items();
     }
 
 private:
@@ -137,7 +138,7 @@ public:
     /// make sure that libxml2 parsing is finished.
     void end_parse();
 
-    client::list_bucket_result result() const;
+    client::list_bucket_result result() &&;
 
     /// \brief frees up the parser context pointer
     ~xml_sax_parser();

--- a/src/v/cloud_storage_clients/xml_sax_parser.h
+++ b/src/v/cloud_storage_clients/xml_sax_parser.h
@@ -14,7 +14,7 @@
 #include "cloud_storage_clients/client.h"
 #include "thirdparty/libxml2/parser.h"
 
-#include <stack>
+#include <seastar/core/iostream.hh>
 
 namespace cloud_storage_clients {
 
@@ -153,5 +153,12 @@ private:
     std::unique_ptr<xmlSAXHandler> _handler;
     xmlParserCtxtPtr _ctx{nullptr};
 };
+
+/*
+ * Process an input stream with SAX XML parser implementation.
+ */
+template<typename Impl>
+seastar::future<client::list_bucket_result> parse_from_stream(
+  seastar::input_stream<char>, std::optional<client::item_filter>);
 
 } // namespace cloud_storage_clients

--- a/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
+++ b/src/v/cloud_topics/level_zero/gc/level_zero_gc.cc
@@ -41,7 +41,7 @@ public:
         auto res = co_await remote_->list_objects(
           bucket_, rtc, object_path_factory::level_zero_data_dir());
         if (res.has_value()) {
-            co_return res.assume_value();
+            co_return std::move(res).assume_value();
         }
         co_return std::unexpected(res.assume_error());
     }

--- a/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
+++ b/src/v/cloud_topics/level_zero/gc/tests/level_zero_gc_tests.cc
@@ -32,7 +32,7 @@ public:
       cloud_storage_clients::client::list_bucket_result,
       cloud_storage_clients::error_outcome>>
     list_objects(seastar::abort_source*) override {
-        std::vector<cloud_storage_clients::client::list_bucket_item> keep;
+        chunked_vector<cloud_storage_clients::client::list_bucket_item> keep;
         for (const auto& object : *listed_) {
             auto not_deleted = true;
             for (const auto& deleted : *deleted_) {

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -323,7 +323,7 @@ ss::future<cloudcheck::verify_list_result> cloudcheck::verify_list(
 
     try {
         auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
-        const cloud_storage::remote::list_result object_list
+        cloud_storage::remote::list_result object_list
           = co_await _cloud_storage_api.local().list_objects(
             bucket, rtc, prefix, std::nullopt, std::nullopt, std::nullopt);
 


### PR DESCRIPTION
Fixes large allocation when listing objects.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
