### PR TITLE
[CORE-13841] ct/housekeeper: Sync L0 start offset to L1

### DIFF
--- a/src/v/cloud_topics/housekeeper/housekeeper.cc
+++ b/src/v/cloud_topics/housekeeper/housekeeper.cc
@@ -58,6 +58,9 @@ ss::future<> housekeeper::do_housekeeping() {
     if (new_start_offset != kafka::offset::min()) {
         co_await _l0_metastore->set_start_offset(_tidp, new_start_offset, &_as);
     }
+    // Sync the start offset back to the L1 metastore.
+    // DeleteRecords may advance the L0 start offset past the L1 start offset.
+    co_await sync_start_offset();
 }
 
 ss::future<> housekeeper::do_loop() {
@@ -128,6 +131,18 @@ housekeeper::do_time_retention(std::chrono::milliseconds duration) {
     }
     auto next_offset = offsets_result.value().next_offset;
     co_return next_offset;
+}
+
+ss::future<> housekeeper::sync_start_offset() {
+    auto start_offset = _l0_metastore->get_start_offset(_tidp);
+    auto result = co_await _l1_metastore->set_start_offset(_tidp, start_offset);
+    if (!result.has_value()) {
+        vlog(
+          cd_log.warn,
+          "Failed to sync start offset to L1 for {}: {}",
+          _tidp,
+          result.error());
+    }
 }
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/housekeeper/housekeeper.h
+++ b/src/v/cloud_topics/housekeeper/housekeeper.h
@@ -25,14 +25,14 @@ namespace cloud_topics {
 // managed by the cloud_topics_manager.
 //
 // L1 retention: L1 retention is computed by periodically querying the
-// metastore, the propagating the updated start offset to L0 metadata storage
+// metastore, then propagating the updated start offset to L0 metadata storage
 // (i.e. l0::ctp_stm). We propagate to L0 so that the fetch path doesn't need to
-// make a RPC in order to service list offset requests. Since we write the data
-// to L0, we rely on the reconciler to actually push the new start offset, since
-// there is an additional Delete Records Kafka RPC that can also advance the
-// start offset for the partition. By centralizing the start offset, we can
-// give read-your-own-write consistency for delete records, and also have a
-// single source of truth for pushing the new start offset to the L1 metastore.
+// make a RPC in order to service list offset requests. There is an additional
+// Delete Records Kafka RPC that can also advance the start offset for the
+// partition. For this reason, the start offset is also back-propagated to L1 at
+// the end of housekeeping. By centralizing the start offset, we can give
+// read-your-own-write consistency for delete records, and also have a single
+// source of truth for pushing the new start offset to the L1 metastore.
 //
 // L0 retention: This is managed entirely by l0::ctp_stm based on the process
 // the reconciler has made.
@@ -44,6 +44,10 @@ public:
     public:
         l0_metadata_storage() = default;
         virtual ~l0_metadata_storage() = default;
+
+        // Get the current start offset for the partition.
+        virtual kafka::offset get_start_offset(const model::topic_id_partition&)
+          = 0;
 
         // Update the start offset to the partition, this must be an
         // idempotent operation.
@@ -95,6 +99,10 @@ private:
     ss::future<> do_loop();
     ss::future<kafka::offset> do_bytes_retention(size_t size);
     ss::future<kafka::offset> do_time_retention(std::chrono::milliseconds);
+    // Syncs the start offset from L0 metadata storage to L1 metastore.
+    // This ensures that L1 has the most up-to-date start offset, including
+    // any updates from Delete Records requests.
+    ss::future<> sync_start_offset();
 
     model::topic_id_partition _tidp;
     l0_metadata_storage* _l0_metastore;

--- a/src/v/cloud_topics/housekeeper/manager.cc
+++ b/src/v/cloud_topics/housekeeper/manager.cc
@@ -34,21 +34,31 @@ public:
         state)
       : _state(state) {}
 
+    kafka::offset
+    get_start_offset(const model::topic_id_partition& tidp) override {
+        auto api = get_api(tidp);
+        return api.get_start_offset();
+    }
+
     ss::future<> set_start_offset(
       const model::topic_id_partition& tidp,
       kafka::offset offset,
       ss::abort_source* as) override {
-        auto& state = _state->at(tidp);
-        auto stm = state.partition->raft()->stm_manager()->get<ctp_stm>();
-        if (!stm) {
-            throw std::runtime_error(fmt::format("no ctp_stm for {}", tidp));
-        }
-        ctp_stm_api api(stm);
+        auto api = get_api(tidp);
         co_await api.set_start_offset(
           offset, model::timeout_clock::now() + stm_timeout, *as);
     }
 
 private:
+    ctp_stm_api get_api(const model::topic_id_partition& tidp) {
+        auto& state = _state->at(tidp);
+        auto stm = state.partition->raft()->stm_manager()->get<ctp_stm>();
+        if (!stm) {
+            throw std::runtime_error(fmt::format("no ctp_stm for {}", tidp));
+        }
+        return ctp_stm_api(stm);
+    }
+
     chunked_hash_map<model::topic_id_partition, housekeeper_manager::state>*
       _state;
 };

--- a/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
+++ b/src/v/cloud_topics/housekeeper/tests/housekeeper_test.cc
@@ -32,6 +32,14 @@ public:
       : _tidp(tidp)
       , _start_offset(start_offset) {}
 
+    kafka::offset
+    get_start_offset(const model::topic_id_partition& tidp) override {
+        if (tidp == _tidp) {
+            return _start_offset;
+        }
+        return kafka::offset{0};
+    }
+
     ss::future<> set_start_offset(
       const model::topic_id_partition& tidp,
       kafka::offset offset,
@@ -122,6 +130,19 @@ public:
     };
 
     kafka::offset start_offset() const { return _l0_metastore.start_offset(); }
+
+    void set_start_offset(kafka::offset offset) {
+        ss::abort_source as;
+        _l0_metastore.set_start_offset(_tidp, offset, &as).get();
+    }
+
+    kafka::offset l1_start_offset() {
+        auto result = _l1_metastore.get_offsets(_tidp).get();
+        if (!result.has_value()) {
+            return kafka::offset{0};
+        }
+        return result.value().start_offset;
+    }
 
     void add_object(object_params params) {
         auto result = handle_error(_l1_metastore.get_offsets(_tidp).get());
@@ -451,4 +472,30 @@ TEST_F(HousekeeperTest, MultipleObjectsBytesRetention) {
 
     housekeeper.do_housekeeping().get();
     EXPECT_EQ(start_offset(), kafka::offset{50});
+}
+
+TEST_F(HousekeeperTest, SyncsToL1) {
+    // This test simulates the scenario where Delete Records updates L0's
+    // start offset, and the housekeeper syncs it to L1.
+    simple_retention_config cfg;
+    auto housekeeper = make_housekeeper(cfg);
+
+    add_object({
+      .records = 100,
+      .size = 1_MiB,
+      .max_timestamp = model::timestamp_clock::now() - 1h,
+    });
+
+    EXPECT_EQ(start_offset(), kafka::offset{0});
+    EXPECT_EQ(l1_start_offset(), kafka::offset{0});
+
+    set_start_offset(kafka::offset{50});
+
+    EXPECT_EQ(start_offset(), kafka::offset{50});
+    EXPECT_EQ(l1_start_offset(), kafka::offset{0});
+
+    housekeeper.do_housekeeping().get();
+
+    EXPECT_EQ(start_offset(), kafka::offset{50});
+    EXPECT_EQ(l1_start_offset(), kafka::offset{50});
 }


### PR DESCRIPTION
L0 is the source of truth for the start offset, even though the start offset is computed based on the retention config and information in the L1 metastore. This is because a Delete Records request may advance the start offset outside of the housekeeping retention mechanism, and it means that the L0 start offset needs to be propagated back to the L1 metastore. This change adds a tiny component that does this sync, and calls it at the end of housekeeping.

The tiny component makes it a bit easier to pull the sync out and relocate it later if we want to. There were plans at one point to do the sync in the reconciler, for example.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
