### PR TITLE
[v24.3.x] [CORE-13523]: Make sure ntp_archiver probes are torn down immediately during partition::stop

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1214,6 +1214,8 @@ ss::future<> ntp_archiver::stop() {
     _leader_cond.broken();
     _flush_cond.broken();
     _wakeup_event.broken();
+
+    _probe.reset();
     co_await _gate.close();
 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -564,6 +564,7 @@ ss::future<> partition::stop() {
               "Stopping archiver on partition: {}",
               partition_ntp);
             co_await _archiver->stop();
+            _archiver.reset(nullptr);
         }
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27742
