### PR TITLE
[CORE-13426] ct: Fix out of order sequence error

### DIFF
--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -28,6 +28,7 @@
 
 #include <chrono>
 #include <exception>
+#include <variant>
 
 using namespace std::chrono_literals;
 
@@ -71,20 +72,20 @@ ss::future<> batcher<Clock>::stop() {
 }
 
 template<class Clock>
-ss::future<result<size_t>>
+ss::future<std::expected<size_t, errc>>
 batcher<Clock>::upload_object(object_id id, iobuf payload) {
     auto content_length = payload.size_bytes();
     vlog(
       _logger.trace,
-      "upload_object is called, upload size: {}",
-      human::bytes(content_length));
+      "upload_object is called, upload size: {} ({} bytes)",
+      human::bytes(content_length),
+      content_length);
 
     auto err = errc::success;
     try {
         // Clock type is not parametrized further down the call chain.
         basic_retry_chain_node<Clock> local_rtc(
           Clock::now() + _upload_timeout(),
-          // Backoff doesn't matter, the operation never retries
           _upload_backoff_interval(),
           retry_strategy::backoff,
           &_rtc);
@@ -118,24 +119,25 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
     } catch (...) {
         auto e = std::current_exception();
         if (ssx::is_shutdown_exception(e)) {
-            err = errc::shutting_down;
+            co_return std::unexpected{errc::shutting_down};
         } else {
             vlog(_logger.error, "Unexpected L0 upload error {}", e);
             // Return early to prevent the double logging below
-            co_return errc::unexpected_failure;
+            co_return std::unexpected{errc::unexpected_failure};
         }
     }
 
     if (err != errc::success) {
         vlog(_logger.warn, "L0 upload error: {}", err);
-        co_return err;
+        co_return std::unexpected{err};
     }
 
     co_return content_length;
 }
 
 template<class Clock>
-ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
+ss::future<std::expected<std::monostate, errc>> batcher<Clock>::run_once(
+  write_pipeline<Clock>::write_requests_list list) noexcept {
     try {
         // NOTE: the main workflow looks like this:
         // - remove expired write requests
@@ -158,12 +160,10 @@ ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
         // collecting the write requests. The second invariant is enforced
         // by the strict order in which the ack() method is called
         // explicitly after the operation is either committed or failed.
-        auto list = _stage.pull_write_requests(
-          10_MiB); // TODO: use configuration parameter
 
         if (list.requests.empty()) {
             vlog(_logger.trace, "No write requests to process");
-            co_return true;
+            co_return std::monostate{};
         }
 
         auto epoch_fut = co_await ss::coroutine::as_future<cluster_epoch>(
@@ -180,7 +180,7 @@ ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
                 list.requests.pop_back();
             }
             _probe.register_epoch_error();
-            co_return errc::failed_to_get_epoch;
+            co_return std::unexpected(errc::failed_to_get_epoch);
         }
 
         aggregator<Clock> aggregator{object_id::create(epoch_fut.get())};
@@ -194,7 +194,7 @@ ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
         auto size_bytes = payload.size_bytes();
         auto result = co_await upload_object(
           aggregator.get_object_id(), std::move(payload));
-        if (result.has_error()) {
+        if (!result) {
             // TODO: fix the error
             // NOTE: it should be possible to translate the
             // error to kafka error at the call site but I
@@ -202,19 +202,19 @@ ss::future<result<bool>> batcher<Clock>::run_once() noexcept {
             // Timeout should work well at this point.
             aggregator.ack_error(errc::timeout);
             _probe.register_error();
-            co_return result.error();
+            co_return std::unexpected{result.error()};
         }
         aggregator.ack();
         _probe.register_upload(size_bytes);
-        co_return list.complete;
+        co_return std::monostate{};
     } catch (...) {
         auto err = std::current_exception();
         if (ssx::is_shutdown_exception(err)) {
             vlog(_logger.debug, "Batcher shutdown error: {}", err);
-            co_return errc::shutting_down;
+            co_return std::unexpected{errc::shutting_down};
         }
         vlog(_logger.error, "Unexpected batcher error: {}", err);
-        co_return errc::unexpected_failure;
+        co_return std::unexpected{errc::unexpected_failure};
     }
 }
 
@@ -239,20 +239,30 @@ ss::future<> batcher<Clock>::bg_controller_loop() {
             vlog(_logger.info, "Batcher upload loop is shutting down");
             co_return;
         }
-        auto res = co_await run_once();
-        if (res.has_error()) {
-            if (res.error() == errc::shutting_down) {
-                vlog(_logger.info, "Batcher upload loop is shutting down");
-                co_return;
-            } else {
-                // Some other (most likely upload) error
-                vlog(
-                  _logger.info, "Batcher upload loop error: {}", res.error());
-                more_work = true;
-            }
-        } else {
-            more_work = !res.value();
-        }
+
+        auto list = _stage.pull_write_requests(
+          10_MiB); // TODO: use configuration parameter
+
+        // We can spawn the work in the background without worrying about memory
+        // usage because the pipeline tracks the memory usage for us and will
+        // stop accepting new write requests if we go over the limit.
+        ssx::spawn_with_gate(_gate, [this, list = std::move(list)]() mutable {
+            return run_once(std::move(list))
+              .then([this](std::expected<std::monostate, errc> res) {
+                  if (!res.has_value()) {
+                      if (res.error() == errc::shutting_down) {
+                          vlog(
+                            _logger.info,
+                            "Batcher upload loop is shutting down");
+                      } else {
+                          vlog(
+                            _logger.info,
+                            "Batcher upload loop error: {}",
+                            res.error());
+                      }
+                  }
+              });
+        });
     }
 }
 

--- a/src/v/cloud_topics/level_zero/batcher/batcher.cc
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.cc
@@ -44,6 +44,9 @@ batcher<Clock>::batcher(
   , _bucket(std::move(bucket))
   , _upload_timeout(
       config::shard_local_cfg().cloud_storage_segment_upload_timeout_ms.bind())
+  , _upload_backoff_interval(
+      config::shard_local_cfg()
+        .cloud_storage_upload_loop_initial_backoff_ms.bind())
   , _upload_interval(
       config::shard_local_cfg()
         .cloud_storage_upload_loop_initial_backoff_ms
@@ -82,8 +85,8 @@ batcher<Clock>::upload_object(object_id id, iobuf payload) {
         basic_retry_chain_node<Clock> local_rtc(
           Clock::now() + _upload_timeout(),
           // Backoff doesn't matter, the operation never retries
-          100ms,
-          retry_strategy::disallow,
+          _upload_backoff_interval(),
+          retry_strategy::backoff,
           &_rtc);
 
         auto path = object_path_factory::level_zero_path(id);

--- a/src/v/cloud_topics/level_zero/batcher/batcher.h
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.h
@@ -84,8 +84,9 @@ private:
     /// - uploads L0 object
     /// - generates placeholders and propagates them
     ///
-    /// \returns false if the method should be called again, true otherwise
-    ss::future<result<bool>> run_once() noexcept;
+    /// \returns error code
+    ss::future<std::expected<std::monostate, errc>>
+      run_once(write_pipeline<Clock>::write_requests_list) noexcept;
 
     /// Background fiber responsible for merging
     /// aggregated log data and sending it to the
@@ -99,7 +100,8 @@ private:
     /// Collect data from every shard and upload stream of data to S3.
     ///
     /// \return size of the uploaded object or error code
-    ss::future<result<size_t>> upload_object(object_id id, iobuf payload);
+    ss::future<std::expected<size_t, errc>>
+    upload_object(object_id id, iobuf payload);
 
     cloud_topics::cluster_services* _cluster_services;
     cloud_io::remote_api<Clock>& _remote;

--- a/src/v/cloud_topics/level_zero/batcher/batcher.h
+++ b/src/v/cloud_topics/level_zero/batcher/batcher.h
@@ -105,6 +105,7 @@ private:
     cloud_io::remote_api<Clock>& _remote;
     cloud_storage_clients::bucket_name _bucket;
     config::binding<std::chrono::milliseconds> _upload_timeout;
+    config::binding<std::chrono::milliseconds> _upload_backoff_interval;
     config::binding<std::chrono::milliseconds> _upload_interval;
 
     ss::gate _gate;

--- a/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
+++ b/src/v/cloud_topics/level_zero/batcher/tests/batcher_test.cc
@@ -92,7 +92,11 @@ public:
 
 namespace cloud_topics::l0 {
 struct batcher_accessor {
-    ss::future<result<bool>> run_once() noexcept { return batcher->run_once(); }
+    ss::future<std::expected<std::monostate, errc>> run_once() noexcept {
+        constexpr static size_t lim = 10_MiB;
+        auto list = batcher->_stage.pull_write_requests(lim);
+        return batcher->run_once(std::move(list));
+    }
 
     cloud_topics::l0::batcher<ss::manual_clock>* batcher;
 };

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -134,11 +134,19 @@ ss::future<client::request_response_t> client::make_request(
     if (is_valid()) {
         if (age < _max_idle_time) {
             // Reuse connection
-            vlog(ctxlog.debug, "reusing connection, age {}", age.count());
+            vlog(
+              ctxlog.debug,
+              "reusing connection, age {}, max idle time {}",
+              age.count(),
+              _max_idle_time.count());
             return ss::make_ready_future<request_response_t>(
               std::make_tuple(req, res));
         } else {
-            vlog(ctxlog.debug, "shutdown connection, age {}", age.count());
+            vlog(
+              ctxlog.debug,
+              "shutdown connection, age {}, max idle time {}",
+              age.count(),
+              _max_idle_time.count());
             // Connection is too old and likeley already received
             // RST packet from the server. If we will try to use
             // it the broken pipe (32) error will be triggered.

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -170,6 +170,7 @@ class EndToEndCloudTopicsTxTest(EndToEndCloudTopicsBase):
             transaction_abort_rate=0.1,
             msgs_per_transaction=self.per_transaction,
             debug_logs=True,
+            tolerate_failed_produce=True,
         )
         self.kgo_producer.start()
         self.kgo_producer.wait()


### PR DESCRIPTION
It is possible to replicate a transactional batch out of order which will be rejected by the `rm_stm`:

- batch with base seq = 700 (10 records) is uploaded and replicated
- next batch with seq = 710 (10 records) is not uploaded, we return timeout error to the kafka client and never trying to replicate the batch
- next batch with seq = 719 (1 record) is uploaded and replicated
- next batch with seq = 710 (probably a retry) is uploaded but is rejected by the `rm_stm`

The problem has several dimensions. 
First, current `batcher` implementation never retries uploads. The batcher uploads one L0 object at a time, in case of failure it just NACK every request in L0 and proceeds with the next bunch of requests.
Second, without CT the `rm_stm` is stepping down leadership when some batch can't be persisted. This avoids situation described above. The client never retries batch 710. It has to recnocile and proceed with another leader instead.

This PR addresses both aspects of this problem.
- It makes `batcher` retry failed requests. The `batcher` no longer waits for the current upload to finish before starting the next upload. So essentially, it can upload multiple L0 objects at a time.
- In case of upload failure (or unexpected failure) the `frontend` not just NACKs the client but steps down the leadership.

The stepdown is only happens if the L0 object contains transactional batch from the corresponding partition.
Concurrent uploads in the batcher are safe because the `write_pipeline` applies memory limits and throttling. The batches which are being uploaded are taken into account.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none