### PR TITLE
[CORE-13829] ct/reconciler: Metrics

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -20,6 +20,21 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "reconciler_probe",
+    srcs = [
+        "reconciler_probe.cc",
+    ],
+    hdrs = [
+        "reconciler_probe.h",
+    ],
+    deps = [
+        "//src/v/config",
+        "//src/v/metrics",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "reconciler",
     srcs = [
         "reconciler.cc",
@@ -38,6 +53,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":reconciler_probe",
         ":reconciliation_consumer",
         "//src/v/base",
         "//src/v/cloud_storage_clients",

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -57,6 +57,7 @@ reconciler::reconciler(l1::io* l1_io, l1::metastore* metastore)
   , _metastore(metastore) {}
 
 ss::future<> reconciler::start() {
+    _probe.setup_metrics();
     ssx::spawn_with_gate(_gate, [this] { return reconciliation_loop(); });
     co_return;
 }
@@ -189,6 +190,8 @@ ss::future<> reconciler::reconciliation_loop() {
 }
 
 ss::future<> reconciler::reconcile() {
+    _probe.increment_rounds();
+
     chunked_vector<ss::shared_ptr<source>> sources;
     // Make a copy of the sources to not worry about concurrent modification.
     for (auto& [_, src] : _sources) {
@@ -352,11 +355,13 @@ reconciler::build_and_put_object(
     // Build the object.
     auto build_result = co_await build_object(ctx, sources);
     if (!build_result.has_value()) {
+        _probe.increment_object_build_failed();
         co_return std::unexpected(build_result.error());
     }
 
     auto obj_meta = std::move(build_result.value());
     if (obj_meta.commits.empty()) {
+        _probe.increment_empty_objects_skipped();
         co_return std::unexpected(
           reconcile_error("Skipping put for object {}: no data", oid));
     }
@@ -364,8 +369,12 @@ reconciler::build_and_put_object(
     // Upload the object.
     auto put_result = co_await put_object(oid, ctx);
     if (!put_result.has_value()) {
+        _probe.increment_object_upload_failed();
         co_return std::unexpected(put_result.error());
     }
+
+    _probe.increment_objects_uploaded();
+    _probe.add_bytes_reconciled(obj_meta.object_info.size_bytes);
 
     co_return obj_meta;
 }
@@ -422,6 +431,8 @@ reconciler::build_object(
         }
         auto meta = read_result.value();
         if (meta.has_value()) {
+            _probe.increment_partitions_reconciled();
+            _probe.add_batches_reconciled(meta->batch_count);
             metas.emplace_back(src, std::move(meta).value());
         }
     }

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -374,7 +374,6 @@ reconciler::build_and_put_object(
     }
 
     _probe.increment_objects_uploaded();
-    _probe.add_bytes_reconciled(obj_meta.object_info.size_bytes);
 
     co_return obj_meta;
 }
@@ -445,6 +444,9 @@ reconciler::build_object(
       "Built L1 object from {} partitions ({} partitions were skipped)",
       metas.size(),
       sources.size() - metas.size());
+    if (!metas.empty()) {
+        _probe.add_bytes_reconciled(obj_info.size_bytes);
+    }
     co_return built_object_metadata{
       .object_info = std::move(obj_info),
       .commits = std::move(metas),

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -15,6 +15,7 @@
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/reconciler/reconciler_probe.h"
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
 #include "cluster/partition.h"
 #include "container/chunked_hash_map.h"
@@ -95,6 +96,8 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+
+    void setup_metrics_for_tests() { _probe.setup_metrics(); }
 
     void attach_partition(
       const model::ntp&,
@@ -256,6 +259,7 @@ private:
     l1::metastore* _metastore;
     ss::gate _gate;
     ss::abort_source _as;
+    reconciler_probe _probe;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/reconciler/reconciler_probe.h"
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cloud_topics::reconciler {
+
+void reconciler_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("cloud_topics:reconciler"),
+      {
+        sm::make_counter(
+          "rounds",
+          [this] { return _rounds; },
+          sm::description("Number of reconciliation rounds")),
+        sm::make_counter(
+          "objects_uploaded",
+          [this] { return _objects_uploaded; },
+          sm::description("Total objects uploaded, including orphans")),
+        sm::make_counter(
+          "bytes_reconciled",
+          [this] { return _bytes_reconciled; },
+          sm::description("Total bytes produced, including metadata")),
+        sm::make_counter(
+          "batches_reconciled",
+          [this] { return _batches_reconciled; },
+          sm::description("Total record batches reconciled")),
+        sm::make_counter(
+          "partitions_reconciled",
+          [this] { return _partitions_reconciled; },
+          sm::description("Counts each time a partition contributed a batch")),
+        sm::make_counter(
+          "object_build_failed",
+          [this] { return _object_build_failed; },
+          sm::description("Total objects that failed to build")),
+        sm::make_counter(
+          "object_upload_failed",
+          [this] { return _object_upload_failed; },
+          sm::description("Total objects that failed to upload")),
+        sm::make_counter(
+          "empty_objects_skipped",
+          [this] { return _empty_objects_skipped; },
+          sm::description(
+            "Total objects skipped because no data was available")),
+      });
+}
+
+} // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "metrics/metrics.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <cstdint>
+
+namespace cloud_topics::reconciler {
+
+class reconciler_probe {
+public:
+    reconciler_probe() = default;
+
+    reconciler_probe(const reconciler_probe&) = delete;
+    reconciler_probe& operator=(const reconciler_probe&) = delete;
+    reconciler_probe(reconciler_probe&&) = delete;
+    reconciler_probe& operator=(reconciler_probe&&) = delete;
+    ~reconciler_probe() = default;
+
+    void setup_metrics();
+
+    void increment_rounds() { ++_rounds; }
+    void increment_objects_uploaded() { ++_objects_uploaded; }
+    void add_bytes_reconciled(uint64_t bytes) { _bytes_reconciled += bytes; }
+    void add_batches_reconciled(uint64_t batches) {
+        _batches_reconciled += batches;
+    }
+    void increment_partitions_reconciled() { ++_partitions_reconciled; }
+    void increment_object_build_failed() { ++_object_build_failed; }
+    void increment_object_upload_failed() { ++_object_upload_failed; }
+    void increment_empty_objects_skipped() { ++_empty_objects_skipped; }
+
+private:
+    metrics::internal_metric_groups _metrics;
+
+    uint64_t _rounds{0};
+    uint64_t _objects_uploaded{0};
+    uint64_t _bytes_reconciled{0};
+    uint64_t _batches_reconciled{0};
+    uint64_t _partitions_reconciled{0};
+    uint64_t _object_build_failed{0};
+    uint64_t _object_upload_failed{0};
+    uint64_t _empty_objects_skipped{0};
+};
+
+} // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.cc
@@ -23,7 +23,8 @@ reconciliation_consumer::reconciliation_consumer(
   , _metadata{
       .base_offset = kafka::offset::min(),
       .last_offset = kafka::offset::min(),
-      .last_timestamp = model::timestamp::min()} {}
+      .last_timestamp = model::timestamp::min(),
+      .batch_count = 0} {}
 
 ss::future<ss::stop_iteration>
 reconciliation_consumer::operator()(model::record_batch batch) {
@@ -43,6 +44,8 @@ reconciliation_consumer::operator()(model::record_batch batch) {
           std::make_pair(
             batch.term(), model::offset_cast(batch.base_offset())));
     }
+
+    ++_metadata.batch_count;
 
     co_await _builder->add_batch(std::move(batch));
 

--- a/src/v/cloud_topics/reconciler/reconciliation_consumer.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_consumer.h
@@ -29,6 +29,7 @@ struct consumer_metadata {
     kafka::offset last_offset;
     model::timestamp last_timestamp;
     absl::btree_map<model::term_id, kafka::offset> terms;
+    uint64_t batch_count{0};
 };
 
 /// Consumes record batches from a reader and writes them to an L1 object.

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -8,6 +8,8 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#pragma once
+
 #include "cloud_topics/data_plane_api.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -1,4 +1,19 @@
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
+
+redpanda_test_cc_library(
+    name = "test_utils",
+    hdrs = [
+        "test_utils.h",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/common:fake_io",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/cloud_topics/reconciler",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "@seastar",
+    ],
+)
 
 redpanda_cc_gtest(
     name = "reconciliation_consumer_test",
@@ -26,6 +41,7 @@ redpanda_cc_gtest(
         "reconciler_test.cc",
     ],
     deps = [
+        ":test_utils",
         "//src/v/cloud_topics/level_one/common:fake_io",
         "//src/v/cloud_topics/level_one/common:object",
         "//src/v/cloud_topics/level_one/metastore:simple",

--- a/src/v/cloud_topics/reconciler/tests/BUILD
+++ b/src/v/cloud_topics/reconciler/tests/BUILD
@@ -55,3 +55,24 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "reconciler_metrics_test",
+    timeout = "short",
+    srcs = [
+        "reconciler_metrics_test.cc",
+    ],
+    deps = [
+        ":test_utils",
+        "//src/v/cloud_topics/level_one/common:fake_io",
+        "//src/v/cloud_topics/level_one/common:object",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/cloud_topics/reconciler",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:metrics",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/common/fake_io.h"
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/reconciler/reconciler.h"
+#include "cloud_topics/reconciler/reconciliation_source.h"
+#include "cloud_topics/reconciler/tests/test_utils.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
+#include "test_utils/metrics.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+
+using namespace cloud_topics;
+using cloud_topics::reconciler::test::fake_source;
+using cloud_topics::reconciler::test::unreliable_io;
+
+namespace {
+
+class ReconcilerMetricsTest : public testing::Test {
+public:
+    ReconcilerMetricsTest() { _reconciler.setup_metrics_for_tests(); }
+
+    ss::shared_ptr<fake_source> add_source() {
+        auto ntp = model::random_ntp();
+        auto tid = model::create_topic_id();
+        auto tidp = model::topic_id_partition(tid, ntp.tp.partition);
+        auto src = ss::make_shared<fake_source>(ntp, tidp);
+        _reconciler.attach_source(src);
+        return src;
+    }
+
+    void reconcile() { _reconciler.reconcile().get(); }
+
+    unreliable_io& io() { return _io; }
+
+private:
+    unreliable_io _io;
+    l1::simple_metastore _metastore;
+    reconciler::reconciler _reconciler{&_io, &_metastore};
+};
+
+using ::testing::Gt;
+using ::testing::Optional;
+
+std::optional<uint64_t> get_reconciliation_rounds() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_rounds");
+}
+
+std::optional<uint64_t> get_objects_uploaded() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_objects_uploaded");
+}
+
+std::optional<uint64_t> get_bytes_reconciled() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_bytes_reconciled");
+}
+
+std::optional<uint64_t> get_batches_reconciled() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_batches_reconciled");
+}
+
+std::optional<uint64_t> get_partitions_reconciled() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_partitions_reconciled");
+}
+
+std::optional<uint64_t> get_object_build_failed() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_object_build_failed");
+}
+
+std::optional<uint64_t> get_object_upload_failed() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_object_upload_failed");
+}
+
+std::optional<uint64_t> get_empty_objects_skipped() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_empty_objects_skipped");
+}
+
+} // namespace
+
+TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
+    EXPECT_THAT(get_reconciliation_rounds(), Optional(0));
+    EXPECT_THAT(get_objects_uploaded(), Optional(0));
+    EXPECT_THAT(get_bytes_reconciled(), Optional(0));
+    EXPECT_THAT(get_batches_reconciled(), Optional(0));
+    EXPECT_THAT(get_partitions_reconciled(), Optional(0));
+    EXPECT_THAT(get_object_build_failed(), Optional(0));
+    EXPECT_THAT(get_object_upload_failed(), Optional(0));
+    EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
+
+    auto src1 = add_source();
+    auto src2 = add_source();
+
+    src1->add_batch({.count = 10});
+    src1->add_batch({.count = 10});
+    src1->add_batch({.count = 10});
+    src2->add_batch({.count = 10});
+    src2->add_batch({.count = 10});
+
+    reconcile();
+
+    EXPECT_THAT(get_reconciliation_rounds(), Optional(1));
+    EXPECT_THAT(get_objects_uploaded(), Optional(1));
+    EXPECT_THAT(get_partitions_reconciled(), Optional(2));
+    EXPECT_THAT(get_batches_reconciled(), Optional(5));
+    EXPECT_THAT(get_bytes_reconciled(), Optional(Gt(0)));
+    EXPECT_THAT(get_object_build_failed(), Optional(0));
+    EXPECT_THAT(get_object_upload_failed(), Optional(0));
+    EXPECT_THAT(get_empty_objects_skipped(), Optional(0));
+
+    auto bytes_after_first = *get_bytes_reconciled();
+
+    reconcile();
+
+    EXPECT_THAT(get_reconciliation_rounds(), Optional(2));
+    EXPECT_THAT(get_objects_uploaded(), Optional(1));
+    EXPECT_THAT(get_partitions_reconciled(), Optional(2));
+    EXPECT_THAT(get_batches_reconciled(), Optional(5));
+    EXPECT_THAT(get_bytes_reconciled(), Optional(bytes_after_first));
+    EXPECT_THAT(get_object_build_failed(), Optional(0));
+    EXPECT_THAT(get_object_upload_failed(), Optional(0));
+    EXPECT_THAT(get_empty_objects_skipped(), Optional(1));
+
+    src1->add_batch({.count = 15});
+
+    reconcile();
+
+    EXPECT_THAT(get_reconciliation_rounds(), Optional(3));
+    EXPECT_THAT(get_objects_uploaded(), Optional(2));
+    EXPECT_THAT(get_partitions_reconciled(), Optional(3));
+    EXPECT_THAT(get_batches_reconciled(), Optional(6));
+    EXPECT_THAT(get_bytes_reconciled(), Optional(Gt(bytes_after_first)));
+    EXPECT_THAT(get_object_build_failed(), Optional(0));
+    EXPECT_THAT(get_object_upload_failed(), Optional(0));
+    EXPECT_THAT(get_empty_objects_skipped(), Optional(1));
+}
+
+TEST_F(ReconcilerMetricsTest, FailedObjectsCounter) {
+    EXPECT_THAT(get_object_upload_failed(), Optional(0));
+
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    io().fail_put_object(true);
+
+    reconcile();
+
+    EXPECT_THAT(get_object_upload_failed(), Optional(1));
+    EXPECT_THAT(get_objects_uploaded(), Optional(0));
+
+    io().fail_put_object(false);
+
+    reconcile();
+
+    EXPECT_THAT(get_object_upload_failed(), Optional(1));
+    EXPECT_THAT(get_objects_uploaded(), Optional(1));
+}

--- a/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_test.cc
@@ -11,6 +11,7 @@
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 #include "cloud_topics/reconciler/reconciler.h"
 #include "cloud_topics/reconciler/reconciliation_source.h"
+#include "cloud_topics/reconciler/tests/test_utils.h"
 #include "gmock/gmock.h"
 #include "model/fundamental.h"
 #include "model/record.h"
@@ -27,123 +28,11 @@
 #include <utility>
 
 using namespace cloud_topics;
+using cloud_topics::reconciler::test::fake_source;
+using cloud_topics::reconciler::test::unreliable_io;
+using cloud_topics::reconciler::test::unreliable_metastore;
 
 namespace {
-
-class fake_source : public reconciler::source {
-public:
-    fake_source(model::ntp ntp, model::topic_id_partition tidp)
-      : reconciler::source(std::move(ntp), tidp) {}
-
-    void add_batch(
-      model::test::record_batch_spec spec,
-      std::optional<model::term_id> term = std::nullopt) {
-        if (!_source_log.empty()) {
-            spec.offset = _source_log.back().last_offset() + model::offset{1};
-        }
-        auto batch = model::test::make_random_batch(spec);
-        if (term.has_value()) {
-            batch.set_term(term.value());
-        }
-        _source_log.push_back(std::move(batch));
-    }
-
-    kafka::offset last_reconciled_offset() override { return _lro; }
-
-    ss::future<std::expected<void, errc>>
-    set_last_reconciled_offset(kafka::offset o, ss::abort_source&) override {
-        if (_fail_set_lro) {
-            co_return std::unexpected(errc::failure);
-        }
-        _lro = o;
-        co_return std::expected<void, errc>{};
-    }
-
-    ss::future<model::record_batch_reader>
-    make_reader(source::reader_config cfg) override {
-        if (_fail_make_reader) {
-            throw std::runtime_error("Failed to make reader");
-        }
-        chunked_vector<model::record_batch> log;
-        size_t size = 0;
-        for (const auto& batch : _source_log) {
-            if (
-              model::offset_cast(batch.base_offset())
-              < last_reconciled_offset()) {
-                continue;
-            }
-            size += batch.size_bytes();
-            log.push_back(batch.copy());
-            if (size > cfg.max_bytes) {
-                break;
-            }
-        }
-        co_return model::make_chunked_memory_record_batch_reader(
-          std::move(log));
-    }
-
-    void fail_set_lro(bool fail) { _fail_set_lro = fail; }
-    void fail_make_reader(bool fail) { _fail_make_reader = fail; }
-
-private:
-    kafka::offset _lro;
-    chunked_vector<model::record_batch> _source_log;
-    bool _fail_set_lro = false;
-    bool _fail_make_reader = false;
-};
-
-class unreliable_metastore : public l1::simple_metastore {
-public:
-    ss::future<std::expected<add_response, errc>> add_objects(
-      const object_metadata_builder& builder,
-      const term_offset_map_t& terms) override {
-        if (_fail_add_objects) {
-            co_return std::unexpected(errc::invalid_request);
-        }
-        if (_fail_add_objects_transiently_count > 0) {
-            _fail_add_objects_transiently_count--;
-            co_return std::unexpected(errc::transport_error);
-        }
-        co_return co_await l1::simple_metastore::add_objects(builder, terms);
-    }
-
-    void fail_add_objects(bool fail) { _fail_add_objects = fail; }
-    void fail_add_objects_transiently(int times) {
-        _fail_add_objects_transiently_count = times;
-    }
-
-private:
-    bool _fail_add_objects = false;
-    int _fail_add_objects_transiently_count = 0;
-};
-
-class unreliable_io : public l1::fake_io {
-public:
-    ss::future<std::expected<std::unique_ptr<l1::staging_file>, errc>>
-    create_tmp_file() override {
-        if (_fail_create_tmp_file) {
-            co_return std::unexpected(errc::file_io_error);
-        }
-        co_return co_await l1::fake_io::create_tmp_file();
-    }
-
-    ss::future<std::expected<void, errc>> put_object(
-      l1::object_id oid,
-      l1::staging_file* file,
-      ss::abort_source* as) override {
-        if (_fail_put_object) {
-            co_return std::unexpected(errc::cloud_op_error);
-        }
-        co_return co_await l1::fake_io::put_object(oid, file, as);
-    }
-
-    void fail_create_tmp_file(bool fail) { _fail_create_tmp_file = fail; }
-    void fail_put_object(bool fail) { _fail_put_object = fail; }
-
-private:
-    bool _fail_create_tmp_file = false;
-    bool _fail_put_object = false;
-};
 
 class ReconcilerTest : public testing::Test {
 public:

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/common/fake_io.h"
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/reconciler/reconciliation_source.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+
+#include <seastar/core/future.hh>
+
+#include <expected>
+#include <optional>
+#include <stdexcept>
+
+namespace cloud_topics::reconciler::test {
+
+class fake_source : public source {
+public:
+    fake_source(model::ntp ntp, model::topic_id_partition tidp)
+      : source(std::move(ntp), tidp) {}
+
+    void add_batch(
+      model::test::record_batch_spec spec,
+      std::optional<model::term_id> term = std::nullopt) {
+        if (!_source_log.empty()) {
+            spec.offset = _source_log.back().last_offset() + model::offset{1};
+        }
+        auto batch = model::test::make_random_batch(spec);
+        if (term.has_value()) {
+            batch.set_term(term.value());
+        }
+        _source_log.push_back(std::move(batch));
+    }
+
+    kafka::offset last_reconciled_offset() override { return _lro; }
+
+    ss::future<std::expected<void, errc>>
+    set_last_reconciled_offset(kafka::offset o, ss::abort_source&) override {
+        if (_fail_set_lro) {
+            co_return std::unexpected(errc::failure);
+        }
+        _lro = o;
+        co_return std::expected<void, errc>{};
+    }
+
+    ss::future<model::record_batch_reader>
+    make_reader(source::reader_config cfg) override {
+        if (_fail_make_reader) {
+            throw std::runtime_error("Failed to make reader");
+        }
+        chunked_vector<model::record_batch> log;
+        size_t size = 0;
+        for (const auto& batch : _source_log) {
+            if (
+              model::offset_cast(batch.base_offset())
+              < last_reconciled_offset()) {
+                continue;
+            }
+            size += batch.size_bytes();
+            log.push_back(batch.copy());
+            if (size > cfg.max_bytes) {
+                break;
+            }
+        }
+        co_return model::make_chunked_memory_record_batch_reader(
+          std::move(log));
+    }
+
+    void fail_set_lro(bool fail) { _fail_set_lro = fail; }
+    void fail_make_reader(bool fail) { _fail_make_reader = fail; }
+
+private:
+    kafka::offset _lro;
+    chunked_vector<model::record_batch> _source_log;
+    bool _fail_set_lro = false;
+    bool _fail_make_reader = false;
+};
+
+class unreliable_metastore : public l1::simple_metastore {
+public:
+    ss::future<std::expected<l1::metastore::add_response, l1::metastore::errc>>
+    add_objects(
+      const l1::metastore::object_metadata_builder& builder,
+      const l1::metastore::term_offset_map_t& terms) override {
+        if (_fail_add_objects) {
+            co_return std::unexpected(l1::metastore::errc::invalid_request);
+        }
+        if (_fail_add_objects_transiently_count > 0) {
+            _fail_add_objects_transiently_count--;
+            co_return std::unexpected(l1::metastore::errc::transport_error);
+        }
+        co_return co_await l1::simple_metastore::add_objects(builder, terms);
+    }
+
+    void fail_add_objects(bool fail) { _fail_add_objects = fail; }
+    void fail_add_objects_transiently(int times) {
+        _fail_add_objects_transiently_count = times;
+    }
+
+private:
+    bool _fail_add_objects = false;
+    int _fail_add_objects_transiently_count = 0;
+};
+
+class unreliable_io : public l1::fake_io {
+public:
+    ss::future<std::expected<std::unique_ptr<l1::staging_file>, l1::io::errc>>
+    create_tmp_file() override {
+        if (_fail_create_tmp_file) {
+            co_return std::unexpected(l1::io::errc::file_io_error);
+        }
+        co_return co_await l1::fake_io::create_tmp_file();
+    }
+
+    ss::future<std::expected<void, l1::io::errc>> put_object(
+      l1::object_id oid,
+      l1::staging_file* file,
+      ss::abort_source* as) override {
+        if (_fail_put_object) {
+            co_return std::unexpected(l1::io::errc::cloud_op_error);
+        }
+        co_return co_await l1::fake_io::put_object(oid, file, as);
+    }
+
+    void fail_create_tmp_file(bool fail) { _fail_create_tmp_file = fail; }
+    void fail_put_object(bool fail) { _fail_put_object = fail; }
+
+private:
+    bool _fail_create_tmp_file = false;
+    bool _fail_put_object = false;
+};
+
+} // namespace cloud_topics::reconciler::test

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -310,3 +310,15 @@ redpanda_test_cc_library(
     visibility = ["//visibility:public"],
     alwayslink = True,  # hooks are installed by a global constructor
 )
+
+redpanda_test_cc_library(
+    name = "metrics",
+    hdrs = [
+        "metrics.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/test_utils/metrics.h
+++ b/src/v/test_utils/metrics.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/type_traits.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_api.hh>
+#include <seastar/core/sstring.hh>
+
+#include <initializer_list>
+#include <optional>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace test_utils {
+
+// Find the value of a metric by name and optional labels.
+// The shard label is automatically added to the label set.
+template<typename T>
+std::optional<T> find_metric_value(
+  std::string_view metric_name,
+  int handle = ss::metrics::default_handle(),
+  std::initializer_list<std::pair<ss::sstring, ss::sstring>> labels = {}) {
+    auto metrics = ss::metrics::impl::get_value_map(handle);
+    auto metrics_it = metrics.find(ss::sstring(metric_name));
+    if (metrics_it == metrics.end()) {
+        return std::nullopt;
+    }
+
+    ss::metrics::impl::labels_type label_set{
+      {ss::metrics::shard_label.name(), std::to_string(ss::this_shard_id())}};
+    for (const auto& [key, value] : labels) {
+        label_set.emplace(key, value);
+    }
+
+    seastar::metrics::impl::metric_family family = metrics_it->second;
+    auto family_it = family.find(label_set);
+    if (family_it == family.end()) {
+        return std::nullopt;
+    }
+
+    ss::metrics::impl::metric_function metric_fn
+      = family_it->second->get_function();
+    seastar::metrics::impl::metric_value sample = metric_fn();
+
+    if constexpr (std::is_same_v<uint64_t, T>) {
+        return sample.ui();
+    } else if constexpr (std::is_same_v<double, T>) {
+        return sample.d();
+    } else {
+        static_assert(base::unsupported_type<T>::value, "unsupported type");
+    }
+}
+
+} // namespace test_utils

--- a/src/v/wasm/tests/BUILD
+++ b/src/v/wasm/tests/BUILD
@@ -231,6 +231,7 @@ redpanda_cc_gtest(
         "//src/v/metrics",
         "//src/v/model",
         "//src/v/test_utils:gtest",
+        "//src/v/test_utils:metrics",
         "//src/v/wasm:engine_probe",
         "//src/v/wasm:logger",
         "@googletest//:gtest",

--- a/src/v/wasm/tests/wasm_probe_test.cc
+++ b/src/v/wasm/tests/wasm_probe_test.cc
@@ -9,68 +9,41 @@
  * by the Apache License, Version 2.0
  */
 
-#include "base/type_traits.h"
 #include "base/units.h"
-#include "gmock/gmock.h"
 #include "metrics/metrics.h"
+#include "test_utils/metrics.h"
 #include "wasm/logger.h"
-
-#include <seastar/core/metrics.hh>
-#include <seastar/core/metrics_api.hh>
-#include <seastar/core/smp.hh>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <wasm/engine_probe.h>
 
 #include <optional>
-#include <type_traits>
 
 namespace wasm {
 
 namespace {
 
-template<typename T>
-std::optional<T> find_metric_value(
-  std::string_view metric_name, const ss::sstring& function_name) {
-    auto metrics = ss::metrics::impl::get_value_map(
-      metrics::public_metrics_handle);
-    auto metrics_it = metrics.find(ss::sstring(metric_name));
-    if (metrics_it == metrics.end()) {
-        return std::nullopt;
-    }
-    seastar::metrics::impl::metric_family family = metrics_it->second;
-    auto family_it = family.find(
-      {{"function_name", function_name},
-       {ss::metrics::shard_label.name(), std::to_string(ss::this_shard_id())}});
-    if (family_it == family.end()) {
-        return std::nullopt;
-    }
-    ss::metrics::impl::metric_function metric_fn
-      = family_it->second->get_function();
-    seastar::metrics::impl::metric_value sample = metric_fn();
-    if constexpr (std::is_same_v<double, T>) {
-        return sample.d();
-    } else if constexpr (std::is_same_v<uint64_t, T>) {
-        return sample.ui();
-    } else {
-        static_assert(base::unsupported_type<T>::value, "unsupported type");
-    }
-}
-
 std::optional<uint64_t>
 reported_memory_usage(const ss::sstring& function_name) {
-    return find_metric_value<uint64_t>(
-      "wasm_engine_memory_usage", function_name);
+    return test_utils::find_metric_value<uint64_t>(
+      "wasm_engine_memory_usage",
+      metrics::public_metrics_handle,
+      {{"function_name", function_name}});
 }
 
 std::optional<uint64_t> reported_max_memory(const ss::sstring& function_name) {
-    return find_metric_value<uint64_t>("wasm_engine_max_memory", function_name);
+    return test_utils::find_metric_value<uint64_t>(
+      "wasm_engine_max_memory",
+      metrics::public_metrics_handle,
+      {{"function_name", function_name}});
 }
 
 std::optional<double> reported_cpu_time(const ss::sstring& function_name) {
-    return find_metric_value<double>(
-      "wasm_engine_cpu_seconds_total", function_name);
+    return test_utils::find_metric_value<double>(
+      "wasm_engine_cpu_seconds_total",
+      metrics::public_metrics_handle,
+      {{"function_name", function_name}});
 }
 
 } // namespace


### PR DESCRIPTION
Metrics added:

- objects_uploaded: Total L1 objects successfully built and uploaded.
  If this goes up, the reconciler is doing something.

- bytes_reconciled: Total bytes of objects produced by reconciliation.
  Basic measure of how much reconciliation goes brrr.

- batches_reconciled: Total record batches processed.
  Basic measure of how much reconciliation goes brrr.

- partitions_reconciled: Counts each time a partition contributes
  batches to an object.
  Useful as a numerator or denominator with other metrics. Can show, for
  example, if reconciliation is dominated by a few busy partitions.

- object_build_failed: Objects that failed to build.

- object_upload_failed: Objects that failed to upload.

- empty_objects_skipped: Objects skipped when no data was available.
  This happens if no partition assigned to the object contributes
  batches. It's useful for measuring load distribution-- if many objects are
  skipped but there is high throughput in bytes/batches, reconciliation is
  concentrated ina few active partitions.

Metrics NOT added:

- Objects accepted by the metastore.
  This is hard to count, because add_objects can succeed, but some or
  all of the objects are not actually accepted into L1 by the metastore.
  Because of the complexity, this metric is not in this change.
## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
