### PR TITLE
ct: properly close builders before upload

### DIFF
--- a/src/v/cloud_topics/level_one/common/object.cc
+++ b/src/v/cloud_topics/level_one/common/object.cc
@@ -327,6 +327,10 @@ public:
       : _output(std::move(output))
       , _opts(opts) {}
 
+    ~object_builder_impl() override {
+        vassert(_closed, "L1 object builders must be closed unconditionally");
+    }
+
     ss::future<> start_partition(model::topic_id_partition tidp) final {
         end_partition();
         co_await serde_write_to_stream(data_type::partition_marker, tidp);
@@ -393,7 +397,10 @@ public:
         co_return info;
     }
 
-    ss::future<> close() final { return _output.close(); }
+    ss::future<> close() final {
+        _closed = true;
+        return _output.close();
+    }
 
     size_t file_size() const final { return _offset; }
 
@@ -444,6 +451,7 @@ private:
     model::topic_id_partition _current_tidp{};
     footer::partition _current_partition;
     options _opts;
+    bool _closed = false;
 };
 
 } // namespace
@@ -459,6 +467,10 @@ class object_reader_impl : public object_reader {
 public:
     explicit object_reader_impl(ss::input_stream<char> input)
       : _input(std::move(input)) {}
+
+    ~object_reader_impl() override {
+        vassert(_closed, "L1 object readers must be closed unconditionally");
+    }
 
     ss::future<result> read_next() final {
         if (_saw_footer) {
@@ -493,7 +505,10 @@ public:
             "unknown data type in object: {}", std::to_underlying(dt)));
     }
 
-    ss::future<> close() final { return _input.close(); }
+    ss::future<> close() final {
+        _closed = true;
+        return _input.close();
+    }
 
 private:
     template<typename T>
@@ -538,6 +553,7 @@ private:
 
     ss::input_stream<char> _input;
     bool _saw_footer = false;
+    bool _closed = false;
 };
 
 } // namespace

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -431,7 +431,8 @@ reconciler::build_object(
     }
     metas.shrink_to_fit();
 
-    auto obj_info = co_await ctx.builder->finish();
+    auto obj_info = co_await ctx.builder->finish().finally(
+      [&ctx] { return ctx.close_builder(); });
     vlog(
       lg.debug,
       "Built L1 object from {} partitions ({} partitions didn't fit)",


### PR DESCRIPTION
- **ct/l1/object: ensure reader/builder is always closed**
- **ct/reconciler: close builders before upload**

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
