### PR TITLE
ct: factor out placeholder construction from l0 reader

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,9 @@ src/v/base/format_to.h.
   latency. See our
   [docs](https://redpandadata.atlassian.net/wiki/x/AQBZTw#Managing-Concurrency-in-the-system)
   for more background.
+- Do not call the `get_exception` method on a future within a logging or
+  assertion statement (e.g. `vlog(..., fut.get_exception(), ...)`). Instead,
+  assign the return value of `get_exception` in a variable and pass the variable.
 
 
 ### C++ coding style

--- a/src/v/cloud_topics/README.md
+++ b/src/v/cloud_topics/README.md
@@ -23,12 +23,12 @@ sequenceDiagram
 ### Missing bits
 
 * In the write path we should populate batch cache with `raft_data` batches
-  instead of `dl_placeholder` batches. Currently, the `dl_placeholder` batches
+  instead of `ctp_placeholder` batches. Currently, the `ctp_placeholder` batches
   are replicated and so they're added to the batch cache. If we want low to
   achieve low latency for tailing consumers we need to make sure that they're
   reading from the batch cache.
 * Reader caching. Currently, the code just consumes from the partition and then
-  creates a `placeholder_extent` for every `dl_placeholder` batch. Then the
+  creates a `placeholder_extent` for every `ctp_placeholder` batch. Then the
   extent gets materialized (which involves expensive I/O). The data pulled by
   the `placeholder_extent` contains information that belongs to different NTPs
   but the reader only uses one that belongs to the NTP from which it's reading

--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -59,55 +59,6 @@ struct placeholder_batches_with_size {
 static constexpr auto L0_upload_default_timeout = 1s;
 static constexpr auto L0_replicate_default_timeout = 1s;
 
-// Create a placeholder batch using the original header and the extent.
-// The caller is supposed to use the correct batch header
-// that matches the extent.
-static model::record_batch make_placeholder_batch(
-  const model::record_batch_header& hdr,
-  const cloud_topics::extent_meta& extent) {
-    vassert(hdr.record_count > 0, "Empty record batch not allowed {}", hdr);
-
-    cloud_topics::dl_placeholder placeholder{
-      .id = extent.id,
-      .offset = extent.first_byte_offset,
-      .size_bytes = extent.byte_range_size,
-    };
-
-    storage::record_batch_builder builder(
-      model::record_batch_type::dl_placeholder, hdr.base_offset);
-
-    builder.set_producer_identity(hdr.producer_id, hdr.producer_epoch);
-    if (hdr.attrs.is_control()) {
-        builder.set_control_type();
-    }
-    if (hdr.attrs.is_transactional()) {
-        builder.set_transactional_type();
-    }
-
-    auto first_key = serde::to_iobuf(
-      cloud_topics::dl_placeholder_record_key::payload);
-
-    auto first_value = serde::to_iobuf(placeholder);
-
-    // In case of a placeholder batch the first record contains the
-    // actual placeholder and the remaining records are empty. The remaining
-    // records are added to avoid confusing any other code that may expect
-    // that the number of records in the batch is equal to the number of
-    // offsets in the header.
-    builder.add_raw_kv(std::move(first_key), std::move(first_value));
-
-    for (int i = 1; i < hdr.record_count; ++i) {
-        builder.add_raw_kv(std::nullopt, std::nullopt);
-    }
-
-    auto ph = std::move(builder).build();
-    ph.header().first_timestamp = hdr.first_timestamp;
-    ph.header().max_timestamp = hdr.max_timestamp;
-    ph.header().base_sequence = hdr.base_sequence;
-    ph.header().reset_size_checksum_metadata(ph.data());
-    return ph;
-}
-
 // Utility function to convert array of extent_meta structs to
 // array of placeholder batches.
 static placeholder_batches_with_size convert_to_placeholders(
@@ -132,7 +83,7 @@ static placeholder_batches_with_size convert_to_placeholders(
 
         // Every extent maps to a single batch produced by the client
         // and therefore we need to create a placeholder batch for it.
-        auto batch = make_placeholder_batch(header, extent);
+        auto batch = encode_placeholder_batch(header, extent);
 
         result.batches.push_back(std::move(batch));
         result.extent_size += extent.byte_range_size;

--- a/src/v/cloud_topics/frontend/frontend.h
+++ b/src/v/cloud_topics/frontend/frontend.h
@@ -70,13 +70,13 @@ struct partition_info {
 /// - Data plane returns a placeholder for the record batch, containing
 ///   metadata to locate data in cloud storage.
 /// - 'cloud_topic_partition' pushes the placeholder to the metadata layer by
-///   replicating 'dl_placeholder' batch.
+///   replicating 'ctp_placeholder' batch.
 ///
 /// Read Request Path:
-/// - 'dl_placeholder' batches are queried from the metadata layer, fetched
+/// - 'ctp_placeholder' batches are queried from the metadata layer, fetched
 ///   from 'cluster::partition'.
 /// - Includes information about aborted transactions.
-/// - 'dl_placeholder' batches are 'materialized' using the data plane.
+/// - 'ctp_placeholder' batches are 'materialized' using the data plane.
 ///
 /// Currently, the data plane is explicitly a sharded service. The control
 /// plane includes 'cluster::partition' and 'ctp_stm', with no explicit API

--- a/src/v/cloud_topics/level_zero/batcher/aggregator.cc
+++ b/src/v/cloud_topics/level_zero/batcher/aggregator.cc
@@ -49,7 +49,7 @@ namespace {
 /// concatenating multiple chunks the offset has to be corrected.
 /// This is done using the `base_byte_offset` parameter.
 template<class Clock>
-void make_dl_placeholders(
+void make_ctp_placeholders(
   prepared_extents<Clock>& ctx,
   l0::write_request<Clock>& req,
   const l0::serialized_chunk& chunk) {
@@ -83,7 +83,7 @@ aggregator<Clock>::get_extents() {
               !req.data_chunk.payload.empty(),
               "Empty write request for ntp: {}",
               key);
-            make_dl_placeholders(ctx, req, req.data_chunk);
+            make_ctp_placeholders(ctx, req, req.data_chunk);
         }
     }
     return std::move(ctx.placeholders);

--- a/src/v/cloud_topics/level_zero/common/BUILD
+++ b/src/v/cloud_topics/level_zero/common/BUILD
@@ -13,6 +13,7 @@ package(
         "//src/v/cloud_topics/level_zero/pipeline/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/reader:__pkg__",
         "//src/v/cloud_topics/level_zero/reader/tests:__pkg__",
+        "//src/v/cloud_topics/level_zero/stm:__pkg__",
         "//src/v/cloud_topics/level_zero/throttler/tests:__pkg__",
         "//src/v/cloud_topics/level_zero/write_request_scheduler:__pkg__",
         "//src/v/cloud_topics/level_zero/write_request_scheduler/tests:__pkg__",

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -225,12 +225,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
               .base_offset = model::offset_cast(batch.base_offset()),
               .last_offset = model::offset_cast(batch.last_offset()),
             };
-            iobuf payload = std::move(batch).release_data();
-            iobuf_parser parser(std::move(payload));
-            auto record = model::parse_one_record_from_buffer(parser);
-            iobuf value = std::move(record).release_value();
-            auto placeholder = serde::from_iobuf<cloud_topics::dl_placeholder>(
-              std::move(value));
+            auto placeholder = parse_placeholder_batch(std::move(batch));
             e.id = placeholder.id;
             e.first_byte_offset = placeholder.offset;
             e.byte_range_size = placeholder.size_bytes;

--- a/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_zero/frontend_reader/reader.cc
@@ -218,7 +218,7 @@ ss::future<> level_zero_log_reader_impl::fetch_metadata(
                 _unhydrated.push_back(std::move(local_batch));
                 continue;
             }
-            if (header.type != model::record_batch_type::dl_placeholder) {
+            if (header.type != model::record_batch_type::ctp_placeholder) {
                 continue;
             }
             cloud_topics::extent_meta e{

--- a/src/v/cloud_topics/level_zero/pipeline/read_request.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_request.h
@@ -33,7 +33,7 @@ struct dataplane_query_result {
 };
 
 /// The query for the data-plane.
-/// The meta field contains a bunch of dl_placeholder batches.
+/// The meta field contains a bunch of ctp_placeholder batches.
 struct dataplane_query {
     size_t output_size_estimate{0};
     chunked_vector<extent_meta> meta;

--- a/src/v/cloud_topics/level_zero/reader/fetch_request_handler.h
+++ b/src/v/cloud_topics/level_zero/reader/fetch_request_handler.h
@@ -23,7 +23,7 @@
 namespace cloud_topics::l0 {
 
 /// Read request handler.
-/// This component can process dl_placeholder batches.
+/// This component can process ctp_placeholder batches.
 /// This component should be split up into separate components in the
 /// future (one for materialization step, one for reading from cache,
 // etc). Currently everything is done in one place for simplicity.

--- a/src/v/cloud_topics/level_zero/reader/materialized_extent.h
+++ b/src/v/cloud_topics/level_zero/reader/materialized_extent.h
@@ -28,7 +28,7 @@ namespace cloud_topics::l0 {
 
 // Materialized placeholder extent
 //
-// Extent represents dl_placeholder with the data
+// Extent represents ctp_placeholder with the data
 // that it represents stored in cloud storage cache or
 // main memory.
 // The extent can be hydrated (the data is moved from the cloud
@@ -40,7 +40,7 @@ struct materialized_extent {
 };
 
 /// Fetch data referenced by the placeholder batch and the content of the
-/// dl_placeholder.
+/// ctp_placeholder.
 /// Return 'true' if the object was downloaded from the cloud storage.
 /// Otherwise, if the object was populated from the cache, return 'false'.
 ss::future<result<bool>> materialize(
@@ -50,7 +50,7 @@ ss::future<result<bool>> materialize(
   cloud_io::basic_cache_service_api<>* cache,
   basic_retry_chain_node<>* rtc);
 
-// Get dl_placeholder and the payload of the object and generate a record
+// Get ctp_placeholder and the payload of the object and generate a record
 // batch
 model::record_batch make_raft_data_batch(materialized_extent extent);
 

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.cc
@@ -77,15 +77,10 @@ void materialized_extent_fixture::produce_placeholders(
         storage::record_batch_builder builder(
           model::record_batch_type::dl_placeholder, source.base_offset());
 
-        builder.add_raw_kv(
-          serde::to_iobuf(cloud_topics::dl_placeholder_record_key::payload),
-          serde::to_iobuf(p));
+        builder.add_raw_kv(std::nullopt, serde::to_iobuf(p));
         // Match number of records in the batch with the 'source'
         for (auto i = 1; i < source.record_count(); i++) {
-            iobuf empty;
-            builder.add_raw_kv(
-              serde::to_iobuf(cloud_topics::dl_placeholder_record_key::empty),
-              std::move(empty));
+            builder.add_raw_kv(std::nullopt, std::nullopt);
         }
         return std::move(builder).build();
     };

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.cc
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.cc
@@ -68,14 +68,14 @@ void materialized_extent_fixture::produce_placeholders(
         size_t offset,
         size_t size,
         const model::record_batch& source) -> model::record_batch {
-        cloud_topics::dl_placeholder p{
+        cloud_topics::ctp_placeholder p{
           .id = id,
           .offset = cloud_topics::first_byte_offset_t(offset),
           .size_bytes = cloud_topics::byte_range_size_t(size),
         };
 
         storage::record_batch_builder builder(
-          model::record_batch_type::dl_placeholder, source.base_offset());
+          model::record_batch_type::ctp_placeholder, source.base_offset());
 
         builder.add_raw_kv(std::nullopt, serde::to_iobuf(p));
         // Match number of records in the batch with the 'source'

--- a/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.h
+++ b/src/v/cloud_topics/level_zero/reader/tests/materialized_extent_fixture.h
@@ -114,7 +114,7 @@ public:
         iobuf_parser parser(std::move(payload));
         auto record = model::parse_one_record_from_buffer(parser);
         iobuf value = std::move(record).release_value();
-        auto placeholder = serde::from_iobuf<cloud_topics::dl_placeholder>(
+        auto placeholder = serde::from_iobuf<cloud_topics::ctp_placeholder>(
           std::move(value));
         e.id = placeholder.id;
         e.first_byte_offset = placeholder.offset;

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -6,6 +6,9 @@ package(default_visibility = [
 
 redpanda_cc_library(
     name = "placeholder",
+    srcs = [
+        "placeholder.cc",
+    ],
     hdrs = [
         "placeholder.h",
     ],

--- a/src/v/cloud_topics/level_zero/stm/BUILD
+++ b/src/v/cloud_topics/level_zero/stm/BUILD
@@ -22,9 +22,12 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/cloud_topics:types",
+        "//src/v/cloud_topics/level_zero/common:extent_meta",
+        "//src/v/model",
         "//src/v/serde",
         "//src/v/serde:named_type",
         "//src/v/serde:uuid",
+        "//src/v/storage:record_batch_builder",
         "//src/v/utils:named_type",
         "//src/v/utils:uuid",
     ],

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -26,8 +26,8 @@ namespace cloud_topics {
 namespace {
 cluster_epoch extract_epoch(model::record_batch&& batch) {
     vassert(
-      batch.header().type == model::record_batch_type::dl_placeholder,
-      "Expected batch type to be dl_placeholder, got {}",
+      batch.header().type == model::record_batch_type::ctp_placeholder,
+      "Expected batch type to be ctp_placeholder, got {}",
       batch.header().type);
     iobuf value;
     batch.for_each_record([&value](model::record&& r) {
@@ -35,7 +35,7 @@ cluster_epoch extract_epoch(model::record_batch&& batch) {
         return ss::stop_iteration::yes;
     });
 
-    auto placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
+    auto placeholder = serde::from_iobuf<ctp_placeholder>(std::move(value));
     return placeholder.id.epoch;
 }
 
@@ -119,7 +119,7 @@ ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {
       model::next_offset(lro),
       co,
       4_MiB,
-      std::make_optional(model::record_batch_type::dl_placeholder),
+      std::make_optional(model::record_batch_type::ctp_placeholder),
       std::nullopt,
       std::nullopt);
 
@@ -155,14 +155,14 @@ ss::future<std::optional<cluster_epoch>> ctp_stm::get_inactive_epoch() {
 
 ss::future<> ctp_stm::do_apply(const model::record_batch& batch) {
     if (
-      batch.header().type != model::record_batch_type::dl_placeholder
+      batch.header().type != model::record_batch_type::ctp_placeholder
       && batch.header().type != model::record_batch_type::ctp_stm_command) {
         co_return;
     }
     vlog(_log.debug, "Applying record batch: {}", batch.header());
 
     switch (batch.header().type) {
-    case model::record_batch_type::dl_placeholder:
+    case model::record_batch_type::ctp_placeholder:
         apply_placeholder(batch);
         break;
 
@@ -215,7 +215,7 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
         value = std::move(r).release_value();
         return ss::stop_iteration::yes;
     });
-    auto placeholder = serde::from_iobuf<dl_placeholder>(std::move(value));
+    auto placeholder = serde::from_iobuf<ctp_placeholder>(std::move(value));
     auto id = placeholder.id;
     // this assertion is made here rather than inside the state object itself
     // because the assertion is about the physical content of the log rather

--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -9,7 +9,55 @@
  */
 #include "cloud_topics/level_zero/stm/placeholder.h"
 
+#include "storage/record_batch_builder.h"
+
 namespace cloud_topics {
+
+model::record_batch encode_placeholder_batch(
+  model::record_batch_header header, extent_meta extent) {
+    vassert(
+      header.record_count > 0, "Empty record batch not allowed {}", header);
+
+    cloud_topics::dl_placeholder placeholder{
+      .id = extent.id,
+      .offset = extent.first_byte_offset,
+      .size_bytes = extent.byte_range_size,
+    };
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::dl_placeholder, header.base_offset);
+
+    builder.set_producer_identity(header.producer_id, header.producer_epoch);
+    if (header.attrs.is_control()) {
+        builder.set_control_type();
+    }
+    if (header.attrs.is_transactional()) {
+        builder.set_transactional_type();
+    }
+
+    auto first_key = serde::to_iobuf(
+      cloud_topics::dl_placeholder_record_key::payload);
+
+    auto first_value = serde::to_iobuf(placeholder);
+
+    // In case of a placeholder batch the first record contains the
+    // actual placeholder and the remaining records are empty. The remaining
+    // records are added to avoid confusing any other code that may expect
+    // that the number of records in the batch is equal to the number of
+    // offsets in the header.
+    builder.add_raw_kv(std::move(first_key), std::move(first_value));
+
+    for (int i = 1; i < header.record_count; ++i) {
+        builder.add_raw_kv(std::nullopt, std::nullopt);
+    }
+
+    auto ph = std::move(builder).build();
+    ph.header().first_timestamp = header.first_timestamp;
+    ph.header().max_timestamp = header.max_timestamp;
+    ph.header().base_sequence = header.base_sequence;
+    ph.header().reset_size_checksum_metadata(ph.data());
+    return ph;
+}
 
 dl_placeholder parse_placeholder_batch(model::record_batch batch) {
     iobuf payload = std::move(batch).release_data();

--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_zero/stm/placeholder.h"
+
+namespace cloud_topics {
+
+dl_placeholder parse_placeholder_batch(model::record_batch batch) {
+    iobuf payload = std::move(batch).release_data();
+    iobuf_parser parser(std::move(payload));
+    auto record = model::parse_one_record_from_buffer(parser);
+    iobuf value = std::move(record).release_value();
+    auto placeholder = serde::from_iobuf<cloud_topics::dl_placeholder>(
+      std::move(value));
+    return placeholder;
+}
+
+} // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -35,17 +35,13 @@ model::record_batch encode_placeholder_batch(
         builder.set_transactional_type();
     }
 
-    auto first_key = serde::to_iobuf(
-      cloud_topics::dl_placeholder_record_key::payload);
-
-    auto first_value = serde::to_iobuf(placeholder);
-
     // In case of a placeholder batch the first record contains the
     // actual placeholder and the remaining records are empty. The remaining
     // records are added to avoid confusing any other code that may expect
     // that the number of records in the batch is equal to the number of
     // offsets in the header.
-    builder.add_raw_kv(std::move(first_key), std::move(first_value));
+    auto first_value = serde::to_iobuf(placeholder);
+    builder.add_raw_kv(std::nullopt, std::move(first_value));
 
     for (int i = 1; i < header.record_count; ++i) {
         builder.add_raw_kv(std::nullopt, std::nullopt);

--- a/src/v/cloud_topics/level_zero/stm/placeholder.cc
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.cc
@@ -18,14 +18,14 @@ model::record_batch encode_placeholder_batch(
     vassert(
       header.record_count > 0, "Empty record batch not allowed {}", header);
 
-    cloud_topics::dl_placeholder placeholder{
+    cloud_topics::ctp_placeholder placeholder{
       .id = extent.id,
       .offset = extent.first_byte_offset,
       .size_bytes = extent.byte_range_size,
     };
 
     storage::record_batch_builder builder(
-      model::record_batch_type::dl_placeholder, header.base_offset);
+      model::record_batch_type::ctp_placeholder, header.base_offset);
 
     builder.set_producer_identity(header.producer_id, header.producer_epoch);
     if (header.attrs.is_control()) {
@@ -55,12 +55,12 @@ model::record_batch encode_placeholder_batch(
     return ph;
 }
 
-dl_placeholder parse_placeholder_batch(model::record_batch batch) {
+ctp_placeholder parse_placeholder_batch(model::record_batch batch) {
     iobuf payload = std::move(batch).release_data();
     iobuf_parser parser(std::move(payload));
     auto record = model::parse_one_record_from_buffer(parser);
     iobuf value = std::move(record).release_value();
-    auto placeholder = serde::from_iobuf<cloud_topics::dl_placeholder>(
+    auto placeholder = serde::from_iobuf<cloud_topics::ctp_placeholder>(
       std::move(value));
     return placeholder;
 }

--- a/src/v/cloud_topics/level_zero/stm/placeholder.h
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_topics/level_zero/common/extent_meta.h"
 #include "cloud_topics/types.h"
 #include "model/record.h"
 #include "serde/envelope.h"
@@ -36,6 +37,9 @@ enum class dl_placeholder_record_key {
     // The record is used to align with raft_data batch
     empty,
 };
+
+model::record_batch
+  encode_placeholder_batch(model::record_batch_header, extent_meta);
 
 dl_placeholder parse_placeholder_batch(model::record_batch);
 

--- a/src/v/cloud_topics/level_zero/stm/placeholder.h
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.h
@@ -11,15 +11,14 @@
 #pragma once
 
 #include "cloud_topics/types.h"
+#include "model/record.h"
 #include "serde/envelope.h"
 #include "serde/rw/named_type.h"
 #include "serde/rw/uuid.h"
 
-// This header contains definition of the dl_placeholder batch
-
 namespace cloud_topics {
 
-struct dl_placeholder // NOLINT
+struct dl_placeholder
   : serde::
       envelope<dl_placeholder, serde::version<0>, serde::compat_version<0>> {
     // unique object id
@@ -37,5 +36,7 @@ enum class dl_placeholder_record_key {
     // The record is used to align with raft_data batch
     empty,
 };
+
+dl_placeholder parse_placeholder_batch(model::record_batch);
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/placeholder.h
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.h
@@ -39,9 +39,9 @@
  */
 namespace cloud_topics {
 
-struct dl_placeholder
+struct ctp_placeholder
   : serde::
-      envelope<dl_placeholder, serde::version<0>, serde::compat_version<0>> {
+      envelope<ctp_placeholder, serde::version<0>, serde::compat_version<0>> {
     /*
      * The object containing the payload of the batch represented by this
      * placeholder.
@@ -60,6 +60,6 @@ struct dl_placeholder
 model::record_batch
   encode_placeholder_batch(model::record_batch_header, extent_meta);
 
-dl_placeholder parse_placeholder_batch(model::record_batch);
+ctp_placeholder parse_placeholder_batch(model::record_batch);
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/placeholder.h
+++ b/src/v/cloud_topics/level_zero/stm/placeholder.h
@@ -17,25 +17,44 @@
 #include "serde/rw/named_type.h"
 #include "serde/rw/uuid.h"
 
+/*
+ * A placeholder is a batch that is replicated into the CTP with its payload
+ * replaced by an address to where the payload is stored. For example, if a
+ * client application produces a batch with a 1 MB payload, a small placeholder
+ * batch may be replicated to the CTP (~100 bytes) with the larger payload
+ * stored in object storage.
+ *
+ * Structure of placeholder batch
+ * ==============================
+ *
+ * - Header: logically identical to the header which would exist if the payload
+ * had been replicatedl. Physically, fields such as checksums and size will
+ * differ.
+ *
+ * - Record 1: placeholder metadata (e.g. address of payload)
+ *
+ * - Record 2+: empty records to give the placeholder batch the same shape as
+ * the original batch. this allows the batch to flow through existing machinery
+ * without requiring special casing to be introduced.
+ */
 namespace cloud_topics {
 
 struct dl_placeholder
   : serde::
       envelope<dl_placeholder, serde::version<0>, serde::compat_version<0>> {
-    // unique object id
+    /*
+     * The object containing the payload of the batch represented by this
+     * placeholder.
+     */
     object_id id;
-    // byte range
+
+    /*
+     * The byte extent [offset, size) of the payload in the object.
+     */
     first_byte_offset_t offset;
     byte_range_size_t size_bytes;
 
     auto serde_fields() { return std::tie(id, offset, size_bytes); }
-};
-
-enum class dl_placeholder_record_key {
-    // The record contains metadata
-    payload,
-    // The record is used to align with raft_data batch
-    empty,
 };
 
 model::record_batch

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -87,12 +87,9 @@ public:
         storage::record_batch_builder builder(
           model::record_batch_type::dl_placeholder, base_offset);
 
-        auto first_key = serde::to_iobuf(
-          cloud_topics::dl_placeholder_record_key::payload);
-
         auto first_value = serde::to_iobuf(placeholder);
 
-        builder.add_raw_kv(std::move(first_key), std::move(first_value));
+        builder.add_raw_kv(std::nullopt, std::move(first_value));
         if (size.has_value()) {
             for (int i = 1; i < size.value(); ++i) {
                 builder.add_raw_kv(std::nullopt, std::nullopt);

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -78,14 +78,14 @@ public:
       int32_t seq,
       std::optional<int> size = std::nullopt) {
         ct::object_id id = ct::object_id::create(e);
-        ct::dl_placeholder placeholder{
+        ct::ctp_placeholder placeholder{
           .id = id,
           .offset = ct::first_byte_offset_t{0},
           .size_bytes = ct::byte_range_size_t{0},
         };
 
         storage::record_batch_builder builder(
-          model::record_batch_type::dl_placeholder, base_offset);
+          model::record_batch_type::ctp_placeholder, base_offset);
 
         auto first_value = serde::to_iobuf(placeholder);
 

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -258,10 +258,8 @@ write_request_scheduler::proxy_write_request(write_request<>* req) noexcept {
     _stage.push_next_stage(proxy);
     auto extents_fut = co_await ss::coroutine::as_future(std::move(fut));
     if (extents_fut.failed()) {
-        vlog(
-          cd_log.error,
-          "Proxy write request failed: {}",
-          extents_fut.get_exception());
+        auto ex = extents_fut.get_exception();
+        vlog(cd_log.error, "Proxy write request failed: {}", ex);
         co_return std::unexpected(errc::upload_failure);
     }
     auto extents = extents_fut.get();

--- a/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
+++ b/src/v/cloud_topics/level_zero/write_request_scheduler/write_request_scheduler.cc
@@ -35,7 +35,7 @@ namespace cloud_topics::l0 {
 
 namespace {
 // Copy extents and share the payload to use on another shard
-static inline serialized_chunk shallow_copy(serialized_chunk& chunk) {
+serialized_chunk shallow_copy(serialized_chunk& chunk) {
     serialized_chunk copy;
     copy.extents = chunk.extents.copy();
     copy.payload = chunk.payload.share(0, chunk.payload.size_bytes());

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1706,7 +1706,7 @@ ss::future<> rm_stm::do_apply(const model::record_batch& b) {
           b.header().producer_id);
     } else if (
       hdr.type == model::record_batch_type::raft_data
-      || hdr.type == model::record_batch_type::dl_placeholder) {
+      || hdr.type == model::record_batch_type::ctp_placeholder) {
         if (hdr.attrs.is_control()) {
             apply_control(bid.pid, parse_control_batch(b));
         } else {

--- a/src/v/cluster/rm_stm_types.cc
+++ b/src/v/cluster/rm_stm_types.cc
@@ -235,7 +235,7 @@ model::control_record_type parse_control_batch(const model::record_batch& b) {
     const auto& hdr = b.header();
     vassert(
       hdr.type == model::record_batch_type::raft_data
-        || hdr.type == model::record_batch_type::dl_placeholder,
+        || hdr.type == model::record_batch_type::ctp_placeholder,
       "expect data batch type got {}",
       hdr.type);
     vassert(hdr.attrs.is_control(), "expect control attrs got {}", hdr.attrs);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -409,8 +409,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::partition_properties_update";
     case record_batch_type::datalake_coordinator:
         return o << "batch_type::datalake_coordinator";
-    case record_batch_type::dl_placeholder:
-        return o << "batch_type::dl_placeholder";
+    case record_batch_type::ctp_placeholder:
+        return o << "batch_type::ctp_placeholder";
     case record_batch_type::ctp_stm_command:
         return o << "batch_type::ctp_stm_command";
     case record_batch_type::datalake_translation_state:

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -56,7 +56,7 @@ enum class record_batch_type : int8_t {
     partition_properties_update
     = 34, // special batch type used to update partition properties
     datalake_coordinator = 35, // datalake::coordinator::*
-    dl_placeholder = 36,       // placeholder batch type used by cloud topics
+    ctp_placeholder = 36,      // placeholder batch type used by cloud topics
     ctp_stm_command = 37,      // ctp_stm command batch
     datalake_translation_state = 38, // maintains state for translation progress
     cluster_link = 39,               // cluster link update batches

--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -178,7 +178,7 @@ class BatchType(Enum):
     group_fence_tx = 33
     partition_properties_update = 34
     datalake_coordinator = 35
-    dl_placeholder = 36
+    ctp_placeholder = 36
     ctp_stm_command = 37
     datalake_translation_state = 38
     unknown = -1


### PR DESCRIPTION
* factors out placeholder construction from l0 reader
* removes placeholder record types
* renames dl_placeholder to ctp_placeholder (from Slack discussion)
* snuck in a copilot suggestion too!

These are all drive-by changes that are accumulating as part of a bigger effort to make the process of batch materialization testable, which is currently baked in tightly to the reader itself.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
