### PR TITLE
datalake: move lag metrics to public metrics

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -14,7 +14,6 @@
 #include "config/configuration.h"
 #include "metrics/metrics.h"
 #include "metrics/prometheus_sanitize.h"
-#include "model/metadata.h"
 #include "pandaproxy/schema_registry/schema_id_validation.h"
 
 #include <seastar/core/metrics.hh>
@@ -23,8 +22,6 @@ namespace cluster {
 
 static const ss::sstring cluster_metrics_name
   = prometheus_sanitize::metrics_name("cluster:partition");
-
-static constexpr int64_t follower_iceberg_lag_metric = 0;
 
 replicated_partition_probe::replicated_partition_probe(
   const partition& p) noexcept
@@ -50,16 +47,6 @@ void replicated_partition_probe::clear_metrics() {
 void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
     setup_internal_metrics(ntp);
     setup_public_metrics(ntp);
-}
-
-int64_t replicated_partition_probe::iceberg_translation_offset_lag() const {
-    return _partition.is_leader() ? _iceberg_translation_offset_lag
-                                  : follower_iceberg_lag_metric;
-}
-
-int64_t replicated_partition_probe::iceberg_commit_offset_lag() const {
-    return _partition.is_leader() ? _iceberg_commit_offset_lag
-                                  : follower_iceberg_lag_metric;
 }
 
 void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
@@ -186,47 +173,6 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
       },
       {},
       {sm::shard_label, metrics::partition_label});
-
-    if (model::is_user_topic(_partition.ntp())) {
-        // Metrics are reported as follows
-        // -2 (default initialized state)
-        // -1 (iceberg disabled state)
-        //  0 (iceberg enabled but follower replicas)
-        // <actual lag> leader replicas
-        _metrics.add_group(
-          cluster_metrics_name,
-          {
-            sm::make_gauge(
-              "iceberg_offsets_pending_translation",
-              [this] {
-                  return _partition.log()->config().iceberg_enabled()
-                           ? iceberg_translation_offset_lag()
-                           : metric_feature_disabled_state;
-              },
-              sm::description(
-                "Total number of offsets that are pending "
-                "translation to iceberg. Lag is reported only on leader "
-                "replicas while followers report 0. -1 is reported if iceberg "
-                "is disabled while -2 indicates the lag is "
-                "not yet computed."),
-              labels),
-            sm::make_gauge(
-              "iceberg_offsets_pending_commit",
-              [this] {
-                  return _partition.log()->config().iceberg_enabled()
-                           ? iceberg_commit_offset_lag()
-                           : metric_feature_disabled_state;
-              },
-              sm::description(
-                "Total number of offsets that are pending "
-                "commit to iceberg catalog.  Lag is reported only on leader "
-                "while followers report 0. -1 is reported if iceberg is "
-                "disabled while -2 indicates the lag is not yet computed."),
-              labels),
-          },
-          {},
-          {sm::shard_label, metrics::partition_label});
-    }
 
     if (
       config::shard_local_cfg().enable_schema_id_validation()
@@ -372,7 +318,6 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
               .aggregate({sm::shard_label, partition_label}),
           });
     }
-
     setup_public_scrubber_metric(ntp);
 }
 

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -33,8 +33,6 @@ public:
         virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void add_bytes_fetched_from_follower(uint64_t) = 0;
         virtual void add_schema_id_validation_failed() = 0;
-        virtual void update_iceberg_translation_offset_lag(int64_t) = 0;
-        virtual void update_iceberg_commit_offset_lag(int64_t) = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual void clear_metrics() = 0;
         virtual ~impl() noexcept = default;
@@ -74,14 +72,6 @@ public:
         _impl->add_schema_id_validation_failed();
     }
 
-    void update_iceberg_translation_offset_lag(int64_t new_lag) {
-        _impl->update_iceberg_translation_offset_lag(new_lag);
-    }
-
-    void update_iceberg_commit_offset_lag(int64_t new_lag) {
-        _impl->update_iceberg_commit_offset_lag(new_lag);
-    }
-
     void clear_metrics() { _impl->clear_metrics(); }
 
 private:
@@ -105,19 +95,9 @@ public:
         ++_schema_id_validation_records_failed;
     };
 
-    void update_iceberg_translation_offset_lag(int64_t new_lag) final {
-        _iceberg_translation_offset_lag = new_lag;
-    }
-
-    void update_iceberg_commit_offset_lag(int64_t new_lag) final {
-        _iceberg_commit_offset_lag = new_lag;
-    }
-
     void clear_metrics() final;
 
 private:
-    int64_t iceberg_translation_offset_lag() const;
-    int64_t iceberg_commit_offset_lag() const;
     void reconfigure_metrics();
     void setup_public_metrics(const model::ntp&);
     void setup_internal_metrics(const model::ntp&);
@@ -135,8 +115,6 @@ private:
     uint64_t _bytes_fetched{0};
     uint64_t _bytes_fetched_from_follower{0};
     uint64_t _schema_id_validation_records_failed{0};
-    int64_t _iceberg_translation_offset_lag{metric_default_initialized_state};
-    int64_t _iceberg_commit_offset_lag{metric_default_initialized_state};
     config::binding<bool> _enable_scrubbing_bind;
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -409,33 +409,6 @@ public:
           new_offset, translation_timestamp, term, timeout, as);
     }
 
-    void update_commit_lag(
-      std::optional<kafka::offset> max_committed_kafka_offset) const final {
-        auto max_translatable_offset = max_offset_for_translation();
-        if (
-          !max_translatable_offset
-          || max_translatable_offset.value() < kafka::offset{0}) {
-            return;
-        }
-        auto offset_lag = max_translatable_offset.value()
-                          - max_committed_kafka_offset.value_or(
-                            kafka::offset{-1});
-        _partition->probe().update_iceberg_commit_offset_lag(offset_lag);
-    }
-
-    void
-    update_translation_lag(kafka::offset max_translated_offset) const final {
-        auto max_translatable_offset = max_offset_for_translation();
-        if (
-          !max_translatable_offset
-          || max_translatable_offset.value() < kafka::offset{0}) {
-            return;
-        }
-        auto offset_lag = max_translatable_offset.value()
-                          - std::max(max_translated_offset, kafka::offset{-1});
-        _partition->probe().update_iceberg_translation_offset_lag(offset_lag);
-    }
-
 private:
     bool has_more_data_to_translate(
       std::optional<kafka::offset> last_translated_offset) {
@@ -630,6 +603,14 @@ public:
     }
 
     size_t buffered_bytes() const final { return _mem_tracker.current_usage(); }
+
+    void report_translation_lag(int64_t new_lag) final {
+        _probe->update_translation_offset_lag(new_lag);
+    }
+
+    void report_commit_lag(int64_t new_lag) final {
+        _probe->update_commit_offset_lag(new_lag);
+    }
 
 private:
     scheduling::clock::duration compute_target_lag() const {

--- a/src/v/datalake/translation/deps.h
+++ b/src/v/datalake/translation/deps.h
@@ -201,14 +201,6 @@ public:
       ss::abort_source&)
       = 0;
 
-    virtual void update_commit_lag(
-      std::optional<kafka::offset> max_committed_kafka_offset) const
-      = 0;
-
-    virtual void
-    update_translation_lag(kafka::offset max_translated_kafka_offset) const
-      = 0;
-
     static std::unique_ptr<data_source>
       make_default_data_source(ss::lw_shared_ptr<cluster::partition>);
 };
@@ -279,6 +271,12 @@ public:
      *  Returns the number of bytes buffered for the parquet file in memory
      */
     virtual size_t buffered_bytes() const = 0;
+
+    // Report and update the lag of data that has yet to be translated.
+    virtual void report_translation_lag(int64_t new_lag) = 0;
+
+    // Report and update the lag of data that has yet to be committed.
+    virtual void report_commit_lag(int64_t new_lag) = 0;
 
     static std::unique_ptr<translation_context>
     make_default_translation_context(

--- a/src/v/datalake/translation/partition_translator.cc
+++ b/src/v/datalake/translation/partition_translator.cc
@@ -158,7 +158,14 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
     // if we reach this point before the most recent batch of files has
     // been committed, the commit lag metric will be out of sync at
     // least until 'wait_for_data' returns and we re-enter the loop.
-    _data_source->update_commit_lag(last_committed_offset);
+    auto max_translatable_offset = _data_source->max_offset_for_translation();
+    if (
+      max_translatable_offset.value_or(kafka::offset::min())
+      >= kafka::offset{0}) {
+        int64_t lag = max_translatable_offset.value()
+                      - last_committed_offset.value_or(kafka::offset{-1});
+        _translation_ctx->report_commit_lag(lag);
+    }
 
     auto next_start_offset = result.last_added_offset
                                ? kafka::next_offset(*result.last_added_offset)
@@ -202,7 +209,13 @@ partition_translator::fetch_translation_offsets(retry_chain_node& rcn) {
     if (
       !current_translation_lto || checkpointed_lto > current_translation_lto) {
         _lag_tracking->notify_data_translated(checkpointed_lto);
-        _data_source->update_translation_lag(checkpointed_lto);
+        if (
+          max_translatable_offset.value_or(kafka::offset::min())
+          >= kafka::offset{0}) {
+            int64_t lag = max_translatable_offset.value()
+                          - std::max(checkpointed_lto, kafka::offset{-1});
+            _translation_ctx->report_translation_lag(lag);
+        }
         current_translation_lto = checkpointed_lto;
     }
 

--- a/src/v/datalake/translation/tests/partition_translator_tests.cc
+++ b/src/v/datalake/translation/tests/partition_translator_tests.cc
@@ -204,9 +204,6 @@ public:
         co_return std::make_error_code(std::errc());
     }
 
-    void update_commit_lag(std::optional<kafka::offset>) const final {}
-    void update_translation_lag(kafka::offset) const final {}
-
 private:
     fake_test_ctx& _test_ctx;
 };
@@ -338,6 +335,10 @@ public:
     }
 
     size_t buffered_bytes() const final { return _buffered_bytes; }
+
+    void report_translation_lag(int64_t) final {}
+
+    void report_commit_lag(int64_t) final {}
 
 private:
     size_t _translated_bytes{0};

--- a/src/v/datalake/translation/translation_probe.cc
+++ b/src/v/datalake/translation/translation_probe.cc
@@ -32,7 +32,42 @@ translation_probe::translation_probe(model::ntp ntp)
         register_created_files_metrics();
         register_invalid_record_metric();
         register_throughput_metrics();
+        register_lag_metrics();
     }
+}
+
+void translation_probe::register_lag_metrics() {
+    namespace sm = ss::metrics;
+    std::vector<sm::label_instance> labels{
+      namespace_label(_ntp.ns()),
+      topic_label(_ntp.tp.topic()),
+      partition_label(_ntp.tp.partition()),
+    };
+    _public_metrics->add_group(
+      prometheus_sanitize::metrics_name("iceberg"),
+      {
+        sm::make_gauge(
+          "pending_translation_lag",
+          _translation_offset_lag,
+          sm::description(
+            "Total number of offsets that are pending translation to iceberg."),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+        sm::make_gauge(
+          "pending_commit_lag",
+          _commit_offset_lag,
+          sm::description(
+            "Total number of offsets that are pending commit to iceberg "
+            "catalog."),
+          labels)
+          .aggregate({
+            sm::shard_label,
+            partition_label,
+          }),
+      });
 }
 
 void translation_probe::register_created_files_metrics() {

--- a/src/v/datalake/translation/translation_probe.h
+++ b/src/v/datalake/translation/translation_probe.h
@@ -65,14 +65,27 @@ public:
         }
     }
 
+    void update_translation_offset_lag(int64_t new_lag) {
+        _translation_offset_lag = new_lag;
+    }
+
+    void update_commit_offset_lag(int64_t new_lag) {
+        _commit_offset_lag = new_lag;
+    }
+
 private:
     void register_created_files_metrics();
     void register_invalid_record_metric();
     void register_throughput_metrics();
+    void register_lag_metrics();
 
 private:
     model::ntp _ntp;
     std::optional<metrics::public_metric_groups> _public_metrics;
+
+    // Lag metrics
+    int64_t _translation_offset_lag = 0;
+    int64_t _commit_offset_lag = 0;
 
     size_t _translations_finished = 0;
     size_t _files_created = 0;

--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -1392,8 +1392,8 @@ message_type {
 
 
 class DatalakeMetricsTest(RedpandaTest):
-    commit_lag = "vectorized_cluster_partition_iceberg_offsets_pending_commit"
-    translation_lag = "vectorized_cluster_partition_iceberg_offsets_pending_translation"
+    commit_lag = "redpanda_iceberg_pending_commit_lag"
+    translation_lag = "redpanda_iceberg_pending_translation_lag"
 
     def __init__(self, test_ctx, *args, **kwargs):
         super(DatalakeMetricsTest, self).__init__(
@@ -1453,11 +1453,11 @@ class DatalakeMetricsTest(RedpandaTest):
                 topic_leader,
                 [DatalakeMetricsTest.commit_lag, DatalakeMetricsTest.translation_lag],
                 labels={
-                    "namespace": "kafka",
-                    "topic": self.topic_name,
-                    "partition": "0",
+                    "redpanda_namespace": "kafka",
+                    "redpanda_topic": self.topic_name,
                 },
                 reduce=sum,
+                metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
             )
 
             # Wait for lag build up

--- a/tests/rptest/tests/datalake/disk_usage_test.py
+++ b/tests/rptest/tests/datalake/disk_usage_test.py
@@ -6,6 +6,7 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+from rptest.services.redpanda import MetricsEndpoint
 import threading
 import time
 
@@ -114,8 +115,12 @@ class DatalakeDiskUsageTest(RedpandaTest):
         return current_size
 
     def translation_lag(self):
-        metric_name = "vectorized_cluster_partition_iceberg_offsets_pending_translation"
-        return self.redpanda.metric_sum(metric_name, expect_metric=True)
+        metric_name = "redpanda_iceberg_pending_translation_lag"
+        return self.redpanda.metric_sum(
+            metric_name,
+            metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
+            expect_metric=True,
+        )
 
     @cluster(num_nodes=2)
     @skip_debug_mode


### PR DESCRIPTION
As part of this we also use the translation probe for these metrics so
it's isolated to the datalake subsystem instead of defining it in the
partition probe for the cluster (the grouping there doesn't make sense).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Add public metrics for lag in Iceberg Topics
