### PR TITLE
[CORE-13829] ct/reconciler: Add mucho metrics

### DIFF
--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -30,6 +30,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/config",
         "//src/v/metrics",
+        "//src/v/utils:log_hist",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -374,6 +374,9 @@ reconciler::build_and_put_object(
     }
 
     _probe.increment_objects_uploaded();
+    _probe.add_bytes_reconciled(obj_meta.object_info.size_bytes);
+    _probe.record_object_size_bytes(obj_meta.object_info.size_bytes);
+    _probe.record_sources_per_object(obj_meta.commits.size());
 
     co_return obj_meta;
 }

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -209,6 +209,7 @@ ss::future<> reconciler::reconcile() {
           lg.warn,
           "Could not create object metadata builder: {}",
           metadata_builder_res.error());
+        _probe.increment_rounds_failed();
         co_return;
     }
     auto& metadata_builder = metadata_builder_res.value();
@@ -219,6 +220,7 @@ ss::future<> reconciler::reconcile() {
           src->topic_id_partition());
         if (!oid.has_value()) {
             vlog(lg.warn, "Could not get object: {}", oid.error());
+            _probe.increment_rounds_failed();
             co_return;
         }
         oid_to_sources[oid.value()].push_back(src);
@@ -285,6 +287,8 @@ ss::future<> reconciler::reconcile() {
 
     // Check if we have any successful objects to commit.
     if (successful_objects.empty()) {
+        // NB: This doesn't count as failing the round because it may be that
+        // all sources are fully reconciled.
         vlog(lg.debug, "No successful objects to commit to metastore");
         co_return;
     }
@@ -296,6 +300,7 @@ ss::future<> reconciler::reconcile() {
         log_error(commit_result.error().with_context(
           "Abandoning reconciliation run because the L1 metastore operation "
           "failed"));
+        _probe.increment_rounds_failed();
         co_return;
     }
 }

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -587,6 +587,7 @@ reconciler::add_objects_with_retry(
               add_result.error()));
         }
 
+        _probe.increment_metastore_retries();
         co_await ss::sleep_abortable(permit.delay, rtc.root_abort_source());
     }
 
@@ -632,6 +633,7 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
             kafka::offset lro = commit.metadata.last_offset;
             auto it = corrected_next_offsets.find(tidp);
             if (it != corrected_next_offsets.end()) {
+                _probe.increment_offset_corrections();
                 // We want the previous offset, because that is what was last
                 // reconciled. During next reconciliation we should get the
                 // offset *after* the LRO to start reading from.

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -455,6 +455,7 @@ reconciler::build_object(
 
 ss::future<std::expected<void, reconcile_error>>
 reconciler::put_object(const l1::object_id& oid, builder_context& ctx) {
+    auto metrics_duration = _probe.measure_object_upload_duration();
     auto put_result = co_await _l1_io->put_object(oid, ctx.staging.get(), &_as);
     if (!put_result.has_value()) {
         co_return std::unexpected(reconcile_error(
@@ -567,8 +568,11 @@ reconciler::add_objects_with_retry(
     retry_chain_node rtc(_as, ss::lowres_clock::now() + timeout, backoff);
     retry_chain_logger ctxlog(lg, rtc, "add_objects");
     for (auto permit = rtc.retry(); permit.is_allowed; permit = rtc.retry()) {
+        auto metrics_duration_add_objects
+          = _probe.measure_metastore_add_objects_duration();
         auto add_result = co_await _metastore->add_objects(
           *meta_builder, terms);
+        metrics_duration_add_objects.reset();
 
         if (add_result.has_value()) {
             co_return std::move(add_result).value();

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -98,6 +98,7 @@ public:
     ss::future<> stop();
 
     void setup_metrics_for_tests() { _probe.setup_metrics(); }
+    const reconciler_probe& get_probe_for_tests() const { return _probe; }
 
     void attach_partition(
       const model::ntp&,

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -34,6 +34,10 @@ void reconciler_probe::setup_metrics() {
           [this] { return _rounds; },
           sm::description("Number of reconciliation rounds")),
         sm::make_counter(
+          "rounds_failed",
+          [this] { return _rounds_failed; },
+          sm::description("Number of reconciliation rounds that failed")),
+        sm::make_counter(
           "objects_uploaded",
           [this] { return _objects_uploaded; },
           sm::description("Total objects uploaded, including orphans")),

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -77,6 +77,15 @@ void reconciler_probe::setup_metrics() {
                 .internal_histogram_logform();
           },
           sm::description("Duration of add_objects to metastore")),
+        sm::make_histogram(
+          "object_size_bytes",
+          [this] { return _object_size_bytes.internal_histogram_logform(); },
+          sm::description("Distribution of built L1 object sizes in bytes")),
+        sm::make_histogram(
+          "sources_per_object",
+          [this] { return _sources_per_object.internal_histogram_logform(); },
+          sm::description(
+            "Distribution of number of sources packed into each L1 object")),
       });
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -62,6 +62,15 @@ void reconciler_probe::setup_metrics() {
           [this] { return _empty_objects_skipped; },
           sm::description(
             "Total objects skipped because no data was available")),
+        sm::make_counter(
+          "metastore_retries",
+          [this] { return _metastore_retries; },
+          sm::description("Total metastore operation retries")),
+        sm::make_counter(
+          "offset_corrections",
+          [this] { return _offset_corrections; },
+          sm::description(
+            "Total times the metastore returned a corrected offset")),
 
         // Histograms.
         sm::make_histogram(

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -28,6 +28,7 @@ void reconciler_probe::setup_metrics() {
     _metrics.add_group(
       prometheus_sanitize::metrics_name("cloud_topics:reconciler"),
       {
+        // Counters.
         sm::make_counter(
           "rounds",
           [this] { return _rounds; },
@@ -61,6 +62,21 @@ void reconciler_probe::setup_metrics() {
           [this] { return _empty_objects_skipped; },
           sm::description(
             "Total objects skipped because no data was available")),
+
+        // Histograms.
+        sm::make_histogram(
+          "object_upload_duration_seconds",
+          [this] {
+              return _object_upload_duration.internal_histogram_logform();
+          },
+          sm::description("Duration uploading L1 objects")),
+        sm::make_histogram(
+          "metastore_add_objects_duration_seconds",
+          [this] {
+              return _metastore_add_objects_duration
+                .internal_histogram_logform();
+          },
+          sm::description("Duration of add_objects to metastore")),
       });
 }
 

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -45,6 +45,13 @@ public:
     void increment_object_upload_failed() { ++_object_upload_failed; }
     void increment_empty_objects_skipped() { ++_empty_objects_skipped; }
 
+    void record_object_size_bytes(uint64_t size) {
+        _object_size_bytes.record(size);
+    }
+    void record_sources_per_object(uint64_t count) {
+        _sources_per_object.record(count);
+    }
+
     std::unique_ptr<hist_t::measurement> measure_object_upload_duration() {
         return _object_upload_duration.auto_measure();
     }
@@ -59,6 +66,12 @@ public:
     }
     auto get_metastore_add_objects_duration_for_tests() const {
         return _metastore_add_objects_duration.internal_histogram_logform();
+    }
+    auto get_object_size_bytes_for_tests() const {
+        return _object_size_bytes.internal_histogram_logform();
+    }
+    auto get_sources_per_object_for_tests() const {
+        return _sources_per_object.internal_histogram_logform();
     }
 
 private:
@@ -76,6 +89,8 @@ private:
     // Histograms.
     hist_t _object_upload_duration;
     hist_t _metastore_add_objects_duration;
+    hist_t _object_size_bytes;
+    hist_t _sources_per_object;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -35,6 +35,7 @@ public:
     void setup_metrics();
 
     void increment_rounds() { ++_rounds; }
+    void increment_rounds_failed() { ++_rounds_failed; }
     void increment_objects_uploaded() { ++_objects_uploaded; }
     void add_bytes_reconciled(uint64_t bytes) { _bytes_reconciled += bytes; }
     void add_batches_reconciled(uint64_t batches) {
@@ -80,6 +81,7 @@ private:
     metrics::internal_metric_groups _metrics;
 
     uint64_t _rounds{0};
+    uint64_t _rounds_failed{0};
     uint64_t _objects_uploaded{0};
     uint64_t _bytes_reconciled{0};
     uint64_t _batches_reconciled{0};

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -44,6 +44,8 @@ public:
     void increment_object_build_failed() { ++_object_build_failed; }
     void increment_object_upload_failed() { ++_object_upload_failed; }
     void increment_empty_objects_skipped() { ++_empty_objects_skipped; }
+    void increment_metastore_retries() { ++_metastore_retries; }
+    void increment_offset_corrections() { ++_offset_corrections; }
 
     void record_object_size_bytes(uint64_t size) {
         _object_size_bytes.record(size);
@@ -85,6 +87,8 @@ private:
     uint64_t _object_build_failed{0};
     uint64_t _object_upload_failed{0};
     uint64_t _empty_objects_skipped{0};
+    uint64_t _metastore_retries{0};
+    uint64_t _offset_corrections{0};
 
     // Histograms.
     hist_t _object_upload_duration;

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -11,15 +11,19 @@
 #pragma once
 
 #include "metrics/metrics.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
 
 #include <cstdint>
+#include <memory>
 
 namespace cloud_topics::reconciler {
 
 class reconciler_probe {
 public:
+    using hist_t = log_hist_internal;
+
     reconciler_probe() = default;
 
     reconciler_probe(const reconciler_probe&) = delete;
@@ -41,6 +45,22 @@ public:
     void increment_object_upload_failed() { ++_object_upload_failed; }
     void increment_empty_objects_skipped() { ++_empty_objects_skipped; }
 
+    std::unique_ptr<hist_t::measurement> measure_object_upload_duration() {
+        return _object_upload_duration.auto_measure();
+    }
+
+    std::unique_ptr<hist_t::measurement>
+    measure_metastore_add_objects_duration() {
+        return _metastore_add_objects_duration.auto_measure();
+    }
+
+    auto get_object_upload_duration_for_tests() const {
+        return _object_upload_duration.internal_histogram_logform();
+    }
+    auto get_metastore_add_objects_duration_for_tests() const {
+        return _metastore_add_objects_duration.internal_histogram_logform();
+    }
+
 private:
     metrics::internal_metric_groups _metrics;
 
@@ -52,6 +72,10 @@ private:
     uint64_t _object_build_failed{0};
     uint64_t _object_upload_failed{0};
     uint64_t _empty_objects_skipped{0};
+
+    // Histograms.
+    hist_t _object_upload_duration;
+    hist_t _metastore_add_objects_duration;
 };
 
 } // namespace cloud_topics::reconciler

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -193,3 +193,33 @@ TEST_F(ReconcilerMetricsTest, HistogramMetrics) {
       = probe.get_metastore_add_objects_duration_for_tests();
     EXPECT_GT(metastore_add_objects_duration.sample_count, 0);
 }
+
+// This test depends on the simple metastore packing all sources into one
+// object.
+TEST_F(ReconcilerMetricsTest, ObjectMetrics) {
+    auto src1 = add_source();
+    auto src2 = add_source();
+
+    src1->add_batch({.count = 10});
+    src2->add_batch({.count = 5});
+
+    reconcile();
+
+    const auto& probe = reconciler().get_probe_for_tests();
+
+    auto object_size = probe.get_object_size_bytes_for_tests();
+    EXPECT_EQ(object_size.sample_count, 1);
+
+    auto sources_per_object = probe.get_sources_per_object_for_tests();
+    EXPECT_EQ(sources_per_object.sample_count, 1);
+
+    src1->add_batch({.count = 15});
+
+    reconcile();
+
+    object_size = probe.get_object_size_bytes_for_tests();
+    EXPECT_EQ(object_size.sample_count, 2);
+
+    sources_per_object = probe.get_sources_per_object_for_tests();
+    EXPECT_EQ(sources_per_object.sample_count, 2);
+}

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -110,6 +110,11 @@ std::optional<uint64_t> get_offset_corrections() {
       "cloud_topics_reconciler_offset_corrections");
 }
 
+std::optional<uint64_t> get_rounds_failed() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_rounds_failed");
+}
+
 } // namespace
 
 TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
@@ -282,4 +287,35 @@ TEST_F(ReconcilerMetricsTest, OffsetCorrection) {
 
     EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{19});
     EXPECT_THAT(get_offset_corrections(), Optional(1));
+}
+
+TEST_F(ReconcilerMetricsTest, ReconciliationRoundsFailed) {
+    EXPECT_THAT(get_rounds_failed(), Optional(0));
+
+    auto src = add_source();
+
+    // Reconciling with nothing to do is not a failure.
+    reconcile();
+
+    EXPECT_THAT(get_rounds_failed(), Optional(0));
+    EXPECT_THAT(get_objects_uploaded(), Optional(0));
+
+    // OK, now let's do some work and fail it.
+    src->add_batch({.count = 10});
+
+    metastore().fail_add_objects(true);
+
+    reconcile();
+
+    // We create an orphan T_T.
+    EXPECT_THAT(get_rounds_failed(), Optional(1));
+    EXPECT_THAT(get_objects_uploaded(), Optional(1));
+
+    // Finally, let reconciliation succeed.
+    metastore().fail_add_objects(false);
+
+    reconcile();
+
+    EXPECT_THAT(get_rounds_failed(), Optional(1));
+    EXPECT_THAT(get_objects_uploaded(), Optional(2));
 }

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -28,6 +28,7 @@
 using namespace cloud_topics;
 using cloud_topics::reconciler::test::fake_source;
 using cloud_topics::reconciler::test::unreliable_io;
+using cloud_topics::reconciler::test::unreliable_metastore;
 
 namespace {
 
@@ -47,11 +48,12 @@ public:
     void reconcile() { _reconciler.reconcile().get(); }
 
     unreliable_io& io() { return _io; }
+    unreliable_metastore& metastore() { return _metastore; }
     reconciler::reconciler& reconciler() { return _reconciler; }
 
 private:
     unreliable_io _io;
-    l1::simple_metastore _metastore;
+    unreliable_metastore _metastore;
     reconciler::reconciler _reconciler{&_io, &_metastore};
 };
 
@@ -96,6 +98,16 @@ std::optional<uint64_t> get_object_upload_failed() {
 std::optional<uint64_t> get_empty_objects_skipped() {
     return test_utils::find_metric_value<uint64_t>(
       "cloud_topics_reconciler_empty_objects_skipped");
+}
+
+std::optional<uint64_t> get_metastore_retries() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_metastore_retries");
+}
+
+std::optional<uint64_t> get_offset_corrections() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_offset_corrections");
 }
 
 } // namespace
@@ -222,4 +234,52 @@ TEST_F(ReconcilerMetricsTest, ObjectMetrics) {
 
     sources_per_object = probe.get_sources_per_object_for_tests();
     EXPECT_EQ(sources_per_object.sample_count, 2);
+}
+
+TEST_F(ReconcilerMetricsTest, MetastoreRetries) {
+    EXPECT_THAT(get_metastore_retries(), Optional(0));
+    EXPECT_THAT(get_offset_corrections(), Optional(0));
+
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    metastore().fail_add_objects_transiently(2);
+
+    reconcile();
+
+    EXPECT_THAT(get_metastore_retries(), Optional(2));
+    EXPECT_THAT(get_objects_uploaded(), Optional(1));
+
+    src->add_batch({.count = 5});
+    reconcile();
+
+    EXPECT_THAT(get_metastore_retries(), Optional(2));
+    EXPECT_THAT(get_objects_uploaded(), Optional(2));
+}
+
+// For more explanation of offset correction, see the LROUpdateFailure
+// reconciler unit test.
+TEST_F(ReconcilerMetricsTest, OffsetCorrection) {
+    auto src = add_source();
+
+    src->add_batch({.count = 10});
+    src->fail_set_lro(true);
+
+    reconcile();
+
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{});
+    EXPECT_THAT(get_offset_corrections(), Optional(0));
+
+    src->add_batch({.count = 10});
+    src->fail_set_lro(false);
+
+    reconcile();
+
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{9});
+    EXPECT_THAT(get_offset_corrections(), Optional(1));
+
+    reconcile();
+
+    EXPECT_EQ(src->last_reconciled_offset(), kafka::offset{19});
+    EXPECT_THAT(get_offset_corrections(), Optional(1));
 }

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -47,6 +47,7 @@ public:
     void reconcile() { _reconciler.reconcile().get(); }
 
     unreliable_io& io() { return _io; }
+    reconciler::reconciler& reconciler() { return _reconciler; }
 
 private:
     unreliable_io _io;
@@ -175,4 +176,20 @@ TEST_F(ReconcilerMetricsTest, FailedObjectsCounter) {
 
     EXPECT_THAT(get_object_upload_failed(), Optional(1));
     EXPECT_THAT(get_objects_uploaded(), Optional(1));
+}
+
+TEST_F(ReconcilerMetricsTest, HistogramMetrics) {
+    auto src = add_source();
+    src->add_batch({.count = 10});
+
+    reconcile();
+
+    const auto& probe = reconciler().get_probe_for_tests();
+
+    auto object_upload_duration = probe.get_object_upload_duration_for_tests();
+    EXPECT_GT(object_upload_duration.sample_count, 0);
+
+    auto metastore_add_objects_duration
+      = probe.get_metastore_add_objects_duration_for_tests();
+    EXPECT_GT(metastore_add_objects_duration.sample_count, 0);
 }


### PR DESCRIPTION
Adds:

rounds_failed: How many rounds (totally) failed?

Duration metrics (note all potentially involve I/O) (self-explanatory):

- object_upload_duration_seconds
- metastore_add_objects_duration_seconds

Efficiency metrics:

- object_size_bytes: A histogram of built object sizes.
- sources_per_object: A histogram of the number of sources in each object

Weird stuff metrics:

- metastore_retries: The number of retries of metastore operations.
- offset_corrections: The number of offset corrections from the metastore.

Doesn't add:

Saturation metrics like staleness and LRO vs. LSO lag. These are a bit tough
because they need to updated for all sources but iterating consistently
through all sources without stalling a reactor could be hard. Will be addressed
later.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
