### PR TITLE
CORE-13362 admin: implement AIP-132 ordering parser

### DIFF
--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -144,6 +144,17 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "aip_common_config",
+    hdrs = ["aip_common_config.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/serde/protobuf:base",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "aip_filter",
     srcs = [
         "aip_filter.cc",
@@ -153,6 +164,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":aip_common_config",
         "//src/v/base",
         "//src/v/serde/protobuf:base",
         "//src/v/serde/protobuf:field_mask",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -149,6 +149,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/serde/protobuf:base",
+        "//src/v/serde/protobuf:rpc",
         "@fmt",
         "@seastar",
     ],
@@ -168,6 +169,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/serde/protobuf:base",
         "//src/v/serde/protobuf:field_mask",
+        "//src/v/serde/protobuf:rpc",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
         "@fmt",

--- a/src/v/redpanda/admin/BUILD
+++ b/src/v/redpanda/admin/BUILD
@@ -179,6 +179,28 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "aip_ordering",
+    srcs = [
+        "aip_ordering.cc",
+    ],
+    hdrs = [
+        "aip_ordering.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":aip_common_config",
+        "//src/v/base",
+        "//src/v/serde/protobuf:base",
+        "//src/v/serde/protobuf:field_mask",
+        "//src/v/serde/protobuf:rpc",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/time",
+        "@fmt",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "admin",
     srcs = [
         "debug.cc",

--- a/src/v/redpanda/admin/aip_common_config.h
+++ b/src/v/redpanda/admin/aip_common_config.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/protobuf/base.h"
+
+#include <seastar/util/noncopyable_function.hh>
+
+#include <fmt/ranges.h>
+
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace admin {
+
+using field_type_getter_t = ss::noncopyable_function<serde::pb::field::value_t(
+  std::span<const int32_t> field_numbers)>;
+
+using field_path_converter_t = ss::noncopyable_function<
+  std::optional<std::vector<int32_t>>(std::span<std::string_view> field_path)>;
+
+template<serde::pb::Message MsgType>
+field_type_getter_t make_field_type_getter() {
+    return [](std::span<const int32_t> field_nums) {
+        auto default_obj = MsgType{};
+        auto val = default_obj.lookup_field(field_nums);
+        if (!val) {
+            throw std::runtime_error(
+              fmt::format(
+                "Unknown field lookup for field numbers: {}", field_nums));
+        }
+        return std::move(val->value);
+    };
+}
+
+template<serde::pb::Message MsgType>
+field_path_converter_t make_field_path_converter() {
+    return [](std::span<std::string_view> field_path)
+             -> std::optional<std::vector<int32_t>> {
+        auto res = std::vector<int32_t>{};
+        if (!MsgType::convert_field_path_to_numbers(field_path, &res)) {
+            return std::nullopt;
+        }
+        return res;
+    };
+}
+
+} // namespace admin

--- a/src/v/redpanda/admin/aip_common_config.h
+++ b/src/v/redpanda/admin/aip_common_config.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "serde/protobuf/base.h"
+#include "serde/protobuf/rpc.h"
 
 #include <seastar/util/noncopyable_function.hh>
 
@@ -36,7 +37,7 @@ field_type_getter_t make_field_type_getter() {
         auto default_obj = MsgType{};
         auto val = default_obj.lookup_field(field_nums);
         if (!val) {
-            throw std::runtime_error(
+            throw serde::pb::rpc::internal_exception(
               fmt::format(
                 "Unknown field lookup for field numbers: {}", field_nums));
         }

--- a/src/v/redpanda/admin/aip_filter.cc
+++ b/src/v/redpanda/admin/aip_filter.cc
@@ -15,6 +15,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"
 #include "serde/protobuf/base.h"
+#include "serde/protobuf/rpc.h"
 
 #include <seastar/util/variant_utils.hh>
 
@@ -28,7 +29,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <stdexcept>
 #include <type_traits>
 #include <variant>
 
@@ -186,7 +186,7 @@ std::vector<comparison> parse_expression(std::string_view input) {
         // the unexpected case defensively
         auto err = result.errors().empty() ? std::string_view{"[unknown error]"}
                                            : result.errors().front();
-        throw std::invalid_argument(
+        throw serde::pb::rpc::invalid_argument_exception(
           fmt::format("Failed to parse input: {}", err));
     }
 
@@ -202,7 +202,7 @@ auto get_field_value(
         // This should be impossible, since we could only get field numbers from
         // convert_field_path_to_numbers if the field exists, but handle it to
         // be defensive
-        throw std::runtime_error(
+        throw serde::pb::rpc::internal_exception(
           fmt::format(
             "Unexpected unknown field during filtering: {}", field_numbers));
     }
@@ -307,13 +307,13 @@ auto convert_literal(
 
     constexpr auto expects_quoted = std::is_same_v<SerdeType, ss::sstring>;
     if (expects_quoted && !is_quoted) {
-        throw std::invalid_argument(
+        throw serde::pb::rpc::invalid_argument_exception(
           fmt::format(
             "Expected quoted literal for field '{}', got unquoted '{}'",
             field_path,
             value));
     } else if (!expects_quoted && is_quoted) {
-        throw std::invalid_argument(
+        throw serde::pb::rpc::invalid_argument_exception(
           fmt::format(
             "Expected unquoted literal for field '{}', got quoted '{}'",
             field_path,
@@ -322,7 +322,7 @@ auto convert_literal(
 
     if constexpr (std::is_same_v<literal_type, bool>) {
         if (value != "true" && value != "false") {
-            throw std::invalid_argument(
+            throw serde::pb::rpc::invalid_argument_exception(
               fmt::format(
                 "Expected boolean literal for field '{}', got '{}'",
                 field_path,
@@ -332,7 +332,7 @@ auto convert_literal(
     } else if constexpr (std::is_integral_v<literal_type>) {
         if constexpr (std::is_unsigned_v<literal_type>) {
             if (!value.empty() && value[0] == '-') {
-                throw std::invalid_argument(
+                throw serde::pb::rpc::invalid_argument_exception(
                   fmt::format(
                     "Expected positive integer literal for field '{}', got "
                     "negative '{}'",
@@ -346,7 +346,7 @@ auto convert_literal(
             // Try parsing as a larger type to see if it's a range issue
             absl::int128 temp;
             if (absl::SimpleAtoi(value, &temp)) {
-                throw std::invalid_argument(
+                throw serde::pb::rpc::invalid_argument_exception(
                   fmt::format(
                     "Integer '{}' is out of range for field '{}' (valid "
                     "range: {} to {})",
@@ -356,7 +356,7 @@ auto convert_literal(
                     std::numeric_limits<literal_type>::max()));
             }
 
-            throw std::invalid_argument(
+            throw serde::pb::rpc::invalid_argument_exception(
               fmt::format(
                 "Invalid integer literal '{}' for field '{}'",
                 value,
@@ -367,7 +367,7 @@ auto convert_literal(
         if constexpr (std::is_same_v<literal_type, float>) {
             float result{};
             if (!absl::SimpleAtof(value, &result)) {
-                throw std::invalid_argument(
+                throw serde::pb::rpc::invalid_argument_exception(
                   fmt::format(
                     "Invalid float literal '{}' for field '{}'",
                     value,
@@ -377,7 +377,7 @@ auto convert_literal(
         } else {
             double result{};
             if (!absl::SimpleAtod(value, &result)) {
-                throw std::invalid_argument(
+                throw serde::pb::rpc::invalid_argument_exception(
                   fmt::format(
                     "Invalid floating point literal '{}' for field '{}'",
                     value,
@@ -390,7 +390,7 @@ auto convert_literal(
     } else if constexpr (std::is_same_v<literal_type, absl::Duration>) {
         absl::Duration result;
         if (!absl::ParseDuration(value, &result)) {
-            throw std::invalid_argument(
+            throw serde::pb::rpc::invalid_argument_exception(
               fmt::format(
                 "Invalid duration format '{}' for field '{}' (expected format: "
                 "e.g., '1.3s')",
@@ -402,7 +402,7 @@ auto convert_literal(
         absl::Time result;
         std::string error;
         if (!absl::ParseTime(absl::RFC3339_full, value, &result, &error)) {
-            throw std::invalid_argument(
+            throw serde::pb::rpc::invalid_argument_exception(
               fmt::format(
                 "Invalid timestamp format '{}' for field '{}': {} (expected "
                 "RFC3339 format)",
@@ -422,7 +422,8 @@ build_comparison(const aip_filter_config& config, const comparison& comp) {
       comp.field_path, '.');
     auto field_numbers = config.field_path_converter(path_components);
     if (!field_numbers) {
-        throw std::invalid_argument("Invalid field path: " + comp.field_path);
+        throw serde::pb::rpc::invalid_argument_exception(
+          "Invalid field path: " + comp.field_path);
     }
 
     serde::pb::field::value_t field_type = config.field_type_getter(
@@ -437,7 +438,7 @@ build_comparison(const aip_filter_config& config, const comparison& comp) {
           if constexpr (!info::supports_ordering_comparisons) {
               if (
                 comp.op != comparison_op::EQ && comp.op != comparison_op::NE) {
-                  throw std::invalid_argument(
+                  throw serde::pb::rpc::invalid_argument_exception(
                     fmt::format(
                       "{} field '{}' only supports = and != operators",
                       info::error_name,
@@ -450,7 +451,7 @@ build_comparison(const aip_filter_config& config, const comparison& comp) {
             *field_numbers, comp.op, std::move(value));
       },
       [&](const auto&) -> std::unique_ptr<ast_node> {
-          throw std::invalid_argument(
+          throw serde::pb::rpc::invalid_argument_exception(
             fmt::format(
               "Unsupported field type for field path: {}", comp.field_path));
       });
@@ -490,7 +491,7 @@ aip_filter_parser::create_aip_filter(aip_filter_config config) {
 
     if (config.filter_expression.size() > max_filter_length) {
         // Limit the size of the expression to avoid overly expensive parsing
-        throw std::invalid_argument(
+        throw serde::pb::rpc::invalid_argument_exception(
           fmt::format(
             "Filter expression exceeds maximum length of {} characters (got "
             "{}).",

--- a/src/v/redpanda/admin/aip_filter.h
+++ b/src/v/redpanda/admin/aip_filter.h
@@ -52,10 +52,7 @@ struct aip_filter_config {
     ss::sstring filter_expression;
 };
 
-template<typename T>
-concept ProtobufMessage = std::derived_from<T, serde::pb::base_message>;
-
-template<ProtobufMessage MsgType>
+template<serde::pb::Message MsgType>
 aip_filter_config make_aip_filter_config(std::string_view filter_expression) {
     return aip_filter_config{
       .field_type_getter =

--- a/src/v/redpanda/admin/aip_filter.h
+++ b/src/v/redpanda/admin/aip_filter.h
@@ -11,12 +11,10 @@
 
 #pragma once
 
+#include "redpanda/admin/aip_common_config.h"
 #include "serde/protobuf/base.h"
 
-#include <fmt/ranges.h>
-
 #include <memory>
-#include <vector>
 
 namespace admin {
 
@@ -37,16 +35,12 @@ private:
 
 struct aip_filter_config {
     // A getter for converting field numbers -> a value_t
-    ss::noncopyable_function<serde::pb::field::value_t(
-      std::span<const int32_t> field_numbers)>
-      field_type_getter;
+    field_type_getter_t field_type_getter;
 
     // A converter from field path in filter expression to field numbers.
     // If std::nullopt is returned the filter specified a path that does
     // not exist and filter creation will throw an exception.
-    ss::noncopyable_function<std::optional<std::vector<int32_t>>(
-      std::span<std::string_view> field_path)>
-      field_path_converter;
+    field_path_converter_t field_path_converter;
 
     // The user specified filter expression.
     ss::sstring filter_expression;
@@ -55,25 +49,8 @@ struct aip_filter_config {
 template<serde::pb::Message MsgType>
 aip_filter_config make_aip_filter_config(std::string_view filter_expression) {
     return aip_filter_config{
-      .field_type_getter =
-        [](std::span<const int32_t> field_nums) {
-            auto default_obj = MsgType{};
-            auto val = default_obj.lookup_field(field_nums);
-            if (!val) {
-                throw std::runtime_error(
-                  fmt::format(
-                    "Unknown field lookup for field numbers: {}", field_nums));
-            }
-            return std::move(val->value);
-        },
-      .field_path_converter = [](std::span<std::string_view> field_path)
-        -> std::optional<std::vector<int32_t>> {
-          auto res = std::vector<int32_t>{};
-          if (!MsgType::convert_field_path_to_numbers(field_path, &res)) {
-              return std::nullopt;
-          }
-          return res;
-      },
+      .field_type_getter = make_field_type_getter<MsgType>(),
+      .field_path_converter = make_field_path_converter<MsgType>(),
       .filter_expression = ss::sstring{filter_expression},
     };
 }

--- a/src/v/redpanda/admin/aip_ordering.cc
+++ b/src/v/redpanda/admin/aip_ordering.cc
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "redpanda/admin/aip_ordering.h"
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_split.h"
+#include "serde/protobuf/base.h"
+#include "serde/protobuf/rpc.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <fmt/format.h>
+
+#include <compare>
+#include <string_view>
+#include <type_traits>
+
+namespace admin {
+
+namespace {
+std::optional<sort_order::component::order>
+parse_order_token(std::string_view tok) {
+    if (tok.empty()) {
+        return sort_order::component::order::ascending;
+    }
+
+    if (absl::EqualsIgnoreCase(tok, "asc")) {
+        return sort_order::component::order::ascending;
+    }
+
+    if (absl::EqualsIgnoreCase(tok, "desc")) {
+        return sort_order::component::order::descending;
+    }
+
+    return std::nullopt;
+}
+
+template<typename T>
+concept ComparableValue
+  = std::is_same_v<T, bool> || std::is_same_v<T, int32_t>
+    || std::is_same_v<T, int64_t> || std::is_same_v<T, uint32_t>
+    || std::is_same_v<T, uint64_t> || std::is_same_v<T, float>
+    || std::is_same_v<T, double> || std::is_same_v<T, ss::sstring>
+    || std::is_same_v<T, serde::pb::raw_enum_value>
+    || std::is_same_v<T, absl::Time> || std::is_same_v<T, absl::Duration>
+    || std::is_same_v<T, std::monostate>;
+
+bool is_type_supported(const serde::pb::field::value_t& val) {
+    return ss::visit(
+      val,
+      [](const ComparableValue auto&) { return true; },
+      [](const auto&) { return false; });
+}
+
+auto compare_field_variant(
+  const serde::pb::field::value_t& va,
+  const serde::pb::field::value_t& vb,
+  const std::vector<int32_t>& field_path) {
+    return std::visit(
+      [&field_path](const auto& a, const auto& b) -> std::partial_ordering {
+          using A = std::remove_cvref_t<decltype(a)>;
+          using B = std::remove_cvref_t<decltype(b)>;
+
+          if constexpr (!ComparableValue<A> || !ComparableValue<B>) {
+              throw serde::pb::rpc::internal_exception(
+                fmt::format(
+                  "Unsupported field type during sorting for field path: {}",
+                  field_path));
+          } else if constexpr (
+            std::is_same_v<A, std::monostate>
+            || std::is_same_v<B, std::monostate>) {
+              // Handle monostate (unset fields)
+              if constexpr (std::is_same_v<A, B>) {
+                  return std::partial_ordering::equivalent;
+              } else {
+                  // A=null -> A < B; B=null -> A > B
+                  return std::is_same_v<A, std::monostate>
+                           ? std::partial_ordering::less
+                           : std::partial_ordering::greater;
+              }
+          } else if constexpr (!std::is_same_v<A, B>) {
+              throw serde::pb::rpc::internal_exception(
+                fmt::format("Type mismatch for field path: {}", field_path));
+          } else if constexpr (std::is_same_v<A, serde::pb::raw_enum_value>) {
+              // Compare enums by their variant number
+              return a.number <=> b.number;
+          } else {
+              return a <=> b;
+          }
+      },
+      va,
+      vb);
+}
+
+} // namespace
+
+sort_order::sort_order(std::vector<component> components)
+  : _components(std::move(components)) {}
+
+sort_order sort_order::parse(const aip_ordering_config& config) {
+    auto result = std::vector<component>{};
+
+    auto parts = absl::StrSplit(std::string_view{config.ordering_expr}, ',');
+    for (auto part : parts) {
+        part = absl::StripAsciiWhitespace(part);
+
+        // Split by first space: field [order]
+        auto space_pos = part.find_first_of(' ');
+        auto field = part.substr(0, space_pos);
+        auto ord_tok = (space_pos != std::string_view::npos)
+                         ? absl::StripAsciiWhitespace(part.substr(space_pos))
+                         : std::string_view{};
+
+        if (field.empty()) {
+            throw serde::pb::rpc::invalid_argument_exception(
+              fmt::format(
+                "Invalid (empty) field in ordering expression: '{}'", part));
+        }
+
+        std::vector<std::string_view> path_components = absl::StrSplit(
+          field, '.');
+        auto field_nums = config.field_path_converter(path_components);
+        if (!field_nums) {
+            throw serde::pb::rpc::invalid_argument_exception(
+              fmt::format(
+                "Invalid field path in ordering expression: '{}'", field));
+        }
+
+        auto field_type = config.field_type_getter(*field_nums);
+        if (!is_type_supported(field_type)) {
+            throw serde::pb::rpc::invalid_argument_exception(
+              fmt::format("Unsupported field type for field: '{}'", field));
+        }
+
+        auto ord = parse_order_token(ord_tok);
+        if (!ord) {
+            throw serde::pb::rpc::invalid_argument_exception(
+              fmt::format(
+                "Unknown ordering specifier '{}', must be 'asc' or 'desc'",
+                ord_tok));
+        }
+
+        result.emplace_back(
+          component{.field_numbers = *field_nums, .ord = *ord});
+    }
+
+    if (result.empty()) {
+        throw serde::pb::rpc::invalid_argument_exception(
+          "Ordering expression did not specify any fields");
+    }
+
+    return sort_order(std::move(result));
+}
+
+bool sort_order::operator()(
+  serde::pb::base_message& a, serde::pb::base_message& b) const {
+    for (const auto& comp : _components) {
+        auto fa = a.lookup_field(comp.field_numbers);
+        auto fb = b.lookup_field(comp.field_numbers);
+
+        if (!fa || !fb) {
+            throw serde::pb::rpc::invalid_argument_exception(
+              fmt::format(
+                "Failed field lookup while sorting for field path {}",
+                comp.field_numbers));
+        }
+
+        auto cmp = compare_field_variant(
+          fa->value, fb->value, comp.field_numbers);
+
+        if (cmp == std::partial_ordering::unordered) {
+            // Treat unordered (e.g. NaN) as less so they appear first when
+            // sorting in ascending order (e.g. NaN < 42.0 -> true)
+            cmp = std::partial_ordering::less;
+        }
+
+        if (cmp != std::partial_ordering::equivalent) {
+            // Ascending: cmp as is. Descending: invert
+            return comp.ord == component::order::ascending
+                     ? cmp == std::partial_ordering::less
+                     : cmp == std::partial_ordering::greater;
+        }
+    }
+
+    // All compared equal, a < b should return false
+    return false;
+}
+
+} // namespace admin

--- a/src/v/redpanda/admin/aip_ordering.h
+++ b/src/v/redpanda/admin/aip_ordering.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "redpanda/admin/aip_common_config.h"
+#include "serde/protobuf/base.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <string_view>
+#include <vector>
+
+namespace admin {
+
+struct aip_ordering_config {
+    // Maps a field path to field numbers. Returns nullopt if path is unknown.
+    field_path_converter_t field_path_converter;
+
+    // A getter for converting field numbers -> a value_t
+    field_type_getter_t field_type_getter;
+
+    // The ordering expression to parse (e.g. "foo, bar desc")
+    ss::sstring ordering_expr;
+};
+
+template<serde::pb::Message MsgType>
+auto make_ordering_config(std::string_view ordering_expr) {
+    return admin::aip_ordering_config{
+      .field_path_converter = make_field_path_converter<MsgType>(),
+      .field_type_getter = make_field_type_getter<MsgType>(),
+      .ordering_expr = ss::sstring{ordering_expr},
+    };
+}
+
+/// sort_order parses AIP-132 ordering strings into comparators for sorting
+/// protobuf messages. Supports full AIP-132: comma-separated fields, "desc" for
+/// descending, nested fields, well-known type ordering. Whitespace is ignored.
+/// Example: "foo, bar desc, nested.field"
+/// Ref: https://google.aip.dev/132#ordering
+class sort_order {
+public:
+    struct component {
+        enum class order : uint8_t { ascending, descending };
+        std::vector<int32_t> field_numbers;
+        order ord;
+    };
+
+    static sort_order parse(const aip_ordering_config&);
+
+    // Returns true if a < b, allows passing sort_order to std::sort()
+    bool
+    operator()(serde::pb::base_message& a, serde::pb::base_message& b) const;
+
+private:
+    // Only constructible via parse()
+    explicit sort_order(std::vector<component> components);
+
+    std::vector<component> _components;
+};
+
+} // namespace admin

--- a/src/v/redpanda/admin/tests/BUILD
+++ b/src/v/redpanda/admin/tests/BUILD
@@ -45,3 +45,21 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "aip_ordering_test",
+    timeout = "short",
+    srcs = [
+        "aip_ordering_test.cc",
+    ],
+    deps = [
+        ":aip_test_message_helpers",
+        ":aip_test_message_redpanda_proto",
+        "//src/v/redpanda/admin:aip_ordering",
+        "//src/v/serde/protobuf:rpc",
+        "//src/v/test_utils:gtest",
+        "@abseil-cpp//absl/time",
+        "@fmt",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/redpanda/admin/tests/BUILD
+++ b/src/v/redpanda/admin/tests/BUILD
@@ -1,10 +1,10 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:test.bzl", "redpanda_cc_gtest")
+load("//bazel:test.bzl", "redpanda_cc_gtest", "redpanda_test_cc_library")
 load("//bazel/pbgen:pbgen.bzl", "redpanda_proto_library")
 
 proto_library(
-    name = "aip_filter_test_messages_proto",
-    srcs = ["aip_filter_test_messages.proto"],
+    name = "aip_test_message_proto",
+    srcs = ["aip_test_message.proto"],
     deps = [
         "//proto/redpanda/pbgen:options_proto",
         "@protobuf//:duration_proto",
@@ -13,10 +13,19 @@ proto_library(
 )
 
 redpanda_proto_library(
-    name = "aip_filter_test_messages_redpanda_proto",
-    protos = [":aip_filter_test_messages_proto"],
+    name = "aip_test_message_redpanda_proto",
+    protos = [":aip_test_message_proto"],
     visibility = ["//visibility:public"],
     deps = ["@abseil-cpp//absl/time:time"],
+)
+
+redpanda_test_cc_library(
+    name = "aip_test_message_helpers",
+    hdrs = ["aip_test_message_helpers.h"],
+    deps = [
+        ":aip_test_message_redpanda_proto",
+        "@abseil-cpp//absl/time",
+    ],
 )
 
 redpanda_cc_gtest(
@@ -26,7 +35,8 @@ redpanda_cc_gtest(
         "aip_filter_test.cc",
     ],
     deps = [
-        ":aip_filter_test_messages_redpanda_proto",
+        ":aip_test_message_helpers",
+        ":aip_test_message_redpanda_proto",
         "//src/v/redpanda/admin:aip_filter",
         "//src/v/serde/protobuf:rpc",
         "//src/v/test_utils:gtest",

--- a/src/v/redpanda/admin/tests/BUILD
+++ b/src/v/redpanda/admin/tests/BUILD
@@ -28,6 +28,7 @@ redpanda_cc_gtest(
     deps = [
         ":aip_filter_test_messages_redpanda_proto",
         "//src/v/redpanda/admin:aip_filter",
+        "//src/v/serde/protobuf:rpc",
         "//src/v/test_utils:gtest",
         "@abseil-cpp//absl/time",
         "@fmt",

--- a/src/v/redpanda/admin/tests/aip_filter_test.cc
+++ b/src/v/redpanda/admin/tests/aip_filter_test.cc
@@ -9,10 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-#include "absl/time/clock.h"
 #include "redpanda/admin/aip_filter.h"
+#include "redpanda/admin/tests/aip_test_message_helpers.h"
 #include "serde/protobuf/rpc.h"
-#include "src/v/redpanda/admin/tests/aip_filter_test_messages.proto.h"
+#include "src/v/redpanda/admin/tests/aip_test_message.proto.h"
 
 #include <fmt/ranges.h>
 #include <gmock/gmock.h>
@@ -24,40 +24,11 @@ namespace admin {
 
 namespace rpc = serde::pb::rpc;
 
-namespace {
-aip_filter_test::test_message create_test_message(
-  int32_t int_val = 42,
-  const std::string& str_val = "test",
-  bool bool_val = true,
-  const std::string& nested_name = "nested",
-  int32_t nested_val = 100) {
-    aip_filter_test::test_message msg;
-    msg.set_int_field(int_val);
-    msg.set_string_field(ss::sstring(str_val));
-    msg.set_bool_field(bool_val);
-    msg.set_uint_field(1000);
-    msg.set_double_field(3.14);
-
-    msg.get_nested().set_name(ss::sstring(nested_name));
-    msg.get_nested().set_value(nested_val);
-
-    msg.set_status(aip_filter_test::test_message_status::status_active);
-    msg.set_timestamp_field(absl::Now() - absl::Minutes(5));
-    msg.set_duration_field(absl::Seconds(30));
-
-    msg.set_int32_field(123);
-    msg.set_float_field(2.5f);
-
-    return msg;
-}
-} // namespace
-
 class AIPFilterTest : public ::testing::Test {
 protected:
     auto parse(std::string_view filter_expression) {
-        auto config
-          = admin::make_aip_filter_config<aip_filter_test::test_message>(
-            filter_expression);
+        auto config = admin::make_aip_filter_config<aip_test::test_message>(
+          filter_expression);
         return aip_filter_parser::create_aip_filter(std::move(config));
     }
 };
@@ -214,17 +185,17 @@ TEST_F(AIPFilterTest, EnumFieldOperations) {
     auto msg = create_test_message();
 
     // Test enum equality
-    msg.set_status(aip_filter_test::test_message_status::status_active);
+    msg.set_status(aip_test::test_message_status::status_active);
     EXPECT_TRUE(parse("status = STATUS_ACTIVE")(msg));
     EXPECT_FALSE(parse("status = STATUS_INACTIVE")(msg));
     EXPECT_TRUE(parse("status != STATUS_INACTIVE")(msg));
 
     // Test unspecified value
-    msg.set_status(aip_filter_test::test_message_status::status_unspecified);
+    msg.set_status(aip_test::test_message_status::status_unspecified);
     EXPECT_TRUE(parse("status = STATUS_UNSPECIFIED")(msg));
 
     // Test case sensitivity
-    msg.set_status(aip_filter_test::test_message_status::status_active);
+    msg.set_status(aip_test::test_message_status::status_active);
     EXPECT_FALSE(parse("status = status_active")(msg));
 
     // Only equality operators should work for enums
@@ -483,7 +454,7 @@ TEST_F(AIPFilterTest, IntegerBoundaryValues) {
 }
 
 TEST_F(AIPFilterTest, CardinalityKeywords) {
-    auto msg = aip_filter_test::test_message{};
+    auto msg = aip_test::test_message{};
 
     // Sanity check optional field presence
     EXPECT_FALSE(msg.has_optional_int_field());

--- a/src/v/redpanda/admin/tests/aip_filter_test.cc
+++ b/src/v/redpanda/admin/tests/aip_filter_test.cc
@@ -11,16 +11,18 @@
 
 #include "absl/time/clock.h"
 #include "redpanda/admin/aip_filter.h"
+#include "serde/protobuf/rpc.h"
 #include "src/v/redpanda/admin/tests/aip_filter_test_messages.proto.h"
 
 #include <fmt/ranges.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <stdexcept>
 #include <string>
 
 namespace admin {
+
+namespace rpc = serde::pb::rpc;
 
 namespace {
 aip_filter_test::test_message create_test_message(
@@ -96,7 +98,7 @@ TEST_F(AIPFilterTest, StringFieldComparisons) {
 
     // Test only quoted strings work, unquoted strings throw
     msg.set_string_field(ss::sstring("test"));
-    EXPECT_THROW(parse("string_field = test"), std::invalid_argument);
+    EXPECT_THROW(parse("string_field = test"), rpc::invalid_argument_exception);
     EXPECT_TRUE(parse(R"(string_field = "test")")(msg));
 
     // Test escape sequences in quoted strings
@@ -111,7 +113,8 @@ TEST_F(AIPFilterTest, StringFieldComparisons) {
     msg.set_string_field(ss::sstring{chars.data(), chars.size()});
     EXPECT_TRUE(parse(R"(string_field = "\t\n\r\\\"\xC3\xA9")")(msg));
     EXPECT_THROW(
-      parse(R"(string_field = "invalid-utf8-\xA")"), std::invalid_argument);
+      parse(R"(string_field = "invalid-utf8-\xA")"),
+      rpc::invalid_argument_exception);
 
     // Empty string
     msg.set_string_field(ss::sstring(""));
@@ -133,12 +136,12 @@ TEST_F(AIPFilterTest, BooleanFieldOperations) {
     EXPECT_TRUE(parse("bool_field != true")(msg_false));
 
     // Case sensitivity of true/false
-    EXPECT_THROW(parse("bool_field = TRUE"), std::invalid_argument);
-    EXPECT_THROW(parse("bool_field = True"), std::invalid_argument);
+    EXPECT_THROW(parse("bool_field = TRUE"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("bool_field = True"), rpc::invalid_argument_exception);
 
     // Only = and != allowed for boolean fields
-    EXPECT_THROW(parse("bool_field > true"), std::invalid_argument);
-    EXPECT_THROW(parse("bool_field < false"), std::invalid_argument);
+    EXPECT_THROW(parse("bool_field > true"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("bool_field < false"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, FloatingPointFieldOperations) {
@@ -200,9 +203,11 @@ TEST_F(AIPFilterTest, LogicalAndOperations) {
 
     // Case sensitivity for AND keyword
     EXPECT_THROW(
-      parse("int_field = 1 and bool_field = false"), std::invalid_argument);
+      parse("int_field = 1 and bool_field = false"),
+      rpc::invalid_argument_exception);
     EXPECT_THROW(
-      parse("int_field = 1 And bool_field = false"), std::invalid_argument);
+      parse("int_field = 1 And bool_field = false"),
+      rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, EnumFieldOperations) {
@@ -223,8 +228,10 @@ TEST_F(AIPFilterTest, EnumFieldOperations) {
     EXPECT_FALSE(parse("status = status_active")(msg));
 
     // Only equality operators should work for enums
-    EXPECT_THROW(parse("status > STATUS_ACTIVE"), std::invalid_argument);
-    EXPECT_THROW(parse("status < STATUS_INACTIVE"), std::invalid_argument);
+    EXPECT_THROW(
+      parse("status > STATUS_ACTIVE"), rpc::invalid_argument_exception);
+    EXPECT_THROW(
+      parse("status < STATUS_INACTIVE"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, DurationFieldOperations) {
@@ -290,9 +297,10 @@ TEST_F(AIPFilterTest, FieldOnLeftRequirement) {
     // AIP-160 requires field names on the left side of comparisons
     EXPECT_NO_THROW(parse("int_field = 42"));
     EXPECT_NO_THROW(parse("string_field = \"test\""));
-    EXPECT_THROW(parse("42 = int_field"), std::invalid_argument);
-    EXPECT_THROW(parse("\"test\" = string_field"), std::invalid_argument);
-    EXPECT_THROW(parse("true = bool_field"), std::invalid_argument);
+    EXPECT_THROW(parse("42 = int_field"), rpc::invalid_argument_exception);
+    EXPECT_THROW(
+      parse("\"test\" = string_field"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("true = bool_field"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, GrammarErrorHandling) {
@@ -301,85 +309,94 @@ TEST_F(AIPFilterTest, GrammarErrorHandling) {
     EXPECT_TRUE(parse("")(msg));
 
     // Unknown field errors
-    EXPECT_THROW(parse("unknown_field = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("unknown_field = 1"), rpc::invalid_argument_exception);
     EXPECT_THROW(
-      parse("int_field = 1 AND unknown_field = 2"), std::invalid_argument);
+      parse("int_field = 1 AND unknown_field = 2"),
+      rpc::invalid_argument_exception);
 
     // Type mismatches
-    EXPECT_THROW(parse("int_field = \"not_a_number\""), std::invalid_argument);
     EXPECT_THROW(
-      parse("bool_field = \"not_a_boolean\""), std::invalid_argument);
+      parse("int_field = \"not_a_number\""), rpc::invalid_argument_exception);
+    EXPECT_THROW(
+      parse("bool_field = \"not_a_boolean\""), rpc::invalid_argument_exception);
 
     // Malformed expressions
-    EXPECT_THROW(parse("int_field ="), std::invalid_argument);
-    EXPECT_THROW(parse("= 1"), std::invalid_argument);
-    EXPECT_THROW(parse("int_field 1"), std::invalid_argument);
-    EXPECT_THROW(parse("int_field = 1 AND"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field ="), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("= 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field = 1 AND"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, FieldPathValidation) {
     // Test malformed nested field paths
-    EXPECT_THROW(parse("nested. = 1"), std::invalid_argument);
-    EXPECT_THROW(parse(".nested = 1"), std::invalid_argument);
-    EXPECT_THROW(parse("nested..value = 1"), std::invalid_argument);
-    EXPECT_THROW(parse("nested.nonexistent = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("nested. = 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse(".nested = 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("nested..value = 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(
+      parse("nested.nonexistent = 1"), rpc::invalid_argument_exception);
 
     // Test invalid field name formats
-    EXPECT_THROW(parse("123field = 1"), std::invalid_argument);
-    EXPECT_THROW(parse("-field = 1"), std::invalid_argument);
-    EXPECT_THROW(parse("field- = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("123field = 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("-field = 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("field- = 1"), rpc::invalid_argument_exception);
 
     // Case sensitivity for field names
-    EXPECT_THROW(parse("INT_FIELD = 1"), std::invalid_argument);
-    EXPECT_THROW(parse("Int_Field = 1"), std::invalid_argument);
+    EXPECT_THROW(parse("INT_FIELD = 1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("Int_Field = 1"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, StringEscapingErrors) {
     // Test unterminated quoted strings
-    EXPECT_THROW(parse(R"(string_field = "unclosed)"), std::invalid_argument);
-    EXPECT_THROW(parse(R"(string_field = ")"), std::invalid_argument);
-    EXPECT_THROW(parse(R"(string_field = "\)"), std::invalid_argument);
+    EXPECT_THROW(
+      parse(R"(string_field = "unclosed)"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse(R"(string_field = ")"), rpc::invalid_argument_exception);
+    EXPECT_THROW(
+      parse(R"(string_field = "\)"), rpc::invalid_argument_exception);
 
     // Test invalid escape sequences that should fail
-    EXPECT_THROW(parse(R"(string_field = "\x")"), std::invalid_argument);
+    EXPECT_THROW(
+      parse(R"(string_field = "\x")"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, NumberFormatValidation) {
     // Test invalid number formats
-    EXPECT_THROW(parse("int_field = 1.2.3"), std::invalid_argument);
-    EXPECT_THROW(parse("int_field = .123"), std::invalid_argument);
-    EXPECT_THROW(parse("int_field = 123."), std::invalid_argument);
-    EXPECT_THROW(parse("int_field = --1"), std::invalid_argument);
-    EXPECT_THROW(parse("int_field = ++1"), std::invalid_argument);
+    EXPECT_THROW(parse("int_field = 1.2.3"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field = .123"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field = 123."), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field = --1"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field = ++1"), rpc::invalid_argument_exception);
 
     // Test invalid scientific notation
-    EXPECT_THROW(parse("double_field = 123e"), std::invalid_argument);
-    EXPECT_THROW(parse("double_field = e123"), std::invalid_argument);
-    EXPECT_THROW(parse("double_field = 1e+"), std::invalid_argument);
-    EXPECT_THROW(parse("double_field = 1e-"), std::invalid_argument);
+    EXPECT_THROW(parse("double_field = 123e"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("double_field = e123"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("double_field = 1e+"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("double_field = 1e-"), rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, TimeFormatValidation) {
     // Test invalid duration formats
-    EXPECT_THROW(parse("duration_field = invalid"), std::invalid_argument);
+    EXPECT_THROW(
+      parse("duration_field = invalid"), rpc::invalid_argument_exception);
     EXPECT_THROW(
       parse("duration_field = 120"),
-      std::invalid_argument); // Missing 's'
+      rpc::invalid_argument_exception); // Missing 's'
     EXPECT_THROW(
-      parse("duration_field = s"), std::invalid_argument); // No number
+      parse("duration_field = s"),
+      rpc::invalid_argument_exception); // No number
 
     // Test invalid timestamp formats
     EXPECT_THROW(
-      parse("timestamp_field = \"invalid-timestamp\""), std::invalid_argument);
+      parse("timestamp_field = \"invalid-timestamp\""),
+      rpc::invalid_argument_exception);
     EXPECT_THROW(
       parse("timestamp_field = \"2012-04-21 11:30:00\""),
-      std::invalid_argument); // Missing T
+      rpc::invalid_argument_exception); // Missing T
     EXPECT_THROW(
       parse("timestamp_field = \"2012-04-21T25:30:00Z\""),
-      std::invalid_argument); // Invalid hour
+      rpc::invalid_argument_exception); // Invalid hour
     EXPECT_THROW(
       parse("timestamp_field = \"2012-13-21T11:30:00Z\""),
-      std::invalid_argument); // Invalid month
+      rpc::invalid_argument_exception); // Invalid month
 }
 
 TEST_F(AIPFilterTest, WhitespaceHandling) {
@@ -396,7 +413,8 @@ TEST_F(AIPFilterTest, WhitespaceHandling) {
 
     // Missing space around AND should fail
     EXPECT_THROW(
-      parse("int_field=1AND bool_field=false"), std::invalid_argument);
+      parse("int_field=1AND bool_field=false"),
+      rpc::invalid_argument_exception);
 }
 
 TEST_F(AIPFilterTest, FilterLengthLimits) {
@@ -408,13 +426,13 @@ TEST_F(AIPFilterTest, FilterLengthLimits) {
     // Test filter over the limit (1024 characters)
     constexpr auto length = aip_filter_parser::max_filter_length + 1;
     std::string oversized_filter(length, 'x');
-    EXPECT_THROW(parse(oversized_filter), std::invalid_argument);
+    EXPECT_THROW(parse(oversized_filter), rpc::invalid_argument_exception);
 
     // Verify the error message mentions the limit
     try {
         parse(oversized_filter);
         FAIL() << "Expected exception for oversized filter";
-    } catch (const std::invalid_argument& e) {
+    } catch (const rpc::invalid_argument_exception& e) {
         EXPECT_THAT(std::string(e.what()), ::testing::HasSubstr("1024"));
     }
 }
@@ -449,18 +467,19 @@ TEST_F(AIPFilterTest, IntegerBoundaryValues) {
     // Test int32 boundary values
     msg.set_int32_field(std::numeric_limits<int32_t>::max());
     EXPECT_TRUE(parse("int32_field = 2147483647")(msg));
-    EXPECT_THROW(parse("int32_field < 2147483650"), std::invalid_argument);
+    EXPECT_THROW(
+      parse("int32_field < 2147483650"), rpc::invalid_argument_exception);
 
     msg.set_int32_field(std::numeric_limits<int32_t>::min());
     EXPECT_TRUE(parse("int32_field = -2147483648")(msg));
 
     // Negative values should fail for unsigned types
-    EXPECT_THROW(parse("uint_field = -1"), std::invalid_argument);
+    EXPECT_THROW(parse("uint_field = -1"), rpc::invalid_argument_exception);
 
     // Test overflow conditions
     EXPECT_THROW(
       parse("int_field = 9223372036854775808"),
-      std::invalid_argument); // max + 1
+      rpc::invalid_argument_exception); // max + 1
 }
 
 TEST_F(AIPFilterTest, CardinalityKeywords) {
@@ -473,8 +492,9 @@ TEST_F(AIPFilterTest, CardinalityKeywords) {
     // improvements to our protogen's reflection support
     EXPECT_TRUE(parse("optional_int_field = 0")(msg));
 
-    EXPECT_THROW(parse("repeated_int_field = 0")(msg), std::invalid_argument);
-    EXPECT_THROW(parse("map_field = 0")(msg), std::invalid_argument);
+    EXPECT_THROW(
+      parse("repeated_int_field = 0")(msg), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("map_field = 0")(msg), rpc::invalid_argument_exception);
 }
 
 } // namespace admin

--- a/src/v/redpanda/admin/tests/aip_ordering_test.cc
+++ b/src/v/redpanda/admin/tests/aip_ordering_test.cc
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed by the
+ * Apache License, Version 2.0
+ */
+#include "redpanda/admin/aip_ordering.h"
+#include "redpanda/admin/tests/aip_test_message_helpers.h"
+#include "serde/protobuf/rpc.h"
+#include "src/v/redpanda/admin/tests/aip_test_message.proto.h"
+
+#include <fmt/ranges.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace admin {
+
+namespace rpc = serde::pb::rpc;
+
+class AIPOrderingTest : public ::testing::Test {
+protected:
+    auto parse(std::string_view ordering_expression) {
+        auto config = make_ordering_config<aip_test::test_message>(
+          ordering_expression);
+        return admin::sort_order::parse(config);
+    }
+};
+
+TEST_F(AIPOrderingTest, SimpleAscendingSort) {
+    constexpr auto msg_count = 10;
+    auto msgs = std::vector<aip_test::test_message>{};
+    for (int i = msg_count; i >= 1; --i) {
+        msgs.push_back(create_test_message(i));
+    }
+
+    auto order = parse("int_field");
+    std::ranges::sort(msgs, order);
+    for (int i = 0; i < msg_count; ++i) {
+        EXPECT_EQ(msgs[i].get_int_field(), i + 1);
+    }
+}
+
+TEST_F(AIPOrderingTest, SimpleDescendingSort) {
+    constexpr auto msg_count = 10;
+    auto msgs = std::vector<aip_test::test_message>{};
+    for (int i = 1; i <= msg_count; ++i) {
+        msgs.push_back(create_test_message(i));
+    }
+
+    auto order = parse("int_field desc");
+    std::ranges::sort(msgs, order);
+    for (int i = 0; i < msg_count; ++i) {
+        EXPECT_EQ(msgs[i].get_int_field(), msg_count - i);
+    }
+}
+
+TEST_F(AIPOrderingTest, StringAscendingAndDescending) {
+    auto msgs = std::vector<aip_test::test_message>{};
+    msgs.push_back(create_test_message(1, "ccc"));
+    msgs.push_back(create_test_message(2, "aaa"));
+    msgs.push_back(create_test_message(3, "bbb"));
+
+    auto asc_order = parse("string_field");
+    std::ranges::sort(msgs, asc_order);
+    EXPECT_EQ(msgs[0].get_string_field(), "aaa");
+    EXPECT_EQ(msgs[1].get_string_field(), "bbb");
+    EXPECT_EQ(msgs[2].get_string_field(), "ccc");
+
+    auto desc_order = parse("string_field desc");
+    std::ranges::sort(msgs, desc_order);
+    EXPECT_EQ(msgs[0].get_string_field(), "ccc");
+    EXPECT_EQ(msgs[1].get_string_field(), "bbb");
+    EXPECT_EQ(msgs[2].get_string_field(), "aaa");
+}
+
+TEST_F(AIPOrderingTest, MultiFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+    msgs.push_back(create_test_message(2, "b"));
+    msgs.push_back(create_test_message(1, "b"));
+    msgs.push_back(create_test_message(1, "a"));
+    msgs.push_back(create_test_message(2, "a"));
+
+    auto order = parse("int_field asc, string_field desc");
+    std::ranges::sort(msgs, order);
+
+    // Should be: (1,"b"), (1,"a"), (2,"b"), (2,"a")
+    EXPECT_EQ(msgs[0].get_int_field(), 1);
+    EXPECT_EQ(msgs[0].get_string_field(), "b");
+    EXPECT_EQ(msgs[1].get_int_field(), 1);
+    EXPECT_EQ(msgs[1].get_string_field(), "a");
+    EXPECT_EQ(msgs[2].get_int_field(), 2);
+    EXPECT_EQ(msgs[2].get_string_field(), "b");
+    EXPECT_EQ(msgs[3].get_int_field(), 2);
+    EXPECT_EQ(msgs[3].get_string_field(), "a");
+}
+
+TEST_F(AIPOrderingTest, NestedFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+    msgs.push_back(create_test_message(1, "a", true, "zzz", 10));
+    msgs.push_back(create_test_message(2, "b", true, "abc", 5));
+    msgs.push_back(create_test_message(3, "c", true, "abc", 20));
+
+    auto order = parse("nested.name asc, nested.value desc");
+    std::ranges::sort(msgs, order);
+
+    // Expect "abc", 20 first, then "abc", 5, then "zzz", 10
+    EXPECT_EQ(msgs[0].get_nested().get_name(), "abc");
+    EXPECT_EQ(msgs[0].get_nested().get_value(), 20);
+    EXPECT_EQ(msgs[1].get_nested().get_name(), "abc");
+    EXPECT_EQ(msgs[1].get_nested().get_value(), 5);
+    EXPECT_EQ(msgs[2].get_nested().get_name(), "zzz");
+    EXPECT_EQ(msgs[2].get_nested().get_value(), 10);
+}
+
+TEST_F(AIPOrderingTest, BoolFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+    msgs.push_back(create_test_message(1, "a", true));
+    msgs.push_back(create_test_message(2, "b", false));
+    msgs.push_back(create_test_message(3, "c", true));
+
+    auto order = parse("bool_field desc, int_field asc");
+    std::ranges::sort(msgs, order);
+
+    // Expect all 'true' before 'false', then by int_field
+    EXPECT_TRUE(msgs[0].get_bool_field());
+    EXPECT_TRUE(msgs[1].get_bool_field());
+    EXPECT_FALSE(msgs[2].get_bool_field());
+}
+
+TEST_F(AIPOrderingTest, EnumFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+    msgs.push_back(create_test_message(1, "a"));
+    msgs.push_back(create_test_message(2, "b"));
+    msgs[0].set_status(aip_test::test_message_status::status_inactive);
+    msgs[1].set_status(aip_test::test_message_status::status_active);
+
+    std::ranges::sort(msgs, parse("status"));
+    EXPECT_EQ(
+      msgs[0].get_status(), aip_test::test_message_status::status_active);
+    EXPECT_EQ(
+      msgs[1].get_status(), aip_test::test_message_status::status_inactive);
+
+    std::ranges::sort(msgs, parse("status desc"));
+    EXPECT_EQ(
+      msgs[0].get_status(), aip_test::test_message_status::status_inactive);
+    EXPECT_EQ(
+      msgs[1].get_status(), aip_test::test_message_status::status_active);
+}
+
+TEST_F(AIPOrderingTest, DurationFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+
+    auto& m1 = msgs.emplace_back();
+    m1.set_duration_field(absl::Seconds(20));
+
+    auto& m2 = msgs.emplace_back();
+    m2.set_duration_field(absl::Seconds(10));
+
+    auto order = parse("duration_field");
+
+    std::ranges::sort(msgs, order);
+    EXPECT_EQ(msgs[0].get_duration_field(), absl::Seconds(10));
+    EXPECT_EQ(msgs[1].get_duration_field(), absl::Seconds(20));
+}
+
+TEST_F(AIPOrderingTest, TimestampFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+
+    auto& m1 = msgs.emplace_back();
+    m1.set_timestamp_field(absl::FromUnixMillis(20000));
+
+    auto& m2 = msgs.emplace_back();
+    m2.set_timestamp_field(absl::FromUnixMillis(10000));
+
+    auto order = parse("timestamp_field");
+
+    std::ranges::sort(msgs, order);
+    EXPECT_EQ(msgs[0].get_timestamp_field(), absl::FromUnixMillis(10000));
+    EXPECT_EQ(msgs[1].get_timestamp_field(), absl::FromUnixMillis(20000));
+}
+
+TEST_F(AIPOrderingTest, FloatFieldOrdering) {
+    auto msgs = std::vector<aip_test::test_message>{};
+
+    auto& m1 = msgs.emplace_back();
+    m1.set_float_field(2.5f);
+
+    auto& m2 = msgs.emplace_back();
+    m2.set_float_field(1.5f);
+
+    auto& m3 = msgs.emplace_back();
+    m3.set_float_field(std::numeric_limits<float>::quiet_NaN());
+
+    auto order = parse("float_field");
+    std::ranges::sort(msgs, order);
+    EXPECT_TRUE(std::isnan(msgs[0].get_float_field()));
+    EXPECT_EQ(msgs[1].get_float_field(), 1.5f);
+    EXPECT_EQ(msgs[2].get_float_field(), 2.5f);
+}
+
+TEST_F(AIPOrderingTest, WhitespaceHandling) {
+    auto msgs = std::vector<aip_test::test_message>{};
+    msgs.push_back(create_test_message(3, "c"));
+    msgs.push_back(create_test_message(1, "a"));
+    msgs.push_back(create_test_message(2, "b"));
+
+    auto order = parse(" int_field   ASC ,  string_field DESC ");
+    std::ranges::sort(msgs, order);
+    EXPECT_EQ(msgs[0].get_int_field(), 1);
+    EXPECT_EQ(msgs[1].get_int_field(), 2);
+    EXPECT_EQ(msgs[2].get_int_field(), 3);
+}
+
+TEST_F(AIPOrderingTest, InvalidArguments) {
+    // Invalid field name
+    EXPECT_THROW(parse("nonexistent_field"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("int_field, badfield"), rpc::invalid_argument_exception);
+
+    // Invalid order specified
+    EXPECT_THROW(
+      parse("int_field upside_down"), rpc::invalid_argument_exception);
+    EXPECT_THROW(
+      parse("int_field, string_field foo"), rpc::invalid_argument_exception);
+
+    // Empty ordering throws
+    EXPECT_THROW(parse(""), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse(" , , "), rpc::invalid_argument_exception);
+
+    // Unsupported field types
+    EXPECT_THROW(parse("repeated_field"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("map_field"), rpc::invalid_argument_exception);
+    EXPECT_THROW(parse("nested"), rpc::invalid_argument_exception);
+}
+
+} // namespace admin

--- a/src/v/redpanda/admin/tests/aip_test_message.proto
+++ b/src/v/redpanda/admin/tests/aip_test_message.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package aip_filter_test;
+package aip_test;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";

--- a/src/v/redpanda/admin/tests/aip_test_message_helpers.h
+++ b/src/v/redpanda/admin/tests/aip_test_message_helpers.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed by the
+ * Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "absl/time/clock.h"
+#include "src/v/redpanda/admin/tests/aip_test_message.proto.h"
+
+inline aip_test::test_message create_test_message(
+  int64_t int_val = 42,
+  std::string str_val = "test",
+  bool bool_val = true,
+  std::string nested_name = "nested",
+  int32_t nested_val = 100) {
+    aip_test::test_message msg;
+    msg.set_int_field(int_val);
+    msg.set_string_field(ss::sstring(str_val));
+    msg.set_bool_field(bool_val);
+    msg.set_uint_field(1000);
+    msg.set_double_field(3.14);
+
+    msg.get_nested().set_name(ss::sstring(nested_name));
+    msg.get_nested().set_value(nested_val);
+
+    msg.set_status(aip_test::test_message_status::status_active);
+    msg.set_timestamp_field(absl::Now() - absl::Minutes(5));
+    msg.set_duration_field(absl::Seconds(30));
+
+    msg.set_int32_field(123);
+    msg.set_float_field(2.5f);
+
+    return msg;
+}

--- a/src/v/serde/protobuf/base.h
+++ b/src/v/serde/protobuf/base.h
@@ -159,4 +159,7 @@ public:
     lookup_field(std::span<const int32_t> field_numbers) = 0;
 };
 
+template<typename T>
+concept Message = std::derived_from<T, serde::pb::base_message>;
+
 } // namespace serde::pb


### PR DESCRIPTION
* sort_order parses AIP-132 ordering strings into comparators for sorting protobuf messages. Supports full AIP-132: comma-separated fields, "desc" for descending, nested fields, well-known type ordering. Whitespace is
ignored. Example: "foo, bar desc, nested.field"
Ref: https://google.aip.dev/132#ordering

* Also includes a carry-over change from https://github.com/redpanda-data/redpanda/pull/27704 to use `serde::pb::rpc` exceptions for the filter implementation, instead of `std` exceptions.

See the commit messages for details.

Fixes https://redpandadata.atlassian.net/browse/CORE-13362

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
