### PR TITLE
QE DR chaos - initial tests and configs

### DIFF
--- a/tests/rptest/tests/chaos/__init__.py
+++ b/tests/rptest/tests/chaos/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0

--- a/tests/rptest/tests/chaos/disk_chaos.py
+++ b/tests/rptest/tests/chaos/disk_chaos.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Disk chaos utilities - reusable functions.
+
+This module provides reusable disk failure functions that can be used
+across different test classes for simulating disk issues like space exhaustion,
+I/O throttling, corruption, and failures.
+"""

--- a/tests/rptest/tests/chaos/kafka_chaos.py
+++ b/tests/rptest/tests/chaos/kafka_chaos.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Kafka protocol chaos utilities - reusable functions.
+
+This module provides reusable Kafka protocol manipulation functions that can be used
+across different test classes for simulating protocol-level issues like request delays,
+malformed messages, authentication failures, and API version mismatches.
+"""

--- a/tests/rptest/tests/chaos/network_chaos.py
+++ b/tests/rptest/tests/chaos/network_chaos.py
@@ -1,0 +1,210 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Network chaos utilities - reusable functions.
+
+This module provides reusable network partition functions that can be used
+across different test classes for simulating network failures.
+"""
+
+
+class NetworkChaos:
+    """Utility class for network-related chaos operations."""
+
+    @staticmethod
+    def create_partial_partition(
+        source_cluster, target_cluster, source_node_idx=0, logger=None
+    ):
+        """
+        Create partial network partition: specific source node cannot talk to any target nodes.
+
+        This simulates a realistic scenario where one source node loses connectivity
+        to the target cluster while other nodes maintain their connections.
+
+        Args:
+            source_cluster: Source cluster object
+            target_cluster: Target cluster object
+            source_node_idx: Index of source node to partition (default: 0)
+            logger: Optional logger instance
+        """
+        source_node = source_cluster.service.nodes[source_node_idx]
+
+        if logger:
+            logger.info(
+                f"Creating partial network partition for source node {source_node_idx}"
+            )
+
+        for target_node in target_cluster.service.nodes:
+            # Block traffic both ways from specified source node only
+            cmd = f"iptables -A INPUT -s {target_node.account.hostname} -j DROP"
+            source_node.account.ssh(cmd, allow_fail=True)
+            cmd = f"iptables -A OUTPUT -d {target_node.account.hostname} -j DROP"
+            source_node.account.ssh(cmd, allow_fail=True)
+
+    @staticmethod
+    def create_complete_partition(source_cluster, target_cluster, logger=None):
+        """
+        Create complete network partition between all source and target nodes.
+
+        This simulates a complete network split between data centers where
+        no communication is possible between the two clusters.
+
+        TODO: This implementation creates N×M iptables rules which is inefficient.
+        Should be simplified with one of these approaches:
+        1. Block by subnet if clusters are on different subnets
+        2. Use ipset to group all target IPs and block with a single rule
+        3. Block at interface level if dedicated interfaces exist
+        4. For more realistic testing, consider implementing at router/switch level
+        5. This of cross-region VPC peering with route table manipulation
+        6. Use a proxy tool like toxiproxy to simulate network failures
+        7. Use of 3rd party network chaos tool like Chaos Mesh
+        8  Think of cross-cloud scenarios (one cluster on AWS, another on GCP/Azure)
+
+        Args:
+            source_cluster: Source cluster object
+            target_cluster: Target cluster object
+            logger: Optional logger instance
+        """
+        if logger:
+            logger.info("Creating complete network partition between clusters")
+
+        for source_node in source_cluster.service.nodes:
+            for target_node in target_cluster.service.nodes:
+                # Block all traffic between every source and target node pair
+                cmd = f"iptables -A INPUT -s {target_node.account.hostname} -j DROP"
+                source_node.account.ssh(cmd, allow_fail=True)
+                cmd = f"iptables -A OUTPUT -d {target_node.account.hostname} -j DROP"
+                source_node.account.ssh(cmd, allow_fail=True)
+
+        if logger:
+            logger.info("Complete network partition created")
+
+    @staticmethod
+    def heal_partial_partition(source_cluster, source_node_idx=0, logger=None):
+        """
+        Remove partial network partition rules from specified source node.
+
+        Args:
+            source_cluster: Source cluster object
+            source_node_idx: Index of source node to heal (default: 0)
+            logger: Optional logger instance
+        """
+        source_node = source_cluster.service.nodes[source_node_idx]
+
+        if logger:
+            logger.info(
+                f"Healing partial network partition on source node {source_node_idx}"
+            )
+
+        source_node.account.ssh("iptables -F", allow_fail=True)
+
+    @staticmethod
+    def heal_complete_partition(source_cluster, logger=None):
+        """
+        Remove network partition rules from all source nodes.
+
+        Args:
+            source_cluster: Source cluster object
+            logger: Optional logger instance
+        """
+        if logger:
+            logger.info("Healing complete network partition")
+
+        for source_node in source_cluster.service.nodes:
+            # Flush iptables rules on all source nodes
+            source_node.account.ssh("iptables -F", allow_fail=True)
+
+        if logger:
+            logger.info("Network partition healed")
+
+    @staticmethod
+    def create_asymmetric_partition(
+        source_cluster, target_cluster, direction="source_to_target", logger=None
+    ):
+        """
+        Create asymmetric network partition (one-way block).
+
+        Args:
+            source_cluster: Source cluster object
+            target_cluster: Target cluster object
+            direction: Either "source_to_target" or "target_to_source"
+            logger: Optional logger instance
+        """
+        if logger:
+            logger.info(f"Creating asymmetric partition: {direction}")
+
+        if direction == "source_to_target":
+            # Source can't send to target, but can receive
+            for source_node in source_cluster.service.nodes:
+                for target_node in target_cluster.service.nodes:
+                    cmd = (
+                        f"iptables -A OUTPUT -d {target_node.account.hostname} -j DROP"
+                    )
+                    source_node.account.ssh(cmd, allow_fail=True)
+        else:
+            # Source can't receive from target, but can send
+            for source_node in source_cluster.service.nodes:
+                for target_node in target_cluster.service.nodes:
+                    cmd = f"iptables -A INPUT -s {target_node.account.hostname} -j DROP"
+                    source_node.account.ssh(cmd, allow_fail=True)
+
+    @staticmethod
+    def add_network_delay(
+        cluster, delay_ms=100, jitter_ms=10, node_idx=None, logger=None
+    ):
+        """
+        Add network delay to cluster nodes using tc (traffic control).
+
+        Args:
+            cluster: Cluster object
+            delay_ms: Base delay in milliseconds
+            jitter_ms: Jitter/variance in milliseconds
+            node_idx: Specific node index, or None for all nodes
+            logger: Optional logger instance
+        """
+        nodes = (
+            [cluster.service.nodes[node_idx]]
+            if node_idx is not None
+            else cluster.service.nodes
+        )
+
+        if logger:
+            logger.info(
+                f"Adding {delay_ms}ms delay (±{jitter_ms}ms jitter) to {len(nodes)} nodes"
+            )
+
+        for node in nodes:
+            # Add delay to eth0 interface
+            cmd = f"tc qdisc add dev eth0 root netem delay {delay_ms}ms {jitter_ms}ms"
+            node.account.ssh(cmd, allow_fail=True)
+
+    @staticmethod
+    def remove_network_delay(cluster, node_idx=None, logger=None):
+        """
+        Remove network delay from cluster nodes.
+
+        Args:
+            cluster: Cluster object
+            node_idx: Specific node index, or None for all nodes
+            logger: Optional logger instance
+        """
+        nodes = (
+            [cluster.service.nodes[node_idx]]
+            if node_idx is not None
+            else cluster.service.nodes
+        )
+
+        if logger:
+            logger.info(f"Removing network delay from {len(nodes)} nodes")
+
+        for node in nodes:
+            # Remove tc rules from eth0
+            cmd = "tc qdisc del dev eth0 root"
+            node.account.ssh(cmd, allow_fail=True)

--- a/tests/rptest/tests/chaos/node_chaos.py
+++ b/tests/rptest/tests/chaos/node_chaos.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Node chaos utilities - reusable functions.
+
+This module provides reusable node failure functions that can be used
+across different test classes for simulating node failures and restarts.
+"""
+
+import random
+
+
+class NodeChaos:
+    """Utility class for node-related chaos operations."""
+
+    @staticmethod
+    def kill_node(cluster, node_idx=None, logger=None):
+        """
+        Kill a specific node or random node in the cluster.
+
+        Args:
+            cluster: Cluster object
+            node_idx: Specific node index to kill, or None for random
+            logger: Optional logger instance
+
+        Returns:
+            The node that was killed
+        """
+        if node_idx is None:
+            node_idx = random.randint(0, len(cluster.service.nodes) - 1)
+
+        node = cluster.service.nodes[node_idx]
+
+        if logger:
+            logger.info(f"Killing node {node_idx}: {node.account.hostname}")
+
+        cluster.service.stop_node(node)
+        return node
+
+    @staticmethod
+    def restart_node(cluster, node, logger=None):
+        """
+        Restart a specific node.
+
+        Args:
+            cluster: Cluster object
+            node: Node to restart
+            logger: Optional logger instance
+        """
+        if logger:
+            logger.info(f"Restarting node: {node.account.hostname}")
+
+        cluster.service.start_node(node)
+
+    @staticmethod
+    def rolling_restart(cluster, wait_between_nodes=10, logger=None):
+        """
+        Perform a rolling restart of all nodes in the cluster.
+
+        Args:
+            cluster: Cluster object
+            wait_between_nodes: Seconds to wait between restarting nodes
+            logger: Optional logger instance
+        """
+        if logger:
+            logger.info(
+                f"Starting rolling restart of {len(cluster.service.nodes)} nodes"
+            )
+
+        for i, node in enumerate(cluster.service.nodes):
+            if logger:
+                logger.info(
+                    f"Restarting node {i + 1}/{len(cluster.service.nodes)}: {node.account.hostname}"
+                )
+
+            cluster.service.stop_node(node)
+            time.sleep(5)  # Brief pause after stop
+            cluster.service.start_node(node)
+
+            if i < len(cluster.service.nodes) - 1:  # Don't wait after last node
+                time.sleep(wait_between_nodes)
+
+        if logger:
+            logger.info("Rolling restart completed")
+
+    @staticmethod
+    def kill_partition_leader(
+        cluster, topic_name, partition_id=0, rpk_tool=None, logger=None
+    ):
+        """
+        Kill the leader node for a specific partition.
+
+        Args:
+            cluster: Cluster object
+            topic_name: Name of the topic
+            partition_id: Partition ID (default: 0)
+            rpk_tool: RpkTool instance for the cluster
+            logger: Optional logger instance
+
+        Returns:
+            The leader node that was killed, or None if not found
+        """
+        if rpk_tool is None:
+            from rptest.clients.rpk import RpkTool
+
+            rpk_tool = RpkTool(cluster.service)
+
+        partitions = rpk_tool.describe_topic(topic_name)
+        target_partition = next((p for p in partitions if p.id == partition_id), None)
+
+        if not target_partition:
+            if logger:
+                logger.warning(
+                    f"Partition {partition_id} not found for topic {topic_name}"
+                )
+            return None
+
+        leader_node = None
+        for node in cluster.service.nodes:
+            node_id = cluster.service.idx(node)
+            if node_id == target_partition.leader:
+                leader_node = node
+                break
+
+        if leader_node:
+            if logger:
+                logger.info(
+                    f"Killing leader node {leader_node.account.hostname} for partition {partition_id}"
+                )
+            cluster.service.stop_node(leader_node)
+
+        return leader_node
+
+    @staticmethod
+    def pause_node(cluster, node_idx=None, duration_sec=30, logger=None):
+        """
+        Pause a node using SIGSTOP (simulate long GC pause).
+
+        Args:
+            cluster: Cluster object
+            node_idx: Node index to pause, or None for random
+            duration_sec: How long to pause the node
+            logger: Optional logger instance
+
+        Returns:
+            The node that was paused
+        """
+        if node_idx is None:
+            node_idx = random.randint(0, len(cluster.service.nodes) - 1)
+
+        node = cluster.service.nodes[node_idx]
+
+        if logger:
+            logger.info(f"Pausing node {node_idx} for {duration_sec} seconds")
+
+        # Get the Redpanda process PID
+        pids = cluster.service.pids(node)
+        if pids:
+            for pid in pids:
+                node.account.ssh(f"kill -STOP {pid}", allow_fail=True)
+
+        # Schedule resume
+        import threading
+
+        def resume():
+            if pids:
+                for pid in pids:
+                    node.account.ssh(f"kill -CONT {pid}", allow_fail=True)
+            if logger:
+                logger.info(f"Resumed node {node_idx}")
+
+        timer = threading.Timer(duration_sec, resume)
+        timer.start()
+
+        return node
+
+
+# Import time at module level
+import time

--- a/tests/rptest/tests/chaos/time_chaos.py
+++ b/tests/rptest/tests/chaos/time_chaos.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""
+Time chaos utilities - reusable functions.
+
+This module provides reusable time manipulation functions that can be used
+across different test classes for simulating clock skew, NTP issues,
+time jumps, and timezone changes.
+"""

--- a/tests/rptest/tests/dr_shadow_link/configs/simple_chaos.json
+++ b/tests/rptest/tests/dr_shadow_link/configs/simple_chaos.json
@@ -1,0 +1,19 @@
+{
+  "simple_chaos_config": {
+    "test_duration_sec": 120,
+    "message_count": 1000,
+    "message_size": 512,
+    "rate_limit_kb_per_sec": 10,
+    "replication_timeout_sec": 30,
+    "max_lag_percent": 5,
+    "network_partition_max_lag_percent": 25,
+    "complete_partition_max_lag_percent": 40,
+    "chaos_duration_sec": 30,
+    "recovery_wait_sec": 20,
+    "cluster_config": {
+      "log_segment_size": 16777216,
+      "raft_heartbeat_interval_ms": 300,
+      "controller_snapshot_max_age_sec": 60
+    }
+  }
+}

--- a/tests/rptest/tests/dr_shadow_link/configs/small_test.json
+++ b/tests/rptest/tests/dr_shadow_link/configs/small_test.json
@@ -1,0 +1,24 @@
+{
+  "dr_config": {
+    "topics": {
+      "count": 1,
+      "partitions_per_topic": 3,
+      "replication_factor": 3,
+      "prefix": "test-"
+    },
+    "producers": {
+      "count": 1,
+      "msg_count_per_producer": 1000,
+      "msg_size": 1024,
+      "batch_size": 10,
+      "compression_type": "none"
+    },
+    "consumers": {
+      "count": 0
+    },
+    "verification": {
+      "max_lag_messages": 100,
+      "replication_timeout_sec": 30
+    }
+  }
+}

--- a/tests/rptest/tests/dr_shadow_link/simple_chaos_test.py
+++ b/tests/rptest/tests/dr_shadow_link/simple_chaos_test.py
@@ -1,0 +1,459 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.utils.util import wait_until
+import time
+import random
+import json
+import os
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import (
+    KgoVerifierProducer,
+    KgoVerifierConsumerGroupConsumer,
+)
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+from rptest.tests.chaos.network_chaos import NetworkChaos
+
+
+class SimpleChaosTest(ShadowLinkTestBase):
+    """
+    Simple chaos tests with minimal data for quick testing.
+    Perfect for starting small and gradually increasing complexity.
+    """
+
+    def __init__(self, test_context, *args, **kwargs):
+        super().__init__(test_context, *args, **kwargs)
+
+        # Load configuration if provided
+        config_path = os.path.join(
+            os.path.dirname(__file__), "configs/simple_chaos.json"
+        )
+        if os.path.exists(config_path):
+            with open(config_path, "r") as f:
+                self.chaos_config = json.load(f).get("simple_chaos_config", {})
+        else:
+            self.chaos_config = {}
+
+        # Default configuration with overrides from config file
+        self.max_replication_lag_percent = self.chaos_config.get("max_lag_percent", 5.0)
+        self.chaos_duration_sec = self.chaos_config.get("chaos_duration_sec", 30)
+        self.recovery_wait_sec = self.chaos_config.get("recovery_wait_sec", 20)
+        self.message_count = self.chaos_config.get("message_count", 1000)
+        self.message_size = self.chaos_config.get("message_size", 512)
+        self.rate_limit_kb_per_sec = self.chaos_config.get("rate_limit_kb_per_sec", 10)
+
+    @cluster(num_nodes=8)  # 6 for clusters + 2 for workload
+    def test_simple_kill_node(self):
+        """
+        Simplest chaos test: kill one node and verify data integrity.
+        Quick test with small amount of data.
+        """
+
+        self.logger.info("=== SIMPLE CHAOS TEST: Kill Single Node ===")
+
+        # Create one small topic
+        topic = "simple-chaos-topic"
+        topic_spec = TopicSpec(name=topic, partition_count=3, replication_factor=3)
+        self.source_default_client().create_topic(topic_spec)
+
+        # Create shadow link
+        self.create_link("simple-dr-link")
+
+        # Wait for topic to replicate
+        wait_until(lambda: self.topic_exists_in_target(topic), timeout_sec=30)
+
+        # Start small producer (just 1000 messages)
+        self.logger.info("Starting producer with 1000 messages...")
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.source_cluster.service,
+            topic=topic,
+            msg_size=self.message_size,
+            msg_count=self.message_count,
+            rate_limit_bps=self.rate_limit_kb_per_sec * 1024,
+        )
+        producer.start(clean=False)
+
+        # Wait a bit for some production
+        time.sleep(10)
+
+        # INJECT CHAOS: Kill one source node
+        source_nodes = self.source_cluster.service.nodes
+        node_to_kill = source_nodes[1]  # Kill second node
+
+        self.logger.info(f"\n>>> CHAOS: Killing node {node_to_kill.account.hostname}")
+        self.source_cluster.service.stop_node(node_to_kill)
+
+        # Let it run with node down
+        self.logger.info(
+            f"Running with node down for {self.chaos_duration_sec} seconds..."
+        )
+        time.sleep(self.chaos_duration_sec)
+
+        # Restart the node
+        self.logger.info(
+            f"\n>>> RECOVERY: Restarting node {node_to_kill.account.hostname}"
+        )
+        self.source_cluster.service.start_node(node_to_kill)
+
+        # Wait for producer to finish
+        producer.wait()
+
+        # Start consumer on target to verify
+        self.logger.info("\nStarting consumer on target cluster to verify data...")
+        consumer = KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.target_cluster.service,
+            topic=topic,
+            msg_size=512,
+            readers=1,
+            max_msgs=1000,
+            group_name="verify-group",
+        )
+        consumer.start(clean=False)
+        consumer.wait()
+
+        # Check results
+        self._print_simple_results(producer, consumer)
+
+        # Verify no data loss
+        assert consumer.consumer_status.validator.invalid_reads == 0, (
+            "Data corruption detected!"
+        )
+        assert consumer.consumer_status.validator.valid_reads > 900, (
+            "Too few messages consumed"
+        )
+
+        self.logger.info(
+            "\n✓ TEST PASSED: Data integrity maintained despite node failure"
+        )
+
+    @cluster(num_nodes=8)
+    def test_simple_network_partition(self):
+        """
+        Simple network partition test between clusters.
+        """
+
+        self.logger.info("=== SIMPLE CHAOS TEST: Network Partition ===")
+
+        # Setup
+        topic = "network-partition-topic"
+        topic_spec = TopicSpec(name=topic, partition_count=3, replication_factor=3)
+        self.source_default_client().create_topic(topic_spec)
+
+        self.create_link("partition-dr-link")
+        wait_until(lambda: self.topic_exists_in_target(topic), timeout_sec=30)
+
+        # Start producer
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.source_cluster.service,
+            topic=topic,
+            msg_size=512,
+            msg_count=2000,
+            rate_limit_bps=20480,  # 20KB/s
+        )
+        producer.start(clean=False)
+
+        # Wait for some data
+        time.sleep(15)
+
+        # INJECT CHAOS: Partial network partition (only source node 0)
+        self.logger.info(
+            "\n>>> CHAOS: Creating partial network partition (source node 0 isolated from target cluster)"
+        )
+        NetworkChaos.create_partial_partition(
+            self.source_cluster, self.target_cluster, logger=self.logger
+        )
+
+        # Run with partition
+        self.logger.info(
+            f"Running with network partition for {self.chaos_duration_sec} seconds..."
+        )
+        time.sleep(self.chaos_duration_sec)
+
+        # Heal partial partition
+        self.logger.info("\n>>> RECOVERY: Healing partial network partition")
+        NetworkChaos.heal_partial_partition(self.source_cluster, logger=self.logger)
+
+        # Wait for producer and replication
+        producer.wait()
+        time.sleep(self.recovery_wait_sec)  # Extra time for replication to catch up
+
+        # Verify data
+        self._verify_replication(topic, producer.produce_status.acked)
+
+        self.logger.info(
+            "\n✓ TEST PASSED: Replication recovered after network partition"
+        )
+
+    @cluster(num_nodes=8)
+    def test_simple_rolling_restart(self):
+        """
+        Simple rolling restart of source cluster during replication.
+        """
+
+        self.logger.info("=== SIMPLE CHAOS TEST: Rolling Restart ===")
+
+        # Setup
+        topic = "rolling-restart-topic"
+        topic_spec = TopicSpec(name=topic, partition_count=6, replication_factor=3)
+        self.source_default_client().create_topic(topic_spec)
+
+        self.create_link("rolling-dr-link")
+        wait_until(lambda: self.topic_exists_in_target(topic), timeout_sec=30)
+
+        # Start continuous producer
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.source_cluster.service,
+            topic=topic,
+            msg_size=1024,
+            msg_count=5000,
+            rate_limit_bps=51200,  # 50KB/s
+        )
+        producer.start(clean=False)
+
+        # Start rolling restart after some data
+        time.sleep(10)
+
+        self.logger.info("\n>>> CHAOS: Starting rolling restart")
+        for i, node in enumerate(self.source_cluster.service.nodes):
+            self.logger.info(f"Restarting node {i + 1}/3: {node.account.hostname}")
+            self.source_cluster.service.stop_node(node)
+            time.sleep(5)
+            self.source_cluster.service.start_node(node)
+            time.sleep(10)  # Wait for recovery
+
+        # Wait for producer
+        producer.wait()
+        time.sleep(15)
+
+        # Verify
+        self._verify_replication(topic, producer.produce_status.acked)
+
+        self.logger.info(
+            "\n✓ TEST PASSED: Replication maintained during rolling restart"
+        )
+
+    @cluster(num_nodes=8)
+    def test_simple_leader_kill(self):
+        """
+        Kill partition leaders and verify replication continues.
+        """
+
+        self.logger.info("=== SIMPLE CHAOS TEST: Kill Partition Leader ===")
+
+        # Setup topic with more partitions
+        topic = "leader-kill-topic"
+        topic_spec = TopicSpec(name=topic, partition_count=9, replication_factor=3)
+        self.source_default_client().create_topic(topic_spec)
+
+        self.create_link("leader-dr-link")
+        wait_until(lambda: self.topic_exists_in_target(topic), timeout_sec=30)
+
+        # Start producer
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.source_cluster.service,
+            topic=topic,
+            msg_size=512,
+            msg_count=3000,
+            rate_limit_bps=30720,  # 30KB/s
+        )
+        producer.start(clean=False)
+
+        # Wait for some production
+        time.sleep(10)
+
+        # Find and kill a leader
+        rpk = RpkTool(self.source_cluster.service)
+        partitions = rpk.describe_topic(topic)
+
+        # Pick partition 0's leader
+        partition_0 = next(p for p in partitions if p.id == 0)
+        leader_node = None
+
+        for node in self.source_cluster.service.nodes:
+            node_id = self.source_cluster.service.idx(node)
+            if node_id == partition_0.leader:
+                leader_node = node
+                break
+
+        if leader_node:
+            self.logger.info(
+                f"\n>>> CHAOS: Killing leader node {leader_node.account.hostname} for partition 0"
+            )
+            self.source_cluster.service.stop_node(leader_node)
+
+            # Run without leader
+            time.sleep(self.chaos_duration_sec)
+
+            # Restart
+            self.logger.info(f"\n>>> RECOVERY: Restarting leader node")
+            self.source_cluster.service.start_node(leader_node)
+
+        # Wait for completion
+        producer.wait()
+        time.sleep(15)
+
+        # Verify
+        self._verify_replication(topic, producer.produce_status.acked)
+
+        self.logger.info("\n✓ TEST PASSED: Replication handled leader failure")
+
+    @cluster(num_nodes=8)
+    def test_complete_network_partition(self):
+        """
+        Test complete network partition between source and target clusters.
+        This simulates a complete data center network split.
+        """
+
+        self.logger.info("=== SIMPLE CHAOS TEST: Complete Network Partition ===")
+
+        # Setup
+        topic = "complete-partition-topic"
+        topic_spec = TopicSpec(name=topic, partition_count=3, replication_factor=3)
+        self.source_default_client().create_topic(topic_spec)
+
+        self.create_link("complete-partition-dr-link")
+        wait_until(lambda: self.topic_exists_in_target(topic), timeout_sec=30)
+
+        # Start producer
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.source_cluster.service,
+            topic=topic,
+            msg_size=1024,
+            msg_count=3000,
+            rate_limit_bps=51200,  # 50KB/s
+        )
+        producer.start(clean=False)
+
+        # Wait for some data
+        time.sleep(15)
+
+        # INJECT CHAOS: Complete network partition
+        self.logger.info(
+            "\n>>> CHAOS: Creating COMPLETE network partition between clusters"
+        )
+        NetworkChaos.create_complete_partition(
+            self.source_cluster, self.target_cluster, logger=self.logger
+        )
+
+        # Run with complete partition
+        self.logger.info(
+            f"Running with complete network partition for {self.chaos_duration_sec} seconds..."
+        )
+        time.sleep(self.chaos_duration_sec)
+
+        # Heal partition
+        self.logger.info("\n>>> RECOVERY: Healing complete network partition")
+        NetworkChaos.heal_complete_partition(self.source_cluster, logger=self.logger)
+
+        # Wait for producer and replication
+        producer.wait()
+        time.sleep(
+            self.recovery_wait_sec * 2
+        )  # Extra time for complete partition recovery
+
+        # Verify data with higher lag tolerance for complete partition
+        rpk_source = RpkTool(self.source_cluster.service)
+        rpk_target = RpkTool(self.target_cluster.service)
+
+        source_hw = sum(p.high_watermark for p in rpk_source.describe_topic(topic))
+        target_hw = sum(p.high_watermark for p in rpk_target.describe_topic(topic))
+
+        lag = source_hw - target_hw
+        lag_pct = (lag / source_hw * 100) if source_hw > 0 else 0
+
+        self.logger.info(f"\nREPLICATION STATUS after complete partition:")
+        self.logger.info(f"  Source messages: {source_hw}")
+        self.logger.info(f"  Target messages: {target_hw}")
+        self.logger.info(f"  Lag: {lag} messages ({lag_pct:.1f}%)")
+
+        # Allow higher lag for complete partition (up to 40%)
+        max_lag = self.chaos_config.get("complete_partition_max_lag_percent", 40.0)
+        assert lag_pct <= max_lag, (
+            f"Excessive replication lag: {lag_pct}% (max allowed: {max_lag}%)"
+        )
+
+        self.logger.info(
+            "\n✓ TEST PASSED: Replication recovered after complete network partition"
+        )
+
+    def _verify_replication(self, topic, expected_messages):
+        """Verify data was replicated to target cluster."""
+        rpk_source = RpkTool(self.source_cluster.service)
+        rpk_target = RpkTool(self.target_cluster.service)
+
+        # Get high watermarks
+        source_hw = sum(p.high_watermark for p in rpk_source.describe_topic(topic))
+        target_hw = sum(p.high_watermark for p in rpk_target.describe_topic(topic))
+
+        lag = source_hw - target_hw
+        lag_pct = (lag / source_hw * 100) if source_hw > 0 else 0
+
+        self.logger.info(f"\nREPLICATION STATUS:")
+        self.logger.info(f"  Source messages: {source_hw}")
+        self.logger.info(f"  Target messages: {target_hw}")
+        self.logger.info(f"  Lag: {lag} messages ({lag_pct:.1f}%)")
+        self.logger.info(f"  Expected: ~{expected_messages} messages")
+
+        # Allow configurable lag during chaos recovery
+        max_lag = self.chaos_config.get("network_partition_max_lag_percent", 25.0)
+        assert lag_pct <= max_lag, (
+            f"Excessive replication lag: {lag_pct}% (max allowed: {max_lag}%)"
+        )
+
+        # Run consumer to verify data integrity
+        consumer = KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.target_cluster.service,
+            topic=topic,
+            msg_size=512,
+            readers=1,
+            max_msgs=expected_messages,
+            group_name="final-verify",
+        )
+        consumer.start(clean=False)
+        consumer.wait()
+
+        invalid = consumer.consumer_status.validator.invalid_reads
+        valid = consumer.consumer_status.validator.valid_reads
+
+        self.logger.info(f"\nDATA VERIFICATION:")
+        self.logger.info(f"  Valid reads: {valid}")
+        self.logger.info(f"  Invalid reads: {invalid}")
+
+        assert invalid == 0, f"Data corruption detected: {invalid} invalid reads"
+
+    def _print_simple_results(self, producer, consumer):
+        """Print simple test results."""
+        self.logger.info("\n" + "=" * 50)
+        self.logger.info("SIMPLE CHAOS TEST RESULTS")
+        self.logger.info("=" * 50)
+        self.logger.info(f"Producer:")
+        self.logger.info(f"  Messages sent: {producer.produce_status.sent}")
+        self.logger.info(f"  Messages acked: {producer.produce_status.acked}")
+        self.logger.info(f"  Errors: {producer.produce_status.bad_offsets}")
+        self.logger.info(f"Consumer:")
+        self.logger.info(
+            f"  Valid reads: {consumer.consumer_status.validator.valid_reads}"
+        )
+        self.logger.info(
+            f"  Invalid reads: {consumer.consumer_status.validator.invalid_reads}"
+        )
+        self.logger.info(
+            f"  Data integrity: {'✓ PASSED' if consumer.consumer_status.validator.invalid_reads == 0 else '✗ FAILED'}"
+        )
+        self.logger.info("=" * 50)

--- a/tests/rptest/tests/dr_shadow_link/simple_topic_shadow_test.py
+++ b/tests/rptest/tests/dr_shadow_link/simple_topic_shadow_test.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.cluster_linking_test_base import ShadowLinkTestBase
+
+
+class SimpleTopicShadowTest(ShadowLinkTestBase):
+    """
+    Simple test demonstrating basic shadow-link topic replication between two clusters.
+    Verifies that topics created on source cluster are replicated to target cluster.
+    """
+
+    @cluster(num_nodes=8)  # 6 for clusters + 2 for workload
+    def test_basic_shadow_link_setup(self):
+        """Test basic shadow-link setup between two clusters."""
+
+        # The base class already sets up two clusters:
+        # - self.source_cluster
+        # - self.target_cluster
+
+        # Verify source cluster
+        source_nodes = self.source_cluster.service.started_nodes()
+        self.logger.info(f"Source cluster has {len(source_nodes)} nodes")
+
+        # Verify target cluster
+        target_nodes = self.target_cluster.service.started_nodes()
+        self.logger.info(f"Target cluster has {len(target_nodes)} nodes")
+
+        # Create topic on source
+        topic_name = "dr-test-topic"
+        topic_spec = TopicSpec(name=topic_name, partition_count=3, replication_factor=3)
+        self.source_default_client().create_topic(topic_spec)
+
+        # Wait for topic creation
+        wait_until(
+            lambda: self.topic_exists_in_source(topic_name),
+            timeout_sec=10,
+            err_msg=f"Topic {topic_name} not created on source",
+        )
+
+        self.logger.info(f"Created topic '{topic_name}' on source cluster")
+
+        # Create shadow link
+        self.create_link("test-dr-link")
+
+        # Wait for topic to replicate
+        wait_until(
+            lambda: self.topic_exists_in_target(topic_name),
+            timeout_sec=30,
+            err_msg=f"Topic {topic_name} not replicated to target",
+        )
+
+        self.logger.info(
+            f"Topic '{topic_name}' successfully replicated to target cluster"
+        )


### PR DESCRIPTION
This pull request introduces a new suite of reusable chaos testing utilities for the Redpanda test framework, focusing on modularizing and expanding chaos scenarios for cluster, node, network, disk, time, and Kafka protocol failures.

Additionally, it adds configuration files for chaos scenarios and a basic shadow-link topic replication test. These changes make it easier to simulate and test fault tolerance and recovery in distributed Redpanda deployments. (Initial configs. We would have more customer focused configs and different levels of chaos intencity)

**Chaos utility modules**

* Added `network_chaos.py` with a `NetworkChaos` class providing static methods for creating/healing partial, complete, and asymmetric network partitions, as well as adding/removing network delays using `iptables` and `tc`.
* Added `node_chaos.py` with a `NodeChaos` class offering static methods to kill/restart nodes, perform rolling restarts, kill partition leaders, and pause nodes using signals, improving the ability to simulate node-level failures.
* Added module stubs for disk, time, and Kafka protocol chaos utilities, each with a descriptive docstring outlining their intended use for reusable test functions. [[1]](diffhunk://#diff-432eb5c97f73023a7a885d99499f3e83eadee079d9bdaf6410a456ff49d67496R1-R16) [[2]](diffhunk://#diff-451d0bcbee83278ae5c822d5e134e1e029e52914fddb9d997f8badc1780cf16aR1-R16) [[3]](diffhunk://#diff-27685f98f7f72db719a51f0b9bc3917d2c57b56194930ca7394f9ba01ad3aa49R1-R16)

**Configuration and test additions**

* Added example chaos scenario configuration files: `simple_chaos.json` for time/network partitioning and `small_test.json` for DR (disaster recovery) topic replication, enabling parameterized chaos tests. [[1]](diffhunk://#diff-961bb401f15d5244f10e69f1142b0fb0462311fec54c72ec5911ee1be5440ef7R1-R19) [[2]](diffhunk://#diff-114f856553b6a3cf13c8641ccf0970fa9852afe740480062b5da27ed9810632aR1-R24)
* Added `simple_topic_shadow_test.py` implementing a basic shadow-link replication test between two clusters, verifying topic creation and replication as a foundation for DR tests.


Initial simple tests that were done:

1. Run tests directly calling Python files.
2. Run simple tests by calling specific methods and individual tests

Example:
`ducktape --globals=tests/globals.json     --cluster=ducktape.cluster.json.JsonCluster     --cluster-file=tests/cluster.json     tests/rptest/tests/dr_shadow_link/simple_chaos_test.py::SimpleChaosTest.test_simple_kill_node`

`SESSION REPORT (ALL TESTS)
ducktape version: 0.12.0
session_id:       2025-10-03--005
run time:         1 minute 28.223 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0`

We should be able to merge this PR as long as it doesn't brake CI runs. There are two new folders:
1. `tests/chaos` for reusable chaos components that would be used by DR feature AND other features and projects
2. `tests/dr_shadow_link` for QE chaos tests with customer focused workloads and scenarios 


## Backports Required

- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
