### PR TITLE
ct: Add write request scheduler

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -133,6 +133,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/pipeline:read_pipeline",
         "//src/v/cloud_topics/level_zero/pipeline:write_pipeline",
         "//src/v/cloud_topics/level_zero/reader:fetch_handler",
+        "//src/v/cloud_topics/level_zero/write_request_scheduler",
         "//src/v/model",
         "//src/v/ssx:sharded_service_container",
         "//src/v/storage",

--- a/src/v/cloud_topics/data_plane_impl.cc
+++ b/src/v/cloud_topics/data_plane_impl.cc
@@ -20,6 +20,7 @@
 #include "cloud_topics/level_zero/pipeline/read_pipeline.h"
 #include "cloud_topics/level_zero/pipeline/write_pipeline.h"
 #include "cloud_topics/level_zero/reader/fetch_request_handler.h"
+#include "cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h"
 #include "model/fundamental.h"
 #include "ssx/sharded_service_container.h"
 #include "storage/api.h"
@@ -51,6 +52,11 @@ public:
         co_await construct_service(_write_pipeline);
 
         co_await construct_service(
+          _write_req_scheduler, ss::sharded_parameter([this] {
+              return _write_pipeline.local().register_write_pipeline_stage();
+          }));
+
+        co_await construct_service(
           _batcher,
           ss::sharded_parameter([this] {
               return _write_pipeline.local().register_write_pipeline_stage();
@@ -77,6 +83,8 @@ public:
     }
 
     seastar::future<> start() override {
+        co_await _write_req_scheduler.invoke_on_all(
+          [](auto& s) { return s.start(); });
         co_await _batcher.invoke_on_all([](auto& s) { return s.start(); });
         co_await _fetch_handler.invoke_on_all(
           [](auto& s) { return s.start(); });
@@ -135,6 +143,7 @@ private:
     ss::sharded<l0::cluster_services> _cluster_services;
     // Write path
     ss::sharded<l0::write_pipeline<>> _write_pipeline;
+    ss::sharded<l0::write_request_scheduler> _write_req_scheduler;
     ss::sharded<l0::batcher<>> _batcher;
     // Read path
     ss::sharded<l0::read_pipeline<>> _read_pipeline;

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -48,10 +48,6 @@ batcher<Clock>::batcher(
   , _upload_backoff_interval(
       config::shard_local_cfg()
         .cloud_storage_upload_loop_initial_backoff_ms.bind())
-  , _upload_interval(
-      config::shard_local_cfg()
-        .cloud_storage_upload_loop_initial_backoff_ms
-        .bind()) // TODO: use different config
   , _rtc(_as)
   , _logger(cd_log, _rtc)
   , _stage(std::move(stage))
@@ -224,8 +220,7 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
     bool more_work = false;
     while (!_as.abort_requested()) {
         if (!more_work) {
-            auto wait_res = co_await _stage.wait_until(
-              10_MiB, Clock::now() + _upload_interval(), &_as);
+            auto wait_res = co_await _stage.wait_next(&_as);
             if (wait_res.has_error()) {
                 // Shutting down
                 vlog(

--- a/src/v/cloud_topics/level_zero/batcher/batcher.h
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.h
@@ -108,7 +108,6 @@ private:
     cloud_storage_clients::bucket_name _bucket;
     config::binding<std::chrono::milliseconds> _upload_timeout;
     config::binding<std::chrono::milliseconds> _upload_backoff_interval;
-    config::binding<std::chrono::milliseconds> _upload_interval;
 
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -231,6 +231,11 @@ void write_pipeline<Clock>::stage::push_next_stage(
 }
 
 template<class Clock>
+void write_pipeline<Clock>::stage::signal_next_stage() {
+    _parent->signal(_parent->next_stage(_ps));
+}
+
+template<class Clock>
 write_pipeline<Clock>::write_requests_list
 write_pipeline<Clock>::stage::pull_write_requests(
   size_t max_bytes, size_t max_requests) {

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -127,7 +127,7 @@ write_pipeline<Clock>::write_and_debounce(
 }
 
 template<class Clock>
-void write_pipeline<Clock>::reenqueue(write_request<Clock>& r) {
+void write_pipeline<Clock>::reenqueue(write_request<Clock>& r, bool signal) {
     if (r._hook.is_linked()) {
         r._hook.unlink();
     }
@@ -143,7 +143,9 @@ void write_pipeline<Clock>::reenqueue(write_request<Clock>& r) {
         // and notify the corresponding event filter.
         r.stage = this->next_stage(r.stage);
         this->get_pending().push_back(r);
-        this->signal(r.stage);
+        if (signal) {
+            this->signal(r.stage);
+        }
     }
 }
 
@@ -223,8 +225,9 @@ bool write_pipeline<Clock>::stage::stopped() const noexcept {
 }
 
 template<class Clock>
-void write_pipeline<Clock>::stage::push_next_stage(write_request<Clock>& req) {
-    _parent->reenqueue(req);
+void write_pipeline<Clock>::stage::push_next_stage(
+  write_request<Clock>& req, bool signal) {
+    _parent->reenqueue(req, signal);
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -72,6 +72,11 @@ public:
         /// \param signal If true signal the next stage that new write request
         void push_next_stage(write_request<Clock>& r, bool signal = true);
 
+        /// Notify the next stage that new write requests are available.
+        /// This method should be invoked after 'push_next_stage(..., false)'
+        /// to avoid stalling the pipeline.
+        void signal_next_stage();
+
         /// Extract write requests out of the pipeline atomically.
         /// The caller is responsible for handling each write request.
         /// The request could be either returned using 'push_next_stage'

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -68,7 +68,9 @@ public:
         /// Return write request back into the pipeline.
         /// The write request advances to the next stage of the
         /// pipeline.
-        void push_next_stage(write_request<Clock>&);
+        /// \param r Write request to reenqueue
+        /// \param signal If true signal the next stage that new write request
+        void push_next_stage(write_request<Clock>& r, bool signal = true);
 
         /// Extract write requests out of the pipeline atomically.
         /// The caller is responsible for handling each write request.
@@ -181,7 +183,10 @@ private:
     /// before back into the pipeline.
     /// The method allows to reenqueue requests returned by get_write_requests
     /// method.
-    void reenqueue(write_request<Clock>&);
+    /// \param req Write request to reenqueue
+    /// \param signal If true signal the next stage that new write request is
+    /// available
+    void reenqueue(write_request<Clock>& req, bool signal = true);
 
     // Current bytes (gauge)
     size_t _current_size{0};

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -160,12 +160,14 @@ ss::future<> write_request_scheduler::apply_time_based_fallback() {
     // will always be able to handle the addition L0 upload (e.g. it has
     // borrowing mechanism to do this).
 
-    for (auto& req : shard_bytes) {
-        vlog(
-          cd_log.trace,
-          "map result: {} requests, {} bytes",
-          req.shard,
-          req.bytes);
+    if (cd_log.is_enabled(ss::log_level::trace)) {
+        for (auto& req : shard_bytes) {
+            vlog(
+              cd_log.trace,
+              "map result: {} requests, {} bytes",
+              req.shard,
+              req.bytes);
+        }
     }
 
     // Find the shard with the most bytes to write

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -74,11 +74,6 @@ ss::future<> write_request_scheduler::stop() {
     co_await _gate.close();
 }
 
-struct shard_info {
-    ss::shard_id shard;
-    size_t bytes;
-};
-
 size_t write_request_scheduler::shard_bytes() noexcept {
     // Count bytes but take limits into account.
     size_t total_bytes = 0;
@@ -130,6 +125,34 @@ ss::future<> write_request_scheduler::bg_data_threshold() {
               return l0::request_processing_result::advance_and_continue;
           });
     }
+}
+
+ss::future<>
+write_request_scheduler::pull_and_roundtrip(std::vector<shard_info> infos) {
+    // This method is invoked by the target shard to pull requests from
+    // other shards and forward them to its own pipeline.
+    std::vector<ss::future<>> in_flight;
+    for (const auto& info : infos) {
+        if (ss::this_shard_id() == info.shard) {
+            // Fast path: process requests locally
+            // This shard is the one that has the most data.
+            _stage.process([](write_request<>&) noexcept {
+                return request_processing_result::advance_and_continue;
+            });
+        } else {
+            // Forward requests to target shard by proxying
+            // write requests
+            if (info.bytes > 0) {
+                in_flight.push_back(
+                  container().invoke_on(
+                    info.shard,
+                    [target = ss::this_shard_id()](write_request_scheduler& s) {
+                        return s.forward_to(target);
+                    }));
+            }
+        }
+    }
+    co_await ss::when_all_succeed(in_flight.begin(), in_flight.end());
 }
 
 ss::future<> write_request_scheduler::apply_time_based_fallback() {
@@ -193,21 +216,9 @@ ss::future<> write_request_scheduler::apply_time_based_fallback() {
     // requests that are already on the target shard.
 
     if (max_shard_bytes > 0) {
-        co_await container().invoke_on_all(
-          [this, target_shard](write_request_scheduler& scheduler) {
-              if (ss::this_shard_id() == target_shard) {
-                  // Fast path: process requests locally
-                  // This shard is the one that has the most data.
-                  scheduler._stage.process([this](write_request<>& r) noexcept {
-                      _probe.register_time_fallback(r.size_bytes());
-                      return request_processing_result::advance_and_continue;
-                  });
-              } else {
-                  // Forward requests to target shard by proxying
-                  // write requests
-                  return scheduler.forward_to(target_shard);
-              }
-              return ss::now();
+        co_await container().invoke_on(
+          target_shard, [shard_bytes](write_request_scheduler& scheduler) {
+              return scheduler.pull_and_roundtrip(shard_bytes);
           });
     }
 }

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -132,25 +132,64 @@ write_request_scheduler::pull_and_roundtrip(std::vector<shard_info> infos) {
     // This method is invoked by the target shard to pull requests from
     // other shards and forward them to its own pipeline.
     std::vector<ss::future<>> in_flight;
+    // 1. Schedule all other shards to forward their requests.
+    // 2. Process own requests to trigger the signal.
+    ss::gate target_gate;
     for (const auto& info : infos) {
-        if (ss::this_shard_id() == info.shard) {
-            // Fast path: process requests locally
-            // This shard is the one that has the most data.
-            _stage.process([](write_request<>&) noexcept {
-                return request_processing_result::advance_and_continue;
-            });
-        } else {
+        if (ss::this_shard_id() != info.shard) {
             // Forward requests to target shard by proxying
             // write requests
             if (info.bytes > 0) {
+                // This is not conventional use of the gate. The unique_ptr is
+                // used as a RAII container to pass this gate holder into the
+                // 'roundtrip' method. The 'roundtrip' method will be invoked on
+                // another shard. It guarantees that the gate holder will not be
+                // destroyed while it's running on another shard. To make it
+                // safe the pointer is wrapped with the foreign_ptr. Even if the
+                // exception will be thrown while on another shard the gate
+                // holder will be disposed on the target shard.
+                //
+                // The 'roundtrip' method will submit the continuation back to
+                // the target shard that owns the gate and will eventually
+                // destroy the holder. The target gate will be kept open until
+                // all shards finish forwarding their requests. The foreign_ptr
+                // has zero overhead when disposed on the original shard. It's
+                // just a safety measure, not a correctness requirement.
+                auto ptr = ss::make_foreign(
+                  std::make_unique<ss::gate::holder>(target_gate.hold()));
                 in_flight.push_back(
                   container().invoke_on(
                     info.shard,
-                    [target = ss::this_shard_id()](write_request_scheduler& s) {
-                        return s.forward_to(target);
+                    [target = ss::this_shard_id(),
+                     ptr = std::move(ptr)](write_request_scheduler& s) mutable {
+                        return s.forward_to(target, std::move(ptr));
                     }));
             }
         }
+    }
+    // Wait until all shards have scheduled their requests
+    co_await target_gate.close();
+    // Submit own requests to the pipeline
+    bool signaled = false;
+    for (const auto& info : infos) {
+        if (ss::this_shard_id() == info.shard && info.bytes > 0) {
+            // Fast path: process requests locally
+            // This shard is the one that has the most data.
+            _stage.process([&signaled](write_request<>&) noexcept {
+                signaled = true;
+                return request_processing_result::advance_and_continue;
+            });
+            break;
+        }
+    }
+    if (!signaled) {
+        // It is guaranteed that the shard that has the most data will become
+        // the target shard. But it is also possible that the data threshold
+        // policy will trigger the upload on this shard. In this case the loop
+        // above will see no write requests. Other shards are depositing their
+        // requests to the target shard without signalling the next stage. So we
+        // need to signal it here.
+        _stage.signal_next_stage();
     }
     co_await ss::when_all_succeed(in_flight.begin(), in_flight.end());
 }
@@ -210,10 +249,23 @@ ss::future<> write_request_scheduler::apply_time_based_fallback() {
       max_shard_bytes);
 
     // We can forward write requests to the target shard now
-    // Every shards forwards its own requests. This shard sends
-    // the requests accumulated in the previous step to the
-    // original shard first. There is a fast path for the
-    // requests that are already on the target shard.
+    // Every shards forwards its own requests.
+    //
+    // The information flow:
+    // shard 0:      collect information -> decide target shard
+    // target shard: call 'pull_and_roundtrip' and pass the gate holder
+    // target shard: invoke 'forward_to' on every shard that has data
+    // shard[i]:     call 'roundtrip' method on shard[i], pass gate holder
+    // shard[i]:     invoke 'proxy_write_request' on target shard, pass gate
+    //               holder
+    // target shard: enqueue shard[i] requests to the target shard's pipeline
+    //               and dispose the gate holder that belongs to the
+    //               target shard
+    // target shard: wait until all requests are enqueued by waiting
+    //               on the gate
+    // target shard: process own requests and wait until all
+    //               'proxy_write_request' calls are done on all shards
+    //               by waiting on the gate.
 
     if (max_shard_bytes > 0) {
         co_await container().invoke_on(
@@ -263,7 +315,12 @@ ss::future<> write_request_scheduler::bg_time_based_fallback() {
 /// then copy it and enqueue it to the pipeline on this shard.
 /// Then await the response and return it.
 ss::future<std::expected<write_request_scheduler::foreign_ptr_t, errc>>
-write_request_scheduler::proxy_write_request(write_request<>* req) noexcept {
+write_request_scheduler::proxy_write_request(
+  write_request<>* req, ss::gate::holder target_gate_holder) noexcept {
+    // This is executed in the context of the target shard.
+    // It is safe to dispose the gate holder here because
+    // the holder was created on the target shard and
+    // it will be destroyed on the target shard as well.
     auto h = _gate.hold();
     _probe.register_time_fallback(req->size_bytes());
     _probe.register_receive_xshard(req->size_bytes());
@@ -273,7 +330,8 @@ write_request_scheduler::proxy_write_request(write_request<>* req) noexcept {
       req->expiration_time,
       _stage.id());
     auto fut = proxy.response.get_future();
-    _stage.push_next_stage(proxy);
+    _stage.push_next_stage(proxy, false);
+    target_gate_holder.release();
     auto extents_fut = co_await ss::coroutine::as_future(std::move(fut));
     if (extents_fut.failed()) {
         auto ex = extents_fut.get_exception();
@@ -309,7 +367,12 @@ void write_request_scheduler::ack_write_response(
 }
 
 ss::future<> write_request_scheduler::roundtrip(
-  ss::shard_id shard, write_pipeline<>::write_requests_list list) {
+  ss::shard_id shard,
+  write_pipeline<>::write_requests_list list,
+  ss::foreign_ptr<gate_holder_ptr> target_shard_gate_holder) {
+    // This is executed in the context of the shard that owns the data.
+    // The method submits the continuation back to the target shard
+    // to complete the operation.
     auto h = _gate.hold();
     // Temporary storage for x-shard request and response correlation.
     using response_t
@@ -324,14 +387,19 @@ ss::future<> write_request_scheduler::roundtrip(
         _probe.register_send_xshard(req.size_bytes());
     }
     co_await container().invoke_on(
-      shard, [&results](write_request_scheduler& balancer) mutable {
+      shard,
+      [&results, gh = std::move(target_shard_gate_holder)](
+        write_request_scheduler& balancer) mutable {
+          // This is executed on the target shard
           chunked_vector<ss::future<response_t>> futures;
           for (auto& r : results) {
               vassert(
                 r.response.has_value() == false,
                 "Should not have response yet");
-              futures.emplace_back(balancer.proxy_write_request(r.request));
+              futures.emplace_back(balancer.proxy_write_request(
+                r.request, /*copy gate holder*/ *gh));
           }
+          gh->release();
           return ss::when_all(futures.begin(), futures.end())
             .then([&results](auto fut) {
                 for (size_t i = 0; i < results.size(); i++) {
@@ -349,10 +417,14 @@ ss::future<> write_request_scheduler::roundtrip(
     }
 }
 
-ss::future<> write_request_scheduler::forward_to(ss::shard_id target_shard) {
+ss::future<> write_request_scheduler::forward_to(
+  ss::shard_id target_shard,
+  ss::foreign_ptr<gate_holder_ptr> target_shard_gate_holder) {
+    // Owning shard
     auto req = _stage.pull_write_requests(
       _max_buffer_size(), _max_cardinality());
-    co_await roundtrip(target_shard, std::move(req));
+    co_await roundtrip(
+      target_shard, std::move(req), std::move(target_shard_gate_holder));
 }
 
 } // namespace cloud_topics::l0

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -50,6 +50,11 @@ class write_request_scheduler
   : public ss::peering_sharded_service<write_request_scheduler> {
     friend struct write_request_balancer_accessor;
 
+    struct shard_info {
+        ss::shard_id shard;
+        size_t bytes;
+    };
+
 public:
     explicit write_request_scheduler(write_pipeline<>::stage s);
 
@@ -67,6 +72,11 @@ private:
     /// This method implements the actual fallback mechanism.
     /// It is invoked by the 'bg_time_based_fallback' method.
     ss::future<> apply_time_based_fallback();
+    /// Target shard pulls write requests from pipelines of
+    /// other shards and forwards them to its own pipeline.
+    /// Then it propagates the responses back to the original
+    /// shards.
+    ss::future<> pull_and_roundtrip(std::vector<shard_info> infos);
 
     /// This fiber runs on every shard and is triggered by
     /// the data accumulation threshold. If enough data is accumulated

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.h
@@ -69,13 +69,20 @@ private:
     /// it collects write requests and triggers
     /// uploads.
     ss::future<> bg_time_based_fallback();
+
     /// This method implements the actual fallback mechanism.
     /// It is invoked by the 'bg_time_based_fallback' method.
     ss::future<> apply_time_based_fallback();
+
     /// Target shard pulls write requests from pipelines of
     /// other shards and forwards them to its own pipeline.
     /// Then it propagates the responses back to the original
     /// shards.
+    /// \param infos is a list of shards that have write requests
+    ///        to forward (could be outdated).
+    /// \note The method is invoked on the target shard. It communicates
+    ///       with other shards to instruct them to forward their requests
+    ///       to the target shard to upload.
     ss::future<> pull_and_roundtrip(std::vector<shard_info> infos);
 
     /// This fiber runs on every shard and is triggered by
@@ -93,18 +100,49 @@ private:
     using foreign_ptr_t
       = ss::foreign_ptr<ss::lw_shared_ptr<chunked_vector<extent_meta>>>;
 
-    /// Make a copy of the write request and enqueue it
-    ss::future<std::expected<foreign_ptr_t, errc>>
-    proxy_write_request(write_request<>* req) noexcept;
+    using gate_holder_ptr = std::unique_ptr<ss::gate::holder>;
 
-    ss::future<>
-    roundtrip(ss::shard_id shard, write_pipeline<>::write_requests_list list);
+    /// Make a copy of a single write request and enqueue it
+    /// to the pipeline on the target shard. Wait until it's
+    /// processed and return the response.
+    ///
+    /// \param req is a write request to forward
+    /// \param target_gate_holder is a pointer to the gate holder owned by the
+    ///        target shard
+    /// \note The method is invoked on the target shard (the shard that uploads
+    /// the data).
+    ss::future<std::expected<foreign_ptr_t, errc>> proxy_write_request(
+      write_request<>* req, ss::gate::holder target_gate_holder) noexcept;
 
+    /// Forward all write requests to the target shard
+    /// \param shard is a target shard that should perform the upload
+    /// \param list is a list of write requests to forward
+    /// \param target_shard_gate_holder is a pointer to the gate holder owned by
+    /// the
+    ///        target shard
+    /// \note The method is invoked on the shard that owns the data. It submits
+    /// the continuation
+    ///       to the target shard to complete the operation.
+    ss::future<> roundtrip(
+      ss::shard_id shard,
+      write_pipeline<>::write_requests_list list,
+      ss::foreign_ptr<gate_holder_ptr> target_shard_gate_holder);
+
+    /// Acknowledge the write request with the response
+    /// \param req is a write request to acknowledge
+    /// \param resp is a response to propagate
+    /// \note The response is created on the target shard, the method
+    ///       is invoked on the shard that owns the write request.
     void ack_write_response(
       write_request<>* req, std::expected<foreign_ptr_t, errc> resp);
 
     /// Forward all write requests to the target shard
-    ss::future<> forward_to(ss::shard_id shard);
+    /// \param shard is a target shard that should perform the upload
+    /// \param target_shard_gate_holder is a pointer to the gate holder
+    /// \note The method is invoked on the shard that owns the data.
+    ss::future<> forward_to(
+      ss::shard_id shard,
+      ss::foreign_ptr<gate_holder_ptr> target_shard_gate_holder);
 
     write_pipeline<>::stage _stage;
     ss::abort_source _as;


### PR DESCRIPTION
This PR:
- simplifies the `batcher` by removing scheduling functionality implemented in `write_request_scheduler`;
- allow pipeline stages to interact more precisely by controlling the way the stages are notified;
- modify `write_request_scheduler` to allow it to singal the `batcher` after all write requests are enqueued to avoid spurious uploads;



<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none