### PR TITLE
tests: use statistical model for pass criteria

### DIFF
--- a/tests/ducktape-common-retry.yml
+++ b/tests/ducktape-common-retry.yml
@@ -4,7 +4,15 @@
 #
 # See https://redpandadata.atlassian.net/wiki/x/CAAIRg
 
-zero-drift: &zero-drift
+common_pc_definitions: &common_pc_definitions
+  statistical-default:
+    mode:
+      statistical:
+        compare_with_branch: dev
+        time_window: 2w
+        reject_threshold: 0.01
+        trust_threshold: 0.5
+        max_retry_sessions: 5
   zero-drift:
     mode:
       dynamic_reliability:

--- a/tests/ducktape-merge-retry.yml
+++ b/tests/ducktape-merge-retry.yml
@@ -7,10 +7,10 @@
 # See https://redpandadata.atlassian.net/wiki/x/CAAIRg
 
 pass_criteria:
-  <<: *zero-drift
+  <<: *common_pc_definitions
 retry:
   default:
-    repeat: 20
+    repeat: 10
     retry_on:
       *retry-all-except-nodecrash
-    pass_criteria: zero-drift
+    pass_criteria: statistical-default

--- a/tests/ducktape-pr-retry.yml
+++ b/tests/ducktape-pr-retry.yml
@@ -7,10 +7,10 @@
 # See https://redpandadata.atlassian.net/wiki/x/CAAIRg
 
 pass_criteria:
-  <<: *zero-drift
+  <<: *common_pc_definitions
 retry:
   default:
-    repeat: 20
+    repeat: 10
     retry_on:
       *retry-all-except-nodecrash
-    pass_criteria: fifty-drift
+    pass_criteria: statistical-default


### PR DESCRIPTION
Use statistical mode for retrying ducktape tests and mark them `FAIL` or `PASS`. This feature was introduced in https://github.com/redpanda-data/vtools/pull/3925.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

* none


