### PR TITLE
gh/workflows: fix name of installpack trigger

### DIFF
--- a/.github/workflows/cloud-installpack-bk-trigger.yml
+++ b/.github/workflows/cloud-installpack-bk-trigger.yml
@@ -1,5 +1,5 @@
 ---
-name: check formatting
+name: cloud-installpack-bk-trigger
 on:
   release:
     types: [published]


### PR DESCRIPTION
Fix the name of gh action that triggers install-pack bump

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

jira: [DEVPROD-2393]

## Release Notes

* none


[DEVPROD-2393]: https://redpandadata.atlassian.net/browse/DEVPROD-2393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ