### PR TITLE
[v25.1.x] k/group: replaced use of std::vector with chunked_vector

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2209,7 +2209,7 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
     cluster::simple_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
 
-    std::vector<std::pair<model::topic_partition, offset_metadata>>
+    chunked_vector<std::pair<model::topic_partition, offset_metadata>>
       offset_commits;
 
     const auto expiry_timestamp = [&r]() -> std::optional<model::timestamp> {
@@ -2229,6 +2229,7 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
       };
 
     for (const auto& t : r.data.topics) {
+        offset_commits.reserve(offset_commits.size() + t.partitions.size());
         for (const auto& p : t.partitions) {
             const auto commit_timestamp = get_commit_timestamp(p);
             update_store_offset_builder(
@@ -3477,7 +3478,7 @@ void group::update_subscriptions() {
     _subscriptions = std::move(subs);
 }
 
-std::vector<model::topic_partition> group::filter_expired_offsets(
+chunked_vector<model::topic_partition> group::filter_expired_offsets(
   std::chrono::seconds retention_period,
   const std::function<bool(const model::topic&)>& subscribed,
   const std::function<model::timestamp(const offset_metadata&)>&
@@ -3490,7 +3491,7 @@ std::vector<model::topic_partition> group::filter_expired_offsets(
         .count());
 
     const auto now = model::timestamp::now();
-    std::vector<model::topic_partition> offsets;
+    chunked_vector<model::topic_partition> offsets;
     for (const auto& offset : _offsets) {
         if (offset.second->metadata.non_reclaimable) {
             continue;
@@ -3531,7 +3532,7 @@ std::vector<model::topic_partition> group::filter_expired_offsets(
     return offsets;
 }
 
-std::vector<model::topic_partition>
+chunked_vector<model::topic_partition>
 group::get_expired_offsets(std::chrono::seconds retention_period) {
     const auto not_subscribed = [](const auto&) { return false; };
 
@@ -3619,7 +3620,7 @@ bool group::has_offsets() const {
            || has_transactions_in_progress();
 }
 
-std::vector<model::topic_partition>
+chunked_vector<model::topic_partition>
 group::delete_expired_offsets(std::chrono::seconds retention_period) {
     /*
      * collect and delete expired offsets
@@ -3640,9 +3641,9 @@ group::delete_expired_offsets(std::chrono::seconds retention_period) {
     return offsets;
 }
 
-std::vector<model::topic_partition>
-group::delete_offsets(std::vector<model::topic_partition> offsets) {
-    std::vector<model::topic_partition> deleted_offsets;
+chunked_vector<model::topic_partition>
+group::delete_offsets(const chunked_vector<model::topic_partition>& offsets) {
+    chunked_vector<model::topic_partition> deleted_offsets;
     /*
      * Delete the requested offsets, unless there is at least one active
      * subscription for an offset.

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -709,7 +709,7 @@ public:
      *
      * The set of expired offsets that have been removed is returned.
      */
-    std::vector<model::topic_partition>
+    chunked_vector<model::topic_partition>
     delete_expired_offsets(std::chrono::seconds retention_period);
 
     /*
@@ -717,8 +717,8 @@ public:
      *
      *  Returns the set of offsets that were deleted.
      */
-    std::vector<model::topic_partition>
-    delete_offsets(std::vector<model::topic_partition> offsets);
+    chunked_vector<model::topic_partition>
+    delete_offsets(const chunked_vector<model::topic_partition>& offsets);
 
     void set_lag_metrics(consumer_lag_metrics lag_metrics);
 
@@ -905,12 +905,12 @@ private:
     void update_subscriptions();
     std::optional<absl::node_hash_set<model::topic>> _subscriptions;
 
-    std::vector<model::topic_partition> filter_expired_offsets(
+    chunked_vector<model::topic_partition> filter_expired_offsets(
       std::chrono::seconds retention_period,
       const std::function<bool(const model::topic&)>&,
       const std::function<model::timestamp(const offset_metadata&)>&);
 
-    std::vector<model::topic_partition>
+    chunked_vector<model::topic_partition>
     get_expired_offsets(std::chrono::seconds retention_period);
 
     bool use_dedicated_batch_type_for_fence() const {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -330,7 +330,7 @@ ss::future<size_t> group_manager::delete_expired_offsets(
 }
 
 ss::future<size_t> group_manager::delete_offsets(
-  group_ptr group, std::vector<model::topic_partition> offsets) {
+  group_ptr group, const chunked_vector<model::topic_partition>& offsets) {
     /*
      * build tombstones to persistent offset deletions. the group itself may
      * also be set to dead state in which case we may be able to delete the
@@ -1594,7 +1594,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
         co_return offset_delete_response(error_code::non_empty_group);
     }
 
-    std::vector<model::topic_partition> requested_deletions;
+    chunked_vector<model::topic_partition> requested_deletions;
     for (const auto& topic : r.data.topics) {
         for (const auto& partition : topic.partitions) {
             requested_deletions.emplace_back(
@@ -1605,7 +1605,7 @@ group_manager::offset_delete(offset_delete_request&& r) {
     auto deleted_offsets = group->delete_offsets(requested_deletions);
     co_await delete_offsets(group, deleted_offsets);
 
-    absl::flat_hash_set<model::topic_partition> deleted_offsets_set;
+    chunked_hash_set<model::topic_partition> deleted_offsets_set;
     for (auto& tp : deleted_offsets) {
         deleted_offsets_set.insert(std::move(tp));
     }

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -267,7 +267,7 @@ private:
       group_recovery_consumer_state);
 
     ss::future<size_t> delete_offsets(
-      group_ptr group, std::vector<model::topic_partition> offsets);
+      group_ptr group, const chunked_vector<model::topic_partition>& offsets);
 
     ss::future<> do_recover_group(
       model::term_id,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27829
