### PR TITLE
[CORE-13572] TS: Move notification mechanism from `cloud_storage` to `cloud_io`

### DIFF
--- a/src/v/cloud_io/BUILD
+++ b/src/v/cloud_io/BUILD
@@ -98,10 +98,12 @@ redpanda_cc_library(
         "//src/v/cloud_roles",
         "//src/v/cloud_storage_clients",
         "//src/v/config",
+        "//src/v/container:intrusive",
         "//src/v/model",
         "//src/v/utils:lazy_abort_source",
         "//src/v/utils:retry_chain_node",
         "//src/v/utils:stream_provider",
+        "@abseil-cpp//absl/container:node_hash_set",
         "@seastar",
     ],
 )

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -288,6 +288,13 @@ ss::future<upload_result> remote::upload_stream(
           reader_handle->take_stream(),
           fib.get_timeout());
 
+        notify_external_subscribers(
+          api_activity_notification{
+            api_activity_type::object_upload,
+            fib.retry_count() > 1,
+            content_length},
+          fib);
+
         // `put_object` closed the encapsulated input_stream, but we must
         // call close() on the segment_reader_handle to release the FD.
         co_await reader_handle->close();
@@ -403,6 +410,16 @@ ss::future<download_result> remote::download_stream(
                 uint64_t content_length = co_await cons_str(
                   length, std::move(throttled_st));
                 transfer_details.on_success_size(content_length);
+
+                /// Notify external subscribers about the download activity
+                /// after it completes and we know its size.
+                notify_external_subscribers(
+                  api_activity_notification{
+                    api_activity_type::object_download,
+                    fib.retry_count() > 1,
+                    length},
+                  fib);
+
                 co_return download_result::success;
             } catch (...) {
                 const auto ex = std::current_exception();
@@ -517,6 +534,12 @@ remote::download_object(download_request download_request) {
                 auto buffer
                   = co_await cloud_storage_clients::util::drain_response_stream(
                     resp.value());
+                notify_external_subscribers(
+                  api_activity_notification{
+                    api_activity_type::object_download,
+                    fib.retry_count() > 1,
+                    buffer.size_bytes()},
+                  fib);
                 download_request.payload.append_fragments(std::move(buffer));
                 transfer_details.on_success();
                 co_return download_result::success;
@@ -598,6 +621,10 @@ ss::future<download_result> remote::object_exists(
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto resp = co_await lease.client->head_object(
           bucket, path, fib.get_timeout());
+        notify_external_subscribers(
+          api_activity_notification{
+            api_activity_type::head_object, fib.retry_count() > 1, 0},
+          fib);
         if (resp) {
             vlog(
               ctxlog.debug,
@@ -681,6 +708,11 @@ remote::delete_object(transfer_details transfer_details) {
         transfer_details.on_request(fib.retry_count());
         auto res = co_await lease.client->delete_object(
           bucket, path, fib.get_timeout());
+
+        notify_external_subscribers(
+          api_activity_notification{
+            api_activity_type::delete_object, fib.retry_count() > 1, 0},
+          fib);
 
         if (res) {
             co_return upload_result::success;
@@ -836,6 +868,11 @@ ss::future<upload_result> remote::delete_object_batch(
         req_cb(fib.retry_count());
         auto res = co_await lease.client->delete_objects(
           bucket, keys, fib.get_timeout());
+
+        notify_external_subscribers(
+          api_activity_notification{
+            api_activity_type::delete_plural, fib.retry_count() > 1, 0},
+          fib);
 
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
@@ -1048,6 +1085,11 @@ ss::future<list_result> remote::list_objects(
           delimiter,
           item_filter);
 
+        notify_external_subscribers(
+          api_activity_notification{
+            api_activity_type::list_objects, fib.retry_count() > 1, 0},
+          fib);
+
         if (res) {
             auto list_result = std::move(res.value());
             // Successful call, prepare for future calls by getting
@@ -1169,6 +1211,13 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           fib.get_timeout(),
           upload_request.accept_no_content_response);
 
+        notify_external_subscribers(
+          api_activity_notification{
+            api_activity_type::object_upload,
+            fib.retry_count() > 1,
+            content_length},
+          fib);
+
         if (res) {
             transfer_details.on_success();
             co_return upload_result::success;
@@ -1229,6 +1278,45 @@ remote::propagate_credentials(cloud_roles::credentials credentials) {
       [c = std::move(credentials)](remote& svc) mutable {
           svc._pool.local().load_credentials(std::move(c));
       });
+}
+
+ss::future<api_activity_notification>
+remote::subscribe(remote::event_filter& filter) {
+    _as.check();
+    auto holder = _gate.hold();
+    vassert(filter._hook.is_linked() == false, "Filter is already in use");
+    _subscriptions.push_back(filter);
+    filter._promise.emplace();
+    return filter._promise->get_future().then(
+      [h = std::move(holder)](api_activity_notification r) { return r; });
+    ;
+}
+
+void remote::notify_external_subscribers(
+  api_activity_notification event, const retry_chain_node& caller) {
+    const auto* caller_root = caller.get_root();
+
+    for (auto& flt : _subscriptions) {
+        if (flt._events_to_ignore.contains(event.type)) {
+            continue;
+        }
+
+        if (flt._sources_to_ignore.contains(caller_root)) {
+            continue;
+        }
+
+        // Invariant: the filter._promise is always initialized
+        // by the 'subscribe' method.
+        vassert(
+          flt._promise.has_value(),
+          "Filter object is not initialized properly");
+        flt._promise->set_value(event);
+        flt._promise = std::nullopt;
+        // NOTE: the filter object can be reused by the owner
+    }
+
+    _subscriptions.remove_if(
+      [](const event_filter& f) { return !f._promise.has_value(); });
 }
 
 } // namespace cloud_io

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "absl/container/node_hash_set.h"
 #include "cloud_io/auth_refresh_bg_op.h"
 #include "cloud_io/io_resources.h"
 #include "cloud_io/io_result.h"
@@ -18,6 +19,7 @@
 #include "cloud_roles/refresh_credentials.h"
 #include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/client_pool.h"
+#include "container/intrusive_list_helpers.h"
 #include "model/metadata.h"
 #include "utils/lazy_abort_source.h"
 #include "utils/retry_chain_node.h"
@@ -124,6 +126,21 @@ public:
       = std::nullopt,
       std::function<void(size_t)> throttle_metric_ms_cb = {})
       = 0;
+};
+
+enum class api_activity_type {
+    object_upload,
+    object_download,
+    delete_object,
+    delete_plural,
+    list_objects,
+    head_object,
+};
+
+struct api_activity_notification {
+    api_activity_type type;
+    bool is_retry{false};
+    size_t io_bytes{0};
 };
 
 /// \brief Represents remote endpoint
@@ -304,7 +321,75 @@ public:
 
     const io_resources& resources() const { return *_resources; }
 
+    /// Event filter class.
+    ///
+    /// The filter can be used to subscribe to subset of events.
+    /// For instance, only to object downloads and uploads, or to
+    /// events from all subsystems except one.
+    ///
+    /// The filter is a RAII object. It works until the object
+    /// exists. If the filter is destroyed before the notification
+    /// will be received the receiver of the event will see broken
+    /// promise error.
+    class event_filter {
+        friend class remote;
+
+    public:
+        event_filter() = default;
+
+        explicit event_filter(
+          std::unordered_set<api_activity_type> ignored_events)
+          : _events_to_ignore(std::move(ignored_events)) {}
+
+        void add_source_to_ignore(const retry_chain_node* source) {
+            _sources_to_ignore.insert(source);
+        }
+
+        void remove_source_to_ignore(const retry_chain_node* source) {
+            _sources_to_ignore.erase(source);
+        }
+
+        void cancel() {
+            if (_promise.has_value()) {
+                _hook.unlink();
+                _promise.reset();
+            }
+        }
+
+    private:
+        absl::node_hash_set<const retry_chain_node*> _sources_to_ignore;
+        std::unordered_set<api_activity_type> _events_to_ignore;
+        std::optional<ss::promise<api_activity_notification>> _promise{
+          std::nullopt};
+        intrusive_list_hook _hook;
+    };
+
+    /// Return future that will become available on next cloud I/O
+    /// api operation.
+    ///
+    /// \note The operations which are trigger notifications are object upload,
+    /// object download, object(s) delete, head object, and list objects.
+    /// Every retry generates its own notification. Errors are not propagated to
+    /// the subscriber. The notification is triggered only when the operation is
+    /// finished successfully. The notification contains information about the
+    /// type of the operation and size of the object in bytes.
+    ///
+    /// \param filter is a notification filter which allows to narrow the set of
+    ///        possible notifications by source and type.
+    /// \return the future which will be available after the next cloud storage
+    ///         API operation.
+    ss::future<api_activity_notification> subscribe(event_filter& filter);
+
 private:
+    /// Notify all subscribers about cloud I/O activity.
+    ///
+    /// \param type is a type of activity
+    /// \param source is a retry chain node of the subscriber (pointer equality
+    ///        is used to compare retry_chain_node instances). This parameter is
+    ///        used to prevent subscriber from receiving its own notifications.
+    void notify_external_subscribers(
+      api_activity_notification type, const retry_chain_node& source);
+
     ss::future<> propagate_credentials(cloud_roles::credentials credentials);
 
     ss::sharded<cloud_storage_clients::client_pool>& _pool;
@@ -318,6 +403,8 @@ private:
     model::cloud_storage_backend _cloud_storage_backend;
     cloud_io::provider _provider;
     config::binding<std::chrono::milliseconds> _lease_timeout;
+
+    intrusive_list<event_filter, &event_filter::_hook> _subscriptions;
 };
 
 } // namespace cloud_io

--- a/src/v/cloud_io/tests/BUILD
+++ b/src/v/cloud_io/tests/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_test_cc_library")
+load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_btest", "redpanda_cc_gtest", "redpanda_test_cc_library")
 
 redpanda_test_cc_library(
     name = "scoped_remote",
@@ -112,6 +112,32 @@ redpanda_cc_btest(
         "//src/v/cloud_io:cache",
         "//src/v/test_utils:seastar_boost",
         "@boost//:test",
+        "@seastar",
+        "@seastar//:testing",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "remote_test",
+    timeout = "short",
+    srcs = [
+        "remote_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_storage_clients",
+        "//src/v/config",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:retry_chain_node",
+        "@boost//:range",
+        "@googletest//:gtest",
         "@seastar",
         "@seastar//:testing",
     ],

--- a/src/v/cloud_io/tests/remote_test.cc
+++ b/src/v/cloud_io/tests/remote_test.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "cloud_io/remote.h"
+#include "cloud_io/tests/s3_imposter.h"
+#include "cloud_storage_clients/client_pool.h"
+#include "model/metadata.h"
+#include "test_utils/async.h"
+#include "test_utils/test.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/resource.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/later.hh>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+using namespace cloud_io;
+
+namespace {
+static ss::abort_source never_abort;
+
+constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+
+iobuf make_iobuf(std::string_view str) {
+    iobuf buf;
+    buf.append(str.data(), str.size());
+    return buf;
+}
+} // namespace
+
+class remote_fixture
+  : public s3_imposter_fixture
+  , public seastar_test {
+public:
+    remote_fixture()
+      : s3_imposter_fixture() {}
+
+    ss::future<> SetUpAsync() override {
+        co_await pool.start(10, ss::sharded_parameter([this] { return conf; }));
+        co_await io.start(
+          std::ref(pool),
+          ss::sharded_parameter([this] { return conf; }),
+          ss::sharded_parameter([] { return config_file; }),
+          ss::sharded_parameter([] { return ss::default_scheduling_group(); }));
+    }
+    seastar::future<> TearDownAsync() override {
+        pool.local().shutdown_connections();
+        io.local().request_stop();
+        co_await io.stop();
+        co_await pool.stop();
+    }
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    ss::sharded<cloud_io::remote> io;
+};
+
+TEST_F_CORO(remote_fixture, notify_on_get_object) {
+    set_expectations_and_listen({
+      expectation{.url = "payload-key", .body = "/payload", .slowdown = false},
+    });
+
+    retry_chain_node fib(never_abort, 500ms, 10ms);
+
+    auto filter = remote::event_filter{};
+    auto sub = io.local().subscribe(filter);
+
+    iobuf payload;
+
+    auto fut = io.local().download_object({
+      .transfer_details = {
+        .bucket = bucket_name,
+        .key = cloud_storage_clients::object_key("payload-key"),
+        .parent_rtc = fib,
+      },
+      .display_str = "payload",
+      .payload = payload,
+    });
+
+    auto notification = co_await std::move(sub);
+    EXPECT_EQ(notification.type, api_activity_type::object_download);
+    EXPECT_EQ(notification.is_retry, false);
+    std::ignore = co_await std::move(fut);
+}
+
+TEST_F_CORO(remote_fixture, notify_on_put_object) {
+    co_return;
+    set_expectations_and_listen({
+      expectation{.url = "/payload-key", .slowdown = false},
+    });
+
+    retry_chain_node fib(never_abort, 500ms, 10ms);
+
+    auto filter = remote::event_filter{};
+    auto sub = io.local().subscribe(filter);
+
+    auto fut = io.local().upload_object({
+      .transfer_details = {
+        .bucket = bucket_name,
+        .key = cloud_storage_clients::object_key("/payload-key"),
+        .parent_rtc = fib,
+      },
+      .display_str = "payload",
+      .payload = make_iobuf("payload"),
+    });
+
+    auto notification = co_await std::move(sub);
+    EXPECT_EQ(notification.type, api_activity_type::object_upload);
+    std::ignore = co_await std::move(fut);
+}

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -39,6 +39,7 @@
 #include <boost/range/irange.hpp>
 #include <fmt/chrono.h>
 
+#include <cstddef>
 #include <exception>
 #include <iterator>
 #include <utility>
@@ -168,8 +169,6 @@ ss::future<download_result> remote::do_download_manifest(
          .success_cb = std::nullopt,
          .failure_cb = [this]() { _probe.failed_manifest_download(); },
          .backoff_cb = [this]() { _probe.manifest_download_backoff(); },
-         .on_req_cb = make_notify_cb(
-           api_activity_type::manifest_download, parent),
        },
        .display_str = "manifest",
        .payload = buffer,
@@ -252,39 +251,11 @@ ss::future<upload_result> remote::upload_manifest(
         .success_cb = std::move(success_cb),
         .failure_cb = [this] { _probe.failed_manifest_upload(); },
         .backoff_cb = [this] { _probe.manifest_upload_backoff(); },
-        .on_req_cb = make_notify_cb(api_activity_type::manifest_upload, parent),
       },
       .display_str = to_string(upload_type::manifest),
       .payload = std::move(buf),
       .accept_no_content_response = false,
     });
-}
-
-void remote::notify_external_subscribers(
-  api_activity_notification event, const retry_chain_node& caller) {
-    const auto* caller_root = caller.get_root();
-
-    for (auto& flt : _filters) {
-        if (flt._events_to_ignore.contains(event.type)) {
-            continue;
-        }
-
-        if (flt._sources_to_ignore.contains(caller_root)) {
-            continue;
-        }
-
-        // Invariant: the filter._promise is always initialized
-        // by the 'subscribe' method.
-        vassert(
-          flt._promise.has_value(),
-          "Filter object is not initialized properly");
-        flt._promise->set_value(event);
-        flt._promise = std::nullopt;
-        // NOTE: the filter object can be reused by the owner
-    }
-
-    _filters.remove_if(
-      [](const event_filter& f) { return !f._promise.has_value(); });
 }
 
 ss::future<upload_result> remote::upload_controller_snapshot(
@@ -315,8 +286,6 @@ ss::future<upload_result> remote::upload_controller_snapshot(
           [this](size_t sz) { _probe.register_upload_size(sz); },
         .failure_cb = [this] { _probe.controller_snapshot_failed_upload(); },
         .backoff_cb = [this] { _probe.controller_snapshot_upload_backoff(); },
-        .on_req_cb = make_notify_cb(
-          api_activity_type::controller_snapshot_upload, parent),
       },
       file_size,
       reset_str,
@@ -346,8 +315,6 @@ ss::future<upload_result> remote::upload_segment(
             [this](size_t sz) { _probe.register_upload_size(sz); },
           .failure_cb = [this] { _probe.failed_upload(); },
           .backoff_cb = [this] { _probe.upload_backoff(); },
-          .on_req_cb = make_notify_cb(
-            api_activity_type::segment_upload, parent),
         },
         content_length,
         reset_str,
@@ -373,7 +340,6 @@ ss::future<upload_result> remote::upload_index(
           .parent_rtc = parent,
           .success_cb = [this] { _probe.index_upload(); },
           .failure_cb = [this] { _probe.failed_index_upload(); },
-          .on_req_cb = make_notify_cb(api_activity_type::object_upload, parent),
         },
         .display_str = to_string(upload_type::segment_index),
         .payload = std::move(buf),
@@ -405,9 +371,6 @@ ss::future<download_result> remote::download_stream(
           .failure_cb = [&metrics] { metrics.failed_download_metric(); },
           .backoff_cb = [&metrics] { metrics.download_backoff_metric(); },
           .client_acquire_cb = [this] { _probe.client_acquisition(); },
-          // TODO: pass type in as an argument.
-          .on_req_cb = make_notify_cb(
-            api_activity_type::segment_download, parent),
           .measure_latency_cb =
             [&metrics] { return metrics.download_latency_measurement(); },
         },
@@ -441,8 +404,6 @@ ss::future<download_result> remote::download_segment(
           .failure_cb = [this] { _probe.failed_download(); },
           .backoff_cb = [this] { _probe.download_backoff(); },
           .client_acquire_cb = [this] { _probe.client_acquisition(); },
-          .on_req_cb = make_notify_cb(
-            api_activity_type::segment_download, parent),
           .measure_latency_cb = [this] { return _probe.segment_download(); },
         },
         cons_str,
@@ -471,8 +432,6 @@ ss::future<download_result> remote::download_index(
          .success_cb = [this]() { _probe.index_download(); },
          .failure_cb = [this]() { _probe.failed_index_download(); },
          .backoff_cb = [this]() { _probe.download_backoff(); },
-         .on_req_cb = make_notify_cb(
-           api_activity_type::object_download, parent),
        },
        .display_str = to_string(download_type::segment_index),
        .payload = buffer});
@@ -487,10 +446,6 @@ remote::download_object(download_request download_request) {
     _as.check();
     auto holder = _gate.hold();
     auto details = std::move(download_request.transfer_details);
-    if (!details.on_req_cb.has_value()) {
-        details.on_req_cb = make_notify_cb(
-          api_activity_type::object_download, details.parent_rtc);
-    }
     return io()
       .download_object({
         .transfer_details = std::move(details),
@@ -535,7 +490,6 @@ ss::future<upload_result> remote::delete_object(
         .bucket = bucket,
         .key = path,
         .parent_rtc = parent,
-        .on_req_cb = make_notify_cb(api_activity_type::segment_delete, parent),
       })
       .then([h = std::move(holder)](upload_result r) { return r; });
 }
@@ -552,11 +506,7 @@ ss::future<upload_result> remote::delete_objects(
     _as.check();
     auto holder = _gate.hold();
     return io()
-      .delete_objects(
-        bucket,
-        std::move(keys),
-        parent,
-        make_notify_cb(api_activity_type::segment_delete, parent))
+      .delete_objects(bucket, std::move(keys), parent, [](size_t) {})
       .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
@@ -598,10 +548,6 @@ ss::future<upload_result> remote::upload_object(upload_request req) {
     _as.check();
     auto holder = _gate.hold();
     auto details = std::move(req.transfer_details);
-    if (!details.on_req_cb.has_value()) {
-        details.on_req_cb = make_notify_cb(
-          api_activity_type::object_upload, details.parent_rtc);
-    }
     return io()
       .upload_object({
         .transfer_details = std::move(details),
@@ -612,25 +558,8 @@ ss::future<upload_result> remote::upload_object(upload_request req) {
       .then([h = std::move(holder)](upload_result r) { return r; });
 }
 
-ss::future<api_activity_notification>
-remote::subscribe(remote::event_filter& filter) {
-    _as.check();
-    auto holder = _gate.hold();
-    vassert(filter._hook.is_linked() == false, "Filter is already in use");
-    _filters.push_back(filter);
-    filter._promise.emplace();
-    return filter._promise->get_future().then(
-      [h = std::move(holder)](api_activity_notification r) { return r; });
-    ;
-}
-
-std::function<void(size_t)>
-remote::make_notify_cb(api_activity_type t, retry_chain_node& retry) {
-    return [this, t, &retry](size_t attempt_num) {
-        notify_external_subscribers(
-          api_activity_notification{.type = t, .is_retry = attempt_num > 1},
-          retry);
-    };
+ss::future<api_activity_notification> remote::subscribe(event_filter& filter) {
+    return io().subscribe(filter);
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -44,22 +44,8 @@ class materialized_resources;
 
 inline constexpr ss::shard_id auth_refresh_shard_id = 0;
 
-enum class api_activity_type {
-    segment_upload,
-    segment_download,
-    segment_delete,
-    manifest_upload,
-    manifest_download,
-    controller_snapshot_upload,
-    controller_snapshot_download,
-    object_upload,
-    object_download
-};
-
-struct api_activity_notification {
-    api_activity_type type;
-    bool is_retry;
-};
+using api_activity_type = cloud_io::api_activity_type;
+using api_activity_notification = cloud_io::api_activity_notification;
 
 // Enables creating mocks from remote. A mock class should be extended from this
 // interface in tests, and methods in real code should accept
@@ -419,46 +405,7 @@ public:
 
     materialized_resources& materialized() { return *_materialized; }
 
-    /// Event filter class.
-    ///
-    /// The filter can be used to subscribe to subset of events.
-    /// For instance, only to segment downloads and uploads, or to
-    /// events from all sybsystems except one.
-    /// The filter is a RAII object. It works until the object
-    /// exists. If the filter is destroyed before the notification
-    /// will be received the receiver of the event will see broken
-    /// promise error.
-    class event_filter {
-        friend class remote;
-
-    public:
-        event_filter() = default;
-
-        explicit event_filter(
-          std::unordered_set<api_activity_type> ignored_events)
-          : _events_to_ignore(std::move(ignored_events)) {}
-
-        void add_source_to_ignore(const retry_chain_node* source) {
-            _sources_to_ignore.insert(source);
-        }
-
-        void remove_source_to_ignore(const retry_chain_node* source) {
-            _sources_to_ignore.erase(source);
-        }
-
-        void cancel() {
-            if (_promise.has_value()) {
-                _hook.unlink();
-                _promise.reset();
-            }
-        }
-
-    private:
-        absl::node_hash_set<const retry_chain_node*> _sources_to_ignore;
-        std::unordered_set<api_activity_type> _events_to_ignore;
-        std::optional<ss::promise<api_activity_notification>> _promise;
-        intrusive_list_hook _hook;
-    };
+    using event_filter = cloud_io::remote::event_filter;
 
     /// Return future that will become available on next cloud storage
     /// api operation.
@@ -486,12 +433,6 @@ private:
     cloud_io::remote& io() { return _io.local(); }
     const cloud_io::remote& io() const { return _io.local(); }
 
-    /// Notify all subscribers about segment or manifest upload/download
-    void notify_external_subscribers(
-      api_activity_notification, const retry_chain_node& caller);
-    std::function<void(size_t)>
-    make_notify_cb(api_activity_type t, retry_chain_node& retry);
-
     ss::gate _gate;
     ss::abort_source _as;
 
@@ -500,8 +441,6 @@ private:
 
     // Lifetime: probe has reference to _materialized, must be destroyed after
     remote_probe _probe;
-
-    intrusive_list<event_filter, &event_filter::_hook> _filters;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -172,16 +172,12 @@ public:
 
 TEST_P(all_types_remote_fixture, test_download_manifest_timeout) { // NOLINT
     partition_manifest actual(manifest_ntp, manifest_revision);
-    auto subscription = remote.local().subscribe(allow_all);
     retry_chain_node fib(never_abort, 100ms, 20ms);
     auto res = remote.local()
                  .download_manifest(
                    bucket_name, json_manifest_format_path, actual, fib)
                  .get();
     ASSERT_TRUE(res == download_result::timedout);
-    ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(
-      subscription.get().type == api_activity_type::manifest_download);
 }
 
 TEST_P(all_types_remote_fixture, test_upload_segment) { // NOLINT
@@ -207,13 +203,12 @@ TEST_P(all_types_remote_fixture, test_upload_segment) { // NOLINT
     ASSERT_EQ(req.content_length, clen);
     ASSERT_EQ(req.content, ss::sstring(manifest_payload));
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_upload);
 }
 
 TEST_P(
   all_types_remote_fixture, test_upload_segment_lost_leadership) { // NOLINT
     set_expectations_and_listen({});
-    auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = remote_segment_path{prefixed_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123})};
@@ -234,12 +229,9 @@ TEST_P(
                  .get();
     ASSERT_EQ(res, upload_result::cancelled);
     ASSERT_TRUE(get_requests().empty());
-    ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 }
 
 TEST_P(all_types_remote_fixture, test_upload_segment_timeout) { // NOLINT
-    auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = remote_segment_path{prefixed_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123})};
@@ -256,8 +248,6 @@ TEST_P(all_types_remote_fixture, test_upload_segment_timeout) { // NOLINT
                    bucket_name, path, clen, reset_stream, fib, always_continue)
                  .get();
     ASSERT_TRUE(res == upload_result::timedout);
-    ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 }
 
 TEST_P(all_types_remote_fixture, test_download_segment) { // NOLINT
@@ -300,11 +290,10 @@ TEST_P(all_types_remote_fixture, test_download_segment) { // NOLINT
     auto actual = p.read_string(p.bytes_left());
     ASSERT_TRUE(actual == manifest_payload);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_upload);
 }
 
 TEST_P(all_types_remote_fixture, test_download_segment_timeout) { // NOLINT
-    auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = remote_segment_path{prefixed_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123})};
@@ -319,8 +308,6 @@ TEST_P(all_types_remote_fixture, test_download_segment_timeout) { // NOLINT
                      .download_segment(bucket_name, path, try_consume, fib)
                      .get();
     ASSERT_TRUE(dnl_res == download_result::timedout);
-    ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_download);
 }
 
 TEST_P(all_types_remote_fixture, test_download_segment_range) {
@@ -382,7 +369,7 @@ TEST_P(all_types_remote_fixture, test_download_segment_range) {
       manifest_payload.begin(), manifest_payload.begin() + 2};
     ASSERT_EQ(actual, expected);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_upload);
 
     const auto& req = get_requests()[1];
     ASSERT_EQ(req.method, "GET");
@@ -469,7 +456,7 @@ TEST_P(all_types_remote_fixture, test_segment_delete) { // NOLINT
       = remote.local().segment_exists(bucket_name, path, fib).get();
     ASSERT_TRUE(expected_notfound == download_result::notfound);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_delete);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::delete_object);
 }
 
 TEST_P(all_types_remote_fixture, test_concat_segment_upload) {
@@ -1042,8 +1029,7 @@ TEST_P(all_types_remote_fixture, test_filter_by_source) { // NOLINT
             .get();
     ASSERT_TRUE(res == download_result::success);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(
-      subscription.get().type == api_activity_type::manifest_download);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_download);
 
     // Reuse filter for the next event
     subscription = remote.local().subscribe(flt);
@@ -1053,8 +1039,7 @@ TEST_P(all_types_remote_fixture, test_filter_by_source) { // NOLINT
             .get();
     ASSERT_TRUE(res == download_result::success);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(
-      subscription.get().type == api_activity_type::manifest_download);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_download);
 
     // Remove the rtc node from the filter and re-subscribe. This time we should
     // receive the notification.
@@ -1066,8 +1051,7 @@ TEST_P(all_types_remote_fixture, test_filter_by_source) { // NOLINT
             .get();
     ASSERT_TRUE(res == download_result::success);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(
-      subscription.get().type == api_activity_type::manifest_download);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_download);
 }
 
 TEST_P(all_types_remote_fixture, test_filter_by_type) { // NOLINT
@@ -1076,8 +1060,9 @@ TEST_P(all_types_remote_fixture, test_filter_by_type) { // NOLINT
     retry_chain_node root_rtc(never_abort, 100ms, 20ms);
     partition_manifest actual(manifest_ntp, manifest_revision);
 
-    remote::event_filter flt1({api_activity_type::manifest_download});
-    remote::event_filter flt2({api_activity_type::manifest_upload});
+    remote::event_filter flt1({api_activity_type::object_download});
+    remote::event_filter flt2({api_activity_type::object_upload});
+
     auto subscription1 = remote.local().subscribe(flt1);
     auto subscription2 = remote.local().subscribe(flt2);
 
@@ -1089,8 +1074,7 @@ TEST_P(all_types_remote_fixture, test_filter_by_type) { // NOLINT
     ASSERT_TRUE(dl_res == download_result::success);
     ASSERT_TRUE(!subscription1.available());
     ASSERT_TRUE(subscription2.available());
-    ASSERT_TRUE(
-      subscription2.get().type == api_activity_type::manifest_download);
+    ASSERT_TRUE(subscription2.get().type == api_activity_type::object_download);
 
     auto upl_res
       = remote.local()
@@ -1099,7 +1083,7 @@ TEST_P(all_types_remote_fixture, test_filter_by_type) { // NOLINT
           .get();
     ASSERT_TRUE(upl_res == upload_result::success);
     ASSERT_TRUE(subscription1.available());
-    ASSERT_TRUE(subscription1.get().type == api_activity_type::manifest_upload);
+    ASSERT_TRUE(subscription1.get().type == api_activity_type::object_upload);
 }
 
 TEST_P(all_types_remote_fixture, test_filter_lifetime_1) { // NOLINT
@@ -1121,8 +1105,7 @@ TEST_P(all_types_remote_fixture, test_filter_lifetime_1) { // NOLINT
     // is destroyed.
     ASSERT_TRUE(res == download_result::success);
     ASSERT_TRUE(subscription.available());
-    ASSERT_TRUE(
-      subscription.get().type == api_activity_type::manifest_download);
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_download);
 }
 
 TEST_P(all_types_remote_fixture, test_filter_lifetime_2) { // NOLINT
@@ -1300,36 +1283,6 @@ TEST_P(
                                  .get_downloads_throttled_sum();
         ASSERT_TRUE(times_throttled == 0);
     }
-}
-
-TEST_P(all_types_remote_fixture, test_notification_retry_meta) {
-    set_expectations_and_listen(
-      {expectation{.url = manifest_serde_url, .slowdown = true}});
-
-    retry_chain_node fib(never_abort, 500ms, 10ms);
-    partition_manifest actual(manifest_ntp, manifest_revision);
-    auto filter = remote::event_filter{};
-
-    remote_path_provider path_provider(std::nullopt, std::nullopt);
-    partition_manifest_downloader dl(
-      bucket_name,
-      path_provider,
-      manifest_ntp,
-      manifest_revision,
-      remote.local());
-
-    auto fut = dl.download_manifest(fib, &actual);
-
-    RPTEST_REQUIRE_EVENTUALLY(2s, [&] {
-        auto sub = remote.local().subscribe(filter);
-        return sub.then([](api_activity_notification event) {
-            return ss::make_ready_future<bool>(event.is_retry);
-        });
-    });
-
-    auto res = fut.get();
-    EXPECT_TRUE(res.has_error());
-    EXPECT_TRUE(res.error() == error_outcome::manifest_download_error);
 }
 
 TEST_P(all_types_remote_fixture, test_get_object) {

--- a/src/v/cluster/archival/upload_housekeeping_service.cc
+++ b/src/v/cluster/archival/upload_housekeeping_service.cc
@@ -122,27 +122,22 @@ ss::future<> upload_housekeeping_service::bg_idle_loop() {
         double slow_down_weight = 0;
         switch (event.type) {
         // Write path events
-        case cloud_storage::api_activity_type::manifest_upload:
-        case cloud_storage::api_activity_type::segment_upload:
-        case cloud_storage::api_activity_type::segment_delete:
         case cloud_storage::api_activity_type::object_upload:
+        case cloud_storage::api_activity_type::delete_object:
+        case cloud_storage::api_activity_type::delete_plural:
             weight = 1;
             if (event.is_retry) {
                 slow_down_weight = 1;
             }
             break;
         // Read path events
-        case cloud_storage::api_activity_type::manifest_download:
-        case cloud_storage::api_activity_type::segment_download:
         case cloud_storage::api_activity_type::object_download:
+        case cloud_storage::api_activity_type::list_objects:
+        case cloud_storage::api_activity_type::head_object:
             weight = 1;
             if (event.is_retry) {
                 slow_down_weight = 1;
             }
-            break;
-        // Controller snapshot IO is independent of housekeeping.
-        case cloud_storage::api_activity_type::controller_snapshot_download:
-        case cloud_storage::api_activity_type::controller_snapshot_upload:
             break;
         };
 


### PR DESCRIPTION
Currently, only TS generates notifications (`remote::subscribe` method). The problem is that both `iceberg` and `cloud-topics` are not generating any notifications. The housekeeping uses these notifications to detect idle state.

This PR fixes this by moving notification mechanism down the stack into the `cloud_io`.  There is some "impedance mismatch" between `cloud_io::remote` and `cloud_storage::remote`. The `cloud_storage::remote` operates on segments, manifests, indexes etc. So the notifications are tailored for these artefacts. There is an enum that lists all these objects and notification stores value of this enum.  The `cloud_io::remote` operates on objects without knowing their underlying type.

Luckily this enum is not used much. There is only one place in the code that checks the notification type but only to distinguish between the "read path" and "write path" and assign the same weight for both. So it's absolutely safe to go from all these fine grained enum values to more coarse grained values that `cloud_io` could generate. 

This PR also adds the size of the object to the notification. This will be used by the cloud topics subsystem to estimate the amount of work that every shard is doing to make scheduling decisions. Because of that the notifications are triggered after the download is completed. Otherwise we will not be able to know the exact number of bytes that were downloaded.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none