### PR TITLE
ct/reconciler: Remove unused and unimplemented method

### DIFF
--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -253,14 +253,6 @@ private:
     ss::future<model::record_batch_reader>
     make_reader(frontend*, kafka::offset start_offset, size_t);
 
-    /*
-     * Convert an ntp to a topic_id_partition using the metadata cache.
-     * Returns nullopt if the topic doesn't exist or doesn't have a
-     * topic_id.
-     */
-    std::optional<model::topic_id_partition>
-    ntp_to_topic_id_partition(const model::ntp& ntp) const;
-
 private:
     data_plane_api* _data_plane;
     l1::io* _l1_io;


### PR DESCRIPTION
The use of it and implementation for it were removed by #27691.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
