### PR TITLE
cs/archiver_service: relax metadata consistency check when gaps allowed

### DIFF
--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -120,15 +120,36 @@ is_nested_shutdown_exception(const ss::nested_exception& ex) {
 bool segment_meta_matches_stats(
   const cloud_storage::segment_meta& meta,
   const cloud_storage::segment_record_stats& stats,
-  retry_chain_logger& ctxlog) {
+  retry_chain_logger& ctxlog,
+  bool gaps_allowed) {
     // Validate segment content. The 'stats' is computed when
     // the actual segment is scanned and represents the 'ground truth' about
     // its content. The 'meta' is the expected segment metadata. We
     // shouldn't replicate it if it doesn't match the 'stats'.
+    const auto offsets_valid = [&] {
+        if (gaps_allowed) {
+            /**
+             * Gap may be present either at the beginning or at the end of the
+             * segment. So we check that the stats range is fully contained
+             * within the segments range. Gaps should not influence the segment
+             * size and number of config records.
+             *
+             * base_o                                last_o
+             *   |           segment offsets           |
+             *    <- gap ->                   <- gap ->
+             *             |  stats offsets  |
+             *
+             *           base_o            last_o
+             */
+
+            return stats.base_rp_offset >= meta.base_offset
+                   && stats.last_rp_offset <= meta.committed_offset;
+        }
+        return meta.base_offset == stats.base_rp_offset
+               && meta.committed_offset == stats.last_rp_offset;
+    };
     if (
-      meta.size_bytes != stats.size_bytes
-      || meta.base_offset != stats.base_rp_offset
-      || meta.committed_offset != stats.last_rp_offset
+      meta.size_bytes != stats.size_bytes || !offsets_valid()
       || static_cast<size_t>(meta.delta_offset_end - meta.delta_offset)
            != stats.total_conf_records) {
         vlog(
@@ -2243,7 +2264,12 @@ ntp_archiver::wait_uploads_complete(
             if (
               upload.upload_kind == segment_upload_kind::non_compacted
               && upload.meta.has_value()) {
-                if (!segment_meta_matches_stats(*upload.meta, stats, _rtclog)) {
+                if (!segment_meta_matches_stats(
+                      *upload.meta,
+                      stats,
+                      _rtclog,
+                      _parent.get_ntp_config()
+                        .is_remote_allow_gaps_enabled())) {
                     break;
                 }
             }
@@ -3622,7 +3648,11 @@ ss::future<bool> ntp_archiver::do_upload_local(
         // the actual segment is scanned and represents the 'ground truth' about
         // its content. The 'meta' is the expected segment metadata. We
         // shouldn't replicate it if it doesn't match the 'stats'.
-        if (!segment_meta_matches_stats(meta, stats, _rtclog)) {
+        if (!segment_meta_matches_stats(
+              meta,
+              stats,
+              _rtclog,
+              _parent.get_ntp_config().is_remote_allow_gaps_enabled())) {
             co_return false;
         }
     }


### PR DESCRIPTION
When topic is configured to tolerate gaps the segment metadata consistency check should also allow gaps to exists at the upload chunk boundaries. This commit relaxes ntp archiver metadata check when gaps are allowed to exists in the remote data.

With the relaxed check the logic doesn't require start and end offset of stats to be exactly equal to the values coming from upload metadata but the range defined by the stats offsets must be enclosed within the range defined by segment metadata.

#### Rationale:

The consistency check compares the offsets collected when selecting an upload candidate with the offsets obtained during the full read of the range selected to upload. Since the batches are actually read when building remote segment index the statistics collected during the build are treated as a source of truth for the check.

When gaps exists in the log it may happen that the segment index builder will skip some batches when building the index. When the gap exists either at the begging or the end of upload range the metadata consistency check will fail.

The relaxed check applied when topic property allows remote data gaps to be present is changed in a way to make the gap at the beginning and the end of read range not to fail the consistency check.

Gap in the range will not influence the upload result but it will not be reflected in the stats collected while building remote segment index as the reader will not 'see' a batch with gap offset.

This way the base offset of stats coming from index creation will always be greater than the segment metadata base offset if a gap is at the begging of the range. The analogical rule applies to the last offset of segment stats.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none