### PR TITLE
rpk: Add shadow fail over and improve status

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,7 +9,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250806153840-184e270a51f5.1
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-184e270a51f5.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20250930194408-070fbb41a3d0.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20250813192242-efcc93bcd794.1
@@ -85,7 +85,7 @@ require (
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.7-20250613105001-9f2d3c737feb.1 // indirect
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.7-20240617172850-a48fcebcf8f1.1 // indirect
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250930194408-070fbb41a3d0.1 // indirect
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -8,12 +8,8 @@ buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-18
 buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-184e270a51f5.1/go.mod h1:J6+tKG3WghdUGXXD5lYp/G15vFpzMRvAsbF6+L+YZBQ=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1 h1:mE9lPhqy3ghMKY6fAot31NySa8aI22sUjKbJuMlmDGA=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1/go.mod h1:pUNfu5CqCYitRtXrJ69rHyB7SXdTkDuqqnNwQYI2H1Q=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250930194408-070fbb41a3d0.1 h1:0OXvz9FG7sIqQPNIakEXBUARkhxCnS1zq6+7ttvAi7w=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250930194408-070fbb41a3d0.1/go.mod h1:cW1LlfqRXkA2ia7jETbXwvJr2uR7Aj8xeqbv1R4nfEY=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1 h1:+bBkTuaJtXW9irz6gDCCFHK17BNxjUPB0qIvNOiXSXE=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1/go.mod h1:vJABXSPxk+Oeds+LifrwLGPUkbl7ftBHqNpLAfPcTRA=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20250930194408-070fbb41a3d0.1 h1:w4hn0pk7uzb+l04sEsqGVjglvwi8snvgS+QQBwmpsVU=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20250930194408-070fbb41a3d0.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1 h1:GoNb2M1NqJA97n6Joml7RitfzDJQbLEJKXingogSP/o=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1 h1:CiTv2Rme+0H/2IQpyZFK8SQYRWgRWEvFNxZIfDMYOQQ=

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -10,8 +10,12 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-0
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1/go.mod h1:pUNfu5CqCYitRtXrJ69rHyB7SXdTkDuqqnNwQYI2H1Q=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250930194408-070fbb41a3d0.1 h1:0OXvz9FG7sIqQPNIakEXBUARkhxCnS1zq6+7ttvAi7w=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20250930194408-070fbb41a3d0.1/go.mod h1:cW1LlfqRXkA2ia7jETbXwvJr2uR7Aj8xeqbv1R4nfEY=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1 h1:+bBkTuaJtXW9irz6gDCCFHK17BNxjUPB0qIvNOiXSXE=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1/go.mod h1:vJABXSPxk+Oeds+LifrwLGPUkbl7ftBHqNpLAfPcTRA=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20250930194408-070fbb41a3d0.1 h1:w4hn0pk7uzb+l04sEsqGVjglvwi8snvgS+QQBwmpsVU=
 buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20250930194408-070fbb41a3d0.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1 h1:GoNb2M1NqJA97n6Joml7RitfzDJQbLEJKXingogSP/o=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1 h1:CiTv2Rme+0H/2IQpyZFK8SQYRWgRWEvFNxZIfDMYOQQ=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1/go.mod h1:HJnvbiwx2qZN8HcD30Dijm5Aamjcrk/8/ffTOFrF5Go=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1 h1:31r1Sv/BoVyGzzBfBHcUcyQJz/+4i/fr8wc7gQVihEM=

--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -7,6 +7,7 @@ go_library(
         "create.go",
         "delete.go",
         "describe.go",
+        "failover.go",
         "list.go",
         "mapper.go",
         "shadow.go",

--- a/src/go/rpk/pkg/cli/shadow/config.go
+++ b/src/go/rpk/pkg/cli/shadow/config.go
@@ -75,12 +75,13 @@ func generateSampleConfig() *ShadowLinkConfig {
 	return &ShadowLinkConfig{
 		Name: "sample-shadow-link",
 		ClientOptions: &ShadowLinkClientOptions{
-			BootstrapServers: []string{"localhost:9092"},
-			SourceClusterID:  "source-cluster-id",
+			BootstrapServers: []string{"localhost:9092", "localhost:19092"},
+			SourceClusterID:  "optional-source-cluster-id",
 			TLSSettings: &TLSFileSettings{
+				Enabled:  true,
 				CAPath:   "/path/to/ca.crt",
-				KeyPath:  "/path/to/client.key",
-				CertPath: "/path/to/client.crt",
+				KeyPath:  "/path/to/optional/client.key",
+				CertPath: "/path/to/optional/client.crt",
 			},
 			AuthenticationConfiguration: &ScramConfig{
 				Username:       "username",
@@ -101,6 +102,11 @@ func generateSampleConfig() *ShadowLinkConfig {
 					PatternType: PatternTypeLiteral,
 					FilterType:  FilterTypeInclude,
 					Name:        "*",
+				},
+				{
+					PatternType: PatternTypePrefix,
+					FilterType:  FilterTypeExclude,
+					Name:        "foo-",
 				},
 			},
 			ShadowedTopicProperties: []string{"retention.ms", "segment.ms"},
@@ -124,6 +130,28 @@ func generateSampleConfig() *ShadowLinkConfig {
 					PatternType: PatternTypeLiteral,
 					FilterType:  FilterTypeInclude,
 					Name:        "*",
+				},
+			},
+			ScramCredFilters: []*NameFilter{
+				{
+					PatternType: PatternTypePrefix,
+					FilterType:  FilterTypeExclude,
+					Name:        "admin-",
+				},
+			},
+			ACLFilters: []*ACLFilter{
+				{
+					ResourceFilter: &ACLResourceFilter{
+						ResourceType: ACLResourceTopic,
+						PatternType:  ACLPatternPrefixed,
+						Name:         "test-",
+					},
+					AccessFilter: &ACLAccessFilter{
+						Principal:      "User:admin",
+						Operation:      ACLOperationAny,
+						PermissionType: ACLPermissionTypeAllow,
+						Host:           "*",
+					},
 				},
 			},
 		},

--- a/src/go/rpk/pkg/cli/shadow/create.go
+++ b/src/go/rpk/pkg/cli/shadow/create.go
@@ -75,7 +75,7 @@ skip the confirmation prompt.
 	}
 
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
-	cmd.Flags().StringVar(&cfgLocation, "config-file", "", "Path to configuration file to use for the shadow link; use --help for details")
+	cmd.Flags().StringVarP(&cfgLocation, "config-file", "c", "", "Path to configuration file to use for the shadow link; use --help for details")
 	cmd.MarkFlagRequired("config-file")
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -58,7 +58,7 @@ func newDescribeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.overview, "print-overview", "o", false, "Print the overview section")
 	cmd.Flags().BoolVarP(&opts.client, "print-client", "c", false, "Print the client configuration section")
 	cmd.Flags().BoolVarP(&opts.topic, "print-topic", "t", false, "Print the detailed topic configuration section")
-	cmd.Flags().BoolVarP(&opts.co, "print-consumer", "k", false, "Print the detailed consumer offset configuration section")
+	cmd.Flags().BoolVarP(&opts.co, "print-consumer", "r", false, "Print the detailed consumer offset configuration section")
 	cmd.Flags().BoolVarP(&opts.sec, "print-security", "s", false, "Print the detailed security configuration section")
 	cmd.Flags().BoolVarP(&opts.all, "print-all", "a", false, "Print all sections")
 	return cmd

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -131,6 +131,9 @@ func printOverview(link *adminv2.ShadowLink) {
 	defer tw.Flush()
 	tw.Print("NAME", link.GetName())
 	tw.Print("UID", link.GetUid())
+	if status := link.GetStatus(); status != nil {
+		tw.Print("STATE", strings.TrimPrefix(status.GetState().String(), "SHADOW_LINK_STATE_"))
+	}
 }
 
 func printClient(opts *adminv2.ShadowLinkClientOptions) {

--- a/src/go/rpk/pkg/cli/shadow/failover.go
+++ b/src/go/rpk/pkg/cli/shadow/failover.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package shadow
+
+import (
+	"fmt"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	"connectrpc.com/connect"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newFailoverCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		noConfirm bool
+		all       bool
+		topic     string
+	)
+	cmd := &cobra.Command{
+		Use:   "failover [LINK_NAME]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Failover a Redpanda Shadow Link",
+		Long:  `Failover a Redpanda Shadow Link or a specific topic`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if !all && topic == "" {
+				out.Die("either --all or --topic must be provided")
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load rpk config: %v", err)
+			config.CheckExitCloudAdmin(p)
+
+			cl, err := adminapi.NewClient(cmd.Context(), fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			linkName := args[0]
+			if !noConfirm {
+				sl, err := cl.ShadowLinkService().GetShadowLink(cmd.Context(), connect.NewRequest(&adminv2.GetShadowLinkRequest{
+					Name: linkName,
+				}))
+				out.MaybeDie(err, "unable to get Redpanda Shadow Link %q: %v", linkName, err)
+				printOverview(sl.Msg.GetShadowLink())
+				var confirmed bool
+				if all {
+					confirmed, err = out.Confirm("Are you sure you want to failover all topics for Shadow Link %q?", linkName)
+				} else {
+					confirmed, err = out.Confirm("Are you sure you want to failover the topic %q for Shadow Link %q?", topic, linkName)
+				}
+				out.MaybeDie(err, "unable to confirm Shadow Link failover: %v", err)
+				if !confirmed {
+					out.Exit("Command execution canceled.")
+				}
+			}
+			_, err = cl.ShadowLinkService().FailOver(cmd.Context(), connect.NewRequest(&adminv2.FailOverRequest{
+				Name:            linkName,
+				ShadowTopicName: topic,
+			}))
+			out.MaybeDie(err, "unable to failover Shadow Link: %v", err)
+
+			fmt.Printf(`Successfully initiated the Fail Over for Shadow Link %q. To check the status, run:
+  rpk shadow status %[1]s
+`, linkName)
+		},
+	}
+
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	cmd.Flags().BoolVar(&all, "all", false, "Failover all shadow links")
+	cmd.Flags().StringVar(&topic, "topic", "", "Specific topic to failover. If --all is not set, at least a topic must be provided")
+
+	cmd.MarkFlagsMutuallyExclusive("all", "topic")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -74,6 +74,7 @@ func mapTLSSettings(tls TLSSettings) *adminv2.TLSSettings {
 
 	switch t := tls.(type) {
 	case *TLSFileSettings:
+		pbTLS.Enabled = t.Enabled
 		pbTLS.TlsSettings = &adminv2.TLSSettings_TlsFileSettings{
 			TlsFileSettings: &adminv2.TLSFileSettings{
 				CaPath:   t.CAPath,
@@ -82,6 +83,7 @@ func mapTLSSettings(tls TLSSettings) *adminv2.TLSSettings {
 			},
 		}
 	case *TLSPEMSettings:
+		pbTLS.Enabled = t.Enabled
 		pbTLS.TlsSettings = &adminv2.TLSSettings_TlsPemSettings{
 			TlsPemSettings: &adminv2.TLSPEMSettings{
 				Ca:   t.CA,

--- a/src/go/rpk/pkg/cli/shadow/shadow.go
+++ b/src/go/rpk/pkg/cli/shadow/shadow.go
@@ -25,6 +25,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newShadowConfigCommand(fs, p),
 		newCreateCommand(fs, p),
 		newDeleteCommand(fs, p),
+		newFailoverCommand(fs, p),
 		newDescribeCommand(fs, p),
 		newStatusCommand(fs, p),
 		newListCommand(fs, p),

--- a/src/go/rpk/pkg/cli/shadow/status.go
+++ b/src/go/rpk/pkg/cli/shadow/status.go
@@ -11,6 +11,7 @@ package shadow
 
 import (
 	"fmt"
+	"strings"
 
 	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
 	"connectrpc.com/connect"
@@ -21,7 +22,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type slStatusOptions struct {
+	all      bool
+	overview bool
+	task     bool
+	topic    bool
+}
+
 func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var opts slStatusOptions
 	cmd := &cobra.Command{
 		Use:   "status [LINK_NAME]",
 		Args:  cobra.ExactArgs(1),
@@ -42,8 +51,87 @@ func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			// TODO: handle NotFound error and print a friendly message.
 			out.MaybeDie(err, "unable to get Redpanda Shadow Link status %q: %v", linkName, err)
 
-			fmt.Printf("%+v\n", link.Msg.GetShadowLink().GetStatus()) // TODO: pretty print once all status fields are defined.
+			opts.defaultOrAll()
+			printShadowLinkStatus(link.Msg.GetShadowLink(), opts)
 		},
 	}
+	cmd.Flags().BoolVarP(&opts.overview, "print-overview", "o", false, "Print the overview section")
+	cmd.Flags().BoolVarP(&opts.task, "print-task", "k", false, "Print the task status section")
+	cmd.Flags().BoolVarP(&opts.topic, "print-topic", "t", false, "Print the detailed topic status section")
+	cmd.Flags().BoolVarP(&opts.all, "print-all", "a", false, "Print all sections")
+
 	return cmd
+}
+
+// If no flags are set, default to overview and client sections.
+func (o *slStatusOptions) defaultOrAll() {
+	// We currently default to all sections until we have more fields to show.
+	if o.all || (!o.overview && !o.task && !o.topic) {
+		o.overview, o.task, o.topic = true, true, true
+	}
+}
+
+func printShadowLinkStatus(link *adminv2.ShadowLink, opts slStatusOptions) {
+	status := link.GetStatus()
+	if link == nil || status == nil {
+		fmt.Println("No status available")
+		return
+	}
+	const (
+		secOverview = "Overview"
+		secTasks    = "Tasks"
+		secTopics   = "Topics"
+	)
+
+	sections := out.NewSections(
+		out.ConditionalSectionHeaders(map[string]bool{
+			secOverview: opts.overview,
+			secTasks:    opts.task,
+			secTopics:   opts.topic,
+		})...,
+	)
+
+	sections.Add(secOverview, func() {
+		printOverview(link)
+	})
+
+	sections.Add(secTasks, func() {
+		printTaskStatus(status.GetTaskStatuses())
+	})
+
+	sections.Add(secTopics, func() {
+		printTopicStatus(status.GetShadowTopicStatuses())
+	})
+}
+
+func printTaskStatus(tasks []*adminv2.ShadowLinkTaskStatus) {
+	if len(tasks) == 0 {
+		fmt.Println("No tasks to display right now.")
+		return
+	}
+	t := out.NewTable("Name", "Broker_ID", "State", "Reason")
+	defer t.Flush()
+	for _, task := range tasks {
+		t.Print(task.GetName(), task.GetBrokerId(), strings.TrimPrefix(task.GetState().String(), "TASK_STATE_"), task.GetReason())
+	}
+}
+
+func printTopicStatus(topics []*adminv2.ShadowTopicStatus) {
+	if len(topics) == 0 {
+		fmt.Println("No topic status available.")
+		return
+	}
+	for _, topic := range topics {
+		fmt.Printf("Name: %s ID: %v, State: %s\n", topic.GetName(), topic.GetTopicId(), strings.TrimPrefix(topic.GetState().String(), "SHADOW_TOPIC_STATE_"))
+		printPartitionTable(topic.GetPartitionInformation())
+		fmt.Println()
+	}
+}
+
+func printPartitionTable(partitions []*adminv2.TopicPartitionInformation) {
+	t := out.NewTable("", "Partition", "SRC_LSO", "SRC_HWM", "DST_HWM", "Lag")
+	defer t.Flush()
+	for _, p := range partitions {
+		t.Print("", p.GetPartitionId(), p.GetSourceLastStableOffset(), p.GetSourceHighWatermark(), p.GetHighWatermark(), p.GetSourceHighWatermark()-p.GetHighWatermark())
+	}
 }

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -72,6 +72,8 @@ type TLSSettings interface {
 }
 
 type TLSFileSettings struct {
+	// Whether or not TLS is enabled
+	Enabled bool `json:"enabled" yaml:"enabled"`
 	// Path to the CA
 	CAPath string `json:"ca_path,omitempty" yaml:"ca_path,omitempty"`
 	// Key and Cert are optional but if one is provided, then both must be
@@ -86,6 +88,8 @@ func (*TLSFileSettings) tlsSettingType() string {
 }
 
 type TLSPEMSettings struct {
+	// Whether or not TLS is enabled
+	Enabled bool `json:"enabled" yaml:"enabled"`
 	// The CA
 	CA string `json:"ca,omitempty" yaml:"ca,omitempty"`
 	// Key and Cert are optional but if one is provided, then both must be

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -172,7 +172,7 @@ type NameFilter struct {
 	FilterType FilterType `json:"filter_type,omitempty" yaml:"filter_type,omitempty"`
 	// The resource name, or "*"
 	// Note if "*", must be the _only_ character
-	// and `pattern_type` must be `PATTERN_TYPE_LITERAL`
+	// and `pattern_type` must be `LITERAL`
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -41,6 +41,7 @@ client_options:
     - "broker2:9092"
   source_cluster_id: "source-123"
   tls_settings:
+    enabled: true
     ca_path: "/path/to/ca.crt"
     key_path: "/path/to/key.pem"
     cert_path: "/path/to/cert.pem"
@@ -75,6 +76,7 @@ security_sync_options:
 					BootstrapServers: []string{"broker1:9092", "broker2:9092"},
 					SourceClusterID:  "source-123",
 					TLSSettings: &TLSFileSettings{
+						Enabled:  true,
 						CAPath:   "/path/to/ca.crt",
 						KeyPath:  "/path/to/key.pem",
 						CertPath: "/path/to/cert.pem",
@@ -123,6 +125,7 @@ client_options:
   bootstrap_servers:
     - "broker1:9092"
   tls_settings:
+    enabled: true
     ca: |
       -----BEGIN CERTIFICATE-----
       test-ca-content
@@ -145,9 +148,10 @@ client_options:
 				ClientOptions: &ShadowLinkClientOptions{
 					BootstrapServers: []string{"broker1:9092"},
 					TLSSettings: &TLSPEMSettings{
-						CA:   "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
-						Key:  "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
-						Cert: "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n",
+						Enabled: true,
+						CA:      "-----BEGIN CERTIFICATE-----\ntest-ca-content\n-----END CERTIFICATE-----\n",
+						Key:     "-----BEGIN PRIVATE KEY-----\ntest-key-content\n-----END PRIVATE KEY-----\n",
+						Cert:    "-----BEGIN CERTIFICATE-----\ntest-cert-content\n-----END CERTIFICATE-----\n",
 					},
 					AuthenticationConfiguration: &ScramConfig{
 						Username:       "pemuser",
@@ -347,6 +351,7 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 					"bootstrap_servers": ["broker1:9092", "broker2:9092"],
 					"source_cluster_id": "source-123",
 					"tls_settings": {
+						"enabled": false,
 						"ca_path": "/path/to/ca.crt",
 						"key_path": "/path/to/key.pem",
 						"cert_path": "/path/to/cert.pem"
@@ -388,6 +393,7 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 					BootstrapServers: []string{"broker1:9092", "broker2:9092"},
 					SourceClusterID:  "source-123",
 					TLSSettings: &TLSFileSettings{
+						Enabled:  false,
 						CAPath:   "/path/to/ca.crt",
 						KeyPath:  "/path/to/key.pem",
 						CertPath: "/path/to/cert.pem",
@@ -533,11 +539,13 @@ func TestTLSSettingsUnmarshalJSON(t *testing.T) {
 		{
 			name: "file-based TLS settings",
 			jsonData: `{
+				"enabled": true,
 				"ca_path": "/path/to/ca.crt",
 				"key_path": "/path/to/key.pem",
 				"cert_path": "/path/to/cert.pem"
 			}`,
 			want: &TLSFileSettings{
+				Enabled:  true,
 				CAPath:   "/path/to/ca.crt",
 				KeyPath:  "/path/to/key.pem",
 				CertPath: "/path/to/cert.pem",
@@ -546,14 +554,16 @@ func TestTLSSettingsUnmarshalJSON(t *testing.T) {
 		{
 			name: "PEM-based TLS settings",
 			jsonData: `{
+				"enabled": false,	
 				"ca": "ca-content",
 				"key": "key-content",
 				"cert": "cert-content"
 			}`,
 			want: &TLSPEMSettings{
-				CA:   "ca-content",
-				Key:  "key-content",
-				Cert: "cert-content",
+				Enabled: false,
+				CA:      "ca-content",
+				Key:     "key-content",
+				Cert:    "cert-content",
 			},
 		},
 		{
@@ -656,6 +666,8 @@ func TestShadowLinkConfigChanges(t *testing.T) {
 		// Special-case exclusion for exactly this one field which is also an
 		// enum.
 		regexp.MustCompile(`^security_sync_options\.acl_filters\.access_filter\.operation$`),
+		// A one-of type in protobuf, represented as an interface{} in Go.
+		regexp.MustCompile(`client_options.tls_settings.enabled$`),
 	}
 
 	var walk func(v reflect.Type, parentName string, m map[string]string)

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -554,7 +554,7 @@ func TestTLSSettingsUnmarshalJSON(t *testing.T) {
 		{
 			name: "PEM-based TLS settings",
 			jsonData: `{
-				"enabled": false,	
+				"enabled": false,
 				"ca": "ca-content",
 				"key": "key-content",
 				"cert": "cert-content"


### PR DESCRIPTION
  - Add failover command for shadow links
  - Improve shadow link status output with detailed task and topic information
  - Enhance config example with TLS enabled flag and additional filter examples
  - Add -c shorthand for --config-file flag
  - Bump core version to support new failover and TLS enabled features

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
