### PR TITLE
ts: Improve flush operation

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -1096,7 +1096,9 @@ ss::future<> ntp_archiver::upload_until_term_change_legacy() {
             }
         }
 
-        if (ss::lowres_clock::now() >= _next_housekeeping) {
+        if (
+          ss::lowres_clock::now() >= _next_housekeeping
+          && !flush_in_progress()) {
             co_await housekeeping();
             _next_housekeeping = _housekeeping_jitter();
         }
@@ -3139,6 +3141,13 @@ flush_result ntp_archiver::flush() {
           "partition, or the node is a read replica");
         return flush_result{
           .response = flush_response::rejected, .offset = std::nullopt};
+    }
+
+    if (_local_segment_merger) {
+        _local_segment_merger->set_enabled(false);
+    }
+    if (_scrubber) {
+        _scrubber->set_enabled(false);
     }
 
     _flush_uploads_offset = model::prev_offset(


### PR DESCRIPTION
The flush could potentially take longer if there is a concurrent scrub or adjacent segment merging run or housekeeping is going to run.

This commit improves flush latency a bit by disabling scrubbing when the flush is invoked.

If the archiver uploads segments normally the flush will have to wait until ongoing uploads complete and then the housekeeping may also run. Only after that the flush could be completed by uploading the rest of the partition. This commit disables this housekeeping run so the flush could be completed earlier (maybe_complete_flush is invoked without invoking housekeeping).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none