### PR TITLE
tuner: Don't enable RPS/RFS in MQ mode

### DIFF
--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -30,8 +30,8 @@ type NetCheckersFactory interface {
 	NewNicIRQAffinityChecker(nic network.Nic, mode irq.Mode, mask string) Checker
 	NewNicRpsSetCheckers(interfaces []string, mode irq.Mode, mask string) []Checker
 	NewNicRpsSetChecker(nic network.Nic, mode irq.Mode, mask string) Checker
-	NewNicRfsCheckers(interfaces []string) []Checker
-	NewNicRfsChecker(nic network.Nic) Checker
+	NewNicRfsCheckers(interfaces []string, mode irq.Mode, mask string) []Checker
+	NewNicRfsChecker(nic network.Nic, mode irq.Mode, mask string) Checker
 	NewNicNTupleCheckers(interfaces []string) []Checker
 	NewNicNTupleChecker(nic network.Nic) Checker
 	NewNicXpsCheckers(interfaces []string) []Checker
@@ -180,11 +180,14 @@ func (f *netCheckersFactory) NewNicRpsSetChecker(
 	)
 }
 
-func (f *netCheckersFactory) NewNicRfsCheckers(interfaces []string) []Checker {
-	return f.forNonVirtualInterfaces(interfaces, f.NewNicRfsChecker)
+func (f *netCheckersFactory) NewNicRfsCheckers(interfaces []string, mode irq.Mode, cpuMask string) []Checker {
+	return f.forNonVirtualInterfaces(interfaces,
+		func(nic network.Nic) Checker {
+			return f.NewNicRfsChecker(nic, mode, cpuMask)
+		})
 }
 
-func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic) Checker {
+func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic, mode irq.Mode, cpuMask string) Checker {
 	return NewEqualityChecker(
 		NicRfsChecker,
 		fmt.Sprintf("NIC %s RFS set", nic.Name()),
@@ -193,7 +196,10 @@ func (f *netCheckersFactory) NewNicRfsChecker(nic network.Nic) Checker {
 		func() (interface{}, error) {
 			return isSet(nic, func(currentNic network.Nic) (bool, error) {
 				limits, err := currentNic.GetRpsLimitFiles()
-				queueLimit := network.OneRPSQueueLimit(limits)
+				if err != nil {
+					return false, err
+				}
+				queueLimit, err := network.OneRPSQueueLimit(limits, nic, mode, cpuMask, f.cpuMasks)
 				if err != nil {
 					return false, err
 				}

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -42,7 +42,7 @@ func NewNetTuner(
 			factory.NewNICsBalanceServiceTuner(interfaces),
 			factory.NewNICsIRQsAffinityTuner(interfaces, mode, cpuMask),
 			factory.NewNICsRpsTuner(interfaces, mode, cpuMask),
-			factory.NewNICsRfsTuner(interfaces),
+			factory.NewNICsRfsTuner(interfaces, mode, cpuMask),
 			factory.NewNICsNTupleTuner(interfaces),
 			factory.NewNICsXpsTuner(interfaces),
 			factory.NewRfsTableSizeTuner(),
@@ -55,7 +55,7 @@ type NetTunersFactory interface {
 	NewNICsBalanceServiceTuner(interfaces []string) Tunable
 	NewNICsIRQsAffinityTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
 	NewNICsRpsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
-	NewNICsRfsTuner(interfaces []string) Tunable
+	NewNICsRfsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
 	NewNICsNTupleTuner(interfaces []string) Tunable
 	NewNICsXpsTuner(interfaces []string) Tunable
 	NewRfsTableSizeTuner() Tunable
@@ -186,11 +186,11 @@ func (f *netTunersFactory) NewNICsRpsTuner(
 	)
 }
 
-func (f *netTunersFactory) NewNICsRfsTuner(interfaces []string) Tunable {
+func (f *netTunersFactory) NewNICsRfsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
 	return f.tuneNonVirtualInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.checkersFactory.NewNicRfsChecker(nic)
+			return f.checkersFactory.NewNicRfsChecker(nic, mode, cpuMask)
 		},
 		func(nic network.Nic) TuneResult {
 			zap.L().Sugar().Debugf("Tuning '%s' RFS", nic.Name())
@@ -198,7 +198,10 @@ func (f *netTunersFactory) NewNICsRfsTuner(interfaces []string) Tunable {
 			if err != nil {
 				return NewTuneError(err)
 			}
-			queueLimit := network.OneRPSQueueLimit(limits)
+			queueLimit, err := network.OneRPSQueueLimit(limits, nic, mode, cpuMask, f.cpuMasks)
+			if err != nil {
+				return NewTuneError(err)
+			}
 			for _, limitFile := range limits {
 				err := f.writeIntToFile(limitFile, queueLimit)
 				if err != nil {
@@ -208,6 +211,9 @@ func (f *netTunersFactory) NewNICsRfsTuner(interfaces []string) Tunable {
 			return NewTuneResult(false)
 		},
 		func() (bool, string) {
+			if !f.cpuMasks.IsSupported() {
+				return false, "Tuner is not supported as 'hwloc' is not installed"
+			}
 			return true, ""
 		},
 	)

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -67,13 +67,8 @@ func getDefaultMode(
 	return "", fmt.Errorf("virtual device %s is not supported", nic.Name())
 }
 
-func GetRpsCPUMask(
-	nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks,
-) (string, error) {
-	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
-	if err != nil {
-		return "", err
-	}
+func getEffectiveMode(mode irq.Mode, nic Nic, effectiveCPUMask string, cpuMasks irq.CPUMasks) (irq.Mode, error) {
+	var err error
 	effectiveMode := mode
 	if mode == irq.Default {
 		effectiveMode, err = getDefaultMode(nic, effectiveCPUMask, cpuMasks)
@@ -81,6 +76,36 @@ func GetRpsCPUMask(
 			return "", err
 		}
 	}
+	return effectiveMode, nil
+}
+
+func GetRpsCPUMask(
+	nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks,
+) (string, error) {
+	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
+	if err != nil {
+		return "", err
+	}
+
+	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks)
+	if err != nil {
+		return "", err
+	}
+
+	queueCount, err := nic.GetRxQueueCount()
+	if err != nil {
+		return "", err
+	}
+	puCount, err := cpuMasks.GetNumberOfPUs(effectiveCPUMask)
+	if err != nil {
+		return "", err
+	}
+
+	// In MQ mode, with at least one hardware RX queue per core just disable RPS as it adds no benefit.
+	if queueCount >= int(puCount) && effectiveMode == irq.Mq {
+		return "0x0", nil
+	}
+
 	computationsCPUMask, err := cpuMasks.CPUMaskForComputations(
 		effectiveMode, effectiveCPUMask)
 	if err != nil {
@@ -96,18 +121,17 @@ func GetHwInterfaceIRQsDistribution(
 	if err != nil {
 		return nil, err
 	}
-	effectiveMode := mode
-	if mode == irq.Default {
-		effectiveMode, err = getDefaultMode(nic, effectiveCPUMask, cpuMasks)
-		if err != nil {
-			return nil, err
-		}
+
+	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks)
+	if err != nil {
+		return nil, err
 	}
 
 	maxRxQueues, err := nic.GetMaxRxQueueCount()
 	if err != nil {
 		return nil, err
 	}
+
 	allIRQs, err := nic.GetIRQs()
 	if err != nil {
 		return nil, err
@@ -176,6 +200,30 @@ func CollectIRQs(nic Nic) ([]int, error) {
 	return IRQs, nil
 }
 
-func OneRPSQueueLimit(limits []string) int {
-	return RfsTableSize / len(limits)
+func OneRPSQueueLimit(limits []string, nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks) (int, error) {
+	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
+	if err != nil {
+		return 0, err
+	}
+
+	effectiveMode, err := getEffectiveMode(mode, nic, effectiveCPUMask, cpuMasks)
+	if err != nil {
+		return 0, err
+	}
+
+	queueCount, err := nic.GetRxQueueCount()
+	if err != nil {
+		return 0, err
+	}
+
+	puCount, err := cpuMasks.GetNumberOfPUs(effectiveCPUMask)
+	if err != nil {
+		return 0, err
+	}
+
+	// In MQ mode, with at least one hardware RX queue per core just disable RFS as it adds no benefit.
+	if queueCount >= int(puCount) && effectiveMode == irq.Mq {
+		return 0, nil
+	}
+	return RfsTableSize / len(limits), nil
 }

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -253,7 +253,7 @@ func RedpandaCheckers(
 		NicIRQsAffinitStaticChecker:   {netCheckersFactory.NewNicIRQAffinityStaticChecker(interfaces)},
 		NicIRQsAffinitChecker:         netCheckersFactory.NewNicIRQAffinityCheckers(interfaces, irq.Default, "all"),
 		NicRpsChecker:                 netCheckersFactory.NewNicRpsSetCheckers(interfaces, irq.Default, "all"),
-		NicRfsChecker:                 netCheckersFactory.NewNicRfsCheckers(interfaces),
+		NicRfsChecker:                 netCheckersFactory.NewNicRfsCheckers(interfaces, irq.Default, "all"),
 		NicXpsChecker:                 netCheckersFactory.NewNicXpsCheckers(interfaces),
 		MaxAIOEvents:                  {NewMaxAIOEventsChecker(fs)},
 		ClockSource:                   {NewClockSourceChecker(fs)},

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -66,6 +66,9 @@ class RpkRemoteTool:
     def tune(self, tuner: str) -> str:
         return self._execute([self._rpk_binary(), "redpanda", "tune", tuner, "-v"])
 
+    def check(self) -> str:
+        return self._execute([self._rpk_binary(), "redpanda", "check", "-v"])
+
     def mode_set(self, mode):
         return self._execute([self._rpk_binary(), "redpanda", "mode", mode])
 

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -80,7 +80,7 @@ class NetTunerTest(RedpandaTest):
                 .decode("utf-8")
                 .strip()
             )
-            assert rps_cpu == "f", (
+            assert rps_cpu == "0", (
                 f"rps_cpus for queue {i} is not set correctly, got {rps_cpu}"
             )
 
@@ -97,13 +97,13 @@ class NetTunerTest(RedpandaTest):
         )
 
         for i in range(4):
-            rps_sock_flow_entries = int(
+            per_queue_rps_flow_count = int(
                 node.account.ssh_output(
                     f"cat /sys/class/net/ens5/queues/rx-{i}/rps_flow_cnt"
                 )
                 .decode("utf-8")
                 .strip()
             )
-            assert rps_sock_flow_entries / 4, (
-                f"rps_flow_cnt for queue {i} is not set correctly, got {rps_sock_flow_entries}"
+            assert per_queue_rps_flow_count == 0, (
+                f"rps_flow_cnt for queue {i} is not set correctly, got {per_queue_rps_flow_count}"
             )

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -107,3 +107,10 @@ class NetTunerTest(RedpandaTest):
             assert per_queue_rps_flow_count == 0, (
                 f"rps_flow_cnt for queue {i} is not set correctly, got {per_queue_rps_flow_count}"
             )
+
+        # confirm that we also check cleanly
+        check_output = rpk.check().split()
+
+        for line in check_output:
+            if line.startswith("NIC ens5"):
+                assert line.endswith("true"), f"NIC check failed: {line}"


### PR DESCRIPTION
In MQ mode the tuner would unconditionally enable RPS/RFS.

This is a waste where we have at least one RX queue per CPU as load will
be spread across those CPUs in any case from the hardware side (via
RSS).

Adding RPS/RFS on top just adds more CPU load for no apparent benefit as
interrupt load is already fairly balanced.

Hence, disable RPS/RFS in that case. This is also closer to how such a
system would look out of the box.

From some basic high BPS/RPS testing this halfs %soft CPU load and
reduces softirqs from ~1.6 softirqs per hardware interrupt to just 1.

We still keep it on when the amount of hardware queues is lower than the
amount of vcpus.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
