### PR TITLE
Added cluster linking scheduling group

### DIFF
--- a/bazel/thirdparty/seastar.BUILD
+++ b/bazel/thirdparty/seastar.BUILD
@@ -74,7 +74,7 @@ int_flag(
 
 int_flag(
     name = "scheduling_groups",
-    build_setting_default = 17,
+    build_setting_default = 18,
     make_variable = "SCHEDULING_GROUPS",
 )
 

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -85,8 +85,7 @@ link::link(
   , _config(std::move(config))
   , _cluster_connection(std::move(cluster_connection))
   , _replication_mgr(
-      // todo: fix me
-      ss::default_scheduling_group(),
+      _manager->scheduling_group(),
       std::move(data_source_factory),
       std::move(data_sink_factory))
   , _task_reconciler_interval(task_reconciler_interval) {}

--- a/src/v/cluster_link/link.cc
+++ b/src/v/cluster_link/link.cc
@@ -17,6 +17,7 @@
 #include "ssx/future-util.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/switch_to.hh>
 
 namespace cluster_link {
 namespace {
@@ -98,7 +99,11 @@ ss::future<> link::start() {
     co_await _replication_mgr.start();
     co_await run_task_reconciler();
     _task_reconciler.set_callback([this] {
-        ssx::spawn_with_gate(_gate, [this] { return run_task_reconciler(); });
+        ssx::spawn_with_gate(_gate, [this] {
+            return ss::with_scheduling_group(
+              _manager->scheduling_group(),
+              [this] { return run_task_reconciler(); });
+        });
     });
     _task_reconciler.arm_periodic(_task_reconciler_interval);
 }
@@ -148,6 +153,7 @@ ss::future<> link::stop() noexcept {
 }
 
 ss::future<result<void>> link::register_task(task_factory* tf) {
+    co_await ss::coroutine::switch_to(_manager->scheduling_group());
     vlog(
       cllog.debug,
       "Registering task factory {} for cluster link {} ({})",
@@ -188,6 +194,7 @@ ss::future<> link::handle_on_leadership_change(
   ::model::ntp ntp,
   ntp_leader is_ntp_leader,
   std::optional<::model::term_id> term) {
+    co_await ss::coroutine::switch_to(_manager->scheduling_group());
     vlog(
       cllog.trace,
       "Cluster link {} handling leadership change for {}: {}, term: {}",
@@ -310,6 +317,12 @@ bool link::should_stop_task(task* t) const {
 }
 
 ss::future<> link::run_task_reconciler() {
+    /**
+     * Always run the task reconciler in the manager scheduling group this way
+     * task fibers will be run in the correct scheduling group
+     */
+    // TODO: consider adding a separate scheduling group per task
+    co_await ss::coroutine::switch_to(_manager->scheduling_group());
     auto fut = co_await ss::coroutine::as_future(
       _task_reconciler_mutex.get_units(_as));
     if (fut.failed()) {

--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -16,6 +16,7 @@
 #include "model/namespace.h"
 
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/switch_to.hh>
 
 #include <utility>
 
@@ -83,7 +84,8 @@ manager::manager(
   std::unique_ptr<consumer_groups_router> group_router,
   std::unique_ptr<partition_metadata_provider> partition_metadata_provider,
   ss::lowres_clock::duration task_reconciler_interval,
-  config::binding<int16_t> default_topic_replication)
+  config::binding<int16_t> default_topic_replication,
+  ss::scheduling_group scheduling_group)
   : _self(self)
   , _partition_leader_cache(std::move(partition_leader_cache))
   , _partition_manager(std::move(partition_manager))
@@ -95,14 +97,17 @@ manager::manager(
   , _group_router(std::move(group_router))
   , _partition_metadata_provider(std::move(partition_metadata_provider))
   , _queue(
+      scheduling_group,
       [](const std::exception_ptr& ex) {
           vlog(cllog.warn, "unexpected cluster link manager error: {}", ex);
       },
       ssx::work_queue::is_paused_t::yes)
   , _task_reconciler_interval(task_reconciler_interval)
-  , _default_topic_replication(std::move(default_topic_replication)) {}
+  , _default_topic_replication(std::move(default_topic_replication))
+  , _scheduling_group(scheduling_group) {}
 
 ss::future<> manager::start() {
+    co_await ss::coroutine::switch_to(_scheduling_group);
     vlog(cllog.info, "Starting cluster link manager");
     auto ids = _registry->get_all_link_ids();
     for (auto id : ids) {
@@ -110,7 +115,10 @@ ss::future<> manager::start() {
     }
 
     _link_task_reconciler_timer.set_callback([this] {
-        ssx::spawn_with_gate(_g, [this] { return link_task_reconciler(); });
+        ssx::spawn_with_gate(_g, [this] {
+            return ss::with_scheduling_group(
+              _scheduling_group, [this] { return link_task_reconciler(); });
+        });
     });
     _link_task_reconciler_timer.arm_periodic(_task_reconciler_interval);
     _queue.resume();

--- a/src/v/cluster_link/manager.h
+++ b/src/v/cluster_link/manager.h
@@ -49,7 +49,8 @@ public:
       std::unique_ptr<consumer_groups_router> group_router,
       std::unique_ptr<partition_metadata_provider> partition_metadata_provider,
       ss::lowres_clock::duration task_reconciler_interval,
-      config::binding<int16_t> default_topic_replication);
+      config::binding<int16_t> default_topic_replication,
+      ss::scheduling_group scheduling_group);
     manager(const manager&) = delete;
     manager(manager&&) = delete;
     manager& operator=(const manager&) = delete;
@@ -149,6 +150,10 @@ public:
 
     partition_metadata_provider& get_partition_metadata_provider() noexcept;
 
+    ss::scheduling_group scheduling_group() const noexcept {
+        return _scheduling_group;
+    }
+
 private:
     /// Called periodically to reconcile registered tasks on created links
     ss::future<> link_task_reconciler();
@@ -179,6 +184,7 @@ private:
       "cluster_link::manager::link_task_reconciler"};
     ss::timer<ss::lowres_clock> _link_task_reconciler_timer;
     config::binding<int16_t> _default_topic_replication;
+    ss::scheduling_group _scheduling_group;
     ss::condition_variable _link_created_cv;
     ss::abort_source _as;
     ss::gate _g;

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -25,6 +25,8 @@
 #include "kafka/client/direct_consumer/direct_consumer.h"
 #include "kafka/server/group_router.h"
 
+#include <seastar/coroutine/switch_to.hh>
+
 namespace cluster_link {
 
 using ::cluster::cluster_link::frontend;
@@ -243,7 +245,8 @@ service::service(
   cluster::controller* controller,
   ss::sharded<kafka::group_router>* group_router,
   ss::sharded<cluster::health_monitor_frontend>* hm_frontend,
-  ss::smp_service_group smp_group)
+  ss::smp_service_group smp_group,
+  ss::scheduling_group scheduling_group)
   : _self(self)
   , _plf(plf)
   , _notifications(std::move(notifications))
@@ -254,12 +257,14 @@ service::service(
   , _controller(controller)
   , _group_router(group_router)
   , _hm_frontend(hm_frontend)
-  , _smp_group(smp_group) {}
+  , _smp_group(smp_group)
+  , _scheduling_group(scheduling_group) {}
 
 service::~service() = default;
 
 ss::future<> service::start() {
     vlog(cllog.info, "Starting cluster link service");
+    co_await ss::coroutine::switch_to(_scheduling_group);
     _manager = std::make_unique<manager>(
       _self,
       partition_leader_cache::make_default(_partition_leaders_table),

--- a/src/v/cluster_link/service.cc
+++ b/src/v/cluster_link/service.cc
@@ -279,7 +279,8 @@ ss::future<> service::start() {
       std::make_unique<health_monitor_based_partition_metadata_provider>(
         _hm_frontend),
       30s, // Temporary until we have a proper configuration for this
-      config::shard_local_cfg().default_topic_replication.bind());
+      config::shard_local_cfg().default_topic_replication.bind(),
+      _scheduling_group);
 
     co_await _manager->register_task_factory<source_topic_syncer_factory>();
     co_await _manager->register_task_factory<group_mirroring_task_factory>();

--- a/src/v/cluster_link/service.h
+++ b/src/v/cluster_link/service.h
@@ -42,7 +42,8 @@ public:
       cluster::controller* controller,
       ss::sharded<kafka::group_router>* group_router,
       ss::sharded<cluster::health_monitor_frontend>* hm_frontend,
-      ss::smp_service_group smp_group);
+      ss::smp_service_group smp_group,
+      ss::scheduling_group scheduling_group);
 
     service(const service&) = delete;
     service(service&&) = delete;
@@ -108,6 +109,7 @@ private:
     ss::sharded<kafka::group_router>* _group_router;
     ss::sharded<cluster::health_monitor_frontend>* _hm_frontend;
     ss::smp_service_group _smp_group;
+    ss::scheduling_group _scheduling_group;
     std::unique_ptr<manager> _manager;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;

--- a/src/v/cluster_link/tests/deps.cc
+++ b/src/v/cluster_link/tests/deps.cc
@@ -87,7 +87,8 @@ ss::future<> cluster_link_manager_test_fixture::wire_up_and_start(
           return provider;
       }),
       1s,
-      _default_topic_replication.bind());
+      _default_topic_replication.bind(),
+      ss::default_scheduling_group());
 
     auto notif_id = _table.local().register_for_updates(
       [this](model::id_t id) { _manager.local().on_link_change(id); });

--- a/src/v/cluster_link/tests/link_test.cc
+++ b/src/v/cluster_link/tests/link_test.cc
@@ -187,7 +187,8 @@ public:
           std::make_unique<test_consumer_group_router>(),
           std::make_unique<test_partition_metadata_provider>(),
           task_reconciler_interval,
-          _default_topic_replication.bind());
+          _default_topic_replication.bind(),
+          ss::default_scheduling_group());
     }
 
     virtual ss::future<> TearDownAsync() override {
@@ -423,7 +424,8 @@ public:
           std::make_unique<test_consumer_group_router>(),
           std::make_unique<test_partition_metadata_provider>(),
           task_reconciler_interval,
-          _default_topic_replication.bind());
+          _default_topic_replication.bind(),
+          ss::default_scheduling_group());
         co_await _manager->start();
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1536,7 +1536,8 @@ void application::wire_up_runtime_services(
       controller.get(),
       &group_router,
       &controller->get_health_monitor(),
-      smp_service_groups.cluster_link_smp_sg())
+      smp_service_groups.cluster_link_smp_sg(),
+      sched_groups.cluster_linking_sg())
       .get();
 
     syschecks::systemd_message("Creating kafka usage manager frontend").get();

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -100,6 +100,12 @@ public:
          * storage cache starving out producers.
          */
         _ts_read = co_await ss::create_scheduling_group("ts_read", 500);
+        /**
+         * Group used to handle cluster linking tasks. It includes tasks
+         * synchronizing metadata as well as replication.
+         */
+        _cluster_linking = co_await ss::create_scheduling_group(
+          "cluster_linking", 600);
     }
 
     ss::future<> destroy_groups() {
@@ -118,6 +124,7 @@ public:
         co_await destroy_scheduling_group(_datalake);
         co_await destroy_scheduling_group(_produce);
         co_await destroy_scheduling_group(_ts_read);
+        co_await destroy_scheduling_group(_cluster_linking);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -156,6 +163,8 @@ public:
 
     ss::scheduling_group ts_read_sg() { return _ts_read; }
 
+    ss::scheduling_group cluster_linking_sg() { return _cluster_linking; }
+
     std::vector<std::reference_wrapper<const ss::scheduling_group>>
     all_scheduling_groups() const {
         return {
@@ -174,7 +183,8 @@ public:
           std::cref(_transforms),
           std::cref(_datalake),
           std::cref(_produce),
-          std::cref(_ts_read)};
+          std::cref(_ts_read),
+          std::cref(_cluster_linking)};
     }
 
 private:
@@ -195,4 +205,5 @@ private:
     ss::scheduling_group _datalake;
     ss::scheduling_group _produce;
     ss::scheduling_group _ts_read;
+    ss::scheduling_group _cluster_linking;
 };


### PR DESCRIPTION
Added separate scheduling group for cluster linking subsystem. Cluster linking task, replication and other logic is supposed to run inside the new scheduling group. This way we gain a control over the share of CPU time and IO resources that is given to cluster linking subsystem

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none