### PR TITLE
rptest: disable kerberos and tls_crc32 test

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -17,3 +17,4 @@ quick:
   - tests/rpk_tuner_test.py
   - tests/rpk_cloud_test.py
   - tests/workload_upgrade_runner_test.py # Excluded until CORE-13748 is fixed. 
+  - tests/redpanda_oauth_test.py::RedpandaOIDCTlsTest # exclude until CORE-13761 is fixed

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -18,3 +18,5 @@ quick:
   - tests/rpk_cloud_test.py
   - tests/workload_upgrade_runner_test.py # Excluded until CORE-13748 is fixed. 
   - tests/redpanda_oauth_test.py::RedpandaOIDCTlsTest # exclude until CORE-13761 is fixed
+  - tests/redpanda_kerberos_test.py::RedpandaKerberosConfigTest # exclude until CORE-13787 is fixed
+  - tests/tls_metrics_test.py::TLSMetricsTest.test_crc32c # exclude until CORE-13788 is fixed

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -523,10 +523,9 @@ class RedpandaOIDCTest(RedpandaOIDCTestMethods):
         super(RedpandaOIDCTest, self).__init__(test_context, **kwargs)
 
 
-# TODO(CORE-13761): Re-enable these tests
-# class RedpandaOIDCTlsTest(RedpandaOIDCTestMethods):
-#     def __init__(self, test_context, **kwargs):
-#         super(RedpandaOIDCTlsTest, self).__init__(test_context, use_ssl=True, **kwargs)
+class RedpandaOIDCTlsTest(RedpandaOIDCTestMethods):
+    def __init__(self, test_context, **kwargs):
+        super(RedpandaOIDCTlsTest, self).__init__(test_context, use_ssl=True, **kwargs)
 
 
 class JavaClientOIDCTest(RedpandaOIDCTestBase):


### PR DESCRIPTION
These tests are failing on newer CI infra and are blocking upgrades of underlying pools.

https://redpandadata.atlassian.net/browse/CORE-13761

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
