### PR TITLE
openapi - buf generate read from local files

### DIFF
--- a/buf.gen.openapi.yaml
+++ b/buf.gen.openapi.yaml
@@ -1,9 +1,10 @@
 version: v2
 inputs:
-  - module: buf.build/redpandadata/core
+  - directory: .
+    paths:
+      - proto
     exclude_paths:
       - proto/redpanda/pbgen
-      - redpanda/pbgen
 
 plugins:
   - remote: buf.build/community/sudorandom-connect-openapi:v0.21.2


### PR DESCRIPTION
This pull request makes a small configuration change to the `buf.gen.openapi.yaml` file to update how input sources are specified.

* The `inputs` field now uses the local directory (`.`) instead of referencing the external module `buf.build/redpandadata/core`, allowing `buf generate` to generate OpenAPI spec files based on changes in the local directory. This makes it easier to inspect and compare how changes in the .protos get rendered in the API specs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None