### PR TITLE
`ct/l1`: add `log_collector` and `log_sampler` [CT - Compaction #5]

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -131,6 +131,30 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "log_sampler",
+    srcs = [
+        "log_sampler.cc",
+    ],
+    hdrs = [
+        "log_sampler.h",
+    ],
+    implementation_deps = [
+        "//src/v/ssx:future_util",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":logger",
+        ":meta",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cluster",
+        "//src/v/config",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "committing_policy",
     srcs = [
         "committing_policy.cc",

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -112,6 +112,25 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "log_collector",
+    srcs = [
+        "log_collector.cc",
+    ],
+    hdrs = [
+        "log_collector.h",
+    ],
+    implementation_deps = [
+        "//src/v/ssx:future_util",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "committing_policy",
     srcs = [
         "committing_policy.cc",

--- a/src/v/cloud_topics/level_one/compaction/log_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/log_collector.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cloud_topics::l1 {
+
+log_collector::log_collector(compaction_scheduler* scheduler)
+  : _scheduler(scheduler) {}
+
+ss::future<> log_collector::start() { co_await start_collecting_logs(); }
+
+ss::future<> log_collector::stop() { co_await stop_collecting_logs(); }
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+namespace cloud_topics::l1 {
+
+class compaction_scheduler;
+
+// Responsible for pushing CTPs/logs that require compaction to the
+// `compaction_scheduler` for managing, as well as their removal. Provides a
+// very limited interface to the user- implementors require only adding
+// `start_collecting_logs()` and `stop_collecting_logs()` functions in their
+// concrete classes.
+class log_collector {
+public:
+    log_collector(compaction_scheduler*);
+
+    virtual ~log_collector() noexcept = default;
+
+    // Starts the `log_collector` by calling `manage_logs()`, allowing it to
+    // push CTPs that require compaction to the `compaction_scheduler`, or
+    // remove CTPs that no longer require compaction from the
+    // `compaction_scheduler`.
+    ss::future<> start();
+
+    // Stops the `log_collector` by calling `unmanage_logs()`. The
+    // `compaction_scheduler` will no longer receive updates on which CTPs
+    // require managing. This should only be invoked during application
+    // shutdown.
+    ss::future<> stop();
+
+protected:
+    // Called during start-up. Initiates log collection, allowing for
+    // registration/deregistration of logs with the `compaction_scheduler`. For
+    // example, setting up a callback with a cluster object that pushes newly
+    // managed CTPs to the `compaction_scheduler`.
+    virtual ss::future<> start_collecting_logs() = 0;
+
+    // Called during tear-down. Stops the `log_collector` from making further
+    // registrations/deregistrations of logs with the `compaction_scheduler`
+    // (stopping call-backs, destructing objects or closing background loops,
+    // etc.)
+    virtual ss::future<> stop_collecting_logs() = 0;
+
+protected:
+    // Owned by `app`.
+    compaction_scheduler* _scheduler;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_sampler.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_sampler.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/log_sampler.h"
+
+#include "cloud_topics/level_one/compaction/logger.h"
+#include "config/configuration.h"
+#include "container/chunked_vector.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics::l1 {
+
+log_sampler::log_sampler(
+  metastore* metastore, cluster::metadata_cache* metadata_cache)
+  : _metastore(metastore)
+  , _metadata_cache(metadata_cache) {}
+
+ss::future<chunked_vector<log_info_and_meta>> log_sampler::sample_logs(
+  log_list_t& logs, std::optional<size_t> size_hint) const {
+    chunked_vector<metastore::compaction_sample_spec> to_sample;
+
+    if (size_hint.has_value()) {
+        to_sample.reserve(size_hint.value());
+    }
+
+    auto now = model::timestamp::now();
+    for (const auto& log : logs) {
+        if (!log.link.is_linked()) {
+            continue;
+        }
+
+        auto topic_cfg_opt = _metadata_cache->get_topic_metadata_ref(
+          model::topic_namespace_view(log.ntp.ns, log.ntp.tp.topic));
+
+        if (!topic_cfg_opt.has_value()) {
+            continue;
+        }
+
+        const auto& topic_cfg = topic_cfg_opt.value().get().get_configuration();
+        auto tombstone_removal_ts = [&topic_cfg, now]() -> model::timestamp {
+            // Cleaned ranges with tombstones that were cleaned at or below
+            // tombstone_removal_upper_bound_ts are eligible to have tombstones
+            // entirely removed.
+            auto delete_retention_ms
+              = config::shard_local_cfg().tombstone_retention_ms();
+            if (topic_cfg.properties.delete_retention_ms.has_optional_value()) {
+                delete_retention_ms
+                  = topic_cfg.properties.delete_retention_ms.value();
+            }
+
+            if (topic_cfg.properties.delete_retention_ms.is_disabled()) {
+                delete_retention_ms = std::nullopt;
+            }
+
+            return delete_retention_ms.has_value()
+                     ? now - model::timestamp(delete_retention_ms->count())
+                     : model::timestamp::max();
+        }();
+        to_sample.emplace_back(log.tidp, tombstone_removal_ts);
+    }
+
+    to_sample.shrink_to_fit();
+    auto samples = co_await _metastore->get_compaction_infos(to_sample);
+
+    chunked_vector<log_info_and_meta> ret;
+    ret.reserve(samples.size());
+    for (auto& log : logs) {
+        if (!log.link.is_linked()) {
+            continue;
+        }
+
+        auto& sample = samples.at(log.tidp);
+
+        if (!sample.has_value()) {
+            vlog(
+              compaction_log.warn,
+              "Failed to collect sample for CTP {} during compaction: {}",
+              log.tidp,
+              sample.error());
+            continue;
+        }
+
+        ret.emplace_back(std::move(sample).value(), &log);
+    }
+
+    ret.shrink_to_fit();
+    co_return ret;
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_sampler.h
+++ b/src/v/cloud_topics/level_one/compaction/log_sampler.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cluster/metadata_cache.h"
+#include "container/chunked_vector.h"
+
+namespace cloud_topics::l1 {
+
+// Responsible for issuing `get_compaction_info()` requests to the `metastore`
+// when attempting to schedule a round of compactions. This class does not make
+// any decisions about whether a `log` needs compacting or not, nor does it
+// filter out sampled logs that may not need compaction in its returned
+// container from `sample_logs()`. Scheduling decisions such as those are left
+// to the other components in the `cloud_topics` compaction subsystem.
+class log_sampler {
+public:
+    log_sampler(metastore*, cluster::metadata_cache*);
+
+    // Populates a vector of `log_info_and_meta` from the provided `log_list_t`
+    // by sampling each log's compaction info from the metastore. It is not
+    // guaranteed that every log present in `log_list_t` will have an entry in
+    // the returned vector, e.g. due to concurrent removal or metastore errors.
+    // Also take an optional `size_t` hint for the size of the `log_list_t` (as
+    // calling `.size()` on the `intrusive_list` is an O(n)` operation).
+    ss::future<chunked_vector<log_info_and_meta>>
+    sample_logs(log_list_t&, std::optional<size_t>) const;
+
+private:
+    // TODO: owned by `app`.
+    metastore* _metastore;
+
+    // Owned by `redpanda` application.
+    cluster::metadata_cache* _metadata_cache;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -54,3 +54,22 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "log_sampler_test",
+    timeout = "short",
+    srcs = [
+        "log_sampler_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/compaction:log_sampler",
+        "//src/v/cloud_topics/level_one/compaction:meta",
+        "//src/v/cloud_topics/level_one/frontend_reader/tests:l1_reader_fixture",
+        "//src/v/cluster/tests:cluster_test_fixture",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/tests/log_sampler_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/log_sampler_test.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/log_sampler.h"
+#include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/tests/random_batch.h"
+
+#include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <variant>
+
+using namespace cloud_topics;
+
+class SamplerTestFixture
+  : public l1::l1_reader_fixture
+  , public cluster_test_fixture {};
+
+TEST_F(SamplerTestFixture, TestSampler) {
+    model::node_id n(0);
+    create_node_application(n);
+    auto& cache = get_local_cache(n);
+    l1::log_sampler sampler(&_metastore, &cache);
+    std::vector<std::pair<model::ntp, model::topic_id_partition>> ntidps;
+    const auto topic_names = {"topic_a", "topic_b", "topic_c"};
+    const auto num_topics = topic_names.size();
+    for (const auto& topic : topic_names) {
+        ntidps.push_back(make_ntidp(topic));
+    }
+
+    std::vector<tidp_batches_t> tidp_batches;
+    l1::logs_type_t logs;
+    l1::log_list_t logs_list;
+    for (const auto& [ntp, tidp] : ntidps) {
+        auto [it, success] = logs.emplace(
+          std::make_unique<l1::log_compaction_meta>(tidp, ntp));
+        logs_list.push_back(*it->get());
+        create_topic(model::topic_namespace_view(ntp)).get();
+        auto batches
+          = model::test::make_random_batches(model::offset{0}, 10).get();
+        tidp_batches.emplace_back(tidp, std::move(batches));
+    }
+
+    make_l1_objects(tidp_batches);
+    auto samples = sampler.sample_logs(logs_list, num_topics).get();
+    ASSERT_EQ(samples.size(), num_topics);
+    for (const auto& sample : samples) {
+        ASSERT_FLOAT_EQ(sample.info.dirty_ratio, 1.0);
+        ASSERT_TRUE(sample.info.earliest_dirty_ts.has_value());
+    }
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1042,8 +1042,10 @@ configuration::configuration()
       "The retention time for tombstone records and transaction markers in a "
       "compacted topic.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      std::nullopt,
-      validate_tombstone_retention_ms)
+      24h,
+      validate_tombstone_retention_ms,
+      legacy_default<std::optional<std::chrono::milliseconds>>(
+        std::nullopt, legacy_version{17}))
   , min_cleanable_dirty_ratio(
       *this,
       "min_cleanable_dirty_ratio",


### PR DESCRIPTION
Added here are the `log_collector` and `log_sampler`.

The `log_collector` is a barebones abstract class at this point with only two functions that need to be implemented (`start_collecting_logs()` and `stop_collecting_logs()`).  It is up to the implementer to make this class responsible for pushing CTPs/logs that require compaction to the `compaction_scheduler` (still not present in the tree) for managing, as well as their removal.

The `log_sampler` is responsible for issuing `get_compaction_info()` requests to the `metastore` when attempting to schedule a round of compactions. This class does not make any decisions about whether a `log` needs compacting or not, nor does it filter out sampled logs that may not need compaction in its returned container from `sample_logs()`. Scheduling decisions such as those are left to the other components in the `cloud_topics` compaction subsystem.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
