### PR TITLE
config: mark metadata_dissemination_retry_delay_ms as needs_restart::no

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -684,7 +684,7 @@ configuration::configuration()
       *this,
       "metadata_dissemination_retry_delay_ms",
       "Delay before retrying a topic lookup in a shard or other meta tables.",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0'500ms)
   , metadata_dissemination_retries(
       *this,


### PR DESCRIPTION
RNOT changes this property as part of admin ops fuzzing. Because it was marked as needs restart, but random node ops doesn't actually do these restarts, later changes to configuration options which use the RedpandaService::set_cluster_config interface and specify that they don't expect a restart to be needed, may in fact find that they do need a restart (because of the fuzzer running concurrently). In practice this leads to an ugly nested assertion like this:

    AssertionError('Nodes report restart required but expect_restart is False')
    Traceback (most recent call last):
      File "/root/tests/rptest/services/cluster.py", line 244, in wrapped
        r = f(self, *args, **kwargs)
      File "/root/tests/rptest/tests/random_node_operations_test.py", line 713, in test_node_operations
        cloud_topics_consumer.verify()
      File "/root/tests/rptest/tests/random_node_operations_test.py", line 380, in verify
        self.consumer.wait()
      File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/services/service.py", line 287, in wait
        if not self.wait_node(node, end - now):
      File "/root/tests/rptest/services/kgo_verifier_services.py", line 291, in wait_node
        return self._do_wait_node(node, timeout_sec)
      File "/root/tests/rptest/services/kgo_verifier_services.py", line 332, in _do_wait_node
        self._redpanda.wait_until(
      File "/root/tests/rptest/services/redpanda.py", line 1283, in wait_until
        wait_until(
      File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/utils/util.py", line 57, in wait_until
        raise TimeoutError(err_msg() if callable(err_msg) else err_msg) from last_exception
    ducktape.errors.TimeoutError: KgoVerifierConsumerGroupConsumer-9-140402149106656 didn't complete in 599.99999833107 seconds

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 373, in _do_run
        data = self.run_test()
      File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/tests/runner_client.py", line 433, in run_test
        return self.test_context.function(self.test)
      File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/mark/_mark.py", line 443, in wrapper
        return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
      File "/root/tests/rptest/services/cluster.py", line 247, in wrapped
        _do_post_test_checks(self, True, test_state_initial)
      File "/root/tests/rptest/services/cluster.py", line 186, in _do_post_test_checks
        self.redpanda.maybe_do_internal_scrub()
      File "/root/tests/rptest/services/redpanda.py", line 5680, in maybe_do_internal_scrub
        results = self.wait_for_internal_scrub(cloud_partitions)
      File "/root/tests/rptest/services/redpanda.py", line 5768, in wait_for_internal_scrub
        self.set_cluster_config(
      File "/root/tests/rptest/services/redpanda.py", line 3964, in set_cluster_config
        self._wait_for_config_version(
      File "/root/tests/rptest/services/redpanda.py", line 4032, in _wait_for_config_version
        raise AssertionError(
    AssertionError: Nodes report restart required but expect_restart is False

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

FIXES: https://redpandadata.atlassian.net/browse/CORE-13390

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
