### PR TITLE
cloud_topics/reconciler: add retry mechanism for transport errors

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -52,6 +52,7 @@ redpanda_cc_library(
         "//src/v/model",
         "//src/v/random:generators",
         "//src/v/ssx:future_util",
+        "//src/v/utils:retry_chain_node",
         "@abseil-cpp//absl/container:btree",
         "@seastar",
     ],

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -24,9 +24,14 @@
 #include "model/namespace.h"
 #include "random/generators.h"
 #include "ssx/future-util.h"
+#include "utils/retry_chain_node.h"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/log.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 namespace {
 ss::logger lg("reconciler");
@@ -534,6 +539,37 @@ reconciler::add_object_metadata(
     co_return std::expected<void, reconcile_error>{};
 }
 
+ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>
+reconciler::add_objects_with_retry(
+  std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
+  l1::metastore::term_offset_map_t terms) {
+    static constexpr auto timeout = 5s;
+    static constexpr auto backoff = 100ms;
+
+    retry_chain_node rtc(_as, ss::lowres_clock::now() + timeout, backoff);
+    retry_chain_logger ctxlog(lg, rtc, "add_objects");
+    for (auto permit = rtc.retry(); permit.is_allowed; permit = rtc.retry()) {
+        auto add_result = co_await _metastore->add_objects(
+          *meta_builder, terms);
+
+        if (add_result.has_value()) {
+            co_return std::move(add_result).value();
+        }
+
+        if (add_result.error() != l1::metastore::errc::transport_error) {
+            vlog(
+              lg.error,
+              "Non-retryable error adding objects to the L1 metastore: {}",
+              add_result.error());
+            co_return std::unexpected(add_result.error());
+        }
+
+        co_await ss::sleep_abortable(permit.delay, rtc.root_abort_source());
+    }
+
+    co_return std::unexpected(l1::metastore::errc::transport_error);
+}
+
 ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
   const chunked_vector<built_object_metadata>& objects,
   std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder) {
@@ -551,11 +587,11 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
         }
     }
 
-    auto add_objects_result = co_await _metastore->add_objects(
-      *meta_builder, terms);
+    auto add_objects_result = co_await add_objects_with_retry(
+      std::move(meta_builder), std::move(terms));
     if (!add_objects_result.has_value()) {
         vlog(
-          lg.error,
+          lg.warn,
           "Failed to add objects to the L1 metastore: {}",
           add_objects_result.error());
         // TODO: The objects have been uploaded. The reconciler could

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -262,6 +262,15 @@ private:
     ntp_to_topic_id_partition(const model::ntp& ntp) const;
 
 private:
+    /*
+     * Retry metastore add_objects calls on transport errors.
+     * Other metastore errors are not retried.
+     */
+    ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>
+    add_objects_with_retry(
+      std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
+      l1::metastore::term_offset_map_t terms);
+
     data_plane_api* _data_plane;
     l1::io* _l1_io;
     l1::metastore* _metastore;


### PR DESCRIPTION
Add retry logic to reconciler's metastore add_objects calls to handle transport errors. Previously, the reconciler would immediately fail and abandon the reconciliation round on any metastore error.

Fixes CORE-13427

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
