### PR TITLE
rptest: move cluster config export to @cluster

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -154,6 +154,8 @@ def cluster(
                         redpanda.cloud_storage_diagnostics()
                     raise
 
+            redpanda.export_cluster_config()
+
             if isinstance(redpanda, RedpandaService):
                 if test_failed:
                     redpanda.cloud_storage_diagnostics()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1212,12 +1212,12 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        # Now ensure that this base is part of the right type of object.
-        # For these checks to work, this __init__ method should appear in
-        # the MRO after all the __init__ methods that would set these properties
-        self._check_attr("context", TestContext)
-        self._check_attr("logger", Logger)
         self._usage_stats = UsageStats()
+
+    @property
+    @abstractmethod
+    def logger(self) -> Logger:
+        pass
 
     @property
     def usage_stats(self) -> UsageStats:
@@ -1247,6 +1247,9 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
         """Return a KafkaClientSecurity object suitable for connecting to the Kafka API
         on this broker."""
         pass
+
+    def export_cluster_config(self) -> None:
+        self.logger.debug("export_cluster_config not implemented for this service")
 
     def wait_until(
         self,
@@ -1329,16 +1332,6 @@ class RedpandaServiceABC(ABC, RedpandaServiceConstants):
             backoff_sec,
             err_msg=err_msg,
             logger=logger,
-        )
-
-    def _check_attr(self, name: str, t: Type) -> None:
-        v = getattr(self, name, None)
-        mro = self.__class__.__mro__
-        assert v is not None, (
-            f"RedpandaServiceABC was missing attribute {name} after __init__: {mro}\n"
-        )
-        assert isinstance(v, t), (
-            f"{name} had wrong type, expected {t} but was {type(v)}"
         )
 
     def _extract_samples(
@@ -1582,7 +1575,6 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         # we save the test context under both names since RedpandaService and Service
         # save them under these two names, respetively
         self.context = self._context = context
-        self.logger = context.logger
 
         super().__init__()
 
@@ -1666,6 +1658,10 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         assert self._min_brokers <= node_count, (
             f"Not enough brokers: test needs {self._min_brokers} but cluster has {node_count}"
         )
+
+    @property
+    def logger(self) -> Logger:
+        return self._context.logger
 
     @property
     def kubectl(self) -> KubectlTool:
@@ -2379,7 +2375,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         return {}
 
 
-class RedpandaService(RedpandaServiceABC, Service):
+class RedpandaService(Service, RedpandaServiceABC):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     TRIM_LOGS_KEY = "trim_logs"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
@@ -4449,11 +4445,11 @@ class RedpandaService(RedpandaServiceABC, Service):
             return self.get_version(node)
         return None
 
-    def stop(self, **kwargs: Any) -> None:
+    def export_cluster_config(self) -> None:
         """
-        Override default stop() to execude stop_node in parallel
+        Export the cluster configuration of all nodes to the ducktape log
+        directory for later inspection.
         """
-        self._stop_time = time.time()  # The last time stop is invoked
         self.logger.info("%s: exporting cluster config" % self.who_am_i())
 
         service_dir = os.path.join(
@@ -4476,6 +4472,12 @@ class RedpandaService(RedpandaServiceABC, Service):
             # Configuration is optional: if redpanda has e.g. crashed, you
             # will not be able to get it from the admin API
             self.logger.info(f"{self.who_am_i()}: error getting config: {e}")
+
+    def stop(self, **kwargs: Any) -> None:
+        """
+        Override default stop() to execude stop_node in parallel
+        """
+        self._stop_time = time.time()  # The last time stop is invoked
 
         self.logger.info("%s: stopping service" % self.who_am_i())
 


### PR DESCRIPTION
This should be done only once, don't do it on service stop, but in the @cluster cleanup code, before we stop redpanda.

This saves six seconds on every test, since the second export (due to the second stop) took six seconds. Hat tip to Stephan for noticing this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

