### PR TITLE
[CORE-13450] ct: remove failed pending objects from builder before committing

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -111,6 +111,12 @@ public:
         get_or_create_object_for(const model::topic_id_partition&)
           = 0;
 
+        // Removes a pending object from the builder. The object must be in the
+        // pending state. Further calls to get_or_create_object_for() will not
+        // return the object id. Any other call that references the object id
+        // will return an error.
+        virtual std::expected<void, error> remove_pending_object(object_id) = 0;
+
         // Adds the given partition metadata for the given object. Expected
         // that finish() has not yet been called on the object.
         virtual std::expected<void, error>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -14,6 +14,8 @@
 #include "cloud_topics/level_one/metastore/state_update.h"
 #include "cloud_topics/logger.h"
 
+#include <algorithm>
+
 namespace cloud_topics::l1 {
 
 namespace {
@@ -92,6 +94,7 @@ public:
 
     object_id
     get_or_create_object_for(const model::topic_id_partition&) override;
+    std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>
       add(object_id, metastore::object_metadata::ntp_metadata) override;
     std::expected<void, error>
@@ -128,6 +131,25 @@ object_id replicated_object_builder::get_or_create_object_for(
         return oid;
     }
     return partition_objects.pending_objects_.begin()->first;
+}
+
+std::expected<void, replicated_object_builder::error>
+replicated_object_builder::remove_pending_object(object_id oid) {
+    auto p_it = std::ranges::find_if(partitions_, [oid](auto& p) {
+        return p.second.pending_objects_.contains(oid);
+    });
+    if (p_it == partitions_.end()) {
+        return std::unexpected(
+          error{fmt::format("Object {} is not a pending object", oid)});
+    }
+    auto& [_, objects] = *p_it;
+    auto it = objects.pending_objects_.find(oid);
+    dassert(
+      it != objects.pending_objects_.end(),
+      "Pending objects expected to contain {}",
+      oid);
+    objects.pending_objects_.erase(it);
+    return {};
 }
 
 std::expected<void, replicated_object_builder::error>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -47,6 +47,17 @@ object_id simple_object_builder::get_or_create_object_for(
     return pending_objects_.begin()->first;
 }
 
+std::expected<void, simple_object_builder::error>
+simple_object_builder::remove_pending_object(object_id oid) {
+    auto it = pending_objects_.find(oid);
+    if (it == pending_objects_.end()) {
+        return std::unexpected(
+          error{fmt::format("Object {} is not a pending object", oid)});
+    }
+    pending_objects_.erase(it);
+    return {};
+}
+
 std::expected<void, metastore::object_metadata_builder::error>
 simple_object_builder::add(
   object_id oid, metastore::object_metadata::ntp_metadata ntp_meta) {

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -31,6 +31,7 @@ public:
 
     object_id
     get_or_create_object_for(const model::topic_id_partition&) override;
+    std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>
       add(object_id, metastore::object_metadata::ntp_metadata) override;
     std::expected<void, error>

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -108,6 +108,43 @@ TEST_F(ReplicatedMetastoreTest, TestAddNotFinished) {
     ASSERT_EQ(commit_res.error(), metastore::errc::invalid_request);
 }
 
+TEST_F(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore m(app.get_sharded_l1_metastore_fe()->local());
+    auto tp = make_tp(0);
+    auto ob = m.object_builder();
+
+    // pending object can be removed, but not twice
+    auto oid = ob->get_or_create_object_for(tp);
+    ASSERT_TRUE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
+
+    // after removal, object id shouldn't be reused in this builder
+    auto oid2 = ob->get_or_create_object_for(tp);
+    ASSERT_NE(oid, oid2);
+    oid = oid2;
+
+    // unfinished object with data can be removed
+    ASSERT_TRUE(
+      ob->add(oid, metastore::object_metadata::ntp_metadata{.tidp = tp})
+        .has_value());
+    ASSERT_TRUE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(
+      ob->add(oid, metastore::object_metadata::ntp_metadata{.tidp = tp})
+        .has_value());
+
+    oid2 = ob->get_or_create_object_for(tp);
+    ASSERT_NE(oid, oid2);
+    oid = oid2;
+
+    // finished object cannot be removed
+    oid = ob->get_or_create_object_for(tp);
+    ASSERT_TRUE(ob->finish(oid, 0, 0).has_value());
+    ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->finish(oid, 0, 0).has_value());
+}
+
 TEST_F(ReplicatedMetastoreTest, TestBasicAdd) {
     auto& app = get_ct_app(model::node_id{0});
     replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1049,6 +1049,44 @@ TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
     ASSERT_EQ(0, release_res->size());
 }
 
+TEST(SimpleMetastoreTest, TestObjectBuilderRemovedObjects) {
+    simple_metastore m;
+    auto ob = m.object_builder();
+    const auto topic_id = model::create_topic_id();
+
+    auto gen_object_id = [&] {
+        return ob->get_or_create_object_for(
+          model::topic_id_partition(
+            topic_id, model::partition_id(static_cast<int32_t>(0))));
+    };
+
+    // pending object can be removed, but not twice
+    auto oid = gen_object_id();
+    ASSERT_TRUE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
+
+    // after removal, object id shouldn't be reused in this builder
+    auto oid2 = gen_object_id();
+    ASSERT_NE(oid, oid2);
+    oid = oid2;
+
+    // unfinished object with data can be removed
+    ASSERT_TRUE(ob->add(oid, {}).has_value());
+    ASSERT_TRUE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->add(oid, {}).has_value());
+
+    oid2 = gen_object_id();
+    ASSERT_NE(oid, oid2);
+    oid = oid2;
+
+    // finished object cannot be removed
+    oid = gen_object_id();
+    ASSERT_TRUE(ob->finish(oid, 0, 0).has_value());
+    ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
+    ASSERT_FALSE(ob->finish(oid, 0, 0).has_value());
+}
+
 TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     simple_metastore m;
     auto tp_a = model::topic_id_partition::from(tid_a);

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -268,6 +268,7 @@ ss::future<> reconciler::reconcile() {
     // Process partitions by their object. This should be easier to
     // improve than processing partition-by-partition.
     chunked_vector<built_object_metadata> successful_objects;
+    chunked_vector<l1::object_id> failed_objects;
     for (const auto& [oid, partitions] : oid_to_partitions) {
         auto object_fut = co_await ss::coroutine::as_future(
           reconcile_partitions(oid, partitions));
@@ -284,11 +285,13 @@ ss::future<> reconciler::reconcile() {
             if (is_shutdown) {
                 co_return;
             }
+            failed_objects.push_back(oid);
             continue; // Skip this object and move to the next
         }
 
         auto result = object_fut.get();
         if (!result.has_value()) {
+            failed_objects.push_back(oid);
             // Error was already logged in reconcile_partitions.
             continue; // Skip this object and move to the next
         }
@@ -297,12 +300,19 @@ ss::future<> reconciler::reconcile() {
         auto add_result = co_await add_object_metadata(
           oid, obj_metadata, metadata_builder.get());
         if (!add_result.has_value()) {
+            failed_objects.push_back(oid);
             // Error was already logged in add_object_metadata.
             continue; // Skip this object and move to the next
         }
 
         // Success - collect the metadata for final processing.
         successful_objects.push_back(std::move(obj_metadata));
+    }
+
+    for (const auto& oid : failed_objects) {
+        auto rm_ret = metadata_builder->remove_pending_object(oid);
+        vassert(
+          rm_ret.has_value(), "Removing object {} in non-pending state", oid);
     }
 
     // Check if we have any successful objects to commit.


### PR DESCRIPTION

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
