### PR TITLE
storage: miscellaneous clean up

### DIFF
--- a/src/v/cloud_topics/level_zero/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_zero/frontend_reader/BUILD
@@ -27,6 +27,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_zero/common:extent_meta",
         "//src/v/model",
         "//src/v/storage",
+        "//src/v/utils:prefix_logger",
         "@boost//:outcome",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -33,7 +33,8 @@ level_zero_log_reader_impl::level_zero_log_reader_impl(
   data_plane_api* ct_api)
   : _config(cfg)
   , _ctp(std::move(ctp))
-  , _ct_api(ct_api) {}
+  , _ct_api(ct_api)
+  , _log(cd_log, fmt::format("[{}/{}]", fmt::ptr(this), _ctp->ntp())) {}
 
 ss::future<model::record_batch_reader::storage_t>
 level_zero_log_reader_impl::do_load_slice(
@@ -97,7 +98,7 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
             break;
         }
         vlog(
-          cd_log.trace,
+          _log.trace,
           "Loaded batch from cache for {}: {} @ term {}",
           current,
           batch.value().base_offset(),
@@ -131,7 +132,7 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
     _config.start_offset = current;
     if (_config.start_offset > _config.max_offset) {
         vlog(
-          cd_log.debug,
+          _log.debug,
           "reached end of stream, start offset: {}, max offset: {}, "
           "current: {}",
           _config.start_offset,
@@ -219,7 +220,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         }
         if (!_unhydrated.empty()) {
             vlog(
-              cd_log.debug,
+              _log.debug,
               "Fetched {} L0 meta batches from the underlying "
               "partition, first offset: {}, last offset: {}",
               _unhydrated.size(),
@@ -227,7 +228,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
               _unhydrated.back().header.last_offset());
         } else {
             vlog(
-              cd_log.debug,
+              _log.debug,
               "No L0 meta batches fetched from the underlying partition, "
               "start offset: {}, max offset: {}",
               cfg.start_offset,
@@ -235,7 +236,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         }
     } catch (...) {
         vlog(
-          cd_log.info,
+          _log.info,
           "Failed to fetch metadata from the underlying partition: {}",
           std::current_exception());
         _hydrated.clear();
@@ -251,7 +252,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
   model::timeout_clock::time_point deadline) {
     if (_current == state::end_of_stream_state) {
         _current = state::end_of_stream_state;
-        vlog(cd_log.trace, "Materialize batches called while EOS");
+        vlog(_log.trace, "Materialize batches called while EOS");
         co_return;
     }
     vassert(
@@ -263,7 +264,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         // We're already materialized.
         _current = state::materialized_state;
         vlog(
-          cd_log.trace,
+          _log.trace,
           "Materialize batches call redundant, already materialized");
         co_return;
     }
@@ -271,7 +272,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
     if (_unhydrated.empty()) {
         // Nothing to materialize.
         _current = state::end_of_stream_state;
-        vlog(cd_log.trace, "Materialize batches without unhydrated batches");
+        vlog(_log.trace, "Materialize batches without unhydrated batches");
         co_return;
     }
 
@@ -298,7 +299,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                 // limit). In this case we don't want to stall the reader
                 // completely.
                 vlog(
-                  cd_log.trace,
+                  _log.trace,
                   "Materialize batches overshot at {} bytes, config: {}, last "
                   "hydrated batch size: {}",
                   materialize_bytes,
@@ -313,24 +314,21 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                 materialize_bytes += meta->byte_range_size;
                 to_materialize.push_back(*meta);
                 vlog(
-                  cd_log.trace,
+                  _log.trace,
                   "Materialize {} bytes total...",
                   materialize_bytes);
             }
         }
         size_t materialize_count = to_materialize.size();
         vlog(
-          cd_log.trace,
+          _log.trace,
           "Invoking 'materialize' for {}: {} bytes, {} batches to materialize",
           _ctp->ntp(),
           materialize_bytes,
           materialize_count);
         // Ask data layer to bring data from the cloud storage.
         auto mat_res = co_await _ct_api->materialize(
-          _ctp->ntp(),
-          materialize_bytes,
-          std::move(to_materialize),
-          deadline);
+          _ctp->ntp(), materialize_bytes, std::move(to_materialize), deadline);
         if (mat_res.has_error()) {
             throw std::runtime_error(
               fmt::format(
@@ -367,7 +365,7 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                   // Propagate materialized batches to the record batch cache
                   if (cache_enabled()) {
                       vlog(
-                        cd_log.trace,
+                        _log.trace,
                         "Putting batch for {} to cache: {}, term: {}",
                         _ctp->ntp(),
                         batch.base_offset(),
@@ -392,12 +390,12 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         _hydrated = std::move(hydrated);
         // Materialize batches from the L0 meta batches.
         vlog(
-          cd_log.debug,
+          _log.debug,
           "Materialized {} batches from the L0 meta batches",
           _hydrated.size());
     } catch (...) {
         vlog(
-          cd_log.info,
+          _log.info,
           "Failed to materialize batches {}",
           std::current_exception());
         _hydrated.clear();
@@ -426,7 +424,7 @@ bool level_zero_log_reader_impl::cache_enabled() const {
 void level_zero_log_reader_impl::consume_materialized_batches(
   chunked_circular_buffer<model::record_batch>* dest) {
     vlog(
-      cd_log.debug,
+      _log.debug,
       "consuming {} materialized batches, cached {} extents",
       _hydrated.size(),
       _unhydrated.size());

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -166,7 +166,6 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         storage::local_log_reader_config cfg(
           start_offset,
           max_offset,
-          _config.min_bytes,
           _config.max_bytes,
           // We need to fetch both raft data batches for transaction control
           // markers as well as placeholder batches to hydrate from object

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -29,10 +29,10 @@ static constexpr size_t L0_max_bytes_per_metadata_fetch = 4_KiB;
 
 level_zero_log_reader_impl::level_zero_log_reader_impl(
   cloud_topic_log_reader_config& cfg,
-  ss::lw_shared_ptr<cluster::partition> underlying,
+  ss::lw_shared_ptr<cluster::partition> ctp,
   data_plane_api* ct_api)
   : _config(cfg)
-  , _underlying(std::move(underlying))
+  , _ctp(std::move(ctp))
   , _ct_api(ct_api) {}
 
 ss::future<model::record_batch_reader::storage_t>
@@ -86,7 +86,7 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
     while (materialized_bytes < _config.max_bytes
            && current <= _config.max_offset) {
         auto batch = _ct_api->cache_get(
-          _underlying->ntp(), kafka::offset_cast(current));
+          _ctp->ntp(), kafka::offset_cast(current));
         size_t batch_size = 0;
         if (!batch.has_value()) {
             // We hit a gap in the cache and have to download objects
@@ -118,7 +118,7 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
           batch->base_offset() <= kafka::offset_cast(current)
             && kafka::offset_cast(current) <= batch->last_offset(),
           "Unexpected batch for {}, got range: [{},{}] for offset {}",
-          _underlying->ntp(),
+          _ctp->ntp(),
           batch->base_offset(),
           batch->last_offset(),
           current);
@@ -157,8 +157,8 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         co_return;
     }
     try {
-        // Fetch metadata from the _underlying
-        auto ot_state = _underlying->get_offset_translator_state();
+        // Fetch metadata from the _ctp
+        auto ot_state = _ctp->get_offset_translator_state();
         auto start_offset = ot_state->to_log_offset(
           kafka::offset_cast(_config.start_offset));
         auto max_offset = ot_state->to_log_offset(
@@ -186,7 +186,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         // to fetch L0 meta batches first and then parse them.
         cfg.max_bytes = L0_max_bytes_per_metadata_fetch;
 
-        auto reader = co_await _underlying->make_local_reader(cfg);
+        auto reader = co_await _ctp->make_local_reader(cfg);
         auto placeholders = co_await model::consume_reader_to_chunked_vector(
           std::move(reader), deadline);
 
@@ -322,12 +322,12 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
         vlog(
           cd_log.trace,
           "Invoking 'materialize' for {}: {} bytes, {} batches to materialize",
-          _underlying->ntp(),
+          _ctp->ntp(),
           materialize_bytes,
           materialize_count);
         // Ask data layer to bring data from the cloud storage.
         auto mat_res = co_await _ct_api->materialize(
-          _underlying->ntp(),
+          _ctp->ntp(),
           materialize_bytes,
           std::move(to_materialize),
           deadline);
@@ -369,10 +369,10 @@ ss::future<> level_zero_log_reader_impl::materialize_batches(
                       vlog(
                         cd_log.trace,
                         "Putting batch for {} to cache: {}, term: {}",
-                        _underlying->ntp(),
+                        _ctp->ntp(),
                         batch.base_offset(),
                         batch.term());
-                      _ct_api->cache_put(_underlying->ntp(), batch.copy());
+                      _ct_api->cache_put(_ctp->ntp(), batch.copy());
                   }
                   return batch;
               },
@@ -414,7 +414,7 @@ bool level_zero_log_reader_impl::cache_enabled() const {
     if (_config.skip_cache) {
         return false;
     }
-    if (!_underlying->log()->config().cache_enabled()) {
+    if (!_ctp->log()->config().cache_enabled()) {
         return false;
     }
     if (config::shard_local_cfg().disable_batch_cache()) {

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.h
@@ -12,6 +12,7 @@
 #include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/log_reader_config.h"
 #include "model/record_batch_reader.h"
+#include "utils/prefix_logger.h"
 
 namespace cluster {
 class partition;
@@ -130,6 +131,7 @@ private:
     cloud_topic_log_reader_config _config;
     ss::lw_shared_ptr<cluster::partition> _ctp;
     data_plane_api* _ct_api;
+    prefix_logger _log;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.h
@@ -128,7 +128,7 @@ private:
     chunked_circular_buffer<model::record_batch> _hydrated;
 
     cloud_topic_log_reader_config _config;
-    ss::lw_shared_ptr<cluster::partition> _underlying;
+    ss::lw_shared_ptr<cluster::partition> _ctp;
     data_plane_api* _ct_api;
 };
 

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -117,7 +117,6 @@ ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {
     storage::local_log_reader_config cfg(
       model::next_offset(lro),
       co,
-      0,
       4_MiB,
       std::make_optional(model::record_batch_type::dl_placeholder),
       std::nullopt,

--- a/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
+++ b/src/v/cluster/cloud_metadata/tests/cluster_metadata_utils.h
@@ -69,7 +69,6 @@ read_recovery_stages(cluster::partition& controller_prt) {
     storage::local_log_reader_config reader_config(
       model::offset(0),
       controller_prt.raft()->committed_offset(),
-      0,
       std::numeric_limits<size_t>::max(),
       model::record_batch_type::cluster_recovery_cmd,
       std::nullopt,

--- a/src/v/kafka/data/replicated_partition.cc
+++ b/src/v/kafka/data/replicated_partition.cc
@@ -42,7 +42,6 @@ storage::local_log_reader_config kafka_to_local_log_reader_config(
     return storage::local_log_reader_config(
       /*start_offset=*/start_offset,
       /*max_offset=*/max_offset,
-      /*min_bytes=*/cfg.min_bytes,
       /*max_bytes=*/cfg.max_bytes,
       /*type_filter=*/std::nullopt,
       /*first_timestamp=*/cfg.first_timestamp,

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1080,7 +1080,6 @@ ss::future<> group_manager::handle_partition_leader_change(
                 storage::local_log_reader_config reader_config(
                   p->partition->raft_start_offset(),
                   model::model_limits<model::offset>::max(),
-                  0,
                   std::numeric_limits<size_t>::max(),
                   std::nullopt,
                   std::nullopt,

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -245,7 +245,6 @@ recovery_stm::read_range_for_recovery(
     storage::local_log_reader_config cfg(
       start_offset,
       model::offset::max(),
-      1,
       read_size,
       std::nullopt,
       std::nullopt,

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3104,7 +3104,6 @@ disk_log_impl::make_reader(timequery_config config) {
           local_log_reader_config config(
             start_offset,
             cfg.max_offset,
-            0,
             2048, // We just need one record batch
             cfg.type_filter,
             cfg.time,

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -88,7 +88,8 @@ private:
 
 class log_segment_batch_reader {
 public:
-    static constexpr size_t max_buffer_size = 32 * 1024; // 32KB
+    static constexpr size_t max_buffer_size
+      = local_log_reader_config::segment_reader_max_buffer_size;
 
     log_segment_batch_reader(
       segment&, local_log_reader_config& config, probe& p) noexcept;

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -200,7 +200,6 @@ TEST_F(log_builder_fixture, iterator_invalidation) {
     auto data_batches = b.consume(local_log_reader_config(
                                     model::offset(0),
                                     model::model_limits<model::offset>::max(),
-                                    0,
                                     std::numeric_limits<size_t>::max(),
                                     data,
                                     std::nullopt,
@@ -209,7 +208,6 @@ TEST_F(log_builder_fixture, iterator_invalidation) {
     auto config_batches = b.consume(local_log_reader_config(
                                       model::offset(0),
                                       model::model_limits<model::offset>::max(),
-                                      0,
                                       std::numeric_limits<size_t>::max(),
                                       configuration,
                                       std::nullopt,

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -85,7 +85,6 @@ TEST(reader_test, test_can_read_single_batch_same_offset) {
     storage::local_log_reader_config reader_config(
       model::offset(1),
       model::offset(1),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -104,7 +103,6 @@ TEST(reader_test, test_can_read_multiple_batches) {
     storage::local_log_reader_config reader_config(
       batches.front().base_offset(),
       batches.back().last_offset(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -122,7 +120,6 @@ TEST(reader_test, test_does_not_read_past_committed_offset_one_segment) {
     storage::local_log_reader_config reader_config(
       batches.back().last_offset() + model::offset(1),
       batches.back().last_offset() + model::offset(1),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -140,7 +137,6 @@ TEST(reader_test, test_does_not_read_past_committed_offset_multiple_segments) {
     storage::local_log_reader_config reader_config(
       batches.back().last_offset(),
       batches.back().last_offset(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -160,7 +156,6 @@ TEST(reader_test, test_does_not_read_past_max_bytes) {
     storage::local_log_reader_config reader_config(
       batches.front().base_offset(),
       batches.front().last_offset(),
-      0,
       static_cast<size_t>(batches.begin()->size_bytes()),
       std::nullopt,
       std::nullopt,
@@ -180,7 +175,6 @@ TEST(reader_test, test_reads_at_least_one_batch) {
     storage::local_log_reader_config reader_config(
       batches.front().base_offset(),
       batches.front().last_offset(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -200,7 +194,6 @@ TEST(reader_test, test_read_batch_range) {
     storage::local_log_reader_config reader_config(
       batches.front().base_offset(),
       batches.back().last_offset(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -227,7 +220,6 @@ TEST(reader_test, test_batch_type_filter) {
     storage::local_log_reader_config reader_config(
       batches.front().base_offset(),
       batches.back().last_offset(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -247,7 +239,6 @@ TEST(reader_test, test_batch_type_filter) {
         auto config = local_log_reader_config(
           batches.front().base_offset(),
           batches.back().last_offset(),
-          0,
           std::numeric_limits<size_t>::max(),
           type_filter,
           std::nullopt,
@@ -285,7 +276,6 @@ TEST(reader_test, test_does_not_read_past_max_offset) {
     storage::local_log_reader_config reader_config(
       batches.front().base_offset(),
       batches.back().last_offset(),
-      0,
       std::numeric_limits<size_t>::max(),
       std::nullopt,
       std::nullopt,
@@ -368,7 +358,6 @@ TEST(reader_test, test_ghost_read_with_index_overflow) {
     storage::local_log_reader_config reader_config(
       model::offset{100},
       model::offset::max(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,
@@ -419,7 +408,6 @@ TEST(reader_test, test_read_with_index_overflow_base) {
     storage::local_log_reader_config reader_config(
       s->offsets().get_base_offset(),
       model::offset::max(),
-      0,
       model::model_limits<model::offset>::max(),
       std::nullopt,
       std::nullopt,

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2108,7 +2108,6 @@ TEST_F(storage_test_fixture, reader_reusability_test_parser_header) {
     storage::local_log_reader_config reader_cfg(
       model::offset(0),
       model::model_limits<model::offset>::max(),
-      0,
       4096,
       std::nullopt,
       std::nullopt,
@@ -2324,7 +2323,6 @@ TEST_F(storage_test_fixture, disposing_in_use_reader) {
     storage::local_log_reader_config reader_cfg(
       model::offset(0),
       model::offset::max(),
-      0,
       4096,
       std::nullopt,
       std::nullopt,
@@ -2603,7 +2601,6 @@ TEST_F(storage_test_fixture, reader_prevents_log_shutdown) {
     storage::local_log_reader_config reader_cfg(
       model::offset(0),
       model::model_limits<model::offset>::max(),
-      0,
       std::numeric_limits<int64_t>::max(),
       std::nullopt,
       std::nullopt,
@@ -3347,7 +3344,6 @@ static storage::log_gap_analysis analyze(storage::log& log) {
     storage::local_log_reader_config reader_cfg(
       model::offset(0),
       model::model_limits<model::offset>::max(),
-      0,
       10_MiB,
       std::nullopt,
       std::nullopt,
@@ -4155,7 +4151,6 @@ TEST_F(storage_test_fixture, reader_reusability_max_bytes) {
             storage::local_log_reader_config reader_cfg(
               model::offset(0),
               model::model_limits<model::offset>::max(),
-              0,
               reader_max_bytes,
               std::nullopt,
               std::nullopt,

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -50,13 +50,12 @@ std::optional<kafka::offset> stm_manager::lowest_pinned_data_offset() const {
 fmt::iterator local_log_reader_config::format_to(fmt::iterator it) const {
     return fmt::format_to(
       it,
-      "start_offset:{}, max_offset:{}, min_bytes:{}, max_bytes:{}, "
+      "start_offset:{}, max_offset:{}, max_bytes:{}, "
       "strict_max_bytes:{}, type_filter: {}, first_timestamp:{}, "
       "bytes_consumed:{}, over_budget:{}, skip_batch_cache:{}, "
       "skip_readers_cache:{}, abortable:{}, client_address:{}",
       start_offset,
       max_offset,
-      min_bytes,
       max_bytes,
       strict_max_bytes,
       type_filter,

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -322,7 +322,6 @@ struct local_log_reader_config {
     local_log_reader_config(
       model::offset start_offset,
       model::offset max_offset,
-      size_t min_bytes,
       size_t max_bytes,
       std::optional<model::record_batch_type> type_filter,
       std::optional<model::timestamp> time,
@@ -331,7 +330,6 @@ struct local_log_reader_config {
       bool strict_max_bytes = false)
       : start_offset(start_offset)
       , max_offset(max_offset)
-      , min_bytes(min_bytes)
       , max_bytes(max_bytes)
       , type_filter(type_filter)
       , first_timestamp(time)
@@ -350,7 +348,6 @@ struct local_log_reader_config {
       : local_log_reader_config(
           start_offset,
           max_offset,
-          0,
           std::numeric_limits<size_t>::max(),
           std::nullopt,
           std::nullopt,
@@ -360,7 +357,6 @@ struct local_log_reader_config {
 
     model::offset start_offset;
     model::offset max_offset;
-    size_t min_bytes;
     size_t max_bytes;
 
     // Batch type to filter for (i.e specified type will be the only one

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/format_to.h"
+#include "base/units.h"
 #include "compaction/types.h"
 #include "container/chunked_vector.h"
 #include "model/fundamental.h"
@@ -417,6 +418,10 @@ struct local_log_reader_config {
     std::optional<ss::semaphore::clock::time_point> read_lock_deadline{};
 
     fmt::iterator format_to(fmt::iterator it) const;
+
+    // The amount of data accumulated when reading from a segment before
+    // returning results to the reader.
+    static constexpr size_t segment_reader_max_buffer_size{32_KiB};
 };
 
 // Empty, invalid reader config which is sometimes useful as a placeholder


### PR DESCRIPTION
* Remove unused reader configuration option
* Use context logger in CT L0 reader
* Expose buffer size as hint

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
