### PR TITLE
admin: wcr support for uuid override

### DIFF
--- a/src/v/cluster/cloud_metadata/manifest_downloads.cc
+++ b/src/v/cluster/cloud_metadata/manifest_downloads.cc
@@ -438,4 +438,31 @@ check_bucket_contains_cluster_names(
       "cluster names");
 }
 
+ss::future<std::expected<bool, std::string>> check_cluster_name_owns_uuid(
+  cloud_storage::remote& remote,
+  const cloud_storage_clients::bucket_name& bucket,
+  const ss::sstring& cluster_name,
+  const model::cluster_uuid& cluster_uuid,
+  retry_chain_node& retry_node) {
+    auto td = cloud_io::transfer_details{
+      .bucket = bucket,
+      .key = cluster_name_ref_for_uuid_key(cluster_name, cluster_uuid),
+      .parent_rtc = retry_node,
+    };
+    iobuf payload;
+    auto download_result = co_await remote.download_object({
+      .transfer_details = std::move(td),
+      .type = cloud_storage::download_type::object,
+      .payload = payload,
+    });
+    if (download_result == cloud_storage::download_result::success) {
+        co_return true;
+    } else if (download_result == cloud_storage::download_result::notfound) {
+        co_return false;
+    }
+    co_return std::unexpected(
+      fmt::format(
+        "Error checking cluster name ownership: {}", download_result));
+}
+
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/manifest_downloads.h
+++ b/src/v/cluster/cloud_metadata/manifest_downloads.h
@@ -90,4 +90,11 @@ check_bucket_contains_cluster_names(
   const cloud_storage_clients::bucket_name& bucket,
   retry_chain_node& retry_node);
 
+ss::future<std::expected<bool, std::string>> check_cluster_name_owns_uuid(
+  cloud_storage::remote& remote,
+  const cloud_storage_clients::bucket_name& bucket,
+  const ss::sstring& cluster_name,
+  const model::cluster_uuid& cluster_uuid,
+  retry_chain_node& retry_node);
+
 } // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/tests/BUILD
+++ b/src/v/cluster/cloud_metadata/tests/BUILD
@@ -59,7 +59,6 @@ redpanda_cc_gtest(
         "//src/v/cloud_storage",
         "//src/v/cloud_storage:types",
         "//src/v/cluster",
-        "//src/v/cluster/tests:topic_properties_generator",
         "//src/v/cluster/tests:tx_compaction_utils_gtest",
         "//src/v/config",
         "//src/v/model",

--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -15,15 +15,13 @@
 #include "cluster/cloud_metadata/tests/cluster_metadata_utils.h"
 #include "cluster/cloud_metadata/tests/manual_mixin.h"
 #include "cluster/cloud_metadata/uploader.h"
-#include "cluster/cluster_recovery_reconciler.h"
+#include "cluster/cluster_recovery_manager.h"
 #include "cluster/config_frontend.h"
-#include "cluster/controller_snapshot.h"
 #include "cluster/feature_manager.h"
 #include "cluster/id_allocator_frontend.h"
 #include "cluster/partition.h"
 #include "cluster/partition_manager.h"
 #include "cluster/security_frontend.h"
-#include "cluster/tests/topic_properties_generator.h"
 #include "cluster/tests/tx_compaction_utils.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
@@ -32,6 +30,7 @@
 #include "model/namespace.h"
 #include "redpanda/application.h"
 #include "redpanda/tests/fixture.h"
+#include "security/credential_store.h"
 #include "security/scram_credential.h"
 #include "security/tests/license_utils.h"
 #include "security/types.h"
@@ -45,6 +44,7 @@
 #include <seastar/util/defer.hh>
 
 using namespace cluster::cloud_metadata;
+
 namespace {
 ss::logger logger("backend_test");
 static ss::abort_source never_abort;
@@ -234,7 +234,6 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
                          .initialize_recovery(bucket)
                          .get();
     ASSERT_TRUE(recover_err.has_value());
-    ASSERT_EQ(recover_err.value(), cluster::errc::success);
 
     // If configured, start leadership transfers.
     ss::gate gate;
@@ -414,7 +413,6 @@ TEST_F(ClusterRecoveryBackendTest, TestRecoverMissingTopicManifest) {
                              .initialize_recovery(bucket)
                              .get();
         ASSERT_TRUE(recover_err.has_value());
-        ASSERT_EQ(recover_err.value(), cluster::errc::success);
         RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
             return !app.controller->get_cluster_recovery_table()
                       .local()
@@ -513,7 +511,6 @@ TEST_F(ClusterRecoveryBackendTest, TestRecoverFailedDownload) {
                          .initialize_recovery(bucket)
                          .get();
     ASSERT_TRUE(recover_err.has_value());
-    ASSERT_EQ(recover_err.value(), cluster::errc::success);
     RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
         return !app.controller->get_cluster_recovery_table()
                   .local()

--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -231,7 +231,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     // Perform recovery.
     auto recover_err = app.controller->get_cluster_recovery_manager()
                          .local()
-                         .initialize_recovery(bucket)
+                         .initialize_recovery(bucket, std::nullopt)
                          .get();
     ASSERT_TRUE(recover_err.has_value());
 
@@ -410,7 +410,7 @@ TEST_F(ClusterRecoveryBackendTest, TestRecoverMissingTopicManifest) {
         // Attempt a recovery.
         auto recover_err = app.controller->get_cluster_recovery_manager()
                              .local()
-                             .initialize_recovery(bucket)
+                             .initialize_recovery(bucket, std::nullopt)
                              .get();
         ASSERT_TRUE(recover_err.has_value());
         RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
@@ -508,7 +508,7 @@ TEST_F(ClusterRecoveryBackendTest, TestRecoverFailedDownload) {
     // Attempt a recovery.
     auto recover_err = app.controller->get_cluster_recovery_manager()
                          .local()
-                         .initialize_recovery(bucket)
+                         .initialize_recovery(bucket, std::nullopt)
                          .get();
     ASSERT_TRUE(recover_err.has_value());
     RPTEST_REQUIRE_EVENTUALLY(10s, [&] {

--- a/src/v/cluster/cluster_recovery_manager.cc
+++ b/src/v/cluster/cluster_recovery_manager.cc
@@ -10,18 +10,14 @@
 #include "cluster/cluster_recovery_manager.h"
 
 #include "base/seastarx.h"
-#include "cloud_storage/cache_service.h"
 #include "cloud_storage/remote.h"
-#include "cloud_storage/remote_file.h"
 #include "cluster/cloud_metadata/cluster_manifest.h"
+#include "cluster/cloud_metadata/error_outcome.h"
 #include "cluster/cloud_metadata/manifest_downloads.h"
 #include "cluster/cluster_recovery_table.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/commands.h"
-#include "cluster/config_frontend.h"
 #include "cluster/errc.h"
-#include "cluster/logger.h"
-#include "cluster/security_frontend.h"
 #include "config/configuration.h"
 
 #include <seastar/core/abort_source.hh>
@@ -79,26 +75,33 @@ cluster_recovery_manager::sync_leader(ss::abort_source& as) {
     co_return synced_term;
 }
 
-ss::future<result<cluster::errc, cloud_metadata::error_outcome>>
+ss::future<checked<void, cluster_recovery_manager::errc>>
 cluster_recovery_manager::initialize_recovery(
   cloud_storage_clients::bucket_name bucket) {
     if (!_remote.local_is_initialized()) {
-        co_return cluster::errc::invalid_request;
+        vlog(clusterlog.warn, "Cloud storage is not configured/initialized");
+        co_return errc::misconfigured;
     }
     if (config::node().recovery_mode_enabled()) {
-        co_return cluster::errc::feature_disabled;
+        vlog(
+          clusterlog.warn, "Node is in recovery mode, cannot start recovery");
+        co_return errc::misconfigured;
     }
     auto synced_term = co_await sync_leader(_sharded_as.local());
     if (!synced_term.has_value()) {
-        co_return cluster::errc::not_leader_controller;
+        vlog(clusterlog.warn, "Not leader, cannot start recovery");
+        co_return errc::not_a_leader;
     }
     if (_recovery_table.local().is_recovery_active()) {
-        co_return cluster::errc::cluster_already_exists;
+        co_return errc::already_in_progress;
     }
     if (
       !_raft0->is_leader()
       || !_storage.local().get_cluster_uuid().has_value()) {
-        co_return cluster::errc::not_leader_controller;
+        vlog(
+          clusterlog.warn,
+          "Lost leadership or storage uuid disappeared, cannot start recovery");
+        co_return errc::not_a_leader;
     }
     const auto& ignored_uuid = _storage.local().get_cluster_uuid().value();
     auto cluster_name = config::shard_local_cfg().cloud_storage_cluster_name();
@@ -113,7 +116,12 @@ cluster_recovery_manager::initialize_recovery(
           "Error finding cluster manifests in bucket {}: {}",
           bucket,
           cluster_manifest_res.error());
-        co_return cluster_manifest_res.error();
+        if (
+          cluster_manifest_res.error()
+          == cloud_metadata::error_outcome::no_matching_metadata) {
+            co_return errc::no_matching_metadata;
+        }
+        co_return errc::unknown;
     }
     auto& manifest = cluster_manifest_res.value();
     vlog(clusterlog.info, "Found cluster manifest for recovery: {}", manifest);
@@ -129,14 +137,14 @@ cluster_recovery_manager::initialize_recovery(
       cluster_recovery_init_cmd(0, std::move(data)),
       model::timeout_clock::now() + 30s,
       synced_term);
-    if (errc != errc::success) {
+    if (errc != cluster::errc::success) {
         vlog(
           clusterlog.warn,
           "Error replicating recovery initialization command: {}",
           errc.message());
-        co_return cluster::errc::replication_error;
+        co_return errc::unknown;
     }
-    co_return cluster::errc::success;
+    co_return outcome::success();
 }
 
 ss::future<cluster::errc> cluster_recovery_manager::replicate_update(
@@ -160,7 +168,7 @@ ss::future<cluster::errc> cluster_recovery_manager::replicate_update(
       cluster_recovery_update_cmd(0, std::move(data)),
       model::timeout_clock::now() + 30s,
       std::make_optional(term));
-    if (errc != errc::success) {
+    if (errc != cluster::errc::success) {
         vlog(
           clusterlog.warn,
           "Error replicating recovery update command: {}",

--- a/src/v/cluster/cluster_recovery_manager.cc
+++ b/src/v/cluster/cluster_recovery_manager.cc
@@ -75,9 +75,136 @@ cluster_recovery_manager::sync_leader(ss::abort_source& as) {
     co_return synced_term;
 }
 
+namespace {
+
+ss::future<checked<void, cluster_recovery_manager::errc>> check_can_use_uuid(
+  cloud_storage::remote& _remote,
+  cloud_storage_clients::bucket_name bucket,
+  std::optional<ss::sstring> cluster_name,
+  model::cluster_uuid cluster_uuid_override,
+  retry_chain_node& fib) {
+    // Validate that the provided cluster UUID is owned by the configured
+    // cluster name or that the bucket does not contain any cluster
+    // name references.
+    if (cluster_name.has_value()) {
+        auto uses_cluster_id_res
+          = co_await cluster::cloud_metadata::check_cluster_name_owns_uuid(
+            _remote, bucket, *cluster_name, cluster_uuid_override, fib);
+        if (!uses_cluster_id_res.has_value()) {
+            vlog(
+              clusterlog.warn,
+              "Error checking cluster name ownership: {}",
+              uses_cluster_id_res.error());
+            co_return cluster_recovery_manager::errc::unknown;
+        }
+        if (!uses_cluster_id_res.value()) {
+            vlog(
+              clusterlog.warn,
+              "Cluster name {} does not own cluster UUID {}. Cannot proceed.",
+              *cluster_name,
+              cluster_uuid_override);
+            co_return cluster_recovery_manager::errc::misconfigured;
+        }
+    } else {
+        // If cluster name is not configured we need to error out if the
+        // bucket contains any cluster name references to avoid customer
+        // shooting themselves in the foot.
+        auto uses_cluster_id_res = co_await cluster::cloud_metadata::
+          check_bucket_contains_cluster_names(_remote, bucket, fib);
+        if (!uses_cluster_id_res.has_value()) {
+            vlog(
+              clusterlog.warn,
+              "Error checking if bucket contains cluster names: {}",
+              uses_cluster_id_res.error());
+            co_return cluster_recovery_manager::errc::unknown;
+        }
+        if (uses_cluster_id_res.value()) {
+            vlog(
+              clusterlog.warn,
+              "Cluster name references exist in bucket {}, but no cluster "
+              "name is configured. Cannot proceed. Please check "
+              "`cloud_storage_cluster_name` config property.",
+              bucket());
+            co_return cluster_recovery_manager::errc::misconfigured;
+        }
+    }
+
+    co_return outcome::success();
+}
+
+ss::future<checked<
+  cloud_metadata::cluster_metadata_manifest,
+  cluster_recovery_manager::errc>>
+download_manifest_for_recovery(
+  cloud_storage::remote& _remote,
+  cloud_storage_clients::bucket_name bucket,
+  std::optional<model::cluster_uuid> cluster_uuid_override,
+  std::optional<ss::sstring> cluster_name,
+  model::cluster_uuid ignored_uuid,
+  retry_chain_node& fib) {
+    if (!cluster_uuid_override.has_value()) {
+        vlog(
+          clusterlog.info,
+          "No cluster UUID override provided. Will search for latest manifest "
+          "(cluster name: {})",
+          cluster_name);
+        auto cluster_manifest_res = co_await cluster::cloud_metadata::
+          download_highest_manifest_in_bucket(
+            _remote, bucket, fib, cluster_name, ignored_uuid);
+        if (cluster_manifest_res.has_error()) {
+            vlog(
+              clusterlog.warn,
+              "Error finding cluster manifests: {}",
+              cluster_manifest_res.error());
+            if (
+              cluster_manifest_res.error()
+              == cloud_metadata::error_outcome::no_matching_metadata) {
+                co_return cluster_recovery_manager::errc::no_matching_metadata;
+            }
+            co_return cluster_recovery_manager::errc::unknown;
+        }
+        co_return std::move(cluster_manifest_res.value());
+    }
+
+    vlog(
+      clusterlog.info,
+      "Using user-provided cluster UUID override for recovery (cluster uuid "
+      "override: {}, cluster name: {})",
+      cluster_uuid_override,
+      cluster_name);
+
+    auto can_use_res = co_await check_can_use_uuid(
+      _remote, bucket, cluster_name, *cluster_uuid_override, fib);
+    if (can_use_res.has_error()) {
+        co_return can_use_res.error();
+    }
+
+    auto cluster_manifest_res
+      = co_await cluster::cloud_metadata::download_highest_manifest_for_cluster(
+        _remote, cluster_uuid_override.value(), bucket, fib);
+    if (cluster_manifest_res.has_error()) {
+        vlog(
+          clusterlog.warn,
+          "Error finding cluster manifests for cluster UUID "
+          "{}: {}",
+          cluster_uuid_override.value(),
+          cluster_manifest_res.error());
+        if (
+          cluster_manifest_res.error()
+          == cloud_metadata::error_outcome::no_matching_metadata) {
+            co_return cluster_recovery_manager::errc::no_matching_metadata;
+        }
+        co_return cluster_recovery_manager::errc::unknown;
+    }
+    co_return std::move(cluster_manifest_res.value());
+}
+
+} // namespace
+
 ss::future<checked<void, cluster_recovery_manager::errc>>
 cluster_recovery_manager::initialize_recovery(
-  cloud_storage_clients::bucket_name bucket) {
+  cloud_storage_clients::bucket_name bucket,
+  std::optional<model::cluster_uuid> cluster_uuid_override) {
     if (!_remote.local_is_initialized()) {
         vlog(clusterlog.warn, "Cloud storage is not configured/initialized");
         co_return errc::misconfigured;
@@ -103,33 +230,29 @@ cluster_recovery_manager::initialize_recovery(
           "Lost leadership or storage uuid disappeared, cannot start recovery");
         co_return errc::not_a_leader;
     }
-    const auto& ignored_uuid = _storage.local().get_cluster_uuid().value();
     auto cluster_name = config::shard_local_cfg().cloud_storage_cluster_name();
+    const auto& this_cluster_uuid = _storage.local().get_cluster_uuid().value();
     // TODO: protect with semaphore with a term check.
     auto fib = retry_chain_node{_sharded_as.local(), 30s, 1s};
-    auto cluster_manifest_res
-      = co_await cluster::cloud_metadata::download_highest_manifest_in_bucket(
-        _remote.local(), bucket, fib, cluster_name, ignored_uuid);
-    if (cluster_manifest_res.has_error()) {
-        vlog(
-          clusterlog.warn,
-          "Error finding cluster manifests in bucket {}: {}",
-          bucket,
-          cluster_manifest_res.error());
-        if (
-          cluster_manifest_res.error()
-          == cloud_metadata::error_outcome::no_matching_metadata) {
-            co_return errc::no_matching_metadata;
-        }
-        co_return errc::unknown;
+    auto manifest_res = co_await download_manifest_for_recovery(
+      _remote.local(),
+      bucket,
+      cluster_uuid_override,
+      cluster_name,
+      this_cluster_uuid,
+      fib);
+    if (manifest_res.has_error()) {
+        co_return manifest_res.error();
     }
-    auto& manifest = cluster_manifest_res.value();
-    vlog(clusterlog.info, "Found cluster manifest for recovery: {}", manifest);
+    vlog(
+      clusterlog.info,
+      "Found cluster manifest for recovery: {}",
+      manifest_res.value());
 
     // Replicate an update to start recovery. Once applied, this will update
     // the recovery table.
     cluster_recovery_init_cmd_data data;
-    data.state.manifest = std::move(manifest);
+    data.state.manifest = std::move(manifest_res.value());
     data.state.bucket = std::move(bucket);
     auto errc = co_await replicate_and_wait(
       _controller_stm,

--- a/src/v/cluster/cluster_recovery_manager.h
+++ b/src/v/cluster/cluster_recovery_manager.h
@@ -26,6 +26,16 @@ namespace cluster {
 
 class cluster_recovery_manager {
 public:
+    enum class errc : uint8_t {
+        success = 0,
+        unknown,
+        not_a_leader,
+        misconfigured,
+        no_matching_metadata,
+        already_in_progress,
+    };
+
+public:
     static constexpr ss::shard_id shard = 0;
     cluster_recovery_manager(
       ss::sharded<ss::abort_source>&,
@@ -43,7 +53,7 @@ public:
     ss::future<std::optional<model::term_id>> sync_leader(ss::abort_source&);
 
     // Starts a recovery if one isn't already in progress.
-    ss::future<result<cluster::errc, cloud_metadata::error_outcome>>
+    ss::future<checked<void, errc>>
     initialize_recovery(cloud_storage_clients::bucket_name bucket);
 
     // Returns true if the update was successfuly replicated and applied.

--- a/src/v/cluster/cluster_recovery_manager.h
+++ b/src/v/cluster/cluster_recovery_manager.h
@@ -53,8 +53,9 @@ public:
     ss::future<std::optional<model::term_id>> sync_leader(ss::abort_source&);
 
     // Starts a recovery if one isn't already in progress.
-    ss::future<checked<void, errc>>
-    initialize_recovery(cloud_storage_clients::bucket_name bucket);
+    ss::future<checked<void, errc>> initialize_recovery(
+      cloud_storage_clients::bucket_name bucket,
+      std::optional<model::cluster_uuid> cluster_uuid_override);
 
     // Returns true if the update was successfuly replicated and applied.
     // Otherwise, logs a warning and returns false.

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -167,6 +167,7 @@ redpanda_cc_library(
 redpanda_cc_library(
     name = "admin",
     srcs = [
+        "cluster_recovery.cc",
         "debug.cc",
         "debug_bundle.cc",
         "kafka.cc",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -208,6 +208,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         "//src/v/features:enterprise_feature_messages",
+        "//src/v/utils:uuid",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/v/redpanda/admin/cluster_recovery.cc
+++ b/src/v/redpanda/admin/cluster_recovery.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/configuration.h"
+#include "cluster/cluster_recovery_manager.h"
+#include "cluster/cluster_recovery_table.h"
+#include "cluster/controller.h"
+#include "redpanda/admin/api-doc/shadow_indexing.json.hh"
+#include "redpanda/admin/server.h"
+
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::initialize_cluster_recovery(
+  std::unique_ptr<ss::http::request> request,
+  std::unique_ptr<ss::http::reply> reply) {
+    reply->set_content_type("json");
+    if (config::node().recovery_mode_enabled()) {
+        throw ss::httpd::bad_request_exception(
+          "Cluster restore is not available, recovery mode enabled");
+    }
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*request, model::controller_ntp);
+    }
+    auto& bucket_property = cloud_storage::configuration::get_bucket_config();
+    if (!bucket_property.is_overriden() || !bucket_property().has_value()) {
+        throw ss::httpd::bad_request_exception(
+          "Cluster recovery is not available. Missing bucket property");
+    }
+    cloud_storage_clients::bucket_name bucket(bucket_property().value());
+    auto result = ss::httpd::shadow_indexing_json::init_recovery_result{};
+    auto error_res
+      = co_await _controller->get_cluster_recovery_manager().invoke_on(
+        cluster::cluster_recovery_manager::shard,
+        [bucket](auto& mgr) { return mgr.initialize_recovery(bucket); });
+    if (error_res.has_error()) {
+        throw ss::httpd::base_exception{
+          ssx::sformat(
+            "Error starting cluster recovery request: {}", error_res.error()),
+          ss::http::reply::status_type::internal_server_error};
+    }
+    auto err = error_res.value();
+    if (err == cluster::errc::not_leader_controller) {
+        throw co_await redirect_to_leader(*request, model::controller_ntp);
+    }
+    if (err == cluster::errc::cluster_already_exists) {
+        throw ss::httpd::base_exception{
+          "Recovery already active", ss::http::reply::status_type::conflict};
+    }
+    if (err == cluster::errc::invalid_request) {
+        throw ss::httpd::base_exception{
+          "Cloud storage not available",
+          ss::http::reply::status_type::bad_request};
+    }
+    // Generic other errors. Just give up and throw.
+    if (err != cluster::errc::success) {
+        throw ss::httpd::base_exception{
+          "Error starting cluster recovery request",
+          ss::http::reply::status_type::internal_server_error};
+    }
+
+    result.status = "Recovery initialized";
+    reply->set_status(ss::http::reply::status_type::accepted, result.to_json());
+    co_return reply;
+}
+ss::future<ss::json::json_return_type>
+admin_server::get_cluster_recovery(std::unique_ptr<ss::http::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+    ss::httpd::shadow_indexing_json::cluster_recovery_status ret;
+    ret.state = "inactive";
+
+    auto latest_recovery
+      = _controller->get_cluster_recovery_table().local().current_recovery();
+    if (
+      !latest_recovery.has_value()
+      || latest_recovery.value().get().stage
+           == cluster::recovery_stage::complete) {
+        co_return ret;
+    }
+    auto& recovery = latest_recovery.value().get();
+    ret.state = ssx::sformat("{}", recovery.stage);
+    if (recovery.error_msg.has_value()) {
+        ret.error = recovery.error_msg.value();
+    }
+    co_return ret;
+}

--- a/src/v/redpanda/admin/cluster_recovery.cc
+++ b/src/v/redpanda/admin/cluster_recovery.cc
@@ -13,16 +13,58 @@
 #include "cluster/cluster_recovery_manager.h"
 #include "cluster/cluster_recovery_table.h"
 #include "cluster/controller.h"
+#include "json/validator.h"
+#include "model/fundamental.h"
 #include "redpanda/admin/api-doc/shadow_indexing.json.hh"
 #include "redpanda/admin/server.h"
+#include "redpanda/admin/util.h"
+#include "utils/uuid.h"
 
 #include <optional>
+#include <string_view>
+
+namespace {
+
+json::validator make_initialize_cluster_recovery_validator() {
+    const std::string_view schema = R"({
+  "type": "object",
+  "properties": {
+    "cluster_uuid_override": {
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "additionalProperties": false
+})";
+    return json::validator(schema);
+}
+
+} // namespace
 
 ss::future<std::unique_ptr<ss::http::reply>>
 admin_server::initialize_cluster_recovery(
   std::unique_ptr<ss::http::request> request,
   std::unique_ptr<ss::http::reply> reply) {
+    static thread_local auto body_validator(
+      make_initialize_cluster_recovery_validator());
+
+    std::optional<model::cluster_uuid> cluster_uuid_override;
+
+    auto doc = co_await parse_optional_json_body(request.get());
+    if (doc.has_value()) {
+        admin::apply_validator(body_validator, *doc);
+
+        if (doc->HasMember("cluster_uuid_override")) {
+            cluster_uuid_override = model::cluster_uuid(
+              uuid_t::from_string((*doc)["cluster_uuid_override"].GetString()));
+            if (!cluster_uuid_override.has_value()) {
+                throw ss::httpd::bad_request_exception("Invalid UUID format");
+            }
+        }
+    }
+
     reply->set_content_type("json");
+
     if (config::node().recovery_mode_enabled()) {
         throw ss::httpd::bad_request_exception(
           "Cluster restore is not available, recovery mode enabled");
@@ -39,8 +81,9 @@ admin_server::initialize_cluster_recovery(
     auto result = ss::httpd::shadow_indexing_json::init_recovery_result{};
     auto error_res
       = co_await _controller->get_cluster_recovery_manager().invoke_on(
-        cluster::cluster_recovery_manager::shard, [bucket](auto& mgr) {
-            return mgr.initialize_recovery(bucket, std::nullopt);
+        cluster::cluster_recovery_manager::shard,
+        [bucket, cluster_uuid_override](auto& mgr) {
+            return mgr.initialize_recovery(bucket, cluster_uuid_override);
         });
     if (error_res.has_error()) {
         switch (error_res.error()) {

--- a/src/v/redpanda/admin/cluster_recovery.cc
+++ b/src/v/redpanda/admin/cluster_recovery.cc
@@ -40,35 +40,37 @@ admin_server::initialize_cluster_recovery(
         cluster::cluster_recovery_manager::shard,
         [bucket](auto& mgr) { return mgr.initialize_recovery(bucket); });
     if (error_res.has_error()) {
-        throw ss::httpd::base_exception{
-          ssx::sformat(
-            "Error starting cluster recovery request: {}", error_res.error()),
-          ss::http::reply::status_type::internal_server_error};
-    }
-    auto err = error_res.value();
-    if (err == cluster::errc::not_leader_controller) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
-    }
-    if (err == cluster::errc::cluster_already_exists) {
-        throw ss::httpd::base_exception{
-          "Recovery already active", ss::http::reply::status_type::conflict};
-    }
-    if (err == cluster::errc::invalid_request) {
-        throw ss::httpd::base_exception{
-          "Cloud storage not available",
-          ss::http::reply::status_type::bad_request};
-    }
-    // Generic other errors. Just give up and throw.
-    if (err != cluster::errc::success) {
-        throw ss::httpd::base_exception{
-          "Error starting cluster recovery request",
-          ss::http::reply::status_type::internal_server_error};
+        switch (error_res.error()) {
+        case cluster::cluster_recovery_manager::errc::success:
+            vassert(false, "unreachable");
+        case cluster::cluster_recovery_manager::errc::unknown:
+            throw ss::httpd::base_exception{
+              ssx::sformat(
+                "Error starting cluster recovery request. Check logs for "
+                "details."),
+              ss::http::reply::status_type::internal_server_error};
+        case cluster::cluster_recovery_manager::errc::not_a_leader:
+            throw co_await redirect_to_leader(*request, model::controller_ntp);
+        case cluster::cluster_recovery_manager::errc::misconfigured:
+            throw ss::httpd::base_exception{
+              "Cluster is misconfigured for recovery. Check logs for details.",
+              ss::http::reply::status_type::bad_request};
+        case cluster::cluster_recovery_manager::errc::no_matching_metadata:
+            throw ss::httpd::base_exception{
+              "Error starting cluster recovery request: No matching metadata",
+              ss::http::reply::status_type::internal_server_error};
+        case cluster::cluster_recovery_manager::errc::already_in_progress:
+            throw ss::httpd::base_exception{
+              "Recovery already active",
+              ss::http::reply::status_type::conflict};
+        }
     }
 
     result.status = "Recovery initialized";
     reply->set_status(ss::http::reply::status_type::accepted, result.to_json());
     co_return reply;
 }
+
 ss::future<ss::json::json_return_type>
 admin_server::get_cluster_recovery(std::unique_ptr<ss::http::request> req) {
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {

--- a/src/v/redpanda/admin/cluster_recovery.cc
+++ b/src/v/redpanda/admin/cluster_recovery.cc
@@ -16,6 +16,8 @@
 #include "redpanda/admin/api-doc/shadow_indexing.json.hh"
 #include "redpanda/admin/server.h"
 
+#include <optional>
+
 ss::future<std::unique_ptr<ss::http::reply>>
 admin_server::initialize_cluster_recovery(
   std::unique_ptr<ss::http::request> request,
@@ -37,8 +39,9 @@ admin_server::initialize_cluster_recovery(
     auto result = ss::httpd::shadow_indexing_json::init_recovery_result{};
     auto error_res
       = co_await _controller->get_cluster_recovery_manager().invoke_on(
-        cluster::cluster_recovery_manager::shard,
-        [bucket](auto& mgr) { return mgr.initialize_recovery(bucket); });
+        cluster::cluster_recovery_manager::shard, [bucket](auto& mgr) {
+            return mgr.initialize_recovery(bucket, std::nullopt);
+        });
     if (error_res.has_error()) {
         switch (error_res.error()) {
         case cluster::cluster_recovery_manager::errc::success:

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -637,6 +637,23 @@ admin_server::parse_json_body(ss::http::request* req) {
     }
 }
 
+ss::future<std::optional<json::Document>>
+admin_server::parse_optional_json_body(ss::http::request* req) {
+    json::Document doc;
+    auto content = co_await ss::util::read_entire_stream_contiguous(
+      *req->content_stream);
+    if (content.empty()) {
+        co_return std::nullopt;
+    }
+    doc.Parse(content);
+    if (doc.HasParseError()) {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("JSON parse error: {}", doc.GetParseError()));
+    } else {
+        co_return doc;
+    }
+}
+
 namespace {
 
 /**

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -18,8 +18,6 @@
 #include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/spillover_manifest.h"
 #include "cluster/archival/ntp_archiver_service.h"
-#include "cluster/cluster_recovery_manager.h"
-#include "cluster/cluster_recovery_table.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/config_frontend.h"
 #include "cluster/controller.h"
@@ -4302,83 +4300,6 @@ ss::json::json_return_type serialize_topic_recovery_status(
     return status_log;
 }
 } // namespace
-
-ss::future<std::unique_ptr<ss::http::reply>>
-admin_server::initialize_cluster_recovery(
-  std::unique_ptr<ss::http::request> request,
-  std::unique_ptr<ss::http::reply> reply) {
-    reply->set_content_type("json");
-    if (config::node().recovery_mode_enabled()) {
-        throw ss::httpd::bad_request_exception(
-          "Cluster restore is not available, recovery mode enabled");
-    }
-    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
-    }
-    auto& bucket_property = cloud_storage::configuration::get_bucket_config();
-    if (!bucket_property.is_overriden() || !bucket_property().has_value()) {
-        throw ss::httpd::bad_request_exception(
-          "Cluster recovery is not available. Missing bucket property");
-    }
-    cloud_storage_clients::bucket_name bucket(bucket_property().value());
-    auto result = ss::httpd::shadow_indexing_json::init_recovery_result{};
-    auto error_res
-      = co_await _controller->get_cluster_recovery_manager().invoke_on(
-        cluster::cluster_recovery_manager::shard,
-        [bucket](auto& mgr) { return mgr.initialize_recovery(bucket); });
-    if (error_res.has_error()) {
-        throw ss::httpd::base_exception{
-          ssx::sformat(
-            "Error starting cluster recovery request: {}", error_res.error()),
-          ss::http::reply::status_type::internal_server_error};
-    }
-    auto err = error_res.value();
-    if (err == cluster::errc::not_leader_controller) {
-        throw co_await redirect_to_leader(*request, model::controller_ntp);
-    }
-    if (err == cluster::errc::cluster_already_exists) {
-        throw ss::httpd::base_exception{
-          "Recovery already active", ss::http::reply::status_type::conflict};
-    }
-    if (err == cluster::errc::invalid_request) {
-        throw ss::httpd::base_exception{
-          "Cloud storage not available",
-          ss::http::reply::status_type::bad_request};
-    }
-    // Generic other errors. Just give up and throw.
-    if (err != cluster::errc::success) {
-        throw ss::httpd::base_exception{
-          "Error starting cluster recovery request",
-          ss::http::reply::status_type::internal_server_error};
-    }
-
-    result.status = "Recovery initialized";
-    reply->set_status(ss::http::reply::status_type::accepted, result.to_json());
-    co_return reply;
-}
-ss::future<ss::json::json_return_type>
-admin_server::get_cluster_recovery(std::unique_ptr<ss::http::request> req) {
-    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, model::controller_ntp);
-    }
-    ss::httpd::shadow_indexing_json::cluster_recovery_status ret;
-    ret.state = "inactive";
-
-    auto latest_recovery
-      = _controller->get_cluster_recovery_table().local().current_recovery();
-    if (
-      !latest_recovery.has_value()
-      || latest_recovery.value().get().stage
-           == cluster::recovery_stage::complete) {
-        co_return ret;
-    }
-    auto& recovery = latest_recovery.value().get();
-    ret.state = ssx::sformat("{}", recovery.stage);
-    if (recovery.error_msg.has_value()) {
-        ret.error = recovery.error_msg.value();
-    }
-    co_return ret;
-}
 
 ss::future<ss::json::json_return_type>
 admin_server::query_automated_recovery(std::unique_ptr<ss::http::request> req) {

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -223,7 +223,14 @@ private:
 
     static model::ntp parse_ntp_from_request(ss::httpd::parameters& param);
 
+    /// Parses the JSON body of the request. Throws if the body is not valid
+    /// JSON.
     static ss::future<json::Document> parse_json_body(ss::http::request* req);
+
+    /// Returns nullopt if the body is empty. Throws if the body is not empty
+    /// and not valid JSON.
+    static ss::future<std::optional<json::Document>>
+    parse_optional_json_body(ss::http::request* req);
 
     static model::node_id parse_broker_id(const ss::http::request& req);
 

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1559,7 +1559,13 @@ class Admin:
             "get", "cloud_storage/topic_recovery?extended=true", **request_args
         )
 
-    def initialize_cluster_recovery(self, node=None, **kwargs):
+    def initialize_cluster_recovery(
+        self, node=None, cluster_uuid_override=None, **kwargs
+    ):
+        if cluster_uuid_override is not None:
+            assert "json" not in kwargs, "cannot pass cluster_uuid_override and json"
+            kwargs["json"] = {"cluster_uuid_override": cluster_uuid_override}
+
         request_args = {"node": node, **kwargs}
 
         return self._request("post", "cloud_storage/automated_recovery", **request_args)

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -237,7 +237,7 @@ class ClusterRecoveryWithNameTest(RedpandaTest):
     @cluster(
         num_nodes=1,
         log_allow_list=[
-            "Error starting cluster recovery request: Cluster misconfiguration",
+            "Error starting cluster recovery request. Check logs for details.",
             "Error starting cluster recovery request: No matching metadata",
         ],
     )
@@ -257,7 +257,7 @@ class ClusterRecoveryWithNameTest(RedpandaTest):
         assert excinfo.value.response.status_code == 500
         assert (
             excinfo.value.response.json()["message"]
-            == "Error starting cluster recovery request: Cluster misconfiguration"
+            == "Error starting cluster recovery request. Check logs for details."
         ), excinfo.value.response.json()["message"]
 
         self.logger.info(
@@ -410,4 +410,6 @@ class ClusterRecoveryWithNameTest(RedpandaTest):
     def _cluster_recovery_complete(self):
         state = self.redpanda._admin.get_cluster_recovery_status().json()["state"]
         self.logger.debug(f"Cluster recovery state: {state}")
+        if "failed" in state:
+            raise RuntimeError(f"Cluster recovery failed with state: {state}")
         return "inactive" in state

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -287,6 +287,91 @@ class ClusterRecoveryWithNameTest(RedpandaTest):
         wait_until(self._cluster_recovery_complete, timeout_sec=60, backoff_sec=1)
 
     @cluster(num_nodes=1)
+    def test_admin_recovery_uuid_override(self):
+        rpk = RpkTool(self.redpanda)
+
+        self.redpanda._admin.patch_cluster_config(
+            {
+                "cloud_storage_cluster_name": "test-my-cluster",
+            }
+        )
+        self._wait_for_metadata_upload()
+        initial_cluster_uuid = self.redpanda._admin.get_cluster_uuid()
+        self.logger.debug(f"Initial cluster uuid: {initial_cluster_uuid}")
+
+        self.logger.info(
+            "Recreating the cluster with the same name but do not attempt recovery"
+        )
+        self._stop_and_recreate_cluster(
+            {
+                "cloud_storage_cluster_name": "test-my-cluster",
+            }
+        )
+        self._wait_for_metadata_upload()
+
+        self.logger.info("Verifying that no recovery happened")
+        topics_on_cluster = set(rpk.list_topics())
+        assert len(topics_on_cluster) == 0, (
+            f"Expected no topics to be restored but have: {topics_on_cluster}"
+        )
+
+        self.logger.info("Recreate the cluster and attempt recovery from the first one")
+        self._stop_and_recreate_cluster(
+            {
+                # Do not set the name yet, we want to validate that recovery fails without it first.
+                "cloud_storage_cluster_name": None,
+            }
+        )
+        self.logger.info(
+            "Verifying that recovery without name fails if uuid override is provided, name is not set but bucket contains multiple clusters"
+        )
+        with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+            self.redpanda._admin.initialize_cluster_recovery(
+                cluster_uuid_override=initial_cluster_uuid
+            )
+        assert excinfo.value.response.status_code == 400, (
+            f"Status: {excinfo.value.response.status_code}"
+        )
+        assert (
+            excinfo.value.response.json()["message"]
+            == "Cluster is misconfigured for recovery. Check logs for details."
+        ), excinfo.value.response.json()["message"]
+
+        self.logger.info("Set a different cluster name and attempt to recovery")
+        self.redpanda._admin.patch_cluster_config(
+            {
+                "cloud_storage_cluster_name": "some-random-name",
+            }
+        )
+        with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+            self.redpanda._admin.initialize_cluster_recovery(
+                cluster_uuid_override=initial_cluster_uuid
+            )
+        assert excinfo.value.response.status_code == 400, (
+            f"Status: {excinfo.value.response.status_code}"
+        )
+        assert (
+            excinfo.value.response.json()["message"]
+            == "Cluster is misconfigured for recovery. Check logs for details."
+        ), excinfo.value.response.json()["message"]
+
+        self.logger.info("Set the correct cluster name and attempt to recovery")
+        self.redpanda._admin.patch_cluster_config(
+            {
+                "cloud_storage_cluster_name": "test-my-cluster",
+            }
+        )
+        self.redpanda._admin.initialize_cluster_recovery(
+            cluster_uuid_override=initial_cluster_uuid
+        )
+        wait_until(self._cluster_recovery_complete, timeout_sec=60, backoff_sec=1)
+
+        topics_on_cluster = set(rpk.list_topics())
+        assert len(topics_on_cluster) == len(self.topics), (
+            f"Incorrect topics restored {topics_on_cluster} but expected {[t.name for t in self.topics]}"
+        )
+
+    @cluster(num_nodes=1)
     def test_bootstrap_with_recovery(self):
         bootstrap_wcr_conf = {
             "cloud_storage_attempt_cluster_restore_on_bootstrap": True,


### PR DESCRIPTION
WCR subsystem uploads cluster manifests periodically to object storage
keyed by cluster UUID and a sequence number.

When a cluster is re-created, it gets a new cluster UUID and the
sequence number is initialized as the highest seen so far in the bucket.

Here is an example of a cluster (assigned <uuid-a> initially) after it
uploaded 3 manifests then was re-created (assigned <uuid-b> this time).

```
/
+- cluster_metadata/
   +- <uuid-a>/manifests/
   |  +- 0/cluster_manifest.json
   |  +- 1/cluster_manifest.json
   |  +- 2/cluster_manifest.json (topic A exists)
   + <uuid-b>/manifests/
      +- 3/cluster_manifest.json (empty)
      +- 4/cluster_manifest.json (empty)
```

Attempting WCR searches for highest sequence number ignoring current
cluster uuid (i.e. <uuid-b). If we run WCR, we will pick
`/cluster_metadata/<uuid-a>/manifests/2/cluster_manifest.json` as source
of truth.

This eventually would lead to creation of another manfiest:

```
/
+- cluster_metadata/
   # ...
   +- <uuid-b>/manifests/
      # ...
      +- 5/cluster_manifest.json (topic A recovered)
```

This algorithm (A1) is known to reach an undesirable result in the
following scenario: Imagine that we start with the same state as above
prior to restore but we do not run restore but instead re-create the
cluster once more. This can happen either because an operator wanted to
restart recovery process from scratch or because a disaster happened in
short span before recovery had a chance to finish/start. And we end with
this picture:

```
/
+- cluster_metadata/
   +- <uuid-a>/manifests/
   |  +- 0/cluster_manifest.json
   |  +- 1/cluster_manifest.json
   |  +- 2/cluster_manifest.json (topic A exists)
   + <uuid-b>/manifests/
   |  +- 3/cluster_manifest.json (empty)
   |  +- 4/cluster_manifest.json (empty)
   + <uuid-c>/manifests/
      +- 5/cluster_manifest.json (empty)
      +- 6/cluster_manifest.json (empty)
```

If we run the same algorithm (A1) then it will pick
`/cluster_metadata/<uuid-b>/manifests/4/cluster_manifest.json`. However,
we want to recover from <uuid-a> because that's where our data lives.

To support this, we add an optional override to cluster recovery
subsystem where user can explicitly choose from which cluster UUID to
restore.

---

This also works with `cloud_storage_cluster_name` and has guardrails to
prevent restoring from a UUID belonging to a different cluster and has
guardrails to prevent restoring from a UUID belonging to a different
cluster.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
