### PR TITLE
[v25.1.x] c/producer_state: fix missing placeholder in log line

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -369,7 +369,8 @@ result<request_ptr> producer_state::try_emplace_request(
     if (bid.first_seq < 0 || bid.last_seq < 0) {
         vlog(
           _logger.warn,
-          "[{}] request with non idempotent batch {}, term: {}, reset: {}",
+          "[{}] request with non idempotent batch {}, term: {}, reset: {}, "
+          "request_state: {}",
           *this,
           bid,
           current_term,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/27921
