### PR TITLE
gtest_listener_test: bail if fail-fast is set

### DIFF
--- a/src/v/test_utils/tests/gtest_listener_test.cc
+++ b/src/v/test_utils/tests/gtest_listener_test.cc
@@ -62,6 +62,14 @@ int main(int argc, char** argv) {
     auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new rp_test_listener());
 
+    if (GTEST_FLAG_GET(fail_fast)) {
+        // this test makes assumptions about fail fast behavior not being
+        // on so just short-circuit out if the user has set that (e.g.,
+        // via bazel test --test_runner_fail_fast)
+        fmt::print("Skipping test because --gtest_fail_fast is set\n");
+        return 0;
+    }
+
     // Hide stdout to avoid confusing users.
     testing::internal::CaptureStdout();
     int result = RUN_ALL_TESTS();


### PR DESCRIPTION
We can set fail fast in bazel but this test assumes it's off and it is testing internal gtest stuff and relies on all the tests to run in order to verify behavior in main().

So just bail out early if fail-fast is set with rc=0.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
