### PR TITLE
cl/topic_syncer: always set remote allow gaps property

### DIFF
--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -403,7 +403,9 @@ errc frontend::validate_mutation(const cluster_link_cmd& cmd) const {
     validator v{
       _table,
       max_links,
-      {"redpanda.remote.readreplica", "redpanda.remote.recovery"}};
+      {"redpanda.remote.readreplica",
+       "redpanda.remote.recovery",
+       "redpanda.remote.allowgaps"}};
     return v.validate_mutation(cmd);
 }
 

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -471,7 +471,9 @@ void source_topic_syncer::enqueue_update_mirror_topic_commands(
                       "Topic {} property {} changed: {} -> {}",
                       topic,
                       key,
-                      cached_config_it->second,
+                      cached_config_it == mirror_topic_cache.topic_configs.end()
+                        ? "<not-set>"
+                        : cached_config_it->second,
                       val);
                     enqueue_command = true;
                 }

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -29,6 +29,14 @@ const absl::flat_hash_set<ss::sstring> required_topic_properties{
   ss::sstring{kafka::topic_property_timestamp_type},
 };
 
+/*
+ * This map contains topic properties that will be overridden when creating
+ * mirror topics.
+ */
+const absl::flat_hash_map<ss::sstring, ss::sstring>
+  topic_configuration_overrides{
+    {{ss::sstring(kafka::topic_property_remote_allow_gaps), "true"}}};
+
 const absl::flat_hash_set<::model::topic> topic_denylist{
   ::model::kafka_consumer_offsets_topic,
 };
@@ -79,6 +87,28 @@ validate_and_get_configs_from_response(
             configs.emplace(c.name, *c.value);
         }
     }
+
+    // apply overrides
+    for (const auto& [k, v] : topic_configuration_overrides) {
+        auto it = configs.find(k);
+        if (it != configs.end()) {
+            vlog(
+              logger.debug,
+              "Overriding topic property {} value from {} to {}",
+              k,
+              it->second,
+              v);
+            it->second = v;
+        } else {
+            vlog(
+              logger.trace,
+              "Adding topic property override {} with value {}",
+              k,
+              v);
+            configs.emplace(k, v);
+        }
+    }
+
     return configs;
 }
 

--- a/src/v/cluster_link/tests/topic_properties_syncer_test.cc
+++ b/src/v/cluster_link/tests/topic_properties_syncer_test.cc
@@ -251,6 +251,9 @@ TEST_F_CORO(
     });
 }
 
+static constexpr std::string_view topic_properties_remote_allowgaps
+  = "redpanda.remote.allowgaps";
+
 TEST_F_CORO(
   update_properties_invalid_describe_configs_test,
   do_not_return_topic_config_no_mod) {
@@ -263,6 +266,11 @@ TEST_F_CORO(
         }
         return mirror_topic_it->second.copy();
     }();
+    // this property is overridden by default in the source_topic_syncer
+    // to allow gaps in replication
+
+    properties.topic_configs[ss::sstring(topic_properties_remote_allowgaps)]
+      = "true";
 
     chunked_vector<kafka::describe_configs_result> response;
     response.emplace_back(


### PR DESCRIPTION
When using shadow linking target cluster has no control and knowledge about the source topic content. It may contain gaps that were either created by the compaction working in the past or aborted transactions.

In order to allow shadow linking work with tiered storage enable topics and replicate topics with gaps in the offset range we must allow remote gaps in every shadow topic that is created in the target cluster.

Added simple mechanism to set overrides for topic properties in topic syncer.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none