### PR TITLE
gh/workflows: trigger installpack bump when needed

### DIFF
--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -1,5 +1,5 @@
 ---
-name: check formatting
+name: Trigger redpanda install-pack bump
 on:
   release:
     types: [published]

--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -3,12 +3,33 @@ name: Trigger redpanda install-pack bump
 on:
   release:
     types: [published]
+permissions:
+  id-token: write
+  contents: read
 jobs:
-  trigger-bump:
+  check-version:
+    outputs:
+      is_supported: ${{ steps.check_version.outputs.is_supported }}
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
+    steps:
+      - name: Checkout redpanda dev
+        uses: actions/checkout@v5
+        with:
+          ref: 'dev'
+      - name: Check if version is supported in cloud
+        id: check_version
+        run: |
+          set -eo pipefail
+          supported_ga=$(git tag --list | grep '^v.*' | grep -v '\-dev' | grep -v '\-rc' | awk -F. '{print $1 "." $2}' | sort | uniq | tail -2)
+          if grep "$supported" <<< "${{ github.ref_name }}" ; then
+            echo "is_supported=true" >>$GITHUB_OUTPUT
+          else
+            echo "is_supported=false" >>$GITHUB_OUTPUT
+          fi
+  trigger-bump:
+    needs: check-version
+    runs-on: ubuntu-latest
+    if: needs.check-version.outputs.is_supported == 'true'
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Cloud supports the latest 2 versions of redpanda. CI should not trigger
redpanda version bump if the tagged version does not match the supported
by cloud versions

jira: [DEVPROD-2393]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[DEVPROD-2393]: https://redpandadata.atlassian.net/browse/DEVPROD-2393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ