### PR TITLE
pbgen: generate openapi docs

### DIFF
--- a/buf.gen.openapi.yaml
+++ b/buf.gen.openapi.yaml
@@ -1,0 +1,10 @@
+version: v2
+inputs:
+  - module: buf.build/redpandadata/core
+    exclude_paths:
+      - proto/redpanda/pbgen
+      - redpanda/pbgen
+
+plugins:
+  - remote: buf.build/community/sudorandom-connect-openapi:v0.21.2
+    out: vbuild/openapi


### PR DESCRIPTION
For the docs team we need to also generate an openapi spec for our
connect RPCs. The following command can be run to generate openapi
specs:

```
buf generate --template ./buf.gen.openapi.yaml
```

This results in the following files. The `pbgen` files can be ignored
completely, as those are options for our internal protobuf generator
only and doesn't effect others.

```
$ ls --tree vbuild/openapi
openapi
└── redpanda
    ├── core
    │   ├── admin
    │   │   └── v2
    │   │       ├── broker.openapi.yaml
    │   │       └── shadow_link.openapi.yaml
    │   ── common
    │       └── acl.openapi.yaml
    └─ pbgen
        ├── options.openapi.yaml
        └── rpc.openapi.yaml
```

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
