### PR TITLE
iceberg: json schema: accept more chars in date-time format

### DIFF
--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -1212,7 +1212,7 @@ TEST_CORO(IcebergValues, FormatValueTooLong) {
     ASSERT_TRUE_CORO(result.has_error());
     ASSERT_STREQ_CORO(
       result.error().what(),
-      "String value exceeds maximum length of 32 bytes: 69");
+      "String value exceeds maximum length of 64 bytes: 69");
 }
 
 TEST_CORO(IcebergValues, Empty) {

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -106,11 +106,11 @@ convert_primitive(serde::json::parser& p, const primitive_type& ft) {
             return iop.read_string(iop.bytes_left());
         };
 
-        // 32 bytes should be enough for most date/time formats.
+        // 64 bytes should be enough for most date/time formats.
         // There can be unlimited trailing digits for fractional
-        // seconds but 32 should be more than enough.
+        // seconds but 64 should be more than enough.
         // Example: 2025-01-01T01:02:03.11111111111[snip]Z
-        constexpr size_t max_date_time_format_length = 32;
+        constexpr size_t max_date_time_format_length = 64;
 
         if (std::holds_alternative<timestamptz_type>(ft)) {
             auto parse_input = linearize(


### PR DESCRIPTION
Testing with rkp connect showed that 32 isn't enough after all. 64 should be.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
