### PR TITLE
ct/l1: change metastore *_objects signatures to take const refs

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
@@ -126,7 +126,7 @@ protected:
               .value();
         }
 
-        _metastore.add_objects(std::move(meta_builder), term_map).get().value();
+        _metastore.add_objects(*meta_builder, term_map).get().value();
     }
 
     model::record_batch_reader make_reader(

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -304,7 +304,7 @@ TEST_F(l1_reader_test, missing_object) {
         .first_offset = kafka::offset{0},
       });
 
-    _metastore.add_objects(std::move(builder), term_map).get().value();
+    _metastore.add_objects(*builder, term_map).get().value();
 
     auto reader = make_reader(ntp, tidp);
     EXPECT_THROW(read_all(std::move(reader)), std::runtime_error);
@@ -364,7 +364,7 @@ TEST_F(l1_reader_test, empty_offset_range) {
         .term = model::term_id{1},
         .first_offset = high_watermark,
       });
-    _metastore.add_objects(std::move(meta_builder), term_map).get().value();
+    _metastore.add_objects(*meta_builder, term_map).get().value();
 
     // Write some objects after the empty object.
     auto final_batches

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -171,9 +171,8 @@ public:
     // it does not imply that all extents were accepted by the metastore. The
     // response should be examined to determine if subsequent add_objects()
     // requests need to be re-aligned to a different offset.
-    virtual ss::future<std::expected<add_response, errc>> add_objects(
-      std::unique_ptr<object_metadata_builder>, const term_offset_map_t&)
-      = 0;
+    virtual ss::future<std::expected<add_response, errc>>
+    add_objects(const object_metadata_builder&, const term_offset_map_t&) = 0;
 
     // Adds the given objects to the metastore, expecting that the new extents
     // replace an extent or set of extents covering the same range.
@@ -184,7 +183,7 @@ public:
     // correctness, these simplify accounting and makes it easier to validate
     // that we haven't lost data.
     virtual ss::future<std::expected<void, errc>>
-      replace_objects(std::unique_ptr<object_metadata_builder>) = 0;
+    replace_objects(const object_metadata_builder&) = 0;
 
     // Moves the start offset of the given partition's log to the given offset.
     virtual ss::future<std::expected<void, errc>>
@@ -278,8 +277,8 @@ public:
     // Similar to replace_objects(), but with additional constraints based on
     // compaction metadata. See get_compaction_offsets() for more details on
     // expected usage.
-    virtual ss::future<std::expected<void, errc>> compact_objects(
-      std::unique_ptr<object_metadata_builder>, const compaction_map_t&)
+    virtual ss::future<std::expected<void, errc>>
+    compact_objects(const object_metadata_builder&, const compaction_map_t&)
       = 0;
 
     // Returns metadata required to determine what to compact for the given

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -102,12 +102,6 @@ public:
 
 private:
     friend class cloud_topics::l1::replicated_metastore;
-    std::expected<
-      chunked_hash_map<
-        model::partition_id,
-        chunked_vector<metastore::object_metadata>>,
-      error>
-    release();
 
     struct partitioned_objects {
         chunked_hash_map<
@@ -206,33 +200,6 @@ replicated_object_builder::finish(
     return {};
 }
 
-std::expected<
-  chunked_hash_map<
-    model::partition_id,
-    chunked_vector<metastore::object_metadata>>,
-  replicated_object_builder::error>
-replicated_object_builder::release() {
-    for (const auto& [partition_id, partition_objects] : partitions_) {
-        if (!partition_objects.pending_objects_.empty()) {
-            return std::unexpected(error{"Unfinished objects remain"});
-        }
-    }
-
-    chunked_hash_map<
-      model::partition_id,
-      chunked_vector<metastore::object_metadata>>
-      result;
-    for (auto& [partition_id, partition_objects] : partitions_) {
-        chunked_vector<metastore::object_metadata> metas;
-        for (auto& obj : partition_objects.finished_objects_) {
-            metas.push_back(std::move(obj));
-        }
-        result.emplace(partition_id, std::move(metas));
-    }
-
-    partitions_.clear();
-    return result;
-}
 } // anonymous namespace
 
 replicated_metastore::replicated_metastore(frontend& fe)
@@ -282,18 +249,19 @@ replicated_metastore::get_offsets(const model::topic_id_partition& tidp) {
 
 ss::future<std::expected<metastore::add_response, metastore::errc>>
 replicated_metastore::add_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const metastore::object_metadata_builder& builder,
   const metastore::term_offset_map_t& terms) {
-    auto replicated_builder = std::unique_ptr<replicated_object_builder>(
-      static_cast<replicated_object_builder*>(builder.release()));
+    auto& replicated_builder = static_cast<const replicated_object_builder&>(
+      builder);
 
-    auto objects_result = replicated_builder->release();
-    if (!objects_result.has_value()) {
-        vlog(
-          cd_log.error,
-          "Error while sending request: {}",
-          objects_result.error());
-        co_return std::unexpected(metastore::errc::invalid_request);
+    for (const auto& [partition_id, partition_objects] :
+         replicated_builder.partitions_) {
+        if (!partition_objects.pending_objects_.empty()) {
+            vlog(
+              cd_log.error,
+              "Error while sending request: unfinished objects remain");
+            co_return std::unexpected(metastore::errc::invalid_request);
+        }
     }
     chunked_hash_map<model::partition_id, term_state_update_t>
       partitioned_terms;
@@ -310,7 +278,8 @@ replicated_metastore::add_objects(
         }
     }
     add_response resp;
-    for (auto& [partition_id, partition_objects] : objects_result.value()) {
+    for (auto& [partition_id, partition_objects] :
+         replicated_builder.partitions_) {
         auto terms_it = partitioned_terms.find(partition_id);
         if (terms_it == partitioned_terms.end()) {
             // TODO: consider making this less strict, down to the STM layer?
@@ -324,7 +293,7 @@ replicated_metastore::add_objects(
         req.metastore_partition = partition_id;
         req.new_terms = std::move(terms_it->second);
         chunked_vector<new_object> new_objects;
-        for (auto& obj : partition_objects) {
+        for (auto& obj : partition_objects.finished_objects_) {
             new_objects.emplace_back(meta_to_rpc_obj(obj));
         }
         req.new_objects = std::move(new_objects);
@@ -349,23 +318,25 @@ replicated_metastore::add_objects(
 
 ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::replace_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder) {
-    auto replicated_builder = std::unique_ptr<replicated_object_builder>(
-      static_cast<replicated_object_builder*>(builder.release()));
+  const metastore::object_metadata_builder& builder) {
+    auto& replicated_builder = static_cast<const replicated_object_builder&>(
+      builder);
 
-    auto objects_result = replicated_builder->release();
-    if (!objects_result) {
-        vlog(
-          cd_log.error,
-          "Error while sending request: {}",
-          objects_result.error());
-        co_return std::unexpected(metastore::errc::invalid_request);
+    for (const auto& [partition_id, partition_objects] :
+         replicated_builder.partitions_) {
+        if (!partition_objects.pending_objects_.empty()) {
+            vlog(
+              cd_log.error,
+              "Error while sending request: unfinished objects remain");
+            co_return std::unexpected(metastore::errc::invalid_request);
+        }
     }
-    for (auto& [partition_id, partition_objects] : objects_result.value()) {
+    for (auto& [partition_id, partition_objects] :
+         replicated_builder.partitions_) {
         rpc::replace_objects_request req;
         req.metastore_partition = partition_id;
         chunked_vector<new_object> new_objects;
-        for (auto& obj : partition_objects) {
+        for (auto& obj : partition_objects.finished_objects_) {
             new_objects.emplace_back(meta_to_rpc_obj(obj));
         }
         req.new_objects = std::move(new_objects);
@@ -538,18 +509,19 @@ replicated_metastore::get_end_offset_for_term(
 
 ss::future<std::expected<void, metastore::errc>>
 replicated_metastore::compact_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const metastore::object_metadata_builder& builder,
   const metastore::compaction_map_t& compaction_updates) {
-    auto replicated_builder = std::unique_ptr<replicated_object_builder>(
-      static_cast<replicated_object_builder*>(builder.release()));
+    auto& replicated_builder = static_cast<const replicated_object_builder&>(
+      builder);
 
-    auto objects_result = replicated_builder->release();
-    if (!objects_result) {
-        vlog(
-          cd_log.error,
-          "Error while sending request: {}",
-          objects_result.error());
-        co_return std::unexpected(metastore::errc::invalid_request);
+    for (const auto& [partition_id, partition_objects] :
+         replicated_builder.partitions_) {
+        if (!partition_objects.pending_objects_.empty()) {
+            vlog(
+              cd_log.error,
+              "Error while sending request: unfinished objects remain");
+            co_return std::unexpected(metastore::errc::invalid_request);
+        }
     }
     chunked_hash_map<
       model::partition_id,
@@ -561,7 +533,7 @@ replicated_metastore::compact_objects(
             vlog(cd_log.warn, "Unable to get metastore partition for {}", tp);
             co_return std::unexpected(errc::transport_error);
         }
-        if (!objects_result->contains(*metastore_partition)) {
+        if (!replicated_builder.partitions_.contains(*metastore_partition)) {
             vlog(
               cd_log.error,
               "Expected objects for partition {}",
@@ -571,11 +543,12 @@ replicated_metastore::compact_objects(
         compaction_updates_by_partition[*metastore_partition].emplace(
           tp, meta_to_rpc_compact_update(update));
     }
-    for (auto& [partition_id, partition_objects] : objects_result.value()) {
+    for (auto& [partition_id, partition_objects] :
+         replicated_builder.partitions_) {
         rpc::replace_objects_request req;
         req.metastore_partition = partition_id;
         chunked_vector<new_object> new_objects;
-        for (auto& obj : partition_objects) {
+        for (auto& obj : partition_objects.finished_objects_) {
             new_objects.emplace_back(meta_to_rpc_obj(obj));
         }
         req.new_objects = std::move(new_objects);

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -29,11 +29,10 @@ public:
     get_offsets(const model::topic_id_partition&) override;
 
     ss::future<std::expected<add_response, errc>> add_objects(
-      std::unique_ptr<object_metadata_builder>,
-      const term_offset_map_t&) override;
+      const object_metadata_builder&, const term_offset_map_t&) override;
 
     ss::future<std::expected<void, errc>>
-      replace_objects(std::unique_ptr<object_metadata_builder>) override;
+    replace_objects(const object_metadata_builder&) override;
 
     ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) override;
@@ -54,8 +53,7 @@ public:
       const model::topic_id_partition&, kafka::offset) override;
 
     ss::future<std::expected<void, errc>> compact_objects(
-      std::unique_ptr<object_metadata_builder>,
-      const compaction_map_t&) override;
+      const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
 

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -98,7 +98,8 @@ simple_object_builder::release() {
     if (!pending_objects_.empty()) {
         return std::unexpected(
           error{fmt::format(
-            "Builder still has {} pending object", pending_objects_.size())});
+            "Builder still has {} pending object(s)",
+            pending_objects_.size())});
     }
     return std::exchange(finished_objects_, {});
 }
@@ -151,15 +152,17 @@ simple_metastore::get_offsets(
 
 ss::future<std::expected<metastore::add_response, metastore::errc>>
 simple_metastore::add_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const metastore::object_metadata_builder& builder,
   const term_offset_map_t& terms) {
-    auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
-    auto objects_res = simple_builder->release();
-    if (!objects_res.has_value()) {
-        vlog(cd_log.error, "Failed to add: {}", objects_res.error());
+    auto& simple_builder = dynamic_cast<const simple_object_builder&>(builder);
+    if (!simple_builder.pending_objects_.empty()) {
+        vlog(
+          cd_log.error,
+          "Failed to add: builder still has {} pending object(s)",
+          simple_builder.pending_objects_.size());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
-    co_return co_await add_objects(objects_res.value(), terms);
+    co_return co_await add_objects(simple_builder.finished_objects_, terms);
 }
 
 ss::future<std::expected<metastore::add_response, metastore::errc>>
@@ -191,14 +194,16 @@ simple_metastore::add_objects(
 
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::replace_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder) {
-    auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
-    auto objects_res = simple_builder->release();
-    if (!objects_res.has_value()) {
-        vlog(cd_log.error, "Failed to replace: {}", objects_res.error());
+  const metastore::object_metadata_builder& builder) {
+    auto& simple_builder = dynamic_cast<const simple_object_builder&>(builder);
+    if (!simple_builder.pending_objects_.empty()) {
+        vlog(
+          cd_log.error,
+          "Failed to replace: builder still has {} pending object(s)",
+          simple_builder.pending_objects_.size());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
-    co_return co_await replace_objects(objects_res.value());
+    co_return co_await replace_objects(simple_builder.finished_objects_);
 }
 
 ss::future<std::expected<void, metastore::errc>>
@@ -458,15 +463,18 @@ simple_metastore::compact_objects(
 
 ss::future<std::expected<void, metastore::errc>>
 simple_metastore::compact_objects(
-  std::unique_ptr<metastore::object_metadata_builder> builder,
+  const metastore::object_metadata_builder& builder,
   const compaction_map_t& compaction_metas) {
-    auto* simple_builder = dynamic_cast<simple_object_builder*>(builder.get());
-    auto objects_res = simple_builder->release();
-    if (!objects_res.has_value()) {
-        vlog(cd_log.error, "Failed to compact: {}", objects_res.error());
+    auto& simple_builder = dynamic_cast<const simple_object_builder&>(builder);
+    if (!simple_builder.pending_objects_.empty()) {
+        vlog(
+          cd_log.error,
+          "Failed to compact: builder still has {} pending object(s)",
+          simple_builder.pending_objects_.size());
         co_return std::unexpected(metastore::errc::invalid_request);
     }
-    co_return co_await compact_objects(objects_res.value(), compaction_metas);
+    co_return co_await compact_objects(
+      simple_builder.finished_objects_, compaction_metas);
 }
 
 ss::future<

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -58,13 +58,12 @@ public:
     get_offsets(const model::topic_id_partition&) override;
 
     ss::future<std::expected<add_response, errc>> add_objects(
-      std::unique_ptr<object_metadata_builder>,
-      const term_offset_map_t&) override;
+      const object_metadata_builder&, const term_offset_map_t&) override;
     ss::future<std::expected<add_response, errc>> add_objects(
       const chunked_vector<object_metadata>&, const term_offset_map_t&);
 
     ss::future<std::expected<void, errc>>
-      replace_objects(std::unique_ptr<object_metadata_builder>) override;
+    replace_objects(const object_metadata_builder&) override;
     ss::future<std::expected<void, errc>>
     replace_objects(const chunked_vector<object_metadata>&);
 
@@ -87,8 +86,7 @@ public:
       const model::topic_id_partition&, kafka::offset) override;
 
     ss::future<std::expected<void, errc>> compact_objects(
-      std::unique_ptr<object_metadata_builder>,
-      const compaction_map_t&) override;
+      const object_metadata_builder&, const compaction_map_t&) override;
     ss::future<std::expected<void, errc>> compact_objects(
       const chunked_vector<object_metadata>&, const compaction_map_t&);
 

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -81,7 +81,7 @@ public:
               metastore::term_offset{
                 .term = model::term_id{0}, .first_offset = o{0}});
         }
-        auto add_res = meta.add_objects(std::move(objs), terms).get();
+        auto add_res = meta.add_objects(*objs, terms).get();
         ASSERT_TRUE_CORO(add_res.has_value());
     }
 };
@@ -139,7 +139,7 @@ TEST_F(ReplicatedMetastoreTest, TestAddNotFinished) {
         .size = 500,
       });
     ASSERT_TRUE(add_res.has_value()) << add_res.error();
-    auto commit_res = meta.add_objects(std::move(obj_builder), {}).get();
+    auto commit_res = meta.add_objects(*obj_builder, {}).get();
     ASSERT_FALSE(commit_res.has_value());
     ASSERT_EQ(commit_res.error(), metastore::errc::invalid_request);
 }
@@ -273,7 +273,7 @@ TEST_F(ReplicatedMetastoreTest, TestBasicCompact) {
         update.new_cleaned_range->last_offset = o{999};
         cmap[make_tp(i)] = std::move(update);
     }
-    auto cmp_res = meta.compact_objects(std::move(new_objs), cmap).get();
+    auto cmp_res = meta.compact_objects(*new_objs, cmap).get();
     ASSERT_TRUE(cmp_res.has_value()) << fmt::to_string(cmp_res.error());
 
     // Check across the partitions of the L1 metastore that we have the right
@@ -400,7 +400,7 @@ TEST_F(ReplicatedMetastoreTest, TestNotLeader) {
         terms[tp].emplace_back(
           metastore::term_offset{
             .term = model::term_id{0}, .first_offset = next_to_send});
-        auto commit_res = meta.add_objects(std::move(obj_builder), terms).get();
+        auto commit_res = meta.add_objects(*obj_builder, terms).get();
         if (!commit_res.has_value()) {
             while (true) {
                 if (ss::lowres_clock::now() > deadline) {
@@ -465,7 +465,7 @@ TEST_F(ReplicatedMetastoreTest, TestInvalidTermRequest) {
     }
     // This constitutes an incorrectly formed request, and is not expected
     // ever, hence overall failure.
-    auto add_res = meta.add_objects(std::move(objs), terms).get();
+    auto add_res = meta.add_objects(*objs, terms).get();
     ASSERT_FALSE(add_res.has_value());
     ASSERT_EQ(add_res.error(), metastore::errc::invalid_request);
 }
@@ -500,7 +500,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetTermForOffset) {
       metastore::term_offset{
         .term = model::term_id{2}, .first_offset = o{100}});
 
-    auto add_res = meta.add_objects(std::move(obj_builder), terms).get();
+    auto add_res = meta.add_objects(*obj_builder, terms).get();
     ASSERT_TRUE(add_res.has_value());
 
     const auto assert_term_eq = [&](kafka::offset o, model::term_id t) {
@@ -559,7 +559,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
       metastore::term_offset{
         .term = model::term_id{2}, .first_offset = o{100}});
 
-    auto add_res = meta.add_objects(std::move(obj_builder), terms).get();
+    auto add_res = meta.add_objects(*obj_builder, terms).get();
     ASSERT_TRUE(add_res.has_value());
 
     auto assert_end_offset_eq = [&](

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1108,10 +1108,9 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_TRUE(add_res.has_value());
         auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
-        auto add_obj_res = m.add_objects(
-                              std::move(ob),
-                              terms_builder().add(tid_a, 0_tm, 0_o).build())
-                             .get();
+        auto add_obj_res
+          = m.add_objects(*ob, terms_builder().add(tid_a, 0_tm, 0_o).build())
+              .get();
         ASSERT_TRUE(add_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();
@@ -1135,10 +1134,9 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_TRUE(add_res.has_value());
         auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
-        auto add_obj_res = m.add_objects(
-                              std::move(ob),
-                              terms_builder().add(tid_a, 0_tm, 10_o).build())
-                             .get();
+        auto add_obj_res
+          = m.add_objects(*ob, terms_builder().add(tid_a, 0_tm, 10_o).build())
+              .get();
         ASSERT_TRUE(add_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();
@@ -1162,7 +1160,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_TRUE(add_res.has_value());
         auto fin_res = ob->finish(o_a, 0, 1000);
         ASSERT_TRUE(fin_res.has_value());
-        auto replace_obj_res = m.replace_objects(std::move(ob)).get();
+        auto replace_obj_res = m.replace_objects(*ob).get();
         ASSERT_TRUE(replace_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();
@@ -1189,8 +1187,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
 
         cm_builder cmb;
         cmb.clean(tid_a, 10_o, 19_o);
-        auto compact_obj_res
-          = m.compact_objects(std::move(ob), cmb.build()).get();
+        auto compact_obj_res = m.compact_objects(*ob, cmb.build()).get();
         ASSERT_TRUE(compact_obj_res.has_value());
 
         auto offsets_res = m.get_offsets(tp_a).get();

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -558,7 +558,7 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
     }
 
     auto add_objects_result = co_await _metastore->add_objects(
-      std::move(meta_builder), terms);
+      *meta_builder, terms);
     if (!add_objects_result.has_value()) {
         vlog(
           lg.error,


### PR DESCRIPTION
Change add_objects, replace_objects, and commit_objects method signatures to take const refs instead of taking unique_ptr by value. This enables retry scenarios where the builder needs to remain usable after the call.

The replicated metastore's release method is no longer used and is removed. The simple metastore still uses this method for testing, so it remains.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
