### PR TITLE
cl/replicator: fix duration overflow

### DIFF
--- a/src/v/cluster_link/replication/partition_replicator.cc
+++ b/src/v/cluster_link/replication/partition_replicator.cc
@@ -15,6 +15,8 @@
 
 #include <seastar/coroutine/switch_to.hh>
 
+using namespace std::chrono_literals;
+
 namespace cluster_link::replication {
 
 static constexpr std::chrono::seconds base_backoff{1};
@@ -110,8 +112,9 @@ ss::future<bool> partition_replicator::handle_replication_result(
 
 ss::future<> partition_replicator::replicate_and_wait(
   replicate_ctx ctx, ss::gate& gate, ss::abort_source& as) {
-    auto stages = _sink->replicate(
-      std::move(ctx.batches), model::max_duration, as);
+    static constexpr auto large_timeout
+      = std::chrono::duration_cast<model::timeout_clock::duration>(5min);
+    auto stages = _sink->replicate(std::move(ctx.batches), large_timeout, as);
     auto enqueue_f = co_await ss::coroutine::as_future(
       std::move(stages.request_enqueued));
     std::exception_ptr eptr = nullptr;

--- a/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
+++ b/src/v/cluster_link/replication/tests/partition_replicator_tests.cc
@@ -106,7 +106,7 @@ public:
 
     raft::replicate_stages replicate(
       chunked_vector<model::record_batch> batches,
-      model::timeout_clock::duration,
+      model::timeout_clock::duration duration,
       ss::abort_source&) final {
         if (_fail_replication) {
             if (tests::random_bool()) {
@@ -115,9 +115,15 @@ public:
             result<raft::replicate_result> err{raft::errc::not_leader};
             return raft::replicate_stages{ss::now(), ssx::now(err)};
         }
+        auto with_timeout = [duration](auto&& f) {
+            return ss::with_timeout(
+              model::timeout_clock::now() + duration,
+              std::forward<decltype(f)>(f));
+        };
         return raft::replicate_stages{
-          _replication_mu.get_units().discard_result(),
-          replicate_success(model::offset_cast(batches.back().last_offset()))};
+          with_timeout(_replication_mu.get_units().discard_result()),
+          with_timeout(replicate_success(
+            model::offset_cast(batches.back().last_offset())))};
     }
 
     void notify_replicator_failure(model::term_id) final {}


### PR DESCRIPTION
max_duration addition overflows when evaluating timepoints like now() + max_duration. Instead rely on a large-ish timeout beyond which replication is most likely stuck for practical purposes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
