### PR TITLE
kafka/server: use truncating logger for `log_request`

### DIFF
--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -73,7 +73,7 @@ struct handler_template {
     static void log_request(
       const request_header& header, const typename api::request_type& request) {
         vlog(
-          klog.trace,
+          kwire.trace,
           "[client_id: {}] handling {} v{} request {}",
           header.client_id,
           api::name,


### PR DESCRIPTION
We've seen oversized allocations at high topic or partition counts for certain APIs.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Prevent oversized allocations when the kafka logger is at trace level
