### PR TITLE
tests/Dockfiler: remove EXPOSE 8080

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -415,9 +415,6 @@ COPY --chown=0:0 --chmod=0644 lsan_suppressions.txt /opt/lsan_suppressions.txt
 # copy ubsan suppressions file
 COPY --chown=0:0 --chmod=0644 ubsan_suppressions.txt /opt/ubsan_suppressions.txt
 
-# expose port 8080 for any http examples within clients
-EXPOSE 8080
-
 # copy known ssh keys
 COPY --chown=0:0 --chmod=0755 tests/docker/ssh /root/.ssh
 


### PR DESCRIPTION
As far as I can tell this does nothing these days, it only has an effect if you use `-P` with `docker run`, which we don't do (in taskfiles anyway), and it seems to trigger this bug:

https://github.com/moby/moby/issues/51040

Causing new images to be created on every build, which means docker compose up recreates the containers on every test run, which is a big hit to iteration time with fast tests.

xref:
https://redpandadata.slack.com/archives/C07HD9U0EHL/p1758724406249699

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
