### PR TITLE
kafka/server: removing polling fetch implementation

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -736,9 +736,10 @@ configuration::configuration()
   , fetch_read_strategy(
       *this,
       "fetch_read_strategy",
-      "The strategy used to fulfill fetch requests. * `polling`: Repeatedly "
-      "polls every partition in the request for new data. The polling interval "
-      "is set by `fetch_reads_debounce_timeout` (deprecated). * `non_polling`: "
+      "The strategy used to fulfill fetch requests. * `polling`: If "
+      "`fetch_reads_debounce_timeout` is set to its default value, then this "
+      "acts exactly like `non_polling`; otherwise, it acts like "
+      "`non_polling_with_debounce` (deprecated). * `non_polling`: "
       "The backend is signaled when a partition has new data, so Redpanda does "
       "not need to repeatedly read from every partition in the fetch. Redpanda "
       "Data recommends using this value for most workloads, because it can "

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -671,75 +671,6 @@ bool shard_fetch::empty() const {
     return requests.empty();
 }
 
-/**
- * Top-level handler for fetching from single shard. The result is
- * unwrapped and any errors from the storage sub-system are translated
- * into kafka specific response codes. On failure or success the
- * partition response is finalized and placed into its position in the
- * response message.
- */
-static ss::future<>
-handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
-    // if over budget skip the fetch.
-    if (octx.bytes_left <= 0) {
-        return ss::now();
-    }
-    // no requests for this shard, do nothing
-    if (fetch.empty()) {
-        return ss::now();
-    }
-
-    const bool foreign_read = shard != ss::this_shard_id();
-
-    // dispatch to remote core
-    return octx.rctx.partition_manager()
-      .invoke_on(
-        shard,
-        octx.ssg,
-        [foreign_read, configs = std::move(fetch.requests), &octx](
-          cluster::partition_manager& mgr) mutable {
-            // &octx is captured only to immediately use its accessors here so
-            // that there is a list of all objects accessed next to `invoke_on`.
-            // This is meant to help avoiding unintended cross shard access
-            return fetch_ntps(
-              mgr,
-              octx.rctx.metadata_cache(),
-              octx.rctx.server().local().get_replica_selector(),
-              std::move(configs),
-              octx.rctx.server().local().read_probe(),
-              foreign_read,
-              octx.deadline,
-              octx.bytes_left,
-              octx.rctx.server().local().memory(),
-              octx.rctx.server().local().memory_fetch_sem());
-        })
-      .then([responses = std::move(fetch.responses),
-             start_time = fetch.start_time,
-             &octx](auto results) mutable {
-          fill_fetch_responses(octx, std::move(results), responses, start_time);
-      });
-}
-
-class parallel_fetch_plan_executor final : public fetch_plan_executor::impl {
-    ss::future<> execute_plan(op_context& octx, fetch_plan plan) final {
-        std::vector<ss::future<>> fetches;
-        fetches.reserve(ss::smp::count);
-
-        // start fetching from random shard to make sure that we fetch data from
-        // all the partition even if we reach fetch message size limit
-        const ss::shard_id start_shard_idx = random_generators::get_int(
-          ss::smp::count - 1);
-        for (size_t i = 0; i < ss::smp::count; ++i) {
-            auto shard = (start_shard_idx + i) % ss::smp::count;
-
-            fetches.push_back(handle_shard_fetch(
-              shard, octx, std::move(plan.fetches_per_shard[shard])));
-        }
-
-        return ss::when_all_succeed(fetches.begin(), fetches.end());
-    }
-};
-
 class fetch_worker {
 public:
     // Passed from the coordinator shard to fetch workers.
@@ -1060,9 +991,7 @@ public:
     ss::future<> execute_plan(op_context& octx, fetch_plan plan) final {
         auto fetch_read_strategy
           = config::shard_local_cfg().fetch_read_strategy();
-        if (
-          fetch_read_strategy
-          == model::fetch_read_strategy::non_polling_with_debounce) {
+        if (is_fetch_strategy_with_debounce(fetch_read_strategy)) {
             co_await ss::sleep(
               std::min(
                 config::shard_local_cfg().fetch_reads_debounce_timeout(),
@@ -1190,6 +1119,21 @@ private:
         }
 
         return true;
+    }
+
+    bool is_fetch_strategy_with_debounce(model::fetch_read_strategy s) const {
+        if (s == model::fetch_read_strategy::non_polling_with_debounce) {
+            return true;
+        }
+
+        if (
+          s == model::fetch_read_strategy::polling
+          && !config::shard_local_cfg()
+                .fetch_reads_debounce_timeout.is_default()) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -1530,50 +1474,6 @@ class simple_fetch_planner final : public fetch_planner::impl {
     }
 };
 
-/**
- * Process partition fetch requests.
- *
- * Each request is handled serially in the order they appear in the request.
- * There are a couple reasons why we are not **yet** processing these in
- * parallel. First, Kafka expects to some extent that the order of the
- * partitions in the request is an implicit priority on which partitions to
- * read from. This is closely related to the request budget limits specified
- * in terms of maximum bytes and maximum time delay.
- *
- * Once we start processing requests in parallel we'll have to work through
- * various challenges. First, once we dispatch in parallel, we'll need to
- * develop heuristics for dealing with the implicit priority order. We'll
- * also need to develop techniques and heuristics for dealing with budgets
- * since global budgets aren't trivially divisible onto each core when
- * partition requests may produce non-uniform amounts of data.
- *
- * w.r.t. what is needed to parallelize this, there are no data dependencies
- * between partition requests within the fetch request, and so they can be
- * run fully in parallel. The only dependency that exists is that the
- * response must be reassembled such that the responses appear in these
- * order as the partitions in the request.
- */
-static ss::future<> fetch_topic_partitions(op_context& octx) {
-    auto planner = make_fetch_planner<simple_fetch_planner>();
-
-    auto fetch_plan = planner.create_plan(octx);
-
-    fetch_plan_executor executor
-      = make_fetch_plan_executor<parallel_fetch_plan_executor>();
-    co_await executor.execute_plan(octx, std::move(fetch_plan));
-
-    if (octx.should_stop_fetch()) {
-        co_return;
-    }
-
-    octx.reset_context();
-    // debounce next read retry
-    co_await ss::sleep(
-      std::min(
-        config::shard_local_cfg().fetch_reads_debounce_timeout(),
-        octx.request.data.max_wait_ms));
-}
-
 namespace testing {
 kafka::fetch_plan make_simple_fetch_plan(op_context& octx) {
     auto planner = make_fetch_planner<simple_fetch_planner>();
@@ -1583,28 +1483,11 @@ kafka::fetch_plan make_simple_fetch_plan(op_context& octx) {
 
 namespace {
 ss::future<> do_fetch(op_context& octx) {
-    switch (config::shard_local_cfg().fetch_read_strategy) {
-    case model::fetch_read_strategy::polling: {
-        // first fetch, do not wait
-        co_await fetch_topic_partitions(octx).then([&octx] {
-            return ss::do_until(
-              [&octx] { return octx.should_stop_fetch(); },
-              [&octx] { return fetch_topic_partitions(octx); });
-        });
-    } break;
-    case model::fetch_read_strategy::non_polling:
-    case model::fetch_read_strategy::non_polling_with_pid:
-    case model::fetch_read_strategy::non_polling_with_debounce: {
-        auto planner = make_fetch_planner<simple_fetch_planner>();
-        auto fetch_plan = planner.create_plan(octx);
+    auto planner = make_fetch_planner<simple_fetch_planner>();
+    auto fetch_plan = planner.create_plan(octx);
 
-        nonpolling_fetch_plan_executor executor;
-        co_await executor.execute_plan(octx, std::move(fetch_plan));
-    } break;
-    default: {
-        vassert(false, "not implemented");
-    } break;
-    }
+    nonpolling_fetch_plan_executor executor;
+    co_await executor.execute_plan(octx, std::move(fetch_plan));
 }
 } // namespace
 


### PR DESCRIPTION
Any existing clusters that are configured to use polling fetch will instead use the non-polling fetch with debounce strategy.

We have delayed removing the polling fetch implementation due to at least one known workload showing better performance with it when debounce is set high enough. The known workload is https://gist.github.com/ballard26/f9adcb33f48477d23911bf4004ca69a9. And the performance results for it with different fetch strategies can be found here https://perf-team-public.s3.us-west-2.amazonaws.com/reports/polling_v_non_polling . The key results are the following:

| Config | P50 E2E Latency | 
|-|-|
| non-polling | 88ms |
| non-polling-1ms-debounce | 89ms |
| non-polling-10ms-debounce | 79ms |
| polling-1ms-debounce | 79ms |
| polling-10ms-debounce | 75ms |
| non-polling-pid | 63ms |

With the polling fetch showing a 10-20% improvement with debounce. The non-polling fetch showing a 0-10% improvement with debounce. Lastly the non-polling implementation with debounce dynamically controlled with a pid showing a 28% improvement. 

At this point the `non-polling-pid` implementation shows the best results for the given workload and the cost of constantly maintaining the polling implementation doesn't seem worth the small benefits we're seeing from it. Hence its removal in this PR.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
