### PR TITLE
[CORE-14259] Fixes [UX-518] -add maintenance status to cluster health command

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -32,6 +32,7 @@ type healthResponse struct {
 	ControllerID              int      `json:"controller_id" yaml:"controller_id"`
 	AllNodes                  []int    `json:"all_nodes" yaml:"all_nodes"`
 	NodesDown                 []int    `json:"nodes_down" yaml:"nodes_down"`
+	NodesInMaintenance        []int    `json:"nodes_in_maintenance" yaml:"nodes_in_maintenance"`
 	NodesInRecoveryMode       []int    `json:"nodes_in_recovery_mode" yaml:"nodes_in_recovery_mode"`
 	LeaderlessPartitions      []string `json:"leaderless_partitions" yaml:"leaderless_partitions"`
 	LeaderlessCount           *int     `json:"leaderless_count,omitempty" yaml:"leaderless_count,omitempty"`
@@ -99,8 +100,12 @@ Get cluster health information and exit when the cluster is healthy:
 				ret, err := cl.GetHealthOverview(cmd.Context())
 				out.MaybeDie(err, "unable to request cluster health: %v", err)
 				exit10 = !ret.IsHealthy
+				brokers, err := cl.Brokers(cmd.Context())
+				if err != nil {
+					zap.L().Sugar().Warnf("unable to get broker list for maintenance status: %v; skipping maintenance status", err)
+				}
 				if !reflect.DeepEqual(ret, lastOverview) {
-					hr := buildHealthResponses(&ret, clusterUUID)
+					hr := buildHealthResponses(&ret, brokers, clusterUUID)
 					if isText, _, s, err := f.Format(hr); !isText {
 						out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
 						fmt.Println(s)
@@ -130,12 +135,21 @@ Get cluster health information and exit when the cluster is healthy:
 	return cmd
 }
 
-func buildHealthResponses(hov *rpadmin.ClusterHealthOverview, clusterUUID *string) healthResponse {
+func buildHealthResponses(hov *rpadmin.ClusterHealthOverview, brokers []rpadmin.Broker, clusterUUID *string) healthResponse {
 	// This is needed as NodesInRecoveryMode can be nil, and the json formatter
 	// will print "null" instead of an empty array.
 	nodesInRecoveryMode := hov.NodesInRecoveryMode
 	if len(nodesInRecoveryMode) == 0 {
 		nodesInRecoveryMode = []int{}
+	}
+	var nodesInMaintenance []int
+	for _, b := range brokers {
+		if b.Maintenance != nil && b.Maintenance.Draining {
+			nodesInMaintenance = append(nodesInMaintenance, b.NodeID)
+		}
+	}
+	if len(nodesInMaintenance) == 0 {
+		nodesInMaintenance = []int{}
 	}
 	return healthResponse{
 		ClusterUUID:               clusterUUID,
@@ -144,6 +158,7 @@ func buildHealthResponses(hov *rpadmin.ClusterHealthOverview, clusterUUID *strin
 		ControllerID:              hov.ControllerID,
 		AllNodes:                  hov.AllNodes,
 		NodesDown:                 hov.NodesDown,
+		NodesInMaintenance:        nodesInMaintenance,
 		NodesInRecoveryMode:       nodesInRecoveryMode,
 		LeaderlessPartitions:      hov.LeaderlessPartitions,
 		LeaderlessCount:           hov.LeaderlessCount,
@@ -181,6 +196,9 @@ func printHealthOverview(hr healthResponse) {
 	tw.Print("Controller ID:", hr.ControllerID)
 	tw.Print("All nodes:", hr.AllNodes)
 	tw.Print("Nodes down:", hr.NodesDown)
+	if len(hr.NodesInMaintenance) > 0 {
+		tw.Print("Nodes in maintenance:", hr.NodesInMaintenance)
+	}
 	if hr.NodesInRecoveryMode != nil {
 		tw.Print("Nodes in recovery mode:", hr.NodesInRecoveryMode)
 	}

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -142,14 +142,11 @@ func buildHealthResponses(hov *rpadmin.ClusterHealthOverview, brokers []rpadmin.
 	if len(nodesInRecoveryMode) == 0 {
 		nodesInRecoveryMode = []int{}
 	}
-	var nodesInMaintenance []int
+	nodesInMaintenance := []int{}
 	for _, b := range brokers {
 		if b.Maintenance != nil && b.Maintenance.Draining {
 			nodesInMaintenance = append(nodesInMaintenance, b.NodeID)
 		}
-	}
-	if len(nodesInMaintenance) == 0 {
-		nodesInMaintenance = []int{}
 	}
 	return healthResponse{
 		ClusterUUID:               clusterUUID,


### PR DESCRIPTION
When reviewing a cluster's health, nodes in Maintenance mode can be easy to overlook, leading to difficulty resolving certain issues. This PR adds maintenance node visibility to `rpk cluster health` to help quickly identify if any nodes are in maintenance mode.

Uses `cl.Brokers()` to fetch the broker list and checks each broker's `maintenance_status.draining` field. This avoids any server-side changes while still surfacing maintenance state in a single additional API call. Nodes in maintenance are only displayed when at least one node is draining.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v26.2.x
- [x] v26.1.x
- [x] v25.3.x

## UX Changes

* `rpk cluster health` now displays a "Nodes in maintenance" line when one or more nodes are in maintenance mode.

## Release Notes

### Improvements

* `rpk cluster health` will now display any nodes that may be in maintenance mode.