### PR TITLE
Use shadow linking scheduling group in replicator and topic reconciler 

### DIFF
--- a/src/v/cluster_link/manager.cc
+++ b/src/v/cluster_link/manager.cc
@@ -585,7 +585,8 @@ ss::future<> manager::start_topic_reconciler() {
           _topic_metadata_cache.get(),
           _registry.get(),
           topic_reconciler_interval,
-          _default_topic_replication);
+          _default_topic_replication,
+          _scheduling_group);
     }
     try {
         co_await _topic_reconciler->start();

--- a/src/v/cluster_link/replication/link_replication_mgr.cc
+++ b/src/v/cluster_link/replication/link_replication_mgr.cc
@@ -61,7 +61,7 @@ ss::future<> link_replication_manager::do_start_replicator(
     auto source = _source_factory->make_source(ntp);
     auto sink = _sink_factory->make_sink(ntp);
     auto replicator = std::make_unique<partition_replicator>(
-      ntp, term, std::move(source), std::move(sink));
+      ntp, term, std::move(source), std::move(sink), _sg);
     auto [r_it, _] = _replicators.emplace(ntp, std::move(replicator));
     co_await r_it->second->start();
 }

--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -13,6 +13,8 @@
 #include "cluster_link/logger.h"
 #include "ssx/future-util.h"
 
+#include <seastar/coroutine/switch_to.hh>
+
 namespace cluster_link::replication {
 
 static constexpr std::chrono::seconds base_backoff{1};
@@ -22,16 +24,19 @@ partition_replicator::partition_replicator(
   const model::ntp& ntp,
   model::term_id term,
   std::unique_ptr<data_source> source,
-  std::unique_ptr<data_sink> sink)
+  std::unique_ptr<data_sink> sink,
+  ss::scheduling_group scheduling_group)
   : _term(term)
   , _log(cllog, fmt::format("[{}-term-{}] replicator", ntp, term))
   , _source(std::move(source))
   , _sink(std::move(sink))
+  , _scheduling_group(scheduling_group)
   , _backoff_policy(
       make_exponential_backoff_policy<ss::lowres_clock>(
         base_backoff, max_backoff)) {}
 
 ss::future<> partition_replicator::start() {
+    co_await ss::coroutine::switch_to(_scheduling_group);
     vlog(_log.trace, "Starting replicator");
     co_await _sink->start();
     co_await _source->start(
@@ -48,6 +53,7 @@ ss::future<> partition_replicator::start() {
 }
 
 ss::future<> partition_replicator::stop() {
+    co_await ss::coroutine::switch_to(_scheduling_group);
     vlog(_log.trace, "Stopping replicator");
     _as.request_abort();
     // closing the gate first ensures all the units are returned to the

--- a/src/v/cluster_link/replication/partition_replicator.h
+++ b/src/v/cluster_link/replication/partition_replicator.h
@@ -58,7 +58,8 @@ public:
       const ::model::ntp& ntp,
       ::model::term_id,
       std::unique_ptr<data_source> source,
-      std::unique_ptr<data_sink> sink);
+      std::unique_ptr<data_sink> sink,
+      ss::scheduling_group sg = ss::default_scheduling_group());
     ss::future<> start();
     ss::future<> stop();
 
@@ -88,6 +89,7 @@ private:
     ss::abort_source _as;
     std::unique_ptr<data_source> _source;
     std::unique_ptr<data_sink> _sink;
+    ss::scheduling_group _scheduling_group;
     // to pipeline multiple replicate requests in parallel
     static constexpr ssize_t max_in_flight_requests = 5;
     ssx::semaphore _max_requests{

--- a/src/v/cluster_link/tests/topic_reconciler_test.cc
+++ b/src/v/cluster_link/tests/topic_reconciler_test.cc
@@ -54,7 +54,8 @@ public:
           _ftmc.get(),
           _link_registry.get(),
           1s,
-          _default_topic_replication.bind());
+          _default_topic_replication.bind(),
+          ss::default_scheduling_group());
         co_await _reconciler->start();
 
         set_required_topic_properties(

--- a/src/v/cluster_link/topic_reconciler.cc
+++ b/src/v/cluster_link/topic_reconciler.cc
@@ -18,6 +18,8 @@
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
 
+#include <seastar/coroutine/switch_to.hh>
+
 #include <exception>
 
 using namespace std::chrono_literals;
@@ -28,12 +30,14 @@ topic_reconciler::topic_reconciler(
   kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
   link_registry* link_registry,
   ss::lowres_clock::duration run_interval,
-  config::binding<int16_t> default_topic_replication)
+  config::binding<int16_t> default_topic_replication,
+  ss::scheduling_group scheduling_group)
   : _topic_creator(topic_creator)
   , _topic_metadata_cache(topic_metadata_cache)
   , _link_registry(link_registry)
   , _run_interval(run_interval)
-  , _default_topic_replication(std::move(default_topic_replication)) {}
+  , _default_topic_replication(std::move(default_topic_replication))
+  , _scheduling_group(scheduling_group) {}
 
 ss::future<> topic_reconciler::start() {
     vlog(cllog.info, "Starting topic reconciler");
@@ -79,6 +83,7 @@ void topic_reconciler::trigger(model::id_t link_id) {
 }
 
 ss::future<> topic_reconciler::execute(std::optional<model::id_t> link_id) {
+    co_await ss::coroutine::switch_to(_scheduling_group);
     static constexpr auto max_concurrent_reconcilations = 5;
     vlog(cllog.trace, "Executing topic reconciler, link_id: {}", link_id);
     auto units = co_await _reconciler_mutex.get_units(_as);

--- a/src/v/cluster_link/topic_reconciler.h
+++ b/src/v/cluster_link/topic_reconciler.h
@@ -28,7 +28,8 @@ public:
       kafka::data::rpc::topic_metadata_cache* topic_metadata_cache,
       link_registry* link_registry,
       ss::lowres_clock::duration run_interval,
-      config::binding<int16_t> default_topic_replication);
+      config::binding<int16_t> default_topic_replication,
+      ss::scheduling_group sg);
     topic_reconciler(const topic_reconciler&) = delete;
     topic_reconciler(topic_reconciler&&) = delete;
     topic_reconciler& operator=(const topic_reconciler&) = delete;
@@ -79,6 +80,7 @@ private:
     ss::timer<ss::lowres_clock> _reconciler_timer;
     ss::lowres_clock::duration _run_interval;
     config::binding<int16_t> _default_topic_replication;
+    ss::scheduling_group _scheduling_group;
     ss::abort_source _as;
     ss::gate _gate;
 };


### PR DESCRIPTION
In a previous PR introducing shadow linking scheduling group i missed adding it into partition replicator and topic reconciler. 
This PR adds the scheduling group for the components that were previously missing it.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none