### PR TITLE
rpk: allow directory to be used for bundle -o

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -58,27 +59,26 @@ const linuxUtilsRoot = "utils"
 //   - File Extension: if no extension is provided we default to .zip
 //   - File Location: we check for write permissions in the pwd (for backcompat);
 //     if permission is denied we default to $HOME unless isFlag is true.
-func determineFilepath(fs afero.Fs, rp *config.RedpandaYaml, path string, isFlag bool) (finalPath string, err error) {
+func determineFilepath(fs afero.Fs, rp *config.RedpandaYaml, pathArg string, isFlag bool) (finalPath string, err error) {
 	// if it's empty, use ./<timestamp>-bundle.zip
-	if path == "" {
+	if isDir, _ := afero.IsDir(fs, pathArg); isDir || pathArg == "" {
 		timestamp := time.Now().Unix()
 		if rp.Redpanda.AdvertisedRPCAPI != nil {
-			path = fmt.Sprintf("%v-%d-bundle.zip", common.SanitizeName(rp.Redpanda.AdvertisedRPCAPI.Address), timestamp)
+			finalPath = fmt.Sprintf("%v-%d-bundle.zip", common.SanitizeName(rp.Redpanda.AdvertisedRPCAPI.Address), timestamp)
 		} else {
-			path = fmt.Sprintf("%d-bundle.zip", timestamp)
+			finalPath = fmt.Sprintf("%d-bundle.zip", timestamp)
 		}
-	} else if isDir, _ := afero.IsDir(fs, path); isDir {
-		return "", fmt.Errorf("output file path is a directory, please specify the name of the file")
-	}
-
-	// Check for file extension, if extension is empty, defaults to .zip
-	switch ext := filepath.Ext(path); ext {
-	case ".zip":
-		finalPath = path
-	case "":
-		finalPath = path + ".zip"
-	default:
-		return "", fmt.Errorf("extension %q not supported", ext)
+		finalPath = path.Join(pathArg, finalPath) // Prepend dir if specified, no-op if not
+	} else {
+		// Check for file extension, if extension is empty, defaults to .zip
+		switch ext := filepath.Ext(pathArg); ext {
+		case ".zip":
+			finalPath = pathArg
+		case "":
+			finalPath = pathArg + ".zip"
+		default:
+			return "", fmt.Errorf("extension %q not supported", ext)
+		}
 	}
 
 	// Now we check for write permissions:
@@ -90,11 +90,11 @@ func determineFilepath(fs afero.Fs, rp *config.RedpandaYaml, path string, isFlag
 		if isFlag {
 			// If the user sets the output flag, we fail if we don't have
 			// write permissions
-			return "", fmt.Errorf("unable to create bundle file in %q: %v", path, err)
+			return "", fmt.Errorf("unable to create bundle file in %q: %v", pathArg, err)
 		}
 		home, err := os.UserHomeDir()
 		if err != nil {
-			out.Die("unable to create bundle file in %q due to permission issues and cannot use home directory: %v", path, err)
+			out.Die("unable to create bundle file in %q due to permission issues and cannot use home directory: %v", pathArg, err)
 		}
 		// We are here only if the user did not specify a flag so finalpath
 		// here is the <timestamp>-bundle.zip string

--- a/src/go/rpk/pkg/cli/debug/remotebundle/download.go
+++ b/src/go/rpk/pkg/cli/debug/remotebundle/download.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -205,21 +206,19 @@ func filterCompletedBrokers(status []statusResponse) (readyBrokers, erroredBroke
 	return ready, errored
 }
 
-func fileLocation(fs afero.Fs, path string) (string, error) {
+func fileLocation(fs afero.Fs, pathArg string) (string, error) {
 	// If it's empty, use "./<timestamp>-remote-bundle.zip"
-	if path == "" {
-		path = fmt.Sprintf("%d-remote-bundle.zip", time.Now().Unix())
-	} else if isDir, _ := afero.IsDir(fs, path); isDir {
-		return "", fmt.Errorf("output file path is a directory, please specify the name of the file")
+	if isDir, _ := afero.IsDir(fs, pathArg); isDir || pathArg == "" {
+		return path.Join(pathArg, fmt.Sprintf("%d-remote-bundle.zip", time.Now().Unix())), nil
 	}
 
 	var finalPath string
 	// Check for file extension, if extension is empty, defaults to .zip
-	switch ext := filepath.Ext(path); ext {
+	switch ext := filepath.Ext(pathArg); ext {
 	case ".zip":
-		finalPath = path
+		finalPath = pathArg
 	case "":
-		finalPath = path + ".zip"
+		finalPath = pathArg + ".zip"
 	default:
 		return "", fmt.Errorf("extension %q not supported", ext)
 	}


### PR DESCRIPTION
Previously we explicitly disallowed this, but allowing this as a path to put the default-named file in helps with automation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
