### PR TITLE
[CORE-13370] archival: Fix retention fallthrough behavior

### DIFF
--- a/src/v/cloud_storage/recovery_errors.cc
+++ b/src/v/cloud_storage/recovery_errors.cc
@@ -14,11 +14,11 @@
 
 namespace cloud_storage {
 
-const char* recovery_error_category::name() const noexcept {
+const char* recovery_error_category_type::name() const noexcept {
     return "recovery_error_code";
 }
 
-std::string recovery_error_category::message(int c) const {
+std::string recovery_error_category_type::message(int c) const {
     switch (static_cast<recovery_error_code>(c)) {
     case recovery_error_code::success:
         return "recovery successful";
@@ -37,13 +37,13 @@ std::string recovery_error_category::message(int c) const {
     }
 }
 
-const std::error_category& error_category() noexcept {
-    static const recovery_error_category e;
+const std::error_category& recovery_error_category() noexcept {
+    static const recovery_error_category_type e;
     return e;
 }
 
 std::error_code make_error_code(recovery_error_code e) noexcept {
-    return {static_cast<int>(e), error_category()};
+    return {static_cast<int>(e), recovery_error_category()};
 }
 
 recovery_error_ctx

--- a/src/v/cloud_storage/recovery_errors.h
+++ b/src/v/cloud_storage/recovery_errors.h
@@ -28,13 +28,13 @@ enum class recovery_error_code {
     unknown_error,
 };
 
-class recovery_error_category : public std::error_category {
+class recovery_error_category_type : public std::error_category {
 public:
     const char* name() const noexcept final;
     std::string message(int c) const final;
 };
 
-const std::error_category& error_category() noexcept;
+const std::error_category& recovery_error_category() noexcept;
 
 std::error_code make_error_code(recovery_error_code e) noexcept;
 

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3331,9 +3331,11 @@ ss::future<> ntp_archiver::apply_retention() {
         if (error != cluster::errc::success) {
             vlog(
               _rtclog.warn,
-              "Failed to update archival metadata STM start offest according "
+              "Failed to update archival metadata STM start offset according "
               "to retention policy: {}",
               error);
+            throw std::runtime_error(fmt_with_ctx(
+              fmt::format, "Failed to update start offset: {}", error));
         }
     } else {
         vlog(

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -3018,6 +3018,23 @@ ss::future<> ntp_archiver::apply_spillover() {
     const auto manifest_upload_timeout = _conf->manifest_upload_timeout();
     const auto manifest_upload_backoff = _conf->cloud_storage_initial_backoff();
 
+    // Check the spillover invariant.
+    // The start_offset of the manifest must be equal to the begin_offset of
+    // the first segment in the manifest.
+    if (auto so = manifest().get_start_offset();
+        so.has_value() && !manifest().empty()) {
+        auto fo = manifest().begin()->base_offset;
+        if (fo != so.value()) {
+            vlog(
+              _rtclog.error,
+              "Spillover invariant violated: manifest start_offset {}, first "
+              "segment base_offset {}",
+              so.value(),
+              fo);
+            co_return;
+        }
+    }
+
     if (manifest_size_limit.has_value()) {
         vlog(
           _rtclog.debug,

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -54,6 +54,10 @@ SCRUBBER_LOG_ALLOW_LIST = [
     # manifest will refuse to apply the command and log the error below.
     r"cloud_storage - .* New replacement segment does not line up with previous segment",
     r"cluster - .* Can't add segment:",
+    # The same could happen with spillover. Spillover assumes that the start offset is
+    # aligned with the first segment in the manifest but this may not be the case after
+    # after the manifest reset.
+    r"archival - .* Spillover invariant violated",
 ]
 
 


### PR DESCRIPTION
In the `ntp_archiver::apply_retention` method we're not throwing exception if we failed to replicate the command that moves start offset forward. This leads to a situation when even if we failed to replicate the command the `apply_gc` and `apply_spillover` methods are invoked. This leads to a situation when spillover invariant is broken. The `apply_spillover` method expects that the start offset is aligned with the first segment in the STM manifest. If this is not the case the spillover manifest that it produces can't be applied.

This is what leads to this problem:
- `apply_retention` fails to replicate the command due to timeout. The timeout could be caused by the high cpu load. The command is still replciated and applied asynchronously.
- `apply_gc` invoked before the command that moves start offset is applied. The method does nothing since start offset is still aligned with the first segment in the manifest.
- `apply_spillover` is invoked after the command is applied. Now the start offset is moved forward and is no longer aligned with the first segment in the manifest. The method creates a spillover manifest, uploads it, puts it to the cloud storage cache, and replicates the command that adds spill metadata to the manifest. The command fails because it can't pass the check in the manifest (the manifest expects that the base offset of the spill is equal to start offset.

Before https://github.com/redpanda-data/redpanda/pull/27714 was merged this could cause cloud storage cache to fill up. Now this can only create a single failed spillover attempt. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none