### PR TITLE
ct: Fix write-request-scheduler test

### DIFF
--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2024 Redpanda Data, Inc.
+// Copyright 2025 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -278,9 +278,14 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
     });
 
     size_t shard0_data_size = 0;
-    auto buf = co_await model::test::make_random_batches();
+    auto buf1 = co_await model::test::make_random_batches();
+    auto buf2 = co_await model::test::make_random_batches();
     chunked_vector<model::record_batch> batches;
-    for (auto& b : buf) {
+    for (auto& b : buf1) {
+        shard0_data_size += b.size_bytes();
+        batches.push_back(std::move(b));
+    }
+    for (auto& b : buf2) {
         shard0_data_size += b.size_bytes();
         batches.push_back(std::move(b));
     }
@@ -293,6 +298,7 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
 
     // Check that number of upload requests matches expectation.
     // The shard that has the most data should handle the request.
+    ASSERT_NE_CORO(shard0_data_size, shard1_data_size);
     auto expected_shard = shard0_data_size > shard1_data_size ? 0 : 1;
     auto num_requests = co_await request_sink.invoke_on(
       expected_shard, [](auto& s) { return s.write_requests_acked; });


### PR DESCRIPTION
The test fails if both shards generate exactly the same amount of data. This commit fixes this by forcing one of the shards to generate more data and checking that both values doesn't match.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none