### PR TITLE
storage: fix possible use-after-move violation

### DIFF
--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -60,8 +60,9 @@ model::record_batch record_batch_builder::build() && {
     if (!_timestamp) {
         _timestamp = model::timestamp::now();
     }
+    auto header = build_header();
     auto batch = model::record_batch(
-      build_header(), std::move(_records), model::record_batch::tag_ctor_ng{});
+      header, std::move(_records), model::record_batch::tag_ctor_ng{});
     if (_compression == model::compression::none) {
         batch.header().reset_size_checksum_metadata(batch.data());
         return batch;
@@ -73,8 +74,9 @@ ss::future<model::record_batch> record_batch_builder::build_async() && {
     if (!_timestamp) {
         _timestamp = model::timestamp::now();
     }
+    auto header = build_header();
     auto batch = model::record_batch(
-      build_header(), std::move(_records), model::record_batch::tag_ctor_ng{});
+      header, std::move(_records), model::record_batch::tag_ctor_ng{});
     if (_compression == model::compression::none) {
         batch.header().reset_size_checksum_metadata(batch.data());
         co_return batch;


### PR DESCRIPTION
build_header() depends on `_records`. parameter evaluation order is unspecified. it's not clear if that _also_ includes constructing the final values, but if it does then this is undefined behavior.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
