### PR TITLE
[v25.2.x] iceberg: streaming parsing for table metadata

### DIFF
--- a/src/v/iceberg/BUILD
+++ b/src/v/iceberg/BUILD
@@ -753,6 +753,7 @@ redpanda_cc_library(
     implementation_deps = [
         ":table_metadata_json",
         "//src/v/bytes:iobuf_parser",
+        "//src/v/bytes:streambuf",
         "//src/v/json",
     ],
     include_prefix = "iceberg",

--- a/src/v/iceberg/table_io.cc
+++ b/src/v/iceberg/table_io.cc
@@ -10,8 +10,10 @@
 #include "iceberg/table_io.h"
 
 #include "bytes/iobuf_parser.h"
+#include "bytes/streambuf.h"
 #include "iceberg/table_metadata_json.h"
 #include "json/chunked_buffer.h"
+#include "json/istreamwrapper.h"
 
 namespace iceberg {
 
@@ -19,10 +21,11 @@ ss::future<checked<table_metadata, metadata_io::errc>>
 table_io::download_table_meta(const table_metadata_path& path) {
     return download_object<table_metadata>(
       path(), "iceberg::table_metadata", [](iobuf b) {
-          iobuf_parser p(std::move(b));
-          auto sz = p.bytes_left();
+          iobuf_istreambuf ibuf(b);
+          std::istream stream(&ibuf);
+          json::IStreamWrapper s(stream);
           json::Document parsed;
-          parsed.Parse(p.read_string(sz));
+          parsed.ParseStream(s);
           return parse_table_meta(parsed);
       });
 }


### PR DESCRIPTION


## Backports Required


- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Bug Fixes

* Prevent oversized allocations when table metadata gets large
