### PR TITLE
Support `FindCoordinatorRequest` version `4` in consumer groups mirroring task

### DIFF
--- a/src/v/cluster_link/group_mirroring_task.cc
+++ b/src/v/cluster_link/group_mirroring_task.cc
@@ -662,6 +662,7 @@ group_mirroring_task::list_groups_from_broker(::model::node_id broker_id) {
 
 ss::future<group_mirroring_task::result_t>
 group_mirroring_task::update_group_coordinators() {
+    static constexpr kafka::api_version batched_find_coordinator_v{4};
     auto& c_connection = get_cluster_connection();
 
     auto versions = co_await c_connection.supported_api_versions(
@@ -670,39 +671,71 @@ group_mirroring_task::update_group_coordinators() {
         co_return std::unexpected<error>(
           "Remote cluster does not support find coordinator API");
     }
-
     bool errored = false;
-    // TODO: add support for batched find coordinator, this will require
-    // supporting FindCoordinatorRequest v4
-    co_await ss::max_concurrent_for_each(
-      _groups_to_mirror.begin(),
-      _groups_to_mirror.end(),
-      concurrent_requests_limit,
-      [this,
-       &errored,
-       version = get_max_supported<kafka::find_coordinator_api>(*versions)](
-        auto& entry) {
-          return do_find_coordinator(entry.first, version)
-            .then([this, &entry, &errored](
+    const auto max_supported_v = get_max_supported<kafka::find_coordinator_api>(
+      *versions);
+    if (max_supported_v >= batched_find_coordinator_v) {
+        chunked_vector<ss::sstring> group_ids;
+        group_ids.reserve(_groups_to_mirror.size());
+        std::ranges::transform(
+          _groups_to_mirror,
+          std::back_inserter(group_ids),
+          [](const auto& entry) { return entry.first(); });
+        auto coordinators = co_await do_find_coordinator_batched(
+          std::move(group_ids), max_supported_v);
+        if (!coordinators.has_value()) {
+            co_return std::unexpected{std::move(coordinators.error())};
+        }
+
+        for (auto& coord : coordinators.value()) {
+            if (coord.error_code != kafka::error_code::none) {
+                vlog(
+                  logger().warn,
+                  "Error finding coordinator for {} - {}",
+                  coord.key,
+                  coord.error_code);
+                continue;
+            }
+            auto it = _groups_to_mirror.find(
+              kafka::group_id(std::move(coord.key)));
+            if (it != _groups_to_mirror.end()) {
+                it->second.coordinator_id = coord.node_id;
+                vlog(
+                  logger().trace,
+                  "Group {} coordinator discovered: {}",
+                  coord.key,
+                  coord.node_id);
+            }
+        }
+
+    } else {
+        co_await ss::max_concurrent_for_each(
+          _groups_to_mirror.begin(),
+          _groups_to_mirror.end(),
+          concurrent_requests_limit,
+          [this, &errored, max_supported_v](auto& entry) {
+              return do_find_coordinator(entry.first, max_supported_v)
+                .then(
+                  [this, &entry, &errored](
                     std::expected<::model::node_id, group_mirroring_task::error>
                       result) {
-                if (result.has_value()) {
-                    vlog(
-                      logger().trace,
-                      "Group {} coordinator discovered: {}",
-                      entry.first,
-                      *result);
-                    entry.second.coordinator_id = *result;
-                } else {
-                    errored |= true;
-                }
-            });
-      });
+                      if (result.has_value()) {
+                          vlog(
+                            logger().trace,
+                            "Group {} coordinator discovered: {}",
+                            entry.first,
+                            *result);
+                          entry.second.coordinator_id = *result;
+                      } else {
+                          errored |= true;
+                      }
+                  });
+          });
+    }
 
     if (!errored) {
         _needs_coordinator_update = false;
     }
-
     co_return result_t{};
 }
 
@@ -719,7 +752,8 @@ group_mirroring_task::do_find_coordinator(
     req.data.key = group_id;
     // limit version to 3 as the next one use batched api
     auto resp = co_await get_cluster_connection().dispatch_to_any(
-      std::move(req), std::min(max_version, kafka::api_version(3)));
+      std::move(req),
+      std::min(max_version, std::min(max_version, kafka::api_version{3})));
 
     if (resp.data.error_code != kafka::error_code::none) {
         vlog(
@@ -732,6 +766,35 @@ group_mirroring_task::do_find_coordinator(
           resp.data.error_code));
     }
     co_return resp.data.node_id;
+}
+
+ss::future<std::expected<
+  chunked_vector<kafka::coordinator>,
+  group_mirroring_task::error>>
+group_mirroring_task::do_find_coordinator_batched(
+  chunked_vector<ss::sstring> group_ids, kafka::api_version max_version) {
+    vlog(
+      logger().trace,
+      "Requesting find coordinator for {} groups",
+      group_ids.size());
+    kafka::find_coordinator_request req;
+    req.data.key_type = kafka::coordinator_type::group;
+    req.data.coordinator_keys = std::move(group_ids);
+
+    auto resp = co_await get_cluster_connection().dispatch_to_any(
+      std::move(req), std::min(max_version, max_version));
+
+    if (resp.data.error_code != kafka::error_code::none) {
+        vlog(
+          logger().warn,
+          "Error finding coordinator for groups - {}",
+          resp.data.error_code);
+        co_return std::unexpected(error(
+          ssx::sformat("Error finding coordinator for groups"),
+          resp.data.error_code));
+    }
+
+    co_return std::move(resp.data.coordinators);
 }
 
 std::string_view

--- a/src/v/cluster_link/group_mirroring_task.h
+++ b/src/v/cluster_link/group_mirroring_task.h
@@ -112,6 +112,10 @@ private:
     ss::future<std::expected<::model::node_id, error>> do_find_coordinator(
       const kafka::group_id& group_id, kafka::api_version max_version);
 
+    ss::future<std::expected<chunked_vector<kafka::coordinator>, error>>
+    do_find_coordinator_batched(
+      chunked_vector<ss::sstring> group_ids, kafka::api_version max_version);
+
     inline bool should_group_be_mirrored(
       const kafka::group_id& group_id,
       const chunked_hash_set<::model::partition_id>&

--- a/src/v/cluster_link/tests/group_mirroring_task_test.cc
+++ b/src/v/cluster_link/tests/group_mirroring_task_test.cc
@@ -277,7 +277,9 @@ public:
     }
 
     ss::future<kafka::client::response_t> handle_find_coordinator_request(
-      ::model::node_id, kafka::client::request_t req, kafka::api_version) {
+      ::model::node_id,
+      kafka::client::request_t req,
+      kafka::api_version version) {
         auto fc_req = std::get<kafka::find_coordinator_request>(std::move(req));
         if (fc_req.data.key_type != kafka::coordinator_type::group) {
             co_return kafka::find_coordinator_response{
@@ -285,21 +287,37 @@ public:
               ssx::sformat(
                 "Unsupported coordinator type: {}", fc_req.data.key_type)};
         }
-
-        kafka::group_id gr{std::move(fc_req.data.key)};
-        auto it = source_cluster_group.find(gr);
-        if (it == source_cluster_group.end()) {
-            co_return kafka::find_coordinator_response{
-              kafka::error_code::coordinator_not_available,
-              ssx::sformat("Unknown group: {}", gr)};
+        // older versions only support single key
+        if (version < kafka::api_version(4)) {
+            auto coordinator = do_find_coordinator(
+              kafka::group_id(std::move(fc_req.data.key)));
+            co_return kafka::find_coordinator_response(
+              coordinator.node_id, coordinator.host, coordinator.port);
         }
 
-        co_return kafka::find_coordinator_response{
-          kafka::error_code::none,
-          std::nullopt,
-          it->second.coordinator_id,
-          "localhost",
-          9092};
+        kafka::find_coordinator_response resp;
+        resp.data.error_code = kafka::error_code::none;
+        for (auto& key : fc_req.data.coordinator_keys) {
+            kafka::coordinator coordinator = do_find_coordinator(
+              kafka::group_id(std::move(key)));
+            resp.data.coordinators.push_back(std::move(coordinator));
+        }
+        co_return resp;
+    }
+
+    kafka::coordinator do_find_coordinator(const kafka::group_id& group) {
+        auto it = source_cluster_group.find(group);
+        if (it == source_cluster_group.end()) {
+            throw std::runtime_error(ssx::sformat("Unknown group: {}", group));
+        }
+
+        return kafka::coordinator{
+          .key = group,
+          .node_id = it->second.coordinator_id,
+          .host = "localhost",
+          .port = 9092,
+          .error_code = kafka::error_code::none,
+          .error_message = std::nullopt};
     }
 
     ss::future<kafka::client::response_t> handle_offset_fetch_request(
@@ -378,6 +396,47 @@ TEST_F(group_mirroring_task_test, check_if_task_follows_the_leader) {
  */
 TEST_F(group_mirroring_task_test, test_happy_path_offsets_mirroring) {
     make_current_node_leader_for({0, 1, 2, 3});
+    fixture()->upsert_link(get_default_metadata()).get();
+
+    bool is_active = wait_for_task_state(model::task_state::active).get();
+    ASSERT_TRUE(is_active);
+
+    // set consumer group offsets
+
+    kafka::group_id test_group("t-group");
+
+    consumer_group_metadata metadata;
+    metadata.group_id = test_group;
+    metadata.coordinator_id = ::model::node_id(0);
+    source_cluster_group[test_group] = std::move(metadata);
+
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 100}, {4, 312}}}});
+    set_source_cluster_high_watermark(
+      {{"t-topic", {{0, 1000}, {1, 1000}, {4, 1000}}}});
+    /**
+     * Verify if offset is mirrored
+     */
+    wait_for_mirrored_offsets(test_group, {{"t-topic", {{0, 100}, {4, 312}}}})
+      .get();
+    set_source_cluster_group_offsets(
+      test_group, {{"t-topic", {{0, 0}, {4, 312}, {1, 10}}}});
+
+    wait_for_mirrored_offsets(
+      test_group, {{"t-topic", {{0, 0}, {4, 312}, {1, 10}}}})
+      .get();
+}
+
+TEST_F(group_mirroring_task_test, test_find_coordinator_v3) {
+    make_current_node_leader_for({0, 1, 2, 3});
+    for (int i = 0; i < 3; ++i) {
+        ::model::node_id id{i};
+        fixture()->get_cluster_mock().set_supported_versions(
+          id,
+          kafka::find_coordinator_api::key,
+          {.min = kafka::find_coordinator_api::min_valid,
+           .max = kafka::api_version(3)});
+    }
     fixture()->upsert_link(get_default_metadata()).get();
 
     bool is_active = wait_for_task_state(model::task_state::active).get();


### PR DESCRIPTION
Starting from version 4 `FindCoordinatorRequest` supports querying for
coordinator for multiple resources in a single request. Recently we
added support for version 4 in Redpanda.

This PR adds support for `FindCoordinatorRequest` to consumer groups mirroring task. This reduces the numer of requests exchanged between source and target clusters. 
 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none