### PR TITLE
vector_bench: remove randomness

### DIFF
--- a/src/v/container/tests/BUILD
+++ b/src/v/container/tests/BUILD
@@ -85,7 +85,6 @@ redpanda_test_cc_library(
     visibility = ["//visibility:private"],
     deps = [
         "//src/v/base",
-        "//src/v/random:generators",
         "@seastar//:benchmark",
     ],
 )

--- a/src/v/container/tests/bench_utils.h
+++ b/src/v/container/tests/bench_utils.h
@@ -9,9 +9,10 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "base/seastarx.h"
 #include "base/type_traits.h"
-#include "random/generators.h"
 
+#include <seastar/core/sstring.hh>
 #include <seastar/testing/perf_tests.hh>
 
 #include <string>
@@ -30,29 +31,23 @@ struct large_struct {
 };
 
 template<typename ValueT>
-static auto make_value() {
+[[gnu::noinline]]
+static ValueT make_value() {
     if constexpr (std::is_same_v<ValueT, int64_t>) {
-        return static_cast<int64_t>(random_generators::get_int<int64_t>());
-
+        return 42;
     } else if constexpr (std::is_same_v<ValueT, ss::sstring>) {
-        constexpr size_t max_str_len = 64;
-        return random_generators::gen_alphanum_string(
-          random_generators::get_int<size_t>(0, max_str_len));
+        return ss::sstring(42, 'x'); // large than SSO size (15)
     } else if constexpr (std::is_same_v<ValueT, large_struct>) {
         constexpr size_t max_str_len = 64;
         constexpr size_t max_num_cardinality = 16;
         return large_struct{
-          .foo = random_generators::get_int<size_t>(0, max_num_cardinality),
-          .bar = random_generators::get_int<size_t>(0, max_num_cardinality),
-          .qux = random_generators::gen_alphanum_string(
-            random_generators::get_int<size_t>(0, max_str_len)),
-          .baz = random_generators::gen_alphanum_string(
-            random_generators::get_int<size_t>(0, max_str_len)),
-          .more = random_generators::gen_alphanum_string(
-            random_generators::get_int<size_t>(0, max_str_len)),
-          .data = random_generators::gen_alphanum_string(
-            random_generators::get_int<size_t>(0, max_str_len)),
-          .okdone = random_generators::get_int<size_t>(),
+          .foo = max_num_cardinality / 3,
+          .bar = max_num_cardinality - 2,
+          .qux = std::string(max_str_len / 8, 'x'),
+          .baz = std::string(max_str_len / 4, 'x'),
+          .more = std::string(max_str_len / 2, 'x'),
+          .data = std::string(max_str_len / 1, 'x'),
+          .okdone = 4242,
         };
     } else {
         static_assert(base::unsupported_type<ValueT>::value, "unsupported");

--- a/src/v/container/tests/vector_bench.cc
+++ b/src/v/container/tests/vector_bench.cc
@@ -20,73 +20,66 @@
 #include <vector>
 
 template<typename Vector, size_t Size>
-class VectorBenchTest {
+struct VectorBenchTest {
+    using value_type = typename Vector::value_type;
+
     static auto make_value() {
         return ::make_value<typename Vector::value_type>();
     }
-    static auto make_filled() {
+
+    static Vector make_filled() {
         Vector v;
         std::generate_n(std::back_inserter(v), Size, make_value);
         return v;
     }
 
-public:
+    value_type val = make_value();
+    Vector filled = make_filled();
+    std::vector<size_t> indexes = [] {
+        random_generators::rng rng{0};
+        std::vector<size_t> indexes;
+        std::generate_n(std::back_inserter(indexes), 1000, [&]() {
+            return rng.get_int(0uz, Size - 1);
+        });
+        return indexes;
+    }();
+
+    [[gnu::noinline]]
     void run_sort_test() {
-        auto v = make_filled();
-        perf_tests::start_measuring_time();
-        std::sort(v.begin(), v.end());
-        perf_tests::stop_measuring_time();
+        std::sort(filled.begin(), filled.end());
     }
 
+    [[gnu::noinline]]
     void run_fifo_test() {
         Vector v;
-        auto val = make_value();
-        perf_tests::start_measuring_time();
         for (size_t i = 0; i < Size; ++i) {
             v.push_back(val);
         }
-        for (const auto& e : v) {
-            perf_tests::do_not_optimize(e);
-        }
-        perf_tests::stop_measuring_time();
+        perf_tests::do_not_optimize(v);
     }
 
+    [[gnu::noinline]]
     void run_lifo_test() {
         Vector v;
-        auto val = make_value();
-        perf_tests::start_measuring_time();
         for (size_t i = 0; i < Size; ++i) {
             v.push_back(val);
         }
         while (!v.empty()) {
             v.pop_back();
         }
-        perf_tests::stop_measuring_time();
     }
 
+    [[gnu::noinline]]
     void run_fill_test() {
-        Vector v;
-        auto val = make_value();
-        perf_tests::start_measuring_time();
-        std::fill_n(std::back_inserter(v), Size, val);
-        perf_tests::stop_measuring_time();
+        Vector v = make_filled();
+        perf_tests::do_not_optimize(v);
     }
 
+    [[gnu::noinline]]
     void run_random_access_test() {
-        auto v = make_filled();
-        std::vector<size_t> indexes;
-        std::generate_n(std::back_inserter(indexes), 1000, [&v]() {
-            return random_generators::get_int<size_t>(0, v.size() - 1);
-        });
-        perf_tests::start_measuring_time();
-        perf_tests::do_not_optimize(v.front());
-        perf_tests::do_not_optimize(v.back());
         for (size_t index : indexes) {
-            perf_tests::do_not_optimize(v[index]);
+            perf_tests::do_not_optimize(filled[index]);
         }
-        perf_tests::do_not_optimize(v.front());
-        perf_tests::do_not_optimize(v.back());
-        perf_tests::stop_measuring_time();
     }
 };
 


### PR DESCRIPTION
Remove the use of random number generation from the vector benchmark tests to improve reproducibility and reduce benchmark variance.

The random element generation was contributing to measurement noise and making it difficult to detect real performance regressions or improvements. By using deterministic data patterns instead, the benchmarks now produce more consistent and reliable results. For example sometimes the string length in the test enabled SSO optimizations, and sometimes it did not, leading to significant performance differences that were not related to the code being measured.

This change affects the VectorBenchTest Random variants, replacing random data generation with predictable patterns that still exercise the same code paths but with reduced variance between runs.

We also add the [[gnu::noinline]] attribute to the benchmark methods to prevent the compiler from inlining them, which can sometimes lead to optimizations that distort the benchmark results.

Finally, we remove use of perf_tests::start_measuring() and perf_tests::stop_measuring() around the code under test, as these are very expensive, reduce the number of iterations and the accuracy of the results. It is possible to avoid them by doing most of the setup in the fixture constructor.

Results before this change:

```
test                                                            iterations             runtime              allocs               tasks                inst              cycles
VectorBenchTest_std_vector_int64_t_64.Sort                           44758     1.403us ± 0.15%       0.000 ± 0.00%       0.000 ± 0.00%      4745.5 ± 0.01%      3750.8 ± 0.20%
VectorBenchTest_std_vector_int64_t_64.Fifo                           80223   662.577ns ± 0.22%       7.000 ± 0.00%       0.000 ± 0.00%      1969.0 ± 0.00%       832.9 ± 0.79%
VectorBenchTest_std_vector_int64_t_64.Lifo                           80966   647.086ns ± 0.04%       7.000 ± 0.00%       0.000 ± 0.00%      1710.0 ± 0.00%       775.6 ± 0.03%
VectorBenchTest_std_vector_int64_t_64.Fill                           80826   654.905ns ± 0.25%       7.000 ± 0.00%       0.000 ± 0.00%      1711.0 ± 0.00%       803.0 ± 1.44%
VectorBenchTest_std_vector_int64_t_64.RandomAccess                   19643   792.532ns ± 0.02%       0.000 ± 0.00%       0.000 ± 0.00%      5395.0 ± 0.00%      1242.3 ± 0.08%
VectorBenchTest_chunked_vector_int64_t_64.Sort                       32423     2.238us ± 0.15%       0.000 ± 0.00%       0.000 ± 0.00%     10578.4 ± 0.02%      7034.4 ± 0.13%
VectorBenchTest_chunked_vector_int64_t_64.Fifo                       74198   751.993ns ± 0.08%       6.000 ± 0.00%       0.000 ± 0.00%      2837.0 ± 0.00%      1169.5 ± 0.22%
VectorBenchTest_chunked_vector_int64_t_64.Lifo                       68602   860.073ns ± 0.10%       6.000 ± 0.00%       0.000 ± 0.00%      2800.0 ± 0.00%      1603.7 ± 0.04%
VectorBenchTest_chunked_vector_int64_t_64.Fill                       75927   720.600ns ± 0.14%       6.000 ± 0.00%       0.000 ± 0.00%      2178.0 ± 0.00%      1049.2 ± 0.08%
VectorBenchTest_chunked_vector_int64_t_64.RandomAccess               16346     1.043us ± 0.29%       0.000 ± 0.00%       0.000 ± 0.00%     10401.0 ± 0.00%      2202.5 ± 0.09%
VectorBenchTest_std_vector_sstring_64.Sort                            8623     5.184us ± 0.07%       0.000 ± 0.00%       0.000 ± 0.00%     21961.4 ± 0.02%     18739.6 ± 0.02%
VectorBenchTest_std_vector_sstring_64.Fifo                           56694   939.223ns ± 0.07%      56.199 ± 0.03%       0.000 ± 0.00%      6349.4 ± 0.02%      1887.9 ± 0.26%
VectorBenchTest_std_vector_sstring_64.Lifo                           56115     1.074us ± 0.03%      56.263 ± 0.12%       0.000 ± 0.00%      8682.1 ± 0.09%      2422.4 ± 0.07%
VectorBenchTest_std_vector_sstring_64.Fill                           55943   942.821ns ± 0.15%      56.239 ± 0.03%       0.000 ± 0.00%      6207.2 ± 0.02%      1869.7 ± 0.16%
VectorBenchTest_std_vector_sstring_64.RandomAccess                    8494   868.923ns ± 0.02%       0.000 ± 0.00%       0.000 ± 0.00%      5394.0 ± 0.00%      1555.8 ± 0.02%
VectorBenchTest_chunked_vector_sstring_64.Sort                        7805     6.356us ± 0.06%       0.000 ± 0.00%       0.000 ± 0.00%     32748.5 ± 0.01%     23335.9 ± 0.14%
VectorBenchTest_chunked_vector_sstring_64.Fifo                       55157   995.387ns ± 0.29%      56.257 ± 0.23%       0.000 ± 0.00%      7783.3 ± 0.11%      2090.2 ± 0.39%
VectorBenchTest_chunked_vector_sstring_64.Lifo                       54451     1.138us ± 0.05%      56.130 ± 0.11%       0.000 ± 0.00%      9728.6 ± 0.07%      2691.1 ± 0.06%
VectorBenchTest_chunked_vector_sstring_64.Fill                       54792   967.908ns ± 0.19%      56.133 ± 0.10%       0.000 ± 0.00%      7065.5 ± 0.05%      1969.1 ± 0.20%
VectorBenchTest_chunked_vector_sstring_64.RandomAccess                8362     1.047us ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%     10398.0 ± 0.00%      2211.3 ± 0.17%
VectorBenchTest_std_vector_large_struct_64.Sort                       3156     3.542us ± 0.10%       0.000 ± 0.00%       0.000 ± 0.00%     24848.9 ± 0.05%     12052.5 ± 0.00%
VectorBenchTest_std_vector_large_struct_64.Fifo                      27536     2.024us ± 0.37%     172.325 ± 0.04%       0.000 ± 0.00%     21807.6 ± 0.05%      6106.9 ± 0.07%
VectorBenchTest_std_vector_large_struct_64.Lifo                      27941     2.467us ± 0.25%     172.659 ± 0.10%       0.000 ± 0.00%     29808.4 ± 0.02%      7923.9 ± 0.18%
VectorBenchTest_std_vector_large_struct_64.Fill                      27603     2.001us ± 0.16%     172.434 ± 0.31%       0.000 ± 0.00%     21567.5 ± 0.19%      6066.6 ± 0.21%
VectorBenchTest_std_vector_large_struct_64.RandomAccess               2956   901.474ns ± 0.26%       0.000 ± 0.00%       0.000 ± 0.00%      5394.0 ± 0.00%      1508.4 ± 0.08%
VectorBenchTest_chunked_vector_large_struct_64.Sort                   3041     4.598us ± 0.02%       0.000 ± 0.00%       0.000 ± 0.00%     35607.8 ± 0.11%     16293.1 ± 0.12%
VectorBenchTest_chunked_vector_large_struct_64.Fifo                  26863     2.076us ± 0.12%     173.431 ± 0.06%       0.000 ± 0.00%     23164.4 ± 0.03%      6339.0 ± 0.21%
VectorBenchTest_chunked_vector_large_struct_64.Lifo                  27244     2.537us ± 0.13%     173.281 ± 0.07%       0.000 ± 0.00%     31111.2 ± 0.06%      8209.5 ± 0.21%
VectorBenchTest_chunked_vector_large_struct_64.Fill                  27217     2.033us ± 0.17%     173.292 ± 0.18%       0.000 ± 0.00%     22380.4 ± 0.10%      6197.2 ± 0.09%
VectorBenchTest_chunked_vector_large_struct_64.RandomAccess           2960     1.109us ± 0.12%       0.000 ± 0.00%       0.000 ± 0.00%     11399.0 ± 0.00%      2353.0 ± 0.21%
VectorBenchTest_std_vector_int64_t_10000.Sort                          455   190.222us ± 0.07%       0.000 ± 0.00%       0.000 ± 0.00%   1588787.9 ± 0.02%    755185.9 ± 0.04%
VectorBenchTest_std_vector_int64_t_10000.Fifo                        12583     7.319us ± 0.37%      15.000 ± 0.00%       0.000 ± 0.00%    103696.0 ± 0.00%     27236.8 ± 0.14%
VectorBenchTest_std_vector_int64_t_10000.Lifo                        15298     5.888us ± 0.05%      15.000 ± 0.00%       0.000 ± 0.00%     63701.0 ± 0.00%     21602.3 ± 0.06%
VectorBenchTest_std_vector_int64_t_10000.Fill                        15301     5.883us ± 0.05%      15.000 ± 0.00%       0.000 ± 0.00%     63702.0 ± 0.00%     21591.8 ± 0.07%
VectorBenchTest_std_vector_int64_t_10000.RandomAccess                 2523     1.150us ± 0.05%       0.000 ± 0.00%       0.000 ± 0.00%      5395.0 ± 0.00%      2539.9 ± 0.13%
VectorBenchTest_chunked_vector_int64_t_10000.Sort                      155   613.392us ± 0.05%       0.000 ± 0.00%       0.000 ± 0.00%   2906129.5 ± 0.02%   2439566.2 ± 0.03%
VectorBenchTest_chunked_vector_int64_t_10000.Fifo                     5680    16.953us ± 0.10%      14.000 ± 0.00%       0.000 ± 0.00%    253733.0 ± 0.00%     65635.0 ± 0.15%
VectorBenchTest_chunked_vector_int64_t_10000.Lifo                     5291    18.232us ± 0.08%      14.000 ± 0.00%       0.000 ± 0.00%    243916.0 ± 0.00%     70745.3 ± 0.09%
VectorBenchTest_chunked_vector_int64_t_10000.Fill                     7478    12.602us ± 0.12%      14.000 ± 0.00%       0.000 ± 0.00%    153690.0 ± 0.00%     48327.9 ± 0.12%
VectorBenchTest_chunked_vector_int64_t_10000.RandomAccess             2276     1.197us ± 0.16%       0.000 ± 0.00%       0.000 ± 0.00%     10401.0 ± 0.00%      2703.2 ± 0.10%
VectorBenchTest_std_vector_sstring_10000.Sort                           40     1.577ms ± 0.05%       0.000 ± 0.00%       0.000 ± 0.00%   7260557.4 ± 0.21%   6270986.4 ± 0.07%
VectorBenchTest_std_vector_sstring_10000.Fifo                          867    70.529us ± 0.17%    7662.059 ± 1.05%       0.000 ± 0.00%    932733.7 ± 0.70%    278458.4 ± 0.25%
VectorBenchTest_std_vector_sstring_10000.Lifo                          828   117.308us ± 0.21%    7708.237 ± 0.47%       0.000 ± 0.00%   1504506.2 ± 0.35%    465081.5 ± 0.26%
VectorBenchTest_std_vector_sstring_10000.Fill                          864    68.645us ± 0.46%    7549.722 ± 0.92%       0.000 ± 0.00%    903931.3 ± 0.60%    270907.1 ± 0.43%
VectorBenchTest_std_vector_sstring_10000.RandomAccess                  107     1.010us ± 0.85%       0.000 ± 0.00%       0.000 ± 0.00%      5394.0 ± 0.00%      1577.3 ± 0.30%
VectorBenchTest_chunked_vector_sstring_10000.Sort                       36     1.918ms ± 0.25%       0.000 ± 0.00%       0.000 ± 0.00%   9918962.8 ± 0.16%   7627396.7 ± 0.23%
VectorBenchTest_chunked_vector_sstring_10000.Fifo                      911    65.457us ± 0.48%    7754.749 ± 0.85%       0.000 ± 0.00%   1069401.0 ± 0.48%    258584.0 ± 0.43%
VectorBenchTest_chunked_vector_sstring_10000.Lifo                      914   111.817us ± 0.18%    7784.053 ± 0.98%       0.000 ± 0.00%   1578584.7 ± 0.71%    443422.4 ± 0.14%
VectorBenchTest_chunked_vector_sstring_10000.Fill                      927    62.918us ± 0.18%    7750.628 ± 0.14%       0.000 ± 0.00%    959254.9 ± 0.08%    248189.3 ± 0.33%
VectorBenchTest_chunked_vector_sstring_10000.RandomAccess              108     1.180us ± 1.91%       0.000 ± 0.00%       0.000 ± 0.00%     10398.0 ± 0.00%      2210.1 ± 0.32%
VectorBenchTest_std_vector_large_struct_10000.Sort                      17     1.390ms ± 0.10%       0.000 ± 0.00%       0.000 ± 0.00%   9212672.4 ± 0.03%   5521858.1 ± 0.10%
VectorBenchTest_std_vector_large_struct_10000.Fifo                     195   340.359us ± 0.39%   25912.436 ± 2.57%       0.000 ± 0.00%   3682671.2 ± 1.61%   1349809.9 ± 0.53%
VectorBenchTest_std_vector_large_struct_10000.Lifo                     195   503.979us ± 0.61%   25656.026 ± 0.80%       0.000 ± 0.00%   5500265.7 ± 0.61%   2002339.1 ± 0.58%
VectorBenchTest_std_vector_large_struct_10000.Fill                     200   337.929us ± 0.27%   26815.000 ± 0.19%       0.000 ± 0.00%   3726329.0 ± 0.11%   1340417.7 ± 0.20%
VectorBenchTest_std_vector_large_struct_10000.RandomAccess              23     1.627us ± 4.34%       0.000 ± 0.00%       0.000 ± 0.00%      5394.0 ± 0.00%      1574.6 ± 0.60%
VectorBenchTest_chunked_vector_large_struct_10000.Sort                  17     1.780ms ± 0.17%       0.000 ± 0.00%       0.000 ± 0.00%  12327871.1 ± 0.07%   7077792.6 ± 0.26%
VectorBenchTest_chunked_vector_large_struct_10000.Fifo                 279   198.600us ± 1.46%   25795.609 ± 1.95%       0.000 ± 0.00%   3181741.1 ± 1.54%    786749.0 ± 1.43%
VectorBenchTest_chunked_vector_large_struct_10000.Lifo                 269   369.006us ± 1.13%   25824.257 ± 1.01%       0.000 ± 0.00%   5038599.7 ± 0.90%   1466054.2 ± 1.06%
VectorBenchTest_chunked_vector_large_struct_10000.Fill                 271   194.130us ± 0.19%   25855.258 ± 0.43%       0.000 ± 0.00%   3066677.3 ± 0.30%    768693.2 ± 0.22%
VectorBenchTest_chunked_vector_large_struct_10000.RandomAccess          23     1.633us ± 2.00%       0.000 ± 0.00%       0.000 ± 0.00%     11399.0 ± 0.00%      2437.8 ± 0.37%
VectorBenchTest_std_vector_int64_t_1048576.Sort                          4    25.203ms ± 0.20%       0.000 ± 0.00%       0.000 ± 0.00% 253236453.8 ± 0.13% 100264773.0 ± 0.09%
VectorBenchTest_std_vector_int64_t_1048576.Fifo                        118   819.841us ± 0.55%      21.000 ± 0.00%       0.000 ± 0.00%  10491760.8 ± 0.00%   3259418.7 ± 0.54%
VectorBenchTest_std_vector_int64_t_1048576.Lifo                        160   605.866us ± 0.42%      21.000 ± 0.00%       0.000 ± 0.00%   6297467.6 ± 0.00%   2407954.9 ± 0.40%
VectorBenchTest_std_vector_int64_t_1048576.Fill                        157   626.510us ± 1.37%      21.000 ± 0.00%       0.000 ± 0.00%   6297468.6 ± 0.00%   2488239.6 ± 1.42%
VectorBenchTest_std_vector_int64_t_1048576.RandomAccess                 33     3.221us ± 7.74%       0.000 ± 0.00%       0.000 ± 0.00%      5395.0 ± 0.00%      8363.0 ± 5.97%
VectorBenchTest_chunked_vector_int64_t_1048576.Sort                      1    97.330ms ± 0.22%       0.000 ± 0.00%       0.000 ± 0.00% 433242041.0 ± 0.19% 387104126.0 ± 0.27%
VectorBenchTest_chunked_vector_int64_t_1048576.Fifo                     56     1.775ms ± 1.54%      83.000 ± 0.00%       0.000 ± 0.00%  26235903.8 ± 0.00%   7055363.9 ± 1.62%
VectorBenchTest_chunked_vector_int64_t_1048576.Lifo                     59     1.719ms ± 0.35%      83.000 ± 0.00%       0.000 ± 0.00%  25197439.7 ± 0.00%   6836654.3 ± 0.30%
VectorBenchTest_chunked_vector_int64_t_1048576.Fill                    100   999.736us ± 0.05%      83.000 ± 0.00%       0.000 ± 0.00%  15750037.0 ± 0.00%   3970710.9 ± 0.16%
VectorBenchTest_chunked_vector_int64_t_1048576.RandomAccess             34     3.059us ± 1.38%       0.000 ± 0.00%       0.000 ± 0.00%     10401.0 ± 0.00%      8292.4 ± 1.25%
```

after:

```
test                                                            iterations             runtime              allocs               tasks                inst              cycles
VectorBenchTest_std_vector_int64_t_64.Sort                         1437367    69.639ns ± 0.28%       0.000 ± 0.00%       0.000 ± 0.00%      1212.0 ± 0.00%       277.4 ± 0.19%
VectorBenchTest_std_vector_int64_t_64.Fifo                         1426644    69.831ns ± 0.05%       7.000 ± 0.00%       0.000 ± 0.00%      1508.0 ± 0.00%       278.1 ± 0.05%
VectorBenchTest_std_vector_int64_t_64.Lifo                         1336615    74.878ns ± 0.36%       7.000 ± 0.00%       0.000 ± 0.00%      1490.0 ± 0.00%       298.2 ± 0.34%
VectorBenchTest_std_vector_int64_t_64.Fill                         1332105    76.027ns ± 0.72%       7.000 ± 0.00%       0.000 ± 0.00%      1365.0 ± 0.00%       302.8 ± 0.72%
VectorBenchTest_std_vector_int64_t_64.RandomAccess                  362793   274.821ns ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%      6018.0 ± 0.00%      1094.6 ± 0.02%
VectorBenchTest_chunked_vector_int64_t_64.Sort                      831969   118.899ns ± 0.15%       0.000 ± 0.00%       0.000 ± 0.00%      2837.0 ± 0.00%       473.3 ± 0.17%
VectorBenchTest_chunked_vector_int64_t_64.Fifo                      834538   119.687ns ± 0.28%       6.000 ± 0.00%       0.000 ± 0.00%      2225.0 ± 0.00%       476.8 ± 0.32%
VectorBenchTest_chunked_vector_int64_t_64.Lifo                      548285   186.922ns ± 2.10%       6.000 ± 0.00%       0.000 ± 0.00%      2872.0 ± 0.00%       744.3 ± 2.05%
VectorBenchTest_chunked_vector_int64_t_64.Fill                      857996   115.952ns ± 0.07%       6.000 ± 0.00%       0.000 ± 0.00%      2096.0 ± 0.00%       461.9 ± 0.06%
VectorBenchTest_chunked_vector_int64_t_64.RandomAccess              214180   466.362ns ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%     11018.0 ± 0.00%      1857.2 ± 0.03%
VectorBenchTest_std_vector_sstring_64.Sort                          298898   333.887ns ± 0.03%       0.000 ± 0.00%       0.000 ± 0.00%      6015.0 ± 0.00%      1330.0 ± 0.01%
VectorBenchTest_std_vector_sstring_64.Fifo                          198939   504.864ns ± 0.09%      71.000 ± 0.00%       0.000 ± 0.00%     10160.0 ± 0.00%      2011.3 ± 0.13%
VectorBenchTest_std_vector_sstring_64.Lifo                          201304   494.657ns ± 0.18%      71.000 ± 0.00%       0.000 ± 0.00%      9996.0 ± 0.00%      1970.7 ± 0.22%
VectorBenchTest_std_vector_sstring_64.Fill                          152281   657.855ns ± 0.25%      71.000 ± 0.00%       0.000 ± 0.00%      9172.0 ± 0.00%      2620.4 ± 0.16%
VectorBenchTest_std_vector_sstring_64.RandomAccess                  380149   262.947ns ± 0.08%       0.000 ± 0.00%       0.000 ± 0.00%      6018.0 ± 0.00%      1046.4 ± 0.02%
VectorBenchTest_chunked_vector_sstring_64.Sort                      233999   425.715ns ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%      8042.0 ± 0.00%      1695.5 ± 0.02%
VectorBenchTest_chunked_vector_sstring_64.Fifo                      203629   492.846ns ± 0.54%      71.000 ± 0.00%       0.000 ± 0.00%     10549.0 ± 0.00%      1962.7 ± 0.56%
VectorBenchTest_chunked_vector_sstring_64.Lifo                      180846   548.864ns ± 0.56%      71.000 ± 0.00%       0.000 ± 0.00%     11129.0 ± 0.00%      2185.1 ± 0.54%
VectorBenchTest_chunked_vector_sstring_64.Fill                      146526   680.214ns ± 0.03%      71.000 ± 0.00%       0.000 ± 0.00%      9845.0 ± 0.00%      2709.0 ± 0.02%
VectorBenchTest_chunked_vector_sstring_64.RandomAccess              193685   514.700ns ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%     11018.0 ± 0.00%      2049.7 ± 0.02%
VectorBenchTest_std_vector_large_struct_64.Sort                      78507     1.270us ± 0.02%       0.000 ± 0.00%       0.000 ± 0.00%     22333.0 ± 0.00%      5057.2 ± 0.04%
VectorBenchTest_std_vector_large_struct_64.Fifo                      73061     1.331us ± 0.15%     135.000 ± 0.00%       0.000 ± 0.00%     24777.0 ± 0.00%      5301.4 ± 0.08%
VectorBenchTest_std_vector_large_struct_64.Lifo                      77703     1.284us ± 0.08%     135.000 ± 0.00%       0.000 ± 0.00%     24902.0 ± 0.00%      5111.6 ± 0.02%
VectorBenchTest_std_vector_large_struct_64.Fill                      70803     1.398us ± 0.05%     135.000 ± 0.00%       0.000 ± 0.00%     20194.0 ± 0.00%      5569.8 ± 0.05%
VectorBenchTest_std_vector_large_struct_64.RandomAccess             396665   252.068ns ± 0.09%       0.000 ± 0.00%       0.000 ± 0.00%      5017.0 ± 0.00%      1002.9 ± 0.02%
VectorBenchTest_chunked_vector_large_struct_64.Sort                  70207     1.424us ± 0.08%       0.000 ± 0.00%       0.000 ± 0.00%     24594.0 ± 0.00%      5669.1 ± 0.06%
VectorBenchTest_chunked_vector_large_struct_64.Fifo                  73236     1.389us ± 0.16%     136.000 ± 0.00%       0.000 ± 0.00%     25763.0 ± 0.00%      5531.7 ± 0.11%
VectorBenchTest_chunked_vector_large_struct_64.Lifo                  70023     1.432us ± 0.24%     136.000 ± 0.00%       0.000 ± 0.00%     26341.0 ± 0.00%      5701.9 ± 0.21%
VectorBenchTest_chunked_vector_large_struct_64.Fill                  68660     1.464us ± 0.24%     136.000 ± 0.00%       0.000 ± 0.00%     21017.0 ± 0.00%      5831.2 ± 0.24%
VectorBenchTest_chunked_vector_large_struct_64.RandomAccess         216836   461.598ns ± 0.07%       0.000 ± 0.00%       0.000 ± 0.00%     11017.0 ± 0.00%      1837.3 ± 0.07%
VectorBenchTest_std_vector_int64_t_10000.Sort                        16423     6.087us ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%    160249.0 ± 0.00%     24222.8 ± 0.02%
VectorBenchTest_std_vector_int64_t_10000.Fifo                        18913     5.281us ± 0.02%      15.000 ± 0.00%       0.000 ± 0.00%     83522.0 ± 0.00%     21019.0 ± 0.03%
VectorBenchTest_std_vector_int64_t_10000.Lifo                        18856     5.302us ± 0.03%      15.000 ± 0.00%       0.000 ± 0.00%     83496.0 ± 0.00%     21105.8 ± 0.01%
VectorBenchTest_std_vector_int64_t_10000.Fill                        18972     5.262us ± 0.04%      15.000 ± 0.00%       0.000 ± 0.00%     63491.0 ± 0.00%     20963.2 ± 0.03%
VectorBenchTest_std_vector_int64_t_10000.RandomAccess               299602   333.309ns ± 0.14%       0.000 ± 0.00%       0.000 ± 0.00%      6018.0 ± 0.00%      1326.9 ± 0.10%
VectorBenchTest_chunked_vector_int64_t_10000.Sort                     5748    17.401us ± 0.15%       0.000 ± 0.00%       0.000 ± 0.00%    420217.1 ± 0.00%     69218.1 ± 0.20%
VectorBenchTest_chunked_vector_int64_t_10000.Fifo                     8277    12.076us ± 0.29%      14.000 ± 0.00%       0.000 ± 0.00%    193743.1 ± 0.00%     47982.0 ± 0.16%
VectorBenchTest_chunked_vector_int64_t_10000.Lifo                     5784    17.221us ± 0.02%      14.000 ± 0.00%       0.000 ± 0.00%    293750.1 ± 0.00%     68570.7 ± 0.03%
VectorBenchTest_chunked_vector_int64_t_10000.Fill                     8372    11.946us ± 0.06%      14.000 ± 0.00%       0.000 ± 0.00%    173742.1 ± 0.00%     47549.0 ± 0.02%
VectorBenchTest_chunked_vector_int64_t_10000.RandomAccess           210208   474.556ns ± 0.04%       0.000 ± 0.00%       0.000 ± 0.00%     11018.0 ± 0.00%      1887.2 ± 0.03%
VectorBenchTest_std_vector_sstring_10000.Sort                         2056    48.421us ± 0.07%       0.000 ± 0.00%       0.000 ± 0.00%    910447.2 ± 0.00%    192811.7 ± 0.05%
VectorBenchTest_std_vector_sstring_10000.Fifo                          736   135.097us ± 0.03%   10015.000 ± 0.00%       0.000 ± 0.00%   1870317.7 ± 0.00%    537971.3 ± 0.05%
VectorBenchTest_std_vector_sstring_10000.Lifo                          662   137.671us ± 0.08%   10015.000 ± 0.00%       0.000 ± 0.00%   1840388.7 ± 0.00%    548249.6 ± 0.07%
VectorBenchTest_std_vector_sstring_10000.Fill                          597   167.106us ± 0.10%   10015.000 ± 0.00%       0.000 ± 0.00%   1730127.8 ± 0.00%    665414.6 ± 0.03%
VectorBenchTest_std_vector_sstring_10000.RandomAccess               372899   267.658ns ± 0.03%       0.000 ± 0.00%       0.000 ± 0.00%      6018.0 ± 0.00%      1065.5 ± 0.02%
VectorBenchTest_chunked_vector_sstring_10000.Sort                     1505    66.225us ± 0.12%       0.000 ± 0.00%       0.000 ± 0.00%   1220578.3 ± 0.00%    263667.2 ± 0.12%
VectorBenchTest_chunked_vector_sstring_10000.Fifo                      768   129.571us ± 0.13%   10016.000 ± 0.00%       0.000 ± 0.00%   1812287.7 ± 0.00%    516110.1 ± 0.12%
VectorBenchTest_chunked_vector_sstring_10000.Lifo                      728   136.915us ± 0.13%   10016.000 ± 0.00%       0.000 ± 0.00%   1902216.1 ± 0.00%    545390.7 ± 0.14%
VectorBenchTest_chunked_vector_sstring_10000.Fill                      612   163.672us ± 0.06%   10016.000 ± 0.00%       0.000 ± 0.00%   1702214.1 ± 0.00%    651876.6 ± 0.04%
VectorBenchTest_chunked_vector_sstring_10000.RandomAccess           194834   514.917ns ± 0.12%       0.000 ± 0.00%       0.000 ± 0.00%     11018.0 ± 0.00%      2049.2 ± 0.13%
VectorBenchTest_std_vector_large_struct_10000.Sort                     467   213.895us ± 0.16%       0.000 ± 0.00%       0.000 ± 0.00%   3430220.1 ± 0.00%    850301.5 ± 0.12%
VectorBenchTest_std_vector_large_struct_10000.Fifo                     220   452.734us ± 0.06%   20015.000 ± 0.00%       0.000 ± 0.00%   4735824.7 ± 0.00%   1799573.1 ± 0.08%
VectorBenchTest_std_vector_large_struct_10000.Lifo                     217   459.202us ± 0.05%   20015.000 ± 0.00%       0.000 ± 0.00%   4755716.0 ± 0.00%   1826133.0 ± 0.03%
VectorBenchTest_std_vector_large_struct_10000.Fill                     182   503.621us ± 0.02%   20015.000 ± 0.00%       0.000 ± 0.00%   4035573.7 ± 0.00%   2002436.2 ± 0.04%
VectorBenchTest_std_vector_large_struct_10000.RandomAccess          392858   253.957ns ± 0.02%       0.000 ± 0.00%       0.000 ± 0.00%      5017.0 ± 0.00%      1011.3 ± 0.01%
VectorBenchTest_chunked_vector_large_struct_10000.Sort                 418   239.060us ± 0.14%       0.000 ± 0.00%       0.000 ± 0.00%   3777897.2 ± 0.00%    950601.9 ± 0.05%
VectorBenchTest_chunked_vector_large_struct_10000.Fifo                 310   320.699us ± 0.10%   20025.000 ± 0.00%       0.000 ± 0.00%   4188676.8 ± 0.00%   1275858.0 ± 0.07%
VectorBenchTest_chunked_vector_large_struct_10000.Lifo                 303   328.022us ± 0.06%   20025.000 ± 0.00%       0.000 ± 0.00%   4278571.3 ± 0.00%   1305087.5 ± 0.03%
VectorBenchTest_chunked_vector_large_struct_10000.Fill                 273   362.395us ± 0.08%   20025.000 ± 0.00%       0.000 ± 0.00%   3448587.5 ± 0.00%   1442395.6 ± 0.15%
VectorBenchTest_chunked_vector_large_struct_10000.RandomAccess      216611   462.156ns ± 0.06%       0.000 ± 0.00%       0.000 ± 0.00%     11017.0 ± 0.00%      1839.7 ± 0.05%
VectorBenchTest_std_vector_int64_t_1048576.Sort                        155   643.971us ± 0.09%       0.000 ± 0.00%       0.000 ± 0.00%  16777468.2 ± 0.00%   2559518.7 ± 0.08%
VectorBenchTest_std_vector_int64_t_1048576.Fifo                        156   616.799us ± 0.18%      21.000 ± 0.00%       0.000 ± 0.00%   8394125.1 ± 0.00%   2452734.1 ± 0.20%
VectorBenchTest_std_vector_int64_t_1048576.Lifo                        158   616.640us ± 0.10%      21.000 ± 0.00%       0.000 ± 0.00%   8394093.1 ± 0.00%   2450693.8 ± 0.12%
VectorBenchTest_std_vector_int64_t_1048576.Fill                        158   612.570us ± 0.02%      21.000 ± 0.00%       0.000 ± 0.00%   6296930.1 ± 0.00%   2435311.5 ± 0.02%
VectorBenchTest_std_vector_int64_t_1048576.RandomAccess             199955   498.814ns ± 0.05%       0.000 ± 0.00%       0.000 ± 0.00%      6018.0 ± 0.00%      1986.1 ± 0.07%
VectorBenchTest_chunked_vector_int64_t_1048576.Sort                     55     1.831ms ± 0.12%       0.000 ± 0.00%       0.000 ± 0.00%  44040418.0 ± 0.00%   7286861.7 ± 0.07%
VectorBenchTest_chunked_vector_int64_t_1048576.Fifo                     94     1.061ms ± 0.11%      83.000 ± 0.00%       0.000 ± 0.00%  19955847.2 ± 0.00%   4217736.4 ± 0.17%
VectorBenchTest_chunked_vector_int64_t_1048576.Lifo                     64     1.574ms ± 0.09%      83.000 ± 0.00%       0.000 ± 0.00%  30441742.7 ± 0.00%   6258760.2 ± 0.02%
VectorBenchTest_chunked_vector_int64_t_1048576.Fill                     97     1.035ms ± 0.03%      83.000 ± 0.00%       0.000 ± 0.00%  17858694.1 ± 0.00%   4117377.2 ± 0.01%
VectorBenchTest_chunked_vector_int64_t_1048576.RandomAccess         189143   527.243ns ± 0.07%       0.000 ± 0.00%       0.000 ± 0.00%     11018.0 ± 0.00%      2099.3 ± 0.02%
```

Note how the "instructions" and "allocs" columns now have uniformly 0.00% deviation (relative MAD). The overall variation in runtime/cycles is also reduced.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
