### PR TITLE
kafka/server: keep const ref alive on the stack in futurized function

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -329,7 +329,7 @@ ss::future<size_t> group_manager::delete_expired_offsets(
      * delete expired offsets from the group
      */
     auto offsets = group->delete_expired_offsets(retention_period);
-    return delete_offsets(group, std::move(offsets));
+    co_return co_await delete_offsets(group, offsets);
 }
 
 ss::future<size_t> group_manager::delete_offsets(


### PR DESCRIPTION
Regression from https://github.com/redpanda-data/redpanda/pull/27829

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
