### PR TITLE
RNG visibility improvements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -191,5 +191,6 @@ test:lldb --strategy=TestRunner=local
 
 # always pass through the following variables if they are set in the environment
 test --test_env=REDPANDA_RNG_SEEDING_MODE
+test --test_env=REDPANDA_DEBUG_TEST_HOOKS
 
 try-import %workspace%/user.bazelrc

--- a/bazel/bench_wrapper.py
+++ b/bazel/bench_wrapper.py
@@ -67,6 +67,16 @@ def main():
         f"[bench-wrapper] command           : {' '.join(sys.argv[1:])}", file=sys.stderr
     )
 
+    def printenv(name: str):
+        v = os.getenv(name, None)
+        v = "(unset)" if v is None else v
+        print(f"{name}={v} ", file=sys.stderr, end="")
+
+    print("[bench-wrapper] ", end="", file=sys.stderr)
+    printenv("REDPANDA_RNG_SEEDING_MODE")
+    printenv("REDPANDA_RNG_SEEDING_MODE_DEFAULT")
+    print(file=sys.stderr)
+
     if verbose != 0:
         print("[bench-wrapper] env begin:", file=sys.stderr)
         for k, v in os.environ.items():

--- a/src/v/container/tests/absl_map_bench.cc
+++ b/src/v/container/tests/absl_map_bench.cc
@@ -161,3 +161,27 @@ INT_KEY_MAP_PERF_TEST(std_hash, uint64_t, int64_t, SIZE);
 INT_KEY_MAP_PERF_TEST(absl_btree_map, uint64_t, int64_t, SIZE);
 INT_KEY_MAP_PERF_TEST(absl_flat_map, uint64_t, int64_t, SIZE);
 INT_KEY_MAP_PERF_TEST(chunked_map, uint64_t, int64_t, SIZE);
+
+static inline auto absl_next_seed() {
+    return absl::container_internal::NextSeed();
+}
+
+PERF_TEST(absl_next_seed, next_seed_10000) {
+    constexpr size_t inner_iters = 10000;
+    for (size_t i = 0; i < inner_iters; ++i) {
+        perf_tests::do_not_optimize(absl_next_seed());
+    }
+
+    return inner_iters;
+}
+
+PERF_TEST(absl_next_seed, find_seed_again) {
+    auto first_seed = absl_next_seed();
+    while (absl_next_seed() != first_seed) {
+    }
+}
+
+PERF_TEST(absl_next_seed, find_seed_0) {
+    while (absl_next_seed() != 0) {
+    }
+}

--- a/src/v/random/BUILD
+++ b/src/v/random/BUILD
@@ -13,6 +13,7 @@ redpanda_cc_library(
     deps = [
         "//src/v/base",
         "@abseil-cpp//absl/random",
+        "@fmt",
         "@seastar",
     ],
 )

--- a/src/v/random/generators.cc
+++ b/src/v/random/generators.cc
@@ -27,32 +27,39 @@ using internal::chars;
 
 using seed_type = rng::seed_type;
 
+namespace internal {
+// get the default seeding mode from the environment
+seeding_mode default_seeding_policy() {
+    static const seeding_mode global_seeding_mode = [] {
+        // REDPANDA_RNG_SEEDING_MODE overrides REDPANDA_RNG_SEEDING_MODE_DEFAULT
+        // which overrides the default
+        auto mode_cstr = std::getenv("REDPANDA_RNG_SEEDING_MODE");
+        if (!mode_cstr) {
+            mode_cstr = std::getenv("REDPANDA_RNG_SEEDING_MODE_DEFAULT");
+        }
+        if (!mode_cstr) {
+            // default mode when nothing is specified
+            return seeding_mode::random_seed;
+        }
+
+        std::string_view mode = mode_cstr;
+        if (mode == "random") {
+            return seeding_mode::random_seed;
+        } else if (mode == "fixed") {
+            return seeding_mode::fixed_seed;
+        }
+        vassert(false, "Invalid REDPANDA_RNG_SEEDING_MODE: {}", mode);
+    }();
+
+    return global_seeding_mode;
+}
+
+} // namespace internal
+
 namespace {
 constexpr seed_type fixed_seed = 0xDEADBEEF;
 
 std::atomic<int64_t> seed_generation = 0;
-
-// get the default seeding mode from the environment
-const seeding_mode global_seeding_mode = [] {
-    // REDPANDA_RNG_SEEDING_MODE overrides REDPANDA_RNG_SEEDING_MODE_DEFAULT
-    // which overrides the default
-    auto mode_cstr = std::getenv("REDPANDA_RNG_SEEDING_MODE");
-    if (!mode_cstr) {
-        mode_cstr = std::getenv("REDPANDA_RNG_SEEDING_MODE_DEFAULT");
-    }
-    if (!mode_cstr) {
-        // default mode when nothing is specified
-        return seeding_mode::random_seed;
-    }
-
-    std::string_view mode = mode_cstr;
-    if (mode == "random") {
-        return seeding_mode::random_seed;
-    } else if (mode == "fixed") {
-        return seeding_mode::fixed_seed;
-    }
-    vassert(false, "Invalid REDPANDA_RNG_SEEDING_MODE: {}", mode);
-}();
 
 seed_type random_seed() {
     // use a thread-local random device as random_device creation is
@@ -85,14 +92,11 @@ struct global_state_state {
 static thread_local global_state_state global_state;
 
 seed_type get_initial_seed() {
-    return global_seeding_mode == seeding_mode::fixed_seed ? fixed_seed
-                                                           : random_seed();
+    return internal::default_seeding_policy() == seeding_mode::fixed_seed
+             ? fixed_seed
+             : random_seed();
 }
 } // namespace
-
-namespace internal {
-seeding_mode default_seeding_policy() { return global_seeding_mode; }
-} // namespace internal
 
 rng::rng() noexcept
   : rng(get_initial_seed()) {}

--- a/src/v/random/generators.cc
+++ b/src/v/random/generators.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <random>
+#include <sstream>
 
 namespace random_generators {
 
@@ -72,8 +73,16 @@ std::seed_seq seed_to_seq(seed_type seed) {
 }
 
 // state to implement the global() rng object and its reseeding semantics
-thread_local rng global_instance;
-thread_local int64_t last_seed_gen = -1;
+struct global_state_state {
+    rng global_instance;
+    int64_t last_seed_gen = -1;
+    // the number of times global() has been called, since process start
+    size_t access_count = 0;
+    // the value of access_count at the last reseeding event
+    size_t access_count_at_reseed = 0;
+};
+
+static thread_local global_state_state global_state;
 
 seed_type get_initial_seed() {
     return global_seeding_mode == seeding_mode::fixed_seed ? fixed_seed
@@ -97,15 +106,57 @@ rng::rng(seed_type seed)
 
 rng with_random_seed() { return rng{random_seed_tag{}}; }
 
-rng& global() {
-    // if a reseeding has been requested, apply it here
-    if (last_seed_gen != seed_generation.load(std::memory_order_relaxed))
-      [[unlikely]] {
-        global_instance = rng{};
-        last_seed_gen = seed_generation;
+fmt::iterator rng::format_to(fmt::iterator it) const {
+    it = fmt::format_to(
+      it, "rng{{initial_seed: {:08X}, state: ", initial_seed_);
+
+    // the only way to get the internal pcg64 state is to parse it out of the
+    // ostream<< output for the engine
+    auto gen_state = fmt::format("{}", gen_);
+    std::stringstream ss(gen_state);
+    std::vector<uint64_t> state_vector;
+    uint64_t temp{};
+
+    // Use the extraction operator >> to read numbers one by one
+    while (ss >> temp) {
+        state_vector.emplace_back(temp);
     }
 
-    return global_instance;
+    if (state_vector.size() == 6) {
+        // only the last two numbers are the variable engine state, the first 4
+        // are fixed
+        it = fmt::format_to(
+          it, "[{:016X}, {:016X}]}}", state_vector[4], state_vector[5]);
+    } else {
+        // unexpected format, just print the raw output
+        it = fmt::format_to(it, " (raw) {}}}", gen_state);
+    }
+
+    return it;
+}
+
+rng& global() {
+    auto& gs = global_state;
+    // if a reseeding has been requested, apply it here
+    if (gs.last_seed_gen != seed_generation.load(std::memory_order_relaxed))
+      [[unlikely]] {
+        gs.global_instance = rng{};
+        gs.last_seed_gen = seed_generation;
+        gs.access_count_at_reseed = gs.access_count;
+    }
+
+    ++gs.access_count;
+
+    return gs.global_instance;
+}
+
+ss::sstring global_state_string() {
+    // avoid global() here to avoid incrementing access_count
+    return fmt::format(
+      "global rng state: accesses: {}, accesses since reseed: {}, rng: {}",
+      global_state.access_count,
+      global_state.access_count - global_state.access_count_at_reseed,
+      global_state.global_instance);
 }
 
 void fill_buffer_randomchars(char* start, size_t amount) {

--- a/src/v/random/generators.cc
+++ b/src/v/random/generators.cc
@@ -94,13 +94,13 @@ namespace internal {
 seeding_mode default_seeding_policy() { return global_seeding_mode; }
 } // namespace internal
 
-rng::rng()
+rng::rng() noexcept
   : rng(get_initial_seed()) {}
 
-rng::rng(random_seed_tag)
+rng::rng(random_seed_tag) noexcept
   : rng(random_seed()) {}
 
-rng::rng(seed_type seed)
+rng::rng(seed_type seed) noexcept
   : gen_(seed_to_seq(seed))
   , initial_seed_(seed) {}
 

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "absl/random/random.h"
+#include "base/format_to.h"
 #include "base/seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -169,6 +170,10 @@ public:
     /// @return A reference to the underlying PCG64 engine
     engine_type& engine() { return gen_; }
 
+    /// Print internal state and other information for this rng to the
+    /// given formatter iterator.
+    fmt::iterator format_to(fmt::iterator) const;
+
 private:
     engine_type gen_;
     seed_type initial_seed_;
@@ -182,6 +187,12 @@ rng with_random_seed();
 /// Get the global rng instance, creating and seeding it if necessary.
 /// @return A reference to the global rng object
 rng& global();
+
+/// Return a string, suitable for logging, which describes the current
+/// state of the global rng instance: this is the state of the underlying
+/// rng object returned by global() and some additional information about
+/// how many times it has been accessed.
+ss::sstring global_state_string();
 
 namespace internal {
 

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -43,15 +43,15 @@ public:
     /// Initializes an rng object using the _default_ seed
     /// policy, which is fixed in most contexts, but random in
     /// fuzz test contexts.
-    rng();
+    rng() noexcept;
 
     /// Initializes an rng object using a random seed regardless
     /// of the default policy.
-    explicit rng(random_seed_tag);
+    explicit rng(random_seed_tag) noexcept;
 
     /// Initializes with a given seed.
     /// @param seed The seed value to initialize the generator with
-    explicit rng(seed_type seed);
+    explicit rng(seed_type seed) noexcept;
 
     /// The initial seed used to create this rng object.
     /// If you create another object with the same seed it should

--- a/src/v/random/tests/random_seeding_test.cc
+++ b/src/v/random/tests/random_seeding_test.cc
@@ -61,6 +61,11 @@ using random_generators::rng;
 constexpr int get_int_0 = 1822407592;
 constexpr int get_int_1 = 1412255784;
 
+// capture some global get_int calls, to see what happens before the
+// test hooks run
+const int global_get_int_0 = get_int<int>();
+const int global_get_int_1 = get_int<int>();
+
 using namespace random_generators::internal;
 
 // return true if the global seeding mode is other than "fixed"
@@ -76,6 +81,15 @@ void check_two_random_numbers() {
     }
     RPTEST_EXPECT_EQ(get_int<int>(), get_int_0);
     RPTEST_EXPECT_EQ(get_int<int>(), get_int_1);
+}
+
+MAKE_TEST_CASE(test_expected_global) {
+    if (not_fixed()) {
+        // only applies in fixed mode
+        return;
+    }
+    RPTEST_EXPECT_EQ(global_get_int_0, get_int_0);
+    RPTEST_EXPECT_EQ(global_get_int_1, get_int_1);
 }
 
 MAKE_TEST_CASE(test_expected_values) { check_two_random_numbers(); }

--- a/src/v/test_utils/BUILD
+++ b/src/v/test_utils/BUILD
@@ -274,7 +274,9 @@ redpanda_test_cc_library(
         "global_test_hooks.h",
     ],
     implementation_deps = [
+        "//src/v/random:generators",
         "//src/v/random:test_seeding",
+        "//src/v/test_utils:test_env",
         "@fmt",
     ],
     visibility = ["//visibility:public"],

--- a/src/v/test_utils/boost_test_hooks.cc
+++ b/src/v/test_utils/boost_test_hooks.cc
@@ -20,6 +20,11 @@ public:
     virtual void test_unit_start(const test_unit& test) override {
         test_hooks::before_test_case(test.full_name());
     }
+
+    virtual void test_unit_finish(
+      const test_unit& test, [[maybe_unused]] unsigned long elapsed) override {
+        test_hooks::after_test_case(test.full_name());
+    }
 };
 
 BOOST_TEST_GLOBAL_CONFIGURATION(boost_hooks);

--- a/src/v/test_utils/global_test_hooks.cc
+++ b/src/v/test_utils/global_test_hooks.cc
@@ -9,16 +9,51 @@
  * by the Apache License, Version 2.0
  */
 
-#include "random/test_seeding.h"
+#include "test_utils/global_test_hooks.h"
 
+#include "random/generators.h"
+#include "random/test_seeding.h"
+#include "test_utils/test_env.h"
+
+#include <fmt/core.h>
+
+#include <cstdlib>
 #include <string>
+#include <string_view>
+
+using namespace std::literals;
 
 namespace test_hooks {
 
-void before_test_case([[maybe_unused]] const std::string& test_name) {
-    // reset seeds for each test case to ensure reproducibility
-    random_generators::reset_seed_for_tests();
+namespace {
+
+constexpr std::string_view debug_hooks_str = "REDPANDA_DEBUG_TEST_HOOKS";
+
+const bool debug_hooks = test_env::getenv(std::string{debug_hooks_str}, "0")
+                         != "0";
+
+static void maybe_debug_log(std::string_view hook, std::string_view test_name) {
+    if (debug_hooks) {
+        fmt::print(
+          stderr,
+          "{} {} {}: {}\n",
+          debug_hooks_str,
+          hook,
+          test_name,
+          random_generators::global_state_string());
+    }
 }
 
-void after_test_case([[maybe_unused]] const std::string& test_name) {}
+} // namespace
+
+void before_test_case(const std::string& test_name) {
+    // reset seeds for each test case to improve reproducibility, see
+    // https://redpandadata.atlassian.net/wiki/spaces/CORE/pages/1406271495/Random+values+in+tests
+    random_generators::reset_seed_for_tests();
+    maybe_debug_log("before_test_case", test_name);
+}
+
+void after_test_case(const std::string& test_name) {
+    maybe_debug_log("after_test_case", test_name);
+}
 } // namespace test_hooks

--- a/src/v/test_utils/test_env.cc
+++ b/src/v/test_utils/test_env.cc
@@ -38,4 +38,21 @@ std::string random_dir_path(std::string prefix, size_t suffix_len) {
     return std::filesystem::path(test_tmpdir()) / (prefix + suffix);
 }
 
+// Return the value of the given environment variable, or the given
+// default value if the variable is not set.
+std::string getenv(
+  std::string_view name, // NOLINT(bugprone-easily-swappable-parameters)
+  std::string_view default_value) noexcept {
+    const char* v = std::getenv(std::string{name}.c_str());
+    return v ? v : std::string{default_value};
+}
+
+std::string getenv_default(
+  std::string_view name_sv, // NOLINT(bugprone-easily-swappable-parameters)
+  std::string_view default_value) noexcept {
+    std::string name{name_sv};
+    const char* v = std::getenv(name.c_str());
+    return v ? v : test_env::getenv(name + "_DEFAULT", default_value);
+}
+
 } // namespace test_env

--- a/src/v/test_utils/test_env.h
+++ b/src/v/test_utils/test_env.h
@@ -26,4 +26,19 @@ namespace test_env {
 std::string
 random_dir_path(std::string prefix = "test.dir_", size_t suffix_len = 6);
 
+// Return the value of the given environment variable, or the given
+// default value if the variable is not set.
+std::string
+getenv(std::string_view name, std::string_view default_value = "") noexcept;
+
+// Given the name of an environment variable, say X, return the value of the
+// environment variable X, if present, otherwise the value of the variable
+// X_DEFAULT if present, otherwise default_value.
+//
+// This falls back to X_DEFAULT to make it easier to set a default value in
+// bazel (which sets the _DEFAULT version), and then allow overrides via
+// the command line or environment by setting X.
+std::string getenv_default(
+  std::string_view name, std::string_view default_value = "") noexcept;
+
 } // namespace test_env

--- a/src/v/test_utils/tests/BUILD
+++ b/src/v/test_utils/tests/BUILD
@@ -52,3 +52,16 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "test_env_test",
+    timeout = "short",
+    srcs = [
+        "test_env_test.cc",
+    ],
+    deps = [
+        "//src/v/test_utils:gtest",
+        "//src/v/test_utils:test_env",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/test_utils/tests/test_env_test.cc
+++ b/src/v/test_utils/tests/test_env_test.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "test_utils/test_env.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <string>
+#include <unordered_set>
+
+class test_env_test : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // save and restore TEST_TMPDIR as other tests rely on this
+        auto test_tmpdir = std::getenv("TEST_TMPDIR");
+        if (test_tmpdir) {
+            saved_test_tmpdir_ = test_tmpdir;
+        }
+    }
+
+    void TearDown() override {
+        // Restore original environment state
+        if (saved_test_tmpdir_) {
+            setenv("TEST_TMPDIR", saved_test_tmpdir_->c_str(), 1);
+        } else {
+            unsetenv("TEST_TMPDIR");
+        }
+    }
+
+private:
+    std::optional<std::string> saved_test_tmpdir_;
+};
+
+TEST_F(test_env_test, random_dir_path_with_defaults) {
+    // Set up TEST_TMPDIR
+    setenv("TEST_TMPDIR", "/tmp/test", 1);
+
+    auto path = test_env::random_dir_path();
+
+    // Should be under TEST_TMPDIR
+    EXPECT_TRUE(path.starts_with("/tmp/test/"));
+    // Should have default prefix
+    EXPECT_TRUE(path.find("test.dir_") != std::string::npos);
+    // Should have 6 character suffix (default)
+    auto prefix_pos = path.find("test.dir_");
+    ASSERT_NE(prefix_pos, std::string::npos);
+    constexpr size_t default_prefix_len = 9; // length of "test.dir_"
+    auto suffix_start = prefix_pos + default_prefix_len;
+    auto suffix = path.substr(suffix_start);
+    constexpr size_t default_suffix_len = 6;
+    EXPECT_EQ(suffix.length(), default_suffix_len);
+
+    // Suffix should be alphanumeric
+    for (char c : suffix) {
+        EXPECT_TRUE(std::isalnum(c));
+    }
+}
+
+TEST_F(test_env_test, random_dir_path_with_custom_parameters) {
+    setenv("TEST_TMPDIR", "/tmp/custom", 1);
+
+    constexpr size_t custom_suffix_len = 10;
+    auto path = test_env::random_dir_path("my_prefix_", custom_suffix_len);
+
+    EXPECT_TRUE(path.starts_with("/tmp/custom/"));
+    EXPECT_TRUE(path.find("my_prefix_") != std::string::npos);
+
+    // Check suffix length
+    auto prefix_pos = path.find("my_prefix_");
+    ASSERT_NE(prefix_pos, std::string::npos);
+    constexpr size_t custom_prefix_len = 10; // length of "my_prefix_"
+    auto suffix_start = prefix_pos + custom_prefix_len;
+    auto suffix = path.substr(suffix_start);
+    EXPECT_EQ(suffix.length(), custom_suffix_len);
+}
+
+TEST_F(test_env_test, random_dir_path_no_test_tmpdir) {
+    unsetenv("TEST_TMPDIR");
+
+    auto path = test_env::random_dir_path();
+
+    // Should still work but path might be relative
+    EXPECT_TRUE(path.find("test.dir_") != std::string::npos);
+}
+
+TEST_F(test_env_test, random_dir_path_uniqueness) {
+    setenv("TEST_TMPDIR", "/tmp/unique", 1);
+
+    // Generate multiple paths and ensure they're different
+    std::unordered_set<std::string> paths;
+    constexpr int num_iterations = 100;
+    for (int i = 0; i < num_iterations; ++i) {
+        auto path = test_env::random_dir_path();
+        EXPECT_TRUE(paths.insert(path).second)
+          << "Duplicate path generated: " << path;
+    }
+}
+
+TEST_F(test_env_test, getenv_with_default) {
+    // Test with existing environment variable
+    setenv("TEST_ENV_TEST_VAR", "test_value", 1);
+    EXPECT_EQ(test_env::getenv("TEST_ENV_TEST_VAR", "default"), "test_value");
+
+    // Test with non-existing environment variable
+    unsetenv("TEST_ENV_TEST_VAR");
+    EXPECT_EQ(test_env::getenv("TEST_ENV_TEST_VAR", "default"), "default");
+
+    // Test with empty default
+    EXPECT_EQ(test_env::getenv("TEST_ENV_TEST_VAR"), "");
+}
+
+TEST_F(test_env_test, getenv_empty_variable) {
+    // Test with empty environment variable (set but empty)
+    setenv("TEST_ENV_TEST_VAR", "", 1);
+    EXPECT_EQ(test_env::getenv("TEST_ENV_TEST_VAR", "default"), "");
+}
+
+TEST_F(test_env_test, getenv_default_fallback) {
+    // Test primary variable exists
+    setenv("TEST_ENV_TEST_VAR", "primary_value", 1);
+    unsetenv("TEST_ENV_TEST_VAR_DEFAULT");
+    EXPECT_EQ(
+      test_env::getenv_default("TEST_ENV_TEST_VAR", "fallback"),
+      "primary_value");
+
+    // Test primary doesn't exist, default exists
+    unsetenv("TEST_ENV_TEST_VAR");
+    setenv("TEST_ENV_TEST_VAR_DEFAULT", "default_value", 1);
+    EXPECT_EQ(
+      test_env::getenv_default("TEST_ENV_TEST_VAR", "fallback"),
+      "default_value");
+
+    // Test neither exists, use fallback
+    unsetenv("TEST_ENV_TEST_VAR");
+    unsetenv("TEST_ENV_TEST_VAR_DEFAULT");
+    EXPECT_EQ(
+      test_env::getenv_default("TEST_ENV_TEST_VAR", "fallback"), "fallback");
+
+    // Test with empty fallback
+    EXPECT_EQ(test_env::getenv_default("TEST_ENV_TEST_VAR"), "");
+}
+
+TEST_F(test_env_test, getenv_default_priority) {
+    // Test that primary variable takes precedence
+    setenv("TEST_ENV_TEST_VAR", "primary_value", 1);
+    setenv("TEST_ENV_TEST_VAR_DEFAULT", "default_value", 1);
+    EXPECT_EQ(
+      test_env::getenv_default("TEST_ENV_TEST_VAR", "fallback"),
+      "primary_value");
+}
+
+TEST_F(test_env_test, GetenvDefaultEmptyValues) {
+    // Test with empty primary variable
+    setenv("TEST_ENV_TEST_VAR", "", 1);
+    setenv("TEST_ENV_TEST_VAR_DEFAULT", "default_value", 1);
+    EXPECT_EQ(test_env::getenv_default("TEST_ENV_TEST_VAR", "fallback"), "");
+
+    // Test with empty default variable
+    unsetenv("TEST_ENV_TEST_VAR");
+    setenv("TEST_ENV_TEST_VAR_DEFAULT", "", 1);
+    EXPECT_EQ(test_env::getenv_default("TEST_ENV_TEST_VAR", "fallback"), "");
+}


### PR DESCRIPTION
This is stuff to help diagnose RNG issues in test, something we needed anyway but really the direct the result of looking at the partition allocator sim failure.

This pull request introduces improvements to the random number generator (`rng`) infrastructure and enhances test utilities, particularly around environment variable handling and test reproducibility. The changes add new introspection and debugging capabilities for the global RNG, provide more robust and flexible environment variable utilities, and introduce comprehensive unit tests for these utilities.

**Enhancements to RNG Infrastructure and Debugging:**

* Added a `format_to` method to the `rng` class for detailed introspection of its internal state, and a `global_state_string` function to log the state and usage statistics of the global RNG instance. This supports improved debugging and reproducibility in tests. [[1]](diffhunk://#diff-7b73e2bd7b2ccccd23a41dace46ae3079af2b17e7566725d56d121e1824c4f39R173-R176) [[2]](diffhunk://#diff-384e56051a4b9075d3edf697e1c053f566cb4c5d8be697ffcb6f2c68bbdec44bR109-R159)
* Refactored the global RNG state to track access counts and reseeding events, enabling better tracking of RNG usage across tests.
* Introduced performance tests for RNG seeding in `absl_map_bench.cc`.

**Test Utilities and Environment Variable Handling:**

* Added `getenv` and `getenv_default` functions to `test_env`, allowing tests to retrieve environment variables with fallback and default logic, improving test configuration flexibility and integration with Bazel. [[1]](diffhunk://#diff-eeb4bea5affef0ca5ebe20dbfb92ea9654d51ab99cdb3c9082c23bad327b3345R29-R42) [[2]](diffhunk://#diff-f702e8ce69a54c58601dee411929023d587991b56a777c07d49bd761640c5afdR41-R63)
* Updated test utilities to use these environment helpers and to optionally log RNG state before and after each test case when `REDPANDA_DEBUG_TEST_HOOKS` is set, aiding in debugging test flakiness. [[1]](diffhunk://#diff-16d308a282e90fe4a9745c712a5f99cd5ce44ec43afdd89a6803d6a79d17475fR12-R58) [[2]](diffhunk://#diff-4106679433b5d101d4b23c27cb489620982aae9b202ef3325963764233a63cdfR23-R27)

**Testing Improvements:**

* Added a new test target and comprehensive unit tests for `test_env` functions, ensuring correctness and robustness of temporary directory generation and environment variable handling. [[1]](diffhunk://#diff-826f6f280b294d551b55ec9fd7178b365275d639bf50b3ab3e2ab1cb3eac5558R55-R67) [[2]](diffhunk://#diff-0a85ca30a7d3182a66cb5e62f6904451d55962fe7ebf4a6da961f9598b309ce0R1-R171)
* Updated Bazel build files to include new dependencies and tests. [[1]](diffhunk://#diff-9635d6ee45bda33c3af409bad8c81c9619696d3c99840ac483ae43cae3d05131R277-R279) [[2]](diffhunk://#diff-200fc98ffb7a099706b017a20621b225cb3c254cdb41b4b0b0e263277187b944R16)

**Other Minor Updates:**

* Included necessary header and dependency updates to support new features and tests. [[1]](diffhunk://#diff-7b73e2bd7b2ccccd23a41dace46ae3079af2b17e7566725d56d121e1824c4f39R15) [[2]](diffhunk://#diff-384e56051a4b9075d3edf697e1c053f566cb4c5d8be697ffcb6f2c68bbdec44bR20)

These changes collectively improve test reproducibility, debugging, and configuration flexibility for developers working with the codebase.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
