### PR TITLE
ct: L0 reader metadata fetch improvements

### DIFF
--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -24,9 +24,6 @@
 
 namespace cloud_topics {
 
-// TODO: add config
-static constexpr size_t L0_max_bytes_per_metadata_fetch = 4_KiB;
-
 level_zero_log_reader_impl::level_zero_log_reader_impl(
   cloud_topic_log_reader_config& cfg,
   ss::lw_shared_ptr<cluster::partition> ctp,
@@ -157,10 +154,28 @@ storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
       kafka::offset_cast(_config.start_offset));
     auto max_offset = ot_state->to_log_offset(
       kafka::offset_cast(_config.max_offset));
+
+    /*
+     * Used to set max_bytes on the log reader for the L0 CTP. Placeholder
+     * batches in the CTP lack a payload, so a few small batches may materialize
+     * into a large read. For example, a placeholder batch is roughly 110 bytes.
+     * If the maximum read size is set to 4K, then ~40 batches will be returned
+     * per read. If each materialized batch is 1 MB then the reader will be able
+     * to stream 40 MB without performing another read from the CTP. The default
+     * Kafka fetch size is 64 MB, so it is useful to read more than 4K.
+     *
+     * Default to the size of the segment reader buffer (32 KiB at the time of
+     * writing). This is a small size used across all existing workloads, and
+     * for cloud topics it provides plenty of metadata to drive large scans when
+     * materialized batches are big.
+     */
+    const auto ctp_reader_max_bytes
+      = storage::local_log_reader_config::segment_reader_max_buffer_size;
+
     storage::local_log_reader_config cfg(
       start_offset,
       max_offset,
-      _config.max_bytes,
+      ctp_reader_max_bytes,
       // We need to fetch both raft data batches for transaction control
       // markers as well as placeholder batches to hydrate from object
       // storage, so we don't include a typefilter and instead postfilter
@@ -169,16 +184,11 @@ storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
       _config.first_timestamp,
       _config.abort_source,
       _config.client_address);
+
+    // The cloud topics reader (user of this log reader) operates in kafka
+    // offset space so this automatic translation saves a few steps.
     cfg.translate_offsets = model::translate_offsets::yes;
-    // This parameter defines how many bytes we want to fetch
-    // from the underlying partition in one go.
-    // The L0 meta batches are small, so we can fetch a lot of them in a
-    // single request and then gradually materialize them.
-    // The 'cfg.max_bytes' doesn't limit the size of the materialized
-    // batches, because it is fetching L0 meta batches, which have different
-    // size. In order to know the size of the materialized batches we need
-    // to fetch L0 meta batches first and then parse them.
-    cfg.max_bytes = L0_max_bytes_per_metadata_fetch;
+
     return cfg;
 }
 

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -146,6 +146,42 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
     return std::nullopt;
 }
 
+storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
+    /*
+     * The requested offset range in the cloud topic reader configuration are
+     * specified as offsets in the kafka adddress space and need to first be
+     * converted into physical log offsets for log reader configuration.
+     */
+    auto ot_state = _ctp->get_offset_translator_state();
+    auto start_offset = ot_state->to_log_offset(
+      kafka::offset_cast(_config.start_offset));
+    auto max_offset = ot_state->to_log_offset(
+      kafka::offset_cast(_config.max_offset));
+    storage::local_log_reader_config cfg(
+      start_offset,
+      max_offset,
+      _config.max_bytes,
+      // We need to fetch both raft data batches for transaction control
+      // markers as well as placeholder batches to hydrate from object
+      // storage, so we don't include a typefilter and instead postfilter
+      // here.
+      /*type_filter=*/std::nullopt,
+      _config.first_timestamp,
+      _config.abort_source,
+      _config.client_address);
+    cfg.translate_offsets = model::translate_offsets::yes;
+    // This parameter defines how many bytes we want to fetch
+    // from the underlying partition in one go.
+    // The L0 meta batches are small, so we can fetch a lot of them in a
+    // single request and then gradually materialize them.
+    // The 'cfg.max_bytes' doesn't limit the size of the materialized
+    // batches, because it is fetching L0 meta batches, which have different
+    // size. In order to know the size of the materialized batches we need
+    // to fetch L0 meta batches first and then parse them.
+    cfg.max_bytes = L0_max_bytes_per_metadata_fetch;
+    return cfg;
+}
+
 ss::future<> level_zero_log_reader_impl::fetch_metadata(
   model::timeout_clock::time_point deadline) {
     vassert(
@@ -158,35 +194,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
         co_return;
     }
     try {
-        // Fetch metadata from the _ctp
-        auto ot_state = _ctp->get_offset_translator_state();
-        auto start_offset = ot_state->to_log_offset(
-          kafka::offset_cast(_config.start_offset));
-        auto max_offset = ot_state->to_log_offset(
-          kafka::offset_cast(_config.max_offset));
-        storage::local_log_reader_config cfg(
-          start_offset,
-          max_offset,
-          _config.max_bytes,
-          // We need to fetch both raft data batches for transaction control
-          // markers as well as placeholder batches to hydrate from object
-          // storage, so we don't include a typefilter and instead postfilter
-          // here.
-          /*type_filter=*/std::nullopt,
-          _config.first_timestamp,
-          _config.abort_source,
-          _config.client_address);
-        cfg.translate_offsets = model::translate_offsets::yes;
-        // This parameter defines how many bytes we want to fetch
-        // from the underlying partition in one go.
-        // The L0 meta batches are small, so we can fetch a lot of them in a
-        // single request and then gradually materialize them.
-        // The 'cfg.max_bytes' doesn't limit the size of the materialized
-        // batches, because it is fetching L0 meta batches, which have different
-        // size. In order to know the size of the materialized batches we need
-        // to fetch L0 meta batches first and then parse them.
-        cfg.max_bytes = L0_max_bytes_per_metadata_fetch;
-
+        auto cfg = ctp_read_config();
         auto reader = co_await _ctp->make_local_reader(cfg);
         auto placeholders = co_await model::consume_reader_to_chunked_vector(
           std::move(reader), deadline);

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -206,11 +206,11 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
     try {
         auto cfg = ctp_read_config();
         auto reader = co_await _ctp->make_local_reader(cfg);
-        auto placeholders = co_await model::consume_reader_to_chunked_vector(
+        auto batches = co_await model::consume_reader_to_chunked_vector(
           std::move(reader), deadline);
 
         // Convert L0 meta batches to extent_meta structures.
-        for (auto&& batch : placeholders) {
+        for (auto&& batch : batches) {
             auto& header = batch.header();
             if (header.type == model::record_batch_type::raft_data) {
                 local_log_batch local_batch{.header = header};

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -146,7 +146,7 @@ level_zero_log_reader_impl::maybe_load_slices_from_cache() {
 storage::local_log_reader_config level_zero_log_reader_impl::ctp_read_config() {
     /*
      * The requested offset range in the cloud topic reader configuration are
-     * specified as offsets in the kafka adddress space and need to first be
+     * specified as offsets in the kafka address space and need to first be
      * converted into physical log offsets for log reader configuration.
      */
     auto ot_state = _ctp->get_offset_translator_state();

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -206,11 +206,11 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
     try {
         auto cfg = ctp_read_config();
         auto reader = co_await _ctp->make_local_reader(cfg);
-        auto batches = co_await model::consume_reader_to_chunked_vector(
-          std::move(reader), deadline);
+        auto batches = std::move(reader).generator(deadline);
 
         // Convert L0 meta batches to extent_meta structures.
-        for (auto&& batch : batches) {
+        while (auto maybe_batch = co_await batches()) {
+            auto batch = std::move(maybe_batch).value();
             auto& header = batch.header();
             if (header.type == model::record_batch_type::raft_data) {
                 local_log_batch local_batch{.header = header};

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.h
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.h
@@ -18,6 +18,10 @@ namespace cluster {
 class partition;
 }
 
+namespace storage {
+struct local_log_reader_config;
+}
+
 namespace cloud_topics {
 class data_plane_api;
 
@@ -86,7 +90,10 @@ private:
 
     bool cache_enabled() const;
 
-    // Fetch L0 meta batches from the underlying partition
+    // Prepare a local log reader configuration for reading placeholder and
+    // other metadata batches from the CTP.
+    storage::local_log_reader_config ctp_read_config();
+
     ss::future<> fetch_metadata(model::timeout_clock::time_point deadline);
     ss::future<> materialize_batches(model::timeout_clock::time_point deadline);
     void consume_materialized_batches(


### PR DESCRIPTION
* Increase the size of the L0 reader metadata read size
* Avoid double materialization of L0 metadata batches

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
