### PR TITLE
ducktape: Wait for an active Trino worker

### DIFF
--- a/tests/rptest/services/trino_service.py
+++ b/tests/rptest/services/trino_service.py
@@ -126,10 +126,26 @@ iceberg.{{ catalog_type }}-catalog.uri={{ catalog_uri }}
     def wait_node(self, node, timeout_sec):
         def _ready():
             try:
+                # Wait for server initialization.
                 self.run_query_fetch_all("show catalogs")
+
+                # Wait for the worker to register with the coordinator.
+                # Even though the coordinator and worker are in the same process,
+                # sometimes queries race with worker registration.
+                active_workers = self.run_query_fetch_all(
+                    "SELECT count(*) FROM system.runtime.nodes WHERE state = 'active'"
+                )
+                active_worker_count = len(active_workers) if active_workers else 0
+
+                if active_worker_count < 1:
+                    self.logger.debug(f"Trino initialized but has no active workers")
+                    return False
+
                 return True
             except Exception:
-                self.logger.debug(f"Exception querying catalog", exc_info=True)
+                self.logger.debug(
+                    f"Exception during Trino readiness check", exc_info=True
+                )
             return False
 
         wait_until(


### PR DESCRIPTION
Ducktape tests considered Trino ready when it fulfilled a `show catalogs` query; however, this query can be executed on the coordinator with no active workers. Occasionally, even though the worker and coordinator are in the same process in our Ducktape test cluster, query execution raced with worker registration, causing tests to fail with NO_NODES_AVAILABLE.

This fixes the issue by adding a second check for readiness that verifies there is at least one active worker registered.

Fixes CORE-8355

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
