### PR TITLE
Fixes UX-509: Adding TopicID to `rpk topic describe` & `rpk topic list` command

### DIFF
--- a/src/go/rpk/pkg/cli/topic/describe.go
+++ b/src/go/rpk/pkg/cli/topic/describe.go
@@ -11,6 +11,7 @@ package topic
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -188,6 +189,11 @@ func printDescribedTopics(summary, configs, partitions bool, topics []describedT
 			tw := out.NewTabWriter()
 			defer tw.Flush()
 			tw.PrintColumn("NAME", topic.Summary.Name)
+			// Topic ID does not exist in older versions of RP & Kafka
+			// so it is possible this field is empty
+			if topic.Summary.ID != (topicID{}) {
+				tw.PrintColumn("TOPIC-ID", topic.Summary.ID)
+			}
 			if topic.Summary.Internal {
 				tw.PrintColumn("INTERNAL", topic.Summary.Internal)
 			}
@@ -217,6 +223,45 @@ func printDescribedTopics(summary, configs, partitions bool, topics []describedT
 	}
 }
 
+// topicID was added in KIP 516.
+type topicID [16]byte
+
+// MarshalText, MarshalJSON, MarshalYAML are used to encode the topicID
+// into a base64 encoding, before the output is provided to the user.
+//
+// If topicID does not exist, due to older versions
+// of Kafka or RP then it will return null or empty string, depending
+// on the output form.
+func (t topicID) MarshalText() ([]byte, error) {
+	if t == (topicID{}) {
+		return []byte(""), nil
+	}
+	encodedStr := base64.RawURLEncoding.EncodeToString(t[:])
+	return []byte(encodedStr), nil
+}
+
+func (t topicID) String() string {
+	text, _ := t.MarshalText()
+	return string(text)
+}
+
+func (t topicID) MarshalJSON() ([]byte, error) {
+	if t == (topicID{}) {
+		return []byte("null"), nil
+	}
+	encodedStr := base64.RawURLEncoding.EncodeToString(t[:])
+	return []byte(fmt.Sprintf(`"%s"`, encodedStr)), nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (t topicID) MarshalYAML() ([]byte, error) {
+	if t == (topicID{}) {
+		return nil, nil
+	}
+	encodedStr := base64.RawURLEncoding.EncodeToString(t[:])
+	return []byte(encodedStr), nil
+}
+
 type describedTopic struct {
 	Summary    describeTopicSummary     `json:"summary" yaml:"summary"`
 	Configs    []describeTopicConfig    `json:"configs" yaml:"configs"`
@@ -226,16 +271,18 @@ type describedTopic struct {
 }
 
 type describeTopicSummary struct {
-	Name       string `json:"name" yaml:"name"`
-	Internal   bool   `json:"internal" yaml:"internal"`
-	Partitions int    `json:"partitions" yaml:"partitions"`
-	Replicas   int    `json:"replicas" yaml:"replicas"`
-	Error      string `json:"error" yaml:"error"`
+	Name       string  `json:"name" yaml:"name"`
+	ID         topicID `json:"id" yaml:"id"`
+	Internal   bool    `json:"internal" yaml:"internal"`
+	Partitions int     `json:"partitions" yaml:"partitions"`
+	Replicas   int     `json:"replicas" yaml:"replicas"`
+	Error      string  `json:"error" yaml:"error"`
 }
 
 func buildDescribeTopicSummary(topic kmsg.MetadataResponseTopic) describeTopicSummary {
 	resp := describeTopicSummary{
 		Name:       *topic.Topic,
+		ID:         topic.TopicID,
 		Internal:   topic.IsInternal,
 		Partitions: len(topic.Partitions),
 	}
@@ -443,7 +490,7 @@ func getDescribeUsed(partitions []kmsg.MetadataResponseTopicPartition, offsets [
 			u.Stable = true
 		}
 	}
-	return
+	return u
 }
 
 type startStableEndOffset struct {

--- a/src/go/rpk/pkg/cli/topic/describe_test.go
+++ b/src/go/rpk/pkg/cli/topic/describe_test.go
@@ -224,6 +224,7 @@ func TestPartitionHeaderAndRow(t *testing.T) {
 func TestGetDescribeUsed(t *testing.T) {
 	testCases := []struct {
 		name       string
+		id         topicID
 		partitions []kmsg.MetadataResponseTopicPartition
 		offsets    []startStableEndOffset
 		expected   uses
@@ -303,6 +304,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "test-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 3,
 						Replicas:   2,
@@ -317,7 +319,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: `[{"summary":{"name":"test-topic","internal":false,"partitions":3,"replicas":2,"error":""},"configs":[{"key":"retention.ms","value":"604800000","source":"DEFAULT_CONFIG"}],"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0},{"partition":1,"leader":2,"epoch":0,"replicas":[2,1],"log_start_offset":0,"high_watermark":0},{"partition":2,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0}]}]`,
+			expectedOutput: `[{"summary":{"name":"test-topic","id":"9HrBC1jMQ3KlZw4CssPUeQ","internal":false,"partitions":3,"replicas":2,"error":""},"configs":[{"key":"retention.ms","value":"604800000","source":"DEFAULT_CONFIG"}],"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0},{"partition":1,"leader":2,"epoch":0,"replicas":[2,1],"log_start_offset":0,"high_watermark":0},{"partition":2,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0}]}]`,
 			expectedReturn: true,
 		},
 		{
@@ -327,6 +329,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "topic1",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 2,
 						Replicas:   2,
@@ -342,6 +345,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "topic2",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   true,
 						Partitions: 1,
 						Replicas:   3,
@@ -354,7 +358,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: `[{"summary":{"name":"topic1","internal":false,"partitions":2,"replicas":2,"error":""},"configs":[{"key":"retention.ms","value":"86400000","source":"DYNAMIC_TOPIC_CONFIG"}],"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0},{"partition":1,"leader":2,"epoch":0,"replicas":[2,1],"log_start_offset":0,"high_watermark":0}]},{"summary":{"name":"topic2","internal":true,"partitions":1,"replicas":3,"error":""},"configs":[{"key":"cleanup.policy","value":"compact","source":"STATIC_BROKER_CONFIG"}],"partitions":[{"partition":0,"leader":3,"epoch":0,"replicas":[1,2,3],"log_start_offset":0,"high_watermark":0}]}]`,
+			expectedOutput: `[{"summary":{"name":"topic1","id":"9HrBC1jMQ3KlZw4CssPUeQ","internal":false,"partitions":2,"replicas":2,"error":""},"configs":[{"key":"retention.ms","value":"86400000","source":"DYNAMIC_TOPIC_CONFIG"}],"partitions":[{"partition":0,"leader":1,"epoch":0,"replicas":[1,2],"log_start_offset":0,"high_watermark":0},{"partition":1,"leader":2,"epoch":0,"replicas":[2,1],"log_start_offset":0,"high_watermark":0}]},{"summary":{"name":"topic2","id":"9HrBC1jMQ3KlZw4CssPUeQ","internal":true,"partitions":1,"replicas":3,"error":""},"configs":[{"key":"cleanup.policy","value":"compact","source":"STATIC_BROKER_CONFIG"}],"partitions":[{"partition":0,"leader":3,"epoch":0,"replicas":[1,2,3],"log_start_offset":0,"high_watermark":0}]}]`,
 			expectedReturn: true,
 		},
 		{
@@ -364,6 +368,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "error-topic-1",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 0,
 						Replicas:   0,
@@ -375,6 +380,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "partial-error-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 2,
 						Replicas:   3,
@@ -406,6 +412,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "normal-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 1,
 						Replicas:   1,
@@ -428,6 +435,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					"summary": {
 						"name": "error-topic-1",
+                        "id": "9HrBC1jMQ3KlZw4CssPUeQ",
 						"internal": false,
 						"partitions": 0,
 						"replicas": 0,
@@ -439,6 +447,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					"summary": {
 						"name": "partial-error-topic",
+                        "id": "9HrBC1jMQ3KlZw4CssPUeQ",
 						"internal": false,
 						"partitions": 2,
 						"replicas": 3,
@@ -476,6 +485,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					"summary": {
 						"name": "normal-topic",
+                        "id": "9HrBC1jMQ3KlZw4CssPUeQ",
 						"internal": false,
 						"partitions": 1,
 						"replicas": 1,
@@ -509,6 +519,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "test-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 1,
 						Replicas:   1,
@@ -523,6 +534,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 			},
 			expectedOutput: `- summary:
     name: test-topic
+    id: 9HrBC1jMQ3KlZw4CssPUeQ
     internal: false
     partitions: 1
     replicas: 1
@@ -548,6 +560,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "error-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 0,
 						Replicas:   0,
@@ -557,6 +570,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 			},
 			expectedOutput: `- summary:
     name: error-topic
+    id: 9HrBC1jMQ3KlZw4CssPUeQ
     internal: false
     partitions: 0
     replicas: 0
@@ -572,6 +586,7 @@ func TestPrintDescribedTopicsFormatter(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "test-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 1,
 						Replicas:   1,
@@ -631,6 +646,7 @@ func TestPrintDescribedTopics(t *testing.T) {
 				{
 					Summary: describeTopicSummary{
 						Name:       "test-topic",
+						ID:         topicID{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
 						Internal:   false,
 						Partitions: 2,
 						Replicas:   3,
@@ -647,6 +663,7 @@ func TestPrintDescribedTopics(t *testing.T) {
 			expectedOutput: `SUMMARY
 =======
 NAME        test-topic
+TOPIC-ID    9HrBC1jMQ3KlZw4CssPUeQ
 PARTITIONS  2
 REPLICAS    3
 

--- a/src/go/rpk/pkg/cli/topic/list.go
+++ b/src/go/rpk/pkg/cli/topic/list.go
@@ -112,9 +112,10 @@ func executeTopicList(adm *kadm.Client, topics []string, re bool) (kadm.TopicDet
 }
 
 type summarizedList struct {
-	Name       string `json:"name" yaml:"name"`
-	Partitions int    `json:"partitions" yaml:"partitions"`
-	Replicas   int    `json:"replicas" yaml:"replicas"`
+	Name       string  `json:"name" yaml:"name"`
+	ID         topicID `json:"id" yaml:"id"`
+	Partitions int     `json:"partitions" yaml:"partitions"`
+	Replicas   int     `json:"replicas" yaml:"replicas"`
 }
 
 func summarizedListView(internal bool, topics kadm.TopicDetails) (resp []summarizedList) {
@@ -125,12 +126,13 @@ func summarizedListView(internal bool, topics kadm.TopicDetails) (resp []summari
 		}
 		s := summarizedList{
 			Name:       topic.Topic,
+			ID:         topicID(topic.ID),
 			Partitions: len(topic.Partitions),
 			Replicas:   topic.Partitions.NumReplicas(),
 		}
 		resp = append(resp, s)
 	}
-	return
+	return resp
 }
 
 func printSummarizedListView(f config.OutFormatter, topics []summarizedList, w io.Writer) {
@@ -140,15 +142,16 @@ func printSummarizedListView(f config.OutFormatter, topics []summarizedList, w i
 		return
 	}
 
-	tw := out.NewTableTo(w, "NAME", "PARTITIONS", "REPLICAS")
+	tw := out.NewTableTo(w, "NAME", "TOPIC-ID", "PARTITIONS", "REPLICAS")
 	defer tw.Flush()
 	for _, topic := range topics {
-		tw.Print(topic.Name, topic.Partitions, topic.Replicas)
+		tw.Print(topic.Name, topic.ID, topic.Partitions, topic.Replicas)
 	}
 }
 
 type detailedListTopic struct {
 	Name          string                  `json:"name" yaml:"name"`
+	ID            topicID                 `json:"id" yaml:"id"`
 	Partitions    int                     `json:"partitions" yaml:"partitions"`
 	Replicas      int                     `json:"replicas" yaml:"replicas"`
 	PartitionList []detailedListPartition `json:"partition_list" yaml:"partition_list"`
@@ -161,7 +164,7 @@ type detailedListTopic struct {
 type detailedListPartition struct {
 	Partition       int32   `json:"partition" yaml:"partition"`
 	Leader          int32   `json:"leader" yaml:"leader"`
-	Epoch           int32   `json:"epoch,omitempty" yaml:"epoch"`
+	Epoch           int32   `json:"epoch,omitempty" yaml:"epoch,omitempty"`
 	Replicas        []int32 `json:"replicas" yaml:"replicas"`
 	OfflineReplicas []int32 `json:"offline_replicas" yaml:"offline_replicas"`
 	LoadError       string  `json:"load_error" yaml:"load_error"`
@@ -175,6 +178,7 @@ func detailedListView(internal bool, topics kadm.TopicDetails) (resp []detailedL
 		}
 		d := detailedListTopic{
 			Name:       topic.Topic,
+			ID:         topicID(topic.ID),
 			Partitions: len(topic.Partitions),
 			isInternal: topic.IsInternal,
 		}
@@ -202,7 +206,7 @@ func detailedListView(internal bool, topics kadm.TopicDetails) (resp []detailedL
 		}
 		resp = append(resp, d)
 	}
-	return
+	return resp
 }
 
 func printDetailedListView(f config.OutFormatter, topics []detailedListTopic, w io.Writer) {
@@ -219,7 +223,11 @@ func printDetailedListView(f config.OutFormatter, topics []detailedListTopic, w 
 		} else {
 			topicName = topic.Name
 		}
-		fmt.Fprintf(w, "%s, %d partitions, %d replicas\n", topicName, topic.Partitions, topic.Replicas)
+		var idStr string
+		if topic.ID != (topicID{}) {
+			idStr = topic.ID.String() + ", "
+		}
+		fmt.Fprintf(w, "%s, %s%d partitions, %d replicas\n", topicName, idStr, topic.Partitions, topic.Replicas)
 		headers := []string{"", "partition", "leader"}
 		if topic.isEpoch {
 			headers = append(headers, "epoch")

--- a/src/go/rpk/pkg/cli/topic/list_test.go
+++ b/src/go/rpk/pkg/cli/topic/list_test.go
@@ -3,7 +3,9 @@ package topic
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -85,8 +87,8 @@ func TestSummarizedListView(t *testing.T) {
 	s := summarizedListView(false, topics)
 
 	cases := []testCase{
-		Text(`NAME        PARTITIONS  REPLICAS
-test-topic  2           3
+		Text(`NAME        TOPIC-ID  PARTITIONS  REPLICAS
+test-topic            2           3
 `),
 		JSON(t, s),
 		YAML(t, s),
@@ -127,9 +129,9 @@ func TestSummarizedListViewWithInternal(t *testing.T) {
 	s := summarizedListView(true, topics)
 
 	cases := []testCase{
-		Text(`NAME            PARTITIONS  REPLICAS
-internal-topic  1           1
-test-topic      2           3
+		Text(`NAME            TOPIC-ID  PARTITIONS  REPLICAS
+internal-topic            1           1
+test-topic                2           3
 `),
 		JSON(t, s),
 		YAML(t, s),
@@ -181,7 +183,7 @@ func TestEmptyTopicList(t *testing.T) {
 		printSummarizedListView(f, s, b)
 		switch format {
 		case "text":
-			require.Equal(t, "NAME  PARTITIONS  REPLICAS\n", b.String())
+			require.Equal(t, "NAME  TOPIC-ID  PARTITIONS  REPLICAS\n", b.String())
 		case "json":
 			require.Equal(t, "[]\n", b.String())
 		case "yaml":
@@ -280,6 +282,25 @@ func captureOutput(f func()) string {
 	return buf.String()
 }
 
+// UnmarshalJSON read string and turn into topicID
+func (t *topicID) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "null" || s == "" {
+		return nil
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return fmt.Errorf("failed to decode topicID from base64: %w", err)
+	}
+	if len(decoded) != 16 {
+		return fmt.Errorf("decoded topicID has incorrect length: got %d, want 16", len(decoded))
+	}
+
+	copy(t[:], decoded)
+	return nil
+}
+
 func TestTopicListCommand_Basic(t *testing.T) {
 	cmd, _ := setupTestCommand(t, "topic1", "topic2", "topic3")
 
@@ -293,59 +314,65 @@ func TestTopicListCommand_Basic(t *testing.T) {
 	err := json.Unmarshal([]byte(output), &topics)
 	require.NoError(t, err)
 
-	expectedTopics := []summarizedList{
-		{Name: "topic1", Partitions: 1, Replicas: 1},
-		{Name: "topic2", Partitions: 1, Replicas: 1},
-		{Name: "topic3", Partitions: 1, Replicas: 1},
+	// Since topicID is randomly generated
+	// it won't be possible to hardcode an exact
+	// match, so instead, just verify
+	// one was created.
+	actuals := make(map[string]summarizedList)
+	for _, topic := range topics {
+		actuals[topic.Name] = topic
 	}
 
-	require.Equal(t, expectedTopics, topics)
+	expectedNames := []string{"topic1", "topic2", "topic3"}
+	for _, name := range expectedNames {
+		actual, ok := actuals[name]
+		require.True(t, ok, "topic %q not found", name)
+
+		// Make sure TopicID exists.
+		require.NotEqual(t, topicID{}, actual.ID, "topic %q has a nil ID", name)
+
+		// Check predictable fields.
+		require.Equal(t, 1, actual.Partitions)
+		require.Equal(t, 1, actual.Replicas)
+	}
 }
 
 func TestTopicListCommand_RegexFiltering(t *testing.T) {
 	tests := []struct {
-		name         string
-		topics       []string
-		regexPattern string
-		expected     []summarizedList
+		name          string
+		topics        []string
+		regexPattern  string
+		expectedNames []string
 	}{
 		{
-			name:         "match single pattern",
-			topics:       []string{"user-events", "user-login", "system-metrics", "system-logs"},
-			regexPattern: "user-.*",
-			expected: []summarizedList{
-				{Name: "user-events", Partitions: 1, Replicas: 1},
-				{Name: "user-login", Partitions: 1, Replicas: 1},
-			},
+			name:          "match single pattern",
+			topics:        []string{"user-events", "user-login", "system-metrics", "system-logs"},
+			regexPattern:  "user-.*",
+			expectedNames: []string{"user-events", "user-login"},
 		},
 		{
-			name:         "match all with wildcard",
-			topics:       []string{"topic1", "topic2"},
-			regexPattern: ".*",
-			expected: []summarizedList{
-				{Name: "topic1", Partitions: 1, Replicas: 1},
-				{Name: "topic2", Partitions: 1, Replicas: 1},
-			},
+			name:          "match all with wildcard",
+			topics:        []string{"topic1", "topic2"},
+			regexPattern:  ".*",
+			expectedNames: []string{"topic1", "topic2"},
 		},
 		{
-			name:         "exact match",
-			topics:       []string{"exact-topic", "exact-topic-2", "other"},
-			regexPattern: "exact-topic",
-			expected: []summarizedList{
-				{Name: "exact-topic", Partitions: 1, Replicas: 1},
-			},
+			name:          "exact match",
+			topics:        []string{"exact-topic", "exact-topic-2", "other"},
+			regexPattern:  "exact-topic",
+			expectedNames: []string{"exact-topic"},
 		},
 		{
-			name:         "no match returns empty",
-			topics:       []string{"topic1", "topic2", "topic3"},
-			regexPattern: "nonexistent-.*",
-			expected:     []summarizedList{},
+			name:          "no match returns empty",
+			topics:        []string{"topic1", "topic2", "topic3"},
+			regexPattern:  "nonexistent-.*",
+			expectedNames: []string{},
 		},
 		{
-			name:         "partial match fails due to incorrect regex",
-			topics:       []string{"user-events", "events-user"},
-			regexPattern: "events",
-			expected:     []summarizedList{},
+			name:          "partial match fails due to incorrect regex",
+			topics:        []string{"user-events", "events-user"},
+			regexPattern:  "events",
+			expectedNames: []string{},
 		},
 	}
 
@@ -353,19 +380,33 @@ func TestTopicListCommand_RegexFiltering(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd, _ := setupTestCommand(t, tt.topics...)
 
-			// Execute list command with regex and JSON format
 			cmd.SetArgs([]string{"list", "--regex", tt.regexPattern, "--format=json"})
 			output := captureOutput(func() {
 				cmd.Execute()
 			})
 
-			// Parse JSON output
-			var topics []summarizedList
-			err := json.Unmarshal([]byte(output), &topics)
+			var actualTopics []summarizedList
+			err := json.Unmarshal([]byte(output), &actualTopics)
 			require.NoError(t, err)
 
-			// Compare full structure
-			require.Equal(t, tt.expected, topics)
+			require.Len(t, actualTopics, len(tt.expectedNames))
+
+			actualsByName := make(map[string]summarizedList)
+			for _, topic := range actualTopics {
+				actualsByName[topic.Name] = topic
+			}
+
+			for _, expectedName := range tt.expectedNames {
+				actual, ok := actualsByName[expectedName]
+				require.True(t, ok, "expected topic %q not found in results", expectedName)
+
+				// Make sure UUID was created.
+				require.NotEqual(t, topicID{}, actual.ID, "topic %q has a nil ID", actual.Name)
+
+				// Check predicted fields.
+				require.Equal(t, 1, actual.Partitions, "topic %q has wrong partition count", actual.Name)
+				require.Equal(t, 1, actual.Replicas, "topic %q has wrong replica count", actual.Name)
+			}
 		})
 	}
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -662,12 +662,23 @@ class RpkTool:
 
         def topic_line(line):
             parts = line.split()
+            # If TOPIC-ID is present, we have 4 columns. We normalize to 3
+            # columns [NAME, PARTITIONS, REPLICAS] to maintain compatibility
+            # with existing tests that index into the result.
+            if len(parts) == 4:
+                parts = [parts[0], parts[2], parts[3]]
             assert len(parts) == 3
             return parts[0] if not detailed else parts
 
         lines = output.splitlines()
         for i, line in enumerate(lines):
-            if line.split() == ["NAME", "PARTITIONS", "REPLICAS"]:
+            header = line.split()
+            if header == ["NAME", "PARTITIONS", "REPLICAS"] or header == [
+                "NAME",
+                "TOPIC-ID",
+                "PARTITIONS",
+                "REPLICAS",
+            ]:
                 return map(topic_line, lines[i + 1 :])
 
         assert False, "Unexpected output format"


### PR DESCRIPTION
In KIP-516, Topics are giving unique ID's when they are created. Making these UUID's visible when using `rpk` can help when it comes to potentially troubleshooting. Such as when a topic is deleted and recreated with the same name, it would assign a different Topic ID, which is a really nice signal if a user has removed and re-created a topic by the same name.  Or if we're even talking to the same cluster.

The topicID follows the same process as other tools where the TopicID is a UUID, which is then base64 encoded when outputted in the cli command. 

## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* `rpk topic describe <topic-name>` will now display the TopicID, if one exists.
* `rpk topic list` will now display the TopicID, if one exists.

### Bug Fixes

* fixed an issue where `rpk` would panic when running `rpk topic list --detailed --format help`

### Features


### Improvements

* `rpk topic describe <topic-name>` will now display the TopicID. If it one exists.
* `rpk topic list` will now display the TopicID, if one exists.


