### PR TITLE
`cluster`: replace `std::vector` with `chunked_vector` in `data_plan`

### DIFF
--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -16,6 +16,7 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/types.h"
+#include "container/chunked_vector.h"
 #include "model/metadata.h"
 
 #include <chrono>
@@ -81,8 +82,8 @@ public:
 
     struct plan_data {
         partition_balancer_violations violations;
-        std::vector<ntp_reassignment> reassignments;
-        std::vector<model::ntp> cancellations;
+        chunked_vector<ntp_reassignment> reassignments;
+        chunked_vector<model::ntp> cancellations;
         chunked_hash_map<model::ntp, reallocation_failure_details>
           reallocation_failures;
         bool counts_rebalancing_finished = false;


### PR DESCRIPTION
We saw oversized allocations here in a `PartitionBalancerScaleTest` \[1\]. The `reassignments` data member was the culprit, but it is worth making `cancellations` a `chunked_vector` at this point too.

Replace the `std::vector<>` usages with non-contiguous `chunked_vector`s.

\[1\]: https://buildkite.com/redpanda/redpanda/builds/72961#01998191-16db-4a89-9d6d-e3f40acd3bc0

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Prevents an oversized allocation in the partition balancing subsystem.
