### PR TITLE
Fixed `kafka::batch_reader` undefined behavior

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -150,6 +150,7 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
           "size of a header preamble (base offset and size_bytes), (current "
           "buffer size: {})",
           kbatch.size_bytes());
+        short_read = true;
         return iobuf{};
     }
     auto batch_length =

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -144,7 +144,12 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
         + sizeof(model::record_batch_header::size_bytes);
 
     if (unlikely(kbatch.size_bytes() < kafka_length_diff)) {
-        vlog(klog.error, "kbatch is unexpectedly small");
+        vlog(
+          klog.warn,
+          "unable to parse kafka batch, size of the buffer is smaller than the "
+          "size of a header preamble (base offset and size_bytes), (current "
+          "buffer size: {})",
+          kbatch.size_bytes());
         return iobuf{};
     }
     auto batch_length =

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -62,9 +62,11 @@ inline constexpr size_t kafka_header_size = sizeof(int64_t) + // base offset
 class kafka_batch_adapter {
 public:
     iobuf adapt(iobuf&&);
-
-    bool v2_format;
-    bool valid_crc;
+    /**
+     * Default to false, the values are set after calling adapt().
+     */
+    bool v2_format{false};
+    bool valid_crc{false};
     bool legacy_error{false};
     bool short_read{false};
 

--- a/src/v/kafka/protocol/tests/batch_reader_test.cc
+++ b/src/v/kafka/protocol/tests/batch_reader_test.cc
@@ -271,6 +271,57 @@ SEASTAR_THREAD_TEST_CASE(batch_reader_truncated_last_batch) {
       truncated_batches.back().base_offset());
 }
 
+SEASTAR_THREAD_TEST_CASE(
+  batch_reader_truncated_last_batch_varying_truncation_point) {
+    auto ctx = make_context(base_offset, many_batches);
+    // truncate the last batch
+
+    const auto all_batches
+      = model::consume_reader_to_memory(
+          model::make_record_batch_reader<kafka::batch_reader>(
+            ctx.record_set.copy()),
+          model::no_timeout)
+          .get();
+    for (size_t i = 1; i < model::packed_record_batch_header_size + 10; ++i) {
+        const auto last_batch_sz = all_batches.back().header().size_bytes;
+        auto truncated_buffer = ctx.record_set.copy().share(
+          0, ctx.record_set.size_bytes() - last_batch_sz + i);
+        auto non_tolerating_reader
+          = model::make_record_batch_reader<kafka::batch_reader>(
+            truncated_buffer.copy());
+        // reader is expected to fail on truncated batch, as the flag was not
+        // set to tolerate the truncation
+        BOOST_REQUIRE_EXCEPTION(
+          model::consume_reader_to_memory(
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            std::move(non_tolerating_reader),
+            model::no_timeout)
+            .get(),
+          kafka::exception,
+          [](const kafka::exception& e) {
+              return e.error == kafka::error_code::corrupt_message;
+          });
+
+        auto tolerating_reader
+          = model::make_record_batch_reader<kafka::batch_reader>(
+            truncated_buffer.copy(),
+            kafka::batch_reader::tolerate_partial_last_batch::yes);
+
+        auto truncated_batches = model::consume_reader_to_memory(
+                                   std::move(tolerating_reader),
+                                   model::no_timeout)
+                                   .get();
+
+        /**
+         * Validate that indeed the last batch was truncated.
+         */
+        BOOST_REQUIRE_EQUAL(truncated_batches.size(), all_batches.size() - 1);
+        BOOST_REQUIRE_EQUAL(
+          std::next(all_batches.rbegin())->base_offset(),
+          truncated_batches.back().base_offset());
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(batch_reader_truncated_batch_in_the_middle) {
     /** make some batches */
     auto input = model::test::make_random_batches(base_offset, 10).get();


### PR DESCRIPTION
Previously when a batch buffer was shorter than the size of two fields indicating the base offset and batch the `short_read` flag wasn't set. This lead to a situation in which a reader continued and accessed
not initialised booleans triggering undefined behavior sanitiser. Now that the flag is correctly set and boolean flags are recognised the reader will correctly return an error or ignore partial batch if it is configured to do so.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none