### PR TITLE
ct: Make write_request_scheduler_test more robust

### DIFF
--- a/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/tests/write_request_scheduler_test.cc
@@ -224,6 +224,24 @@ static ss::future<size_t> write_until_threshold(
     co_return num_requests_sent;
 }
 
+/// Same as model::test_make_random_batches but allows to specify number of
+/// batches and size of every batch (same size for all)
+static auto make_random_batches(size_t num_batches, size_t batch_size) {
+    chunked_vector<model::record_batch> batches;
+    for (size_t i = 0; i < num_batches; i++) {
+        auto batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::offset(i),
+            .allow_compression = false,
+            .count = 1,
+            .records = 1,
+            .record_sizes = std::vector<size_t>{batch_size},
+          });
+        batches.push_back(std::move(batch));
+    }
+    return batches;
+}
+
 TEST_F_CORO(write_request_balancer_fixture, time_based_fallback_test) {
     // This test produces some batches and expects time based threshold
     // mechanism to trigger the upload.
@@ -262,34 +280,22 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
     co_await start(
       /*disable_data_threshold=*/true, /*disable_time_based_fallback=*/false);
 
+    static constexpr size_t batch_size = 0x1000;
+    static constexpr size_t num_batches_hi = 99;
+    static constexpr size_t num_batches_lo = 10;
+
     std::atomic<size_t> shard1_data_size = 0;
     auto fut = ss::smp::submit_to(ss::shard_id(1), [this, &shard1_data_size] {
-        return model::test::make_random_batches().then(
-          [this, &shard1_data_size](auto buf) {
-              for (const model::record_batch& b : buf) {
-                  shard1_data_size += b.size_bytes();
-              }
-              chunked_vector<model::record_batch> batches;
-              std::move(buf.begin(), buf.end(), std::back_inserter(batches));
-              vlog(test_log.info, "Calling write_and_debounce on shard 1");
-              return pipeline.local().write_and_debounce(
-                test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
-          });
+        auto batches = make_random_batches(num_batches_hi, batch_size);
+        for (const model::record_batch& b : batches) {
+            shard1_data_size += b.size_bytes();
+        }
+        vlog(test_log.info, "Calling write_and_debounce on shard 1");
+        return pipeline.local().write_and_debounce(
+          test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
     });
 
-    size_t shard0_data_size = 0;
-    auto buf1 = co_await model::test::make_random_batches();
-    auto buf2 = co_await model::test::make_random_batches();
-    chunked_vector<model::record_batch> batches;
-    for (auto& b : buf1) {
-        shard0_data_size += b.size_bytes();
-        batches.push_back(std::move(b));
-    }
-    for (auto& b : buf2) {
-        shard0_data_size += b.size_bytes();
-        batches.push_back(std::move(b));
-    }
-
+    auto batches = make_random_batches(num_batches_lo, batch_size);
     vlog(test_log.info, "Calling write_and_debounce on shard 0");
     auto s0_placeholders = co_await pipeline.local().write_and_debounce(
       test_ntp0, std::move(batches), ss::lowres_clock::now() + 10s);
@@ -298,10 +304,8 @@ TEST_F_CORO(write_request_balancer_fixture, test_core_affinity) {
 
     // Check that number of upload requests matches expectation.
     // The shard that has the most data should handle the request.
-    ASSERT_NE_CORO(shard0_data_size, shard1_data_size);
-    auto expected_shard = shard0_data_size > shard1_data_size ? 0 : 1;
     auto num_requests = co_await request_sink.invoke_on(
-      expected_shard, [](auto& s) { return s.write_requests_acked; });
+      ss::shard_id(1), [](auto& s) { return s.write_requests_acked; });
     ASSERT_EQ_CORO(num_requests, 2);
 
     co_await stop();


### PR DESCRIPTION
Make test deterministic by explicitly specifying batch sizes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none