### PR TITLE
ct/l1: erase partition when removing last object leaves it empty

### DIFF
--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -149,6 +149,9 @@ replicated_object_builder::remove_pending_object(object_id oid) {
       "Pending objects expected to contain {}",
       oid);
     objects.pending_objects_.erase(it);
+    if (objects.pending_objects_.empty()) {
+        partitions_.erase(p_it);
+    }
     return {};
 }
 

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -181,6 +181,45 @@ TEST_F(ReplicatedMetastoreTest, TestBuilderRemovedObjects) {
     ASSERT_FALSE(ob->finish(oid, 0, 0).has_value());
 }
 
+// Regression test, where removing an object from the builder left some
+// metadata behind, which would result in a failure.
+TEST_F(ReplicatedMetastoreTest, TestBuilderRemoveObjectRemovesPartition) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore m(app.get_sharded_l1_metastore_fe()->local());
+    auto tp1 = make_tp(0);
+    auto tp2 = make_tp(1);
+    auto ob = m.object_builder().get().value();
+
+    // Add and remove an object, setting up potential for an old bug where an
+    // empty partition is left behind after removal.
+    auto oid1 = ob->get_or_create_object_for(tp1).value();
+    ASSERT_TRUE(ob->remove_pending_object(oid1).has_value());
+
+    // Now add an object as normal.
+    auto oid2 = ob->get_or_create_object_for(tp2).value();
+    auto add_res = ob->add(
+      oid2,
+      metastore::object_metadata::ntp_metadata{
+        .tidp = tp2,
+        .base_offset = o{0},
+        .last_offset = o{199},
+        .max_timestamp = ts{10000},
+        .pos = 0,
+        .size = 500,
+      });
+    ASSERT_TRUE(add_res.has_value()) << add_res.error();
+    auto fin_res = ob->finish(oid2, 500, 1000);
+    metastore::term_offset_map_t terms;
+    terms[tp2].emplace_back(
+      metastore::term_offset{.term = model::term_id{1}, .first_offset = o{0}});
+
+    // There should be no issues here. Previously Redpanda would complain that
+    // it needed term information routed to the domain for tp1, despite the
+    // object for tp1 being removed.
+    auto commit_res = m.add_objects(*ob, terms).get();
+    ASSERT_TRUE(commit_res.has_value());
+}
+
 TEST_F(ReplicatedMetastoreTest, TestBasicAdd) {
     auto& app = get_ct_app(model::node_id{0});
     replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());


### PR DESCRIPTION
We were previously leaving behind empty partitions in the builder. This meant that after a bad object is removed from the builder, the call to replicated_metastore::add_objects() would examine the empty set of objects meant for a given metastore partition, and expect there to be terms routed for that partition. This resulted in the following error:

ERROR 2025-09-24 06:14:38,875 [shard 0:main] cloud_topics - replicated_metastore.cc:320 - No term metadata routed to partition 1

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
