### PR TITLE
ct: fix shutdown hang

### DIFF
--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -25,7 +25,7 @@ namespace cloud_topics {
 
 namespace {
 
-static constexpr auto stm_timeout = std::chrono::seconds(30);
+static constexpr auto stm_timeout = std::chrono::seconds(10);
 
 class l0_metastore_impl : public housekeeper::l0_metadata_storage {
 public:
@@ -45,6 +45,8 @@ public:
         co_await api.set_start_offset(
           offset, model::timeout_clock::now() + stm_timeout);
     }
+
+    void abort() { _as.request_abort(); }
 
 private:
     ss::abort_source _as;
@@ -103,6 +105,7 @@ void housekeeper_manager::start_housekeeper(
           _retention_configuration.get(),
           config::shard_local_cfg()
             .cloud_storage_housekeeping_interval_ms.bind());
+        vlog(cd_log.debug, "starting housekeeper for: {}", tidp);
         auto [it, _] = _state.emplace(
           tidp,
           state{
@@ -119,6 +122,7 @@ void housekeeper_manager::stop_housekeeper(model::topic_id_partition tidp) {
         if (it == _state.end()) {
             return ss::now();
         }
+        vlog(cd_log.debug, "stopping housekeeper for: {}", tidp);
         return it->second.housekeeper->stop().then(
           [this, it] { _state.erase(it); });
     });
@@ -128,6 +132,8 @@ ss::future<> housekeeper_manager::start() { co_return; }
 
 ss::future<> housekeeper_manager::stop() {
     vlog(cd_log.info, "stopping cloud_topics::housekeeper_manager");
+    // NOLINTNEXTLINE(*static-cast-downcast*)
+    static_cast<l0_metastore_impl*>(_l0_metastore.get())->abort();
     co_await _queue.shutdown();
     vlog(cd_log.info, "cloud_topics::housekeeper_manager queue stopped");
     for (auto& [tidp, state] : _state) {

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -159,7 +159,7 @@ ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
           10_MiB); // TODO: use configuration parameter
 
         if (list.requests.empty()) {
-            vlog(_logger.debug, "No write requests to process");
+            vlog(_logger.trace, "No write requests to process");
             co_return true;
         }
 

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -116,7 +116,7 @@ write_pipeline<Clock>::get_write_requests(
     this->remove_timed_out_requests();
 
     vlog(
-      cd_log.debug, "get_write_requests called with max_bytes = {}", max_bytes);
+      cd_log.trace, "get_write_requests called with max_bytes = {}", max_bytes);
 
     auto& pending = this->get_pending();
 
@@ -141,7 +141,7 @@ write_pipeline<Clock>::get_write_requests(
     result.requests.splice(result.requests.end(), pending, pending.begin(), it);
     result.complete = pending.empty();
     vlog(
-      cd_log.debug,
+      cd_log.trace,
       "get_write_requests returned {} elements, containing {} ({}B)",
       result.requests.size(),
       human::bytes(acc_size),

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -55,7 +55,8 @@ ctp_stm_api::replicated_apply(
     vlog(
       _rtclog.debug, "Replicating batch {} in term {}", batch.header(), term);
 
-    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, _rtc.root_abort_source());
     opts.set_force_flush();
     auto res = co_await _stm->_raft->replicate(term, std::move(batch), opts);
 
@@ -67,7 +68,8 @@ ctp_stm_api::replicated_apply(
     }
 
     try {
-        co_await _stm->wait(res.value().last_offset, deadline);
+        co_await _stm->wait(
+          res.value().last_offset, deadline, _rtc.root_abort_source());
     } catch (...) {
         co_return std::unexpected(ctp_stm_api_errc::timeout);
     }
@@ -101,6 +103,10 @@ ctp_stm_api::advance_reconciled_offset(
 ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
 ctp_stm_api::set_start_offset(
   kafka::offset start_offset, model::timeout_clock::time_point deadline) {
+    if (start_offset <= get_start_offset()) {
+        co_return std::monostate{};
+    }
+
     vlog(
       _rtclog.debug,
       "Replicating ctp_stm_cmd::set_new_start_offset{{{}}}",


### PR DESCRIPTION
These log lines are super spammy, so make them trace level, not debug.

Also fix a shutdown hang where waiting to sync the STM (which presumably is stopped due to shutdown) in housekeeping.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
