### PR TITLE
[CORE-13481] model: Log topic_id as base64

### DIFF
--- a/src/v/model/BUILD
+++ b/src/v/model/BUILD
@@ -71,6 +71,7 @@ redpanda_cc_library(
         "//src/v/serde:vector",
         "//src/v/ssx:sformat",
         "//src/v/strings:string_switch",
+        "//src/v/utils:base64",
         "//src/v/utils:move_canary",
         "//src/v/utils:named_type",
         "//src/v/utils:to_string",

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "base/format_to.h"
 #include "base/seastarx.h"
 #include "base/vassert.h"
 #include "bytes/iobuf.h"
@@ -535,9 +536,28 @@ constexpr std::string_view to_string_view(fips_mode_flag f) {
 std::ostream& operator<<(std::ostream& os, const fips_mode_flag& f);
 std::istream& operator>>(std::istream& is, fips_mode_flag& f);
 
-using topic_id = named_type<uuid_t, struct topic_id_type>;
+struct topic_id : named_type<uuid_t, struct topic_id_tag> {
+    static topic_id create() { return topic_id{uuid_t::create()}; }
+    using base = named_type<uuid_t, struct topic_id_tag>;
+    using base::base;
+    using base::operator=;
 
-inline topic_id create_topic_id() { return topic_id{uuid_t::create()}; }
+    fmt::iterator format_to(fmt::iterator it) const;
+
+    constexpr friend bool
+    operator==(const topic_id& lhs, const topic_id& rhs) noexcept
+      = default;
+    constexpr friend auto
+    operator<=>(const topic_id& lhs, const topic_id& rhs) noexcept
+      = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const topic_id& u) {
+        return H::combine(std::move(h), static_cast<const base&>(u));
+    }
+};
+
+inline topic_id create_topic_id() { return topic_id::create(); }
 
 struct topic_id_partition {
     topic_id_partition() = default;

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -10,6 +10,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
+#include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "model/compression.h"
@@ -24,6 +25,7 @@
 #include "serde/rw/sstring.h"
 #include "serde/serde_exception.h"
 #include "strings/string_switch.h"
+#include "utils/base64.h"
 #include "utils/to_string.h"
 
 #include <seastar/core/print.hh>
@@ -781,6 +783,12 @@ std::istream& operator>>(std::istream& is, fips_mode_flag& f) {
             to_string_view(fips_mode_flag::permissive),
             fips_mode_flag::permissive);
     return is;
+}
+
+fmt::iterator topic_id::format_to(fmt::iterator it) const {
+    const auto& uuid = (*this)().uuid();
+    const bytes_view bv{uuid.begin(), uuid.size()};
+    return fmt::format_to(it, "{}", bytes_to_base64(bv));
 }
 
 topic_id_partition topic_id_partition::from(std::string_view s) {


### PR DESCRIPTION
[KIP-514](https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers) suggests that Topic IDs should be rendered as base64 encoded, so switch logging to use base64.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
