### PR TITLE
CORE-13360 admin: implement generic AIP-160 filter parsing 

### DIFF
--- a/bazel/pbgen/main.go
+++ b/bazel/pbgen/main.go
@@ -636,7 +636,7 @@ func (g *headerGenerator) generateMessage(msg protoreflect.MessageDescriptor, w 
 	w.Println("// Convert a field path into a path of field numbers.")
 	w.Println("std::optional<std::vector<int32_t>> convert_field_path_to_numbers(std::span<std::string_view> field_path) const override;")
 	w.Println("// Look up a field based on the field numbers.")
-	w.Println("std::optional<serde::pb::field> lookup_field(std::span<int32_t> field_numbers) override;")
+	w.Println("std::optional<serde::pb::field> lookup_field(std::span<const int32_t> field_numbers) override;")
 	w.Println()
 	w.Println("// NOTE: This is intended to be used by field_mask only. Do not use directly.")
 	w.Println("static bool is_valid_field_path(std::span<const ss::sstring> path);")
@@ -804,7 +804,7 @@ func (g *implGenerator) generateMessagePathToNumbersHelper(msg protoreflect.Mess
 }
 
 func (g *implGenerator) generateMessageTraversalHelper(msg protoreflect.MessageDescriptor, w *codewriter) {
-	w.Printf("std::optional<serde::pb::field> %s::lookup_field(std::span<int32_t> field_numbers) {\n", g.cppTypeName(msg))
+	w.Printf("std::optional<serde::pb::field> %s::lookup_field(std::span<const int32_t> field_numbers) {\n", g.cppTypeName(msg))
 	defer w.Println("}")
 	w.Indent()
 	defer w.Dedent()

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -144,6 +144,22 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "field_registry",
+    srcs = ["field_registry.cc"],
+    hdrs = [
+        "field_registry.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/redpanda/admin/tests:aip_filter_test_messages_redpanda_proto",
+        "//src/v/serde/protobuf:base",
+        "//src/v/utils:named_type",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/time",
+    ],
+)
+
+redpanda_cc_library(
     name = "admin",
     srcs = [
         "debug.cc",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -160,6 +160,28 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "aip_filter",
+    srcs = [
+        "aip_filter.cc",
+    ],
+    hdrs = [
+        "aip_filter.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":field_registry",
+        "//src/v/base",
+        "//src/v/redpanda/admin/tests:aip_filter_test_messages_redpanda_proto",
+        "//src/v/serde/protobuf:base",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/time",
+        "@boost//:spirit",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "admin",
     srcs = [
         "debug.cc",

--- a/src/v/redpanda/admin/aip_filter.cc
+++ b/src/v/redpanda/admin/aip_filter.cc
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "redpanda/admin/aip_filter.h"
+
+#include "absl/strings/escaping.h"
+#include "absl/strings/numbers.h"
+#include "absl/time/time.h"
+#include "src/v/redpanda/admin/tests/aip_filter_test_messages.proto.h"
+
+#include <boost/spirit/home/x3.hpp>
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <type_traits>
+
+namespace admin {
+
+namespace spirit_parser {
+namespace x3 = boost::spirit::x3;
+
+namespace {
+std::string unescape_quoted_string(std::string_view escaped) {
+    std::string result;
+    std::string error;
+
+    if (!absl::CUnescape(escaped, &result, &error)) {
+        throw std::invalid_argument(
+          fmt::format("Invalid escape sequence in quoted string: {}", error));
+    }
+
+    return result;
+}
+} // namespace
+
+class expression_parser {
+public:
+    explicit expression_parser(std::string_view input)
+      : _input(input) {}
+
+private:
+    std::string_view _input;
+
+    auto grammar() const {
+        // Handle escaped characters in quoted strings (see unit tests for
+        // examples). We unescape the quoted string while parsing, since we
+        // already handle their detection here, so the AST will have unescaped
+        // strings already
+        auto escaped_or_regular_char = ('\\' >> x3::char_) | (x3::char_ - '"');
+        auto quoted_string_content = x3::rule<
+          class quoted_string_content_tag,
+          std::string>{"quoted_string_content"}
+        = x3::raw[*escaped_or_regular_char];
+
+        auto quoted_string
+          = x3::rule<class quoted_string_tag, std::string>{"quoted_string"}
+        = x3::lexeme['"' >> quoted_string_content >> '"'][([](auto& ctx) {
+              x3::_val(ctx) = unescape_quoted_string(x3::_attr(ctx));
+          })];
+
+        auto field_name
+          = x3::rule<class field_name_tag, std::string>{"field_name"}
+        = x3::lexeme
+          [(x3::alpha | x3::char_('_')) >> *(x3::alnum | x3::char_("_."))];
+
+        auto operator_symbols = []() {
+            x3::symbols<comparison_op> ops;
+            ops.add("!=", comparison_op::NE)("<=", comparison_op::LE)(
+              ">=", comparison_op::GE)("=", comparison_op::EQ)(
+              "<", comparison_op::LT)(">", comparison_op::GT);
+            return ops;
+        }();
+
+        auto unquoted_value
+          = x3::rule<class unquoted_value_tag, std::string>{"unquoted_value"}
+        = x3::lexeme
+          [+(x3::char_ - x3::space - x3::char_("\"")) - x3::string("AND")];
+
+        auto value
+          = x3::rule<class value_tag, std::pair<std::string, bool>>{"value"}
+        = (quoted_string[([](auto& ctx) {
+              x3::_val(ctx) = std::make_pair(x3::_attr(ctx), true);
+          })])
+          | (unquoted_value[([](auto& ctx) {
+                x3::_val(ctx) = std::make_pair(x3::_attr(ctx), false);
+            })]);
+
+        // <AIP-160> Unlike in most programming languages, field names must
+        // appear on the left-hand side of a comparison operator; the right-hand
+        // side only accepts literals and logical operators. </>
+        auto comparison_rule
+          = x3::rule<class comparison_tag, comparison>{"comparison"}
+        = (field_name >> operator_symbols >> value)[([](auto& ctx) {
+              auto& comp = x3::_val(ctx);
+              auto& field = boost::fusion::at_c<0>(x3::_attr(ctx));
+              auto& op = boost::fusion::at_c<1>(x3::_attr(ctx));
+              auto& val = boost::fusion::at_c<2>(x3::_attr(ctx));
+
+              comp.field_path = field;
+              comp.op = op;
+              comp.value = val.first;
+              comp.value_is_quoted = val.second;
+          })];
+
+        return comparison_rule % x3::lit("AND");
+    }
+
+public:
+    std::vector<comparison> parse() const {
+        if (_input.empty()) {
+            return {};
+        }
+
+        auto iter = _input.begin();
+        auto end = _input.end();
+        auto result = std::vector<comparison>{};
+
+        auto success = x3::phrase_parse(
+          iter, end, grammar(), x3::space, result);
+
+        if (!success || iter != end) {
+            auto remaining = std::string(iter, end);
+            auto position = std::distance(_input.begin(), iter);
+
+            if (!success) {
+                throw std::invalid_argument(
+                  fmt::format(
+                    "Parse error at position {}: '{}'", position, remaining));
+            } else {
+                throw std::invalid_argument(
+                  fmt::format(
+                    "Unexpected characters at position {}: '{}'",
+                    position,
+                    remaining));
+            }
+        }
+
+        return result;
+    }
+};
+
+} // namespace spirit_parser
+
+template<typename T>
+struct and_node : public ast_node<T> {
+    std::vector<std::unique_ptr<ast_node<T>>> children;
+
+    bool evaluate(T& obj) const override {
+        return std::ranges::all_of(
+          children, [&obj](const auto& child) { return child->evaluate(obj); });
+    }
+};
+
+template<typename T, typename F>
+struct comparison_node : public ast_node<T> {
+    std::function<F(T&)> getField;
+    comparison_op op;
+    F literalValue;
+
+    comparison_node(std::function<F(T&)> accessor, comparison_op oper, F value)
+      : getField(std::move(accessor))
+      , op(oper)
+      , literalValue(std::move(value)) {}
+
+    bool evaluate(T& obj) const override {
+        F fieldVal = getField(obj);
+        switch (op) {
+        case comparison_op::EQ:
+            return fieldVal == literalValue;
+        case comparison_op::NE:
+            return fieldVal != literalValue;
+        case comparison_op::LT:
+            return fieldVal < literalValue;
+        case comparison_op::GT:
+            return fieldVal > literalValue;
+        case comparison_op::LE:
+            return fieldVal <= literalValue;
+        case comparison_op::GE:
+            return fieldVal >= literalValue;
+        }
+        return false;
+    }
+};
+
+template<typename T>
+filter_predicate<T>::filter_predicate(std::unique_ptr<ast_node<T>> root)
+  : _root(std::move(root)) {}
+
+template<typename T>
+bool filter_predicate<T>::operator()(T& obj) const {
+    return _root ? _root->evaluate(obj) : true;
+}
+
+template<typename T>
+aip_filter_parser<T>::aip_filter_parser(const field_registry<T>& registry)
+  : _registry(registry) {}
+
+template<typename T>
+filter_predicate<T>
+aip_filter_parser<T>::parse(std::string_view filter_expression) const {
+    if (filter_expression.empty()) {
+        return filter_predicate<T>(nullptr);
+    }
+
+    if (filter_expression.size() > max_filter_length) {
+        // Limit the size of the expression to avoid overly expensive parsing or
+        // filter predicates
+        throw std::invalid_argument(
+          fmt::format(
+            "Filter expression exceeds maximum length of {} characters (got "
+            "{})",
+            max_filter_length,
+            filter_expression.size()));
+    }
+
+    spirit_parser::expression_parser parser(filter_expression);
+    auto comparisons = parser.parse();
+    return filter_predicate<T>(build_ast(comparisons));
+}
+
+template<typename T>
+std::unique_ptr<ast_node<T>> aip_filter_parser<T>::build_ast(
+  const std::vector<comparison>& comparisons) const {
+    if (comparisons.empty()) {
+        return nullptr;
+    }
+
+    if (comparisons.size() == 1) {
+        return build_comparison(comparisons[0]);
+    }
+
+    auto and_node_obj = std::make_unique<and_node<T>>();
+    for (const auto& comp : comparisons) {
+        and_node_obj->children.push_back(build_comparison(comp));
+    }
+    return and_node_obj;
+}
+
+template<typename T>
+std::unique_ptr<ast_node<T>>
+aip_filter_parser<T>::build_comparison(const comparison& comp) const {
+    auto validate_comparison_ops = [&](std::string_view type_name) {
+        if (comp.op != comparison_op::EQ && comp.op != comparison_op::NE) {
+            throw std::invalid_argument(
+              fmt::format(
+                "{} field '{}' only supports = and != operators",
+                type_name,
+                comp.field_path));
+        }
+    };
+
+    auto field_info = _registry.get_field_info(comp.field_path);
+
+    return std::visit(
+      [&](const auto& getter) -> std::unique_ptr<ast_node<T>> {
+          // Example:
+          //   GetterType = int64_getter
+          //   GetterFnType = std::function<int64_t(T&)>
+          //   ReturnType = int64_t
+          using GetterType = std::decay_t<decltype(getter)>;
+          using GetterFnType = typename GetterType::type;
+          using ReturnType = std::invoke_result_t<GetterFnType, T&>;
+
+          if constexpr (std::is_same_v<
+                          GetterType,
+                          typename field_accessor_info<T>::bool_getter>) {
+              validate_comparison_ops("Boolean");
+          } else if constexpr (std::is_same_v<
+                                 GetterType,
+                                 typename field_accessor_info<
+                                   T>::enum_getter>) {
+              validate_comparison_ops("Enum");
+          }
+
+          auto value = convert_literal<ReturnType>(
+            comp.value, comp.value_is_quoted, comp.field_path);
+          return std::make_unique<comparison_node<T, ReturnType>>(
+            GetterFnType(getter), comp.op, std::move(value));
+      },
+      field_info.getter);
+}
+
+template<typename T>
+template<typename FieldType>
+FieldType aip_filter_parser<T>::convert_literal(
+  std::string_view value, bool is_quoted, std::string_view field_path) const {
+    if constexpr (std::is_same_v<FieldType, bool>) {
+        if (value != "true" && value != "false") {
+            throw std::invalid_argument(
+              fmt::format(
+                "Expected boolean literal for field '{}'", field_path));
+        }
+        return value == "true";
+    } else if constexpr (std::is_integral_v<FieldType>) {
+        if (is_quoted) {
+            throw std::invalid_argument(
+              fmt::format(
+                "Expected integer literal for field '{}'", field_path));
+        }
+        if constexpr (std::is_unsigned_v<FieldType>) {
+            if (!value.empty() && value[0] == '-') {
+                throw std::invalid_argument(
+                  fmt::format(
+                    "Expected positive integer literal for field '{}'",
+                    field_path));
+            }
+        }
+        FieldType result;
+        if (!absl::SimpleAtoi(value, &result)) {
+            throw std::invalid_argument(
+              fmt::format(
+                "Expected integer literal for field '{}'", field_path));
+        }
+        return result;
+    } else if constexpr (std::is_same_v<FieldType, double>) {
+        if (is_quoted) {
+            throw std::invalid_argument(
+              fmt::format(
+                "Expected numeric literal for field '{}'", field_path));
+        }
+        double result{};
+        if (!absl::SimpleAtod(value, &result)) {
+            throw std::invalid_argument(
+              fmt::format(
+                "Expected numeric literal for field '{}'", field_path));
+        }
+        return result;
+    } else if constexpr (std::is_same_v<FieldType, ss::sstring>) {
+        return ss::sstring{value};
+    } else if constexpr (std::is_same_v<FieldType, absl::Duration>) {
+        absl::Duration result;
+        if (!absl::ParseDuration(value, &result)) {
+            throw std::invalid_argument(
+              fmt::format(
+                "Invalid duration format for field '{}': {}",
+                field_path,
+                value));
+        }
+        return result;
+    } else if constexpr (std::is_same_v<FieldType, absl::Time>) {
+        absl::Time result;
+        std::string error;
+        if (!absl::ParseTime(absl::RFC3339_full, value, &result, &error)) {
+            throw std::invalid_argument(
+              fmt::format(
+                "Invalid timestamp format for field '{}': {} ({})",
+                field_path,
+                value,
+                error));
+        }
+        return result;
+    } else {
+        throw std::invalid_argument(
+          fmt::format("Unsupported conversion for field '{}'", field_path));
+    }
+}
+
+// Explicitly instantiating for all supported protobuf types to avoid having to
+// expose all the templated code in the header
+template class filter_predicate<aip_filter_test::test_message>;
+template class aip_filter_parser<aip_filter_test::test_message>;
+
+} // namespace admin

--- a/src/v/redpanda/admin/aip_filter.h
+++ b/src/v/redpanda/admin/aip_filter.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "redpanda/admin/field_registry.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace admin {
+
+enum class comparison_op : uint8_t { EQ, NE, LT, GT, LE, GE };
+
+struct comparison {
+    std::string field_path;
+    comparison_op op;
+    std::string value;
+    bool value_is_quoted;
+};
+
+template<typename T>
+struct ast_node {
+    virtual ~ast_node() = default;
+    virtual bool evaluate(T& obj) const = 0;
+};
+
+/// A filter predicate object that can be applied to objects of type T
+template<typename T>
+class filter_predicate {
+public:
+    explicit filter_predicate(std::unique_ptr<ast_node<T>> root);
+    bool operator()(T& obj) const;
+
+private:
+    std::unique_ptr<ast_node<T>> _root;
+};
+
+/// aip_filter_parser parses AIP-160 compliant, human-readable filter expression
+/// strings into filter_predicate's to allow filtering protobuf objects.
+///
+/// Supports a subset of the AIP-160 spec:
+/// - Field comparisons (`=`, `!=`, `<`, `>`, `<=`, `>=`)
+/// - Logical AND chaining: condition1 AND condition2
+/// - Nested field access: parent.child = value
+/// - Escape sequences: field = "string with \"quotes\""
+/// - Enum types
+/// - RFC3339 timestamps and ISO-like duration parsing via abseil
+///
+/// Ref: https://google.aip.dev/160
+template<typename T>
+class aip_filter_parser {
+public:
+    constexpr static size_t max_filter_length = 1024;
+
+    explicit aip_filter_parser(const field_registry<T>& registry);
+
+    filter_predicate<T> parse(std::string_view filter_expression) const;
+
+private:
+    std::unique_ptr<ast_node<T>>
+    build_ast(const std::vector<comparison>& comparisons) const;
+    std::unique_ptr<ast_node<T>> build_comparison(const comparison& comp) const;
+
+    template<typename FieldType>
+    FieldType convert_literal(
+      std::string_view value,
+      bool is_quoted,
+      std::string_view field_path) const;
+
+    const field_registry<T>& _registry;
+};
+
+} // namespace admin

--- a/src/v/redpanda/admin/field_registry.cc
+++ b/src/v/redpanda/admin/field_registry.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "redpanda/admin/field_registry.h"
+
+#include "absl/strings/str_split.h"
+#include "src/v/redpanda/admin/tests/aip_filter_test_messages.proto.h"
+
+#include <string_view>
+#include <type_traits>
+
+namespace admin {
+
+template<RedpandaProtobufMessage T>
+field_accessor_info<T> protobuf_field_registry<T>::get_field_info(
+  const std::string& field_path) const {
+    auto field_numbers_opt = convert_field_path_to_numbers(field_path);
+    if (!field_numbers_opt) {
+        throw std::invalid_argument("Invalid field path: " + field_path);
+    }
+
+    T sample_instance;
+    auto field_opt = sample_instance.lookup_field(*field_numbers_opt);
+    if (!field_opt) {
+        throw std::invalid_argument("Field not found: " + field_path);
+    }
+
+    const auto& field = *field_opt;
+    auto field_numbers = *field_numbers_opt; // Copy for lambda capture
+
+    return std::visit(
+      [&field_path,
+       field_numbers](const auto& value) -> field_accessor_info<T> {
+          using ValueType = std::decay_t<decltype(value)>;
+          return create_field_accessor<ValueType>(field_path, field_numbers);
+      },
+      field.value);
+}
+
+template<RedpandaProtobufMessage T>
+std::optional<std::vector<int32_t>>
+protobuf_field_registry<T>::convert_field_path_to_numbers(
+  const std::string& field_path) const {
+    std::vector<std::string_view> path_components = absl::StrSplit(
+      field_path, '.');
+
+    T sample_instance;
+    return sample_instance.convert_field_path_to_numbers(path_components);
+}
+
+// clang-format off
+// Helper that maps protobuf field types to their corresponding field accessor function types
+template<typename T, typename ValueType> struct field_getter_type;
+template<typename T> struct field_getter_type<T, bool> { using type = typename field_accessor_info<T>::bool_getter; };
+template<typename T> struct field_getter_type<T, serde::pb::raw_enum_value> { using type = typename field_accessor_info<T>::enum_getter; };
+template<typename T> struct field_getter_type<T, uint32_t> { using type = typename field_accessor_info<T>::uint64_getter; };
+template<typename T> struct field_getter_type<T, uint64_t> { using type = typename field_accessor_info<T>::uint64_getter; };
+template<typename T> struct field_getter_type<T, int32_t> { using type = typename field_accessor_info<T>::int64_getter; };
+template<typename T> struct field_getter_type<T, int64_t> { using type = typename field_accessor_info<T>::int64_getter; };
+template<typename T> struct field_getter_type<T, float> { using type = typename field_accessor_info<T>::double_getter; };
+template<typename T> struct field_getter_type<T, double> { using type = typename field_accessor_info<T>::double_getter; };
+template<typename T> struct field_getter_type<T, ss::sstring> { using type = typename field_accessor_info<T>::string_getter; };
+template<typename T> struct field_getter_type<T, iobuf> { using type = typename field_accessor_info<T>::string_getter; };
+template<typename T> struct field_getter_type<T, absl::Time> { using type = typename field_accessor_info<T>::time_getter; };
+template<typename T> struct field_getter_type<T, absl::Duration> { using type = typename field_accessor_info<T>::duration_getter; };
+// clang-format on
+
+template<RedpandaProtobufMessage T>
+template<typename ValueType>
+field_accessor_info<T> protobuf_field_registry<T>::create_field_accessor(
+  const std::string& field_path, const std::vector<int32_t>& field_numbers) {
+    if constexpr (std::is_same_v<ValueType, std::monostate>) {
+        throw std::invalid_argument(
+          "Cannot create accessor for unset field: " + field_path);
+    } else if constexpr (requires {
+                             typename field_getter_type<T, ValueType>::type;
+                         }) {
+        using GetterType = typename field_getter_type<T, ValueType>::type;
+        using ReturnType = std::invoke_result_t<typename GetterType::type, T&>;
+
+        return field_accessor_info<T>{
+          .getter = GetterType{[field_numbers](T& obj) {
+              return extract_field_value<ReturnType>(obj, field_numbers);
+          }}};
+    } else {
+        throw std::invalid_argument(
+          "Unsupported field type for filtering: " + field_path);
+    }
+}
+
+template<RedpandaProtobufMessage T>
+template<typename ReturnType>
+ReturnType protobuf_field_registry<T>::extract_field_value(
+  T& obj, const std::vector<int32_t>& field_numbers) {
+    auto field_opt = obj.lookup_field(field_numbers);
+    if (!field_opt) {
+        throw std::runtime_error("Field lookup failed during extraction");
+    }
+
+    return std::visit(
+      [](const auto& value) -> ReturnType {
+          using ValueType = std::decay_t<decltype(value)>;
+
+          if constexpr (std::is_same_v<ReturnType, ValueType>) {
+              return value;
+          } else if constexpr (std::is_same_v<ReturnType, int64_t>) {
+              if constexpr (std::is_same_v<ValueType, int32_t>) {
+                  return static_cast<int64_t>(value);
+              }
+          } else if constexpr (std::is_same_v<ReturnType, uint64_t>) {
+              if constexpr (std::is_same_v<ValueType, uint32_t>) {
+                  return static_cast<uint64_t>(value);
+              }
+          } else if constexpr (std::is_same_v<ReturnType, double>) {
+              if constexpr (std::is_same_v<ValueType, float>) {
+                  return static_cast<double>(value);
+              }
+          } else if constexpr (std::is_same_v<ReturnType, ss::sstring>) {
+              if constexpr (std::
+                              is_same_v<ValueType, serde::pb::raw_enum_value>) {
+                  return ss::sstring{value.name};
+              }
+          }
+          throw std::runtime_error("Unsupported field value type conversion");
+      },
+      field_opt->value);
+}
+
+template<typename T>
+std::unique_ptr<field_registry<T>> make_field_registry() {
+    return std::make_unique<protobuf_field_registry<T>>();
+}
+
+// Explicitly instantiating for all supported protobuf types to avoid having to
+// expose all the templated code in the header
+template class protobuf_field_registry<aip_filter_test::test_message>;
+template std::unique_ptr<field_registry<aip_filter_test::test_message>>
+make_field_registry<aip_filter_test::test_message>();
+
+} // namespace admin

--- a/src/v/redpanda/admin/field_registry.h
+++ b/src/v/redpanda/admin/field_registry.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "absl/time/time.h"
+#include "serde/protobuf/base.h"
+#include "utils/named_type.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace admin {
+
+/// Generic reusable accessor for looking up the value of a specific field on an
+/// object
+template<typename T>
+struct field_accessor_info {
+    // clang-format off
+    using int64_getter = named_type<std::function<int64_t(T&)>, struct int64_getter_tag>;
+    using uint64_getter = named_type<std::function<uint64_t(T&)>, struct uint64_getter_tag>;
+    using double_getter = named_type<std::function<double(T&)>, struct double_getter_tag>;
+    using bool_getter = named_type<std::function<bool(T&)>, struct bool_getter_tag>;
+    using string_getter = named_type<std::function<ss::sstring(T&)>, struct string_getter_tag>;
+    using duration_getter = named_type<std::function<absl::Duration(T&)>, struct duration_getter_tag>;
+    using time_getter = named_type<std::function<absl::Time(T&)>, struct time_getter_tag>;
+    using enum_getter = named_type<std::function<ss::sstring(T&)>, struct enum_getter_tag>;
+    // clang-format on
+
+    using getter_t = std::variant<
+      int64_getter,
+      uint64_getter,
+      double_getter,
+      bool_getter,
+      string_getter,
+      duration_getter,
+      time_getter,
+      enum_getter>;
+
+    getter_t getter;
+};
+
+/// Interface for translating field names to field accessors for an object T
+template<typename T>
+class field_registry {
+public:
+    virtual ~field_registry() = default;
+
+    /**
+     * Get field accessor information for a given field path.
+     * @throws std::invalid_argument if field path is not found
+     */
+    virtual field_accessor_info<T>
+    get_field_info(const std::string& field_path) const = 0;
+};
+
+template<typename T>
+concept RedpandaProtobufMessage = std::derived_from<T, serde::pb::base_message>;
+
+/// A registry implementation that uses reflection to dynamically look up fields
+/// on a protobuf message generated using redpanda's protobuf serde generator.
+template<RedpandaProtobufMessage T>
+class protobuf_field_registry : public field_registry<T> {
+public:
+    field_accessor_info<T>
+    get_field_info(const std::string& field_path) const override;
+
+private:
+    std::optional<std::vector<int32_t>>
+    convert_field_path_to_numbers(const std::string& field_path) const;
+
+    template<typename ValueType>
+    static field_accessor_info<T> create_field_accessor(
+      const std::string& field_path, const std::vector<int32_t>& field_numbers);
+
+    template<typename ReturnType>
+    static ReturnType
+    extract_field_value(T& obj, const std::vector<int32_t>& field_numbers);
+};
+
+template<typename T>
+std::unique_ptr<field_registry<T>> make_field_registry();
+
+} // namespace admin

--- a/src/v/redpanda/admin/tests/BUILD
+++ b/src/v/redpanda/admin/tests/BUILD
@@ -1,0 +1,36 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel/pbgen:pbgen.bzl", "redpanda_proto_library")
+
+proto_library(
+    name = "aip_filter_test_messages_proto",
+    srcs = ["aip_filter_test_messages.proto"],
+    deps = [
+        "//proto/redpanda/pbgen:options_proto",
+        "@protobuf//:duration_proto",
+        "@protobuf//:timestamp_proto",
+    ],
+)
+
+redpanda_proto_library(
+    name = "aip_filter_test_messages_redpanda_proto",
+    protos = [":aip_filter_test_messages_proto"],
+    visibility = ["//visibility:public"],
+    deps = ["@abseil-cpp//absl/time:time"],
+)
+
+redpanda_cc_gtest(
+    name = "aip_filter_test",
+    timeout = "short",
+    srcs = [
+        "aip_filter_test.cc",
+    ],
+    deps = [
+        ":aip_filter_test_messages_redpanda_proto",
+        "//src/v/redpanda/admin:aip_filter",
+        "//src/v/redpanda/admin:field_registry",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/time",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/redpanda/admin/tests/aip_filter_test.cc
+++ b/src/v/redpanda/admin/tests/aip_filter_test.cc
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "absl/time/clock.h"
+#include "redpanda/admin/aip_filter.h"
+#include "redpanda/admin/field_registry.h"
+#include "src/v/redpanda/admin/tests/aip_filter_test_messages.proto.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace admin {
+
+aip_filter_test::test_message create_test_message(
+  int32_t int_val = 42,
+  const std::string& str_val = "test",
+  bool bool_val = true,
+  const std::string& nested_name = "nested",
+  int32_t nested_val = 100) {
+    aip_filter_test::test_message msg;
+    msg.set_int_field(int_val);
+    msg.set_string_field(ss::sstring(str_val));
+    msg.set_bool_field(bool_val);
+    msg.set_uint_field(1000);
+    msg.set_double_field(3.14);
+
+    msg.get_nested().set_name(ss::sstring(nested_name));
+    msg.get_nested().set_value(nested_val);
+
+    msg.set_status(aip_filter_test::test_message_status::status_active);
+    msg.set_timestamp_field(absl::Now() - absl::Minutes(5));
+    msg.set_duration_field(absl::Seconds(30));
+
+    msg.set_int32_field(123);
+    msg.set_float_field(2.5f);
+
+    return msg;
+}
+
+class AIPFilterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _field_registry = make_field_registry<aip_filter_test::test_message>();
+        _parser = std::make_unique<
+          admin::aip_filter_parser<aip_filter_test::test_message>>(
+          *_field_registry);
+    }
+
+    auto parse(std::string_view filter_expression) {
+        return _parser->parse(filter_expression);
+    }
+
+private:
+    std::unique_ptr<field_registry<aip_filter_test::test_message>>
+      _field_registry;
+    std::unique_ptr<aip_filter_parser<aip_filter_test::test_message>> _parser;
+};
+
+TEST_F(AIPFilterTest, IntegerFieldcomparisons) {
+    auto msg = create_test_message(42);
+
+    // Test all comparison operators for int64
+    EXPECT_TRUE(parse("int_field = 42")(msg));
+    EXPECT_TRUE(parse("int_field != 41")(msg));
+    EXPECT_TRUE(parse("int_field < 43")(msg));
+    EXPECT_TRUE(parse("int_field <= 42")(msg));
+    EXPECT_TRUE(parse("int_field > 41")(msg));
+    EXPECT_TRUE(parse("int_field >= 42")(msg));
+
+    // Test zero and negative values
+    msg.set_int_field(0);
+    EXPECT_TRUE(parse("int_field = 0")(msg));
+    msg.set_int_field(-42);
+    EXPECT_TRUE(parse("int_field = -42")(msg));
+
+    // Test int32 field (smaller integer type)
+    msg.set_int32_field(12345);
+    EXPECT_TRUE(parse("int32_field = 12345")(msg));
+    EXPECT_FALSE(parse("int32_field = 12346")(msg));
+    EXPECT_TRUE(parse("int32_field > 12344")(msg));
+    EXPECT_TRUE(parse("int32_field < 12346")(msg));
+}
+
+TEST_F(AIPFilterTest, StringFieldcomparisons) {
+    auto msg = create_test_message(1, "client-b");
+
+    // Basic string operations
+    EXPECT_TRUE(parse(R"(string_field = "client-b")")(msg));
+    EXPECT_TRUE(parse(R"(string_field != "client-a")")(msg));
+    EXPECT_TRUE(parse(R"(string_field > "client-a")")(msg));
+    EXPECT_TRUE(parse(R"(string_field < "client-c")")(msg));
+
+    // Test both quoted and unquoted strings work
+    msg.set_string_field(ss::sstring("test"));
+    EXPECT_TRUE(parse("string_field = test")(msg));
+    EXPECT_TRUE(parse(R"(string_field = "test")")(msg));
+
+    // Test escape sequences in quoted strings
+    msg.set_string_field(ss::sstring(R"(client"with"quotes)"));
+    EXPECT_TRUE(parse(R"(string_field = "client\"with\"quotes")")(msg));
+
+    // Empty string
+    msg.set_string_field(ss::sstring(""));
+    EXPECT_TRUE(parse(R"(string_field = "")")(msg));
+
+    // String with spaces
+    msg.set_string_field(ss::sstring("client with spaces"));
+    EXPECT_TRUE(parse(R"(string_field = "client with spaces")")(msg));
+}
+
+TEST_F(AIPFilterTest, BooleanFieldOperations) {
+    auto msg_true = create_test_message(1, "test", true);
+    auto msg_false = create_test_message(1, "test", false);
+
+    // Only equality and inequality supported for booleans
+    EXPECT_TRUE(parse("bool_field = true")(msg_true));
+    EXPECT_TRUE(parse("bool_field = false")(msg_false));
+    EXPECT_TRUE(parse("bool_field != false")(msg_true));
+    EXPECT_TRUE(parse("bool_field != true")(msg_false));
+
+    // Case sensitivity of true/false
+    EXPECT_THROW(parse("bool_field = TRUE"), std::invalid_argument);
+    EXPECT_THROW(parse("bool_field = True"), std::invalid_argument);
+
+    // Only = and != allowed for boolean fields
+    EXPECT_THROW(parse("bool_field > true"), std::invalid_argument);
+    EXPECT_THROW(parse("bool_field < false"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, FloatingPointFieldOperations) {
+    auto msg = create_test_message();
+
+    // Test double field operations
+    msg.set_double_field(5.5);
+    EXPECT_TRUE(parse("double_field = 5.5")(msg));
+    EXPECT_TRUE(parse("double_field > 5.4")(msg));
+    EXPECT_TRUE(parse("double_field < 5.6")(msg));
+    EXPECT_TRUE(parse("double_field != 5.4")(msg));
+
+    // Test scientific notation for double
+    msg.set_double_field(1e5);
+    EXPECT_TRUE(parse("double_field = 1e5")(msg));
+    EXPECT_TRUE(parse("double_field = 1E5")(msg));
+    EXPECT_TRUE(parse("double_field = 100000")(msg));
+    msg.set_double_field(-1.5e-10);
+    EXPECT_TRUE(parse("double_field = -1.5e-10")(msg));
+
+    // Test zero values
+    msg.set_double_field(0.0);
+    EXPECT_TRUE(parse("double_field = 0")(msg));
+    EXPECT_TRUE(parse("double_field = -0.0")(msg));
+
+    // Test float field (smaller floating-point type)
+    msg.set_float_field(2.5f);
+    EXPECT_TRUE(parse("float_field = 2.5")(msg));
+    EXPECT_FALSE(parse("float_field = 2.6")(msg));
+    EXPECT_TRUE(parse("float_field > 2.4")(msg));
+    EXPECT_TRUE(parse("float_field < 2.6")(msg));
+    EXPECT_TRUE(parse("float_field = 2.5e0")(msg));
+}
+
+TEST_F(AIPFilterTest, NestedFieldAccess) {
+    auto msg = create_test_message(1, "test", true, "admin", 200);
+
+    EXPECT_TRUE(parse("nested.name = \"admin\"")(msg));
+    EXPECT_TRUE(parse("nested.value = 200")(msg));
+    EXPECT_FALSE(parse("nested.name = \"other\"")(msg));
+
+    msg.get_nested().set_name(ss::sstring(""));
+    msg.get_nested().set_value(0);
+    EXPECT_TRUE(parse("nested.name = \"\"")(msg));
+    EXPECT_TRUE(parse("nested.value = 0")(msg));
+}
+
+TEST_F(AIPFilterTest, LogicalAndOperations) {
+    auto msg = create_test_message(1, "test", false);
+
+    // Basic AND operations
+    EXPECT_TRUE(parse("int_field = 1 AND bool_field = false")(msg));
+    EXPECT_FALSE(parse("int_field = 1 AND bool_field = true")(msg));
+    EXPECT_FALSE(parse("int_field = 2 AND bool_field = false")(msg));
+
+    // Multiple conditions
+    EXPECT_TRUE(parse(
+      "int_field = 1 AND bool_field = false AND string_field = \"test\"")(msg));
+
+    // Case sensitivity for AND keyword
+    EXPECT_THROW(
+      parse("int_field = 1 and bool_field = false"), std::invalid_argument);
+    EXPECT_THROW(
+      parse("int_field = 1 And bool_field = false"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, EnumFieldOperations) {
+    auto msg = create_test_message();
+
+    // Test enum equality
+    msg.set_status(aip_filter_test::test_message_status::status_active);
+    EXPECT_TRUE(parse("status = \"STATUS_ACTIVE\"")(msg));
+    EXPECT_FALSE(parse("status = \"STATUS_INACTIVE\"")(msg));
+    EXPECT_TRUE(parse("status != \"STATUS_INACTIVE\"")(msg));
+
+    // Test unspecified value
+    msg.set_status(aip_filter_test::test_message_status::status_unspecified);
+    EXPECT_TRUE(parse("status = \"STATUS_UNSPECIFIED\"")(msg));
+
+    // Test case sensitivity
+    msg.set_status(aip_filter_test::test_message_status::status_active);
+    EXPECT_FALSE(parse("status = \"status_active\"")(msg));
+
+    // Only equality operators should work for enums
+    EXPECT_THROW(parse("status > \"STATUS_ACTIVE\""), std::invalid_argument);
+    EXPECT_THROW(parse("status < \"STATUS_INACTIVE\""), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, DurationFieldOperations) {
+    auto msg = create_test_message();
+
+    // Test basic duration formats
+    msg.set_duration_field(absl::Seconds(30));
+    EXPECT_TRUE(parse("duration_field = 30s")(msg));
+
+    msg.set_duration_field(absl::Milliseconds(1500));
+    EXPECT_TRUE(parse("duration_field = 1.5s")(msg));
+
+    msg.set_duration_field(absl::ZeroDuration());
+    EXPECT_TRUE(parse("duration_field = 0s")(msg));
+
+    msg.set_duration_field(absl::Milliseconds(1));
+    EXPECT_TRUE(parse("duration_field = 0.001s")(msg));
+
+    // All comparison operators should work for durations
+    msg.set_duration_field(absl::Seconds(30));
+    EXPECT_TRUE(parse("duration_field > 29s")(msg));
+    EXPECT_TRUE(parse("duration_field < 31s")(msg));
+    EXPECT_TRUE(parse("duration_field >= 30s")(msg));
+    EXPECT_TRUE(parse("duration_field <= 30s")(msg));
+    EXPECT_TRUE(parse("duration_field != 29s")(msg));
+}
+
+TEST_F(AIPFilterTest, TimestampFieldOperations) {
+    auto msg = create_test_message();
+    absl::Time test_time;
+    std::string error;
+
+    // Test RFC-3339 format
+    ASSERT_TRUE(
+      absl::ParseTime(
+        absl::RFC3339_full, "2012-04-21T11:30:00Z", &test_time, &error));
+    msg.set_timestamp_field(std::move(test_time));
+    EXPECT_TRUE(parse("timestamp_field = \"2012-04-21T11:30:00Z\"")(msg));
+
+    // Test with fractional seconds
+    ASSERT_TRUE(
+      absl::ParseTime(
+        absl::RFC3339_full, "2012-04-21T11:30:00.123Z", &test_time, &error));
+    msg.set_timestamp_field(std::move(test_time));
+    EXPECT_TRUE(parse("timestamp_field = \"2012-04-21T11:30:00.123Z\"")(msg));
+
+    // Test with timezone offset
+    ASSERT_TRUE(
+      absl::ParseTime(
+        absl::RFC3339_full, "2012-04-21T11:30:00-04:00", &test_time, &error));
+    msg.set_timestamp_field(std::move(test_time));
+    EXPECT_TRUE(parse("timestamp_field = \"2012-04-21T11:30:00-04:00\"")(msg));
+
+    // All comparison operators should work for timestamps
+    EXPECT_TRUE(parse("timestamp_field > \"2012-04-21T11:29:00-04:00\"")(msg));
+    EXPECT_TRUE(parse("timestamp_field < \"2012-04-21T11:31:00-04:00\"")(msg));
+}
+
+TEST_F(AIPFilterTest, FieldOnLeftRequirement) {
+    // AIP-160 requires field names on the left side of comparisons
+    EXPECT_NO_THROW(parse("int_field = 42"));
+    EXPECT_NO_THROW(parse("string_field = \"test\""));
+    EXPECT_THROW(parse("42 = int_field"), std::invalid_argument);
+    EXPECT_THROW(parse("\"test\" = string_field"), std::invalid_argument);
+    EXPECT_THROW(parse("true = bool_field"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, GrammarErrorHandling) {
+    // Empty filter should always match
+    auto msg = create_test_message();
+    EXPECT_TRUE(parse("")(msg));
+
+    // Unknown field errors
+    EXPECT_THROW(parse("unknown_field = 1"), std::invalid_argument);
+    EXPECT_THROW(
+      parse("int_field = 1 AND unknown_field = 2"), std::invalid_argument);
+
+    // Type mismatches
+    EXPECT_THROW(parse("int_field = \"not_a_number\""), std::invalid_argument);
+    EXPECT_THROW(
+      parse("bool_field = \"not_a_boolean\""), std::invalid_argument);
+
+    // Malformed expressions
+    EXPECT_THROW(parse("int_field ="), std::invalid_argument);
+    EXPECT_THROW(parse("= 1"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field 1"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field = 1 AND"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, FieldPathValidation) {
+    // Test malformed nested field paths
+    EXPECT_THROW(parse("nested. = 1"), std::invalid_argument);
+    EXPECT_THROW(parse(".nested = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("nested..value = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("nested.nonexistent = 1"), std::invalid_argument);
+
+    // Test invalid field name formats
+    EXPECT_THROW(parse("123field = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("-field = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("field- = 1"), std::invalid_argument);
+
+    // Case sensitivity for field names
+    EXPECT_THROW(parse("INT_FIELD = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("Int_Field = 1"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, StringEscapingErrors) {
+    // Test unterminated quoted strings
+    EXPECT_THROW(parse("string_field = \"unclosed"), std::invalid_argument);
+    EXPECT_THROW(parse("string_field = \""), std::invalid_argument);
+    EXPECT_THROW(parse("string_field = \"\\"), std::invalid_argument);
+
+    // Test invalid escape sequences that should fail
+    EXPECT_THROW(parse("string_field = \"\\x\""), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, NumberFormatValidation) {
+    // Test invalid number formats
+    EXPECT_THROW(parse("int_field = 1.2.3"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field = .123"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field = 123."), std::invalid_argument);
+    EXPECT_THROW(parse("int_field = --1"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field = ++1"), std::invalid_argument);
+
+    // Test invalid scientific notation
+    EXPECT_THROW(parse("double_field = 123e"), std::invalid_argument);
+    EXPECT_THROW(parse("double_field = e123"), std::invalid_argument);
+    EXPECT_THROW(parse("double_field = 1e+"), std::invalid_argument);
+    EXPECT_THROW(parse("double_field = 1e-"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, TimeFormatValidation) {
+    // Test invalid duration formats
+    EXPECT_THROW(parse("duration_field = invalid"), std::invalid_argument);
+    EXPECT_THROW(
+      parse("duration_field = 120"),
+      std::invalid_argument); // Missing 's'
+    EXPECT_THROW(
+      parse("duration_field = s"), std::invalid_argument); // No number
+
+    // Test invalid timestamp formats
+    EXPECT_THROW(
+      parse("timestamp_field = \"invalid-timestamp\""), std::invalid_argument);
+    EXPECT_THROW(
+      parse("timestamp_field = \"2012-04-21 11:30:00\""),
+      std::invalid_argument); // Missing T
+    EXPECT_THROW(
+      parse("timestamp_field = \"2012-04-21T25:30:00Z\""),
+      std::invalid_argument); // Invalid hour
+    EXPECT_THROW(
+      parse("timestamp_field = \"2012-13-21T11:30:00Z\""),
+      std::invalid_argument); // Invalid month
+}
+
+TEST_F(AIPFilterTest, WhitespaceHandling) {
+    auto msg = create_test_message(1, "test", false);
+
+    // Various whitespace formats should work
+    EXPECT_TRUE(parse("int_field=1")(msg));
+    EXPECT_TRUE(parse("int_field = 1")(msg));
+    EXPECT_TRUE(parse("  int_field  =  1  ")(msg));
+
+    // AND with whitespace
+    EXPECT_TRUE(parse("int_field=1 AND bool_field=false")(msg));
+    EXPECT_TRUE(parse("  int_field  =  1  AND  bool_field  =  false  ")(msg));
+
+    // Missing space around AND should fail
+    EXPECT_THROW(
+      parse("int_field=1AND bool_field=false"), std::invalid_argument);
+}
+
+TEST_F(AIPFilterTest, FilterLengthLimits) {
+    // Test filter at reasonable length
+    std::string reasonable_filter
+      = "int_field = 42 AND string_field = \"test\"";
+    EXPECT_NO_THROW(parse(reasonable_filter));
+
+    // Test filter over the limit (1024 characters)
+    constexpr auto length
+      = aip_filter_parser<aip_filter_test::test_message>::max_filter_length + 1;
+    std::string oversized_filter(length, 'x');
+    EXPECT_THROW(parse(oversized_filter), std::invalid_argument);
+
+    // Verify the error message mentions the limit
+    try {
+        parse(oversized_filter);
+        FAIL() << "Expected exception for oversized filter";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("1024"));
+    }
+}
+
+TEST_F(AIPFilterTest, PredicateReusability) {
+    auto predicate = parse("int_field = 1 AND bool_field = false");
+
+    // Same predicate can be used multiple times
+    auto msg1 = create_test_message(1, "uid1", false);
+    auto msg2 = create_test_message(1, "uid2", false);
+    auto msg3 = create_test_message(2, "uid3", false);
+
+    EXPECT_TRUE(predicate(msg1));
+    EXPECT_TRUE(predicate(msg2));
+    EXPECT_FALSE(predicate(msg3));
+}
+
+TEST_F(AIPFilterTest, IntegerBoundaryValues) {
+    auto msg = create_test_message();
+
+    // Test basic boundary values
+    msg.set_int_field(std::numeric_limits<int64_t>::max());
+    EXPECT_TRUE(parse("int_field = 9223372036854775807")(msg));
+
+    msg.set_int_field(std::numeric_limits<int64_t>::min());
+    EXPECT_TRUE(parse("int_field = -9223372036854775808")(msg));
+
+    // Test unsigned boundaries
+    msg.set_uint_field(std::numeric_limits<uint64_t>::max());
+    EXPECT_TRUE(parse("uint_field = 18446744073709551615")(msg));
+
+    // Test int32 boundary values
+    msg.set_int32_field(std::numeric_limits<int32_t>::max());
+    EXPECT_TRUE(parse("int32_field = 2147483647")(msg));
+
+    msg.set_int32_field(std::numeric_limits<int32_t>::min());
+    EXPECT_TRUE(parse("int32_field = -2147483648")(msg));
+
+    // Negative values should fail for unsigned types
+    EXPECT_THROW(parse("uint_field = -1"), std::invalid_argument);
+
+    // Test overflow conditions
+    EXPECT_THROW(
+      parse("int_field = 9223372036854775808"),
+      std::invalid_argument); // max + 1
+}
+
+TEST_F(AIPFilterTest, CardinalityKeywords) {
+    auto msg = aip_filter_test::test_message{};
+
+    // Sanity check optional field presence
+    EXPECT_FALSE(msg.has_optional_int_field());
+
+    // TODO(CORE-13425): this should be false as per the AIP-160, but requires
+    // improvements to our protogen's reflection support
+    EXPECT_TRUE(parse("optional_int_field = 0")(msg));
+
+    EXPECT_THROW(parse("repeated_int_field = 0")(msg), std::invalid_argument);
+    EXPECT_THROW(parse("map_field = 0")(msg), std::invalid_argument);
+}
+
+} // namespace admin

--- a/src/v/redpanda/admin/tests/aip_filter_test_messages.proto
+++ b/src/v/redpanda/admin/tests/aip_filter_test_messages.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package aip_filter_test;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+message TestMessage {
+    message NestedInfo {
+        string name = 1;
+        int32 value = 2;
+    }
+
+    enum Status {
+        STATUS_UNSPECIFIED = 0;
+        STATUS_ACTIVE = 1;
+        STATUS_INACTIVE = 2;
+    }
+
+    int64 int_field = 1;
+    string string_field = 2;
+    bool bool_field = 3;
+    uint64 uint_field = 4;
+    double double_field = 5;
+
+    NestedInfo nested = 6;
+
+    Status status = 7;
+
+    google.protobuf.Timestamp timestamp_field = 8;
+    google.protobuf.Duration duration_field = 9;
+
+    int32 int32_field = 10;
+    float float_field = 11;
+    optional int64 optional_int_field = 12;
+    repeated int64 repeated_int_field = 13;
+    map<int64, int64> map_field = 14;
+}

--- a/src/v/serde/protobuf/base.h
+++ b/src/v/serde/protobuf/base.h
@@ -156,7 +156,7 @@ public:
     // The same as `lookup_field_by_path`, except using field numbers instead of
     // a field path.
     virtual std::optional<field>
-    lookup_field(std::span<int32_t> field_numbers) = 0;
+    lookup_field(std::span<const int32_t> field_numbers) = 0;
 };
 
 } // namespace serde::pb


### PR DESCRIPTION
As part of the client monitoring project, we are going to adopt (a subset of) the AIP-160 spec to allow for complex filtering of resources returned by `List*` endpoints of the Admin v2 API.

This PR implements a parser that can be used to parse AIP-160 compliant, human-readable filter expression strings into filter_predicate's to allow filtering protobuf objects.

Supports a subset of the AIP-160 spec:
- Field comparisons (`=`, `!=`, `<`, `>`, `<=`, `>=`)
- Logical AND chaining: condition1 AND condition2
- Nested field access: parent.child = value
- Escape sequences: field = "string with \"quotes\""
- Enum types
- RFC3339 timestamps and ISO-like duration parsing via abseil

Ref: https://google.aip.dev/160

Fixes https://redpandadata.atlassian.net/browse/CORE-13360

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
