### PR TITLE
[v25.2.x] iceberg: json schema: accept more chars in date-time format

### DIFF
--- a/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_json_tests.cc
@@ -1204,7 +1204,7 @@ TEST_CORO(IcebergValues, FormatValueTooLong) {
     ASSERT_TRUE_CORO(result.has_error());
     ASSERT_STREQ_CORO(
       result.error().what(),
-      "String value exceeds maximum length of 32 bytes: 69");
+      "String value exceeds maximum length of 64 bytes: 69");
 }
 
 TEST_CORO(IcebergValues, Empty) {

--- a/src/v/iceberg/conversion/values_json.cc
+++ b/src/v/iceberg/conversion/values_json.cc
@@ -99,11 +99,11 @@ std::optional<primitive_value> convert_primitive(
             return iop.read_string(iop.bytes_left());
         };
 
-        // 32 bytes should be enough for most date/time formats.
+        // 64 bytes should be enough for most date/time formats.
         // There can be unlimited trailing digits for fractional
-        // seconds but 32 should be more than enough.
+        // seconds but 64 should be more than enough.
         // Example: 2025-01-01T01:02:03.11111111111[snip]Z
-        constexpr size_t max_date_time_format_length = 32;
+        constexpr size_t max_date_time_format_length = 64;
 
         if (std::holds_alternative<timestamptz_type>(ft)) {
             auto parse_input = linearize(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27888
