### PR TITLE
[CORE-13428] ct: recompute batch crc in L0 data plane

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -100,7 +100,7 @@ static model::record_batch make_placeholder_batch(
     ph.header().first_timestamp = hdr.first_timestamp;
     ph.header().max_timestamp = hdr.max_timestamp;
     ph.header().base_sequence = hdr.base_sequence;
-    ph.header().header_crc = model::internal_header_only_crc(ph.header());
+    ph.header().reset_size_checksum_metadata(ph.data());
     return ph;
 }
 
@@ -141,7 +141,7 @@ static void update_batch_base_offset(
   model::record_batch& src, model::offset offset, model::term_id term) {
     src.set_term(term);
     src.header().base_offset = offset;
-    src.header().header_crc = model::internal_header_only_crc(src.header());
+    src.header().reset_size_checksum_metadata(src.data());
 }
 
 static chunked_vector<model::record_batch>

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -361,14 +361,10 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                   model::record_batch batch = std::move(*batches_it);
                   ++batches_it;
                   auto size = batch.header().size_bytes;
-                  auto crc = batch.header().crc;
                   batch.header() = local_batch_header;
                   batch.header().type = model::record_batch_type::raft_data;
                   batch.header().size_bytes = size;
-                  batch.header().crc = crc;
-                  // Recalculate the header crc
-                  batch.header().header_crc = model::internal_header_only_crc(
-                    batch.header());
+                  batch.header().reset_size_checksum_metadata(batch.data());
                   // Propagate materialized batches to the record batch cache
                   if (cache_enabled()) {
                       vlog(


### PR DESCRIPTION
_Note: this an alternative / subset of https://github.com/redpanda-data/redpanda/pull/27662. The primary difference is that this PR doesn't change the batch builder. It's not clear to me why the batch builder changed and why it appeared that the timestamps were being changed in a subtle way set timestamp / first timestamp and if this affected CRC calculation_. 

Context:

When we return batches to consumer, we take a materialized batch (header, payload) from cloud storage, fiddling with the header so that it has the correct base_offset, then recompute the CRC. Next, we swap out the header in the materialized batch for the header from the placeholder, and we retain the CRC from the materialized batch. The apparent assumption here is that the fields under the kafka crc are identical. Indeed, they nearly are identical, but nearly isn't good enough. The difference I see in my experiments are that they differ only by their attributes: the placeholder batch has CreateTime and the materialized batch has LogAppendTime. Everything else is the same.

But that is still enough to fail the CRC check on the client side. This patch fixes up all CRCs on created batches. A follow up to this PR is to make the chain of custody and source of truth for metadata much clearer.

The change in this PR is live here https://github.com/redpanda-data/redpanda/pull/27638 with the cloud topics enabled random node operations test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
