### PR TITLE
[v25.1.x] kafka/server: use truncating logger for `log_request`

### DIFF
--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -73,7 +73,7 @@ struct handler_template {
     static void log_request(
       const request_header& header, const typename api::request_type& request) {
         vlog(
-          klog.trace,
+          kwire.trace,
           "[client_id: {}] handling {} v{} request {}",
           header.client_id,
           api::name,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27806
