### PR TITLE
ct: make STM apis abortable

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -176,14 +176,14 @@ static void update_batches(
     }
 }
 
-static ss::lw_shared_ptr<cloud_topics::ctp_stm_api> make_ctp_stm_api(
-  retry_chain_node& rtc, ss::lw_shared_ptr<cluster::partition> p) {
+static ss::lw_shared_ptr<cloud_topics::ctp_stm_api>
+make_ctp_stm_api(ss::lw_shared_ptr<cluster::partition> p) {
     auto stm = p->raft()->stm_manager()->get<cloud_topics::ctp_stm>();
     if (!stm) {
         throw std::runtime_error(
           fmt::format("ctp_stm not found for partition {}", p->ntp()));
     }
-    return ss::make_lw_shared<cloud_topics::ctp_stm_api>(rtc, stm);
+    return ss::make_lw_shared<cloud_topics::ctp_stm_api>(stm);
 }
 
 static ss::future<std::vector<cluster::tx::tx_range>>
@@ -213,10 +213,9 @@ get_aborted_transactions_local(
 
 frontend::frontend(
   ss::lw_shared_ptr<cluster::partition> p, data_plane_api* app) noexcept
-  : _rtc(_as)
-  , _partition(std::move(p))
+  : _partition(std::move(p))
   , _data_plane(app)
-  , _ctp_stm_api(make_ctp_stm_api(_rtc, _partition)) {}
+  , _ctp_stm_api(make_ctp_stm_api(_partition)) {}
 
 const model::ntp& frontend::ntp() const { return _partition->ntp(); }
 
@@ -246,9 +245,15 @@ kafka::offset frontend::start_offset() const {
 }
 
 ss::future<std::expected<kafka::offset, frontend_errc>>
-frontend::sync_effective_start(model::timeout_clock::duration duration) {
-    bool synced = co_await _ctp_stm_api->sync_in_term(
-      model::timeout_clock::now() + duration);
+frontend::sync_effective_start(
+  model::timeout_clock::duration duration, ss::abort_source& as) {
+    return sync_effective_start(model::timeout_clock::now() + duration, as);
+}
+
+ss::future<std::expected<kafka::offset, frontend_errc>>
+frontend::sync_effective_start(
+  model::timeout_clock::time_point deadline, ss::abort_source& as) {
+    bool synced = co_await _ctp_stm_api->sync_in_term(deadline, as);
     if (!synced) {
         co_return std::unexpected(frontend_errc::timeout);
     }
@@ -400,11 +405,10 @@ struct upload_and_replicate_stages {
       chunked_vector<model::record_batch> batches,
       model::batch_identity batch_id,
       raft::replicate_options opts,
-      retry_chain_node& rtc,
       std::chrono::milliseconds timeout)
       : ntp(partition->ntp())
       , partition(std::move(partition))
-      , ctp_stm_api(make_ctp_stm_api(rtc, this->partition))
+      , ctp_stm_api(make_ctp_stm_api(this->partition))
       , batches(std::move(batches))
       , batch_id(batch_id)
       , opts(update_replicate_options(opts))
@@ -640,7 +644,6 @@ raft::replicate_stages frontend::replicate(
       std::move(batch_vec),
       batch_id,
       opts,
-      _rtc,
       opts.timeout.value_or(L0_replicate_default_timeout));
 
     raft::replicate_stages out(raft::errc::success);
@@ -689,8 +692,9 @@ ss::future<std::expected<void, frontend_errc>> frontend::prefix_truncate(
     if (truncation_point > high_watermark()) {
         co_return std::unexpected(frontend_errc::offset_out_of_range);
     }
+    ss::abort_source as;
     auto result = co_await _ctp_stm_api->set_start_offset(
-      truncation_point, deadline);
+      truncation_point, deadline, as);
     if (!result.has_value()) {
         switch (result.error()) {
         case ctp_stm_api_errc::not_leader:
@@ -749,9 +753,8 @@ frontend::validate_fetch_offset(
         }
         co_return std::monostate{};
     }
-
-    auto timeout = deadline - model::timeout_clock::now();
-    auto so = co_await sync_effective_start(timeout);
+    ss::abort_source as;
+    auto so = co_await sync_effective_start(deadline, as);
     if (!so) {
         co_return std::unexpected(so.error());
     }

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -92,7 +92,11 @@ public:
     const model::ntp& ntp() const;
 
     ss::future<std::expected<kafka::offset, frontend_errc>>
-    sync_effective_start(model::timeout_clock::duration timeout);
+    sync_effective_start(
+      model::timeout_clock::duration timeout, ss::abort_source& as);
+    ss::future<std::expected<kafka::offset, frontend_errc>>
+    sync_effective_start(
+      model::timeout_clock::time_point deadline, ss::abort_source& as);
 
     /// This method defines starting offset for translation in data-lake
     /// subsystem
@@ -162,8 +166,6 @@ private:
     std::unique_ptr<model::record_batch_reader::impl>
     make_l1_reader(cloud_topic_log_reader_config& cfg) const;
 
-    ss::abort_source _as;
-    retry_chain_node _rtc;
     ss::lw_shared_ptr<cluster::partition> _partition;
     data_plane_api* _data_plane;
     ss::lw_shared_ptr<cloud_topics::ctp_stm_api> _ctp_stm_api;

--- a/src/v/cloud_topics/housekeeper/housekeeper.cc
+++ b/src/v/cloud_topics/housekeeper/housekeeper.cc
@@ -56,7 +56,7 @@ ss::future<> housekeeper::do_housekeeping() {
         new_start_offset = std::max(new_start_offset, offset);
     }
     if (new_start_offset != kafka::offset::min()) {
-        co_await _l0_metastore->set_start_offset(_tidp, new_start_offset);
+        co_await _l0_metastore->set_start_offset(_tidp, new_start_offset, &_as);
     }
 }
 

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -47,8 +47,9 @@ public:
 
         // Update the start offset to the partition, this must be an
         // idempotent operation.
-        virtual ss::future<>
-        set_start_offset(const model::topic_id_partition&, kafka::offset) = 0;
+        virtual ss::future<> set_start_offset(
+          const model::topic_id_partition&, kafka::offset, ss::abort_source*)
+          = 0;
     };
 
     // A wrapper around a source of configuration for a give topic id +

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -35,7 +35,9 @@ public:
       : _state(state) {}
 
     ss::future<> set_start_offset(
-      const model::topic_id_partition& tidp, kafka::offset offset) override {
+      const model::topic_id_partition& tidp,
+      kafka::offset offset,
+      ss::abort_source* as) override {
         auto& state = _state->at(tidp);
         auto stm = state.partition->raft()->stm_manager()->get<ctp_stm>();
         if (!stm) {
@@ -43,13 +45,10 @@ public:
         }
         ctp_stm_api api(stm);
         co_await api.set_start_offset(
-          offset, model::timeout_clock::now() + stm_timeout, _as);
+          offset, model::timeout_clock::now() + stm_timeout, *as);
     }
 
-    void abort() { _as.request_abort(); }
-
 private:
-    ss::abort_source _as;
     chunked_hash_map<model::topic_id_partition, housekeeper_manager::state>*
       _state;
 };
@@ -131,8 +130,6 @@ ss::future<> housekeeper_manager::start() { co_return; }
 
 ss::future<> housekeeper_manager::stop() {
     vlog(cd_log.info, "stopping cloud_topics::housekeeper_manager");
-    // NOLINTNEXTLINE(*static-cast-downcast*)
-    static_cast<l0_metastore_impl*>(_l0_metastore.get())->abort();
     co_await _queue.shutdown();
     vlog(cd_log.info, "cloud_topics::housekeeper_manager queue stopped");
     for (auto& [tidp, state] : _state) {

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -41,16 +41,15 @@ public:
         if (!stm) {
             throw std::runtime_error(fmt::format("no ctp_stm for {}", tidp));
         }
-        ctp_stm_api api(_root, stm);
+        ctp_stm_api api(stm);
         co_await api.set_start_offset(
-          offset, model::timeout_clock::now() + stm_timeout);
+          offset, model::timeout_clock::now() + stm_timeout, _as);
     }
 
     void abort() { _as.request_abort(); }
 
 private:
     ss::abort_source _as;
-    retry_chain_node _root{_as};
     chunked_hash_map<model::topic_id_partition, housekeeper_manager::state>*
       _state;
 };

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -33,7 +33,9 @@ public:
       , _start_offset(start_offset) {}
 
     ss::future<> set_start_offset(
-      const model::topic_id_partition& tidp, kafka::offset offset) override {
+      const model::topic_id_partition& tidp,
+      kafka::offset offset,
+      ss::abort_source*) override {
         if (tidp == _tidp) {
             _start_offset = std::max(_start_offset, offset);
         }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -59,9 +59,10 @@ ctp_stm::ctp_stm(ss::logger& logger, raft::consensus* raft)
 
 const model::ntp& ctp_stm::ntp() const noexcept { return _raft->ntp(); }
 
-ss::future<bool>
-ctp_stm::sync_in_term(model::timeout_clock::time_point deadline) {
-    auto sync_result = co_await sync(deadline - model::timeout_clock::now());
+ss::future<bool> ctp_stm::sync_in_term(
+  model::timeout_clock::time_point deadline, ss::abort_source& as) {
+    auto sync_result = co_await sync(
+      deadline - model::timeout_clock::now(), as);
     if (!sync_result) {
         // The replica is not a leader
         vlog(_log.debug, "Not a leader");
@@ -73,7 +74,7 @@ ctp_stm::sync_in_term(model::timeout_clock::time_point deadline) {
     auto committed_offset = _raft->committed_offset();
     if (committed_offset > last_applied()) {
         // The STM is catching up.
-        auto wait_res = co_await wait_no_throw(committed_offset, deadline);
+        auto wait_res = co_await wait_no_throw(committed_offset, deadline, as);
         if (!wait_res) {
             vlog(
               _log.warn,

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -72,7 +72,8 @@ public:
     /// \brief The method is syncing the STM  to minimize races.
     /// \return 'true' if the replica is a leader and the in-memory state of
     /// the STM is up-to-date. Otherwise, return 'false'.
-    ss::future<bool> sync_in_term(model::timeout_clock::time_point deadline);
+    ss::future<bool> sync_in_term(
+      model::timeout_clock::time_point deadline, ss::abort_source& as);
 
 private:
     ss::future<> do_apply(const model::record_batch&) override;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -167,9 +167,7 @@ ctp_stm_api::estimate_inactive_epoch() const noexcept {
 ss::future<bool> ctp_stm_api::sync_in_term(
   model::timeout_clock::time_point deadline, ss::abort_source& as) {
     vlog(cd_log.debug, "Syncing ctp_stm in term {}", _stm->_raft->term());
-    // TODO: plumb this into `sync_in_term`
-    std::ignore = as;
-    co_return co_await _stm->sync_in_term(deadline);
+    co_return co_await _stm->sync_in_term(deadline, as);
 }
 
 ss::future<cluster_epoch_fence> ctp_stm_api::fence_epoch(cluster_epoch e) {

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -10,7 +10,6 @@
 
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
 
-#include "base/outcome.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_commands.h"
 #include "cloud_topics/logger.h"
@@ -18,15 +17,12 @@
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
 #include "raft/consensus.h"
-#include "serde/rw/uuid.h"
 #include "ssx/future-util.h"
 #include "storage/record_batch_builder.h"
-#include "utils/retry_chain_node.h"
 
 #include <seastar/coroutine/as_future.hh>
 
 #include <exception>
-#include <stdexcept>
 
 namespace cloud_topics {
 
@@ -43,26 +39,25 @@ std::ostream& operator<<(std::ostream& o, ctp_stm_api_errc errc) {
     }
 }
 
-ctp_stm_api::ctp_stm_api(retry_chain_node& rtc, ss::shared_ptr<ctp_stm> stm)
-  : _rtc(&rtc)
-  , _rtclog(cd_log, _rtc, stm->ntp().path())
-  , _stm(std::move(stm)) {}
+ctp_stm_api::ctp_stm_api(ss::shared_ptr<ctp_stm> stm)
+  : _stm(std::move(stm)) {}
 
 ss::future<std::expected<model::offset, ctp_stm_api_errc>>
 ctp_stm_api::replicated_apply(
-  model::record_batch&& batch, model::timeout_clock::time_point deadline) {
+  model::record_batch&& batch,
+  model::timeout_clock::time_point deadline,
+  ss::abort_source& as) {
     model::term_id term = _stm->_raft->term();
 
-    vlog(
-      _rtclog.debug, "Replicating batch {} in term {}", batch.header(), term);
+    vlog(cd_log.debug, "Replicating batch {} in term {}", batch.header(), term);
 
     auto opts = raft::replicate_options(
-      raft::consistency_level::quorum_ack, _rtc.root_abort_source());
+      raft::consistency_level::quorum_ack, as);
     opts.set_force_flush();
     auto res = co_await _stm->_raft->replicate(term, std::move(batch), opts);
 
     if (res.has_error()) {
-        vlog(_rtclog.debug, "Failed to replicate batch: {}", res.error());
+        vlog(cd_log.debug, "Failed to replicate batch: {}", res.error());
         if (res.error() == raft::errc::not_leader) {
             co_return std::unexpected(ctp_stm_api_errc::not_leader);
         }
@@ -70,11 +65,10 @@ ctp_stm_api::replicated_apply(
     }
 
     try {
-        co_await _stm->wait(
-          res.value().last_offset, deadline, _rtc.root_abort_source());
+        co_await _stm->wait(res.value().last_offset, deadline, as);
     } catch (...) {
         vlog(
-          _rtclog.warn,
+          cd_log.warn,
           "Failed to wait for replicated command to to be applied: {}",
           std::current_exception());
         co_return std::unexpected(ctp_stm_api_errc::timeout);
@@ -86,12 +80,12 @@ ctp_stm_api::replicated_apply(
 ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
 ctp_stm_api::advance_reconciled_offset(
   kafka::offset last_reconciled_offset,
-  model::timeout_clock::time_point deadline) {
+  model::timeout_clock::time_point deadline,
+  ss::abort_source& as) {
     if (last_reconciled_offset <= get_last_reconciled_offset()) {
         co_return std::monostate{};
     }
-
-    vlog(_rtclog.debug, "Replicating ctp_stm_cmd::advance_reconciled_offset");
+    vlog(cd_log.debug, "Replicating ctp_stm_cmd::advance_reconciled_offset");
 
     storage::record_batch_builder builder(
       model::record_batch_type::ctp_stm_command, model::offset(0));
@@ -101,7 +95,8 @@ ctp_stm_api::advance_reconciled_offset(
       serde::to_iobuf(advance_reconciled_offset_cmd(last_reconciled_offset)));
 
     auto batch = std::move(builder).build();
-    auto apply_result = co_await replicated_apply(std::move(batch), deadline);
+    auto apply_result = co_await replicated_apply(
+      std::move(batch), deadline, as);
 
     if (!apply_result.has_value()) {
         co_return std::unexpected(apply_result.error());
@@ -112,13 +107,15 @@ ctp_stm_api::advance_reconciled_offset(
 
 ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
 ctp_stm_api::set_start_offset(
-  kafka::offset start_offset, model::timeout_clock::time_point deadline) {
+  kafka::offset start_offset,
+  model::timeout_clock::time_point deadline,
+  ss::abort_source& as) {
     if (start_offset <= get_start_offset()) {
         co_return std::monostate{};
     }
 
     vlog(
-      _rtclog.debug,
+      cd_log.debug,
       "Replicating ctp_stm_cmd::set_new_start_offset{{{}}}",
       start_offset);
 
@@ -130,7 +127,8 @@ ctp_stm_api::set_start_offset(
       serde::to_iobuf(set_start_offset_cmd(start_offset)));
 
     auto batch = std::move(builder).build();
-    auto apply_result = co_await replicated_apply(std::move(batch), deadline);
+    auto apply_result = co_await replicated_apply(
+      std::move(batch), deadline, as);
 
     if (!apply_result.has_value()) {
         co_return std::unexpected(apply_result.error());
@@ -155,7 +153,7 @@ ctp_stm_api::get_inactive_epoch() const {
         if (ssx::is_shutdown_exception(e)) {
             co_return std::unexpected(ctp_stm_api_errc::shutdown);
         }
-        vlog(_rtclog.error, "Failed to get minimum epoch from ctp_stm: {}", e);
+        vlog(cd_log.error, "Failed to get minimum epoch from ctp_stm: {}", e);
         co_return std::unexpected(ctp_stm_api_errc::failure);
     }
     co_return res.get();
@@ -166,17 +164,19 @@ ctp_stm_api::estimate_inactive_epoch() const noexcept {
     return _stm->estimate_inactive_epoch();
 }
 
-ss::future<bool>
-ctp_stm_api::sync_in_term(model::timeout_clock::time_point deadline) {
-    vlog(_rtclog.debug, "Syncing ctp_stm in term {}", _stm->_raft->term());
+ss::future<bool> ctp_stm_api::sync_in_term(
+  model::timeout_clock::time_point deadline, ss::abort_source& as) {
+    vlog(cd_log.debug, "Syncing ctp_stm in term {}", _stm->_raft->term());
+    // TODO: plumb this into `sync_in_term`
+    std::ignore = as;
     co_return co_await _stm->sync_in_term(deadline);
 }
 
 ss::future<cluster_epoch_fence> ctp_stm_api::fence_epoch(cluster_epoch e) {
-    vlog(_rtclog.debug, "Fencing epoch {} in term {}", e, _stm->_raft->term());
+    vlog(cd_log.debug, "Fencing epoch {} in term {}", e, _stm->_raft->term());
     auto res = co_await _stm->fence_epoch(e);
     vlog(
-      _rtclog.debug,
+      cd_log.debug,
       "Fence acquired = {} in term {}",
       res.unit.has_value(),
       res.term);

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.h
@@ -10,13 +10,11 @@
 
 #pragma once
 
-#include "base/outcome.h"
 #include "cloud_topics/level_zero/stm/types.h"
 #include "cloud_topics/types.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
-#include "utils/retry_chain_node.h"
 
 #include <seastar/core/gate.hh>
 
@@ -29,7 +27,7 @@ namespace cloud_topics {
 
 class ctp_stm;
 
-enum class ctp_stm_api_errc {
+enum class ctp_stm_api_errc : uint8_t {
     timeout,
     not_leader,
     shutdown,
@@ -42,11 +40,12 @@ class ctp_stm_api {
     friend struct ::ctp_stm_api_accessor;
 
 public:
-    ctp_stm_api(retry_chain_node& rtc, ss::shared_ptr<ctp_stm> stm);
+    explicit ctp_stm_api(ss::shared_ptr<ctp_stm> stm);
     ctp_stm_api(const ctp_stm_api&) noexcept = delete;
     ctp_stm_api& operator=(const ctp_stm_api&) noexcept = delete;
     ctp_stm_api(ctp_stm_api&&) noexcept = delete;
     ctp_stm_api& operator=(ctp_stm_api&&) noexcept = delete;
+    ~ctp_stm_api() noexcept = default;
 
 public:
     /// Get the last reconciled offset from the ctp_stm state.
@@ -55,12 +54,14 @@ public:
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     advance_reconciled_offset(
       kafka::offset last_reconciled_offset,
-      model::timeout_clock::time_point deadline);
+      model::timeout_clock::time_point deadline,
+      ss::abort_source& as);
 
     ss::future<std::expected<std::monostate, ctp_stm_api_errc>>
     set_start_offset(
       kafka::offset new_start_offset,
-      model::timeout_clock::time_point deadline);
+      model::timeout_clock::time_point deadline,
+      ss::abort_source& as);
 
     kafka::offset get_start_offset() const;
 
@@ -84,7 +85,8 @@ public:
     /// with the log messages replicated in the current term.
     /// \return 'true' if the replica is a leader and the in-memory state of
     /// the STM is up-to-date. Otherwise, return 'false'.
-    ss::future<bool> sync_in_term(model::timeout_clock::time_point deadline);
+    ss::future<bool>
+    sync_in_term(model::timeout_clock::time_point deadline, ss::abort_source&);
 
     /// Fence writes
     ss::future<cluster_epoch_fence> fence_epoch(cluster_epoch e);
@@ -97,11 +99,11 @@ private:
     /// Replicate a record batch and wait for it to be applied to the ctp_stm.
     /// Returns the offset at which the batch was applied.
     ss::future<std::expected<model::offset, ctp_stm_api_errc>> replicated_apply(
-      model::record_batch&& batch, model::timeout_clock::time_point deadline);
+      model::record_batch&& batch,
+      model::timeout_clock::time_point deadline,
+      ss::abort_source&);
 
 private:
-    retry_chain_node _rtc;
-    retry_chain_logger _rtclog;
     ss::shared_ptr<ctp_stm> _stm;
 };
 

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -28,9 +28,9 @@ using namespace std::chrono_literals;
 
 struct ctp_stm_api_accessor {
     ss::future<std::expected<model::offset, ct::ctp_stm_api_errc>>
-    replicated_apply(model::record_batch rb) {
+    replicated_apply(model::record_batch rb, ss::abort_source& as) {
         // This function is used to access the private method of ctp_stm_api
-        return api->replicated_apply(std::move(rb), model::no_timeout);
+        return api->replicated_apply(std::move(rb), model::no_timeout, as);
     }
     ct::ctp_stm_api* api;
 };
@@ -38,9 +38,6 @@ struct ctp_stm_api_accessor {
 class ctp_stm_fixture : public raft::raft_fixture {
 public:
     static constexpr auto node_count = 3;
-
-    ctp_stm_fixture()
-      : rtc(as) {}
 
     ss::future<> start() {
         enable_offset_translation();
@@ -67,7 +64,7 @@ public:
             api_by_vnode.emplace(
               node->get_vnode(),
               ss::make_shared<ct::ctp_stm_api>(
-                rtc, node->raft()->stm_manager()->get<ct::ctp_stm>()));
+                node->raft()->stm_manager()->get<ct::ctp_stm>()));
         }
     }
 
@@ -114,11 +111,10 @@ public:
     replicate_record_batch(
       raft::raft_node_instance& node, model::record_batch rb) {
         return ctp_stm_api_accessor{.api = &api(node)}.replicated_apply(
-          std::move(rb));
+          std::move(rb), as);
     }
 
     ss::abort_source as;
-    retry_chain_node rtc;
     absl::flat_hash_map<raft::vnode, ss::shared_ptr<ct::ctp_stm>> stm_by_vnode;
     absl::flat_hash_map<raft::vnode, ss::shared_ptr<ct::ctp_stm_api>>
       api_by_vnode;
@@ -244,7 +240,7 @@ TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
     // now b1 is reconciled and can be removed alongside its epoch (1).
     // First referenced epoch is now 2.
     co_await api(node(*get_leader()))
-      .advance_reconciled_offset(kafka::offset{0}, model::no_timeout);
+      .advance_reconciled_offset(kafka::offset{0}, model::no_timeout, as);
 
     // Check that max and max_seen_epochs remain the same
     auto max_epoch_after = api(node(*get_leader())).get_max_epoch();
@@ -264,7 +260,7 @@ TEST_F_CORO(ctp_stm_fixture, test_last_reconciled_offset) {
     // Advance reconciled offset to the b2 batch.
     // Now all epochs can be discarded.
     co_await api(node(*get_leader()))
-      .advance_reconciled_offset(kafka::offset{1}, model::no_timeout);
+      .advance_reconciled_offset(kafka::offset{1}, model::no_timeout, as);
 
     max_epoch_after = api(node(*get_leader())).get_max_epoch();
     max_seen_epoch_after = api(node(*get_leader())).get_max_seen_epoch();
@@ -316,9 +312,9 @@ TEST_F_CORO(ctp_stm_fixture, test_truncate_all_epochs) {
 
     // Advance reconciled offset to the middle of the first epoch
     co_await api(node(*get_leader()))
-      .advance_reconciled_offset(kafka::offset(50), model::no_timeout);
+      .advance_reconciled_offset(kafka::offset(50), model::no_timeout, as);
     ss::abort_source as;
-    co_await api(node(*get_leader())).sync_in_term(model::no_timeout);
+    co_await api(node(*get_leader())).sync_in_term(model::no_timeout, as);
     inactive_epoch = co_await api(node(*get_leader())).get_inactive_epoch();
     ASSERT_TRUE_CORO(inactive_epoch);
     ASSERT_TRUE_CORO(inactive_epoch->has_value());
@@ -326,7 +322,7 @@ TEST_F_CORO(ctp_stm_fixture, test_truncate_all_epochs) {
 
     // Advance reconciled offset exactly to the end of the first epoch
     co_await api(node(*get_leader()))
-      .advance_reconciled_offset(kafka::offset(99), model::no_timeout);
+      .advance_reconciled_offset(kafka::offset(99), model::no_timeout, as);
     inactive_epoch = co_await api(node(*get_leader())).get_inactive_epoch();
     max_epoch = api(node(*get_leader())).get_max_epoch();
     ASSERT_TRUE_CORO(inactive_epoch);
@@ -350,16 +346,19 @@ TEST_F_CORO(ctp_stm_fixture, test_start_offset) {
     auto start_offset = leader_api.get_start_offset();
     ASSERT_EQ_CORO(start_offset, kafka::offset{0});
 
-    co_await leader_api.set_start_offset(kafka::offset{1}, model::no_timeout);
+    co_await leader_api.set_start_offset(
+      kafka::offset{1}, model::no_timeout, as);
 
     start_offset = leader_api.get_start_offset();
     ASSERT_EQ_CORO(start_offset, kafka::offset{1});
 
-    co_await leader_api.set_start_offset(kafka::offset{2}, model::no_timeout);
+    co_await leader_api.set_start_offset(
+      kafka::offset{2}, model::no_timeout, as);
     start_offset = leader_api.get_start_offset();
     ASSERT_EQ_CORO(start_offset, kafka::offset{2});
 
-    co_await leader_api.set_start_offset(kafka::offset{1}, model::no_timeout);
+    co_await leader_api.set_start_offset(
+      kafka::offset{1}, model::no_timeout, as);
     start_offset = leader_api.get_start_offset();
     ASSERT_EQ_CORO(start_offset, kafka::offset{2});
 }

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -30,6 +30,7 @@
 #include <seastar/util/log.hh>
 
 #include <chrono>
+#include <exception>
 #include <expected>
 
 using namespace std::chrono_literals;
@@ -411,7 +412,15 @@ reconciler::build_object(
             co_return std::unexpected(
               reconcile_error("abort requested while building object"));
         }
-        auto meta = co_await add_source_to_object(ctx, src);
+        auto read_result = co_await add_source_to_object(ctx, src);
+        if (!read_result.has_value()) {
+            // Log an error, we don't want a single stuck partition to
+            // prevent all partitions from being reconciled.
+            log_error(read_result.error().with_context(
+              "unable to reconcile partition {}", src->ntp()));
+            continue;
+        }
+        auto meta = read_result.value();
         if (meta.has_value()) {
             metas.emplace_back(src, std::move(meta).value());
         }
@@ -422,7 +431,7 @@ reconciler::build_object(
       [&ctx] { return ctx.close_builder(); });
     vlog(
       lg.debug,
-      "Built L1 object from {} partitions ({} partitions didn't fit)",
+      "Built L1 object from {} partitions ({} partitions were skipped)",
       metas.size(),
       sources.size() - metas.size());
     co_return built_object_metadata{
@@ -442,7 +451,8 @@ reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
     co_return std::expected<void, reconcile_error>{};
 }
 
-ss::future<std::optional<consumer_metadata>> reconciler::add_source_to_object(
+ss::future<std::expected<std::optional<consumer_metadata>, reconcile_error>>
+reconciler::add_source_to_object(
   builder_context& ctx, ss::shared_ptr<source> src) {
     vlog(
       lg.debug,
@@ -450,17 +460,21 @@ ss::future<std::optional<consumer_metadata>> reconciler::add_source_to_object(
       src->ntp(),
       src->last_reconciled_offset());
 
-    // Since the LRO is the last thing inclusive of what we uploaded to L1, we
-    // want to start reading from the next offset.
-    auto reader = co_await src->make_reader(
-      source::reader_config{
-        .max_bytes = ctx.size_budget,
-        .as = &_as,
-      });
     reconciliation_consumer consumer(
       ctx.builder.get(), src->topic_id_partition());
-    auto metadata = co_await std::move(reader).consume(
-      std::move(consumer), model::no_timeout);
+    std::optional<consumer_metadata> metadata;
+    try {
+        auto reader = co_await src->make_reader(
+          source::reader_config{
+            .max_bytes = ctx.size_budget,
+            .as = &_as,
+          });
+        metadata = co_await std::move(reader).consume(
+          std::move(consumer), model::no_timeout);
+    } catch (...) {
+        co_return std::unexpected(reconcile_error(
+          "unable to consume from L0 partition: {}", std::current_exception()));
+    }
 
     if (!metadata.has_value()) {
         vlog(

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -452,15 +452,11 @@ ss::future<std::optional<consumer_metadata>> reconciler::add_source_to_object(
 
     // Since the LRO is the last thing inclusive of what we uploaded to L1, we
     // want to start reading from the next offset.
-    auto start_offset = kafka::next_offset(src->last_reconciled_offset());
-    auto reader = co_await src->make_reader(cloud_topic_log_reader_config(
-      /*start_offset=*/start_offset,
-      /*max_offset=*/kafka::offset::max(),
-      /*min_bytes=*/1,
-      /*max_bytes=*/ctx.size_budget,
-      /*type_filter=*/std::nullopt,
-      /*time=*/std::nullopt,
-      /*as=*/_as));
+    auto reader = co_await src->make_reader(
+      source::reader_config{
+        .max_bytes = ctx.size_budget,
+        .as = &_as,
+      });
     reconciliation_consumer consumer(
       ctx.builder.get(), src->topic_id_partition());
     auto metadata = co_await std::move(reader).consume(

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -214,7 +214,7 @@ private:
      * Add source data to an L1 object builder. Returns the source
      * metadata if any batches were consumed, nullopt otherwise.
      */
-    ss::future<std::optional<consumer_metadata>>
+    ss::future<std::expected<std::optional<consumer_metadata>, reconcile_error>>
     add_source_to_object(builder_context& ctx, ss::shared_ptr<source> src);
 
     /*

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -13,6 +13,7 @@
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/frontend/frontend.h"
 #include "cloud_topics/level_zero/stm/ctp_stm_api.h"
+#include "cloud_topics/log_reader_config.h"
 #include "cloud_topics/logger.h"
 #include "cluster/partition.h"
 #include "kafka/utils/txn_reader.h"
@@ -59,18 +60,15 @@ public:
       , _partition(std::move(partition)) {}
 
     kafka::offset last_reconciled_offset() override {
-        ss::abort_source as;
-        retry_chain_node rtc{as};
-        ctp_stm_api api(rtc, _partition->raft()->stm_manager()->get<ctp_stm>());
+        ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
         return api.get_last_reconciled_offset();
     }
 
     ss::future<std::expected<void, errc>> set_last_reconciled_offset(
       kafka::offset offset, ss::abort_source& as) override {
-        retry_chain_node rtc{as};
-        ctp_stm_api api(rtc, _partition->raft()->stm_manager()->get<ctp_stm>());
+        ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());
         auto res = co_await api.advance_reconciled_offset(
-          offset, model::no_timeout);
+          offset, model::no_timeout, as);
         if (!res.has_value()) {
             switch (res.error()) {
             case ctp_stm_api_errc::timeout:
@@ -87,8 +85,9 @@ public:
     }
 
     ss::future<model::record_batch_reader>
-    make_reader(cloud_topic_log_reader_config cfg) override {
-        auto effective_start = co_await _fe->sync_effective_start(5s);
+    make_reader(reader_config input_cfg) override {
+        auto effective_start = co_await _fe->sync_effective_start(
+          model::no_timeout, *input_cfg.as);
         if (!effective_start.has_value()) {
             vlog(
               cd_log.warn,
@@ -97,8 +96,6 @@ public:
               effective_start.error());
             co_return model::make_empty_record_batch_reader();
         }
-
-        cfg.start_offset = std::max(effective_start.value(), cfg.start_offset);
 
         auto maybe_lso = _fe->last_stable_offset();
         if (!maybe_lso.has_value()) {
@@ -110,17 +107,24 @@ public:
             co_return model::make_empty_record_batch_reader();
         }
 
-        // It's possible for LSO to be 0, which in this case the previous offset
-        // is model::offset::min(), this is the same as the kafka fetch path.
-        cfg.max_offset = std::min(
-          kafka::prev_offset(maybe_lso.value()), cfg.max_offset);
-
+        // It's possible for LSO to be 0, which in this case the previous
+        // is model::offset::min(), this is the same as the kafka fetch
+        cloud_topic_log_reader_config cfg(
+          /*start_offset=*/std::min(
+            effective_start.value(), last_reconciled_offset()),
+          /*max_offset=*/kafka::prev_offset(maybe_lso.value()),
+          /*min_bytes=*/1,
+          /*max_bytes=*/input_cfg.max_bytes,
+          /*type_filter=*/std::nullopt,
+          /*time=*/std::nullopt,
+          /*as=*/*input_cfg.as);
         if (cfg.max_offset < cfg.start_offset) {
             co_return model::make_empty_record_batch_reader();
         }
         auto reader = co_await _fe->make_reader(
           cfg,
-          /*debounce_deadline=*/std::nullopt);
+          /*debounce_deadline=*/
+          std::nullopt);
 
         // It's important the `aborted_transaction_tracker_impl` takes a shared
         // so we don't have to worry about the lifetimes of the reader and

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -9,7 +9,6 @@
  */
 
 #include "cloud_topics/data_plane_api.h"
-#include "cloud_topics/log_reader_config.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 
@@ -62,12 +61,20 @@ public:
     virtual ss::future<std::expected<void, errc>>
     set_last_reconciled_offset(kafka::offset, ss::abort_source&) = 0;
 
+    struct reader_config {
+        // The soft limit for number of bytes to read.
+        size_t max_bytes;
+        // The abort source for when to stop the reader. The abort source must
+        // live as long as the returned reader from `make_reader`.
+        ss::abort_source* as;
+    };
+
     // Create a reader for the reconciliation source, data should only be read
     // above `last_reconciled_offset`.
     //
     // It *is* valid for this reader to outlive `source`.
     virtual ss::future<model::record_batch_reader>
-      make_reader(cloud_topic_log_reader_config) = 0;
+      make_reader(reader_config) = 0;
 
 private:
     model::ntp _ntp;

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -444,17 +444,16 @@ TEST_F(ReconcilerTest, MultipleSourcesWithFailures) {
 
     reconcile();
 
-    // When one source in an object fails, the entire object fails so none of
-    // the sources in that object get reconciled
+    // When one source in an object fails, then the entire object doesn't fail.
     // NB: This depends on the simple_metastore grouping all sources into the
     //     same object.
-    EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{});
+    EXPECT_EQ(src1->last_reconciled_offset(), kafka::offset{9});
     EXPECT_EQ(src2->last_reconciled_offset(), kafka::offset{});
-    EXPECT_EQ(src3->last_reconciled_offset(), kafka::offset{});
+    EXPECT_EQ(src3->last_reconciled_offset(), kafka::offset{29});
 
-    EXPECT_EQ(metastore_next_offset(src1), std::nullopt);
+    EXPECT_EQ(metastore_next_offset(src1), kafka::offset{10});
     EXPECT_EQ(metastore_next_offset(src2), std::nullopt);
-    EXPECT_EQ(metastore_next_offset(src3), std::nullopt);
+    EXPECT_EQ(metastore_next_offset(src3), kafka::offset{30});
 }
 
 TEST_F(ReconcilerTest, TermTracking) {

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -51,15 +51,14 @@ public:
     }
 
     ss::future<model::record_batch_reader>
-    make_reader(cloud_topic_log_reader_config cfg) override {
+    make_reader(source::reader_config cfg) override {
         chunked_vector<model::record_batch> log;
         size_t size = 0;
         for (const auto& batch : _source_log) {
-            if (model::offset_cast(batch.base_offset()) < cfg.start_offset) {
+            if (
+              model::offset_cast(batch.base_offset())
+              < last_reconciled_offset()) {
                 continue;
-            }
-            if (model::offset_cast(batch.last_offset()) > cfg.max_offset) {
-                break;
             }
             size += batch.size_bytes();
             log.push_back(batch.copy());

--- a/src/v/kafka/data/cloud_topic_partition.cc
+++ b/src/v/kafka/data/cloud_topic_partition.cc
@@ -98,7 +98,8 @@ model::offset cloud_topic_partition::start_offset() const {
 
 ss::future<result<model::offset, error_code>>
 cloud_topic_partition::sync_effective_start(model::timeout_clock::duration d) {
-    auto res = co_await _fe->sync_effective_start(d);
+    ss::abort_source as;
+    auto res = co_await _fe->sync_effective_start(d, as);
     if (!res.has_value()) {
         co_return map_errc(res.error());
     }

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -393,26 +393,40 @@ template<typename BaseT, supported_stm_snapshot T>
 ss::future<> persisted_stm_base<BaseT, T>::wait_offset_committed(
   model::timeout_clock::duration timeout,
   model::offset offset,
-  model::term_id term) {
+  model::term_id term,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
     auto stop_cond = [this, offset, term] {
         return _raft->committed_offset() >= offset || _raft->term() > term;
     };
-
-    return _raft->commit_index_updated().wait(timeout, stop_cond);
+    if (as) {
+        auto abortable_stop_cond = [&stop_cond, as] {
+            return stop_cond() || as->get().abort_requested();
+        };
+        auto sub = as->get().subscribe(
+          [this] noexcept { _raft->commit_index_updated().broadcast(); });
+        co_await _raft->commit_index_updated().wait(
+          timeout, abortable_stop_cond);
+        // If the abort source signalled the updated index, we want this to
+        // throw in that case.
+        as->get().check();
+    } else {
+        co_await _raft->commit_index_updated().wait(timeout, stop_cond);
+    }
 }
 
 template<typename BaseT, supported_stm_snapshot T>
 ss::future<bool> persisted_stm_base<BaseT, T>::do_sync(
   model::timeout_clock::duration timeout,
   model::offset offset,
-  model::term_id term) {
+  model::term_id term,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
     const auto committed = _raft->committed_offset();
     const auto ntp = _raft->ntp();
     _raft->events().notify_commit_index();
 
     if (offset > committed) {
         try {
-            co_await wait_offset_committed(timeout, offset, term);
+            co_await wait_offset_committed(timeout, offset, term, as);
         } catch (const ss::broken_condition_variable&) {
             co_return false;
         } catch (const ss::gate_closed_exception&) {
@@ -437,7 +451,8 @@ ss::future<bool> persisted_stm_base<BaseT, T>::do_sync(
 
     if (_raft->term() == term) {
         try {
-            co_await BaseT::wait(offset, model::timeout_clock::now() + timeout);
+            co_await BaseT::wait(
+              offset, model::timeout_clock::now() + timeout, as);
         } catch (const ss::broken_condition_variable&) {
             co_return false;
         } catch (const ss::gate_closed_exception&) {
@@ -475,8 +490,9 @@ ss::future<bool> persisted_stm_base<BaseT, T>::do_sync(
 }
 
 template<typename BaseT, supported_stm_snapshot T>
-ss::future<bool>
-persisted_stm_base<BaseT, T>::sync(model::timeout_clock::duration timeout) {
+ss::future<bool> persisted_stm_base<BaseT, T>::sync(
+  model::timeout_clock::duration timeout,
+  std::optional<std::reference_wrapper<ss::abort_source>> as) {
     auto term = _raft->term();
     if (!_raft->is_leader()) {
         return ss::make_ready_future<bool>(false);
@@ -489,7 +505,7 @@ persisted_stm_base<BaseT, T>::sync(model::timeout_clock::duration timeout) {
         auto sync_waiter = ss::make_lw_shared<expiring_promise<bool>>();
         _sync_waiters.push_back(sync_waiter);
         return sync_waiter->get_future_with_timeout(
-          deadline, [] { return false; });
+          deadline, [] { return false; }, as);
     }
     _is_catching_up = true;
 
@@ -515,7 +531,7 @@ persisted_stm_base<BaseT, T>::sync(model::timeout_clock::duration timeout) {
         sync_offset = log_offsets.dirty_offset;
     }
 
-    return do_sync(timeout, sync_offset, term).then([this](bool is_synced) {
+    return do_sync(timeout, sync_offset, term, as).then([this](bool is_synced) {
         _is_catching_up = false;
         for (auto& sync_waiter : _sync_waiters) {
             sync_waiter->set_value(is_synced);

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -248,7 +248,10 @@ protected:
      * called within its term it waits until the state machine is caught
      * up with all the events written by the previous leaders
      */
-    ss::future<bool> sync(model::timeout_clock::duration);
+    ss::future<bool> sync(
+      model::timeout_clock::duration,
+      std::optional<std::reference_wrapper<ss::abort_source>> as
+      = std::nullopt);
 
     bool _is_catching_up{false};
     model::term_id _insync_term;
@@ -258,9 +261,15 @@ protected:
 
 private:
     ss::future<> wait_offset_committed(
-      model::timeout_clock::duration, model::offset, model::term_id);
-    ss::future<bool>
-      do_sync(model::timeout_clock::duration, model::offset, model::term_id);
+      model::timeout_clock::duration,
+      model::offset,
+      model::term_id,
+      std::optional<std::reference_wrapper<ss::abort_source>> as);
+    ss::future<bool> do_sync(
+      model::timeout_clock::duration,
+      model::offset,
+      model::term_id,
+      std::optional<std::reference_wrapper<ss::abort_source>> as);
     ss::future<std::optional<stm_snapshot>> load_local_snapshot();
     ss::future<> wait_for_snapshot_hydrated();
 


### PR DESCRIPTION
This will simplify shutdown sequences with abort sources in the API.
The RTC mechanism in the constructor was a bit clunky to use and wasn't in practice being used anywhere.

It'd be great to do this in the metastore as well, but our RPC interface doesn't abort sources at all.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
