### PR TITLE
Track average bytes per offset in fetch metadata cache

### DIFF
--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -400,6 +400,7 @@ redpanda_cc_library(
         "//src/v/utils:absl_sstring_hash",
         "//src/v/utils:ema",
         "//src/v/utils:log_hist",
+        "//src/v/utils:moving_average",
         "//src/v/utils:mutex",
         "//src/v/utils:named_type",
         "//src/v/utils:queue_depth_control",

--- a/src/v/kafka/server/fetch_metadata_cache.h
+++ b/src/v/kafka/server/fetch_metadata_cache.h
@@ -10,7 +10,7 @@
  */
 #pragma once
 
-#include "absl/container/node_hash_map.h"
+#include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
 #include "model/ktp.h"
 
@@ -98,7 +98,7 @@ private:
 
     constexpr static std::chrono::seconds eviction_timeout{60};
     bool _stopped = false;
-    absl::node_hash_map<model::ktp_with_hash, entry> _cache;
+    chunked_hash_map<model::ktp_with_hash, entry> _cache;
     ss::timer<> _eviction_timer;
 };
 } // namespace kafka

--- a/src/v/kafka/server/fetch_metadata_cache.h
+++ b/src/v/kafka/server/fetch_metadata_cache.h
@@ -21,11 +21,6 @@
 namespace kafka {
 
 struct partition_metadata {
-    partition_metadata(model::offset so, model::offset hw, model::offset lso)
-      : start_offset(so)
-      , high_watermark(hw)
-      , last_stable_offset(lso) {}
-
     model::offset start_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;
@@ -33,14 +28,9 @@ struct partition_metadata {
 
 class fetch_metadata_cache {
 public:
-    explicit fetch_metadata_cache() {
-        _eviction_timer.set_callback([this] {
-            if (!_stopped) {
-                evict();
-                _eviction_timer.arm(eviction_timeout);
-            }
-        });
-        _eviction_timer.arm(eviction_timeout);
+    explicit fetch_metadata_cache()
+      : _eviction_timer([this] { evict(); }) {
+        _eviction_timer.arm_periodic(eviction_timeout);
     }
 
     fetch_metadata_cache(const fetch_metadata_cache&) = delete;
@@ -48,12 +38,7 @@ public:
 
     fetch_metadata_cache& operator=(const fetch_metadata_cache&) = delete;
     fetch_metadata_cache& operator=(fetch_metadata_cache&&) = delete;
-    ~fetch_metadata_cache() {
-        _stopped = true;
-        if (_eviction_timer.armed()) {
-            _eviction_timer.cancel();
-        }
-    }
+    ~fetch_metadata_cache() = default;
 
     void insert_or_assign(
       model::ktp_with_hash ktp,
@@ -86,18 +71,13 @@ private:
     };
 
     void evict() {
-        auto now = ss::lowres_clock::now();
-        for (auto it = _cache.begin(); it != _cache.end();) {
-            if (it->second.timestamp + eviction_timeout < now) {
-                _cache.erase(it++);
-                continue;
-            }
-            ++it;
-        }
+        const auto now = ss::lowres_clock::now();
+        std::erase_if(_cache, [&now](const auto& e) {
+            return (e.second.timestamp + eviction_timeout) < now;
+        });
     }
 
     constexpr static std::chrono::seconds eviction_timeout{60};
-    bool _stopped = false;
     chunked_hash_map<model::ktp_with_hash, entry> _cache;
     ss::timer<> _eviction_timer;
 };

--- a/src/v/kafka/server/fetch_metadata_cache.h
+++ b/src/v/kafka/server/fetch_metadata_cache.h
@@ -10,7 +10,10 @@
  */
 #pragma once
 
+#include "config/configuration.h"
 #include "container/chunked_hash_map.h"
+#include "metrics/metrics.h"
+#include "metrics/prometheus_sanitize.h"
 #include "model/fundamental.h"
 #include "model/ktp.h"
 #include "utils/moving_average.h"
@@ -38,7 +41,7 @@ public:
     }
 
     fetch_metadata_cache(const fetch_metadata_cache&) = delete;
-    fetch_metadata_cache(fetch_metadata_cache&&) = default;
+    fetch_metadata_cache(fetch_metadata_cache&&) = delete;
 
     fetch_metadata_cache& operator=(const fetch_metadata_cache&) = delete;
     fetch_metadata_cache& operator=(fetch_metadata_cache&&) = delete;
@@ -54,6 +57,18 @@ public:
         auto& e = _cache[ktp];
         e.reset_ts();
         if (offset_count > 0) {
+            if (e.bytes_per_offset.has_samples()) {
+                auto avg_bytes_per_offset = static_cast<double>(
+                  e.bytes_per_offset.get());
+                auto bytes_per_offset = static_cast<double>(total_size_bytes)
+                                        / static_cast<double>(offset_count);
+                auto abs_err = std::abs(
+                  bytes_per_offset - avg_bytes_per_offset);
+                const auto epsilon = 1e-6; // prevent division by zero
+                auto re = abs_err / (bytes_per_offset + epsilon);
+                _error.update(re, e.timestamp);
+            }
+
             e.bytes_per_offset.update(
               total_size_bytes, e.timestamp, offset_count);
         }
@@ -79,8 +94,28 @@ public:
      */
     size_t size() const { return _cache.size(); }
 
+    void setup_metrics() {
+        if (config::shard_local_cfg().disable_metrics()) {
+            return;
+        }
+
+        namespace sm = ss::metrics;
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:fetch_metadata_cache"),
+          {sm::make_gauge(
+            "error",
+            [this] { return _error.has_samples() ? _error.get() : 0.0; },
+            sm::description(
+              "A moving average of the relative error for bytes per offset."))},
+          {},
+          {sm::shard_label});
+    }
+
 private:
-    using sliding_window_t = timed_moving_average<size_t, ss::lowres_clock>;
+    using entry_sliding_window_t
+      = timed_moving_average<size_t, ss::lowres_clock>;
+    using error_sliding_window_t
+      = timed_moving_average<double, ss::lowres_clock>;
 
     constexpr static std::chrono::seconds eviction_timeout{60};
     constexpr static auto bytes_per_offset_window{1h};
@@ -89,7 +124,7 @@ private:
     struct entry {
         partition_metadata md;
         ss::lowres_clock::time_point timestamp;
-        sliding_window_t bytes_per_offset{
+        entry_sliding_window_t bytes_per_offset{
           bytes_per_offset_window, bytes_per_offset_resolution};
 
         void reset_ts() { timestamp = ss::lowres_clock::now(); }
@@ -104,5 +139,8 @@ private:
 
     chunked_hash_map<model::ktp_with_hash, entry> _cache;
     ss::timer<> _eviction_timer;
+    error_sliding_window_t _error{
+      bytes_per_offset_window, bytes_per_offset_resolution};
+    metrics::internal_metric_groups _metrics;
 };
 } // namespace kafka

--- a/src/v/kafka/server/fetch_metadata_cache.h
+++ b/src/v/kafka/server/fetch_metadata_cache.h
@@ -13,6 +13,7 @@
 #include "container/chunked_hash_map.h"
 #include "model/fundamental.h"
 #include "model/ktp.h"
+#include "utils/moving_average.h"
 
 #include <seastar/core/lowres_clock.hh>
 
@@ -24,7 +25,10 @@ struct partition_metadata {
     model::offset start_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;
+    size_t avg_bytes_per_offset;
 };
+
+using namespace std::chrono_literals;
 
 class fetch_metadata_cache {
 public:
@@ -41,11 +45,26 @@ public:
     ~fetch_metadata_cache() = default;
 
     void insert_or_assign(
-      model::ktp_with_hash ktp,
+      const model::ktp_with_hash& ktp,
       model::offset start_offset,
       model::offset hw,
-      model::offset lso) {
-        _cache.insert_or_assign(std::move(ktp), entry(start_offset, hw, lso));
+      model::offset lso,
+      size_t offset_count,
+      size_t total_size_bytes) {
+        auto& e = _cache[ktp];
+        e.reset_ts();
+        if (offset_count > 0) {
+            e.bytes_per_offset.update(
+              total_size_bytes, e.timestamp, offset_count);
+        }
+        e.md = {
+          .start_offset = start_offset,
+          .high_watermark = hw,
+          .last_stable_offset = lso,
+          .avg_bytes_per_offset = e.bytes_per_offset.has_samples()
+                                    ? e.bytes_per_offset.get()
+                                    : 0,
+        };
     }
 
     std::optional<partition_metadata> get(const model::ktp_with_hash& ktp) {
@@ -61,13 +80,19 @@ public:
     size_t size() const { return _cache.size(); }
 
 private:
-    struct entry {
-        entry(model::offset start_offset, model::offset hw, model::offset lso)
-          : md(start_offset, hw, lso)
-          , timestamp(ss::lowres_clock::now()) {}
+    using sliding_window_t = timed_moving_average<size_t, ss::lowres_clock>;
 
+    constexpr static std::chrono::seconds eviction_timeout{60};
+    constexpr static auto bytes_per_offset_window{1h};
+    constexpr static auto bytes_per_offset_resolution{20min};
+
+    struct entry {
         partition_metadata md;
         ss::lowres_clock::time_point timestamp;
+        sliding_window_t bytes_per_offset{
+          bytes_per_offset_window, bytes_per_offset_resolution};
+
+        void reset_ts() { timestamp = ss::lowres_clock::now(); }
     };
 
     void evict() {
@@ -77,7 +102,6 @@ private:
         });
     }
 
-    constexpr static std::chrono::seconds eviction_timeout{60};
     chunked_hash_map<model::ktp_with_hash, entry> _cache;
     ss::timer<> _eviction_timer;
 };

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -108,7 +108,6 @@ static ss::future<read_result> read_from_partition(
   kafka::partition_proxy part,
   model::offset lso,
   fetch_config config,
-  bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
     auto hw = part.high_watermark();
     auto start_o = part.start_offset();
@@ -190,16 +189,6 @@ static ss::future<read_result> read_from_partition(
         std::rethrow_exception(e);
     }
 
-    if (foreign_read) {
-        co_return read_result(
-          ss::make_foreign<read_result::data_t>(std::move(data)),
-          start_o,
-          hw,
-          lso,
-          delta_from_tip_ms,
-          std::move(aborted_transactions));
-    }
-
     co_return read_result(
       std::move(data),
       start_o,
@@ -218,7 +207,6 @@ static ss::future<read_result> do_read_from_ntp(
   const cluster::metadata_cache& md_cache,
   const replica_selector& replica_selector,
   ntp_fetch_config ntp_config,
-  bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline,
   const bool obligatory_batch_read,
   fetch_memory_units_manager& units_mgr) {
@@ -317,11 +305,7 @@ static ss::future<read_result> do_read_from_ntp(
         }
     }
     read_result result = co_await read_from_partition(
-      std::move(*kafka_partition),
-      maybe_lso.value(),
-      ntp_config.cfg,
-      foreign_read,
-      deadline);
+      std::move(*kafka_partition), maybe_lso.value(), ntp_config.cfg, deadline);
 
     // Note that units can be both increased and decreassed here. Increases
     // happen because there is no strict limit on read size when reading the
@@ -339,7 +323,6 @@ ss::future<read_result> read_from_ntp(
   const replica_selector& replica_selector,
   const model::ktp& ktp,
   fetch_config config,
-  bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline,
   const bool obligatory_batch_read,
   fetch_memory_units_manager& units_mgr) {
@@ -348,7 +331,6 @@ ss::future<read_result> read_from_ntp(
       md_cache,
       replica_selector,
       {{ktp.get_topic(), ktp.get_partition()}, std::move(config)},
-      foreign_read,
       deadline,
       obligatory_batch_read,
       units_mgr);
@@ -468,7 +450,6 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
   const replica_selector& replica_selector,
   chunked_vector<ntp_fetch_config> ntp_fetch_configs,
   read_distribution_probe& read_probe,
-  bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline,
   const size_t bytes_left,
   fetch_memory_units_manager& units_mgr) {
@@ -504,7 +485,6 @@ static ss::future<chunked_vector<read_result>> fetch_ntps(
           md_cache,
           replica_selector,
           ntp_cfg,
-          foreign_read,
           deadline,
           obligatory_batch_read,
           units_mgr);
@@ -548,8 +528,6 @@ public:
     // Contains either references to objects local to the fetch worker shard or
     // copies of data from the coordinator shard.
     struct shard_local_fetch_context {
-        // True if the results of this fetch will be read on a foreign shard.
-        bool foreign_read;
         size_t bytes_left;
         // Specifies the minimum number of bytes this sub-fetch should read
         // before returning.
@@ -670,7 +648,6 @@ private:
           _ctx.srv.get_replica_selector(),
           std::move(requests),
           _ctx.srv.read_probe(),
-          _ctx.foreign_read,
           _ctx.deadline,
           _ctx.bytes_left,
           _ctx.srv.fetch_units_manager());
@@ -1035,15 +1012,12 @@ private:
             co_return;
         }
 
-        const bool foreign_read = fetch.shard != ss::this_shard_id();
-
         fetch_worker::worker_result results
           = co_await octx.rctx.partition_manager().invoke_on(
             fetch.shard,
             [this,
              shard = fetch.shard,
              min_fetch_bytes,
-             foreign_read,
              configs = fetch.requests.copy(),
              &octx](cluster::partition_manager& mgr) mutable
               -> ss::future<fetch_worker::worker_result> {
@@ -1057,7 +1031,6 @@ private:
                 return ss::do_with(
                   fetch_worker(
                     fetch_worker::shard_local_fetch_context{
-                      .foreign_read = foreign_read,
                       .bytes_left = octx.bytes_left,
                       .min_bytes = min_fetch_bytes,
                       .deadline = octx.deadline,

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1320,10 +1320,23 @@ class simple_fetch_planner final : public fetch_planner::impl {
                   auto max_bytes = std::min(
                     bytes_left_in_plan, size_t(fp.max_bytes));
                   /**
-                   * If offset is greater, assume that fetch will read max_bytes
+                   * If the fetch offest is less than the hwm for the partition
+                   * then we try to estimate the number of bytes that can be
+                   * read via a moving average in the md cache. If there isn't
+                   * enough information in the md cache to estimate this then we
+                   * assume the `max_bytes` can be read.
                    */
                   if (fetch_md && fetch_md->high_watermark > fp.fetch_offset) {
-                      bytes_left_in_plan -= max_bytes;
+                      const auto offset_count
+                        = (fetch_md->high_watermark - fp.fetch_offset)() + 1;
+                      const auto est_read_size
+                        = offset_count * fetch_md->avg_bytes_per_offset;
+                      if (est_read_size > 0) {
+                          bytes_left_in_plan -= std::min(
+                            est_read_size, max_bytes);
+                      } else {
+                          bytes_left_in_plan -= max_bytes;
+                      }
                   }
 
                   plan.fetches_per_shard[*shard].push_back(

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -135,10 +135,14 @@ static ss::future<read_result> read_from_partition(
     std::unique_ptr<iobuf> data;
     std::vector<cluster::tx::tx_range> aborted_transactions;
     std::optional<std::chrono::milliseconds> delta_from_tip_ms;
+    model::offset data_base_offset, data_last_offset;
+
     try {
         auto result = co_await rdr.reader.consume(
           kafka_batch_serializer(), deadline ? *deadline : model::no_timeout);
         data = std::make_unique<iobuf>(std::move(result.data));
+        data_base_offset = result.base_offset;
+        data_last_offset = result.last_offset;
         part.probe().add_records_fetched(result.record_count);
         part.probe().add_bytes_fetched(data->size_bytes());
         if (!part.is_leader() && config.read_from_follower) {
@@ -192,6 +196,8 @@ static ss::future<read_result> read_from_partition(
     co_return read_result(
       std::move(data),
       start_o,
+      data_base_offset,
+      data_last_offset,
       hw,
       lso,
       delta_from_tip_ms,

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -395,7 +395,12 @@ static void fill_fetch_responses(
          * Cache fetch metadata
          */
         octx.rctx.get_fetch_metadata_cache().insert_or_assign(
-          ktp, res.start_offset, res.high_watermark, res.last_stable_offset);
+          ktp,
+          res.start_offset,
+          res.high_watermark,
+          res.last_stable_offset,
+          res.offset_count(),
+          res.data_size_bytes());
         /**
          * Over response budget, we will just waste this read, it will cause
          * data to be stored in the cache so next read is fast

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -269,9 +269,7 @@ struct ntp_fetch_config {
  * Simple type aggregating either data or an error
  */
 struct read_result {
-    using foreign_data_t = ss::foreign_ptr<std::unique_ptr<iobuf>>;
     using data_t = std::unique_ptr<iobuf>;
-    using variant_t = std::variant<data_t, foreign_data_t>;
 
     explicit read_result(error_code e)
       : start_offset(-1)
@@ -298,7 +296,7 @@ struct read_result {
       , error(e) {}
 
     read_result(
-      variant_t data,
+      data_t data,
       model::offset start_offset,
       model::offset hw,
       model::offset lso,
@@ -323,38 +321,17 @@ struct read_result {
       , preferred_replica(preferred_replica)
       , error(error_code::none) {}
 
-    bool has_data() const {
-        return ss::visit(
-          data,
-          [](const data_t& d) { return d != nullptr; },
-          [](const foreign_data_t& d) { return !d->empty(); });
-    }
+    bool has_data() const { return data != nullptr; }
 
-    const iobuf& get_data() const {
-        if (std::holds_alternative<data_t>(data)) {
-            return *std::get<data_t>(data);
-        } else {
-            return *std::get<foreign_data_t>(data);
-        }
-    }
+    const iobuf& get_data() const { return *data; }
 
     size_t data_size_bytes() const {
-        return ss::visit(
-          data,
-          [](const data_t& d) { return d == nullptr ? 0 : d->size_bytes(); },
-          [](const foreign_data_t& d) {
-              return d->empty() ? 0 : d->size_bytes();
-          });
+        return data == nullptr ? 0 : data->size_bytes();
     }
 
-    iobuf release_data() && {
-        return ss::visit(
-          data,
-          [](data_t& d) { return std::move(*d); },
-          [](foreign_data_t& d) { return std::move(*d); });
-    }
+    iobuf release_data() && { return std::move(*data); }
 
-    variant_t data;
+    data_t data;
     model::offset start_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;
@@ -451,7 +428,6 @@ ss::future<read_result> read_from_ntp(
   const replica_selector&,
   const model::ktp&,
   fetch_config,
-  bool,
   std::optional<model::timeout_clock::time_point>,
   bool obligatory_batch_read,
   fetch_memory_units_manager& units_mgr);

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -298,12 +298,16 @@ struct read_result {
     read_result(
       data_t data,
       model::offset start_offset,
+      model::offset data_base_offset,
+      model::offset data_last_offset,
       model::offset hw,
       model::offset lso,
       std::optional<std::chrono::milliseconds> delta,
       std::vector<cluster::tx::tx_range> aborted_transactions)
       : data(std::move(data))
       , start_offset(start_offset)
+      , data_base_offset(data_base_offset)
+      , data_last_offset(data_last_offset)
       , high_watermark(hw)
       , last_stable_offset(lso)
       , delta_from_tip_ms(delta)
@@ -331,8 +335,17 @@ struct read_result {
 
     iobuf release_data() && { return std::move(*data); }
 
+    // Returns the number of kafka offsets the result spans.
+    size_t offset_count() const {
+        return data_size_bytes() > 0
+                 ? (data_last_offset - data_base_offset)() + 1
+                 : 0;
+    }
+
     data_t data;
     model::offset start_offset;
+    model::offset data_base_offset;
+    model::offset data_last_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;
     std::optional<std::chrono::milliseconds> delta_from_tip_ms;

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -236,6 +236,7 @@ server::server(
 
     _sasl_probe->setup_metrics(cfg->local().name);
     _read_dist_probe->setup_metrics();
+    _fetch_metadata_cache.setup_metrics();
 }
 ss::future<> server::stop() {
     co_await net::server::stop();

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -752,6 +752,24 @@ redpanda_cc_gtest(
     ],
 )
 
+redpanda_cc_gtest(
+    name = "fetch_metadata_cache_test",
+    timeout = "short",
+    srcs = [
+        "fetch_metadata_cache_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/kafka/server",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/redpanda/tests:fixture",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
 redpanda_cc_btest(
     name = "fetch_test",
     timeout = "short",

--- a/src/v/kafka/server/tests/fetch_metadata_cache_test.cc
+++ b/src/v/kafka/server/tests/fetch_metadata_cache_test.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/units.h"
+#include "kafka/server/fetch_metadata_cache.h"
+#include "model/fundamental.h"
+#include "model/ktp.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+TEST_CORO(fetch_metadata_cache_tests, test_avg_bytes_per_offset) {
+    kafka::fetch_metadata_cache mdc{};
+    EXPECT_EQ(mdc.size(), 0);
+
+    const auto ktp = model::ktp_with_hash{
+      model::topic{"test_topic"}, model::partition_id{1}};
+
+    mdc.insert_or_assign(
+      ktp, model::offset(0), model::offset(10), model::offset(10), 0, 0);
+    auto res = mdc.get(ktp).value();
+    EXPECT_EQ(res.avg_bytes_per_offset, 0);
+    EXPECT_EQ(mdc.size(), 1);
+
+    mdc.insert_or_assign(
+      ktp,
+      model::offset(0),
+      model::offset(15),
+      model::offset(15),
+      5,
+      5 * 1_MiB);
+    res = mdc.get(ktp).value();
+    EXPECT_EQ(res.avg_bytes_per_offset, 1_MiB);
+
+    mdc.insert_or_assign(
+      ktp, model::offset(0), model::offset(15), model::offset(15), 1, 2_MiB);
+    res = mdc.get(ktp).value();
+    EXPECT_GE(res.avg_bytes_per_offset, 1_MiB);
+    co_return;
+}

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -188,7 +188,9 @@ struct fetch_plan : redpanda_thread_fixture {
                   {topic, model::partition_id(i)},
                   model::offset(0),
                   model::offset(100),
-                  model::offset(100));
+                  model::offset(100),
+                  0,
+                  0);
             }
         }
 

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -185,7 +185,6 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
                       octx.rctx.server().local().get_replica_selector(),
                       ktp,
                       config,
-                      true,
                       model::no_timeout,
                       false,
                       octx.rctx.server().local().fetch_units_manager());

--- a/src/v/utils/moving_average.h
+++ b/src/v/utils/moving_average.h
@@ -127,7 +127,7 @@ private:
         auto norm = nanos.count() / _resolution.count();
         return normalized_timestamp_t(norm);
     }
-    const size_t _num_buckets;
+    size_t _num_buckets;
     std::chrono::nanoseconds _resolution;
     std::vector<bucket> _buckets;
     normalized_timestamp_t _end;

--- a/src/v/utils/moving_average.h
+++ b/src/v/utils/moving_average.h
@@ -65,6 +65,7 @@ public:
     using clock_t = Clock;
     using duration_t = typename Clock::duration;
     using timestamp_t = typename Clock::time_point;
+
     timed_moving_average(
       T initial_value,
       std::chrono::nanoseconds depth,
@@ -76,6 +77,15 @@ public:
         vassert(_num_buckets > 0, "Resolution is too small");
         _buckets[index(_end)] = {
           .value = initial_value, .num_samples = 1, .ix = _end};
+    }
+
+    timed_moving_average(
+      std::chrono::nanoseconds depth, std::chrono::nanoseconds resolution)
+      : _num_buckets(depth.count() / resolution.count())
+      , _resolution(resolution)
+      , _buckets(_num_buckets, bucket{})
+      , _end(_num_buckets) {
+        vassert(_num_buckets > 0, "Resolution is too small");
     }
 
     /**
@@ -110,6 +120,10 @@ public:
         }
     }
 
+    /**
+     * @brief Returns the current average. Note that at least one sample needs
+     * to be added to the average before calling this method.
+     */
     T get() const noexcept {
         T running_sum{};
         size_t num_samples = 0;
@@ -124,6 +138,21 @@ public:
         }
         vassert(num_samples != 0, "timed_moving_average invariant broken");
         return running_sum / num_samples;
+    }
+
+    /**
+     * @brief Returns whether any samples have been added to this average.
+     */
+    bool has_samples() const noexcept {
+        // The only time the average won't have any samples is between when it
+        // was created without an initial value and when the first update
+        // occurs. Hence that is the only case that is checked here.
+        const auto& b = _buckets[index(_end)];
+        if (b.ix != _end) {
+            return false;
+        }
+
+        return b.num_samples > 0;
     }
 
 private:

--- a/src/v/utils/moving_average.h
+++ b/src/v/utils/moving_average.h
@@ -78,9 +78,18 @@ public:
           .value = initial_value, .num_samples = 1, .ix = _end};
     }
 
-    // Update moving average
-    // \note time should never go back
-    void update(T v, timestamp_t ts) noexcept {
+    /**
+     * @brief Updates moving average. Note that timestamps shouldn't ever move
+     * backwards
+     *
+     * @param v The new sample to be added to the average
+     * @param ts The timestamp for when the sample occurred.
+     * @param num_samples If `v` contains more than one sample indicate how many
+     * here. Note that this must be greater than 0.
+     */
+    void update(T v, timestamp_t ts, size_t num_samples = 1) noexcept {
+        vassert(
+          num_samples > 0, "at least one sample needs to be in the update");
         // NOTE: we have to add num_buckets to the value to avoid
         // overflow.
         auto end = normalize(ts) + normalized_timestamp_t(_num_buckets);
@@ -93,11 +102,11 @@ public:
         auto& bucket = _buckets[index(end)];
         if (bucket.ix == _end) {
             bucket.value += v;
-            bucket.num_samples += 1;
+            bucket.num_samples += num_samples;
         } else {
             bucket.ix = _end;
             bucket.value = v;
-            bucket.num_samples = 1;
+            bucket.num_samples = num_samples;
         }
     }
 

--- a/src/v/utils/tests/moving_average_test.cc
+++ b/src/v/utils/tests/moving_average_test.cc
@@ -33,6 +33,23 @@ BOOST_AUTO_TEST_CASE(test_moving_average) {
 
     BOOST_REQUIRE_EQUAL(ma.get(), 5);
 }
+BOOST_AUTO_TEST_CASE(test_timed_moving_average_no_int_val) {
+    const auto eps = 0.001;
+    constexpr auto depth = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      1s);
+    constexpr auto resolution
+      = std::chrono::duration_cast<std::chrono::nanoseconds>(100ms);
+    timed_moving_average<double, ss::lowres_clock> ma(depth, resolution);
+    BOOST_REQUIRE(!ma.has_samples());
+    auto bt = ss::lowres_clock::now();
+    ma.update(0, bt);
+    BOOST_REQUIRE_CLOSE(ma.get(), 0, eps);
+    ma.update(1, bt + 100ms);
+    BOOST_REQUIRE_CLOSE(ma.get(), 0.5, eps);
+    // evict everything
+    ma.update(0, bt + 5s);
+    BOOST_REQUIRE_CLOSE(ma.get(), 0, eps);
+}
 
 BOOST_AUTO_TEST_CASE(test_timed_moving_average) {
     const auto eps = 0.001;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
When creating a fetch plan the previous assumption was that if the fetch offset was less than the HWM then we'd be able to read `fp.max_bytes` from that ntp. More often than not though `fp.max_bytes` wasn't close to the bytes actually read from the partition. A few issues arose from this. When the estimate was too large it'd result in partitions being skipped in wide fetches. And when the estimate was too small it'd result in read amplification where we'd read more data than could fit in the response.

To improve things this PR tracks averages bytes read per offset in the fetch metadata cache. This value is then used in the planner to make a better estimate of the bytes that can be read between two offsets for a given ntp.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none