### PR TITLE
Use deterministic seeds in benchmarks

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -355,7 +355,8 @@ def redpanda_test_cc_library(
         local_defines = [],
         visibility = None,
         implementation_deps = [],
-        deps = []):
+        deps = [],
+        alwayslink = False):
     cc_library(
         name = name,
         srcs = srcs,
@@ -371,6 +372,7 @@ def redpanda_test_cc_library(
         features = [
             "layering_check",
         ],
+        alwayslink = alwayslink,
     )
 
 def redpanda_cc_bench(

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -438,6 +438,12 @@ def redpanda_cc_bench(
         "resources:memory:{}".format(_parse_bytes(memory) / (1 << 20)),
     ]
 
+    # all benches must include the hooks
+    deps.append(
+        "//src/v/test_utils:rpbench_hooks",
+    )
+
+
     tags = tags + ["bench"]
 
     binary_name = name + "_binary"

--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -443,6 +443,10 @@ def redpanda_cc_bench(
         "//src/v/test_utils:rpbench_hooks",
     )
 
+    env = {
+        # see https://redpandadata.atlassian.net/wiki/x/BwDSUw
+        "REDPANDA_RNG_SEEDING_MODE_DEFAULT": "fixed",
+    } | env
 
     tags = tags + ["bench"]
 

--- a/src/v/random/generators.cc
+++ b/src/v/random/generators.cc
@@ -27,7 +27,7 @@ using internal::chars;
 using seed_type = rng::seed_type;
 
 namespace {
-constexpr seed_type fixed_seed = 1234567891u;
+constexpr seed_type fixed_seed = 0xDEADBEEF;
 
 std::atomic<int64_t> seed_generation = 0;
 
@@ -75,7 +75,7 @@ std::seed_seq seed_to_seq(seed_type seed) {
 thread_local rng global_instance;
 thread_local int64_t last_seed_gen = -1;
 
-std::random_device::result_type get_initial_seed() {
+seed_type get_initial_seed() {
     return global_seeding_mode == seeding_mode::fixed_seed ? fixed_seed
                                                            : random_seed();
 }

--- a/src/v/random/tests/random_seeding_test.cc
+++ b/src/v/random/tests/random_seeding_test.cc
@@ -58,8 +58,8 @@ using random_generators::rng;
 // and maintaining their own rng object.
 
 // the first and second values expected from `get_int` with the default seed
-constexpr int get_int_0 = 79693958;
-constexpr int get_int_1 = 1828472881;
+constexpr int get_int_0 = 1822407592;
+constexpr int get_int_1 = 1412255784;
 
 using namespace random_generators::internal;
 

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -295,3 +295,17 @@ redpanda_test_cc_library(
     deps = [
     ],
 )
+
+# The hook implementation for perf tests, installs the global test hooks.
+redpanda_test_cc_library(
+    name = "rpbench_hooks",
+    srcs = [
+        "rpbench_hooks.cc",
+    ],
+    implementation_deps = [
+        ":global_test_hooks",
+        "@seastar//:benchmark",
+    ],
+    visibility = ["//visibility:public"],
+    alwayslink = True,  # hooks are installed by a global constructor
+)

--- a/src/v/test_utils/rpbench_hooks.cc
+++ b/src/v/test_utils/rpbench_hooks.cc
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "test_utils/global_test_hooks.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+PERF_PRE_RUN_HOOK([](const sstring& test_group, const sstring& test_case) {
+    test_hooks::before_test_case(test_group + "." + test_case);
+});


### PR DESCRIPTION
Finally, here's the fixed seeding for benchmarks.

I tried it on `hash_bench.murmur_hash_x86_32.iobuf` which seems to use some randomness to make iobufs.

It has a small run-to-run `inst` variation at default settings (duration=1), larger with shorter durations. With this change _and_ a fixed duration, there is no varation at all (to the 7 sig figs shown), however, with the default duration=1, the iteration estimation process it used which sometimes produces different numbers of iterations. This again introduces some small amount of randomness when the iteration counts varies.

This randomness is much less than before since if we vary from 721000 iterations to 723000 the next run the first 721000 iterations are the same and only the additional 2000 will differ, so a lot of the variations is washed out by the large number of invariant executions. Also there is no run-to-run variation (i.e., the stuff reported by MAD) since the same number of iterations is used for all runs in one invocation.

AI's idea:

This pull request introduces improvements to the benchmarking infrastructure and random seed handling, ensuring more consistent and reliable performance tests. The main changes include the addition of a global hooks library for benchmarks, updates to the random seed logic, and enhancements to Bazel rules for test and benchmark targets.

**Benchmark infrastructure enhancements:**

* Added a new `rpbench_hooks` library in `src/v/test_utils/BUILD` and implemented its source in `src/v/test_utils/rpbench_hooks.cc`. This library installs global test hooks for performance tests using a global constructor and is always linked to benchmark targets. [[1]](diffhunk://#diff-9635d6ee45bda33c3af409bad8c81c9619696d3c99840ac483ae43cae3d05131R298-R311) [[2]](diffhunk://#diff-76985b87579947929c7100cd8295befa68263f07536b960cb4ed9edf12809d2eR1-R18)
* Updated the Bazel rule `redpanda_cc_bench` in `bazel/test.bzl` to automatically include `rpbench_hooks` as a dependency for all benchmarks, ensuring hooks are always installed.

**Random seed handling improvements:**

* Changed the fixed seed value in `src/v/random/generators.cc` from `1234567891u` to `0xDEADBEEF` for improved clarity and uniqueness.
* Updated the type of the return value of `get_initial_seed()` to match `seed_type`, aligning with the new fixed seed and improving type safety.

**Bazel rule improvements:**

* Modified the `redpanda_test_cc_library` Bazel rule in `bazel/test.bzl` to support the `alwayslink` parameter, allowing certain libraries (like hooks) to be always linked when needed. [[1]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7L358-R359) [[2]](diffhunk://#diff-489eea9466c18eb7f2be368c8c9c3b4d1c3a0ccda97ed1f4a80973468d8605e7R375)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
