### PR TITLE
cluster/tests: depend on application

### DIFF
--- a/src/v/cluster/tests/BUILD
+++ b/src/v/cluster/tests/BUILD
@@ -49,7 +49,7 @@ redpanda_test_cc_library(
         "//src/v/config",
         "//src/v/model",
         "//src/v/random:generators",
-        "//src/v/redpanda",
+        "//src/v/redpanda:application",
         "//src/v/redpanda/tests:fixture",
         "//src/v/resource_mgmt:cpu_scheduling",
         "//src/v/test_utils:async",


### PR DESCRIPTION
Instead of the redpanda binary.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
