### PR TITLE
app: prevent incompatible downgrades

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -3584,16 +3584,9 @@ void application::load_feature_table_snapshot() {
           "indicates that all nodes in cluster were previously >= that version",
           my_version,
           snap.version);
-        // From this point, it is undefined to whether this process will be able
-        // to decode anything it sees on the network or on disk.
-        //
-        // This case will have stricter enforcement in future, to protect the
-        // user from acccidentally getting a cluster into a broken state by
-        // downgrading too far:
-        // https://github.com/redpanda-data/redpanda/issues/7018
-#ifndef NDEBUG
-        vassert(my_version >= snap.version, "Incompatible downgrade detected");
-#endif
+        vassert(
+          config::node().upgrade_override_checks || my_version >= snap.version,
+          "Incompatible downgrade detected");
     } else {
         vlog(
           _log.debug,


### PR DESCRIPTION
I did some investigation, and it looks like we just never followed up on strictly preventing downgrades for release builds. This now enforces this.


FIXES: https://redpandadata.atlassian.net/browse/CORE-1066

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Incompatible downgrades are now strictly forbidden by refusing to startup

