### PR TITLE
introduce iobuf::linearize_to_string

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -9,6 +9,7 @@
 
 #include "bytes/iobuf.h"
 
+#include "base/units.h"
 #include "base/vassert.h"
 #include "bytes/details/io_allocation_size.h"
 
@@ -277,4 +278,18 @@ iobuf::placeholder iobuf::reserve(size_t sz) {
     placeholder p(back, back.size(), sz);
     back.reserve(sz);
     return p;
+}
+
+ss::sstring iobuf::linearize_to_string() const {
+    constexpr static size_t max_size = 128_KiB;
+    if (size_bytes() > max_size) {
+        throw std::runtime_error(
+          fmt::format("string too big: {}", size_bytes()));
+    }
+    ss::sstring out{ss::sstring::initialized_later{}, size_bytes()};
+    auto it = out.begin();
+    for (const auto& frag : *this) {
+        it = std::copy_n(frag.get(), frag.size(), it);
+    }
+    return out;
 }

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -269,6 +269,10 @@ public:
 
     std::string hexdump(size_t) const;
 
+    // Linearize this iobuf to a string. Note that if the iobuf is over 128KiB
+    // this method will throw as to not cause an oversized allocation.
+    ss::sstring linearize_to_string() const;
+
 private:
     void prepend(std::unique_ptr<fragment>);
 

--- a/src/v/bytes/tests/BUILD
+++ b/src/v/bytes/tests/BUILD
@@ -8,6 +8,7 @@ redpanda_cc_btest(
         "utils.h",
     ],
     deps = [
+        "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iobuf_parser",

--- a/src/v/bytes/tests/iobuf_tests.cc
+++ b/src/v/bytes/tests/iobuf_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "base/units.h"
 #include "bytes/bytes.h"
 #include "bytes/details/io_allocation_size.h"
 #include "bytes/iobuf.h"
@@ -30,6 +31,7 @@
 #include <cstdint>
 #include <iterator>
 #include <span>
+#include <stdexcept>
 
 SEASTAR_THREAD_TEST_CASE(test_copy_equal) {
     iobuf buf;
@@ -827,6 +829,7 @@ SEASTAR_THREAD_TEST_CASE(iobuf_hexdump) {
   00000000 | 41 65 6e 65 61 6e 20 73  65 64 20 6c 65 6f 20 70  | Aenean sed leo p
   00000010 | 6f 72 74 74 69 74 6f 72  2e                       | orttitor.)");
 }
+
 SEASTAR_THREAD_TEST_CASE(iobuf_tail) {
     iobuf buf = iobuf::from("hello");
     buf.append_fragments(iobuf::from("world"));
@@ -836,4 +839,13 @@ SEASTAR_THREAD_TEST_CASE(iobuf_tail) {
     BOOST_CHECK_EQUAL(buf.tail(10), "helloworld");
     BOOST_CHECK_EQUAL(buf.tail(0), "");
     BOOST_CHECK_THROW(buf.tail(11), std::out_of_range);
+}
+
+SEASTAR_THREAD_TEST_CASE(iobuf_linearize) {
+    iobuf buf = iobuf::from("hello");
+    BOOST_CHECK_EQUAL(buf.linearize_to_string(), "hello");
+    BOOST_CHECK_EQUAL(buf.tail(3).linearize_to_string(), "llo");
+    BOOST_CHECK_EQUAL(iobuf{}.linearize_to_string(), "");
+    iobuf large = iobuf::from(std::string(128_KiB + 1, 'a'));
+    BOOST_CHECK_THROW(large.linearize_to_string(), std::runtime_error);
 }

--- a/src/v/cloud_roles/BUILD
+++ b/src/v/cloud_roles/BUILD
@@ -131,6 +131,7 @@ redpanda_cc_library(
         "//src/v/net:tls",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sformat",
+        "//src/v/strings:utf8",
         "//src/v/utils:base64",
         "//src/v/utils:file_io",
         "//src/v/utils:named_type",

--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_roles/logger.h"
 #include "request_response_helpers.h"
+#include "strings/utf8.h"
 
 namespace cloud_roles {
 
@@ -28,8 +29,9 @@ ss::sstring read_string_from_response(cloud_roles::api_response response) {
     vassert(
       std::holds_alternative<iobuf>(response),
       "response does not contain iobuf");
-    iobuf_const_parser parser(std::get<iobuf>(response));
-    return parser.read_string(parser.bytes_left());
+    auto str = std::get<iobuf>(response).linearize_to_string();
+    validate_utf8(str);
+    return str;
 }
 
 void add_metadata_token_to_request(

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -224,11 +224,6 @@ ss::input_stream<char> make_manifest_stream(std::string_view json) {
     return make_iobuf_input_stream(std::move(i));
 }
 
-ss::sstring iobuf_to_string(iobuf buf) {
-    iobuf_parser parser{std::move(buf)};
-    return parser.read_string_unsafe(parser.bytes_left());
-}
-
 } // namespace
 
 class bucket_view_fixture : public http_imposter_fixture {
@@ -483,7 +478,7 @@ private:
     void set_expectations_for_manifest(
       const cloud_storage::partition_manifest& manifest) {
         const auto path = manifest.get_manifest_path(path_provider)().string();
-        const auto reply_body = iobuf_to_string(manifest.to_iobuf());
+        const auto reply_body = manifest.to_iobuf().linearize_to_string();
 
         when()
           .request(fmt::format("/{}", path))

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -217,8 +217,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_POST_roundtrip) {
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected
             = "\"" + std::string(httpd_server_reply)
               + "\""; // sestar will return json string containing the
@@ -282,8 +281,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_GET_streaming_roundtrip) {
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected
             = "\"" + std::string(httpd_server_reply)
               + "\""; // sestar will return json string containing the
@@ -311,8 +309,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_POST_streaming_roundtrip) {
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected
             = "\"" + std::string(httpd_server_reply)
               + "\""; // sestar will return json string containing the
@@ -334,8 +331,7 @@ SEASTAR_THREAD_TEST_CASE(test_error_500) {
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(
             header.result(), boost::beast::http::status::internal_server_error);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           BOOST_REQUIRE(actual.find("/fail-status-500") != std::string::npos);
       });
 }
@@ -354,8 +350,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_GET_roundtrip) {
       std::nullopt,
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected = "\"" + std::string(httpd_server_reply) + "\"";
           BOOST_REQUIRE_EQUAL(expected, actual);
       });
@@ -378,8 +373,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_PUT_roundtrip) {
       ss::sstring(httpd_server_reply),
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected = "\"\"";
           BOOST_REQUIRE_EQUAL(expected, actual);
       });
@@ -403,8 +397,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_PUT_empty_roundtrip) {
       std::move(stream),
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected = "\"\"";
           BOOST_REQUIRE_EQUAL(expected, actual);
       });
@@ -466,8 +459,7 @@ private:
             auto tmpbuf = _fin.read().get();
             buffer.append(std::move(tmpbuf));
             if (buffer.size_bytes() > _expected_data.size()) {
-                iobuf_parser parser(buffer.copy());
-                ss::sstring body = parser.read_string(parser.bytes_left());
+                ss::sstring body = buffer.linearize_to_string();
                 if (body.find(_expected_data) != ss::sstring::npos) {
                     _fin.close().get();
                     return buffer;
@@ -602,8 +594,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor) {
       false,
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected = ss::sstring(httpd_server_reply);
           BOOST_REQUIRE_EQUAL(expected, actual);
       });
@@ -684,8 +675,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_chunked_encoding) {
       false,
       [](const http::client::response_header& header, iobuf&& body) {
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected = ss::sstring(httpd_server_reply);
           BOOST_REQUIRE_EQUAL(expected, actual);
       });
@@ -764,8 +754,7 @@ void run_framing_test_using_impostor(
             iobuf_parser pbuf(encoder.encode(std::move(tmp)));
             chunks.push_back(pbuf.read_string(pbuf.bytes_left()));
         }
-        iobuf_parser ptail(encoder.encode_eof());
-        chunks.push_back(ptail.read_string(ptail.bytes_left()));
+        chunks.push_back(encoder.encode_eof().linearize_to_string());
 
         test_impostor_request(
           config,
@@ -776,8 +765,7 @@ void run_framing_test_using_impostor(
           [](const http::client::response_header& header, iobuf&& body) {
               BOOST_REQUIRE_EQUAL(
                 header.result(), boost::beast::http::status::ok);
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
+              std::string actual = body.linearize_to_string();
               std::string expected = ss::sstring(httpd_server_reply);
               BOOST_REQUIRE_EQUAL(expected, actual);
           });
@@ -834,8 +822,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_no_content_length) {
           // Expect normal reply despite the absence of content-length
           // header
           BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
-          iobuf_parser parser(std::move(body));
-          std::string actual = parser.read_string(parser.bytes_left());
+          std::string actual = body.linearize_to_string();
           std::string expected = ss::sstring(httpd_server_reply);
           BOOST_REQUIRE_EQUAL(expected, actual);
       });
@@ -919,8 +906,7 @@ SEASTAR_THREAD_TEST_CASE(default_host_request_header) {
     BOOST_REQUIRE_EQUAL(
       response->get_headers().result(), boost::beast::http::status::ok);
 
-    iobuf_const_parser parser(body);
-    const auto body_str = parser.read_string(parser.bytes_left());
+    const auto body_str = body.linearize_to_string();
 
     rapidjson::Document doc;
     doc.Parse(body_str);
@@ -956,8 +942,7 @@ SEASTAR_THREAD_TEST_CASE(custom_host_request_header) {
     BOOST_REQUIRE_EQUAL(
       response->get_headers().result(), boost::beast::http::status::ok);
 
-    iobuf_const_parser parser(body);
-    const auto body_str = parser.read_string(parser.bytes_left());
+    const auto body_str = body.linearize_to_string();
 
     rapidjson::Document doc;
     doc.Parse(body_str);
@@ -989,8 +974,7 @@ SEASTAR_THREAD_TEST_CASE(post_method) {
     BOOST_REQUIRE_EQUAL(
       response->get_headers().result(), boost::beast::http::status::ok);
 
-    iobuf_parser parser(std::move(body));
-    std::string actual = parser.read_string(parser.bytes_left());
+    std::string actual = body.linearize_to_string();
     std::string expected
       = "\"" + std::string(httpd_server_reply)
         + "\""; // sestar will return json string containing the

--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -715,7 +715,7 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":table_metadata_json",
-        "//src/v/bytes:iobuf_parser",
+        "//src/v/bytes:streambuf",
         "//src/v/json",
     ],
     deps = [

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -101,9 +101,7 @@ convert_primitive(serde::json::parser& p, const primitive_type& ft) {
                     max_bytes,
                     buf.size_bytes()));
             }
-
-            iobuf_const_parser iop(buf);
-            return iop.read_string(iop.bytes_left());
+            return buf.linearize_to_string();
         };
 
         // 32 bytes should be enough for most date/time formats.

--- a/src/v/iceberg/table_io.cc
+++ b/src/v/iceberg/table_io.cc
@@ -19,10 +19,8 @@ ss::future<checked<table_metadata, metadata_io::errc>>
 table_io::download_table_meta(const table_metadata_path& path) {
     return download_object<table_metadata>(
       path(), "iceberg::table_metadata", [](iobuf b) {
-          iobuf_parser p(std::move(b));
-          auto sz = p.bytes_left();
           json::Document parsed;
-          parsed.Parse(p.read_string(sz));
+          parsed.Parse(b.linearize_to_string());
           return parse_table_meta(parsed);
       });
 }
@@ -40,9 +38,7 @@ ss::future<checked<size_t, metadata_io::errc>> table_io::upload_table_meta(
 ss::future<checked<int, metadata_io::errc>>
 table_io::download_version_hint(const version_hint_path& path) {
     return download_object<int>(path(), "iceberg::version_hint", [](iobuf b) {
-        iobuf_parser p(std::move(b));
-        auto sz = p.bytes_left();
-        auto version_str = p.read_string(sz);
+        auto version_str = b.linearize_to_string();
         return std::stoi(version_str);
     });
 }

--- a/src/v/iceberg/table_io.cc
+++ b/src/v/iceberg/table_io.cc
@@ -9,9 +9,10 @@
  */
 #include "iceberg/table_io.h"
 
-#include "bytes/iobuf_parser.h"
+#include "bytes/streambuf.h"
 #include "iceberg/table_metadata_json.h"
 #include "json/chunked_buffer.h"
+#include "json/istreamwrapper.h"
 
 namespace iceberg {
 
@@ -19,8 +20,11 @@ ss::future<checked<table_metadata, metadata_io::errc>>
 table_io::download_table_meta(const table_metadata_path& path) {
     return download_object<table_metadata>(
       path(), "iceberg::table_metadata", [](iobuf b) {
+          iobuf_istreambuf ibuf(b);
+          std::istream stream(&ibuf);
+          json::IStreamWrapper s(stream);
           json::Document parsed;
-          parsed.Parse(b.linearize_to_string());
+          parsed.ParseStream(s);
           return parse_table_meta(parsed);
       });
 }

--- a/src/v/iceberg/tests/rest_catalog_test.cc
+++ b/src/v/iceberg/tests/rest_catalog_test.cc
@@ -127,8 +127,7 @@ ss::future<http::downloaded_response> handle_token_request(
       "application/x-www-form-urlencoded");
 
     EXPECT_TRUE(payload.has_value());
-    iobuf_parser parser{std::move(payload.value())};
-    auto received = parser.read_string(parser.bytes_left());
+    auto received = payload.value().linearize_to_string();
 
     EXPECT_TRUE(query_params_equal(
       absl::flat_hash_map<ss::sstring, ss::sstring>{
@@ -422,8 +421,7 @@ ss::future<http::downloaded_response> handle_commit_table_txn(
   std::optional<iobuf> payload,
   [[maybe_unused]] ss::lowres_clock::duration timeout) {
     EXPECT_TRUE(payload.has_value());
-    iobuf_parser parser(std::move(*payload));
-    auto json_str = parser.read_string(parser.bytes_left());
+    auto json_str = payload->linearize_to_string();
     json::Document doc;
     doc.Parse(json_str);
     // validate that the request is a valid json

--- a/src/v/serde/json/detail/tests/string_test.cc
+++ b/src/v/serde/json/detail/tests/string_test.cc
@@ -23,7 +23,6 @@
  * the License.
  */
 
-#include "bytes/iobuf_parser.h"
 #include "serde/json/detail/string.h"
 
 #include <gtest/gtest.h>
@@ -32,15 +31,6 @@
 #include <string_view>
 
 using namespace serde::json::detail;
-
-namespace {
-
-std::string iobuf_as_string(iobuf b) {
-    iobuf_parser p(std::move(b));
-    return p.read_string(p.bytes_left());
-}
-
-} // namespace
 
 struct test_case {
     std::string_view input;
@@ -311,7 +301,8 @@ TEST_P(string_parse_test, test_string) {
     EXPECT_EQ(pos, expected_pos);
     EXPECT_EQ(err, expected_err);
     if (expected_err == string_parser::result::done) {
-        EXPECT_EQ(iobuf_as_string(std::move(parser).value()), expected_output);
+        EXPECT_EQ(
+          std::move(parser).value().linearize_to_string(), expected_output);
     } else {
         EXPECT_THROW(std::move(parser).value(), std::runtime_error);
     }
@@ -352,7 +343,8 @@ TEST_P(string_parse_test, test_piecewise) {
         EXPECT_THROW(parser.advance(buf, err), std::runtime_error);
 
         // Check that the value is correct.
-        EXPECT_EQ(iobuf_as_string(std::move(parser).value()), expected_output)
+        EXPECT_EQ(
+          std::move(parser).value().linearize_to_string(), expected_output)
           << "When split as: " << input.substr(0, i) << " | "
           << input.substr(i);
     }
@@ -381,7 +373,7 @@ TEST(piecewise_string_test, test_string) {
 
         // Check that the value is correct.
         EXPECT_EQ(
-          iobuf_as_string(std::move(parser).value()),
+          std::move(parser).value().linearize_to_string(),
           "hello world\nhello universe")
           << "When split as: " << json_string.substr(0, i) << " | "
           << json_string.substr(i);

--- a/src/v/serde/json/tests/dom.cc
+++ b/src/v/serde/json/tests/dom.cc
@@ -21,9 +21,8 @@ namespace serde::json::test::dom {
 
 namespace {
 
-std::string iobuf_as_string(iobuf b) {
-    iobuf_parser p(std::move(b));
-    return absl::CHexEscape(p.read_string(p.bytes_left()));
+std::string iobuf_as_string(const iobuf& b) {
+    return absl::CHexEscape(b.linearize_to_string());
 }
 
 void debug_format_value(std::ostream& os, const value& v, int base_indent = 0) {
@@ -31,15 +30,13 @@ void debug_format_value(std::ostream& os, const value& v, int base_indent = 0) {
 
     ss::visit(
       v.data(),
-      [&os](const iobuf& v) {
-          os << "string(" << iobuf_as_string(v.copy()) << ")";
-      },
+      [&os](const iobuf& v) { os << "string(" << iobuf_as_string(v) << ")"; },
       [&os, base_indent](const json_object& v) {
           os << "object(";
           for (const auto& [k, v] : v) {
               os << "\n"
                  << std::string(base_indent + 2, ' ') << "key("
-                 << iobuf_as_string(k.copy()) << ") :\n";
+                 << iobuf_as_string(k) << ") :\n";
               debug_format_value(os, v, base_indent + 4);
           }
           if (v.size() == 0) {

--- a/src/v/serde/json/tests/writer_test.cc
+++ b/src/v/serde/json/tests/writer_test.cc
@@ -28,12 +28,7 @@
 namespace {
 
 std::string to_string(serde::json::writer&& w) {
-    iobuf b = std::move(w).finish();
-    std::string output;
-    for (const auto& frag : b) {
-        output.append(frag.get(), frag.size());
-    }
-    return output;
+    return std::move(w).finish().linearize_to_string();
 }
 
 class JsonWriterTest : public ::testing::Test {

--- a/src/v/serde/protobuf/json.cc
+++ b/src/v/serde/protobuf/json.cc
@@ -110,21 +110,6 @@ void check_error(peekable_parser* parser) {
 namespace {
 constexpr static size_t max_numeric_string_size = 128;
 
-ss::sstring linearize_iobuf(iobuf b) {
-    constexpr static size_t max_allocation_size = 128_KiB;
-    if (b.size_bytes() > max_allocation_size) {
-        throw std::runtime_error(
-          fmt::format(
-            "string too big: {} > {}", b.size_bytes(), max_allocation_size));
-    }
-    ss::sstring result{ss::sstring::initialized_later{}, b.size_bytes()};
-    char* dest = result.data();
-    for (const auto& frag : b) {
-        dest = std::copy_n(frag.get(), frag.size(), dest);
-    }
-    return result;
-}
-
 template<typename T>
 T iobuf_to_number(iobuf b) {
     if (b.size_bytes() > max_numeric_string_size) {
@@ -134,7 +119,7 @@ T iobuf_to_number(iobuf b) {
             b.size_bytes(),
             max_numeric_string_size));
     }
-    auto str = linearize_iobuf(std::move(b));
+    auto str = b.linearize_to_string();
     T result{};
     if constexpr (std::is_floating_point_v<T>) {
         bool ok{};
@@ -219,7 +204,7 @@ double transform_map_key(iobuf key_string) {
 
 template<>
 ss::sstring transform_map_key(iobuf key_string) {
-    return linearize_iobuf(std::move(key_string));
+    return key_string.linearize_to_string();
 }
 
 bool read_bool(peekable_parser* parser) {
@@ -254,7 +239,7 @@ ss::sstring read_string(peekable_parser* parser) {
         throw std::runtime_error(
           fmt::format("expected string, got: {}", parser->token()));
     }
-    return linearize_iobuf(parser->value_string());
+    return parser->value_string().linearize_to_string();
 }
 iobuf read_string_as_bytes(peekable_parser* parser) {
     if (parser->token() != token::value_string) [[unlikely]] {

--- a/src/v/serde/protobuf/tests/round_trip_test.cc
+++ b/src/v/serde/protobuf/tests/round_trip_test.cc
@@ -24,18 +24,6 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <protobuf_mutator/mutator.h>
 
-namespace {
-
-std::string iobuf_to_string(const iobuf& b) {
-    std::string output;
-    for (const auto& frag : b) {
-        output.append(frag.get(), frag.size());
-    }
-    return output;
-}
-
-} // namespace
-
 TEST(ProtobufCompat, RoundtripSerdeSimple) {
     proto::example::person_phone_number original;
     original.set_number("123-456-7890");
@@ -59,8 +47,9 @@ TEST(ProtobufCompat, RoundtripSerdeEmptyConformanceProto) {
                           std::move(serialized))
                           .get()));
     EXPECT_EQ(original, deserialized)
-      << "original: " << iobuf_to_string(original.to_json().get())
-      << "\ndeserialized: " << iobuf_to_string(deserialized.to_json().get());
+      << "original: " << original.to_json().get().linearize_to_string()
+      << "\ndeserialized: "
+      << deserialized.to_json().get().linearize_to_string();
     deserialized = {};
     EXPECT_NO_THROW(
       deserialized
@@ -68,8 +57,9 @@ TEST(ProtobufCompat, RoundtripSerdeEmptyConformanceProto) {
           original.to_json().get())
           .get());
     EXPECT_EQ(original, deserialized)
-      << "original: " << iobuf_to_string(original.to_json().get())
-      << "\ndeserialized: " << iobuf_to_string(deserialized.to_json().get());
+      << "original: " << original.to_json().get().linearize_to_string()
+      << "\ndeserialized: "
+      << deserialized.to_json().get().linearize_to_string();
 }
 
 TEST(ProtobufCompat, RoundtripSerde) {
@@ -132,7 +122,8 @@ TEST(ProtobufCompat, LibprotobufCompat) {
     // Protobuf
     std::string libpb_serialized;
     EXPECT_TRUE(libpb_version.SerializeToString(&libpb_serialized));
-    auto serde_serialized = iobuf_to_string(serde_version.to_proto().get());
+    auto serde_serialized
+      = serde_version.to_proto().get().linearize_to_string();
     proto::example::person serde_parsed;
     EXPECT_NO_THROW(
       serde_parsed = proto::example::person::from_proto(
@@ -166,7 +157,7 @@ TEST(ProtobufCompat, LibprotobufCompat) {
           << libpb_serialized;
         EXPECT_EQ(serde_version, serde_parsed);
     }
-    serde_serialized = iobuf_to_string(serde_version.to_json().get());
+    serde_serialized = serde_version.to_json().get().linearize_to_string();
     libpb_parsed = {};
     EXPECT_TRUE(
       google::protobuf::json::JsonStringToMessage(
@@ -193,7 +184,7 @@ TEST(ProtobufCompat, RandomizedConformanceTest) {
         if (!serde) {
             continue;
         }
-        auto serde_serialized = iobuf_to_string(serde->to_proto().get());
+        auto serde_serialized = serde->to_proto().get().linearize_to_string();
         protobuf_test_messages::editions::TestAllTypesEdition2023 libpb_parsed;
         if (!libpb_parsed.ParseFromString(serde_serialized)) {
             FAIL() << "Failed to parse libpb from serde serialized data";
@@ -238,7 +229,7 @@ TEST(ProtobufCompat, RandomizedConformanceJsonTest) {
                 from_json(&p, &serde)
                   .get())
               << libpb_serialized;
-            auto serde_serialized = iobuf_to_string(serde.to_json().get());
+            auto serde_serialized = serde.to_json().get().linearize_to_string();
             protobuf_test_messages::editions::TestAllTypesEdition2023
               libpb_parsed;
             ASSERT_TRUE(
@@ -296,11 +287,12 @@ TEST(ProtobufCompat, Wellknown) {
                         serialized.copy())
                         .get()));
     EXPECT_EQ(original, deserialized)
-      << "Proto: " << iobuf_to_string(original.to_json().get())
-      << "\nDeserialized: " << iobuf_to_string(deserialized.to_json().get());
+      << "Proto: " << original.to_json().get().linearize_to_string()
+      << "\nDeserialized: "
+      << deserialized.to_json().get().linearize_to_string();
     deserialized = {};
     example::WellKnownProtos libpb;
-    EXPECT_TRUE(libpb.ParseFromString(iobuf_to_string(serialized.copy())));
+    EXPECT_TRUE(libpb.ParseFromString(serialized.linearize_to_string()));
     EXPECT_NO_THROW(
       (deserialized = proto::example::well_known_protos::from_proto(
                         iobuf::from(libpb.SerializeAsString()))
@@ -312,16 +304,17 @@ TEST(ProtobufCompat, Wellknown) {
     EXPECT_NO_THROW(
       (deserialized
        = proto::example::well_known_protos::from_json(serialized.copy()).get()))
-      << "JSON: " << iobuf_to_string(serialized);
+      << "JSON: " << serialized.linearize_to_string();
     EXPECT_EQ(original, deserialized)
-      << "Proto: " << iobuf_to_string(original.to_json().get())
-      << "\nDeserialized: " << iobuf_to_string(deserialized.to_json().get());
+      << "Proto: " << original.to_json().get().linearize_to_string()
+      << "\nDeserialized: "
+      << deserialized.to_json().get().linearize_to_string();
 
     libpb = {};
     deserialized = {};
     ASSERT_TRUE(
       google::protobuf::json::JsonStringToMessage(
-        iobuf_to_string(serialized.copy()), &libpb, {})
+        serialized.linearize_to_string(), &libpb, {})
         .ok());
     std::string libpb_serialized;
     ASSERT_TRUE(

--- a/src/v/wasm/tests/wasi_test.cc
+++ b/src/v/wasm/tests/wasi_test.cc
@@ -9,10 +9,10 @@
  * by the Apache License, Version 2.0
  */
 
-#include "absl/container/flat_hash_set.h"
-#include "bytes/iobuf_parser.h"
 #include "json/document.h"
 #include "wasm/tests/wasm_fixture.h"
+
+#include <algorithm>
 
 TEST_F(WasmTestFixture, Wasi) {
     load_wasm("wasi.wasm");
@@ -20,8 +20,7 @@ TEST_F(WasmTestFixture, Wasi) {
     auto result = transform(batch);
     const auto& result_records = result.copy_records();
     ASSERT_EQ(result_records.size(), 1);
-    iobuf_const_parser parser(result_records.front().value());
-    const auto& value = parser.read_string(parser.bytes_left());
+    const auto& value = result_records.front().value().linearize_to_string();
     json::Document doc;
     doc.Parse(value);
     std::vector<std::string> program_args;
@@ -40,7 +39,7 @@ TEST_F(WasmTestFixture, Wasi) {
         environment_variables.emplace_back(v);
     }
     // The order here doesn't matter, so sort the values.
-    std::sort(environment_variables.begin(), environment_variables.end());
+    std::ranges::sort(environment_variables);
     std::vector<std::string> expected_env{
       ss::format("REDPANDA_INPUT_TOPIC={}", meta().input_topic.tp()),
       ss::format(


### PR DESCRIPTION
There are a bunch of places (especially in tests) where we want to linearize small iobufs into strings. Make a dedicated method for this that also prevents oversized allocs.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Prevent oversized allocations when table metadata gets large
