### PR TITLE
compaction_idx_bench: make it deterministic

### DIFF
--- a/src/v/storage/tests/compaction_idx_bench.cc
+++ b/src/v/storage/tests/compaction_idx_bench.cc
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/node_hash_map.h"
 #include "compaction/key.h"
 #include "model/fundamental.h"
 #include "random/generators.h"
@@ -16,28 +14,41 @@
 #include "storage/compaction_reducers.h"
 #include "test_utils/random_bytes.h"
 
+#include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/testing/perf_tests.hh>
 
-#include <unordered_map>
+#include <cstddef>
 
 struct reducer_bench {
-    storage::internal::compaction_key_reducer reducer;
+    // around 50K is enough to hit the max mem limit, so
+    // are benching 50/50 with/without evictions
+    static constexpr size_t keys_per_iteration = 100'000;
+
+    using reducer_t = storage::internal::compaction_key_reducer;
+    using rand_t = random_generators::rng;
+
+    static ss::future<size_t>
+    reduce_n_keys(rand_t& rng, reducer_t& reducer, size_t n) {
+        for (size_t i = 0; i < n; ++i) {
+            model::offset o{0};
+            auto key = tests::random_bytes(20, rng);
+
+            storage::compacted_index::entry entry(
+              storage::compacted_index::entry_type::key,
+              compaction::compaction_key(std::move(key)),
+              o,
+              0);
+
+            co_await reducer(std::move(entry)).discard_result();
+        }
+        co_return n;
+    }
 };
 
-PERF_TEST_F(reducer_bench, compaction_key_reducer_test) {
-    model::offset o{0};
-    auto key = tests::random_bytes(20);
-
-    storage::compacted_index::entry entry(
-      storage::compacted_index::entry_type::key,
-      compaction::compaction_key(std::move(key)),
-      o,
-      0);
-
-    perf_tests::start_measuring_time();
-    return reducer(std::move(entry)).discard_result().finally([] {
-        perf_tests::stop_measuring_time();
-    });
+PERF_TEST_CN(reducer_bench, compaction_key_reducer_test) {
+    rand_t rng; // start the rng sequence from the default seed every time
+    reducer_t reducer; // fresh reducer every time
+    co_return co_await reduce_n_keys(rng, reducer, keys_per_iteration);
 }

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -137,6 +137,7 @@ redpanda_test_cc_library(
     deps = [
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
+        "//src/v/random:generators",
     ],
 )
 

--- a/src/v/test_utils/random_bytes.cc
+++ b/src/v/test_utils/random_bytes.cc
@@ -8,10 +8,11 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#include "test_utils/random_bytes.h"
+
 #include "bytes/bytes.h"
 #include "bytes/details/io_fragment.h"
 #include "bytes/iobuf.h"
-#include "random/generators.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -19,33 +20,31 @@
 
 namespace tests {
 
-bytes random_bytes(size_t n) {
+bytes random_bytes(size_t n, rng_t& rng) {
     bytes b(bytes::initialized_later{}, n);
-    std::generate_n(b.begin(), n, [] {
-        return random_generators::get_int<bytes::value_type>();
-    });
+    std::generate_n(
+      b.begin(), n, [&] { return rng.get_int<bytes::value_type>(); });
     return b;
 }
 
-iobuf random_iobuf(size_t n) {
-    const auto b = random_generators::gen_alphanum_string(n);
+iobuf random_iobuf(size_t n, rng_t& rng) {
+    const auto b = rng.gen_alphanum_string(n);
     iobuf io;
     io.append(b.data(), n);
     return io;
 }
 
-iobuf fragmented_iobuf(std::string_view str, int n_fragments) {
+iobuf fragmented_iobuf(std::string_view str, int n_fragments, rng_t& rng) {
     auto remaining_len = str.length();
     std::vector<size_t> fragment_lengths;
     fragment_lengths.reserve(n_fragments);
     for (int i = 0; i < n_fragments - 1; ++i) {
-        size_t fragment_len = random_generators::get_int(remaining_len);
+        size_t fragment_len = rng.get_int(remaining_len);
         fragment_lengths.push_back(fragment_len);
         remaining_len -= fragment_len;
     }
     fragment_lengths.push_back(remaining_len);
-    std::ranges::shuffle(
-      fragment_lengths, random_generators::global().engine());
+    std::ranges::shuffle(fragment_lengths, rng.engine());
 
     iobuf res;
     auto cur = str.begin();

--- a/src/v/test_utils/random_bytes.h
+++ b/src/v/test_utils/random_bytes.h
@@ -12,17 +12,25 @@
 
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
+#include "random/generators.h"
 
 #include <cstdlib>
 
 namespace tests {
 
-bytes random_bytes(size_t n = 128 * 1024);
+using rng_t = random_generators::rng;
+
+// generate n random bytes with the the given generator
+bytes random_bytes(
+  size_t n = 128 * 1024, rng_t& rng = random_generators::global());
 
 // use limited set of printable ascii chars only
-iobuf random_iobuf(size_t n = 128);
+iobuf random_iobuf(size_t n = 128, rng_t& rng = random_generators::global());
 
 // copy data from string into a randomly split iobuf
-iobuf fragmented_iobuf(std::string_view str, int n_fragments);
+iobuf fragmented_iobuf(
+  std::string_view str,
+  int n_fragments,
+  rng_t& rng = random_generators::global());
 
 } // namespace tests


### PR DESCRIPTION
Remove start/stop timing and fixutre stuff and just do 100K keys into the reducer, using the same rng sequence every time.

This makes the benchmark deterministic and repeatable.

As part of this change, allow the rng object to be specified on some random_bytes methods (1st change in series).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
