### PR TITLE
pandaproxy: relax client lock from mutex to rwlock

### DIFF
--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -15,6 +15,7 @@
 #include "ssx/future-util.h"
 
 #include <seastar/core/loop.hh>
+#include <seastar/core/rwlock.hh>
 
 #include <chrono>
 
@@ -61,7 +62,7 @@ client_ptr kafka_client_cache::make_client(
       to_yaml(cfg, config::redact_secrets::no));
 }
 
-std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
+std::pair<client_ptr, client_lock_ptr> kafka_client_cache::fetch_or_insert(
   credential_t user, config::rest_authn_method authn_method) {
     // This method does not need a gate or lock becase the entire function is
     // synchronous until the point that client clean up is called. Then
@@ -74,7 +75,7 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
     auto it_hash = inner_hash.find(k);
 
     client_ptr client;
-    client_mu_ptr client_mu;
+    client_lock_ptr client_lock;
 
     // When no client is found ...
     if (it_hash == inner_hash.end()) {
@@ -90,8 +91,8 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
         vlog(plog.debug, "Make client for user {}", k);
 
         client = make_client(user, authn_method);
-        client_mu = ss::make_lw_shared<mutex>("client_mu");
-        inner_list.emplace_front(k, client, client_mu);
+        client_lock = ss::make_lw_shared<ss::rwlock>();
+        inner_list.emplace_front(k, client, client_lock);
     } else {
         // If the passwords don't match, update the password on the client, so
         // that it can reconnect.
@@ -109,7 +110,7 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
         }
 
         client = it_hash->client;
-        client_mu = it_hash->client_mu;
+        client_lock = it_hash->client_lock;
 
         // Convert hash iterator to list iterator
         auto it_list = _cache.project<underlying_list>(it_hash);
@@ -122,7 +123,7 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
         inner_list.relocate(inner_list.begin(), it_list);
     }
 
-    return std::make_pair(client, client_mu);
+    return std::make_pair(client, client_lock);
 }
 
 template<typename List, typename Pred>
@@ -139,19 +140,16 @@ ss::future<> remove_client_if(List& list, Pred pred) {
         }
     }
     for (auto& item : remove) {
-        co_await item.client_mu
-          ->with([&item]() {
-              return item.client->stop().handle_exception(
-                [&item](std::exception_ptr ex) {
-                    // The stop failed
-                    vlog(
-                      plog.debug,
-                      "Stale client {} stop already happened {}",
-                      item.key,
-                      ex);
-                });
-          })
-          .finally([client{item.client}]() {});
+        auto holder = co_await item.client_lock->hold_write_lock();
+        co_await item.client->stop().handle_exception(
+          [&item](std::exception_ptr ex) {
+              // The stop failed
+              vlog(
+                plog.debug,
+                "Stale client {} stop already happened {}",
+                item.key,
+                ex);
+          });
     }
 }
 

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -60,9 +60,9 @@ public:
       = ss::futurize<std::invoke_result_t<Func, kafka::client::client&>>>
     typename Futurator::type with_client_for(
       credential_t user, config::rest_authn_method authn_method, Func&& func) {
-        auto [client, client_mu] = fetch_or_insert(
+        auto [client, client_lock] = fetch_or_insert(
           std::move(user), authn_method);
-        auto units = co_await client_mu->get_units();
+        auto units = co_await client_lock->hold_read_lock();
         co_return co_await Futurator::invoke(std::forward<Func>(func), *client);
     }
 
@@ -72,7 +72,7 @@ public:
     size_t max_size() const;
 
 protected:
-    std::pair<client_ptr, client_mu_ptr>
+    std::pair<client_ptr, client_lock_ptr>
     fetch_or_insert(credential_t user, config::rest_authn_method authn_method);
 
 private:

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -183,7 +183,7 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
 
     auto topic = parse::request_param<model::topic>(*rq.req, "topic_name");
 
-    vlog(plog.debug, "get_topics_name: topic: {}", topic);
+    vlog(plog.debug, "post_topics_name: topic: {}", topic);
 
     auto records = co_await rjson_parse(
       *rq.req, ppj::produce_request_handler(req_fmt));

--- a/src/v/pandaproxy/test/kafka_client_cache.cc
+++ b/src/v/pandaproxy/test/kafka_client_cache.cc
@@ -31,7 +31,7 @@ using namespace std::chrono_literals;
 static constexpr auto clean_timer_period = 10s;
 
 namespace pandaproxy {
-using cache_item = std::pair<client_ptr, client_mu_ptr>;
+using cache_item = std::pair<client_ptr, client_lock_ptr>;
 
 struct test_client_cache : public kafka_client_cache {
     explicit test_client_cache(size_t max_size)

--- a/src/v/pandaproxy/types.h
+++ b/src/v/pandaproxy/types.h
@@ -14,6 +14,7 @@
 #include "utils/mutex.h"
 
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/rwlock.hh>
 #include <seastar/core/shared_ptr.hh>
 
 namespace pandaproxy {
@@ -22,7 +23,7 @@ using client_ptr = ss::lw_shared_ptr<kafka::client::client>;
 // Mutex as a shared_ptr because the internal semaphore has a deleted
 // copy-constructor and dereferencing the "timestamped_user" calls the
 // copy-constructor
-using client_mu_ptr = ss::lw_shared_ptr<mutex>;
+using client_lock_ptr = ss::lw_shared_ptr<ss::rwlock>;
 
 struct timestamped_user {
     using clock = ss::lowres_clock;
@@ -31,20 +32,20 @@ struct timestamped_user {
     ss::sstring key;
     client_ptr client;
     time_point last_used;
-    client_mu_ptr client_mu;
+    client_lock_ptr client_lock;
 
     timestamped_user(
-      ss::sstring k, client_ptr c, time_point t, client_mu_ptr mu)
+      ss::sstring k, client_ptr c, time_point t, client_lock_ptr lock)
       : key{std::move(k)}
       , client{std::move(c)}
       , last_used{t}
-      , client_mu{mu} {}
+      , client_lock{std::move(lock)} {}
 
-    timestamped_user(ss::sstring k, client_ptr c, client_mu_ptr mu)
+    timestamped_user(ss::sstring k, client_ptr c, client_lock_ptr lock)
       : key{std::move(k)}
       , client{std::move(c)}
       , last_used{clock::now()}
-      , client_mu{mu} {}
+      , client_lock{std::move(lock)} {}
 };
 
 struct credential_t {


### PR DESCRIPTION
This client_lock is only used for coordinating the stopping of clients. It is sufficient for this to be a read write lock instead of a mutex, since that still keeps the stopping coordination safe, but allows for multiple concurrent requests on the request handling path.

This mutex currently limits pandaproxy performance to 1 in flight request / user when http basic authentication is used. Turning the mutex into a rwlock should significantly improve parallelism in this case.

https://github.com/redpanda-data/redpanda/blob/a4081eb2e81d1091f61aef0e3668c8797de9067d/src/v/pandaproxy/server.h#L220-L233

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes

### Improvements

* Pandaproxy: Allow more parallel requests per user when HTTP basic authentication is enabled

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
