### PR TITLE
[v25.1.x] tests/rpk: tolerate `-1` in epoch field

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -842,7 +842,7 @@ class RpkTool:
 
             initialized = (
                 obj["LEADER"] >= 0
-                and obj["EPOCH"] >= 0
+                and obj["EPOCH"] >= -1
                 and obj["REPLICAS"] != None
                 and obj["LOG-START-OFFSET"] != None
                 and obj["LOG-START-OFFSET"] >= 0


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27733
