### PR TITLE
rptest: disable oidc tls tests temporarily

### DIFF
--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -523,9 +523,10 @@ class RedpandaOIDCTest(RedpandaOIDCTestMethods):
         super(RedpandaOIDCTest, self).__init__(test_context, **kwargs)
 
 
-class RedpandaOIDCTlsTest(RedpandaOIDCTestMethods):
-    def __init__(self, test_context, **kwargs):
-        super(RedpandaOIDCTlsTest, self).__init__(test_context, use_ssl=True, **kwargs)
+# TODO(CORE-13761): Re-enable these tests
+# class RedpandaOIDCTlsTest(RedpandaOIDCTestMethods):
+#     def __init__(self, test_context, **kwargs):
+#         super(RedpandaOIDCTlsTest, self).__init__(test_context, use_ssl=True, **kwargs)
 
 
 class JavaClientOIDCTest(RedpandaOIDCTestBase):


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CORE-13761

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
