### PR TITLE
data-migrate: improve __consumer_offsets topic absense handling

### DIFF
--- a/src/v/cluster/data_migration_backend.cc
+++ b/src/v/cluster/data_migration_backend.cc
@@ -1371,7 +1371,16 @@ ss::future<> backend::reconcile_migration(
 
         for (const auto& group : groups) {
             auto partition = _group_proxy.partition_for(group);
-            vassert(partition, "cannot get ntp for group {}", group);
+            // Group topic existence has been checked on migration creation.
+            // The only reason to disappear is transient topic table lag.
+            while (!partition) {
+                vlog(
+                  dm_log.warn,
+                  "waiting for group {} to be available in partition map",
+                  group);
+                co_await ss::sleep_abortable(1s, _as);
+                partition = _group_proxy.partition_for(group);
+            }
             auto [it, ins] = mrstate.partition_group_map->try_emplace(
               *partition);
             it->second.push_back(group);

--- a/src/v/cluster/data_migration_frontend.cc
+++ b/src/v/cluster/data_migration_frontend.cc
@@ -265,7 +265,8 @@ ss::future<result<id>> frontend::do_create_migration(data_migration migration) {
               dm_log.warn,
               "data migration involving consumer groups failed to create "
               "consumer offsets topic.");
-            co_return errc::topic_not_exists;
+            // presumably leadership changed and we failed to create the topic
+            co_return errc::leadership_changed;
         };
     }
 


### PR DESCRIPTION
1) if it disappeared after being present wait for it to reappear: it only can happen if topic table lags
2) if it is absent for real and we fail to create it throw a retriable error, as it indicates a controller leadership change

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
