### PR TITLE
[v25.2.x] kafka/server: keep const ref alive on the stack in futurized function

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -323,7 +323,7 @@ ss::future<size_t> group_manager::delete_expired_offsets(
      * delete expired offsets from the group
      */
     auto offsets = group->delete_expired_offsets(retention_period);
-    return delete_offsets(group, std::move(offsets));
+    co_return co_await delete_offsets(group, offsets);
 }
 
 ss::future<size_t> group_manager::delete_offsets(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27848
