### PR TITLE
iceberg: fix UB in json serialization

### DIFF
--- a/src/v/iceberg/values_json.cc
+++ b/src/v/iceberg/values_json.cc
@@ -521,9 +521,12 @@ struct rjson_visitor {
           fmt::format(
             "{}{}.{}",
             is_neg ? "-" : "",
-            std::string_view{&integral_part.front(), integral_part.size()},
             std::string_view{
-              &fractional_part.front(), fractional_part.size()}));
+              integral_part.empty() ? nullptr : &integral_part.front(),
+              integral_part.size()},
+            std::string_view{
+              fractional_part.empty() ? nullptr : &fractional_part.front(),
+              fractional_part.size()}));
     }
 
     void operator()(


### PR DESCRIPTION
It's UB to call `front` when a range is `empty`. Found in https://github.com/redpanda-data/redpanda/pull/27696

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
