### PR TITLE
ct/l1: squash unchecked optional access in replicated metastore

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
@@ -56,7 +56,7 @@ protected:
     }
 
     void make_l1_objects(std::vector<tidp_batches_t>& batches_by_tidp) {
-        auto meta_builder = _metastore.object_builder();
+        auto meta_builder = _metastore.object_builder().get().value();
 
         // First record the object ID for each tidp,
         std::map<model::topic_id_partition, l1::object_id> oid_by_tidp;

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h
@@ -61,7 +61,8 @@ protected:
         // First record the object ID for each tidp,
         std::map<model::topic_id_partition, l1::object_id> oid_by_tidp;
         for (auto& [tidp, unused] : batches_by_tidp) {
-            oid_by_tidp[tidp] = meta_builder->get_or_create_object_for(tidp);
+            oid_by_tidp[tidp]
+              = meta_builder->get_or_create_object_for(tidp).value();
         }
 
         // Then create output streams and builders for each object.

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -281,7 +281,7 @@ TEST_F(l1_reader_test, missing_object) {
 
     // Register object in metastore but don't upload.
     // This is corruption and readers should throw.
-    auto builder = _metastore.object_builder();
+    auto builder = _metastore.object_builder().get().value();
     auto oid = builder->get_or_create_object_for(tidp).value();
     builder
       ->add(
@@ -327,7 +327,7 @@ TEST_F(l1_reader_test, empty_offset_range) {
     // Mimic an object from which all partition data has been compacted.
     // The object has no data for the partition, but is registered
     // to cover a non-empty offset range in the metastore.
-    auto meta_builder = _metastore.object_builder();
+    auto meta_builder = _metastore.object_builder().get().value();
 
     auto oid = meta_builder->get_or_create_object_for(tidp).value();
 

--- a/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/tests/reader_test.cc
@@ -282,7 +282,7 @@ TEST_F(l1_reader_test, missing_object) {
     // Register object in metastore but don't upload.
     // This is corruption and readers should throw.
     auto builder = _metastore.object_builder();
-    auto oid = builder->get_or_create_object_for(tidp);
+    auto oid = builder->get_or_create_object_for(tidp).value();
     builder
       ->add(
         oid,
@@ -329,7 +329,7 @@ TEST_F(l1_reader_test, empty_offset_range) {
     // to cover a non-empty offset range in the metastore.
     auto meta_builder = _metastore.object_builder();
 
-    auto oid = meta_builder->get_or_create_object_for(tidp);
+    auto oid = meta_builder->get_or_create_object_for(tidp).value();
 
     auto buf = iobuf{};
     auto builder = l1::object_builder::create(

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -89,6 +89,8 @@ public:
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
+    ss::future<bool> ensure_topic_exists();
+
 private:
     using proto_t = cloud_topics::l1::rpc::impl::l1_rpc_client_protocol;
     using client = cloud_topics::l1::rpc::impl::l1_rpc_client_protocol;
@@ -112,8 +114,6 @@ private:
           || request_has_topic_id_partition<req_t>;
     }
     ss::future<typename req_t::resp_t> process(req_t req, bool local_only);
-
-    ss::future<bool> ensure_topic_exists();
 
     ss::future<rpc::add_objects_reply> add_objects_locally(
       rpc::add_objects_request, const model::ntp& metastore_ntp, ss::shard_id);

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -131,7 +131,9 @@ public:
         kafka::offset start_offset;
         kafka::offset next_offset;
     };
-    virtual std::unique_ptr<object_metadata_builder> object_builder() = 0;
+    virtual ss::future<
+      std::expected<std::unique_ptr<object_metadata_builder>, errc>>
+    object_builder() = 0;
 
     struct term_offset {
         model::term_id term;

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -107,9 +107,8 @@ public:
         // appropriate for the given partition. Potentially shares the object
         // with another partition, if the object is allowed by the metastore to
         // be shared by the other partition.
-        virtual object_id
-        get_or_create_object_for(const model::topic_id_partition&)
-          = 0;
+        virtual std::expected<object_id, error>
+        get_or_create_object_for(const model::topic_id_partition&) = 0;
 
         // Removes a pending object from the builder. The object must be in the
         // pending state. Further calls to get_or_create_object_for() will not

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -234,9 +234,23 @@ replicated_object_builder::release() {
 replicated_metastore::replicated_metastore(frontend& fe)
   : fe_(fe) {}
 
-std::unique_ptr<metastore::object_metadata_builder>
+ss::future<std::expected<
+  std::unique_ptr<metastore::object_metadata_builder>,
+  metastore::errc>>
 replicated_metastore::object_builder() {
-    return std::make_unique<replicated_object_builder>(fe_);
+    auto ensure_fut = co_await ss::coroutine::as_future(
+      fe_.ensure_topic_exists());
+    if (ensure_fut.failed()) {
+        auto ex = ensure_fut.get_exception();
+        vlog(cd_log.warn, "Error while ensuring metastore topic: {}", ex);
+        co_return std::unexpected(errc::transport_error);
+    }
+    auto success = ensure_fut.get();
+    if (!success) {
+        vlog(cd_log.warn, "Ensuring metastore topic did not succeed");
+        co_return std::unexpected(errc::transport_error);
+    }
+    co_return std::make_unique<replicated_object_builder>(fe_);
 }
 
 ss::future<std::expected<metastore::offsets_response, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -162,6 +162,10 @@ std::expected<void, replicated_object_builder::error>
 replicated_object_builder::add(
   object_id oid, metastore::object_metadata::ntp_metadata ntp_meta) {
     auto metastore_pid = fe_.metastore_partition(ntp_meta.tidp);
+    if (!metastore_pid) {
+        return std::unexpected(
+          error{"could not determine metastore partition for add()"});
+    }
     auto& partition_objects = partitions_[*metastore_pid];
     auto it = partition_objects.pending_objects_.find(oid);
     if (it == partition_objects.pending_objects_.end()) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -92,7 +92,7 @@ public:
       = delete;
     replicated_object_builder& operator=(replicated_object_builder&&) = delete;
 
-    object_id
+    std::expected<object_id, error>
     get_or_create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>
@@ -120,9 +120,15 @@ private:
     chunked_hash_map<model::partition_id, partitioned_objects> partitions_;
 };
 
-object_id replicated_object_builder::get_or_create_object_for(
+std::expected<object_id, replicated_object_builder::error>
+replicated_object_builder::get_or_create_object_for(
   const model::topic_id_partition& tidp) {
     auto metastore_pid = fe_.metastore_partition(tidp);
+    if (!metastore_pid) {
+        return std::unexpected(
+          error{"could not determine metastore partition for "
+                "get_or_create_object_for()"});
+    }
     auto& partition_objects = partitions_[*metastore_pid];
 
     if (partition_objects.pending_objects_.empty()) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -22,7 +22,8 @@ class replicated_metastore : public metastore {
 public:
     explicit replicated_metastore(frontend& fe);
 
-    std::unique_ptr<object_metadata_builder> object_builder() override;
+    ss::future<std::expected<std::unique_ptr<object_metadata_builder>, errc>>
+    object_builder() override;
 
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -122,9 +122,11 @@ new_object make_new_object(const metastore::object_metadata& o) {
     return new_o;
 }
 
-std::unique_ptr<metastore::object_metadata_builder>
+ss::future<std::expected<
+  std::unique_ptr<metastore::object_metadata_builder>,
+  metastore::errc>>
 simple_metastore::object_builder() {
-    return std::make_unique<simple_object_builder>();
+    co_return std::make_unique<simple_object_builder>();
 }
 
 ss::future<std::expected<metastore::offsets_response, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -35,7 +35,8 @@ term_state_update_t make_terms_update(const metastore::term_offset_map_t& m) {
 }
 } // namespace
 
-object_id simple_object_builder::get_or_create_object_for(
+std::expected<object_id, simple_object_builder::error>
+simple_object_builder::get_or_create_object_for(
   const model::topic_id_partition&) {
     // The simple metastore isn't partitioned at all, so have all partitions
     // blindly share any existing object.

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -51,7 +51,8 @@ private:
 class domain_manager;
 class simple_metastore : public metastore {
 public:
-    std::unique_ptr<object_metadata_builder> object_builder() override;
+    ss::future<std::expected<std::unique_ptr<object_metadata_builder>, errc>>
+    object_builder() override;
 
     ss::future<std::expected<offsets_response, errc>>
     get_offsets(const model::topic_id_partition&) override;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -29,7 +29,7 @@ public:
     simple_object_builder& operator=(const simple_object_builder&) = delete;
     simple_object_builder& operator=(simple_object_builder&&) = delete;
 
-    object_id
+    std::expected<object_id, error>
     get_or_create_object_for(const model::topic_id_partition&) override;
     std::expected<void, error> remove_pending_object(object_id) override;
     std::expected<void, error>

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -48,7 +48,7 @@ public:
       int partitions_count,
       int last_offset,
       std::unique_ptr<metastore::object_metadata_builder>* objs) {
-        auto ret = meta.object_builder();
+        auto ret = meta.object_builder().get().value();
         for (int i = 0; i < partitions_count; ++i) {
             auto tp = make_tp(i);
             auto oid = ret->get_or_create_object_for(tp).value();
@@ -89,7 +89,7 @@ public:
 TEST_F(ReplicatedMetastoreTest, TestMissingMetastore) {
     auto& app = get_ct_app(model::node_id{0});
     replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
-    auto obj_builder = meta.object_builder();
+    auto obj_builder = meta.object_builder().get().value();
     auto& tp_fe = get_node_application(model::node_id{0})
                     ->controller->get_topics_frontend()
                     .local();
@@ -108,13 +108,20 @@ TEST_F(ReplicatedMetastoreTest, TestMissingMetastore) {
     auto tp = make_tp(0);
     auto oid = obj_builder->get_or_create_object_for(tp);
     ASSERT_FALSE(oid.has_value());
+
+    // Creating an object builder should attempt to create the metastore topic
+    // since it doesn't exist.
+    auto builder_res = meta.object_builder().get();
+    ASSERT_TRUE(builder_res.has_value());
+    oid = builder_res.value()->get_or_create_object_for(tp);
+    ASSERT_TRUE(oid.has_value());
 }
 
 TEST_F(ReplicatedMetastoreTest, TestAddNotFinished) {
     auto& app = get_ct_app(model::node_id{0});
     replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
     auto tp = make_tp(0);
-    auto obj_builder = meta.object_builder();
+    auto obj_builder = meta.object_builder().get().value();
     auto oid = obj_builder->get_or_create_object_for(tp).value();
     auto add_res = obj_builder->add(
       oid,
@@ -136,7 +143,7 @@ TEST_F(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
     auto& app = get_ct_app(model::node_id{0});
     replicated_metastore m(app.get_sharded_l1_metastore_fe()->local());
     auto tp = make_tp(0);
-    auto ob = m.object_builder();
+    auto ob = m.object_builder().get().value();
 
     // pending object can be removed, but not twice
     auto oid = ob->get_or_create_object_for(tp).value();
@@ -367,7 +374,7 @@ TEST_F(ReplicatedMetastoreTest, TestNotLeader) {
             timed_out = true;
             break;
         }
-        auto obj_builder = meta.object_builder();
+        auto obj_builder = meta.object_builder().get().value();
         auto oid = obj_builder->get_or_create_object_for(tp).value();
         kafka::offset next_last{next_to_send() + 99};
         auto add_res = obj_builder->add(
@@ -464,7 +471,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetTermForOffset) {
 
     auto tp = make_tp(0);
 
-    auto obj_builder = meta.object_builder();
+    auto obj_builder = meta.object_builder().get().value();
     auto oid1 = obj_builder->get_or_create_object_for(tp).value();
     auto add_res1 = obj_builder->add(
       oid1,
@@ -523,7 +530,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
     auto tp = make_tp(0);
 
     // Set up initial objects with multiple terms
-    auto obj_builder = meta.object_builder();
+    auto obj_builder = meta.object_builder().get().value();
     auto oid1 = obj_builder->get_or_create_object_for(tp).value();
     auto add_res1 = obj_builder->add(
       oid1,

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -109,6 +109,11 @@ TEST_F(ReplicatedMetastoreTest, TestMissingMetastore) {
     auto oid = obj_builder->get_or_create_object_for(tp);
     ASSERT_FALSE(oid.has_value());
 
+    // Adding an object should fail immediately too because the metastore topic
+    // doesn't exist and we don't know how to partition objects.
+    auto add_res = obj_builder->add(create_object_id(), {});
+    ASSERT_FALSE(add_res.has_value());
+
     // Creating an object builder should attempt to create the metastore topic
     // since it doesn't exist.
     auto builder_res = meta.object_builder().get();

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -51,7 +51,7 @@ public:
         auto ret = meta.object_builder();
         for (int i = 0; i < partitions_count; ++i) {
             auto tp = make_tp(i);
-            auto oid = ret->get_or_create_object_for(tp);
+            auto oid = ret->get_or_create_object_for(tp).value();
             auto add_res = ret->add(
               oid,
               metastore::object_metadata::ntp_metadata{
@@ -86,12 +86,36 @@ public:
     }
 };
 
+TEST_F(ReplicatedMetastoreTest, TestMissingMetastore) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+    auto obj_builder = meta.object_builder();
+    auto& tp_fe = get_node_application(model::node_id{0})
+                    ->controller->get_topics_frontend()
+                    .local();
+    tp_fe.dispatch_delete_topics({model::l1_metastore_nt}, 10s).get();
+    for (const auto& node_id : instance_ids()) {
+        auto& tp_state = get_node_application(node_id)
+                           ->controller->get_topics_state()
+                           .local();
+        RPTEST_REQUIRE_EVENTUALLY(10s, [&tp_state] {
+            return !tp_state.contains(model::l1_metastore_nt);
+        });
+    }
+
+    // We won't be able to find the partition of the metastore topic because it
+    // doesn't exist.
+    auto tp = make_tp(0);
+    auto oid = obj_builder->get_or_create_object_for(tp);
+    ASSERT_FALSE(oid.has_value());
+}
+
 TEST_F(ReplicatedMetastoreTest, TestAddNotFinished) {
     auto& app = get_ct_app(model::node_id{0});
     replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
     auto tp = make_tp(0);
     auto obj_builder = meta.object_builder();
-    auto oid = obj_builder->get_or_create_object_for(tp);
+    auto oid = obj_builder->get_or_create_object_for(tp).value();
     auto add_res = obj_builder->add(
       oid,
       metastore::object_metadata::ntp_metadata{
@@ -115,12 +139,12 @@ TEST_F(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
     auto ob = m.object_builder();
 
     // pending object can be removed, but not twice
-    auto oid = ob->get_or_create_object_for(tp);
+    auto oid = ob->get_or_create_object_for(tp).value();
     ASSERT_TRUE(ob->remove_pending_object(oid).has_value());
     ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
 
     // after removal, object id shouldn't be reused in this builder
-    auto oid2 = ob->get_or_create_object_for(tp);
+    auto oid2 = ob->get_or_create_object_for(tp).value();
     ASSERT_NE(oid, oid2);
     oid = oid2;
 
@@ -134,12 +158,12 @@ TEST_F(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
       ob->add(oid, metastore::object_metadata::ntp_metadata{.tidp = tp})
         .has_value());
 
-    oid2 = ob->get_or_create_object_for(tp);
+    oid2 = ob->get_or_create_object_for(tp).value();
     ASSERT_NE(oid, oid2);
     oid = oid2;
 
     // finished object cannot be removed
-    oid = ob->get_or_create_object_for(tp);
+    oid = ob->get_or_create_object_for(tp).value();
     ASSERT_TRUE(ob->finish(oid, 0, 0).has_value());
     ASSERT_FALSE(ob->remove_pending_object(oid).has_value());
     ASSERT_FALSE(ob->finish(oid, 0, 0).has_value());
@@ -344,7 +368,7 @@ TEST_F(ReplicatedMetastoreTest, TestNotLeader) {
             break;
         }
         auto obj_builder = meta.object_builder();
-        auto oid = obj_builder->get_or_create_object_for(tp);
+        auto oid = obj_builder->get_or_create_object_for(tp).value();
         kafka::offset next_last{next_to_send() + 99};
         auto add_res = obj_builder->add(
           oid,
@@ -441,7 +465,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetTermForOffset) {
     auto tp = make_tp(0);
 
     auto obj_builder = meta.object_builder();
-    auto oid1 = obj_builder->get_or_create_object_for(tp);
+    auto oid1 = obj_builder->get_or_create_object_for(tp).value();
     auto add_res1 = obj_builder->add(
       oid1,
       metastore::object_metadata::ntp_metadata{
@@ -500,7 +524,7 @@ TEST_F(ReplicatedMetastoreTest, TestGetEndOffsetForTerm) {
 
     // Set up initial objects with multiple terms
     auto obj_builder = meta.object_builder();
-    auto oid1 = obj_builder->get_or_create_object_for(tp);
+    auto oid1 = obj_builder->get_or_create_object_for(tp).value();
     auto add_res1 = obj_builder->add(
       oid1,
       metastore::object_metadata::ntp_metadata{

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -995,7 +995,7 @@ TEST(SimpleMetastoreTest, TestCompactionOffsetsNoTombstones) {
 
 TEST(SimpleMetastoreTest, TestObjectBuilder) {
     simple_metastore m;
-    auto ob = m.object_builder();
+    auto ob = m.object_builder().get().value();
     auto tp_a = model::topic_id_partition::from(tid_a);
 
     // Creating objects for the same partition will result in the same object.
@@ -1035,7 +1035,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
 TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
     // Test calls for objects that don't exist in the builder.
     simple_metastore m;
-    auto ob = m.object_builder();
+    auto ob = m.object_builder().get().value();
     auto add_res = ob->add(create_object_id(), {});
     ASSERT_FALSE(add_res.has_value());
 
@@ -1051,7 +1051,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilderBadObjects) {
 
 TEST(SimpleMetastoreTest, TestObjectBuilderRemovedObjects) {
     simple_metastore m;
-    auto ob = m.object_builder();
+    auto ob = m.object_builder().get().value();
     const auto topic_id = model::create_topic_id();
 
     auto gen_object_id = [&] {
@@ -1093,7 +1093,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     simple_metastore m;
     auto tp_a = model::topic_id_partition::from(tid_a);
     {
-        auto ob = m.object_builder();
+        auto ob = m.object_builder().get().value();
         auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
@@ -1120,7 +1120,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_EQ(10_o, offsets_res->next_offset);
     }
     {
-        auto ob = m.object_builder();
+        auto ob = m.object_builder().get().value();
         auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
@@ -1147,7 +1147,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_EQ(20_o, offsets_res->next_offset);
     }
     {
-        auto ob = m.object_builder();
+        auto ob = m.object_builder().get().value();
         auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
@@ -1171,7 +1171,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
         ASSERT_EQ(20_o, offsets_res->next_offset);
     }
     {
-        auto ob = m.object_builder();
+        auto ob = m.object_builder().get().value();
         auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -999,16 +999,16 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
     auto tp_a = model::topic_id_partition::from(tid_a);
 
     // Creating objects for the same partition will result in the same object.
-    auto o_a = ob->get_or_create_object_for(tp_a);
-    auto o_a_2 = ob->get_or_create_object_for(tp_a);
+    auto o_a = ob->get_or_create_object_for(tp_a).value();
+    auto o_a_2 = ob->get_or_create_object_for(tp_a).value();
     ASSERT_EQ(o_a, o_a_2);
 
     // Creating objects for different partitions will result in the same
     // object.
     auto tp_b = model::topic_id_partition::from(tid_b);
-    auto o_b = ob->get_or_create_object_for(tp_b);
+    auto o_b = ob->get_or_create_object_for(tp_b).value();
     ASSERT_EQ(o_a, o_b);
-    auto o_b_2 = ob->get_or_create_object_for(tp_b);
+    auto o_b_2 = ob->get_or_create_object_for(tp_b).value();
     ASSERT_EQ(o_b, o_b_2);
 
     // Add a partition's metadata to the object.
@@ -1017,7 +1017,7 @@ TEST(SimpleMetastoreTest, TestObjectBuilder) {
     // Finish the current object. The next object will be different.
     ASSERT_TRUE(ob->finish(o_a, 0, 1000).has_value());
 
-    auto o_a_3 = ob->get_or_create_object_for(tp_a);
+    auto o_a_3 = ob->get_or_create_object_for(tp_a).value();
     ASSERT_NE(o_a_2, o_a_3);
 
     // We can't release the result until we finish all objects.
@@ -1055,9 +1055,11 @@ TEST(SimpleMetastoreTest, TestObjectBuilderRemovedObjects) {
     const auto topic_id = model::create_topic_id();
 
     auto gen_object_id = [&] {
-        return ob->get_or_create_object_for(
-          model::topic_id_partition(
-            topic_id, model::partition_id(static_cast<int32_t>(0))));
+        return ob
+          ->get_or_create_object_for(
+            model::topic_id_partition(
+              topic_id, model::partition_id(static_cast<int32_t>(0))))
+          .value();
     };
 
     // pending object can be removed, but not twice
@@ -1092,7 +1094,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     auto tp_a = model::topic_id_partition::from(tid_a);
     {
         auto ob = m.object_builder();
-        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{
@@ -1119,7 +1121,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     }
     {
         auto ob = m.object_builder();
-        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{
@@ -1146,7 +1148,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     }
     {
         auto ob = m.object_builder();
-        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{
@@ -1170,7 +1172,7 @@ TEST(SimpleMetastoreTest, TestUpdateWithObjectBuilder) {
     }
     {
         auto ob = m.object_builder();
-        auto o_a = ob->get_or_create_object_for(tp_a);
+        auto o_a = ob->get_or_create_object_for(tp_a).value();
         auto add_res = ob->add(
           o_a,
           metastore::object_metadata::ntp_metadata{

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -216,7 +216,15 @@ ss::future<> reconciler::reconcile() {
     }
 
     // Begin by creating the set of objects to be built.
-    auto metadata_builder = _metastore->object_builder();
+    auto metadata_builder_res = co_await _metastore->object_builder();
+    if (!metadata_builder_res.has_value()) {
+        vlog(
+          lg.warn,
+          "Could not create object metadata builder: {}",
+          metadata_builder_res.error());
+        co_return;
+    }
+    auto& metadata_builder = metadata_builder_res.value();
     chunked_hash_map<l1::object_id, chunked_vector<attached_partition>>
       oid_to_partitions;
     for (const auto& p : partitions) {

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -221,7 +221,11 @@ ss::future<> reconciler::reconcile() {
       oid_to_partitions;
     for (const auto& p : partitions) {
         auto oid = metadata_builder->get_or_create_object_for(p->tidp);
-        oid_to_partitions[oid].push_back(p);
+        if (!oid.has_value()) {
+            vlog(lg.warn, "Could not get object: {}", oid.error());
+            co_return;
+        }
+        oid_to_partitions[oid.value()].push_back(p);
     }
 
     // Process partitions by their object. This should be easier to


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Squashes a couple instances of UB caused by unchecked optional access when getting the partition of the metastore topic for some data when the metastore topic did not exist, instead returning errors as appropriate.

In addition, makes object_builder() also attempt to create the metastore topic if it doesn't exist, to limit the window where these errors will pop up.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
