### PR TITLE
iceberg: json schema: accept integers as numbers (doubles)

### DIFF
--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -898,6 +898,8 @@ TEST_CORO(IcebergValues, ValuePrimitives) {
       {"boolean", "true", iceberg::boolean_value(true)},
       {"boolean", "false", iceberg::boolean_value(false)},
       {"integer", "42", iceberg::long_value(42)},
+      {"integer", "42.0", iceberg::long_value(42)},
+      {"integer", "4.2e1", iceberg::long_value(42)},
       {"integer", "-42", iceberg::long_value(-42)},
       {"number", "42", iceberg::double_value(42)},
       {"number", "3.14", iceberg::double_value(3.14)},

--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -899,6 +899,7 @@ TEST_CORO(IcebergValues, ValuePrimitives) {
       {"boolean", "false", iceberg::boolean_value(false)},
       {"integer", "42", iceberg::long_value(42)},
       {"integer", "-42", iceberg::long_value(-42)},
+      {"number", "42", iceberg::double_value(42)},
       {"number", "3.14", iceberg::double_value(3.14)},
       {"string", R"("foo")", iceberg::string_value(iobuf::from("foo"))},
     });

--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <rapidjson/error/en.h>
 
+#include <limits>
 #include <string_view>
 #include <utility>
 #include <variant>
@@ -901,6 +902,20 @@ TEST_CORO(IcebergValues, ValuePrimitives) {
       {"integer", "42.0", iceberg::long_value(42)},
       {"integer", "4.2e1", iceberg::long_value(42)},
       {"integer", "-42", iceberg::long_value(-42)},
+      {"integer",
+       "9223372036854775807",
+       iceberg::long_value(std::numeric_limits<int64_t>::max())},
+      {"integer",
+       "-9223372036854775808",
+       iceberg::long_value(std::numeric_limits<int64_t>::min())},
+      // Integer.{MIN,MAX}_SAFE_INTEGER in JavaScript. No guarantees beyond
+      // this range for now because of parser limitations.
+      {"integer",
+       "9.007199254740991e15",
+       iceberg::long_value(9007199254740991)},
+      {"integer",
+       "-9.007199254740991e15",
+       iceberg::long_value(-9007199254740991)},
       {"number", "42", iceberg::double_value(42)},
       {"number", "3.14", iceberg::double_value(3.14)},
       {"string", R"("foo")", iceberg::string_value(iobuf::from("foo"))},
@@ -923,6 +938,42 @@ TEST_CORO(IcebergValues, ValuePrimitives) {
           std::move(result.value()));
 
         EXPECT_EQ(*result_value->fields[0], expected);
+    }
+}
+
+TEST_CORO(IcebergValues, ValuePrimitivesInvalid) {
+    const auto json_primitives = std::to_array<
+      std::tuple<std::string_view, std::string_view, std::string>>({
+      {"integer",
+       "42.1",
+       "Cannot convert non-integer double value 42.1 to integer without "
+       "precision loss"},
+      {"integer",
+       "42e100",
+       "Cannot convert non-integer double value 4.2e+101 to integer without "
+       "precision loss"},
+      // No support for 2^63 with scientific notation because json parser(s) see
+      // a double.
+      {"integer",
+       "9.223372036854775807e18",
+       "Cannot convert non-integer double value 9.223372036854778e+18 to "
+       "integer without precision loss"},
+    });
+
+    for (const auto& [type, value, err] : json_primitives) {
+        SCOPED_TRACE(fmt::format("Testing type: {}, value: {}", type, value));
+
+        auto schema = fmt::format(
+          R"({{
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "{}"
+          }})",
+          type);
+        auto result = co_await to_iceberg_value(
+          schema, fmt::format("{}", value));
+
+        ASSERT_TRUE_CORO(result.has_error());
+        ASSERT_STREQ_CORO(err.c_str(), result.error().what());
     }
 }
 

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -63,13 +63,32 @@ convert_primitive(serde::json::parser& p, const primitive_type& ft) {
                 ft));
         }
     case token::value_double:
-        if (!std::holds_alternative<double_type>(ft)) {
+        if (std::holds_alternative<double_type>(ft)) {
+            return iceberg::double_value(p.value_double());
+        } else if (std::holds_alternative<long_type>(ft)) {
+            double source_value = p.value_double();
+            // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+            double int_part;
+            if (
+              std::modf(source_value, &int_part) != 0.0
+
+              || int_part
+                   < static_cast<double>(std::numeric_limits<int64_t>::min())
+              || int_part
+                   > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+                throw value_conversion_exception(
+                  fmt::format(
+                    "Cannot convert non-integer double value {} to integer "
+                    "without precision loss",
+                    source_value));
+            }
+            return iceberg::long_value(static_cast<int64_t>(int_part));
+        } else {
             throw value_conversion_exception(
               fmt::format(
                 "Mismatch json between json double value and schema type: {}",
                 ft));
         }
-        return iceberg::double_value(p.value_double());
     case token::value_string: {
         // Trivial case for string type.
         if (std::holds_alternative<string_type>(ft)) {

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -52,13 +52,16 @@ convert_primitive(serde::json::parser& p, const primitive_type& ft) {
         }
         return iceberg::boolean_value(false);
     case token::value_int:
-        if (!std::holds_alternative<long_type>(ft)) {
+        if (std::holds_alternative<long_type>(ft)) {
+            return iceberg::long_value(p.value_int());
+        } else if (std::holds_alternative<double_type>(ft)) {
+            return iceberg::double_value(static_cast<double>(p.value_int()));
+        } else {
             throw value_conversion_exception(
               fmt::format(
                 "Mismatch json between json integer value and schema type: {}",
                 ft));
         }
-        return iceberg::long_value(p.value_int());
     case token::value_double:
         if (!std::holds_alternative<double_type>(ft)) {
             throw value_conversion_exception(

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -69,13 +69,11 @@ convert_primitive(serde::json::parser& p, const primitive_type& ft) {
             double source_value = p.value_double();
             // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
             double int_part;
-            if (
-              std::modf(source_value, &int_part) != 0.0
-
-              || int_part
-                   < static_cast<double>(std::numeric_limits<int64_t>::min())
-              || int_part
-                   > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+            const bool is_integer = (std::modf(source_value, &int_part) == 0.0);
+            const bool can_be_represented_as_iceberg_long
+              = is_integer
+                && (int_part >= static_cast<double>(std::numeric_limits<int64_t>::min()) && int_part <= static_cast<double>(std::numeric_limits<int64_t>::max()));
+            if (!can_be_represented_as_iceberg_long) {
                 throw value_conversion_exception(
                   fmt::format(
                     "Cannot convert non-integer double value {} to integer "


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Iceberg/JSON Schema: Fix a bug where we would fail to parse integers when schema indicates number (floating point).

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
