### PR TITLE
[v25.1.x] datalake: clean up files after translation error

### DIFF
--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -349,7 +349,8 @@ ss::future<writer_error> record_multiplexer::flush_writers() {
 }
 
 ss::future<result<record_multiplexer::write_result, writer_error>>
-record_multiplexer::finish() && {
+record_multiplexer::finish(
+  record_multiplexer::finished_files& finished_files) && {
     auto writers = std::move(_writers);
     for (auto& [id, writer] : writers) {
         auto res = co_await std::move(*writer).finish();
@@ -362,7 +363,7 @@ record_multiplexer::finish() && {
             std::move(
               files.begin(),
               files.end(),
-              std::back_inserter(_result->data_files));
+              std::back_inserter(finished_files.data_files));
         }
     }
     if (_invalid_record_writer) {
@@ -375,7 +376,7 @@ record_multiplexer::finish() && {
             std::move(
               files.begin(),
               files.end(),
-              std::back_inserter(_result->dlq_files));
+              std::back_inserter(finished_files.dlq_files));
         }
     }
     if (_error && !is_recoverable_error(_error.value())) {

--- a/src/v/datalake/record_multiplexer.h
+++ b/src/v/datalake/record_multiplexer.h
@@ -56,11 +56,6 @@ public:
         kafka::offset start_offset;
         // last offset of the last translated batch (inclusive)
         kafka::offset last_offset;
-        // vector containing a list of files that were written during
-        // translation.
-        chunked_vector<partitioning_writer::partitioned_file> data_files;
-        // files with invalid records
-        chunked_vector<partitioning_writer::partitioned_file> dlq_files;
         // Total number of kafka bytes processed by the multiplexer
         uint64_t kafka_bytes_processed{0};
     };
@@ -104,12 +99,19 @@ public:
      */
     ss::future<writer_error> flush_writers();
 
+    struct finished_files {
+        // vector containing a list of files that were written during
+        // translation.
+        chunked_vector<partitioning_writer::partitioned_file> data_files;
+        // files with invalid records
+        chunked_vector<partitioning_writer::partitioned_file> dlq_files;
+    };
     /**
      * Cleanup and return the result. Should be the last operation to
      * be called. May not be called in parallel while multiplexing is in
      * progress.
      */
-    ss::future<result<write_result, writer_error>> finish() &&;
+    ss::future<result<write_result, writer_error>> finish(finished_files&) &&;
 
     size_t buffered_bytes() const;
 

--- a/src/v/datalake/record_schema_resolver.cc
+++ b/src/v/datalake/record_schema_resolver.cc
@@ -292,6 +292,22 @@ binary_type_resolver::resolve_identifier(schema_identifier) const {
 }
 
 ss::future<checked<type_and_buf, type_resolver::errc>>
+test_binary_type_resolver::resolve_buf_type(std::optional<iobuf> b) const {
+    if (injected_error_.has_value()) {
+        co_return *injected_error_;
+    }
+    co_return co_await binary_type_resolver::resolve_buf_type(std::move(b));
+}
+
+ss::future<checked<resolved_type, type_resolver::errc>>
+test_binary_type_resolver::resolve_identifier(schema_identifier id) const {
+    if (injected_error_.has_value()) {
+        co_return *injected_error_;
+    }
+    co_return co_await binary_type_resolver::resolve_identifier(std::move(id));
+}
+
+ss::future<checked<type_and_buf, type_resolver::errc>>
 record_schema_resolver::resolve_buf_type(std::optional<iobuf> b) const {
     if (!b.has_value()) {
         vlog(datalake_log.trace, "Ignoring tombstone value");

--- a/src/v/datalake/record_schema_resolver.h
+++ b/src/v/datalake/record_schema_resolver.h
@@ -148,6 +148,20 @@ public:
     ~binary_type_resolver() override = default;
 };
 
+class test_binary_type_resolver : public binary_type_resolver {
+public:
+    ss::future<checked<type_and_buf, type_resolver::errc>>
+    resolve_buf_type(std::optional<iobuf> b) const override;
+
+    ss::future<checked<resolved_type, errc>>
+      resolve_identifier(schema_identifier) const override;
+    ~test_binary_type_resolver() override = default;
+    void set_fail_requests(type_resolver::errc e) { injected_error_ = e; }
+
+private:
+    std::optional<type_resolver::errc> injected_error_{};
+};
+
 // record_schema_resolver uses the schema registry wire format
 // to decode messages and resolve their schemas.
 class record_schema_resolver : public type_resolver {

--- a/src/v/datalake/tests/gtest_record_multiplexer_test.cc
+++ b/src/v/datalake/tests/gtest_record_multiplexer_test.cc
@@ -87,13 +87,13 @@ TEST(DatalakeMultiplexerTest, TestMultiplexer) {
       .multiplex(
         std::move(reader), kafka::offset{start_offset}, model::no_timeout, as)
       .get();
-    auto result = std::move(multiplexer).finish().get();
+    record_multiplexer::finished_files files;
+    auto result = std::move(multiplexer).finish(files).get();
 
     ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(result.value().data_files.size(), 1);
+    ASSERT_EQ(files.data_files.size(), 1);
     EXPECT_EQ(
-      result.value().data_files[0].local_file.row_count,
-      record_count * batch_count);
+      files.data_files[0].local_file.row_count, record_count * batch_count);
     EXPECT_EQ(result.value().start_offset(), start_offset);
     // Subtract one since offsets end at 0, and this is an inclusive range.
     EXPECT_EQ(
@@ -136,7 +136,8 @@ TEST(DatalakeMultiplexerTest, TestMultiplexerWriteError) {
     multiplexer
       .multiplex(std::move(reader), kafka::offset{0}, model::no_timeout, as)
       .get();
-    auto res = std::move(multiplexer).finish().get();
+    record_multiplexer::finished_files files;
+    auto res = std::move(multiplexer).finish(files).get();
     ASSERT_TRUE(res.has_error());
     EXPECT_EQ(res.error(), datalake::writer_error::parquet_conversion_error);
 }
@@ -190,13 +191,13 @@ TEST(DatalakeMultiplexerTest, WritesDataFiles) {
       .multiplex(
         std::move(reader), kafka::offset{start_offset}, model::no_timeout, as)
       .get();
-    auto result = std::move(multiplexer).finish().get();
+    record_multiplexer::finished_files files;
+    auto result = std::move(multiplexer).finish(files).get();
 
     ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(result.value().data_files.size(), 1);
+    ASSERT_EQ(files.data_files.size(), 1);
     EXPECT_EQ(
-      result.value().data_files[0].local_file.row_count,
-      record_count * batch_count);
+      files.data_files[0].local_file.row_count, record_count * batch_count);
     EXPECT_EQ(result.value().start_offset(), start_offset);
     // Subtract one since offsets end at 0, and this is an inclusive range.
     EXPECT_EQ(
@@ -305,7 +306,8 @@ TEST_F(RecordMultiplexerParquetTest, TestSimple) {
       .multiplex(
         std::move(reader), kafka::offset{start_offset}, model::no_timeout, as)
       .get();
-    auto res = std::move(mux).finish().get();
+    record_multiplexer::finished_files files;
+    auto res = std::move(mux).finish(files).get();
     ASSERT_FALSE(res.has_error()) << res.error();
     EXPECT_EQ(res.value().start_offset(), start_offset());
 

--- a/src/v/datalake/tests/record_multiplexer_bench.cc
+++ b/src/v/datalake/tests/record_multiplexer_bench.cc
@@ -257,7 +257,8 @@ struct counting_consumer {
         return mux.do_multiplex(std::move(batch), kafka::offset{}, as);
     }
     ss::future<counting_consumer> end_of_stream() {
-        auto res = co_await std::move(mux).finish();
+        datalake::record_multiplexer::finished_files files;
+        auto res = co_await std::move(mux).finish(files);
         if (res.has_error()) [[unlikely]] {
             throw std::runtime_error(
               fmt::format("failed to end stream: {}", res.error()));

--- a/src/v/datalake/tests/record_multiplexer_test.cc
+++ b/src/v/datalake/tests/record_multiplexer_test.cc
@@ -126,6 +126,7 @@ public:
       const records_param& param,
       model::offset o,
       const std::function<void(storage::record_batch_builder&)>& cb,
+      record_multiplexer::finished_files& files,
       bool expect_error = false) {
         auto start_offset = o;
         ss::circular_buffer<model::record_batch> batches;
@@ -173,7 +174,7 @@ public:
             mux.flush_writers().get();
         }
         EXPECT_EQ(total_batches, total_split_batches);
-        auto res = std::move(mux).finish().get();
+        auto res = std::move(mux).finish(files).get();
         if (expect_error) {
             EXPECT_TRUE(res.has_error());
         } else {
@@ -248,21 +249,27 @@ public:
     std::optional<record_multiplexer::write_result> mux(
       model::offset o,
       const std::function<void(storage::record_batch_builder&)>& cb,
+      record_multiplexer::finished_files& files,
       bool expect_error = false) {
-        return RecordMultiplexerTestBase::mux(GetParam(), o, cb, expect_error);
+        return RecordMultiplexerTestBase::mux(
+          GetParam(), o, cb, files, expect_error);
     }
 };
 
 TEST_P(RecordMultiplexerParamTest, TestNoSchema) {
     auto start_offset = model::offset{0};
-    auto res = mux(start_offset, [](storage::record_batch_builder& b) {
-        b.add_raw_kv(std::nullopt, iobuf::from("foobar"));
-    });
+    record_multiplexer::finished_files files;
+    auto res = mux(
+      start_offset,
+      [](storage::record_batch_builder& b) {
+          b.add_raw_kv(std::nullopt, iobuf::from("foobar"));
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res.value().data_files.size(), 0);
+    EXPECT_EQ(files.data_files.size(), 0);
 
     assert_dlq_table(ntp.tp.topic, true);
-    EXPECT_EQ(res.value().dlq_files.size(), GetParam().hrs);
+    EXPECT_EQ(files.dlq_files.size(), GetParam().hrs);
 }
 
 TEST_P(RecordMultiplexerParamTest, TestSimpleAvroRecords) {
@@ -273,16 +280,20 @@ TEST_P(RecordMultiplexerParamTest, TestSimpleAvroRecords) {
 
     // Add Avro records.
     auto start_offset = model::offset{0};
-    auto res = mux(start_offset, [&gen](storage::record_batch_builder& b) {
-        auto res = gen.add_random_avro_record(b, "avro_v1", std::nullopt).get();
-        ASSERT_FALSE(res.has_error());
-    });
+    record_multiplexer::finished_files files;
+    auto res = mux(
+      start_offset,
+      [&gen](storage::record_batch_builder& b) {
+          auto res
+            = gen.add_random_avro_record(b, "avro_v1", std::nullopt).get();
+          ASSERT_FALSE(res.has_error());
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
-    EXPECT_EQ(write_res.data_files.size(), GetParam().hrs);
+    EXPECT_EQ(files.data_files.size(), GetParam().hrs);
 
     std::unordered_set<int> hrs;
-    for (auto& f : write_res.data_files) {
+    for (auto& f : files.data_files) {
         hrs.emplace(get_hour(f.partition_key));
         EXPECT_EQ(f.local_file.row_count, GetParam().records_per_hr());
     }
@@ -306,22 +317,25 @@ TEST_P(RecordMultiplexerParamTest, TestAvroRecordsMultipleSchemas) {
 
     auto start_offset = model::offset{0};
     int i = 0;
-    auto res = mux(start_offset, [&gen, &i](storage::record_batch_builder& b) {
-        auto res = gen
-                     .add_random_avro_record(
-                       b, (++i % 2) ? "avro_v1" : "avro_v2", std::nullopt)
-                     .get();
-        ASSERT_FALSE(res.has_error());
-    });
+    record_multiplexer::finished_files files;
+    auto res = mux(
+      start_offset,
+      [&gen, &i](storage::record_batch_builder& b) {
+          auto res = gen
+                       .add_random_avro_record(
+                         b, (++i % 2) ? "avro_v1" : "avro_v2", std::nullopt)
+                       .get();
+          ASSERT_FALSE(res.has_error());
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
 
     // There should be twice as many files as normal, since we have twice the
     // schemas.
-    EXPECT_EQ(write_res.data_files.size(), 2 * GetParam().hrs);
+    EXPECT_EQ(files.data_files.size(), 2 * GetParam().hrs);
 
     std::unordered_set<int> hrs;
-    for (auto& f : write_res.data_files) {
+    for (auto& f : files.data_files) {
         hrs.emplace(get_hour(f.partition_key));
         // Each file should have half the records as normal, since we have
         // twice the files.
@@ -364,18 +378,21 @@ TEST_F(RecordMultiplexerTest, TestAvroRecordsWithRedpandaField) {
 
     // Add Avro records.
     auto start_offset = model::offset{0};
+    record_multiplexer::finished_files files;
     auto res = mux(
-      default_param, start_offset, [&gen](storage::record_batch_builder& b) {
+      default_param,
+      start_offset,
+      [&gen](storage::record_batch_builder& b) {
           auto res
             = gen.add_random_avro_record(b, "avro_rp", std::nullopt).get();
           ASSERT_FALSE(res.has_error());
-      });
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    const auto& write_res = res.value();
-    EXPECT_EQ(write_res.data_files.size(), default_param.hrs);
+    EXPECT_EQ(files.data_files.size(), default_param.hrs);
 
     std::unordered_set<int> hrs;
-    for (auto& f : write_res.data_files) {
+    for (auto& f : files.data_files) {
         hrs.emplace(get_hour(f.partition_key));
         EXPECT_EQ(f.local_file.row_count, default_param.records_per_hr());
     }
@@ -395,19 +412,23 @@ TEST_F(RecordMultiplexerTest, TestAvroRecordsWithRedpandaField) {
 
 TEST_F(RecordMultiplexerTest, TestMissingSchema) {
     auto start_offset = model::offset{0};
+    record_multiplexer::finished_files files;
     auto res = mux(
-      default_param, start_offset, [](storage::record_batch_builder& b) {
+      default_param,
+      start_offset,
+      [](storage::record_batch_builder& b) {
           iobuf buf;
           // Append data with a magic 0 byte that doesn't actually correspond to
           // anything.
           buf.append("\0\0\0\0\0\0\0", 7);
           b.add_raw_kv(std::nullopt, std::move(buf));
-      });
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res.value().data_files.size(), 0);
+    EXPECT_EQ(files.data_files.size(), 0);
 
     assert_dlq_table(ntp.tp.topic, true);
-    EXPECT_EQ(res.value().dlq_files.size(), default_param.hrs);
+    EXPECT_EQ(files.dlq_files.size(), default_param.hrs);
 
     EXPECT_EQ(
       get_or_create_probe(ntp)->counter_ref(
@@ -424,6 +445,7 @@ TEST_F(RecordMultiplexerTest, TestBadData) {
     auto schema_id = reg_res.value();
 
     auto start_offset = model::offset{0};
+    record_multiplexer::finished_files files;
     auto res = mux(
       default_param,
       start_offset,
@@ -436,12 +458,13 @@ TEST_F(RecordMultiplexerTest, TestBadData) {
           buf.append((const uint8_t*)(&encoded_id), 4);
           buf.append("\1\1", 2);
           b.add_raw_kv(std::nullopt, std::move(buf));
-      });
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res.value().data_files.size(), 0);
+    EXPECT_EQ(files.data_files.size(), 0);
 
     assert_dlq_table(ntp.tp.topic, true);
-    EXPECT_EQ(res.value().dlq_files.size(), default_param.hrs);
+    EXPECT_EQ(files.dlq_files.size(), default_param.hrs);
 
     EXPECT_EQ(
       get_or_create_probe(ntp)->counter_ref(
@@ -467,34 +490,43 @@ TEST_F(RecordMultiplexerTest, TestBadSchemaChange) {
 
     // Write with a valid schema.
     auto start_offset = model::offset{0};
+    record_multiplexer::finished_files files;
     auto res = mux(
-      default_param, start_offset++, [&gen](storage::record_batch_builder& b) {
+      default_param,
+      start_offset++,
+      [&gen](storage::record_batch_builder& b) {
           auto res
             = gen.add_random_avro_record(b, "avro_v1", std::nullopt).get();
           ASSERT_FALSE(res.has_error());
-      });
+      },
+      files);
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res.value().data_files.size(), default_param.hrs);
+    EXPECT_EQ(files.data_files.size(), default_param.hrs);
 
     // This should have registered the valid schema.
     auto schema = get_current_schema();
     EXPECT_EQ(schema->highest_field_id(), 10);
 
+    files.data_files.clear();
+    files.dlq_files.clear();
     // Now try writing with an incompatible schema.
     res = mux(
-      default_param, start_offset, [&gen](storage::record_batch_builder& b) {
+      default_param,
+      start_offset,
+      [&gen](storage::record_batch_builder& b) {
           auto res
             = gen.add_random_avro_record(b, "incompat", std::nullopt).get();
           ASSERT_FALSE(res.has_error());
-      });
+      },
+      files);
 
     // No new files should have been written to the main table.
     ASSERT_TRUE(res.has_value());
-    EXPECT_EQ(res.value().data_files.size(), 0);
+    EXPECT_EQ(files.data_files.size(), 0);
 
     // The DLQ table should have the invalid records.
     assert_dlq_table(ntp.tp.topic, true);
-    EXPECT_EQ(res.value().dlq_files.size(), default_param.hrs);
+    EXPECT_EQ(files.dlq_files.size(), default_param.hrs);
 
     // The schema for the main table should not have changed.
     schema = get_current_schema();
@@ -527,7 +559,8 @@ TEST_F(RecordMultiplexerTest, TestMultiplexingFromMiddleOfBatch) {
       .multiplex(
         std::move(reader), kafka::offset{start_offset}, model::no_timeout, as)
       .get();
-    auto result = std::move(mux).finish().get();
+    record_multiplexer::finished_files files;
+    auto result = std::move(mux).finish(files).get();
     EXPECT_FALSE(result.has_error()) << result.error();
     EXPECT_EQ(result.value().start_offset(), start_offset);
     EXPECT_EQ(result.value().last_offset(), last_offset);

--- a/src/v/datalake/tests/translation_task_test.cc
+++ b/src/v/datalake/tests/translation_task_test.cc
@@ -35,7 +35,6 @@ using namespace std::chrono_literals;
 using namespace testing;
 using namespace datalake;
 namespace {
-auto schema_resolver = std::make_unique<binary_type_resolver>();
 auto translator = std::make_unique<default_translator>();
 const auto ntp = model::ntp{};
 const auto rev = model::revision_id{123};
@@ -51,6 +50,7 @@ public:
       , tmp_dir("translation_task_test")
       , test_rcn(as, 10s, 1s)
       , cloud_io(sr->remote.local(), bucket_name)
+      , schema_resolver(std::make_unique<test_binary_type_resolver>())
       , schema_mgr(std::make_unique<simple_schema_manager>(
           iceberg::uri_converter(sr->remote.local().provider())
             .to_uri(bucket_name, "test")))
@@ -149,6 +149,7 @@ public:
     temporary_dir tmp_dir;
     retry_chain_node test_rcn;
     datalake::cloud_data_io cloud_io;
+    std::unique_ptr<test_binary_type_resolver> schema_resolver;
     std::unique_ptr<simple_schema_manager> schema_mgr;
     std::unique_ptr<table_creator> t_creator;
     datalake::location_provider location_provider;
@@ -270,6 +271,81 @@ TEST_F(TranslateTaskTest, TestUploadError) {
     ASSERT_TRUE(result.has_error());
     ASSERT_EQ(result.error(), datalake::translation_task::errc::cloud_io_error);
     // check no data files are left behind
+    ASSERT_THAT(list_data_files().get(), IsEmpty());
+}
+
+TEST_F(TranslateTaskTest, TestCleanupAfterTransientError) {
+    datalake::translation_task task(
+      ntp,
+      model::revision_id{123},
+      get_writer_factory(),
+      cloud_io,
+      *schema_mgr,
+      *schema_resolver,
+      *translator,
+      *t_creator,
+      model::iceberg_invalid_record_action::dlq_table,
+      location_provider,
+      probe);
+
+    // Translate some data to create some files locally.
+    task.translate_once(make_batches(10, 16), kafka::offset{0}, as).get();
+    auto flush_res = task.flush().get();
+    ASSERT_FALSE(flush_res.has_error());
+
+    // Now make a supposedly transient error happen. This will fail the task
+    // rather than sending the data to the DLQ.
+    schema_resolver->set_fail_requests(type_resolver::errc::registry_error);
+    task
+      .translate_once(
+        make_batches(10, 16, model::offset{160}), kafka::offset{160}, as)
+      .get();
+    auto result = std::move(task)
+                    .finish(
+                      translation_task::custom_partitioning_enabled::yes,
+                      test_rcn,
+                      as)
+                    .get();
+
+    ASSERT_TRUE(result.has_error());
+    ASSERT_EQ(
+      result.error(), datalake::translation_task::errc::type_resolution_error);
+
+    // Check no data files are left behind
+    ASSERT_THAT(list_data_files().get(), IsEmpty());
+}
+
+TEST_F(TranslateTaskTest, TestCleanupAfterTransientErrorDiscard) {
+    datalake::translation_task task(
+      ntp,
+      model::revision_id{123},
+      get_writer_factory(),
+      cloud_io,
+      *schema_mgr,
+      *schema_resolver,
+      *translator,
+      *t_creator,
+      model::iceberg_invalid_record_action::dlq_table,
+      location_provider,
+      probe);
+
+    // Translate some data to create some files locally.
+    task.translate_once(make_batches(10, 16), kafka::offset{0}, as).get();
+    auto flush_res = task.flush().get();
+    ASSERT_FALSE(flush_res.has_error());
+
+    // Now make a supposedly transient error happen. This will fail the task
+    // rather than sending the data to the DLQ.
+    schema_resolver->set_fail_requests(type_resolver::errc::registry_error);
+    task
+      .translate_once(
+        make_batches(10, 16, model::offset{160}), kafka::offset{160}, as)
+      .get();
+    auto result = std::move(task).discard().get();
+    ASSERT_TRUE(result.has_error());
+    ASSERT_EQ(result.error(), datalake::translation_task::errc::file_io_error);
+
+    // Check no data files are left behind
     ASSERT_THAT(list_data_files().get(), IsEmpty());
 }
 // TODO: add more sophisticated test cases when multiplexer will be capable of

--- a/src/v/datalake/translation_task.cc
+++ b/src/v/datalake/translation_task.cc
@@ -118,6 +118,28 @@ delete_local_data_files(
       });
 }
 
+ss::future<checked<std::nullopt_t, translation_task::errc>>
+delete_data_and_dlq_files(
+  prefix_logger& log, const record_multiplexer::finished_files& files) {
+    auto [data_result, dlq_result] = co_await ss::when_all_succeed(
+      delete_local_data_files(log, files.data_files),
+      delete_local_data_files(log, files.dlq_files));
+
+    if (data_result.has_error()) {
+        vlog(
+          log.warn,
+          "error deleting local data files - {}",
+          data_result.error());
+        co_return data_result.error();
+    }
+    if (dlq_result.has_error()) {
+        vlog(
+          log.warn, "error deleting local dlq files - {}", data_result.error());
+        co_return dlq_result.error();
+    }
+    co_return std::nullopt;
+}
+
 ss::future<
   checked<chunked_vector<coordinator::data_file>, translation_task::errc>>
 upload_files(
@@ -280,10 +302,19 @@ translation_task::finish(
   custom_partitioning_enabled is_custom_partitioning_enabled,
   retry_chain_node& rcn,
   ss::abort_source& as) && {
-    auto mux_result = co_await std::move(_multiplexer).finish();
+    record_multiplexer::finished_files files;
+    auto mux_result = co_await std::move(_multiplexer).finish(files);
     if (mux_result.has_error()) {
         auto mux_err = mux_result.error();
-        vlog(_log.warn, "Error writing data files - {}", mux_err);
+        vlog(
+          _log.warn,
+          "Error writing data files - {}, deleting {} data files and {} DLQ "
+          "files",
+          mux_result.error(),
+          files.data_files.size(),
+          files.dlq_files.size());
+        [[maybe_unused]] auto _ = co_await delete_data_and_dlq_files(
+          _log, files);
         co_return map_error_code(mux_err);
     }
     auto write_result = std::move(mux_result).value();
@@ -294,21 +325,18 @@ translation_task::finish(
           "{}, dlq files: {}",
           write_result.start_offset,
           write_result.last_offset,
-          write_result.data_files.size(),
-          write_result.dlq_files.size());
+          files.data_files.size(),
+          files.dlq_files.size());
     }
 
     size_t rows_added = 0;
     size_t bytes_added = 0;
-    for (const auto& file : write_result.data_files) {
+    for (const auto& file : files.data_files) {
         rows_added += file.local_file.row_count;
         bytes_added += file.local_file.size_bytes;
     }
     _translation_probe->on_translation_finished(
-      write_result.data_files.size(),
-      rows_added,
-      bytes_added,
-      write_result.dlq_files.size());
+      files.data_files.size(), rows_added, bytes_added, files.dlq_files.size());
 
     coordinator::translated_offset_range ret{
       .start_offset = write_result.start_offset,
@@ -327,7 +355,7 @@ translation_task::finish(
         auto upload_res = co_await upload_files(
           _log,
           *_cloud_io,
-          write_result.data_files,
+          files.data_files,
           is_custom_partitioning_enabled,
           rcn,
           lazy_as);
@@ -342,7 +370,7 @@ translation_task::finish(
         auto dlq_upload_res = co_await upload_files(
           _log,
           *_cloud_io,
-          write_result.dlq_files,
+          files.dlq_files,
           is_custom_partitioning_enabled,
           rcn,
           lazy_as);
@@ -357,31 +385,21 @@ translation_task::finish(
 
 ss::future<checked<std::nullopt_t, translation_task::errc>>
 translation_task::discard() && {
-    auto mux_result = co_await std::move(_multiplexer).finish();
+    record_multiplexer::finished_files files;
+    auto mux_result = co_await std::move(_multiplexer).finish(files);
     if (mux_result.has_error()) {
-        vlog(_log.warn, "Error writing data files - {}", mux_result.error());
+        vlog(
+          _log.warn,
+          "Error writing data files - {}, deleting {} data files and {} DLQ "
+          "files",
+          mux_result.error(),
+          files.data_files.size(),
+          files.dlq_files.size());
+        [[maybe_unused]] auto _ = co_await delete_data_and_dlq_files(
+          _log, files);
         co_return errc::file_io_error;
     }
-    auto write_result = std::move(mux_result).value();
-    auto [data_result, dlq_result] = co_await ss::when_all_succeed(
-      delete_local_data_files(_log, write_result.data_files),
-      delete_local_data_files(_log, write_result.dlq_files));
-
-    if (data_result.has_error()) {
-        vlog(
-          _log.warn,
-          "error deleting local data files - {}",
-          data_result.error());
-        co_return data_result.error();
-    }
-    if (dlq_result.has_error()) {
-        vlog(
-          _log.warn,
-          "error deleting local dlq files - {}",
-          data_result.error());
-        co_return dlq_result.error();
-    }
-    co_return std::nullopt;
+    co_return co_await delete_data_and_dlq_files(_log, files);
 }
 
 size_t translation_task::buffered_bytes() const {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27737

    CONFLICTS:
    - this branch doesn't have some logging at the top of finish()
    - different formatting in this branch in translation_task_test
    - this branch is missing a test in record_multiplexer_test that was
      affected by the signature change of finish()