### PR TITLE
[v25.2.x] `cluster`: replace `std::vector` with `chunked_vector` in `data_plan`

### DIFF
--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -16,6 +16,7 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "model/metadata.h"
 
 #include <chrono>
@@ -81,8 +82,8 @@ public:
 
     struct plan_data {
         partition_balancer_violations violations;
-        std::vector<ntp_reassignment> reassignments;
-        std::vector<model::ntp> cancellations;
+        chunked_vector<ntp_reassignment> reassignments;
+        chunked_vector<model::ntp> cancellations;
         chunked_hash_map<model::ntp, reallocation_failure_details>
           reallocation_failures;
         bool counts_rebalancing_finished = false;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27754
