### PR TITLE
DisablingPartitionsTest::test_disable: deflake hwm

### DIFF
--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -451,13 +451,26 @@ class DisablingPartitionsTest(RedpandaTest):
             ts = topics if topic is None else [topic]
             ret = dict()
             for topic in ts:
-                for p in rpk.describe_topic(topic):
-                    ret[f"{topic}/{p.id}"] = p.high_watermark
+                for p in rpk.describe_topic(topic, tolerant=True):
+                    if p.high_watermark:
+                        ret[f"{topic}/{p.id}"] = p.high_watermark
             self.logger.debug("high watermarks: %s", ret)
             return ret
 
-        orig_hwms = get_hwms()
-        assert len(orig_hwms) == 4
+        def wait_for_hwms(expected, topic=None):
+            def _wait_for_hwms():
+                ret = get_hwms(topic)
+                return len(ret) == expected, ret
+
+            return wait_until_result(
+                lambda: _wait_for_hwms(),
+                timeout_sec=30,
+                backoff_sec=2,
+                err_msg="Never found expected number of high watermarks",
+            )
+
+        orig_hwms = wait_for_hwms(4)
+
         for topic in topics:
             assert (
                 sum(hwm for ntp, hwm in orig_hwms.items() if ntp.startswith(topic))
@@ -480,8 +493,7 @@ class DisablingPartitionsTest(RedpandaTest):
             err_msg="failed to wait until all disabled partitions are shut down",
         )
 
-        hwms2 = get_hwms()
-        assert len(hwms2) == 1
+        hwms2 = wait_for_hwms(1)
         assert hwms2["mytopic1/0"] == orig_hwms["mytopic1/0"]
 
         # test that producing to disabled partitions fails, while producing to
@@ -498,8 +510,7 @@ class DisablingPartitionsTest(RedpandaTest):
             lambda: rpk.produce("mytopic2", "key", "msg"), "producing should fail"
         )
 
-        hwms3 = get_hwms()
-        assert len(hwms2) == 1
+        hwms3 = wait_for_hwms(1)
         assert hwms3["mytopic1/0"] == hwms2["mytopic1/0"] + 1000
 
         # the same with consuming
@@ -580,7 +591,7 @@ class DisablingPartitionsTest(RedpandaTest):
 
         # test that producing and consuming works after re-enabling all partitions
 
-        hwms4 = get_hwms()
+        hwms4 = wait_for_hwms(4)
         assert set(hwms4.keys()) == set(orig_hwms.keys())
         for ntp, hwm in hwms4.items():
             if ntp == "mytopic1/0":
@@ -591,8 +602,8 @@ class DisablingPartitionsTest(RedpandaTest):
         _produce(self, "mytopic1")
         _produce(self, "mytopic2")
 
-        assert sum(hwm for hwm in get_hwms("mytopic1").values()) == 3000
-        assert sum(hwm for hwm in get_hwms("mytopic2").values()) == 2000
+        assert sum(hwm for hwm in wait_for_hwms(2, "mytopic1").values()) == 3000
+        assert sum(hwm for hwm in wait_for_hwms(2, "mytopic2").values()) == 2000
 
         rpk.consume("mytopic1", n=3000, quiet=True)
         rpk.consume("mytopic2", n=2000, quiet=True)


### PR DESCRIPTION
Per description in describe_topic: "this will omit any partitions which do not have full metadata in the response: this means that if we are unlucky and a partition returns NOT_LEADER due to a leadership transfer... it will be missing"

This test asserts on all expected metadata being found.

The solution is to retry in cases where the expected partition metadata is not found.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
### Improvements
* Stabilizes DisablingPartitionsTest

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
