### PR TITLE
bazel/sesatar: update seastar

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -250,7 +250,7 @@
   "moduleExtensions": {
     "//bazel:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "s9bbJVSMWR4PNtLWGHW3/faOk8JoIBGCbUi9NbMhupg=",
+        "bzlTransitiveDigest": "gW8JHMN6ogYtKeGa5M06AbADs+WumBL/xFa/N/1UQMw=",
         "usagesDigest": "FEiDyZe9eAU6yEqnarZf0XMEUk+prUyYClvq1RU1J98=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -421,9 +421,9 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file": "@@//bazel/thirdparty:seastar.BUILD",
-              "sha256": "90bdab177471382c90904e774c815bf893de18e15e5f4213e3abf57631d2f7d6",
-              "strip_prefix": "seastar-17685bcf73b07b93d7f888220e762e4b4e4c4426",
-              "url": "https://github.com/redpanda-data/seastar/archive/17685bcf73b07b93d7f888220e762e4b4e4c4426.tar.gz"
+              "sha256": "0c87b316697c9722c28f1826bb2f37f4fe7391cc8422193122ed2d9ab3beff16",
+              "strip_prefix": "seastar-28a0d0062a3c1f4889cc2e074ce413d6d4e010a4",
+              "url": "https://github.com/redpanda-data/seastar/archive/28a0d0062a3c1f4889cc2e074ce413d6d4e010a4.tar.gz"
             }
           },
           "unordered_dense": {

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -162,9 +162,9 @@ def data_dependency():
     http_archive(
         name = "seastar",
         build_file = "//bazel/thirdparty:seastar.BUILD",
-        sha256 = "90bdab177471382c90904e774c815bf893de18e15e5f4213e3abf57631d2f7d6",
-        strip_prefix = "seastar-17685bcf73b07b93d7f888220e762e4b4e4c4426",
-        url = "https://github.com/redpanda-data/seastar/archive/17685bcf73b07b93d7f888220e762e4b4e4c4426.tar.gz",
+        sha256 = "0c87b316697c9722c28f1826bb2f37f4fe7391cc8422193122ed2d9ab3beff16",
+        strip_prefix = "seastar-28a0d0062a3c1f4889cc2e074ce413d6d4e010a4",
+        url = "https://github.com/redpanda-data/seastar/archive/28a0d0062a3c1f4889cc2e074ce413d6d4e010a4.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
To:

0c87b316697c9722c28f1826bb2f37f4fe7391cc8422193122ed2d9ab3beff16

This primarily brings in the ability to add hooks which run before each PERF_TEST run.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
