### PR TITLE
[CORE-13429] ct: cancel pending requests on write_pipeline shutdown

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -165,6 +165,7 @@ public:
         for (auto& f : _filters) {
             f.cancel();
         }
+        remove_requests_for_shutdown();
         co_await std::move(fut);
     }
 
@@ -183,25 +184,43 @@ protected:
         return _stages.next_stage(s);
     }
 
-    /// Find all timed out requests and remove them from the list
-    /// atomically.
-    void remove_timed_out_requests() {
+    /// Resolve every pending write that matches the predicate with an error.
+    template<typename Pred>
+    void remove_requests(Pred pred, errc error, std::string_view reason) {
         chunked_vector<ss::weak_ptr<Request>> expired;
         for (auto& wr : _pending) {
-            if (wr.has_expired()) {
+            if (pred(wr)) {
                 expired.push_back(wr.weak_from_this());
             }
         }
         if (!expired.empty()) {
-            vlog(_logger.debug, "{} requests have expired", expired.size());
+            vlog(
+              _logger.debug, "{} requests removed: {}", expired.size(), reason);
         }
         for (auto& wp : expired) {
             if (wp != nullptr) {
-                vlog(_logger.debug, "{} requests have expired", wp->ntp);
+                vlog(_logger.debug, "{} requests removed: {}", wp->ntp, reason);
                 wp->_hook.unlink();
-                wp->set_value(errc::timeout);
+                wp->set_value(error);
             }
         }
+    }
+
+    /// Find all timed out requests and remove them from the list
+    /// atomically.
+    void remove_timed_out_requests() {
+        remove_requests(
+          [](const auto& wr) { return wr.has_expired(); },
+          errc::timeout,
+          "expired");
+    }
+
+    /// Remove every pending request and resolve with shutdown error.
+    void remove_requests_for_shutdown() {
+        remove_requests(
+          [](const auto&) { return true; },
+          errc::shutting_down,
+          "shutting down");
     }
 
     basic_retry_chain_logger<Clock>& logger() { return _logger; }


### PR DESCRIPTION
In a recent run of RNOT we observed many instances of

    ducktape.errors.TimeoutError: Redpanda node docker-rp-14 failed to stop in 30 seconds

The logs for rp-14, we see that the last service that was attempted to shutdown was the L0 write pipeline.

    INFO  2025-09-19 07:05:19,419 [shard 0:main]
    main/cloud_topics::data_plane - sharded_service_container.h:94 -
    Stopping cloud_topics::l0::write_pipeline<seastar::lowres_clock>, ..next
    to shutdown is cloud_topics::l0::cluster_services

The only thing that write_pipeline::stop blocks on is its gate closing. And the only place we see the gate being held is in write_and_debounce where requests are put onto a pending list and then awaited for the request to finish.

Things like the batcher process requests from the pending list. In the shutdown sequenece we see that the batcher is stopped before the write pipeline. Maybe that order is ideal or not, but in general when the write pipeline stops it appears to be waiting on never-to-be-resolved requests.

This PR resolves this by resolving any pending requests with an appropriate error message when the write pipeline is stopped.

A recent run of the RNOT tests https://buildkite.com/redpanda/redpanda/builds/72633#0199683b-5c2f-4a07-b104-c5a61a8144a6 containing this fix shows no instances of "failed to stop in 30 seconds" where as a run without the fixes show several instances of this error https://buildkite.com/redpanda/redpanda/builds/72579#01996020-d0ae-4044-8611-ee5297b0b947.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
