### PR TITLE
ci: remove `install-pack` slash command

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -7,7 +7,6 @@ on:
       - ci-repeat-command
       - dt-command
       - microbench-command
-      - install-pack-command
       - rp-unit-test-command
       - test-arm64-command
       - test-codecov-command

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -30,7 +30,6 @@ jobs:
             ci-repeat
             dt
             microbench
-            install-pack
             rp-unit-test
             test-arm64
             test-codecov


### PR DESCRIPTION
This command is currently not working. Remove it to avoid confusion

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none