### PR TITLE
[CORE-13424] ct/reconciler: store LRO in CTP STM

### DIFF
--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -159,7 +159,7 @@ ss::future<> app::wire_up_notifications() {
               if (partition) {
                   r.attach_partition(ntp, tidp, std::move(*partition));
               } else {
-                  r.detach_partition(ntp);
+                  r.detach(ntp);
               }
           });
     });

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -81,7 +81,6 @@ ss::future<> app::construct(
 
     co_await construct_service(
       reconciler,
-      data_plane.get(),
       ss::sharded_parameter([this] { return &l1_io.local(); }),
       ss::sharded_parameter([this] { return &replicated_metastore.local(); }));
 
@@ -152,12 +151,13 @@ ss::future<> app::wire_up_notifications() {
     });
     co_await reconciler.invoke_on_all([this](auto& r) {
         manager.local().on_ctp_partition_leader(
-          [&r](
+          [this, &r](
             const model::ntp& ntp,
             const model::topic_id_partition& tidp,
             auto partition) noexcept {
               if (partition) {
-                  r.attach_partition(ntp, tidp, std::move(*partition));
+                  r.attach_partition(
+                    ntp, tidp, data_plane.get(), std::move(*partition));
               } else {
                   r.detach(ntp);
               }

--- a/src/v/cloud_topics/level_one/common/abstract_io.cc
+++ b/src/v/cloud_topics/level_one/common/abstract_io.cc
@@ -30,3 +30,24 @@ io::read_object_as_iobuf(object_extent extent, ss::abort_source* as) {
 }
 
 } // namespace cloud_topics::l1
+
+auto fmt::formatter<cloud_topics::l1::io::errc>::format(
+  const cloud_topics::l1::io::errc& err, fmt::format_context& ctx) const
+  -> decltype(ctx.out()) {
+    std::string_view name = "unknown";
+    switch (err) {
+    case cloud_topics::l1::io::errc::file_io_error:
+        name = "file_io_error";
+        break;
+    case cloud_topics::l1::io::errc::cloud_missing_object:
+        name = "cloud_missing_object";
+        break;
+    case cloud_topics::l1::io::errc::cloud_op_error:
+        name = "cloud_op_error";
+        break;
+    case cloud_topics::l1::io::errc::cloud_op_timeout:
+        name = "cloud_op_timeout";
+        break;
+    }
+    return fmt::format_to(ctx.out(), "cloud_topics::l1::io::errc::{}", name);
+}

--- a/src/v/cloud_topics/level_one/common/abstract_io.h
+++ b/src/v/cloud_topics/level_one/common/abstract_io.h
@@ -20,7 +20,6 @@
 #include <seastar/core/reactor.hh>
 
 #include <expected>
-#include <limits>
 
 namespace cloud_topics::l1 {
 
@@ -102,3 +101,11 @@ protected:
 };
 
 } // namespace cloud_topics::l1
+
+template<>
+struct fmt::formatter<cloud_topics::l1::io::errc>
+  : fmt::formatter<std::string_view> {
+    auto
+    format(const cloud_topics::l1::io::errc&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
+};

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -87,6 +87,10 @@ ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
 ctp_stm_api::advance_reconciled_offset(
   kafka::offset last_reconciled_offset,
   model::timeout_clock::time_point deadline) {
+    if (last_reconciled_offset <= get_last_reconciled_offset()) {
+        co_return std::monostate{};
+    }
+
     vlog(_rtclog.debug, "Replicating ctp_stm_cmd::advance_reconciled_offset");
 
     storage::record_batch_builder builder(

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -25,6 +25,7 @@
 
 #include <seastar/coroutine/as_future.hh>
 
+#include <exception>
 #include <stdexcept>
 
 namespace cloud_topics {
@@ -61,6 +62,7 @@ ctp_stm_api::replicated_apply(
     auto res = co_await _stm->_raft->replicate(term, std::move(batch), opts);
 
     if (res.has_error()) {
+        vlog(_rtclog.debug, "Failed to replicate batch: {}", res.error());
         if (res.error() == raft::errc::not_leader) {
             co_return std::unexpected(ctp_stm_api_errc::not_leader);
         }
@@ -71,6 +73,10 @@ ctp_stm_api::replicated_apply(
         co_await _stm->wait(
           res.value().last_offset, deadline, _rtc.root_abort_source());
     } catch (...) {
+        vlog(
+          _rtclog.warn,
+          "Failed to wait for replicated command to to be applied: {}",
+          std::current_exception());
         co_return std::unexpected(ctp_stm_api_errc::timeout);
     }
 

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -23,13 +23,20 @@ redpanda_cc_library(
     name = "reconciler",
     srcs = [
         "reconciler.cc",
+        "reconciliation_source.cc",
     ],
     hdrs = [
         "reconciler.h",
+        "reconciliation_source.h",
     ],
     implementation_deps = [
         "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics:log_reader_config",
+        "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/frontend",
+        "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
+        "//src/v/kafka/utils:txn_reader",
+        "//src/v/utils:retry_chain_node",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -44,11 +51,9 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/common:object_utils",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
-        "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
         "//src/v/cluster",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",
-        "//src/v/kafka/utils:txn_reader",
         "//src/v/model",
         "//src/v/random:generators",
         "//src/v/ssx:future_util",

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -30,8 +30,6 @@ redpanda_cc_library(
         "reconciliation_source.h",
     ],
     implementation_deps = [
-        "//src/v/cloud_topics:data_plane_api",
-        "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/frontend",
         "//src/v/cloud_topics/level_zero/stm:ctp_stm_api",
@@ -43,6 +41,8 @@ redpanda_cc_library(
         ":reconciliation_consumer",
         "//src/v/base",
         "//src/v/cloud_storage_clients",
+        "//src/v/cloud_topics:data_plane_api",
+        "//src/v/cloud_topics:log_reader_config",
         "//src/v/cloud_topics:object_utils",
         "//src/v/cloud_topics:types",
         "//src/v/cloud_topics/level_one/common:abstract_io",

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -615,6 +615,10 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
             auto result = co_await partition.source->set_last_reconciled_offset(
               lro, _as);
             if (!result.has_value()) {
+                vlog(
+                  lg.warn,
+                  "Failed to update LRO: {}",
+                  std::to_underlying(result.error()));
                 // Don't fail early, just keep going until we're done.
                 reconcile_result = std::unexpected(
                   reconcile_error::metadata_failure);

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -17,11 +17,11 @@
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/log_reader_config.h"
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
+#include "cloud_topics/reconciler/reconciliation_source.h"
 #include "cluster/partition.h"
-#include "kafka/utils/txn_reader.h"
 #include "model/fundamental.h"
-#include "model/namespace.h"
 #include "random/generators.h"
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
@@ -35,26 +35,6 @@ using namespace std::chrono_literals;
 
 namespace {
 ss::logger lg("reconciler");
-
-class aborted_transaction_tracker_impl
-  : public kafka::aborted_transaction_tracker {
-public:
-    aborted_transaction_tracker_impl(
-      cloud_topics::frontend* fe,
-      ss::lw_shared_ptr<const storage::offset_translator_state> translator)
-      : _fe(fe)
-      , _translator(std::move(translator)) {}
-
-    ss::future<std::vector<model::tx_range>>
-    compute_aborted_transactions(model::offset base, model::offset max) final {
-        return _fe->aborted_transactions(
-          model::offset_cast(base), model::offset_cast(max), _translator);
-    }
-
-private:
-    cloud_topics::frontend* _fe;
-    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
-};
 
 } // namespace
 
@@ -82,17 +62,23 @@ void reconciler::attach_partition(
   const model::ntp& ntp,
   model::topic_id_partition tidp,
   ss::lw_shared_ptr<cluster::partition> partition) {
-    if (_partitions.contains(ntp)) {
-        return;
-    }
-    vlog(lg.debug, "Attaching partition {} (tidp: {})", ntp, tidp);
-    auto attached = ss::make_lw_shared<attached_partition_info>(
-      tidp, partition);
-    _partitions.emplace(ntp, std::move(attached));
+    attach_source(make_source(ntp, tidp, _data_plane, std::move(partition)));
 }
 
-void reconciler::detach_partition(const model::ntp& ntp) {
-    if (auto it = _partitions.find(ntp); it != _partitions.end()) {
+void reconciler::attach_source(ss::shared_ptr<source> src) {
+    if (_sources.contains(src->ntp())) {
+        return;
+    }
+    vlog(
+      lg.debug,
+      "Attaching partition {} (tidp: {})",
+      src->ntp(),
+      src->topic_id_partition());
+    _sources.emplace(src->ntp(), src);
+}
+
+void reconciler::detach(const model::ntp& ntp) {
+    if (auto it = _sources.find(ntp); it != _sources.end()) {
         vlog(lg.debug, "Detaching partition {}", ntp);
         /*
          * This upcall doesn't synchronize with the rest of the reconciler,
@@ -100,7 +86,7 @@ void reconciler::detach_partition(const model::ntp& ntp) {
          * it shouldn't be assumed that the attached partition remains in the
          * _partitions collection.
          */
-        _partitions.erase(it);
+        _sources.erase(it);
     }
 }
 
@@ -125,7 +111,7 @@ ss::future<> reconciler::reconciliation_loop() {
         vlog(
           lg.debug,
           "Reconciliation loop tick with {} attached partitions",
-          _partitions.size());
+          _sources.size());
 
         // clang-format off
         /*
@@ -191,26 +177,14 @@ ss::future<> reconciler::reconciliation_loop() {
     }
 }
 
-chunked_vector<reconciler::attached_partition>
-reconciler::collect_leader_partitions() const {
-    chunked_vector<attached_partition> leaders;
-    for (const auto& p : _partitions) {
-        if (p.second->partition->is_leader()) {
-            leaders.push_back(p.second);
-        }
-    }
-
-    if (!leaders.empty()) {
-        std::shuffle(
-          leaders.begin(), leaders.end(), random_generators::global().engine());
-    }
-    return leaders;
-}
-
 ss::future<> reconciler::reconcile() {
-    auto partitions = collect_leader_partitions();
-    if (partitions.empty()) {
-        vlog(lg.debug, "No leader partitions to reconcile");
+    chunked_vector<ss::shared_ptr<source>> sources;
+    // Make a copy of the sources to not worry about concurrent modification.
+    for (auto& [_, src] : _sources) {
+        sources.push_back(src);
+    }
+    if (sources.empty()) {
+        vlog(lg.trace, "No leader partitions to reconcile");
         co_return;
     }
 
@@ -224,15 +198,16 @@ ss::future<> reconciler::reconcile() {
         co_return;
     }
     auto& metadata_builder = metadata_builder_res.value();
-    chunked_hash_map<l1::object_id, chunked_vector<attached_partition>>
+    chunked_hash_map<l1::object_id, chunked_vector<ss::shared_ptr<source>>>
       oid_to_partitions;
-    for (const auto& p : partitions) {
-        auto oid = metadata_builder->get_or_create_object_for(p->tidp);
+    for (const auto& src : sources) {
+        auto oid = metadata_builder->get_or_create_object_for(
+          src->topic_id_partition());
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());
             co_return;
         }
-        oid_to_partitions[oid.value()].push_back(p);
+        oid_to_partitions[oid.value()].push_back(src);
     }
 
     // Process partitions by their object. This should be easier to
@@ -241,7 +216,7 @@ ss::future<> reconciler::reconcile() {
     chunked_vector<l1::object_id> failed_objects;
     for (const auto& [oid, partitions] : oid_to_partitions) {
         auto object_fut = co_await ss::coroutine::as_future(
-          reconcile_partitions(oid, partitions));
+          reconcile_sources(oid, partitions));
         if (object_fut.failed()) {
             auto ex = object_fut.get_exception();
             const auto is_shutdown = ssx::is_shutdown_exception(ex);
@@ -304,9 +279,9 @@ ss::future<> reconciler::reconcile() {
 }
 
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
-reconciler::reconcile_partitions(
+reconciler::reconcile_sources(
   const l1::object_id& oid,
-  const chunked_vector<attached_partition>& partitions) {
+  const chunked_vector<ss::shared_ptr<source>>& sources) {
     auto ctx_result = co_await make_context();
     if (!ctx_result.has_value()) {
         co_return std::unexpected(ctx_result.error());
@@ -314,7 +289,7 @@ reconciler::reconcile_partitions(
     auto ctx = std::move(ctx_result.value());
 
     auto fut = co_await ss::coroutine::as_future(
-      build_and_put_object(oid, ctx, partitions));
+      build_and_put_object(oid, ctx, sources));
 
     // Always cleanup.
     auto close_fut = co_await ss::coroutine::as_future(ctx.close_builder());
@@ -358,9 +333,9 @@ ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
 reconciler::build_and_put_object(
   const l1::object_id& oid,
   builder_context& ctx,
-  const chunked_vector<attached_partition>& partitions) {
+  const chunked_vector<ss::shared_ptr<source>>& sources) {
     // Build the object.
-    auto build_result = co_await build_object(ctx, partitions);
+    auto build_result = co_await build_object(ctx, sources);
     if (!build_result.has_value()) {
         co_return std::unexpected(build_result.error());
     }
@@ -419,13 +394,13 @@ reconciler::make_context() {
 
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
 reconciler::build_object(
-  builder_context& ctx, const chunked_vector<attached_partition>& partitions) {
+  builder_context& ctx, const chunked_vector<ss::shared_ptr<source>>& sources) {
     chunked_vector<partition_commit_info> metas;
-    metas.reserve(partitions.size());
-    for (const auto& partition : partitions) {
-        auto meta = co_await add_partition_to_object(ctx, partition);
+    metas.reserve(sources.size());
+    for (const auto& src : sources) {
+        auto meta = co_await add_partition_to_object(ctx, src);
         if (meta.has_value()) {
-            metas.emplace_back(partition, std::move(meta).value());
+            metas.emplace_back(src, std::move(meta).value());
         }
     }
     metas.shrink_to_fit();
@@ -436,9 +411,11 @@ reconciler::build_object(
       lg.debug,
       "Built L1 object from {} partitions ({} partitions didn't fit)",
       metas.size(),
-      partitions.size() - metas.size());
+      sources.size() - metas.size());
     co_return built_object_metadata{
-      .object_info = std::move(obj_info), .partitions = std::move(metas)};
+      .object_info = std::move(obj_info),
+      .partitions = std::move(metas),
+    };
 }
 
 ss::future<std::expected<void, reconcile_error>>
@@ -458,28 +435,38 @@ reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
 
 ss::future<std::optional<partition_metadata>>
 reconciler::add_partition_to_object(
-  builder_context& ctx, const attached_partition& partition) {
+  builder_context& ctx, ss::shared_ptr<source> partition) {
     vlog(
       lg.debug,
       "Processing partition {} with LRO {}",
-      partition->tidp,
-      partition->lro);
+      partition->ntp(),
+      partition->last_reconciled_offset());
 
-    frontend fe(partition->partition, _data_plane);
-    auto reader = co_await make_reader(&fe, partition->lro, ctx.size_budget);
-    reconciliation_consumer consumer(ctx.builder.get(), partition->tidp);
+    auto reader = co_await partition->make_reader(cloud_topic_log_reader_config(
+      /*start_offset=*/partition->last_reconciled_offset(),
+      /*max_offset=*/kafka::offset::max(),
+      /*min_bytes=*/1,
+      /*max_bytes=*/ctx.size_budget,
+      /*type_filter=*/std::nullopt,
+      /*time=*/std::nullopt,
+      /*as=*/_as));
+    reconciliation_consumer consumer(
+      ctx.builder.get(), partition->topic_id_partition());
     auto metadata = co_await std::move(reader).consume(
       std::move(consumer), model::no_timeout);
 
     if (!metadata.has_value()) {
-        vlog(lg.debug, "No batches found for partition {}", partition->tidp);
+        vlog(
+          lg.debug,
+          "No batches found for partition {}",
+          partition->topic_id_partition());
         co_return std::nullopt;
     }
 
     vlog(
       lg.debug,
       "Adding partition {} to L1 object with offsets {}~{}",
-      partition->tidp,
+      partition->topic_id_partition(),
       metadata->base_offset,
       metadata->last_offset);
 
@@ -498,13 +485,13 @@ reconciler::add_object_metadata(
     // topic partition.
     for (const auto& partition : obj_meta.partitions) {
         auto [first, last] = obj_meta.object_info.index.partitions.equal_range(
-          partition.partition->tidp);
+          partition.source->topic_id_partition());
         for (auto it = first; it != last; ++it) {
             const auto& obj_partition = it->second;
             auto add_result = meta_builder->add(
               oid,
               l1::metastore::object_metadata::ntp_metadata{
-                .tidp = partition.partition->tidp,
+                .tidp = partition.source->topic_id_partition(),
                 .base_offset = obj_partition.first_offset,
                 .last_offset = obj_partition.last_offset,
                 .max_timestamp = obj_partition.max_timestamp,
@@ -514,7 +501,7 @@ reconciler::add_object_metadata(
                 vlog(
                   lg.error,
                   "Failed to finish metadata for partition {} of object {}: {}",
-                  partition.partition->tidp,
+                  partition.source->topic_id_partition(),
                   oid,
                   add_result.error());
                 // TODO: The object has been uploaded. The reconciler could
@@ -580,11 +567,12 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
     l1::metastore::term_offset_map_t terms;
     for (const auto& obj_meta : objects) {
         for (const auto& partition : obj_meta.partitions) {
+            auto tidp = partition.source->topic_id_partition();
             chunked_vector<l1::metastore::term_offset> term_offsets;
             for (const auto& [term, first_offset] : partition.metadata.terms) {
                 term_offsets.emplace_back(term, first_offset);
             }
-            terms[partition.partition->tidp] = std::move(term_offsets);
+            terms[tidp] = std::move(term_offsets);
         }
     }
 
@@ -602,78 +590,34 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
 
     // Now update the LRO, taking into account any corrections from
     // the metastore.
-    // TODO: Inform L0 of the update.
     const auto& corrected_next_offsets
       = add_objects_result.value().corrected_next_offsets;
+    std::expected<void, reconcile_error> reconcile_result;
     for (const auto& obj_meta : objects) {
         for (const auto& partition : obj_meta.partitions) {
+            auto tidp = partition.source->topic_id_partition();
             auto next_lro = kafka::offset::min();
-            if (corrected_next_offsets.contains(partition.partition->tidp)) {
-                next_lro = corrected_next_offsets.at(partition.partition->tidp);
+            if (corrected_next_offsets.contains(tidp)) {
+                next_lro = corrected_next_offsets.at(tidp);
             } else {
-                auto [first, last] = obj_meta.object_info.index.partitions
-                                       .equal_range(partition.partition->tidp);
+                auto [first, last]
+                  = obj_meta.object_info.index.partitions.equal_range(tidp);
                 for (auto it = first; it != last; ++it) {
                     const auto& obj_partition = it->second;
                     next_lro = std::max(
                       next_lro, kafka::next_offset(obj_partition.last_offset));
                 }
             }
-            partition.partition->lro = next_lro;
+            auto result = co_await partition.source->set_last_reconciled_offset(
+              next_lro, _as);
+            if (!result.has_value()) {
+                // Don't fail early, just keep going until we're done.
+                reconcile_result = std::unexpected(
+                  reconcile_error::metadata_failure);
+            }
         }
     }
-
-    co_return std::expected<void, reconcile_error>{};
-}
-
-ss::future<model::record_batch_reader> reconciler::make_reader(
-  frontend* fe, kafka::offset start_offset, size_t max_bytes) {
-    auto effective_start = co_await fe->sync_effective_start(5s);
-    if (!effective_start.has_value()) {
-        vlog(
-          lg.warn,
-          "Error querying partition start offset ({}): {}",
-          fe->ntp(),
-          effective_start.error());
-        co_return model::make_empty_record_batch_reader();
-    }
-
-    start_offset = std::max(effective_start.value(), start_offset);
-
-    auto maybe_lso = fe->last_stable_offset();
-    if (!maybe_lso.has_value()) {
-        vlog(
-          lg.warn,
-          "Error querying partition LSO ({}): {}",
-          fe->ntp(),
-          maybe_lso.error());
-        co_return model::make_empty_record_batch_reader();
-    }
-
-    // It's possible for LSO to be 0, which in this case the previous offset
-    // is model::offset::min(), this is the same as the kafka fetch path.
-    auto max_offset = kafka::prev_offset(maybe_lso.value());
-
-    if (max_offset < start_offset) {
-        co_return model::make_empty_record_batch_reader();
-    }
-
-    auto reader = co_await fe->make_reader(
-      cloud_topic_log_reader_config(
-        start_offset,
-        max_offset,
-        0,
-        max_bytes,
-        std::nullopt,
-        std::nullopt,
-        _as),
-      /*debounce_deadline=*/std::nullopt);
-
-    auto tracker = std::make_unique<aborted_transaction_tracker_impl>(
-      fe, std::move(reader.ot_state));
-
-    co_return model::make_record_batch_reader<kafka::read_committed_reader>(
-      std::move(tracker), std::move(reader.reader));
+    co_return reconcile_result;
 }
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -22,7 +22,6 @@
 #include "cloud_topics/reconciler/reconciliation_source.h"
 #include "cluster/partition.h"
 #include "model/fundamental.h"
-#include "random/generators.h"
 #include "ssx/future-util.h"
 #include "utils/retry_chain_node.h"
 
@@ -82,9 +81,9 @@ void reconciler::detach(const model::ntp& ntp) {
         vlog(lg.debug, "Detaching partition {}", ntp);
         /*
          * This upcall doesn't synchronize with the rest of the reconciler,
-         * which means that once a reference to an attached partition is held,
-         * it shouldn't be assumed that the attached partition remains in the
-         * _partitions collection.
+         * which means that once a reference to a source is held,
+         * it shouldn't be assumed that the source remains in the
+         * _sources collection.
          */
         _sources.erase(it);
     }
@@ -199,7 +198,7 @@ ss::future<> reconciler::reconcile() {
     }
     auto& metadata_builder = metadata_builder_res.value();
     chunked_hash_map<l1::object_id, chunked_vector<ss::shared_ptr<source>>>
-      oid_to_partitions;
+      oid_to_sources;
     for (const auto& src : sources) {
         auto oid = metadata_builder->get_or_create_object_for(
           src->topic_id_partition());
@@ -207,19 +206,19 @@ ss::future<> reconciler::reconcile() {
             vlog(lg.warn, "Could not get object: {}", oid.error());
             co_return;
         }
-        oid_to_partitions[oid.value()].push_back(src);
+        oid_to_sources[oid.value()].push_back(src);
     }
 
-    // Process partitions by their object. This should be easier to
-    // improve than processing partition-by-partition.
+    // Process sources by their object. This should be easier to
+    // improve than processing source-by-source.
     chunked_vector<built_object_metadata> successful_objects;
     chunked_vector<l1::object_id> failed_objects;
-    for (const auto& [oid, partitions] : oid_to_partitions) {
+    for (const auto& [oid, sources] : oid_to_sources) {
         if (_as.abort_requested()) {
             co_return;
         }
         auto object_fut = co_await ss::coroutine::as_future(
-          reconcile_sources(oid, partitions));
+          reconcile_sources(oid, sources));
         if (object_fut.failed()) {
             auto ex = object_fut.get_exception();
             const auto is_shutdown = ssx::is_shutdown_exception(ex);
@@ -227,7 +226,7 @@ ss::future<> reconciler::reconcile() {
               lg,
               is_shutdown ? ss::log_level::debug : ss::log_level::error,
               "Exception reconciling {} partitions into object {}: {}",
-              partitions.size(),
+              sources.size(),
               oid,
               ex);
             if (is_shutdown) {
@@ -240,7 +239,7 @@ ss::future<> reconciler::reconcile() {
         auto result = object_fut.get();
         if (!result.has_value()) {
             failed_objects.push_back(oid);
-            // Error was already logged in reconcile_partitions.
+            // Error was already logged in reconcile_sources.
             continue; // Skip this object and move to the next
         }
 
@@ -344,7 +343,7 @@ reconciler::build_and_put_object(
     }
 
     auto obj_meta = std::move(build_result.value());
-    if (obj_meta.partitions.empty()) {
+    if (obj_meta.commits.empty()) {
         vlog(lg.debug, "Skipping put for object {}: no data", oid);
         co_return std::unexpected(reconcile_error::build_or_put_failure);
     }
@@ -398,13 +397,13 @@ reconciler::make_context() {
 ss::future<std::expected<reconciler::built_object_metadata, reconcile_error>>
 reconciler::build_object(
   builder_context& ctx, const chunked_vector<ss::shared_ptr<source>>& sources) {
-    chunked_vector<partition_commit_info> metas;
+    chunked_vector<commit_info> metas;
     metas.reserve(sources.size());
     for (const auto& src : sources) {
         if (_as.abort_requested()) {
             co_return std::unexpected(reconcile_error::build_or_put_failure);
         }
-        auto meta = co_await add_partition_to_object(ctx, src);
+        auto meta = co_await add_source_to_object(ctx, src);
         if (meta.has_value()) {
             metas.emplace_back(src, std::move(meta).value());
         }
@@ -420,7 +419,7 @@ reconciler::build_object(
       sources.size() - metas.size());
     co_return built_object_metadata{
       .object_info = std::move(obj_info),
-      .partitions = std::move(metas),
+      .commits = std::move(metas),
     };
 }
 
@@ -439,19 +438,18 @@ reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
     co_return std::expected<void, reconcile_error>{};
 }
 
-ss::future<std::optional<partition_metadata>>
-reconciler::add_partition_to_object(
-  builder_context& ctx, ss::shared_ptr<source> partition) {
+ss::future<std::optional<consumer_metadata>> reconciler::add_source_to_object(
+  builder_context& ctx, ss::shared_ptr<source> src) {
     vlog(
       lg.debug,
       "Processing partition {} with LRO {}",
-      partition->ntp(),
-      partition->last_reconciled_offset());
+      src->ntp(),
+      src->last_reconciled_offset());
 
     // Since the LRO is the last thing inclusive of what we uploaded to L1, we
     // want to start reading from the next offset.
-    auto start_offset = kafka::next_offset(partition->last_reconciled_offset());
-    auto reader = co_await partition->make_reader(cloud_topic_log_reader_config(
+    auto start_offset = kafka::next_offset(src->last_reconciled_offset());
+    auto reader = co_await src->make_reader(cloud_topic_log_reader_config(
       /*start_offset=*/start_offset,
       /*max_offset=*/kafka::offset::max(),
       /*min_bytes=*/1,
@@ -460,7 +458,7 @@ reconciler::add_partition_to_object(
       /*time=*/std::nullopt,
       /*as=*/_as));
     reconciliation_consumer consumer(
-      ctx.builder.get(), partition->topic_id_partition());
+      ctx.builder.get(), src->topic_id_partition());
     auto metadata = co_await std::move(reader).consume(
       std::move(consumer), model::no_timeout);
 
@@ -468,14 +466,14 @@ reconciler::add_partition_to_object(
         vlog(
           lg.debug,
           "No batches found for partition {}",
-          partition->topic_id_partition());
+          src->topic_id_partition());
         co_return std::nullopt;
     }
 
     vlog(
       lg.debug,
       "Adding partition {} to L1 object with offsets {}~{}",
-      partition->topic_id_partition(),
+      src->topic_id_partition(),
       metadata->base_offset,
       metadata->last_offset);
 
@@ -491,15 +489,15 @@ std::expected<void, reconcile_error> reconciler::add_object_metadata(
     // partition of the cloud topic and the partition of the L1 object.
     // There may be multiple partitions in the L1 object for a cloud
     // topic partition.
-    for (const auto& partition : obj_meta.partitions) {
+    for (const auto& commit : obj_meta.commits) {
         auto [first, last] = obj_meta.object_info.index.partitions.equal_range(
-          partition.source->topic_id_partition());
+          commit.source->topic_id_partition());
         for (auto it = first; it != last; ++it) {
             const auto& obj_partition = it->second;
             auto add_result = meta_builder->add(
               oid,
               l1::metastore::object_metadata::ntp_metadata{
-                .tidp = partition.source->topic_id_partition(),
+                .tidp = commit.source->topic_id_partition(),
                 .base_offset = obj_partition.first_offset,
                 .last_offset = obj_partition.last_offset,
                 .max_timestamp = obj_partition.max_timestamp,
@@ -509,7 +507,7 @@ std::expected<void, reconcile_error> reconciler::add_object_metadata(
                 vlog(
                   lg.error,
                   "Failed to finish metadata for partition {} of object {}: {}",
-                  partition.source->topic_id_partition(),
+                  commit.source->topic_id_partition(),
                   oid,
                   add_result.error());
                 // TODO: The object has been uploaded. The reconciler could
@@ -570,14 +568,14 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
   const chunked_vector<built_object_metadata>& objects,
   std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder) {
     // It's possible to build the terms map as we build the objects, but
-    // I think re-iterating over all the object partitions here is worth
+    // I think re-iterating over all the commits here is worth
     // it in exchange for less context passing among functions.
     l1::metastore::term_offset_map_t terms;
     for (const auto& obj_meta : objects) {
-        for (const auto& partition : obj_meta.partitions) {
-            auto tidp = partition.source->topic_id_partition();
+        for (const auto& commit : obj_meta.commits) {
+            auto tidp = commit.source->topic_id_partition();
             chunked_vector<l1::metastore::term_offset> term_offsets;
-            for (const auto& [term, first_offset] : partition.metadata.terms) {
+            for (const auto& [term, first_offset] : commit.metadata.terms) {
                 term_offsets.emplace_back(term, first_offset);
             }
             terms[tidp] = std::move(term_offsets);
@@ -602,9 +600,9 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
       = add_objects_result.value().corrected_next_offsets;
     std::expected<void, reconcile_error> reconcile_result;
     for (const auto& obj_meta : objects) {
-        for (const auto& partition : obj_meta.partitions) {
-            auto tidp = partition.source->topic_id_partition();
-            kafka::offset lro = partition.metadata.last_offset;
+        for (const auto& commit : obj_meta.commits) {
+            auto tidp = commit.source->topic_id_partition();
+            kafka::offset lro = commit.metadata.last_offset;
             auto it = corrected_next_offsets.find(tidp);
             if (it != corrected_next_offsets.end()) {
                 // We want the previous offset, because that is what was last
@@ -612,7 +610,7 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
                 // offset *after* the LRO to start reading from.
                 lro = kafka::prev_offset(it->second);
             }
-            auto result = co_await partition.source->set_last_reconciled_offset(
+            auto result = co_await commit.source->set_last_reconciled_offset(
               lro, _as);
             if (!result.has_value()) {
                 vlog(

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -40,10 +40,8 @@ ss::logger lg("reconciler");
 
 namespace cloud_topics::reconciler {
 
-reconciler::reconciler(
-  data_plane_api* data_plane, l1::io* l1_io, l1::metastore* metastore)
-  : _data_plane(data_plane)
-  , _l1_io(l1_io)
+reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
+  : _l1_io(l1_io)
   , _metastore(metastore) {}
 
 ss::future<> reconciler::start() {
@@ -61,8 +59,9 @@ ss::future<> reconciler::stop() {
 void reconciler::attach_partition(
   const model::ntp& ntp,
   model::topic_id_partition tidp,
+  data_plane_api* data_plane,
   ss::lw_shared_ptr<cluster::partition> partition) {
-    attach_source(make_source(ntp, tidp, _data_plane, std::move(partition)));
+    attach_source(make_source(ntp, tidp, data_plane, std::move(partition)));
 }
 
 void reconciler::attach_source(ss::shared_ptr<source> src) {
@@ -442,8 +441,11 @@ reconciler::add_partition_to_object(
       partition->ntp(),
       partition->last_reconciled_offset());
 
+    // Since the LRO is the last thing inclusive of what we uploaded to L1, we
+    // want to start reading from the next offset.
+    auto start_offset = kafka::next_offset(partition->last_reconciled_offset());
     auto reader = co_await partition->make_reader(cloud_topic_log_reader_config(
-      /*start_offset=*/partition->last_reconciled_offset(),
+      /*start_offset=*/start_offset,
       /*max_offset=*/kafka::offset::max(),
       /*min_bytes=*/1,
       /*max_bytes=*/ctx.size_budget,
@@ -596,20 +598,16 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
     for (const auto& obj_meta : objects) {
         for (const auto& partition : obj_meta.partitions) {
             auto tidp = partition.source->topic_id_partition();
-            auto next_lro = kafka::offset::min();
-            if (corrected_next_offsets.contains(tidp)) {
-                next_lro = corrected_next_offsets.at(tidp);
-            } else {
-                auto [first, last]
-                  = obj_meta.object_info.index.partitions.equal_range(tidp);
-                for (auto it = first; it != last; ++it) {
-                    const auto& obj_partition = it->second;
-                    next_lro = std::max(
-                      next_lro, kafka::next_offset(obj_partition.last_offset));
-                }
+            kafka::offset lro = partition.metadata.last_offset;
+            auto it = corrected_next_offsets.find(tidp);
+            if (it != corrected_next_offsets.end()) {
+                // We want the previous offset, because that is what was last
+                // reconciled. During next reconciliation we should get the
+                // offset *after* the LRO to start reading from.
+                lro = kafka::prev_offset(it->second);
             }
             auto result = co_await partition.source->set_last_reconciled_offset(
-              next_lro, _as);
+              lro, _as);
             if (!result.has_value()) {
                 // Don't fail early, just keep going until we're done.
                 reconcile_result = std::unexpected(

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_topics/reconciler/reconciler.h"
 
+#include "base/source_location.h"
 #include "base/vlog.h"
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/frontend.h"
@@ -33,12 +34,22 @@
 
 using namespace std::chrono_literals;
 
+namespace cloud_topics::reconciler {
+
 namespace {
 ss::logger lg("reconciler");
 
-} // namespace
+void log_error(
+  const reconcile_error& err,
+  vlog::file_line file_line = vlog::file_line::current()) {
+    lg.log(
+      err.benign ? ss::log_level::debug : ss::log_level::error,
+      "{} - {}",
+      file_line,
+      err.message);
+}
 
-namespace cloud_topics::reconciler {
+} // namespace
 
 reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
   : _l1_io(l1_io)
@@ -239,7 +250,10 @@ ss::future<> reconciler::reconcile() {
         auto result = object_fut.get();
         if (!result.has_value()) {
             failed_objects.push_back(oid);
-            // Error was already logged in reconcile_sources.
+            log_error(result.error().with_context(
+              "Exception reconciling {} partitions into object {}",
+              sources.size(),
+              oid));
             continue; // Skip this object and move to the next
         }
 
@@ -248,7 +262,10 @@ ss::future<> reconciler::reconcile() {
           oid, obj_metadata, metadata_builder.get());
         if (!add_result.has_value()) {
             failed_objects.push_back(oid);
-            // Error was already logged in add_object_metadata.
+            log_error(add_result.error().with_context(
+              "Exception reconciling {} partitions into object {}",
+              sources.size(),
+              oid));
             continue; // Skip this object and move to the next
         }
 
@@ -272,10 +289,9 @@ ss::future<> reconciler::reconcile() {
     auto commit_result = co_await commit_objects(
       successful_objects, std::move(metadata_builder));
     if (!commit_result.has_value()) {
-        vlog(
-          lg.error,
-          "Abandoning reconciliation loop because the L1 metastore operation "
-          "failed");
+        log_error(commit_result.error().with_context(
+          "Abandoning reconciliation run because the L1 metastore operation "
+          "failed"));
         co_return;
     }
 }
@@ -318,14 +334,10 @@ reconciler::reconcile_sources(
 
     if (fut.failed()) {
         auto ex = fut.get_exception();
-        vlogl(
-          lg,
-          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
-                                         : ss::log_level::warn,
-          "Exception building and putting object {}: {}",
-          oid,
-          ex);
-        co_return std::unexpected(reconcile_error::build_or_put_failure);
+        co_return std::unexpected(
+          reconcile_error(
+            "Exception building and putting object {}: {}", oid, ex)
+            .mark_benign(ssx::is_shutdown_exception(ex)));
     }
 
     co_return fut.get();
@@ -344,8 +356,8 @@ reconciler::build_and_put_object(
 
     auto obj_meta = std::move(build_result.value());
     if (obj_meta.commits.empty()) {
-        vlog(lg.debug, "Skipping put for object {}: no data", oid);
-        co_return std::unexpected(reconcile_error::build_or_put_failure);
+        co_return std::unexpected(
+          reconcile_error("Skipping put for object {}: no data", oid));
     }
 
     // Upload the object.
@@ -364,11 +376,10 @@ reconciler::make_context() {
     // Create staging file.
     auto staging_result = co_await _l1_io->create_tmp_file();
     if (!staging_result.has_value()) {
-        vlog(
-          lg.warn,
-          "Failed to create staging file: {}",
-          static_cast<int>(staging_result.error()));
-        co_return std::unexpected(reconcile_error::build_or_put_failure);
+        co_return std::unexpected(
+          reconcile_error(
+            "Failed to create staging file: {}", staging_result.error())
+            .non_benign());
     }
     ctx.staging = std::move(staging_result).value();
 
@@ -377,14 +388,10 @@ reconciler::make_context() {
       ctx.staging->output_stream());
     if (stream_fut.failed()) {
         auto ex = stream_fut.get_exception();
-        vlogl(
-          lg,
-          ssx::is_shutdown_exception(ex) ? ss::log_level::debug
-                                         : ss::log_level::error,
-          "Failed to create output stream: {}",
-          ex);
         co_await ctx.cleanup_staging();
-        co_return std::unexpected(reconcile_error::build_or_put_failure);
+        co_return std::unexpected(
+          reconcile_error("Failed to create output stream: {}", ex)
+            .mark_benign(ssx::is_shutdown_exception(ex)));
     }
 
     auto output_stream = stream_fut.get();
@@ -401,7 +408,8 @@ reconciler::build_object(
     metas.reserve(sources.size());
     for (const auto& src : sources) {
         if (_as.abort_requested()) {
-            co_return std::unexpected(reconcile_error::build_or_put_failure);
+            co_return std::unexpected(
+              reconcile_error("abort requested while building object"));
         }
         auto meta = co_await add_source_to_object(ctx, src);
         if (meta.has_value()) {
@@ -427,12 +435,8 @@ ss::future<std::expected<void, reconcile_error>>
 reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
     auto put_result = co_await _l1_io->put_object(oid, ctx.staging.get(), &_as);
     if (!put_result.has_value()) {
-        vlog(
-          lg.warn,
-          "Failed to put L1 object {}: {}",
-          oid,
-          static_cast<int>(put_result.error()));
-        co_return std::unexpected(reconcile_error::build_or_put_failure);
+        co_return std::unexpected(reconcile_error(
+          "failed to put L1 object {}: {}", oid, put_result.error()));
     }
     vlog(lg.debug, "Successfully put L1 object {}", oid);
     co_return std::expected<void, reconcile_error>{};
@@ -504,15 +508,13 @@ std::expected<void, reconcile_error> reconciler::add_object_metadata(
                 .pos = obj_partition.file_position,
                 .size = obj_partition.length});
             if (!add_result.has_value()) {
-                vlog(
-                  lg.error,
+                // TODO: The object has been uploaded. The reconciler could
+                //       attempt cleanup (or notify a cleanup subsystem).
+                return std::unexpected(reconcile_error(
                   "Failed to finish metadata for partition {} of object {}: {}",
                   commit.source->topic_id_partition(),
                   oid,
-                  add_result.error());
-                // TODO: The object has been uploaded. The reconciler could
-                //       attempt cleanup (or notify a cleanup subsystem).
-                return std::unexpected(reconcile_error::metadata_failure);
+                  add_result.error()));
             }
         }
     }
@@ -520,20 +522,19 @@ std::expected<void, reconcile_error> reconciler::add_object_metadata(
     auto meta_result = meta_builder->finish(
       oid, obj_meta.object_info.footer_offset, obj_meta.object_info.size_bytes);
     if (!meta_result.has_value()) {
-        vlog(
-          lg.error,
-          "Failed to finish metadata for object {}: {}",
-          oid,
-          meta_result.error());
         // TODO: The object has been uploaded. The reconciler could
         //       attempt cleanup (or notify a cleanup subsystem).
-        return std::unexpected(reconcile_error::metadata_failure);
+        return std::unexpected(reconcile_error(
+                                 "Failed to finish metadata for object {}: {}",
+                                 oid,
+                                 meta_result.error())
+                                 .non_benign());
     }
 
     return {};
 }
 
-ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>
+ss::future<std::expected<l1::metastore::add_response, reconcile_error>>
 reconciler::add_objects_with_retry(
   std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
   l1::metastore::term_offset_map_t terms) {
@@ -551,17 +552,16 @@ reconciler::add_objects_with_retry(
         }
 
         if (add_result.error() != l1::metastore::errc::transport_error) {
-            vlog(
-              lg.error,
+            co_return std::unexpected(reconcile_error(
               "Non-retryable error adding objects to the L1 metastore: {}",
-              add_result.error());
-            co_return std::unexpected(add_result.error());
+              add_result.error()));
         }
 
         co_await ss::sleep_abortable(permit.delay, rtc.root_abort_source());
     }
 
-    co_return std::unexpected(l1::metastore::errc::transport_error);
+    co_return std::unexpected(reconcile_error(
+      "ran out of retries attempt to add objects to L1 metastore"));
 }
 
 ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
@@ -585,20 +585,17 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
     auto add_objects_result = co_await add_objects_with_retry(
       std::move(meta_builder), std::move(terms));
     if (!add_objects_result.has_value()) {
-        vlog(
-          lg.warn,
-          "Failed to add objects to the L1 metastore: {}",
-          add_objects_result.error());
         // TODO: The objects have been uploaded. The reconciler could
         //       attempt cleanup (or notify a cleanup subsystem).
-        co_return std::unexpected(reconcile_error::metadata_failure);
+        co_return std::unexpected(add_objects_result.error().with_context(
+          "Failed to add objects to the L1 metastore"));
     }
 
     // Now update the LRO, taking into account any corrections from
     // the metastore.
     const auto& corrected_next_offsets
       = add_objects_result.value().corrected_next_offsets;
-    std::expected<void, reconcile_error> reconcile_result;
+    std::optional<reconcile_error> error;
     for (const auto& obj_meta : objects) {
         for (const auto& commit : obj_meta.commits) {
             auto tidp = commit.source->topic_id_partition();
@@ -613,17 +610,28 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
             auto result = co_await commit.source->set_last_reconciled_offset(
               lro, _as);
             if (!result.has_value()) {
-                vlog(
-                  lg.warn,
-                  "Failed to update LRO: {}",
-                  std::to_underlying(result.error()));
                 // Don't fail early, just keep going until we're done.
-                reconcile_result = std::unexpected(
-                  reconcile_error::metadata_failure);
+                if (error) {
+                    error = error->with_context(
+                      "failed to set LRO in L0: {}", result.error());
+                } else {
+                    error = reconcile_error(
+                      "failed to set LRO in L0: {}", result.error());
+                }
+                if (result.error() == source::errc::failure) {
+                    // Other errors can be expected in normal operating
+                    // conditions.
+                    error = error->non_benign();
+                }
             }
         }
     }
-    co_return reconcile_result;
+    co_return error
+      .transform(
+        [](reconcile_error& err) -> std::expected<void, reconcile_error> {
+            return std::unexpected(std::move(err));
+        })
+      .value_or(std::expected<void, reconcile_error>{});
 }
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -30,6 +30,7 @@
 #include <seastar/util/log.hh>
 
 #include <chrono>
+#include <expected>
 
 using namespace std::chrono_literals;
 
@@ -214,6 +215,9 @@ ss::future<> reconciler::reconcile() {
     chunked_vector<built_object_metadata> successful_objects;
     chunked_vector<l1::object_id> failed_objects;
     for (const auto& [oid, partitions] : oid_to_partitions) {
+        if (_as.abort_requested()) {
+            co_return;
+        }
         auto object_fut = co_await ss::coroutine::as_future(
           reconcile_sources(oid, partitions));
         if (object_fut.failed()) {
@@ -241,7 +245,7 @@ ss::future<> reconciler::reconcile() {
         }
 
         auto obj_metadata = std::move(result).value();
-        auto add_result = co_await add_object_metadata(
+        auto add_result = add_object_metadata(
           oid, obj_metadata, metadata_builder.get());
         if (!add_result.has_value()) {
             failed_objects.push_back(oid);
@@ -397,6 +401,9 @@ reconciler::build_object(
     chunked_vector<partition_commit_info> metas;
     metas.reserve(sources.size());
     for (const auto& src : sources) {
+        if (_as.abort_requested()) {
+            co_return std::unexpected(reconcile_error::build_or_put_failure);
+        }
         auto meta = co_await add_partition_to_object(ctx, src);
         if (meta.has_value()) {
             metas.emplace_back(src, std::move(meta).value());
@@ -475,8 +482,7 @@ reconciler::add_partition_to_object(
     co_return metadata.value();
 }
 
-ss::future<std::expected<void, reconcile_error>>
-reconciler::add_object_metadata(
+std::expected<void, reconcile_error> reconciler::add_object_metadata(
   const l1::object_id& oid,
   const built_object_metadata& obj_meta,
   l1::metastore::object_metadata_builder* meta_builder) {
@@ -508,7 +514,7 @@ reconciler::add_object_metadata(
                   add_result.error());
                 // TODO: The object has been uploaded. The reconciler could
                 //       attempt cleanup (or notify a cleanup subsystem).
-                co_return std::unexpected(reconcile_error::metadata_failure);
+                return std::unexpected(reconcile_error::metadata_failure);
             }
         }
     }
@@ -523,10 +529,10 @@ reconciler::add_object_metadata(
           meta_result.error());
         // TODO: The object has been uploaded. The reconciler could
         //       attempt cleanup (or notify a cleanup subsystem).
-        co_return std::unexpected(reconcile_error::metadata_failure);
+        return std::unexpected(reconcile_error::metadata_failure);
     }
 
-    co_return std::expected<void, reconcile_error>{};
+    return {};
 }
 
 ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -609,7 +609,14 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
             }
             auto result = co_await commit.source->set_last_reconciled_offset(
               lro, _as);
-            if (!result.has_value()) {
+            if (result.has_value()) {
+                vlog(
+                  lg.debug,
+                  "successfully bumped LRO for {} (tidp: {}) to {}",
+                  commit.source->ntp(),
+                  tidp,
+                  lro);
+            } else {
                 // Don't fail early, just keep going until we're done.
                 if (error) {
                     error = error->with_context(

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -35,7 +35,8 @@ class frontend;
 
 namespace cloud_topics::reconciler {
 
-enum class reconcile_error { build_or_put_failure, metadata_failure };
+class source;
+enum class reconcile_error : uint8_t { build_or_put_failure, metadata_failure };
 
 /*
  * The reconciler is the cloud topics subsystem responsible for lifting
@@ -69,40 +70,13 @@ public:
       const model::ntp&,
       model::topic_id_partition,
       ss::lw_shared_ptr<cluster::partition>);
-    void detach_partition(const model::ntp&);
+    void attach_source(ss::shared_ptr<source>);
+    void detach(const model::ntp&);
 
 private:
-    /*
-     * An attached partition is a partition that the reconciler is tracking and
-     * periodically processing. Partitions are attached/detached via upcalls
-     * from the cluster module. The reconciler operates on the leaders of
-     * partitions with affinity to the local shard.
-     */
-    struct attached_partition_info {
-        explicit attached_partition_info(
-          model::topic_id_partition tidp,
-          ss::lw_shared_ptr<cluster::partition> p)
-          : tidp(tidp)
-          , partition(std::move(p)) {}
-
-        model::topic_id_partition tidp;
-
-        ss::lw_shared_ptr<cluster::partition> partition;
-
-        /*
-         * Last reconciled offset. this forms the starting offset when querying
-         * the partition for new data. In later versions of the system this will
-         * be stored in and queried from the partition itself.
-         * TODO: Rename this, and set it using the L0 LRO and the L1 metastore.
-         */
-        kafka::offset lro;
-    };
-
-    using attached_partition = ss::lw_shared_ptr<attached_partition_info>;
-
     // NB: Partition attachment is the only part using ntps instead of
     //     topic id partitions.
-    chunked_hash_map<model::ntp, attached_partition> _partitions;
+    chunked_hash_map<model::ntp, ss::shared_ptr<source>> _sources;
 
 private:
     static constexpr size_t max_object_size = 64_MiB;
@@ -139,7 +113,7 @@ private:
      * Metadata about a partition in an L1 object, used for committing.
      */
     struct partition_commit_info {
-        attached_partition partition;
+        ss::shared_ptr<source> source;
         partition_metadata metadata;
     };
 
@@ -158,33 +132,26 @@ private:
     ssx::semaphore _control_sem{0, "reconciler::semaphore"};
 
     /*
-     * Copy leader partitions from the attached partitions map into a new
-     * container. Shuffles the partitions to avoid starvation during
-     * reconciliation.
-     */
-    chunked_vector<attached_partition> collect_leader_partitions() const;
-
-    /*
-     * One round of reconciliation in which data from one or more partitions
+     * One round of reconciliation in which data from one or more sources
      * may be reconciled into an L1 object. Operates on the set of currently
      * attached partitions.
      */
     ss::future<> reconcile();
 
     /*
-     * Reconcile a set of partitions into an object with id `oid`.
+     * Reconcile a set of sources into an object with id `oid`.
      * The metastore must have previously assigned `oid` to each partition
      * in `partitions`. Returns metadata on success, or an error if building,
      * uploading, or metadata operations fail.
      */
     ss::future<std::expected<built_object_metadata, reconcile_error>>
-    reconcile_partitions(
+    reconcile_sources(
       const l1::object_id& oid,
-      const chunked_vector<attached_partition>& partitions);
+      const chunked_vector<ss::shared_ptr<source>>& partitions);
 
     /*
      * Build and upload an object with id `oid` using the provided context.
-     * Reads data from `partitions` and packages it into the object.
+     * Reads data from `sources` and packages it into the object.
      * Returns metadata on success, or an error if no data was added or
      * if the build/upload fails.
      */
@@ -192,7 +159,7 @@ private:
     build_and_put_object(
       const l1::object_id& oid,
       builder_context& ctx,
-      const chunked_vector<attached_partition>& partitions);
+      const chunked_vector<ss::shared_ptr<source>>& sources);
 
     /*
      * Create a new builder_context for constructing an L1 object.
@@ -202,7 +169,7 @@ private:
 
     /*
      * Build an object described by `ctx` and containing data from
-     * `partitions`, which must all belong to the same L1 domain.
+     * `sources`, which must all belong to the same L1 domain.
      *
      * Returns empty metadata if no data was added to the object.
      * Returns an error if building fails.
@@ -210,14 +177,14 @@ private:
     ss::future<std::expected<built_object_metadata, reconcile_error>>
     build_object(
       builder_context& ctx,
-      const chunked_vector<attached_partition>& partitions);
+      const chunked_vector<ss::shared_ptr<source>>& sources);
 
     /*
-     * Add partition data to an L1 object builder. Returns the partition
+     * Add source data to an L1 object builder. Returns the source
      * metadata if any batches were consumed, nullopt otherwise.
      */
-    ss::future<std::optional<partition_metadata>> add_partition_to_object(
-      builder_context& ctx, const attached_partition& partition);
+    ss::future<std::optional<partition_metadata>>
+    add_partition_to_object(builder_context& ctx, ss::shared_ptr<source> src);
 
     /*
      * Upload an object to cloud storage with the specified id.
@@ -228,7 +195,7 @@ private:
 
     /*
      * Add an object's metadata to the metastore metadata builder.
-     * Adds partition metadata for all partitions in the object.
+     * Adds sources metadata for all sources in the object.
      * Returns an error if any metadata operation fails.
      */
     ss::future<std::expected<void, reconcile_error>> add_object_metadata(
@@ -238,20 +205,12 @@ private:
 
     /*
      * Commit multiple objects to the L1 metastore in a single operation.
-     * Updates the LRO (last reconciled offset) for each partition based on
+     * Updates the LRO (last reconciled offset) for each source based on
      * the committed data, using corrections from the metastore if provided.
      */
     ss::future<std::expected<void, reconcile_error>> commit_objects(
       const chunked_vector<built_object_metadata>& objects,
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
-
-    /*
-     * Build a partition reader that returns batches to be reconciled.
-     * Reading will start from the last reconcilied offset. If there is no
-     * data that needs to be reconciled then an empty reader is returned.
-     */
-    ss::future<model::record_batch_reader>
-    make_reader(frontend*, kafka::offset start_offset, size_t);
 
 private:
     /*

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -36,7 +36,37 @@ class frontend;
 namespace cloud_topics::reconciler {
 
 class source;
-enum class reconcile_error : uint8_t { build_or_put_failure, metadata_failure };
+struct reconcile_error {
+    // The message for this error. It can be accumulated up the stack.
+    std::string message;
+    // If the error is an expected error in normal operation.
+    bool benign = true;
+
+    reconcile_error() = default;
+    // Construct a new reconcile_error, formatting is available.
+    template<typename... T>
+    explicit reconcile_error(fmt::format_string<T...> msg, T&&... args)
+      : message(fmt::format(msg, std::forward<T>(args)...)) {}
+
+    // Add context to this message by wrapping the previous error message.
+    template<typename... T>
+    reconcile_error with_context(fmt::format_string<T...> msg, T&&... args) {
+        auto new_message = fmt::format(
+          "{}: {}", fmt::format(msg, std::forward<T>(args)...), message);
+        reconcile_error result;
+        result.message = new_message;
+        result.benign = benign;
+        return result;
+    }
+
+    // Mark this error as unexpected and not benign.
+    reconcile_error mark_benign(bool benign) {
+        auto copy = *this;
+        copy.benign = benign;
+        return copy;
+    }
+    reconcile_error non_benign() { return mark_benign(false); }
+};
 
 /*
  * The reconciler is the cloud topics subsystem responsible for lifting
@@ -148,7 +178,7 @@ private:
     ss::future<std::expected<built_object_metadata, reconcile_error>>
     reconcile_sources(
       const l1::object_id& oid,
-      const chunked_vector<ss::shared_ptr<source>>& soruces);
+      const chunked_vector<ss::shared_ptr<source>>& sources);
 
     /*
      * Build and upload an object with id `oid` using the provided context.
@@ -217,7 +247,7 @@ private:
      * Retry metastore add_objects calls on transport errors.
      * Other metastore errors are not retried.
      */
-    ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>
+    ss::future<std::expected<l1::metastore::add_response, reconcile_error>>
     add_objects_with_retry(
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
       l1::metastore::term_offset_map_t terms);

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -55,7 +55,7 @@ enum class reconcile_error : uint8_t { build_or_put_failure, metadata_failure };
  */
 class reconciler {
 public:
-    reconciler(data_plane_api*, l1::io*, l1::metastore*);
+    reconciler(l1::io*, l1::metastore*);
 
     reconciler(const reconciler&) = delete;
     reconciler& operator=(const reconciler&) = delete;
@@ -69,9 +69,17 @@ public:
     void attach_partition(
       const model::ntp&,
       model::topic_id_partition,
+      data_plane_api*,
       ss::lw_shared_ptr<cluster::partition>);
     void attach_source(ss::shared_ptr<source>);
     void detach(const model::ntp&);
+
+    /*
+     * One round of reconciliation in which data from one or more sources
+     * may be reconciled into an L1 object. Operates on the set of currently
+     * attached partitions.
+     */
+    ss::future<> reconcile();
 
 private:
     // NB: Partition attachment is the only part using ntps instead of
@@ -130,13 +138,6 @@ private:
     // Top-level background worker that drives reconciliation.
     ss::future<> reconciliation_loop();
     ssx::semaphore _control_sem{0, "reconciler::semaphore"};
-
-    /*
-     * One round of reconciliation in which data from one or more sources
-     * may be reconciled into an L1 object. Operates on the set of currently
-     * attached partitions.
-     */
-    ss::future<> reconcile();
 
     /*
      * Reconcile a set of sources into an object with id `oid`.
@@ -212,7 +213,6 @@ private:
       const chunked_vector<built_object_metadata>& objects,
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
 
-private:
     /*
      * Retry metastore add_objects calls on transport errors.
      * Other metastore errors are not retried.
@@ -222,7 +222,6 @@ private:
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
       l1::metastore::term_offset_map_t terms);
 
-    data_plane_api* _data_plane;
     l1::io* _l1_io;
     l1::metastore* _metastore;
     ss::gate _gate;

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -118,11 +118,11 @@ private:
     };
 
     /*
-     * Metadata about a partition in an L1 object, used for committing.
+     * Metadata about a source in an L1 object, used for committing.
      */
-    struct partition_commit_info {
+    struct commit_info {
         ss::shared_ptr<source> source;
-        partition_metadata metadata;
+        consumer_metadata metadata;
     };
 
     /*
@@ -132,7 +132,7 @@ private:
      */
     struct built_object_metadata {
         l1::object_builder::object_info object_info;
-        chunked_vector<partition_commit_info> partitions;
+        chunked_vector<commit_info> commits;
     };
 
     // Top-level background worker that drives reconciliation.
@@ -141,14 +141,14 @@ private:
 
     /*
      * Reconcile a set of sources into an object with id `oid`.
-     * The metastore must have previously assigned `oid` to each partition
-     * in `partitions`. Returns metadata on success, or an error if building,
+     * The metastore must have previously assigned `oid` to each source
+     * in `sources`. Returns metadata on success, or an error if building,
      * uploading, or metadata operations fail.
      */
     ss::future<std::expected<built_object_metadata, reconcile_error>>
     reconcile_sources(
       const l1::object_id& oid,
-      const chunked_vector<ss::shared_ptr<source>>& partitions);
+      const chunked_vector<ss::shared_ptr<source>>& soruces);
 
     /*
      * Build and upload an object with id `oid` using the provided context.
@@ -184,8 +184,8 @@ private:
      * Add source data to an L1 object builder. Returns the source
      * metadata if any batches were consumed, nullopt otherwise.
      */
-    ss::future<std::optional<partition_metadata>>
-    add_partition_to_object(builder_context& ctx, ss::shared_ptr<source> src);
+    ss::future<std::optional<consumer_metadata>>
+    add_source_to_object(builder_context& ctx, ss::shared_ptr<source> src);
 
     /*
      * Upload an object to cloud storage with the specified id.

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -199,7 +199,7 @@ private:
      * Adds sources metadata for all sources in the object.
      * Returns an error if any metadata operation fails.
      */
-    ss::future<std::expected<void, reconcile_error>> add_object_metadata(
+    std::expected<void, reconcile_error> add_object_metadata(
       const l1::object_id& oid,
       const built_object_metadata& info,
       l1::metastore::object_metadata_builder* meta_builder);

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
@@ -12,6 +12,8 @@
 
 #include "model/timestamp.h"
 
+#include <seastar/core/coroutine.hh>
+
 namespace cloud_topics::reconciler {
 
 reconciliation_consumer::reconciliation_consumer(

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
@@ -23,7 +23,6 @@ reconciliation_consumer::reconciliation_consumer(
   , _metadata{
       .base_offset = kafka::offset::min(),
       .last_offset = kafka::offset::min(),
-      .base_timestamp = model::timestamp::max(),
       .last_timestamp = model::timestamp::min()} {}
 
 ss::future<ss::stop_iteration>
@@ -35,8 +34,6 @@ reconciliation_consumer::operator()(model::record_batch batch) {
 
     // NOTE: Only data batches here. It's safe to use timestamps without
     //       checking the batch type.
-    _metadata.base_timestamp = std::min(
-      batch.header().first_timestamp, _metadata.base_timestamp);
     _metadata.last_timestamp = std::max(
       batch.header().max_timestamp, _metadata.last_timestamp);
     _metadata.last_offset = model::offset_cast(batch.last_offset());
@@ -52,7 +49,7 @@ reconciliation_consumer::operator()(model::record_batch batch) {
     co_return ss::stop_iteration::no;
 }
 
-std::optional<partition_metadata> reconciliation_consumer::end_of_stream() {
+std::optional<consumer_metadata> reconciliation_consumer::end_of_stream() {
     if (_metadata.base_offset != kafka::offset::min()) {
         return _metadata;
     }

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.h
@@ -16,7 +16,6 @@
 #include "model/record.h"
 #include "model/timestamp.h"
 
-#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 
 #include <optional>

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.h
@@ -24,15 +24,14 @@ namespace cloud_topics::reconciler {
 
 // Metadata about a range of batches consumed by a reconciliation
 // consumer.
-struct partition_metadata {
+struct consumer_metadata {
     kafka::offset base_offset;
     kafka::offset last_offset;
-    model::timestamp base_timestamp;
     model::timestamp last_timestamp;
     absl::btree_map<model::term_id, kafka::offset> terms;
 };
 
-/// Consumes record batches from a partition and writes them to an L1 object.
+/// Consumes record batches from a reader and writes them to an L1 object.
 /// Produces metadata about the consumed range including offsets, timestamps,
 /// and term transitions.
 class reconciliation_consumer {
@@ -41,12 +40,12 @@ public:
       l1::object_builder* builder, model::topic_id_partition tidp);
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
-    std::optional<partition_metadata> end_of_stream();
+    std::optional<consumer_metadata> end_of_stream();
 
 private:
     l1::object_builder* _builder;
     model::topic_id_partition _tidp;
-    partition_metadata _metadata;
+    consumer_metadata _metadata;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reconciler/reconciliation_source.h"
+
+#include "cloud_topics/data_plane_api.h"
+#include "cloud_topics/frontend/frontend.h"
+#include "cloud_topics/level_zero/stm/ctp_stm_api.h"
+#include "cloud_topics/logger.h"
+#include "cluster/partition.h"
+#include "kafka/utils/txn_reader.h"
+#include "model/fundamental.h"
+#include "model/timeout_clock.h"
+#include "utils/retry_chain_node.h"
+
+#include <expected>
+#include <utility>
+
+namespace cloud_topics::reconciler {
+
+namespace {
+
+class aborted_transaction_tracker_impl
+  : public kafka::aborted_transaction_tracker {
+public:
+    aborted_transaction_tracker_impl(
+      ss::lw_shared_ptr<cloud_topics::frontend> fe,
+      ss::lw_shared_ptr<const storage::offset_translator_state> translator)
+      : _fe(std::move(fe))
+      , _translator(std::move(translator)) {}
+
+    ss::future<std::vector<model::tx_range>>
+    compute_aborted_transactions(model::offset base, model::offset max) final {
+        return _fe->aborted_transactions(
+          model::offset_cast(base), model::offset_cast(max), _translator);
+    }
+
+private:
+    ss::lw_shared_ptr<cloud_topics::frontend> _fe;
+    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
+};
+
+class l0_source : public source {
+public:
+    l0_source(
+      model::ntp ntp,
+      model::topic_id_partition tidp,
+      data_plane_api* dp_api,
+      ss::lw_shared_ptr<cluster::partition> partition)
+      : source(std::move(ntp), tidp)
+      , _fe(ss::make_lw_shared<frontend>(partition, dp_api))
+      , _partition(std::move(partition)) {}
+
+    kafka::offset last_reconciled_offset() override {
+        ss::abort_source as;
+        retry_chain_node rtc{as};
+        ctp_stm_api api(rtc, _partition->raft()->stm_manager()->get<ctp_stm>());
+        return api.get_last_reconciled_offset();
+    }
+
+    ss::future<std::expected<void, errc>> set_last_reconciled_offset(
+      kafka::offset offset, ss::abort_source& as) override {
+        retry_chain_node rtc{as};
+        ctp_stm_api api(rtc, _partition->raft()->stm_manager()->get<ctp_stm>());
+        auto res = co_await api.advance_reconciled_offset(
+          offset, model::no_timeout);
+        if (!res.has_value()) {
+            switch (res.error()) {
+            case ctp_stm_api_errc::timeout:
+                co_return std::unexpected(errc::timeout);
+            case ctp_stm_api_errc::not_leader:
+                co_return std::unexpected(errc::not_leader);
+            case ctp_stm_api_errc::shutdown:
+                co_return std::unexpected(errc::shutdown);
+            case ctp_stm_api_errc::failure:
+                co_return std::unexpected(errc::failure);
+            }
+        }
+        co_return std::expected<void, errc>();
+    }
+
+    ss::future<model::record_batch_reader>
+    make_reader(cloud_topic_log_reader_config cfg) override {
+        auto effective_start = co_await _fe->sync_effective_start(5s);
+        if (!effective_start.has_value()) {
+            vlog(
+              cd_log.warn,
+              "Error querying partition start offset ({}): {}",
+              _fe->ntp(),
+              effective_start.error());
+            co_return model::make_empty_record_batch_reader();
+        }
+
+        cfg.start_offset = std::max(effective_start.value(), cfg.start_offset);
+
+        auto maybe_lso = _fe->last_stable_offset();
+        if (!maybe_lso.has_value()) {
+            vlog(
+              cd_log.warn,
+              "Error querying partition LSO ({}): {}",
+              _fe->ntp(),
+              maybe_lso.error());
+            co_return model::make_empty_record_batch_reader();
+        }
+
+        // It's possible for LSO to be 0, which in this case the previous offset
+        // is model::offset::min(), this is the same as the kafka fetch path.
+        cfg.max_offset = std::min(
+          kafka::prev_offset(maybe_lso.value()), cfg.max_offset);
+
+        if (cfg.max_offset < cfg.start_offset) {
+            co_return model::make_empty_record_batch_reader();
+        }
+        auto reader = co_await _fe->make_reader(
+          cfg,
+          /*debounce_deadline=*/std::nullopt);
+
+        // It's important the `aborted_transaction_tracker_impl` takes a shared
+        // so we don't have to worry about the lifetimes of the reader and
+        // source.
+        auto tracker = std::make_unique<aborted_transaction_tracker_impl>(
+          _fe, std::move(reader.ot_state));
+
+        co_return model::make_record_batch_reader<kafka::read_committed_reader>(
+          std::move(tracker), std::move(reader.reader));
+    }
+
+private:
+    ss::lw_shared_ptr<frontend> _fe;
+    ss::lw_shared_ptr<cluster::partition> _partition;
+};
+
+} // namespace
+
+ss::shared_ptr<source> make_source(
+  model::ntp ntp,
+  model::topic_id_partition tidp,
+  data_plane_api* dp_api,
+  ss::lw_shared_ptr<cluster::partition> p) {
+    return ss::make_shared<l0_source>(
+      std::move(ntp), tidp, dp_api, std::move(p));
+}
+
+} // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -149,3 +149,25 @@ ss::shared_ptr<source> make_source(
 }
 
 } // namespace cloud_topics::reconciler
+
+auto fmt::formatter<cloud_topics::reconciler::source::errc>::format(
+  const cloud_topics::reconciler::source::errc& err,
+  fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    std::string_view name = "unknown";
+    switch (err) {
+    case cloud_topics::reconciler::source::errc::timeout:
+        name = "timeout";
+        break;
+    case cloud_topics::reconciler::source::errc::not_leader:
+        name = "not_leader";
+        break;
+    case cloud_topics::reconciler::source::errc::shutdown:
+        name = "shutdown";
+        break;
+    case cloud_topics::reconciler::source::errc::failure:
+        name = "failure";
+        break;
+    }
+    return fmt::format_to(
+      ctx.out(), "cloud_topics::reconciler::source::errc::{}", name);
+}

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/data_plane_api.h"
+#include "cloud_topics/log_reader_config.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+#include <expected>
+
+namespace cluster {
+class partition;
+}
+
+namespace cloud_topics::reconciler {
+
+// An abstraction for what the reconciler reads from, as well as the source for
+// bookkeeping progress that has been made.
+class source {
+public:
+    // Error codes for a reconcilation source.
+    enum class errc : uint8_t {
+        timeout,
+        not_leader,
+        shutdown,
+        failure,
+    };
+
+    source(model::ntp ntp, model::topic_id_partition tidp)
+      : _ntp(std::move(ntp))
+      , _tidp(tidp) {}
+    source(const source&) = delete;
+    source(source&&) = delete;
+    source& operator=(const source&) = delete;
+    source& operator=(source&&) = delete;
+    virtual ~source() = default;
+
+    // The NTP for this source
+    const model::ntp& ntp() const { return _ntp; }
+    // The topic ID + partition for the source
+    const model::topic_id_partition& topic_id_partition() const {
+        return _tidp;
+    }
+
+    // Get the last reconciled offset for this source, or kafka::offset::min()
+    // if none.
+    virtual kafka::offset last_reconciled_offset() = 0;
+
+    // Set the last reconciled offset for this source.
+    //
+    // This operation is idempotent, the last reconciled offset never moves
+    // back.
+    virtual ss::future<std::expected<void, errc>>
+    set_last_reconciled_offset(kafka::offset, ss::abort_source&) = 0;
+
+    // Create a reader for the reconciliation source, data should only be read
+    // above `last_reconciled_offset`.
+    //
+    // It *is* valid for this reader to outlive `source`.
+    virtual ss::future<model::record_batch_reader>
+      make_reader(cloud_topic_log_reader_config) = 0;
+
+private:
+    model::ntp _ntp;
+    model::topic_id_partition _tidp;
+};
+
+// Make a reconciliation source from L0 components (data plane) and the cluster
+// partition (containing metadata).
+ss::shared_ptr<source> make_source(
+  model::ntp,
+  model::topic_id_partition,
+  data_plane_api*,
+  ss::lw_shared_ptr<cluster::partition>);
+
+} // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -83,3 +83,11 @@ ss::shared_ptr<source> make_source(
   ss::lw_shared_ptr<cluster::partition>);
 
 } // namespace cloud_topics::reconciler
+
+template<>
+struct fmt::formatter<cloud_topics::reconciler::source::errc>
+  : fmt::formatter<std::string_view> {
+    auto format(
+      const cloud_topics::reconciler::source::errc&,
+      fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -18,3 +18,24 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "reconciler_test",
+    timeout = "short",
+    srcs = [
+        "reconciler_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/common:fake_io",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/cloud_topics/reconciler",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:random_bytes",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/common/fake_io.h"
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/reconciler/reconciler.h"
+#include "cloud_topics/reconciler/reconciliation_source.h"
+#include "gmock/gmock.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
+
+#include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
+
+#include <expected>
+#include <utility>
+
+using namespace cloud_topics;
+
+namespace {
+
+class fake_source : public reconciler::source {
+public:
+    fake_source(model::ntp ntp, model::topic_id_partition tidp)
+      : reconciler::source(std::move(ntp), tidp) {}
+
+    void add_batch(model::test::record_batch_spec spec) {
+        if (!_source_log.empty()) {
+            spec.offset = _source_log.back().last_offset() + model::offset{1};
+        }
+        auto batch = model::test::make_random_batch(spec);
+        _source_log.push_back(std::move(batch));
+    }
+
+    kafka::offset last_reconciled_offset() override { return _lro; }
+
+    ss::future<std::expected<void, errc>>
+    set_last_reconciled_offset(kafka::offset o, ss::abort_source&) override {
+        _lro = o;
+        co_return std::expected<void, errc>{};
+    }
+
+    ss::future<model::record_batch_reader>
+    make_reader(cloud_topic_log_reader_config cfg) override {
+        chunked_vector<model::record_batch> log;
+        size_t size = 0;
+        for (const auto& batch : _source_log) {
+            if (model::offset_cast(batch.base_offset()) < cfg.start_offset) {
+                continue;
+            }
+            if (model::offset_cast(batch.last_offset()) > cfg.max_offset) {
+                break;
+            }
+            size += batch.size_bytes();
+            log.push_back(batch.copy());
+            if (size > cfg.max_bytes) {
+                break;
+            }
+        }
+        co_return model::make_chunked_memory_record_batch_reader(
+          std::move(log));
+    }
+
+private:
+    kafka::offset _lro;
+    chunked_vector<model::record_batch> _source_log;
+};
+
+class ReconcilerTest : public testing::Test {
+public:
+    ss::shared_ptr<fake_source> add_source() {
+        auto ntp = model::random_ntp();
+        auto tid = model::create_topic_id();
+        auto src = ss::make_shared<fake_source>(
+          ntp, model::topic_id_partition{tid, ntp.tp.partition});
+        _reconciler.attach_source(src);
+        return src;
+    }
+
+    void reconcile() { _reconciler.reconcile().get(); }
+
+    std::optional<kafka::offset>
+    metastore_next_offset(ss::shared_ptr<fake_source> src) {
+        auto offsets = _metastore.get_offsets(src->topic_id_partition()).get();
+        if (!offsets.has_value()) {
+            return std::nullopt;
+        }
+        return offsets.value().next_offset;
+    }
+
+private:
+    l1::fake_io _io;
+    l1::simple_metastore _metastore;
+    reconciler::reconciler _reconciler{&_io, &_metastore};
+};
+
+using ::testing::Optional;
+
+} // namespace
+
+TEST_F(ReconcilerTest, EmptySource) {
+    auto src = add_source();
+    reconcile();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{});
+    EXPECT_EQ(metastore_next_offset(src), std::nullopt);
+}
+
+TEST_F(ReconcilerTest, SingleSource) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+    src->add_batch({.count = 10});
+    src->add_batch({.count = 10});
+    reconcile();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{29});
+    EXPECT_THAT(metastore_next_offset(src), Optional(kafka::offset{30}));
+    src->add_batch({.count = 10});
+    reconcile();
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{39});
+    EXPECT_THAT(metastore_next_offset(src), Optional(kafka::offset{40}));
+}

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -187,6 +187,8 @@ class EndToEndCloudTopicsTxTest(EndToEndCloudTopicsBase):
             loop=False,
             nodes=[traffic_node],
             use_transactions=True,
+            debug_logs=True,
+            trace_logs=True,
         )
         self.kgo_consumer.start(clean=False)
         self.kgo_consumer.wait()


### PR DESCRIPTION
Rework the cloud topics reconciler to introduce an abstraction for "source", which a source is L0.
The abstraction allows us to easily mock all the L0 infrastructure that depends on annoying to setup
machinary like cluster::partition, ct::data_plane_api, etc.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
