### PR TITLE
k/group: replaced use of std::vector with chunked_vector

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2222,7 +2222,7 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
     cluster::simple_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
 
-    std::vector<std::pair<model::topic_partition, offset_metadata>>
+    chunked_vector<std::pair<model::topic_partition, offset_metadata>>
       offset_commits;
 
     const auto expiry_timestamp = [&r]() -> std::optional<model::timestamp> {
@@ -2242,6 +2242,7 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
       };
 
     for (const auto& t : r.data.topics) {
+        offset_commits.reserve(offset_commits.size() + t.partitions.size());
         for (const auto& p : t.partitions) {
             const auto commit_timestamp = get_commit_timestamp(p);
             update_store_offset_builder(
@@ -3504,7 +3505,7 @@ void group::update_subscriptions() {
     _subscriptions = std::move(subs);
 }
 
-std::vector<model::topic_partition> group::filter_expired_offsets(
+chunked_vector<model::topic_partition> group::filter_expired_offsets(
   std::chrono::seconds retention_period,
   const std::function<bool(const model::topic&)>& subscribed,
   const std::function<model::timestamp(const offset_metadata&)>&
@@ -3517,7 +3518,7 @@ std::vector<model::topic_partition> group::filter_expired_offsets(
         .count());
 
     const auto now = model::timestamp::now();
-    std::vector<model::topic_partition> offsets;
+    chunked_vector<model::topic_partition> offsets;
     for (const auto& offset : _offsets) {
         if (offset.second->metadata.non_reclaimable) {
             continue;
@@ -3558,7 +3559,7 @@ std::vector<model::topic_partition> group::filter_expired_offsets(
     return offsets;
 }
 
-std::vector<model::topic_partition>
+chunked_vector<model::topic_partition>
 group::get_expired_offsets(std::chrono::seconds retention_period) {
     const auto not_subscribed = [](const auto&) { return false; };
 
@@ -3646,7 +3647,7 @@ bool group::has_offsets() const {
            || has_transactions_in_progress();
 }
 
-std::vector<model::topic_partition>
+chunked_vector<model::topic_partition>
 group::delete_expired_offsets(std::chrono::seconds retention_period) {
     /*
      * collect and delete expired offsets
@@ -3667,9 +3668,9 @@ group::delete_expired_offsets(std::chrono::seconds retention_period) {
     return offsets;
 }
 
-std::vector<model::topic_partition>
-group::delete_offsets(std::vector<model::topic_partition> offsets) {
-    std::vector<model::topic_partition> deleted_offsets;
+chunked_vector<model::topic_partition>
+group::delete_offsets(const chunked_vector<model::topic_partition>& offsets) {
+    chunked_vector<model::topic_partition> deleted_offsets;
     /*
      * Delete the requested offsets, unless there is at least one active
      * subscription for an offset.

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -709,7 +709,7 @@ public:
      *
      * The set of expired offsets that have been removed is returned.
      */
-    std::vector<model::topic_partition>
+    chunked_vector<model::topic_partition>
     delete_expired_offsets(std::chrono::seconds retention_period);
 
     /*
@@ -717,8 +717,8 @@ public:
      *
      *  Returns the set of offsets that were deleted.
      */
-    std::vector<model::topic_partition>
-    delete_offsets(std::vector<model::topic_partition> offsets);
+    chunked_vector<model::topic_partition>
+    delete_offsets(const chunked_vector<model::topic_partition>& offsets);
 
     void set_lag_metrics(consumer_lag_metrics lag_metrics);
 
@@ -912,12 +912,12 @@ private:
     void update_subscriptions();
     std::optional<absl::node_hash_set<model::topic>> _subscriptions;
 
-    std::vector<model::topic_partition> filter_expired_offsets(
+    chunked_vector<model::topic_partition> filter_expired_offsets(
       std::chrono::seconds retention_period,
       const std::function<bool(const model::topic&)>&,
       const std::function<model::timestamp(const offset_metadata&)>&);
 
-    std::vector<model::topic_partition>
+    chunked_vector<model::topic_partition>
     get_expired_offsets(std::chrono::seconds retention_period);
 
     bool use_dedicated_batch_type_for_fence() const {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -333,7 +333,7 @@ ss::future<size_t> group_manager::delete_expired_offsets(
 }
 
 ss::future<size_t> group_manager::delete_offsets(
-  group_ptr group, std::vector<model::topic_partition> offsets) {
+  group_ptr group, const chunked_vector<model::topic_partition>& offsets) {
     /*
      * build tombstones to persistent offset deletions. the group itself may
      * also be set to dead state in which case we may be able to delete the
@@ -1759,7 +1759,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
         co_return offset_delete_response(error_code::non_empty_group);
     }
 
-    std::vector<model::topic_partition> requested_deletions;
+    chunked_vector<model::topic_partition> requested_deletions;
     for (const auto& topic : r.data.topics) {
         for (const auto& partition : topic.partitions) {
             requested_deletions.emplace_back(
@@ -1770,7 +1770,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
     auto deleted_offsets = group->delete_offsets(requested_deletions);
     co_await delete_offsets(group, deleted_offsets);
 
-    absl::flat_hash_set<model::topic_partition> deleted_offsets_set;
+    chunked_hash_set<model::topic_partition> deleted_offsets_set;
     for (auto& tp : deleted_offsets) {
         deleted_offsets_set.insert(std::move(tp));
     }

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -290,7 +290,7 @@ private:
       group_recovery_consumer_state);
 
     ss::future<size_t> delete_offsets(
-      group_ptr group, std::vector<model::topic_partition> offsets);
+      group_ptr group, const chunked_vector<model::topic_partition>& offsets);
 
     ss::future<> do_recover_group(
       model::term_id,


### PR DESCRIPTION
Offset manipulation often involves large vector of partition committed offsets. Sometimes when the number of partitions is especially large the large vectors may lead to large allocations.

Replaced all committed offsets manipulation code with chunked vector to prevent large allocations.

Fixes: #CORE-13674

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
