### PR TITLE
[CORE-13046] kafka/server: protect active shadow topics from modification

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -210,6 +210,24 @@ frontend::get_mirror_topics_for_link(id_t id) const {
     return mirror_topics;
 }
 
+bool frontend::has_active_mirror_topic(const model::topic& t) const {
+    const auto active_shadow_topic_in_link = [&t, this](const auto& link_id) {
+        auto link = _table->find_link_by_id(link_id);
+        if (!link) {
+            return false;
+        }
+        const auto& mirror_topics = link->get().state.mirror_topics;
+
+        const auto it = mirror_topics.find(t);
+        if (it == mirror_topics.end()) {
+            return false;
+        }
+
+        return ::cluster_link::model::is_mirror_topic_active(it->second.state);
+    };
+    return std::ranges::any_of(get_all_link_ids(), active_shadow_topic_in_link);
+}
+
 ss::future<errc> frontend::do_mutation(
   cluster_link_cmd cmd, model::timeout_clock::time_point timeout) {
     auto cluster_leader = _leaders->get_leader(model::controller_ntp);

--- a/src/v/cluster/cluster_link/frontend.h
+++ b/src/v/cluster/cluster_link/frontend.h
@@ -91,6 +91,8 @@ public:
       ::cluster_link::model::mirror_topic_metadata>>
     get_mirror_topics_for_link(::cluster_link::model::id_t id) const;
 
+    bool has_active_mirror_topic(const model::topic& t) const;
+
 private:
     ss::future<errc>
       do_mutation(cluster_link_cmd, model::timeout_clock::time_point);

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -253,23 +253,13 @@ ss::future<result<void>> manager::delete_cluster_link(model::name_t name) {
         co_return cl_resp.assume_error();
     }
 
-    const auto is_active = [](const model::mirror_topic_state s) {
-        switch (s) {
-        case model::mirror_topic_state::active:
-        case model::mirror_topic_state::paused:
-            return true;
-        case model::mirror_topic_state::failed:
-        case model::mirror_topic_state::promoted:
-            return false;
-        }
-    };
-
     const auto mirror_topic_states = cl_resp.assume_value().state.mirror_topics
                                      | std::views::values
                                      | std::views::transform(
                                        &model::mirror_topic_metadata::state);
 
-    if (std::ranges::any_of(mirror_topic_states, is_active)) {
+    if (std::ranges::any_of(
+          mirror_topic_states, model::is_mirror_topic_active)) {
         co_return err_info(
           errc::link_has_active_shadow_topics,
           fmt::format(

--- a/src/v/cluster_link/model/types.h
+++ b/src/v/cluster_link/model/types.h
@@ -64,6 +64,17 @@ static constexpr std::string_view to_string_view(mirror_topic_state s) {
 
 std::ostream& operator<<(std::ostream& os, mirror_topic_state s);
 
+inline bool is_mirror_topic_active(mirror_topic_state s) {
+    switch (s) {
+    case mirror_topic_state::active:
+    case mirror_topic_state::paused:
+        return true;
+    case mirror_topic_state::failed:
+    case mirror_topic_state::promoted:
+        return false;
+    }
+}
+
 enum class task_state : uint8_t {
     /// The task is currently active and processing
     active,

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -11,6 +11,7 @@
 #include "kafka/server/handlers/create_partitions.h"
 
 #include "absl/container/node_hash_map.h"
+#include "cluster/cluster_link/frontend.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
@@ -261,6 +262,19 @@ ss::future<response_ptr> create_partitions_handler::handle(
             [name{tp.name}](auto& iter) {
                 return iter.first.tp.topic == name;
             });
+      });
+
+    // check for active shadow topics
+    valid_range_end = validate_range(
+      request.data.topics.begin(),
+      valid_range_end,
+      std::back_inserter(resp.data.results),
+      error_code::policy_violation,
+      "Can't change partitions on an active shadow topic.",
+      [&ctx](const create_partitions_topic& tp) {
+          const auto& cl_frontend
+            = ctx.connection()->server().cluster_link_frontend();
+          return !cl_frontend.has_active_mirror_topic(tp.name);
       });
 
     if (request.data.validate_only) {

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -10,6 +10,7 @@
 #include "kafka/server/handlers/produce.h"
 
 #include "base/likely.h"
+#include "cluster/cluster_link/frontend.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
@@ -256,6 +257,23 @@ partition_produce_stages produce_topic_partition(
             .partition_index = ntp.tp.partition,
             .error_code = validate_batch_res->err,
             .error_message = std::move(validate_batch_res->msg)});
+        return partition_produce_stages{
+          .dispatched = std::move(dispatch_f), .produced = std::move(f)};
+    }
+
+    // Producing directly to an active shadow topic is not allowed
+    auto& cl_frontend
+      = octx.rctx.connection()->server().cluster_link_frontend();
+    const auto is_shadow_topic = cl_frontend.has_active_mirror_topic(
+      ntp.tp.topic);
+    if (unlikely(is_shadow_topic)) {
+        auto dispatch_f = ss::now();
+        auto f = ss::make_ready_future<produce_response::partition>(
+          produce_response::partition{
+            .partition_index = ntp.tp.partition,
+            .error_code = error_code::policy_violation,
+            .error_message
+            = "Producing to an active shadow topic is not allowed"});
         return partition_produce_stages{
           .dispatched = std::move(dispatch_f), .produced = std::move(f)};
     }

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -15,6 +15,7 @@ import re
 from contextlib import nullcontext
 
 
+from confluent_kafka import KafkaException, Producer
 from connectrpc.errors import ConnectError, ConnectErrorCode
 from ducktape.mark import matrix
 from ducktape.mark import ignore
@@ -580,6 +581,26 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
         ):
             self.start_producer_consumer(topic=topic.name, msg_size=128, msg_cnt=100000)
             self.verify()
+
+        # Verify that producing to an active shadow topic is not allowed
+        target_producer = Producer(
+            {"bootstrap.servers": self.target_cluster.service.brokers()}
+        )
+
+        def on_delivery(err, _):
+            if err is not None:
+                raise KafkaException(err)
+
+        with expect_exception(
+            KafkaException, lambda err: "POLICY_VIOLATION" in str(err)
+        ):
+            target_producer.produce(
+                topic.name,
+                key="key1".encode("utf-8"),
+                value="value1".encode("utf-8"),
+                callback=on_delivery,
+            )
+            target_producer.flush()
 
     @cluster(
         num_nodes=7,

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -23,6 +23,8 @@ from ducktape.mark import ignore
 from rptest.clients.admin.proto.redpanda.core.admin.v2 import (
     shadow_link_pb2,
 )
+from rptest.clients.default import DefaultClient
+from rptest.clients.kafka_cli_tools import KafkaCliToolsError
 from rptest.clients.rpk import RpkTool, RPKACLInput, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
@@ -601,6 +603,16 @@ class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
                 callback=on_delivery,
             )
             target_producer.flush()
+
+        # Verify that altering the partitions of an active shadow topic is not allowed
+        target_default_client = DefaultClient(self.target_cluster.service)
+
+        with expect_exception(
+            KafkaCliToolsError, lambda err: "PolicyViolationException" in str(err)
+        ):
+            target_default_client.alter_topic_partition_count(
+                topic.name, topic.partition_count + 2
+            )
 
     @cluster(
         num_nodes=7,


### PR DESCRIPTION
Implements: [CORE-13046](https://redpandadata.atlassian.net/browse/CORE-13046)

Attempting to produce or to alter the partitions of an active shadow topic should result in a policy violation error.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


[CORE-13046]: https://redpandadata.atlassian.net/browse/CORE-13046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ