### PR TITLE
[CORE-13438] ct/reconciler: Reduce cloud storage exception logging to WARN

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -374,7 +374,7 @@ reconciler::reconcile_partitions(
         vlogl(
           lg,
           ssx::is_shutdown_exception(ex) ? ss::log_level::debug
-                                         : ss::log_level::error,
+                                         : ss::log_level::warn,
           "Exception building and putting object {}: {}",
           oid,
           ex);
@@ -475,7 +475,7 @@ reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
     auto put_result = co_await _l1_io->put_object(oid, ctx.staging.get(), &_as);
     if (!put_result.has_value()) {
         vlog(
-          lg.error,
+          lg.warn,
           "Failed to put L1 object {}: {}",
           oid,
           static_cast<int>(put_result.error()));

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -453,11 +453,6 @@ reconciler::build_object(
     chunked_vector<partition_commit_info> metas;
     metas.reserve(partitions.size());
     for (const auto& partition : partitions) {
-        vlog(
-          lg.debug,
-          "Processing partition {} with LRO {}",
-          partition->tidp,
-          partition->lro);
         auto meta = co_await add_partition_to_object(ctx, partition);
         if (meta.has_value()) {
             metas.emplace_back(partition, std::move(meta).value());


### PR DESCRIPTION
This lowers two cloud-storage-related error logs from ERROR to WARN
level.

1. The level zero reader converts download_failure errors into runtime
    exceptions because the reader interface doesn't have a way to pass
    errors. I had wanted to log exceptions at ERROR level, assuming they
    are actually exceptional, but an occasional download failure from the
    cloud storage layer is expected. The reconciler will retry next
    iteration.
2. Failures when uploading objects were being logged at ERROR level,
    even though similar failures are logged at WARN. This was likely an
    oversight.

Also removes a redundant log.

Fixes CORE-13438

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
