### PR TITLE
cl/group_mirroring: gracefully handle find coordinator errors

### DIFF
--- a/src/v/cluster_link/group_mirroring_task.cc
+++ b/src/v/cluster_link/group_mirroring_task.cc
@@ -751,21 +751,37 @@ group_mirroring_task::do_find_coordinator(
     req.data.key_type = kafka::coordinator_type::group;
     req.data.key = group_id;
     // limit version to 3 as the next one use batched api
-    auto resp = co_await get_cluster_connection().dispatch_to_any(
-      std::move(req),
-      std::min(max_version, std::min(max_version, kafka::api_version{3})));
+    try {
+        auto resp = co_await get_cluster_connection().dispatch_to_any(
+          std::move(req),
+          std::min(max_version, std::min(max_version, kafka::api_version{3})));
 
-    if (resp.data.error_code != kafka::error_code::none) {
-        vlog(
-          logger().warn,
-          "Error finding coordinator for {} - {}",
+        if (resp.data.error_code != kafka::error_code::none) {
+            vlog(
+              logger().warn,
+              "Error finding coordinator for {} - {}",
+              group_id,
+              resp.data.error_code);
+            co_return std::unexpected(error(
+              ssx::sformat("Error finding coordinator for {}", group_id),
+              resp.data.error_code));
+        }
+        co_return resp.data.node_id;
+    } catch (...) {
+        auto lvl = ssx::is_shutdown_exception(std::current_exception())
+                     ? ss::log_level::trace
+                     : ss::log_level::warn;
+        vlogl(
+          logger(),
+          lvl,
+          "Exception thrown while finding coordinator for group {} - {}",
           group_id,
-          resp.data.error_code);
-        co_return std::unexpected(error(
-          ssx::sformat("Error finding coordinator for {}", group_id),
-          resp.data.error_code));
+          std::current_exception());
+        co_return std::unexpected<error>(ssx::sformat(
+          "Exception thrown while finding coordinator for group {} - {}",
+          group_id,
+          std::current_exception()));
     }
-    co_return resp.data.node_id;
 }
 
 ss::future<std::expected<
@@ -779,22 +795,38 @@ group_mirroring_task::do_find_coordinator_batched(
       group_ids.size());
     kafka::find_coordinator_request req;
     req.data.key_type = kafka::coordinator_type::group;
+    const auto group_cnt = group_ids.size();
     req.data.coordinator_keys = std::move(group_ids);
+    try {
+        auto resp = co_await get_cluster_connection().dispatch_to_any(
+          std::move(req), std::min(max_version, max_version));
 
-    auto resp = co_await get_cluster_connection().dispatch_to_any(
-      std::move(req), std::min(max_version, max_version));
+        if (resp.data.error_code != kafka::error_code::none) {
+            vlog(
+              logger().warn,
+              "Error finding coordinator for groups - {}",
+              resp.data.error_code);
+            co_return std::unexpected(error(
+              ssx::sformat("Error finding coordinator for groups"),
+              resp.data.error_code));
+        }
 
-    if (resp.data.error_code != kafka::error_code::none) {
-        vlog(
-          logger().warn,
-          "Error finding coordinator for groups - {}",
-          resp.data.error_code);
-        co_return std::unexpected(error(
-          ssx::sformat("Error finding coordinator for groups"),
-          resp.data.error_code));
+        co_return std::move(resp.data.coordinators);
+    } catch (...) {
+        auto lvl = ssx::is_shutdown_exception(std::current_exception())
+                     ? ss::log_level::trace
+                     : ss::log_level::warn;
+        vlogl(
+          logger(),
+          lvl,
+          "Exception thrown while finding coordinators for {} groups - {}",
+          group_cnt,
+          std::current_exception());
+        co_return std::unexpected<error>(ssx::sformat(
+          "Exception thrown while finding coordinators for {} groups - {}",
+          group_cnt,
+          std::current_exception()));
     }
-
-    co_return std::move(resp.data.coordinators);
 }
 
 std::string_view


### PR DESCRIPTION
Looking up for the group coordinator in remote cluster may fail. If that happens the group mirroring task should catch the exception. The exception should not be propagated to the task executor as it will cause task state transition.

Failed request will be retried in the next task run.

Fixes: #CORE-13408

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none