### PR TITLE
model: add record batch reader coroutine generator

### DIFF
--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -19,9 +19,11 @@
 #include "model/timeout_clock.h"
 
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/coroutine/generator.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/optimized_optional.hh>
 #include <seastar/util/variant_utils.hh>
@@ -109,6 +111,38 @@ public:
             return ss::do_with(std::move(c), [this, tm](ReferenceConsumer& c) {
                 return do_peek_each_ref(c, tm);
             });
+        }
+
+        static seastar::coroutine::experimental::generator<model::record_batch>
+        generator(
+          std::unique_ptr<impl> impl, timeout_clock::time_point timeout) {
+            std::exception_ptr eptr;
+            try {
+                while (true) {
+                    if (!impl->is_slice_empty()) {
+                        co_yield impl->pop_batch();
+                        continue;
+                    }
+                    if (impl->is_end_of_stream()) {
+                        break;
+                    }
+                    co_await impl->load_slice(timeout);
+                }
+            } catch (...) {
+                eptr = std::current_exception();
+            }
+            try {
+                co_await impl->finally();
+            } catch (...) {
+                if (eptr) {
+                    throw seastar::nested_exception(
+                      eptr, std::current_exception());
+                }
+                throw;
+            }
+            if (eptr) {
+                std::rethrow_exception(eptr);
+            }
         }
 
     private:
@@ -294,6 +328,21 @@ public:
     auto peek_each_ref(
       ReferenceConsumer consumer, timeout_clock::time_point timeout) & {
         return _impl->peek_each_ref(std::move(consumer), timeout);
+    }
+
+    /*
+     * Create a coroutine generator from the reader.
+     *
+     *    auto gen = std::move(reader).generator();
+     *    while (std::optional<model::record_batch> batch = co_await gen()) {
+     *        ...
+     *    }
+     *
+     * When end of stream is reached std::nullopt will be returned.
+     */
+    seastar::coroutine::experimental::generator<model::record_batch>
+    generator(timeout_clock::time_point timeout) && {
+        return impl::generator(std::move(_impl), timeout);
     }
 
     std::unique_ptr<impl> release() && { return std::move(_impl); }

--- a/src/v/model/tests/BUILD
+++ b/src/v/model/tests/BUILD
@@ -240,3 +240,16 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "record_batch_reader_gtest",
+    timeout = "short",
+    srcs = ["record_batch_reader_gtest.cc"],
+    cpu = 1,
+    deps = [
+        ":random",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/model/tests/record_batch_reader_gtest.cc
+++ b/src/v/model/tests/record_batch_reader_gtest.cc
@@ -1,0 +1,59 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "test_utils/test.h"
+
+template<typename... Offsets>
+chunked_circular_buffer<model::record_batch> make_batches(Offsets... o) {
+    chunked_circular_buffer<model::record_batch> batches;
+    (batches.emplace_back(
+       model::test::make_random_batch(model::offset(o), 1, true)),
+     ...);
+    return batches;
+}
+
+template<typename Container>
+auto copy_batches(const Container& batches) {
+    Container copy;
+    for (auto& batch : batches) {
+        copy.push_back(batch.copy());
+    }
+    return copy;
+}
+
+TEST_CORO(RecordBatchReaderGenerator, EmptyReader) {
+    auto reader = model::make_empty_record_batch_reader();
+    auto gen = std::move(reader).generator(model::no_timeout);
+    while (auto batch = co_await gen()) {
+        ASSERT_TRUE_CORO(false) << "No batches expected";
+    }
+}
+
+TEST_CORO(RecordBatchReaderGenerator, SmallSetMemory) {
+    auto batches = make_batches(1, 2, 3, 4);
+    auto r0 = make_memory_record_batch_reader(copy_batches(batches));
+    auto r1 = make_memory_record_batch_reader(std::move(batches));
+
+    auto r0_materialized = co_await model::consume_reader_to_chunked_vector(
+      std::move(r0), model::no_timeout);
+
+    chunked_vector<model::record_batch> r1_materialized;
+    auto gen = std::move(r1).generator(model::no_timeout);
+    while (auto batch = co_await gen()) {
+        r1_materialized.push_back(std::move(batch.value()));
+    }
+
+    ASSERT_EQ_CORO(r0_materialized.size(), 4);
+    ASSERT_EQ_CORO(r1_materialized.size(), r0_materialized.size());
+    for (int i = 0; i < 4; ++i) {
+        ASSERT_EQ_CORO(r1_materialized[i], r0_materialized[i]);
+    }
+}


### PR DESCRIPTION
Usage:

```
   auto gen = std::move(reader).generator();
   while (std::optional<model::record_batch> batch = co_await gen()) {
       ...
   }
```

When end of stream is reached std::nullopt will be returned.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
