### PR TITLE
Support partial records in kafka fetch responses

### DIFF
--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -131,6 +131,11 @@ batch_reader::do_load_slice(model::timeout_clock::time_point tp) {
         };
         const auto consume_one = [this, &batches]() {
             auto kba = consume_batch();
+
+            if (kba.short_read && _tolerate_partial)
+              [[unlikely]] {
+                return ss::now();
+            }
             if (likely(kba.v2_format && kba.valid_crc && kba.batch)) {
                 batches.push_back(std::move(*kba.batch));
                 return ss::now();

--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -113,12 +113,8 @@ model::offset batch_reader::last_offset() const {
 }
 
 kafka_batch_adapter batch_reader::consume_batch() {
-    iobuf_const_parser p{_buf};
-    const auto hdr = read_record_batch_info(p);
-    const auto size_bytes = hdr.size_bytes();
     kafka_batch_adapter kba;
-    kba.adapt(_buf.share(0, size_bytes));
-    _buf.trim_front(size_bytes);
+    _buf = kba.adapt(std::move(_buf));
     return kba;
 }
 
@@ -132,8 +128,7 @@ batch_reader::do_load_slice(model::timeout_clock::time_point tp) {
         const auto consume_one = [this, &batches]() {
             auto kba = consume_batch();
 
-            if (kba.short_read && _tolerate_partial)
-              [[unlikely]] {
+            if (kba.short_read && _tolerate_partial) [[unlikely]] {
                 return ss::now();
             }
             if (likely(kba.v2_format && kba.valid_crc && kba.batch)) {

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -27,10 +27,23 @@ class batch_reader final : public model::record_batch_reader::impl {
     using storage_t = model::record_batch_reader::storage_t;
 
 public:
+    /**
+     * Kafka brokers may return partial batch in fetch responses. This is to
+     * optimize the maintenance of fetch max bytes. The partial batch is always
+     * the last batch in the fetch response. This flag allows the caller to
+     * indicate that it is ok to ignore the partial batch and stop read earlier.
+     */
+    using tolerate_partial_last_batch
+      = ss::bool_class<struct tolerate_partial_last_batch_tag>;
+
     batch_reader() = default;
 
-    explicit batch_reader(iobuf buf)
-      : _buf(std::move(buf)) {}
+    explicit batch_reader(
+      iobuf buf,
+      tolerate_partial_last_batch tolerate_partial
+      = tolerate_partial_last_batch::no)
+      : _buf(std::move(buf))
+      , _tolerate_partial(tolerate_partial) {}
 
     bool empty() const { return _buf.empty(); }
 
@@ -69,6 +82,8 @@ public:
 private:
     iobuf _buf;
     bool _do_load_slice_failed{false};
+    tolerate_partial_last_batch _tolerate_partial{
+      tolerate_partial_last_batch::no};
 };
 
 } // namespace kafka

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -147,12 +147,22 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
         vlog(klog.error, "kbatch is unexpectedly small");
         return iobuf{};
     }
-
     auto batch_length =
       [peeker{iobuf_parser(kbatch.share(0, kafka_length_diff))}]() mutable {
           peeker.skip(sizeof(model::record_batch_header::base_offset));
           return peeker.consume_be_type<int32_t>() + kafka_length_diff;
       }();
+
+    if (batch_length > kbatch.size_bytes()) {
+        short_read = true;
+        vlog(
+          klog.debug,
+          "batch is unexpectedly small for the indicated batch length: {} > "
+          "{}",
+          batch_length,
+          kbatch.size_bytes());
+        return iobuf{};
+    }
 
     auto remainder = kbatch.share(
       batch_length, kbatch.size_bytes() - batch_length);

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -66,6 +66,7 @@ public:
     bool v2_format;
     bool valid_crc;
     bool legacy_error{false};
+    bool short_read{false};
 
     std::optional<model::record_batch> batch;
 

--- a/src/v/kafka/protocol/tests/BUILD
+++ b/src/v/kafka/protocol/tests/BUILD
@@ -78,6 +78,7 @@ redpanda_cc_btest(
         "//src/v/kafka/protocol",
         "//src/v/model",
         "//src/v/model/tests:random",
+        "//src/v/model/tests:raw_record_batch_factory",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
         "@seastar",

--- a/src/v/kafka/protocol/tests/batch_reader_test.cc
+++ b/src/v/kafka/protocol/tests/batch_reader_test.cc
@@ -15,6 +15,7 @@
 #include "kafka/protocol/kafka_batch_adapter.h"
 #include "model/fundamental.h"
 #include "model/tests/random_batch.h"
+#include "model/tests/raw_record_batch_factory.h"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/sstring.hh>
@@ -219,6 +220,111 @@ SEASTAR_THREAD_TEST_CASE(batch_reader_record_batch_reader_impl_fail_magic) {
     BOOST_REQUIRE_EXCEPTION(
       // NOLINTNEXTLINE(bugprone-use-after-move)
       model::consume_reader_to_memory(std::move(rdr), model::no_timeout).get(),
+      kafka::exception,
+      [](const kafka::exception& e) {
+          return e.error == kafka::error_code::corrupt_message;
+      });
+}
+
+SEASTAR_THREAD_TEST_CASE(batch_reader_truncated_last_batch) {
+    auto ctx = make_context(base_offset, many_batches);
+    // truncate the last batch
+
+    const auto all_batches
+      = model::consume_reader_to_memory(
+          model::make_record_batch_reader<kafka::batch_reader>(
+            ctx.record_set.copy()),
+          model::no_timeout)
+          .get();
+
+    auto non_tolerating_reader
+      = model::make_record_batch_reader<kafka::batch_reader>(
+        ctx.record_set.copy().share(0, ctx.record_set.size_bytes() - 10));
+    // reader is expected to fail on truncated batch, as the flag was not set
+    // to tolerate the truncation
+    BOOST_REQUIRE_EXCEPTION(
+      model::consume_reader_to_memory(
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        std::move(non_tolerating_reader),
+        model::no_timeout)
+        .get(),
+      kafka::exception,
+      [](const kafka::exception& e) {
+          return e.error == kafka::error_code::corrupt_message;
+      });
+
+    auto tolerating_reader
+      = model::make_record_batch_reader<kafka::batch_reader>(
+        ctx.record_set.copy().share(0, ctx.record_set.size_bytes() - 10),
+        kafka::batch_reader::tolerate_partial_last_batch::yes);
+
+    auto truncated_batches = model::consume_reader_to_memory(
+                               std::move(tolerating_reader), model::no_timeout)
+                               .get();
+
+    /**
+     * Validate that indeed the last batch was truncated.
+     */
+    BOOST_REQUIRE_EQUAL(truncated_batches.size(), all_batches.size() - 1);
+    BOOST_REQUIRE_EQUAL(
+      std::next(all_batches.rbegin())->base_offset(),
+      truncated_batches.back().base_offset());
+}
+
+SEASTAR_THREAD_TEST_CASE(batch_reader_truncated_batch_in_the_middle) {
+    /** make some batches */
+    auto input = model::test::make_random_batches(base_offset, 10).get();
+    auto to_truncate = model::test::make_random_batch(
+      model::next_offset(input.back().last_offset()));
+
+    auto truncated_batch
+      = model::test::raw_record_batch_factory::create_record_batch(
+        to_truncate.header(),
+        to_truncate.data().copy().share(0, to_truncate.data().size_bytes() / 2),
+        true);
+    input.push_back(std::move(truncated_batch));
+    for (int i = 0; i < 5; ++i) {
+        input.push_back(
+          model::test::make_random_batch(
+            model::next_offset(input.back().last_offset())));
+    }
+
+    auto batches_buffer
+      = model::make_memory_record_batch_reader(std::move(input))
+          .consume(kafka::kafka_batch_serializer{}, model::no_timeout)
+          .get();
+
+    auto non_tolerating_reader
+      = model::make_record_batch_reader<kafka::batch_reader>(
+        batches_buffer.data.copy());
+
+    BOOST_REQUIRE_EXCEPTION(
+      model::consume_reader_to_memory(
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        std::move(non_tolerating_reader),
+        model::no_timeout)
+        .get(),
+      kafka::exception,
+      [](const kafka::exception& e) {
+          return e.error == kafka::error_code::corrupt_message;
+      });
+
+    /**
+     * Batch is in the middle, the reader should still return corrupted message
+     * error
+     */
+
+    auto tolerating_reader
+      = model::make_record_batch_reader<kafka::batch_reader>(
+        batches_buffer.data.copy(),
+        kafka::batch_reader::tolerate_partial_last_batch::yes);
+
+    BOOST_REQUIRE_EXCEPTION(
+      model::consume_reader_to_memory(
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        std::move(tolerating_reader),
+        model::no_timeout)
+        .get(),
       kafka::exception,
       [](const kafka::exception& e) {
           return e.error == kafka::error_code::corrupt_message;

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -185,7 +185,8 @@ public:
         if (!io) {
             return std::nullopt;
         }
-        return batch_reader(std::move(*io));
+        return batch_reader(
+          std::move(*io), batch_reader::tolerate_partial_last_batch::yes);
     }
 
     std::optional<batch_reader> read_nullable_flex_batch_reader() {
@@ -193,7 +194,8 @@ public:
         if (!io) {
             return std::nullopt;
         }
-        return batch_reader(std::move(*io));
+        return batch_reader(
+          std::move(*io), batch_reader::tolerate_partial_last_batch::yes);
     }
 
     template<

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -965,3 +965,28 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_btest(
+    name = "produce_invalid_batch_test",
+    timeout = "short",
+    srcs = [
+        "produce_invalid_batch_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/config",
+        "//src/v/container:chunked_vector",
+        "//src/v/kafka/client:transport",
+        "//src/v/kafka/protocol",
+        "//src/v/kafka/protocol:metadata",
+        "//src/v/kafka/protocol:produce",
+        "//src/v/model",
+        "//src/v/model/tests:raw_record_batch_factory",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/storage:record_batch_builder",
+        "//src/v/test_utils:scoped_config",
+        "//src/v/test_utils:seastar_boost",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)

--- a/src/v/kafka/server/tests/produce_invalid_batch_test.cc
+++ b/src/v/kafka/server/tests/produce_invalid_batch_test.cc
@@ -1,0 +1,128 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "container/chunked_vector.h"
+#include "kafka/client/transport.h"
+#include "kafka/protocol/produce.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/tests/raw_record_batch_factory.h"
+#include "model/timestamp.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/record_batch_builder.h"
+#include "test_utils/async.h"
+#include "test_utils/boost_fixture.h"
+
+#include <seastar/core/metrics_types.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <vector>
+
+using namespace std::chrono_literals;
+
+struct test_fixture : public redpanda_thread_fixture {
+    const model::topic_namespace test_tp_ns = {
+      model::ns("kafka"), model::topic("test-topic")};
+    void start() {
+        add_topic(test_tp_ns, static_cast<int>(1)).get();
+        producer = std::make_unique<kafka::client::transport>(
+          make_kafka_client().get());
+        producer->connect().get();
+        model::ntp ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+        tests::cooperative_spin_wait_with_timeout(2s, [ntp, this] {
+            auto shard = app.shard_table.local().shard_for(ntp);
+            if (!shard) {
+                return ss::make_ready_future<bool>(false);
+            }
+            return app.partition_manager.invoke_on(
+              *shard, [ntp](cluster::partition_manager& pm) {
+                  return pm.get(ntp)->is_leader();
+              });
+        }).get();
+    }
+
+    model::offset high_watermark() {
+        model::ntp ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
+        auto shard = app.shard_table.local().shard_for(ntp);
+        return app.partition_manager
+          .invoke_on(
+            *shard,
+            [ntp](cluster::partition_manager& mgr) {
+                auto partition = mgr.get(ntp);
+                return partition->high_watermark();
+            })
+          .get();
+    }
+    model::record_batch make_batch(size_t record_count) {
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, model::offset(0));
+
+        for (size_t i = 0; i < record_count; ++i) {
+            iobuf v{};
+            v.append("v", 1);
+            builder.add_raw_kv(iobuf{}, std::move(v));
+        }
+
+        return std::move(builder).build();
+    }
+
+    ss::future<kafka::produce_response>
+    produce_batch(chunked_vector<kafka::produce_request::partition> batches) {
+        kafka::produce_request::topic tp;
+        tp.partitions = std::move(batches);
+        tp.name = test_topic;
+        chunked_vector<kafka::produce_request::topic> topics;
+        topics.push_back(std::move(tp));
+        kafka::produce_request req(std::nullopt, 1, std::move(topics));
+        req.data.timeout_ms = std::chrono::seconds(2);
+        req.has_idempotent = false;
+        req.has_transactional = false;
+        return producer->dispatch(std::move(req), kafka::api_version(7));
+    }
+
+    std::vector<model::offset> fetch_offsets;
+
+    std::unique_ptr<kafka::client::transport> producer;
+    ss::abort_source as;
+
+    const model::topic& test_topic = test_tp_ns.tp;
+};
+
+FIXTURE_TEST(test_handling_message_with_truncated_batch, test_fixture) {
+    wait_for_controller_leadership().get();
+    start();
+    auto deferred_close = ss::defer([this] { producer->stop().get(); });
+    kafka::produce_request::partition partition;
+    partition.partition_index = model::partition_id(0);
+    auto batch_1 = make_batch(128);
+    auto batch_2 = make_batch(128);
+    chunked_vector<kafka::produce_request::partition> batches;
+    model::record_batch truncated_batch_1
+      = model::test::raw_record_batch_factory::create_record_batch(
+        batch_1.header(),
+        batch_1.data().copy().share(0, batch_1.data().size_bytes() / 2),
+        true);
+    // first batch is truncated
+    batches.push_back(
+      kafka::produce_request::partition{
+        .partition_index = model::partition_id(0),
+        .records = kafka::produce_request_record_data{
+          std::move(truncated_batch_1)}});
+
+    batches.push_back(
+      kafka::produce_request::partition{
+        .partition_index = model::partition_id(1),
+        .records = kafka::produce_request_record_data{std::move(batch_2)}});
+
+    auto resp_f = produce_batch(std::move(batches));
+    BOOST_REQUIRE_THROW(
+      resp_f.get(), kafka::client::kafka_request_disconnected_exception);
+};

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -721,7 +721,9 @@ constexpr uint32_t packed_record_batch_header_size
     + sizeof(model::record_batch_header::base_sequence)     // 4
     + sizeof(model::record_batch_header::record_count);     // 4
 static_assert(packed_record_batch_header_size == 61);
-
+namespace test {
+class raw_record_batch_factory;
+}
 class record_batch
   : public serde::envelope<
       model::record_batch,
@@ -966,6 +968,7 @@ private:
     explicit operator bool() const noexcept { return !empty(); }
     friend class ss::optimized_optional<record_batch>;
     friend class record_batch_iterator;
+    friend class test::raw_record_batch_factory;
 
     template<typename Func>
     friend ss::future<>

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -29,6 +29,24 @@ redpanda_test_cc_library(
     ],
 )
 
+redpanda_test_cc_library(
+    name = "raw_record_batch_factory",
+    srcs = [
+    ],
+    hdrs = [
+        "raw_record_batch_factory.h",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
 redpanda_cc_btest(
     name = "ktp_test",
     timeout = "short",

--- a/src/v/model/tests/raw_record_batch_factory.h
+++ b/src/v/model/tests/raw_record_batch_factory.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "model/record.h"
+namespace model::test {
+/**
+ * Simple helper class allowing creation of batch with arbitrary header and
+ * record data.
+ *
+ * It is useful in tests where we want to create batches with invalid
+ * headers/records size/crc etc.
+ */
+class raw_record_batch_factory {
+public:
+    static model::record_batch create_record_batch(
+      model::record_batch_header header, iobuf records, bool compressed) {
+        return {header, std::move(records), compressed};
+    }
+};
+} // namespace model::test


### PR DESCRIPTION
Kafka uses an optimization when sending out FetchRequests to the clients allowing broker to leave last batch from the partition record set partial. Kafka clients must ignore such partial batches. 


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none