### PR TITLE
[CORE-13754] Make `disk_log_impl::adjacent_merge_compact()` pass by value

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -579,7 +579,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
             cfg.asrc->check();
         }
 
-        auto is_compactible_segment = !seg->has_appender()
+        auto is_compactible_segment = !seg->is_closed() && !seg->has_appender()
                                       && seg->is_compacted_segment()
                                       && offsets_compactible(*seg);
         // Skip over segments that that being truncated, or are uncompactible.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -526,7 +526,7 @@ ss::future<compaction_result> disk_log_impl::segment_self_compact(
 }
 
 ss::future<> disk_log_impl::adjacent_merge_compact(
-  segment_set& segments,
+  segment_set segments,
   compaction::compaction_config cfg,
   std::optional<model::offset> new_start_offset) {
     vlog(
@@ -1396,8 +1396,10 @@ ss::future<> disk_log_impl::do_compact(
         || (compact_cfg.hash_key_map && compact_cfg.hash_key_map->capacity() == 0);
 
     if (use_adjacent_merge) {
+        // Make a copy of `_segs` to avoid iterator invalidation in
+        // `adjacent_merge_compact`.
         compact_fut = adjacent_merge_compact(
-          _segs, compact_cfg, new_start_offset);
+          _segs.copy(), compact_cfg, new_start_offset);
     } else {
         compact_fut = sliding_window_compact(compact_cfg, new_start_offset)
                         .then([&](bool compacted) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -240,7 +240,7 @@ public:
       bool force_compaction = false);
 
     ss::future<> adjacent_merge_compact(
-      segment_set& segments,
+      segment_set segments,
       compaction::compaction_config,
       std::optional<model::offset> new_start_offset = std::nullopt);
 

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -51,7 +51,6 @@ public:
     ~segment_set() noexcept;
     segment_set(segment_set&&) noexcept = default;
     segment_set& operator=(segment_set&& o) noexcept = default;
-    segment_set(const segment_set&) = delete;
     segment_set& operator=(const segment_set&) = delete;
 
     size_t size() const { return _handles.size(); }
@@ -89,7 +88,11 @@ public:
     const_reverse_iterator rbegin() const { return _handles.rbegin(); }
     const_reverse_iterator rend() const { return _handles.rend(); }
 
+    segment_set copy() const noexcept { return *this; }
+
 private:
+    segment_set(const segment_set&) noexcept = default;
+
     underlying_t _handles;
 
     friend std::ostream& operator<<(std::ostream&, const segment_set&);

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -1689,7 +1689,7 @@ TEST_F(CompactionFixtureParamTest, TestSegmentConcatenation) {
       std::nullopt,
       cardinality);
 
-    disk_log.adjacent_merge_compact(filtered_seg_set, cfg).get();
+    disk_log.adjacent_merge_compact(filtered_seg_set.copy(), cfg).get();
     auto post_compact_batches = model::consume_reader_to_chunked_vector(
                                   log->make_reader(reader_cfg).get(),
                                   model::no_timeout)
@@ -1745,7 +1745,7 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompaction) {
     // All but the active segment
     ASSERT_EQ(filtered_seg_set.size(), segment_count_before);
 
-    disk_log.adjacent_merge_compact(filtered_seg_set, cfg).get();
+    disk_log.adjacent_merge_compact(filtered_seg_set.copy(), cfg).get();
 
     // Another sanity check after compaction.
     ASSERT_EQ(disk_log.segment_count(), 2);
@@ -1834,7 +1834,7 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
     // All but the active segment.
     ASSERT_EQ(filtered_seg_set.size(), disk_log.segment_count() - 1);
 
-    disk_log.adjacent_merge_compact(filtered_seg_set, cfg).get();
+    disk_log.adjacent_merge_compact(filtered_seg_set.copy(), cfg).get();
 
     // Another sanity check after compaction.
     ASSERT_EQ(disk_log.segment_count(), num_raft_terms + 1);
@@ -1893,7 +1893,7 @@ TEST_F(
         }
 
         storage::segment_set filtered_seg_set(std::move(filtered_segs));
-        l->adjacent_merge_compact(filtered_seg_set, cfg).get();
+        l->adjacent_merge_compact(filtered_seg_set.copy(), cfg).get();
         // Including the active segment
         ASSERT_EQ(l->segment_count(), 2);
     };
@@ -2129,7 +2129,7 @@ TEST_F(CompactionFixtureTest, TestBatchCacheResetAfterAdjacentMerge) {
     auto before_merge = consume(reader_cfg);
     ASSERT_EQ(before_merge.size(), cardinality);
 
-    disk_log.adjacent_merge_compact(segs, cfg).get();
+    disk_log.adjacent_merge_compact(segs.copy(), cfg).get();
 
     ASSERT_EQ(disk_log.segment_count(), 2);
 

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -566,8 +566,10 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
     compaction::compaction_config compaction_cfg(
       model::offset::max(), std::nullopt, std::nullopt, as);
     auto& disk_log = *dynamic_cast<disk_log_impl*>(log.get());
-    disk_log.adjacent_merge_compact(disk_log.segments(), compaction_cfg).get();
-    disk_log.adjacent_merge_compact(disk_log.segments(), compaction_cfg).get();
+    disk_log.adjacent_merge_compact(disk_log.segments().copy(), compaction_cfg)
+      .get();
+    disk_log.adjacent_merge_compact(disk_log.segments().copy(), compaction_cfg)
+      .get();
     for (const auto& s : log->segments()) {
         if (s->has_appender()) {
             continue;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -5417,7 +5417,8 @@ TEST_F(storage_test_fixture, dirty_and_closed_bytes_bookkeeping) {
     };
 
     auto adjacent_merge_func = [&]() {
-        disk_log->adjacent_merge_compact(disk_log->segments(), cfg.compact)
+        disk_log
+          ->adjacent_merge_compact(disk_log->segments().copy(), cfg.compact)
           .get();
     };
 
@@ -6445,7 +6446,7 @@ TEST_F(storage_test_fixture, segment_cached_disk_usage_set_after_compaction) {
 
     // Test adjacent compaction
     {
-        disk_log.adjacent_merge_compact(segs, cfg).get();
+        disk_log.adjacent_merge_compact(segs.copy(), cfg).get();
         for (auto& s : segs) {
             if (s->has_self_compact_timestamp()) {
                 check_cached_sizes(s);
@@ -7088,7 +7089,9 @@ TEST_F(storage_test_fixture, adjacent_merge_compaction_advances_generation_id) {
 
     auto gen_id_before = segs.front()->get_generation_id();
 
-    disk_log.adjacent_merge_compact(segs, cfg).get();
+    {
+        disk_log.adjacent_merge_compact(segs.copy(), cfg).get();
+    }
     ASSERT_EQ(segs.size(), 2);
 
     auto gen_id_after = segs.front()->get_generation_id();

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -164,7 +164,7 @@ ss::future<> disk_log_builder::apply_adjacent_merge_compaction(
   compaction::compaction_config cfg,
   std::optional<model::offset> new_start_offset) {
     return get_disk_log_impl().adjacent_merge_compact(
-      get_disk_log_impl().segments(), cfg, new_start_offset);
+      get_disk_log_impl().segments().copy(), cfg, new_start_offset);
 }
 
 ss::future<bool> disk_log_builder::apply_sliding_window_compaction(


### PR DESCRIPTION
Fixes https://redpandadata.atlassian.net/browse/CORE-13754.

Passing the `segment_set` by reference could lead to a seg fault due to iterator invalidation by concurrent mutation of the underlying `_segs` container while it was being iterated over within `adjacent_merge_compact`.

This path is only taken when `log_compaction_use_sliding_window=false`.

Change the function signature to take `segment_set` by value, forcing the user to perform a copy of the segments container to avoid this issue.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
