### PR TITLE
`rptest`: reduce compaction parameterizations in RNOT

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -756,8 +756,6 @@ class RandomNodeOperationsTest(RandomNodeOperationsBase):
         with_iceberg=[True, False],
         compaction_mode=[
             CompactionMode.SLIDING_WINDOW,
-            CompactionMode.CHUNKED_SLIDING_WINDOW,
-            CompactionMode.ADJACENT_MERGE,
         ],
         cloud_storage_type=get_cloud_storage_type(),
     )


### PR DESCRIPTION
Chunked sliding window compaction has been active in the codebase long enough to feel it is bug-free and adjacent compaction is performed in `SLIDING_WINDOW` mode anyways.

Remove these two parameterizations to cut down on the number of RNOT tests performed in CI.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
