### PR TITLE
storage: fix timequeries for server append time

### DIFF
--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -573,20 +573,22 @@ ss::future<timequery_result> batch_timequery(
     if (batch.compressed()) {
         batch = co_await model::decompress_batch(batch);
     }
+    const auto& header = batch.header();
     co_await batch.for_each_record_async(
-      [&result_o, &result_t, &batch, query_interval, t](
-        const model::record& r) -> ss::future<ss::stop_iteration> {
-          auto record_o = model::offset{r.offset_delta()} + batch.base_offset();
-          auto record_t = model::timestamp(
-            batch.header().first_timestamp() + r.timestamp_delta());
+      [&result_o, &result_t, &header, query_interval, t](
+        const model::record& r) {
+          auto record_o = model::offset{r.offset_delta()} + header.base_offset;
+          auto record_t = header.attrs.timestamp_type()
+                              == model::timestamp_type::create_time
+                            ? model::timestamp(
+                                header.first_timestamp() + r.timestamp_delta())
+                            : header.max_timestamp;
           if (record_t >= t && query_interval.contains(record_o)) {
               result_o = record_o;
               result_t = record_t;
-              return ss::make_ready_future<ss::stop_iteration>(
-                ss::stop_iteration::yes);
+              return ss::stop_iteration::yes;
           } else {
-              return ss::make_ready_future<ss::stop_iteration>(
-                ss::stop_iteration::no);
+              return ss::stop_iteration::no;
           }
       });
 

--- a/src/v/storage/tests/timequery_test.cc
+++ b/src/v/storage/tests/timequery_test.cc
@@ -669,3 +669,35 @@ TEST_F(log_builder_fixture, timequery_clamp) {
 
     b | stop();
 }
+
+TEST_F(log_builder_fixture, timequery_append_time) {
+    using namespace storage; // NOLINT
+
+    b | start();
+
+    b | add_segment(0);
+    // The client sets timestamps from 0-100
+    auto batch = make_random_batch(
+      model::term_id(0), model::offset(0), model::timestamp(0), 100);
+    // server append time says they are all 1000
+    batch.set_max_timestamp(
+      model::timestamp_type::append_time, model::timestamp(1000));
+    b | add_batch(std::move(batch));
+
+    auto log = b.get_log();
+    // If we used the client timestamp we'll get halfway through the batch
+    // if we use the server timestamp we'll get the first record.
+    storage::timequery_config config(
+      log->offsets().start_offset,
+      model::timestamp(50),
+      log->offsets().dirty_offset,
+      std::nullopt);
+
+    auto res = log->timequery(config).get();
+    EXPECT_EQ(
+      res,
+      storage::timequery_result(
+        model::term_id(0), model::offset(0), model::timestamp(1000)));
+
+    b | stop();
+}


### PR DESCRIPTION
It's possible that we return too late of a record index when using
append timestamps due to not correctly extracting the timestamp for the
record when using append_time for the batch timestamp type.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in `ListOffsets` by timestamp when batches are produced with append time instead of the default create time.
