### PR TITLE
raft: error logs for unexpected exceptions

### DIFF
--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -23,6 +23,16 @@ using snapshot_at_offset_supported
   = ss::bool_class<struct snapshot_at_offset_supported_tag>;
 class consensus;
 
+// An exception for an STM to throw during it's `apply` method to mark this as
+// an non-terminal error.
+class stm_apply_exception : public std::runtime_error {
+public:
+    explicit stm_apply_exception(const char* msg)
+      : std::runtime_error(msg) {}
+    explicit stm_apply_exception(const std::string& msg)
+      : std::runtime_error(msg) {}
+};
+
 /**
  * Class defining the state machine behavior when it is created for the first
  * time for a given partition.

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -142,7 +142,7 @@ batch_applicator::apply_to_stm(
 
         co_await state.stm_entry->stm->apply(batch);
         co_return applied_successfully::yes;
-    } catch (...) {
+    } catch (const stm_apply_exception& ex) {
         vlog(
           _log.warn,
           "[{}][{}] error applying batch with base_offset: {} - {}",
@@ -150,9 +150,17 @@ batch_applicator::apply_to_stm(
           state.stm_entry->name,
           batch.base_offset(),
           std::current_exception());
-        state.error = true;
-        co_return applied_successfully::no;
+    } catch (...) {
+        vlog(
+          _log.error,
+          "[{}][{}] unexpected error applying batch with base_offset: {} - {}",
+          _ctx,
+          state.stm_entry->name,
+          batch.base_offset(),
+          std::current_exception());
     }
+    state.error = true;
+    co_return applied_successfully::no;
 }
 
 state_machine_manager::named_stm::named_stm(ss::sstring name, stm_ptr stm)

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -50,6 +50,7 @@ concept StateMachineIterateFunc = requires(
   Func f, const ss::sstring& name, const state_machine_base& stm) {
     { f(name, stm) } -> std::convertible_to<void>;
 };
+
 /**
  * State machine manager is an entry point for registering state machines
  * built on top of replicated log. State machine managers uses a single


### PR DESCRIPTION
By default we should ERROR log STM apply exceptions. Instead we allow a
special exception to be thrown for "expected" errors.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
