### PR TITLE
rptest: adjust type-check.sh for pre-commit hooks

### DIFF
--- a/tests/type-checking/type-check.sh
+++ b/tests/type-checking/type-check.sh
@@ -21,5 +21,5 @@ docker build "$TESTS_DIR" -t $tag -f type-checking/Dockerfile ${TARGET:+--target
 
 # Run the container with the tests directory mounted
 # echo "Running type checker in Docker container..."
-docker run --rm -it \
+docker run --rm -t \
   -v "$TESTS_DIR:$TESTS_DIR" $tag --no-venv --tests-root "$TESTS_DIR" "$@"


### PR DESCRIPTION
Remove `-i` from docker run, since no stdin is needed.

This is to allow running the check in a pre-commit hook, which would otherwise error with:
```
the input device is not a TTY
```

This is safe because the type checker needs no input from stdin. Signals such as ctrl+C are still passed through correctly with docker.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
