### PR TITLE
ct/frontend: Add simple combined reader

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -51,8 +51,6 @@ ss::future<> app::construct(
       storage,
       &controller->get_cluster_epoch_generator());
 
-    co_await construct_service(state, data_plane.get());
-
     // Touch the L1 staging directory before L1 i/o starts.
     co_await ss::recursive_touch_directory(
       config::node().l1_staging_path().string());
@@ -78,6 +76,14 @@ ss::future<> app::construct(
       replicated_metastore, ss::sharded_parameter([this] {
           return std::ref(l1_metastore_fe.local());
       }));
+
+    co_await construct_service(
+      state,
+      data_plane.get(),
+      ss::sharded_parameter([this] { return &replicated_metastore.local(); }),
+      ss::sharded_parameter([this] { return &l1_io.local(); }),
+      ss::sharded_parameter(
+        [&metadata_cache] { return &metadata_cache->local(); }));
 
     co_await construct_service(
       reconciler,

--- a/src/v/cloud_topics/frontend/BUILD
+++ b/src/v/cloud_topics/frontend/BUILD
@@ -36,6 +36,8 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/cloud_topics:data_plane_api",
         "//src/v/cloud_topics:log_reader_config",
+        "//src/v/cloud_topics:state_accessors",
+        "//src/v/cloud_topics/level_one/frontend_reader:reader",
         "//src/v/cloud_topics/level_zero/common:extent_meta",
         "//src/v/cloud_topics/level_zero/frontend_reader",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -12,11 +12,14 @@
 #include "cloud_storage/types.h"
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/errc.h"
+#include "cloud_topics/level_one/frontend_reader/reader.h"
 #include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/level_zero/frontend_reader/reader.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/placeholder.h"
 #include "cloud_topics/logger.h"
+#include "cloud_topics/state_accessors.h"
+#include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "cluster/rm_stm_types.h"
 #include "cluster/types.h"
@@ -280,12 +283,29 @@ ss::future<storage::translating_reader> frontend::make_reader(
     vassert(_data_plane != nullptr, "cloud topics api not initialized");
 
     auto ot_state = _partition->get_offset_translator_state();
+    auto lro = _ctp_stm_api->get_last_reconciled_offset();
+    if (lro > kafka::offset::min() && cfg.start_offset <= lro) {
+        // Read from L1 if some reconciliation has happened (lro > min) and the
+        // range overlaps L1.
+        vlog(
+          cd_log.debug,
+          "Start offset {} <= LRO {}: using L1 reader",
+          cfg.start_offset,
+          lro);
 
-    // TODO: depending on the 'cfg' construct level zero or level one
-    // reader impl.
+        auto impl = make_l1_reader(cfg);
+        co_return storage::translating_reader{
+          model::record_batch_reader(std::move(impl)), std::move(ot_state)};
+    }
+
+    vlog(
+      cd_log.debug,
+      "Start offset {} > LRO {}: using L0 reader",
+      cfg.start_offset,
+      lro);
+
     auto impl = std::make_unique<level_zero_log_reader_impl>(
       cfg, _partition, _data_plane);
-
     co_return storage::translating_reader{
       model::record_batch_reader(std::move(impl)), std::move(ot_state)};
 }
@@ -313,6 +333,32 @@ bool frontend::cache_enabled() const {
         return false;
     }
     return true;
+}
+
+std::optional<model::topic_id_partition>
+frontend::ntp_to_topic_id_partition(const model::ntp& ntp) const {
+    auto ct_state = _partition->get_cloud_topics_state();
+    auto metadata_cache = ct_state->local().get_metadata_cache();
+    auto topic_cfg = metadata_cache->get_topic_cfg(
+      model::topic_namespace_view(ntp));
+    if (!topic_cfg || !topic_cfg->tp_id) {
+        return std::nullopt;
+    }
+    return model::topic_id_partition{*topic_cfg->tp_id, ntp.tp.partition};
+}
+
+std::unique_ptr<model::record_batch_reader::impl>
+frontend::make_l1_reader(cloud_topic_log_reader_config& cfg) const {
+    auto ct_state = _partition->get_cloud_topics_state();
+    auto l1_metastore = ct_state->local().get_l1_metastore();
+    auto l1_io = ct_state->local().get_l1_io();
+
+    auto tidp = ntp_to_topic_id_partition(_partition->ntp());
+    vassert(
+      tidp.has_value(), "No topic id for cloud topic {}", _partition->ntp());
+
+    return std::make_unique<level_one_log_reader_impl>(
+      cfg, _partition->ntp(), *tidp, l1_metastore, l1_io);
 }
 
 ss::future<std::optional<storage::timequery_result>>

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -156,6 +156,12 @@ private:
 
     bool cache_enabled() const;
 
+    std::optional<model::topic_id_partition>
+    ntp_to_topic_id_partition(const model::ntp& ntp) const;
+
+    std::unique_ptr<model::record_batch_reader::impl>
+    make_l1_reader(cloud_topic_log_reader_config& cfg) const;
+
     ss::abort_source _as;
     retry_chain_node _rtc;
     ss::lw_shared_ptr<cluster::partition> _partition;

--- a/src/v/cloud_topics/state_accessors.h
+++ b/src/v/cloud_topics/state_accessors.h
@@ -9,9 +9,18 @@
  */
 #pragma once
 
+namespace cluster {
+class metadata_cache;
+}
+
 namespace cloud_topics {
 
 class data_plane_api;
+
+namespace l1 {
+class metastore;
+class io;
+} // namespace l1
 
 // Encapsulates the required bits to access topic state from cloud topics,
 // with minimal dependencies. This allows it to be passed around through
@@ -19,12 +28,25 @@ class data_plane_api;
 //
 class state_accessors {
 public:
-    explicit state_accessors(data_plane_api* data_plane)
-      : data_plane(data_plane) {}
+    explicit state_accessors(
+      data_plane_api* data_plane,
+      l1::metastore* metastore,
+      l1::io* io,
+      cluster::metadata_cache* metadata_cache)
+      : data_plane(data_plane)
+      , l1_metastore(metastore)
+      , l1_io(io)
+      , metadata_cache(metadata_cache) {}
 
     data_plane_api* get_data_plane() { return data_plane; }
+    l1::metastore* get_l1_metastore() { return l1_metastore; }
+    l1::io* get_l1_io() { return l1_io; }
+    cluster::metadata_cache* get_metadata_cache() { return metadata_cache; }
 
 private:
     data_plane_api* data_plane;
+    l1::metastore* l1_metastore;
+    l1::io* l1_io;
+    cluster::metadata_cache* metadata_cache;
 };
 } // namespace cloud_topics


### PR DESCRIPTION
This adds the ability to read from L0 or L1 by having the frontend pick
one or the other at the time the reader is instantiated. If a client
wants to read from both L0 and L1, it must do so in multiple requests,
creating multiple readers.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
