### PR TITLE
ssx: abortable condvar

### DIFF
--- a/src/v/raft/BUILD
+++ b/src/v/raft/BUILD
@@ -149,6 +149,7 @@ redpanda_cc_library(
         "//src/v/serde:optional",
         "//src/v/serde:vector",
         "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:condition_variable",
         "//src/v/ssx:future_util",
         "//src/v/ssx:semaphore",
         "//src/v/ssx:sformat",

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -39,6 +39,7 @@
 #include "raft/transfer_leadership.h"
 #include "raft/types.h"
 #include "raft/voter_priority_tracker.h"
+#include "ssx/condition_variable.h"
 #include "ssx/semaphore.h"
 #include "storage/log.h"
 #include "storage/snapshot.h"
@@ -394,7 +395,7 @@ public:
 
     model::offset dirty_offset() const { return _log->offsets().dirty_offset; }
 
-    ss::condition_variable& commit_index_updated() {
+    ssx::condition_variable& commit_index_updated() {
         return _commit_index_updated;
     }
 
@@ -910,7 +911,7 @@ private:
     event_manager _event_manager;
     std::unique_ptr<probe> _probe;
     mutable ctx_log _ctxlog;
-    ss::condition_variable _commit_index_updated;
+    ssx::condition_variable _commit_index_updated;
 
     std::chrono::milliseconds _replicate_append_timeout;
     std::chrono::milliseconds _recovery_append_timeout;

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -398,19 +398,12 @@ ss::future<> persisted_stm_base<BaseT, T>::wait_offset_committed(
     auto stop_cond = [this, offset, term] {
         return _raft->committed_offset() >= offset || _raft->term() > term;
     };
+    auto deadline = model::timeout_clock::now() + timeout;
     if (as) {
-        auto abortable_stop_cond = [&stop_cond, as] {
-            return stop_cond() || as->get().abort_requested();
-        };
-        auto sub = as->get().subscribe(
-          [this] noexcept { _raft->commit_index_updated().broadcast(); });
         co_await _raft->commit_index_updated().wait(
-          timeout, abortable_stop_cond);
-        // If the abort source signalled the updated index, we want this to
-        // throw in that case.
-        as->get().check();
+          deadline, as->get(), stop_cond);
     } else {
-        co_await _raft->commit_index_updated().wait(timeout, stop_cond);
+        co_await _raft->commit_index_updated().wait(deadline, stop_cond);
     }
 }
 

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -1,6 +1,18 @@
 load("//bazel:build.bzl", "redpanda_cc_library")
 
 redpanda_cc_library(
+    name = "condition_variable",
+    srcs = ["condition_variable.cc"],
+    hdrs = ["condition_variable.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/container:intrusive",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "thread_worker",
     hdrs = [
         "thread_worker.h",

--- a/src/v/ssx/condition_variable.cc
+++ b/src/v/ssx/condition_variable.cc
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/condition_variable.h"
+
+#include <memory>
+
+namespace ssx {
+
+bool setup_waiter(
+  condition_variable::waiter& w,
+  ss::abort_source& as,
+  condition_variable::abort_subscription_holder& h) {
+    auto sub = as.subscribe([&w, &as] noexcept {
+        w.set_exception(as.abort_requested_exception_ptr());
+    });
+    if (!sub) {
+        w.set_exception(as.abort_requested_exception_ptr());
+        return false;
+    }
+    h.sub = std::move(*sub);
+    return true;
+}
+
+bool setup_waiter(
+  condition_variable::waiter& w,
+  ss::manual_clock::time_point tp,
+  ss::timer<ss::manual_clock>& t) {
+    // A bug in seastar, if a manual clock is past now, the timer doesn't
+    // fire. This is fine with lowres, since it is checked every tick of the
+    // reactor.
+    if (tp <= ss::manual_clock::now()) {
+        w.set_exception(
+          std::make_exception_ptr(ss::condition_variable_timed_out{}));
+        return false;
+    }
+    t.set_callback([&w] {
+        w.set_exception(
+          std::make_exception_ptr(ss::condition_variable_timed_out{}));
+    });
+    t.arm(tp);
+    return true;
+}
+
+void setup_waiter(
+  condition_variable::waiter& w,
+  ss::lowres_clock::time_point tp,
+  ss::timer<ss::lowres_clock>& t) {
+    t.set_callback([&w] {
+        w.set_exception(
+          std::make_exception_ptr(ss::condition_variable_timed_out{}));
+    });
+    t.arm(tp);
+}
+
+void condition_variable::waiter::signal() noexcept {
+    set_value();
+    delete this;
+}
+
+void condition_variable::waiter::set_exception(
+  const std::exception_ptr& ex) noexcept {
+    promise<>::set_exception(ex);
+    delete this;
+}
+
+condition_variable::~condition_variable() { broken(); }
+
+void condition_variable::add_waiter(waiter& w) noexcept {
+    if (_ex) {
+        w.set_exception(_ex);
+        return;
+    }
+    _waiters.push_back(w);
+}
+
+bool condition_variable::wakeup_first() noexcept {
+    if (_waiters.empty()) {
+        return false;
+    }
+    auto& w = _waiters.front();
+    _waiters.pop_front();
+    if (_ex) {
+        w.set_exception(_ex);
+    } else {
+        w.signal();
+    }
+    return true;
+}
+
+bool condition_variable::check_and_consume_signal() noexcept {
+    return std::exchange(_signalled, false);
+}
+
+void condition_variable::signal() noexcept {
+    if (!wakeup_first()) {
+        _signalled = true;
+    }
+}
+
+void condition_variable::broadcast() noexcept {
+    auto tmp(std::move(_waiters));
+    while (!tmp.empty()) {
+        auto& w = tmp.front();
+        tmp.pop_front();
+        if (_ex) {
+            w.set_exception(_ex);
+        } else {
+            w.signal();
+        }
+    }
+}
+
+void condition_variable::broken() noexcept {
+    broken(std::make_exception_ptr(ss::broken_condition_variable()));
+}
+
+void condition_variable::broken(const std::exception_ptr& ep) noexcept {
+    _ex = ep;
+    broadcast();
+}
+
+ss::future<> condition_variable::wait(ss::abort_source& as) noexcept {
+    if (check_and_consume_signal()) {
+        return ss::make_ready_future();
+    }
+    struct waiter_t
+      : public waiter
+      , public abort_subscription_holder {};
+    auto* w = std::make_unique<waiter_t>().release();
+    auto f = w->get_future();
+    if (!setup_waiter(*w, as, *w)) {
+        return f;
+    }
+    add_waiter(*w);
+    return f;
+}
+
+ss::future<>
+condition_variable::wait(ss::lowres_clock::time_point timeout) noexcept {
+    if (check_and_consume_signal()) {
+        return ss::make_ready_future();
+    }
+    struct waiter_t
+      : public waiter
+      , public ss::timer<ss::lowres_clock> {};
+    auto* w = std::make_unique<waiter_t>().release();
+    auto f = w->get_future();
+    setup_waiter(*w, timeout, *w);
+    add_waiter(*w);
+    return f;
+}
+
+ss::future<>
+condition_variable::wait(ss::manual_clock::time_point timeout) noexcept {
+    if (check_and_consume_signal()) {
+        return ss::make_ready_future();
+    }
+    struct waiter_t
+      : public waiter
+      , public ss::timer<ss::manual_clock> {};
+    auto* w = std::make_unique<waiter_t>().release();
+    auto f = w->get_future();
+    if (!setup_waiter(*w, timeout, *w)) {
+        return f;
+    }
+    add_waiter(*w);
+    return f;
+}
+
+ss::future<> condition_variable::wait(
+  ss::lowres_clock::time_point timeout, ss::abort_source& as) noexcept {
+    if (check_and_consume_signal()) {
+        return ss::make_ready_future();
+    }
+    struct waiter_t
+      : public waiter
+      , public ss::timer<ss::lowres_clock>
+      , abort_subscription_holder {};
+    auto* w = std::make_unique<waiter_t>().release();
+    auto f = w->get_future();
+    if (!setup_waiter(*w, as, *w)) {
+        return f;
+    }
+    setup_waiter(*w, timeout, *w);
+    add_waiter(*w);
+    return f;
+}
+
+ss::future<> condition_variable::wait(
+  ss::manual_clock::time_point timeout, ss::abort_source& as) noexcept {
+    if (check_and_consume_signal()) {
+        return ss::make_ready_future();
+    }
+    struct waiter_t
+      : public waiter
+      , public ss::timer<ss::manual_clock>
+      , abort_subscription_holder {};
+    auto* w = std::make_unique<waiter_t>().release();
+    auto f = w->get_future();
+    if (!setup_waiter(*w, as, *w)) {
+        return f;
+    }
+    if (!setup_waiter(*w, timeout, *w)) {
+        return f;
+    }
+    add_waiter(*w);
+    return f;
+}
+
+} // namespace ssx

--- a/src/v/ssx/condition_variable.h
+++ b/src/v/ssx/condition_variable.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "container/intrusive_list_helpers.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/timer.hh>
+
+#include <exception>
+#include <type_traits>
+
+namespace ssx {
+
+// A condition variable that supports abort sources in addition to
+// timeouts.
+class condition_variable {
+public:
+    /// Constructs a condition_variable object.
+    condition_variable() noexcept = default;
+    condition_variable& operator=(const condition_variable& rhs) noexcept
+      = delete;
+    condition_variable& operator=(condition_variable&& rhs) noexcept = delete;
+    condition_variable(const condition_variable& rhs) noexcept = delete;
+    condition_variable(condition_variable&& rhs) noexcept = delete;
+    ~condition_variable();
+
+    // Wait for the condition variable to be signalled.
+    // If the abort_source is notified then the future will resolve with the
+    // exception from the abort_source.
+    ss::future<> wait(ss::abort_source&) noexcept;
+
+    // Wait for the condition variable to be signalled within the deadline.
+    //
+    // If the timepoint is reached then the future fails with
+    // ss::condition_variable_timed_out
+    ss::future<> wait(ss::lowres_clock::time_point) noexcept;
+    ss::future<> wait(ss::manual_clock::time_point) noexcept;
+
+    // Wait for the condition variable to be signalled within the deadline.
+    //
+    // If the timepoint is reached then the future fails with
+    // ss::condition_variable_timed_out
+    //
+    // If the abort_source is notified then the future will resolve with the
+    // exception from the abort_source.
+    ss::future<> wait(ss::manual_clock::time_point, ss::abort_source&) noexcept;
+    ss::future<> wait(ss::lowres_clock::time_point, ss::abort_source&) noexcept;
+
+    // Wait for the condition variable to be signalled until the predicate
+    // returns true.
+    //
+    // If the abort_source is notified then the future will
+    // resolve with the exception from the abort_source.
+    template<typename Pred>
+    requires std::is_invocable_r_v<bool, Pred>
+    ss::future<> wait(ss::abort_source& as, Pred&& pred) noexcept {
+        return ss::do_until(
+          std::forward<Pred>(pred), [this, &as] { return wait(as); });
+    }
+
+    // Wait for the condition variable to be signalled within the deadline until
+    // the predicate returns true.
+    //
+    // If the timepoint is reached then the future fails with
+    // ss::condition_variable_timed_out
+    template<
+      typename Clock = typename ss::lowres_clock,
+      typename Duration = typename Clock::duration,
+      typename Pred>
+    requires std::is_invocable_r_v<bool, Pred>
+    ss::future<>
+    wait(std::chrono::time_point<Clock, Duration> tp, Pred&& pred) noexcept {
+        return ss::do_until(
+          std::forward<Pred>(pred), [this, tp] { return wait(tp); });
+    }
+
+    // Wait for the condition variable to be signalled within the deadline until
+    // the predicate returns true.
+    //
+    // If the timepoint is reached then the future fails with
+    // ss::condition_variable_timed_out
+    //
+    // If the abort_source is notified then the future will resolve with the
+    // exception from the abort_source.
+    template<
+      typename Clock = typename ss::lowres_clock,
+      typename Duration = typename Clock::duration,
+      typename Pred>
+    requires std::is_invocable_r_v<bool, Pred>
+    ss::future<> wait(
+      std::chrono::time_point<Clock, Duration> tp,
+      ss::abort_source& as,
+      Pred&& pred) noexcept {
+        return ss::do_until(
+          std::forward<Pred>(pred), [this, tp, &as] { return wait(tp, as); });
+    }
+
+    // If there are any pending waiters for the condition variable.
+    bool has_waiters() const noexcept { return !_waiters.empty(); }
+    // Notify and wake up a single waiter.
+    void signal() noexcept;
+    // Notify and wake up all waiters.
+    void broadcast() noexcept;
+    // Signal to waiters that an error occurred. `wait` will see an exceptional
+    // future<> containing the provided exception parameter. The future is made
+    // available immediately.
+    void broken() noexcept;
+    // The same as broken, but specify the exception that waiters will see.
+    void broken(const std::exception_ptr&) noexcept;
+
+private:
+    struct waiter : public ss::promise<> {
+        waiter() = default;
+        waiter(const waiter&) = delete;
+        waiter(waiter&&) = delete;
+        waiter& operator=(const waiter&) = delete;
+        waiter& operator=(waiter&&) = delete;
+        virtual ~waiter() = default;
+        void signal() noexcept;
+        void set_exception(const std::exception_ptr& ex) noexcept;
+
+        intrusive_list_hook hook;
+    };
+    struct abort_subscription_holder {
+        ss::abort_source::subscription sub;
+    };
+    friend bool
+    setup_waiter(waiter&, ss::abort_source&, abort_subscription_holder&);
+    friend bool setup_waiter(
+      waiter&, ss::manual_clock::time_point, ss::timer<ss::manual_clock>&);
+    friend void setup_waiter(
+      waiter&, ss::lowres_clock::time_point, ss::timer<ss::lowres_clock>&);
+    void add_waiter(waiter&) noexcept;
+    bool wakeup_first() noexcept;
+    bool check_and_consume_signal() noexcept;
+
+    intrusive_list<waiter, &waiter::hook> _waiters;
+    std::exception_ptr _ex;
+    bool _signalled = false;
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -286,3 +286,18 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "condition_variable_test",
+    timeout = "short",
+    srcs = [
+        "condition_variable_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:condition_variable",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/condition_variable_test.cc
+++ b/src/v/ssx/tests/condition_variable_test.cc
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/condition_variable.h"
+
+#include <seastar/core/manual_clock.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+TEST(ConditionVariable, AbortSource) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    auto fut = cv.wait(as);
+    EXPECT_FALSE(fut.available());
+    cv.signal();
+    fut.get();
+
+    fut = cv.wait(as);
+    EXPECT_FALSE(fut.available());
+    as.request_abort();
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+}
+
+TEST(ConditionVariable, AbortSourceWithCustomException) {
+    class my_cool_exception : public std::exception {};
+    ss::abort_source as;
+    condition_variable cv;
+
+    auto fut = cv.wait(as);
+    as.request_abort_ex(my_cool_exception());
+    EXPECT_THROW(fut.get(), my_cool_exception);
+}
+
+TEST(ConditionVariable, AbortSourceWithPredicate) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    int i = 0;
+    auto fut = cv.wait(as, [&i] { return ++i == 2; });
+    cv.signal();
+    cv.signal();
+    fut.get();
+
+    // Test predicate with abort
+    fut = cv.wait(as, [] { return false; });
+    as.request_abort();
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+}
+
+TEST(ConditionVariable, AbortSourceWithTimeout) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    // Test timeout fires before abort
+    auto fut = cv.wait(ss::manual_clock::now() + 1s, as);
+    EXPECT_FALSE(fut.available());
+    ss::manual_clock::advance(2s);
+    EXPECT_THROW(fut.get(), ss::condition_variable_timed_out);
+
+    // Test abort fires before timeout - need fresh abort_source
+    ss::abort_source as2;
+    fut = cv.wait(ss::manual_clock::now() + 10s, as2);
+    EXPECT_FALSE(fut.available());
+    as2.request_abort();
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+}
+
+TEST(ConditionVariable, AbortSourceWithTimeoutAndPredicate) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    int i = 0;
+    auto fut = cv.wait(
+      ss::manual_clock::now() + 10s, as, [&i] { return ++i == 2; });
+    cv.signal();
+    fut.get();
+
+    cv.signal();
+    fut = cv.wait(ss::manual_clock::now() + 1s, as, [] { return false; });
+    ss::manual_clock::advance(2s);
+    EXPECT_THROW(fut.get(), ss::condition_variable_timed_out);
+
+    fut = cv.wait(ss::manual_clock::now() + 10s, as, [] { return false; });
+    as.request_abort();
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+}
+
+TEST(ConditionVariable, Signal) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    auto fut = cv.wait(as);
+    EXPECT_FALSE(fut.available());
+    cv.signal();
+    fut.get();
+}
+
+TEST(ConditionVariable, Broadcast) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    auto fut1 = cv.wait(as);
+    auto fut2 = cv.wait(as);
+    EXPECT_FALSE(fut1.available());
+    EXPECT_FALSE(fut2.available());
+    cv.broadcast();
+    fut1.get();
+    fut2.get();
+}
+
+TEST(ConditionVariable, Broken) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    auto fut1 = cv.wait(as);
+    auto fut2 = cv.wait(as);
+    EXPECT_FALSE(fut1.available());
+    EXPECT_FALSE(fut2.available());
+    cv.broken();
+    EXPECT_THROW(fut1.get(), ss::broken_condition_variable);
+    EXPECT_THROW(fut2.get(), ss::broken_condition_variable);
+}
+
+TEST(ConditionVariable, BrokenWithCustomException) {
+    class my_exception : public std::exception {};
+    ss::abort_source as;
+    condition_variable cv;
+
+    auto fut = cv.wait(as);
+    cv.broken(std::make_exception_ptr(my_exception()));
+    EXPECT_THROW(fut.get(), my_exception);
+}
+
+TEST(ConditionVariable, HasWaiters) {
+    ss::abort_source as;
+    condition_variable cv;
+
+    EXPECT_FALSE(cv.has_waiters());
+    auto fut = cv.wait(as);
+    EXPECT_TRUE(cv.has_waiters());
+    cv.signal();
+    fut.get();
+    EXPECT_FALSE(cv.has_waiters());
+}
+
+} // namespace ssx


### PR DESCRIPTION
It seems the seastar is not willing to accept new APIs for abort sources in condition_variable, so instead we just implement our own in the `ssx` namespace.

https://github.com/scylladb/seastar/pull/2013
https://github.com/scylladb/seastar/pull/3005
https://github.com/scylladb/seastar/pull/1889
https://github.com/scylladb/seastar/pull/1379

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
