### PR TITLE
[v25.2.x] Fix duplicate metrics registration because of Iceberg credential manager (MANUAL BACKPORT)

### DIFF
--- a/src/v/cloud_io/auth_refresh_bg_op.cc
+++ b/src/v/cloud_io/auth_refresh_bg_op.cc
@@ -10,7 +10,10 @@
 #include "cloud_io/auth_refresh_bg_op.h"
 
 #include "cloud_io/logger.h"
+#include "cloud_roles/refresh_credentials.h"
 #include "ssx/future-util.h"
+
+#include <optional>
 
 namespace cloud_io {
 
@@ -25,9 +28,11 @@ auth_refresh_bg_op::auth_refresh_bg_op(
   , _cloud_credentials_source(cloud_credentials_source) {}
 
 void auth_refresh_bg_op::maybe_start_auth_refresh_op(
-  cloud_roles::credentials_update_cb_t credentials_update_cb) {
+  cloud_roles::credentials_update_cb_t credentials_update_cb,
+  ss::sstring metrics_tag) {
     if (ss::this_shard_id() == auth_refresh_shard_id) {
-        do_start_auth_refresh_op(std::move(credentials_update_cb));
+        do_start_auth_refresh_op(
+          std::move(credentials_update_cb), std::move(metrics_tag));
     }
 }
 
@@ -42,7 +47,8 @@ void auth_refresh_bg_op::set_client_config(
 }
 
 void auth_refresh_bg_op::do_start_auth_refresh_op(
-  cloud_roles::credentials_update_cb_t credentials_update_cb) {
+  cloud_roles::credentials_update_cb_t credentials_update_cb,
+  ss::sstring metrics_tag) {
     if (is_static_config()) {
         // If credentials are static IE not changing, we just need to set the
         // credential object once on all cores with static strings.
@@ -74,12 +80,17 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
                     cloud_roles::aws_service_name{},
                     cloud_roles::aws_region_name{});
               });
-            _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
-              _cloud_credentials_source,
-              _as,
-              std::move(credentials_update_cb),
-              service_name,
-              region_name));
+
+            _refresh_credentials.emplace(
+              cloud_roles::make_refresh_credentials(
+                _cloud_credentials_source,
+                _as,
+                std::move(credentials_update_cb),
+                service_name,
+                region_name,
+                std::nullopt,
+                cloud_roles::default_retry_params,
+                std::move(metrics_tag)));
 
             vlog(
               log.info,

--- a/src/v/cloud_io/auth_refresh_bg_op.cc
+++ b/src/v/cloud_io/auth_refresh_bg_op.cc
@@ -81,16 +81,15 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
                     cloud_roles::aws_region_name{});
               });
 
-            _refresh_credentials.emplace(
-              cloud_roles::make_refresh_credentials(
-                _cloud_credentials_source,
-                _as,
-                std::move(credentials_update_cb),
-                service_name,
-                region_name,
-                std::nullopt,
-                cloud_roles::default_retry_params,
-                std::move(metrics_tag)));
+            _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(
+              _cloud_credentials_source,
+              _as,
+              std::move(credentials_update_cb),
+              service_name,
+              region_name,
+              std::nullopt,
+              cloud_roles::default_retry_params,
+              std::move(metrics_tag)));
 
             vlog(
               log.info,

--- a/src/v/cloud_io/auth_refresh_bg_op.h
+++ b/src/v/cloud_io/auth_refresh_bg_op.h
@@ -46,7 +46,8 @@ public:
     /// started on auth_refresh_shard_id and credentials are copied to other
     /// shards using the callback.
     void maybe_start_auth_refresh_op(
-      cloud_roles::credentials_update_cb_t credentials_update_cb);
+      cloud_roles::credentials_update_cb_t credentials_update_cb,
+      ss::sstring metrics_tag = "");
 
     cloud_storage_clients::client_configuration get_client_config() const;
     void set_client_config(cloud_storage_clients::client_configuration conf);
@@ -55,7 +56,8 @@ public:
 
 private:
     void do_start_auth_refresh_op(
-      cloud_roles::credentials_update_cb_t credentials_update_cb);
+      cloud_roles::credentials_update_cb_t credentials_update_cb,
+      ss::sstring metrics_tag);
 
     ss::gate& _gate;
     ss::abort_source& _as;

--- a/src/v/cloud_roles/probe.cc
+++ b/src/v/cloud_roles/probe.cc
@@ -12,10 +12,14 @@
 
 #include "config/configuration.h"
 #include "metrics/prometheus_sanitize.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/metrics.hh>
 
 namespace cloud_roles {
+
+auth_refresh_probe::auth_refresh_probe(ss::sstring tag)
+  : _tag(std::move(tag)) {}
 
 void auth_refresh_probe::setup_metrics() {
     if (config::shard_local_cfg().disable_metrics()) {
@@ -23,7 +27,10 @@ void auth_refresh_probe::setup_metrics() {
     }
 
     _metrics.add_group(
-      prometheus_sanitize::metrics_name("cloud_roles::auth_refresh"),
+      _tag.empty()
+        ? prometheus_sanitize::metrics_name("cloud_roles::auth_refresh")
+        : prometheus_sanitize::metrics_name(
+            ssx::sformat("cloud_roles::{}_auth_refresh", _tag)),
       {
         ss::metrics::make_counter(
           "successful_fetches",

--- a/src/v/cloud_roles/probe.h
+++ b/src/v/cloud_roles/probe.h
@@ -19,6 +19,9 @@ namespace cloud_roles {
 
 class auth_refresh_probe {
 public:
+    explicit auth_refresh_probe(ss::sstring tag);
+
+public:
     void setup_metrics();
     void reset() { _metrics.clear(); }
 
@@ -33,6 +36,7 @@ public:
     ~auth_refresh_probe() = default;
 
 private:
+    ss::sstring _tag;
     uint64_t _successful_fetches{0};
     uint64_t _fetch_errors{0};
     metrics::internal_metric_groups _metrics;

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -47,12 +47,13 @@ refresh_credentials::refresh_credentials(
   std::unique_ptr<impl> impl,
   ss::abort_source& as,
   credentials_update_cb_t creds_update,
-  aws_region_name region)
+  aws_region_name region,
+  ss::sstring metrics_tag)
   : _impl(std::move(impl))
   , _as(as)
   , _credentials_update(std::move(creds_update))
   , _region{std::move(region)}
-  , _probe(std::make_unique<auth_refresh_probe>()) {}
+  , _probe(std::make_unique<auth_refresh_probe>(std::move(metrics_tag))) {}
 
 void refresh_credentials::start() {
     _probe->setup_metrics();
@@ -381,7 +382,8 @@ refresh_credentials make_refresh_credentials(
   aws_service_name service,
   aws_region_name region,
   std::optional<net::unresolved_address> endpoint,
-  retry_params retry_params) {
+  retry_params retry_params,
+  ss::sstring metrics_tag) {
     switch (cloud_credentials_source) {
     case model::cloud_credentials_source::config_file:
         vlog(
@@ -397,7 +399,8 @@ refresh_credentials make_refresh_credentials(
           std::move(service),
           std::move(region),
           std::move(endpoint),
-          retry_params);
+          retry_params,
+          std::move(metrics_tag));
     case model::cloud_credentials_source::sts:
         return make_refresh_credentials<aws_sts_refresh_impl>(
           as,
@@ -405,7 +408,8 @@ refresh_credentials make_refresh_credentials(
           std::move(service),
           std::move(region),
           std::move(endpoint),
-          retry_params);
+          retry_params,
+          std::move(metrics_tag));
     case model::cloud_credentials_source::gcp_instance_metadata:
         return make_refresh_credentials<gcp_refresh_impl>(
           as,
@@ -413,7 +417,8 @@ refresh_credentials make_refresh_credentials(
           std::move(service),
           std::move(region),
           std::move(endpoint),
-          retry_params);
+          retry_params,
+          std::move(metrics_tag));
     case model::cloud_credentials_source::azure_aks_oidc_federation:
         return make_refresh_credentials<azure_aks_refresh_impl>(
           as,
@@ -421,7 +426,8 @@ refresh_credentials make_refresh_credentials(
           std::move(service),
           std::move(region),
           std::move(endpoint),
-          retry_params);
+          retry_params,
+          std::move(metrics_tag));
     case model::cloud_credentials_source::azure_vm_instance_metadata:
         return make_refresh_credentials<azure_vm_refresh_impl>(
           as,
@@ -429,7 +435,8 @@ refresh_credentials make_refresh_credentials(
           std::move(service),
           std::move(region),
           std::move(endpoint),
-          retry_params);
+          retry_params,
+          std::move(metrics_tag));
     }
 }
 

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -128,7 +128,8 @@ public:
       std::unique_ptr<impl> impl,
       ss::abort_source& as,
       credentials_update_cb_t creds_update,
-      aws_region_name region);
+      aws_region_name region,
+      ss::sstring metrics_tag = "");
 
     void start();
 
@@ -177,7 +178,8 @@ refresh_credentials make_refresh_credentials(
   aws_service_name service,
   aws_region_name region,
   std::optional<net::unresolved_address> endpoint = std::nullopt,
-  retry_params retry_params = default_retry_params) {
+  retry_params retry_params = default_retry_params,
+  ss::sstring metrics_tag = "") {
     ss::sstring host = {
       CredentialsProvider::default_host.data(),
       CredentialsProvider::default_host.size()};
@@ -203,7 +205,11 @@ refresh_credentials make_refresh_credentials(
       as,
       retry_params);
     return refresh_credentials{
-      std::move(impl), as, std::move(creds_update_cb), std::move(region)};
+      std::move(impl),
+      as,
+      std::move(creds_update_cb),
+      std::move(region),
+      std::move(metrics_tag)};
 }
 
 /// Builds a refresh_credentials object based on the credentials source set
@@ -215,6 +221,7 @@ refresh_credentials make_refresh_credentials(
   aws_service_name service,
   aws_region_name region,
   std::optional<net::unresolved_address> endpoint = std::nullopt,
-  retry_params retry_params = default_retry_params);
+  retry_params retry_params = default_retry_params,
+  ss::sstring metrics_tag = "");
 
 } // namespace cloud_roles

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -690,35 +690,13 @@ struct convert<model::iceberg_invalid_record_action> {
 
 template<>
 struct convert<config::datalake_catalog_auth_mode> {
-    static Node encode(const config::datalake_catalog_auth_mode& rhs) {
-        return Node(fmt::format("{}", rhs));
-    }
+    using type = config::datalake_catalog_auth_mode;
 
-    static bool
-    decode(const Node& node, config::datalake_catalog_auth_mode& rhs) {
-        static constexpr auto acceptable_values
-          = config::acceptable_datalake_catalog_auth_modes();
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
         auto value = node.as<std::string>();
-        if (
-          std::find(acceptable_values.begin(), acceptable_values.end(), value)
-          == acceptable_values.end()) {
-            return false;
-        }
-
-        rhs = string_switch<config::datalake_catalog_auth_mode>(
-                std::string_view{value})
-                .match(
-                  to_string_view(config::datalake_catalog_auth_mode::none),
-                  config::datalake_catalog_auth_mode::none)
-                .match(
-                  to_string_view(config::datalake_catalog_auth_mode::bearer),
-                  config::datalake_catalog_auth_mode::bearer)
-                .match(
-                  to_string_view(config::datalake_catalog_auth_mode::oauth2),
-                  config::datalake_catalog_auth_mode::oauth2)
-                .match(
-                  to_string_view(config::datalake_catalog_auth_mode::aws_sigv4),
-                  config::datalake_catalog_auth_mode::aws_sigv4);
+        rhs = boost::lexical_cast<type>(value);
         return true;
     }
 };

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -166,14 +166,6 @@ constexpr std::string_view to_string_view(datalake_catalog_auth_mode cam) {
     }
 }
 
-static constexpr auto acceptable_datalake_catalog_auth_modes() {
-    return std::to_array(
-      {to_string_view(datalake_catalog_auth_mode::none),
-       to_string_view(datalake_catalog_auth_mode::bearer),
-       to_string_view(datalake_catalog_auth_mode::oauth2),
-       to_string_view(datalake_catalog_auth_mode::aws_sigv4)});
-}
-
 inline std::ostream&
 operator<<(std::ostream& os, datalake_catalog_auth_mode cam) {
     return os << to_string_view(cam);

--- a/src/v/datalake/credential_manager.cc
+++ b/src/v/datalake/credential_manager.cc
@@ -214,7 +214,8 @@ void credential_manager::start_auth_refresh_if_needed() {
     auth_refresh_bg_op_->maybe_start_auth_refresh_op(
       [this](cloud_roles::credentials creds) -> ss::future<> {
           return propagate_credentials(std::move(creds));
-      });
+      },
+      "datalake");
 }
 
 ss::future<>

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -332,9 +332,10 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
         auto auth_result = co_await _credential_manager.maybe_sign(
           payload, request.value());
         if (auth_result.has_error()) {
-            co_return tl::unexpected(domain_error{http_call_error{fmt::format(
-              "Failed to sign request with credential manager: {}",
-              auth_result.error().message())}});
+            co_return tl::unexpected(
+              domain_error{http_call_error{fmt::format(
+                "Failed to sign request with credential manager: {}",
+                auth_result.error().message())}});
         }
 
         auto request_target = ss::sstring{

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -332,10 +332,9 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
         auto auth_result = co_await _credential_manager.maybe_sign(
           payload, request.value());
         if (auth_result.has_error()) {
-            co_return tl::unexpected(
-              domain_error{http_call_error{fmt::format(
-                "Failed to sign request with credential manager: {}",
-                auth_result.error().message())}});
+            co_return tl::unexpected(domain_error{http_call_error{fmt::format(
+              "Failed to sign request with credential manager: {}",
+              auth_result.error().message())}});
         }
 
         auto request_target = ss::sstring{

--- a/src/v/iceberg/rest_client/catalog_client.cc
+++ b/src/v/iceberg/rest_client/catalog_client.cc
@@ -329,17 +329,14 @@ ss::future<expected<iobuf>> catalog_client::perform_request(
             co_return tl::unexpected(request.error());
         }
 
-        // Apply AWS SigV4 authentication if needed
-        if (_auth_mode == config::datalake_catalog_auth_mode::aws_sigv4) {
-            auto auth_result = co_await _credential_manager.maybe_sign(
-              payload, request.value());
-            if (auth_result.has_error()) {
-                co_return tl::unexpected(
-                  domain_error{http_call_error{fmt::format(
-                    "Failed to sign request with credential manager: {}",
-                    auth_result.error().message())}});
-            }
+        auto auth_result = co_await _credential_manager.maybe_sign(
+          payload, request.value());
+        if (auth_result.has_error()) {
+            co_return tl::unexpected(domain_error{http_call_error{fmt::format(
+              "Failed to sign request with credential manager: {}",
+              auth_result.error().message())}});
         }
+
         auto request_target = ss::sstring{
           request->target().begin(), request->target().end()};
 


### PR DESCRIPTION
This is a partial backport of #27251.

Includes:
  ✅ Commit 914e25eb7a - iceberg: call into credential manager unconditionally
  ✅ Commit 2511633e04 - cloud_roles: allow customizing metric names for refreshers (the critical fix)
  ✅ Commit 067c99c070 - config: remove some unnecessary code

Excludes because it adds a new feature:
  ⏭️ Commit f9b8bc62bb - datalake: add gcp credential source for catalog and e2e test

Fixes #27344

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Fixed an issue with metrics being registered twice when using an Iceberg REST catalog.

