### PR TITLE
[v24.3.x] Cloud I/O: Independently configurable client lease timeout

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -114,7 +114,9 @@ remote::remote(
   , _cloud_storage_backend{cloud_storage_clients::
                              infer_backend_from_configuration(
                                conf, cloud_credentials_source)}
-  , _provider(infer_provider(_cloud_storage_backend, conf)) {
+  , _provider(infer_provider(_cloud_storage_backend, conf))
+  , _lease_timeout(
+      config::shard_local_cfg().cloud_storage_client_lease_timeout_ms.bind()) {
     vlog(
       log.info, "remote initialized with backend {}", _cloud_storage_backend);
     // If the credentials source is from config file, bypass the background
@@ -255,7 +257,7 @@ ss::future<upload_result> remote::upload_stream(
         }
         auto fut = co_await ss::coroutine::as_future(
           _pool.local().acquire_with_timeout(
-            fib.root_abort_source(), fib.get_timeout(), fib()));
+            fib.root_abort_source(), _lease_timeout(), fib()));
         if (fut.failed()) {
             co_return throw_if_not_timeout(
               fut.get_exception(), upload_result::timedout);
@@ -368,7 +370,7 @@ ss::future<download_result> remote::download_stream(
     auto fut = co_await [this, &fib, &transfer_details] {
         transfer_details.on_client_acquire();
         return ss::coroutine::as_future(_pool.local().acquire_with_timeout(
-          fib.root_abort_source(), fib.get_timeout(), fib()));
+          fib.root_abort_source(), _lease_timeout(), fib()));
     }();
     if (fut.failed()) {
         co_return throw_if_not_timeout(
@@ -491,7 +493,7 @@ remote::download_object(download_request download_request) {
 
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_timeout(), fib()));
+        fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), download_result::timedout);
@@ -582,7 +584,7 @@ ss::future<download_result> remote::object_exists(
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_timeout(), fib()));
+        fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), download_result::timedout);
@@ -659,7 +661,7 @@ remote::delete_object(transfer_details transfer_details) {
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_timeout(), fib()));
+        fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), upload_result::timedout);
@@ -819,7 +821,7 @@ ss::future<upload_result> remote::delete_object_batch(
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_timeout(), fib()));
+        fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), upload_result::timedout);
@@ -1010,7 +1012,7 @@ ss::future<list_result> remote::list_objects(
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_timeout(), fib()));
+        fib.root_abort_source(), _lease_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), cloud_storage_clients::error_outcome::retry);
@@ -1140,7 +1142,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto fut = co_await ss::coroutine::as_future(
           _pool.local().acquire_with_timeout(
-            fib.root_abort_source(), fib.get_timeout(), fib()));
+            fib.root_abort_source(), _lease_timeout(), fib()));
         if (fut.failed()) {
             co_return throw_if_not_timeout(
               fut.get_exception(), upload_result::timedout);

--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -255,7 +255,7 @@ ss::future<upload_result> remote::upload_stream(
         }
         auto fut = co_await ss::coroutine::as_future(
           _pool.local().acquire_with_timeout(
-            fib.root_abort_source(), fib.get_deadline(), fib()));
+            fib.root_abort_source(), fib.get_timeout(), fib()));
         if (fut.failed()) {
             co_return throw_if_not_timeout(
               fut.get_exception(), upload_result::timedout);
@@ -368,7 +368,7 @@ ss::future<download_result> remote::download_stream(
     auto fut = co_await [this, &fib, &transfer_details] {
         transfer_details.on_client_acquire();
         return ss::coroutine::as_future(_pool.local().acquire_with_timeout(
-          fib.root_abort_source(), fib.get_deadline(), fib()));
+          fib.root_abort_source(), fib.get_timeout(), fib()));
     }();
     if (fut.failed()) {
         co_return throw_if_not_timeout(
@@ -491,7 +491,7 @@ remote::download_object(download_request download_request) {
 
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_deadline(), fib()));
+        fib.root_abort_source(), fib.get_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), download_result::timedout);
@@ -582,7 +582,7 @@ ss::future<download_result> remote::object_exists(
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_deadline(), fib()));
+        fib.root_abort_source(), fib.get_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), download_result::timedout);
@@ -659,7 +659,7 @@ remote::delete_object(transfer_details transfer_details) {
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_deadline(), fib()));
+        fib.root_abort_source(), fib.get_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), upload_result::timedout);
@@ -819,7 +819,7 @@ ss::future<upload_result> remote::delete_object_batch(
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_deadline(), fib()));
+        fib.root_abort_source(), fib.get_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), upload_result::timedout);
@@ -1010,7 +1010,7 @@ ss::future<list_result> remote::list_objects(
     retry_chain_logger ctxlog(log, fib);
     auto fut = co_await ss::coroutine::as_future(
       _pool.local().acquire_with_timeout(
-        fib.root_abort_source(), fib.get_deadline(), fib()));
+        fib.root_abort_source(), fib.get_timeout(), fib()));
     if (fut.failed()) {
         co_return throw_if_not_timeout(
           fut.get_exception(), cloud_storage_clients::error_outcome::retry);
@@ -1140,7 +1140,7 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto fut = co_await ss::coroutine::as_future(
           _pool.local().acquire_with_timeout(
-            fib.root_abort_source(), fib.get_deadline(), fib()));
+            fib.root_abort_source(), fib.get_timeout(), fib()));
         if (fut.failed()) {
             co_return throw_if_not_timeout(
               fut.get_exception(), upload_result::timedout);

--- a/src/v/cloud_io/remote.h
+++ b/src/v/cloud_io/remote.h
@@ -316,6 +316,7 @@ private:
 
     model::cloud_storage_backend _cloud_storage_backend;
     cloud_io::provider _provider;
+    config::binding<std::chrono::milliseconds> _lease_timeout;
 };
 
 } // namespace cloud_io

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -437,7 +437,7 @@ auto client_pool::acquire_with_timeout(
   ss::abort_source& as,
   ss::lowres_clock::time_point deadline,
   std::optional<ss::sstring> ctx) -> ss::future<client_lease> {
-    auto lease = co_await acquire(as, deadline);
+    auto lease = co_await acquire(as);
     if (deadline < ss::lowres_clock::time_point::max()) {
         // take a copy of the shared_ptr held by the lease to avoid racing with
         // client_pool teardown

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -435,30 +435,29 @@ ss::future<client_pool::client_lease> client_pool::acquire(
 
 auto client_pool::acquire_with_timeout(
   ss::abort_source& as,
-  ss::lowres_clock::time_point deadline,
+  ss::lowres_clock::duration timeout,
   std::optional<ss::sstring> ctx) -> ss::future<client_lease> {
     auto lease = co_await acquire(as);
-    if (deadline < ss::lowres_clock::time_point::max()) {
+    if (timeout < ss::lowres_clock::duration::max()) {
         // take a copy of the shared_ptr held by the lease to avoid racing with
         // client_pool teardown
-        auto to = deadline - ss::lowres_clock::now();
         lease._wd = std::make_unique<watchdog>(
-          to,
+          timeout,
           [probe = _probe,
            client = lease.client,
-           to,
+           timeout,
            ctx = std::move(ctx)]() mutable {
               if (ctx.has_value()) {
                   vlog(
                     pool_log.debug,
                     "{} - Lease expired after {}ms. Shutting down client...",
                     ctx.value(),
-                    to / 1ms);
+                    timeout / 1ms);
               } else {
                   vlog(
                     pool_log.debug,
                     "Lease expired after {}ms. Shutting down client...",
-                    to / 1ms);
+                    timeout / 1ms);
               }
               if (probe) {
                   probe->register_timeout();

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -154,7 +154,7 @@ public:
     ///              representation of a retry_chain_node.
     ss::future<client_lease> acquire_with_timeout(
       ss::abort_source& as,
-      ss::lowres_clock::time_point deadline,
+      ss::lowres_clock::duration deadline,
       std::optional<ss::sstring> ctx = std::nullopt);
 
     /// \brief Get number of connections

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -234,13 +234,18 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
 
     {
         // call through acquire_with_timeout
+        // NOTE: we currently don't propage a deadline into pool::acquire, so
+        // the idea here is that acquire_with_timeout should hang indefinitely
+        // (because the pool is fully subscribed). So even after exceeding the
+        // provided lease timeout, only the abort source can short circuit
+        // client acquisition.
 
         ss::abort_source as;
-        BOOST_REQUIRE_THROW(
-          pool.local()
-            .acquire_with_timeout(as, ss::lowres_clock::now() + 100ms)
-            .get(),
-          ss::timed_out_error);
+        auto f = pool.local().acquire_with_timeout(
+          as, ss::lowres_clock::now() + 100ms);
+        ss::sleep(500ms).get();
+        as.request_abort();
+        BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
     }
 
     {

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -127,10 +127,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
     using namespace std::chrono_literals;
 
     {
-        auto lease = pool.local()
-                       .acquire_with_timeout(
-                         as, ss::lowres_clock::now() + 100ms)
-                       .get();
+        auto lease = pool.local().acquire_with_timeout(as, 100ms).get();
 
         // The request should fail w/in 500ms due to lease expiry
         // Note that the default timeout for the request itself is 5s
@@ -164,7 +161,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_with_timeout) {
 
         auto lease = pool.local()
                        .acquire_with_timeout(
-                         as, ss::lowres_clock::time_point::max())
+                         as, ss::lowres_clock::duration::max())
                        .get();
 
         BOOST_REQUIRE_EQUAL(lease._wd, nullptr);
@@ -241,8 +238,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_timeout) {
         // client acquisition.
 
         ss::abort_source as;
-        auto f = pool.local().acquire_with_timeout(
-          as, ss::lowres_clock::now() + 100ms);
+        auto f = pool.local().acquire_with_timeout(as, 100ms);
         ss::sleep(500ms).get();
         as.request_abort();
         BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2255,6 +2255,13 @@ configuration::configuration()
       "`check_manifest_and_segment_metadata`.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10)
+  , cloud_storage_client_lease_timeout_ms(
+      *this,
+      "cloud_storage_client_lease_timeout_ms",
+      "Maximum time to hold a cloud storage client lease (ms), after which any "
+      "outstanding connection is immediately closed.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      900s)
   , cloud_storage_segment_size_target(
       *this,
       "cloud_storage_segment_size_target",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -446,6 +446,7 @@ struct configuration final : public config_store {
     enum_property<model::recovery_validation_mode>
       cloud_storage_recovery_topic_validation_mode;
     property<uint32_t> cloud_storage_recovery_topic_validation_depth;
+    property<std::chrono::milliseconds> cloud_storage_client_lease_timeout_ms;
 
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1622,6 +1622,7 @@ class ShadowIndexingTrafficShapingTest(PreallocNodesTest):
                 "cloud_storage_cluster_metadata_upload_interval_ms": 1000,
                 "enable_cluster_metadata_upload_loop": True,
                 "controller_snapshot_max_age_sec": 1,
+                "cloud_storage_client_lease_timeout_ms": 1000,
             },
             environment={"__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS": 5000},
             si_settings=si_settings,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27239 

Closes https://github.com/redpanda-data/redpanda/issues/27851