### PR TITLE
tuner: Add support for RX/TX queue lowering on GCP

### DIFF
--- a/src/go/rpk/pkg/config/redpanda_yaml.go
+++ b/src/go/rpk/pkg/config/redpanda_yaml.go
@@ -178,8 +178,8 @@ type (
 		CoresPerDedicatedInterruptCore *int `yaml:"cores_per_dedicated_interrupt_core,omitempty" json:"cores_per_dedicated_interrupt_core"`
 		// Use GetAllowDedicatedInterruptMode to read
 		AllowDedicatedInterruptMode *bool `yaml:"allow_dedicated_interrupt_mode,omitempty" json:"allow_dedicated_interrupt_mode"`
-		// Use GetAllowRxQueueTuner to read
-		AllowRxQueueTuner *bool `yaml:"allow_rx_queue_tuner,omitempty" json:"allow_rx_queue_tuner"`
+		// Use GetAllowRxTxQueueTuner to read
+		AllowRxTxQueueTuner *bool `yaml:"allow_rx_tx_queue_tuner,omitempty" json:"allow_rx_tx_queue_tuner"`
 	}
 
 	RpkKafkaAPI struct {
@@ -219,9 +219,9 @@ func (t *RpkNodeTuners) GetAllowDedicatedInterruptMode() bool {
 	return false
 }
 
-func (t *RpkNodeTuners) GetAllowRxQueueTuner() bool {
-	if t.AllowRxQueueTuner != nil {
-		return *t.AllowRxQueueTuner
+func (t *RpkNodeTuners) GetAllowRxTxQueueTuner() bool {
+	if t.AllowRxTxQueueTuner != nil {
+		return *t.AllowRxTxQueueTuner
 	}
 	return true
 }

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -437,7 +437,7 @@ func (rpkc *RpkNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		SMP                            *weakInt             `yaml:"smp"`
 		CoresPerDedicatedInterruptCore *weakInt             `yaml:"cores_per_dedicated_interrupt_core"`
 		AllowDedicatedInterruptMode    *weakBool            `yaml:"allow_dedicated_interrupt_mode"`
-		AllowRxQueueTuner              *weakBool            `yaml:"allow_rx_queue_tuner"`
+		AllowRxTxQueueTuner            *weakBool            `yaml:"allow_rx_tx_queue_tuner"`
 	}
 	if err := n.Decode(&internal); err != nil {
 		return err
@@ -485,7 +485,7 @@ func (rpkc *RpkNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	}
 	rpkc.Tuners.CoresPerDedicatedInterruptCore = (*int)(internal.CoresPerDedicatedInterruptCore)
 	rpkc.Tuners.AllowDedicatedInterruptMode = (*bool)(internal.AllowDedicatedInterruptMode)
-	rpkc.Tuners.AllowRxQueueTuner = (*bool)(internal.AllowRxQueueTuner)
+	rpkc.Tuners.AllowRxTxQueueTuner = (*bool)(internal.AllowRxTxQueueTuner)
 	return nil
 }
 

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -26,8 +26,8 @@ import (
 )
 
 type NetCheckersFactory interface {
-	NewNicRxQueueCountCheckers(interfaces []string, mode irq.Mode, cpuMask string) []Checker
-	NewNicRxQueueCountChecker(nic network.Nic, mode irq.Mode, cpuMask string) Checker
+	NewNicRxTxQueueCountCheckers(interfaces []string, mode irq.Mode, cpuMask string) []Checker
+	NewNicRxTxQueueCountChecker(nic network.Nic, mode irq.Mode, cpuMask string) Checker
 	NewNicIRQAffinityStaticChecker(interfaces []string) Checker
 	NewNicIRQAffinityCheckers(interfaces []string, mode irq.Mode, mask string) []Checker
 	NewNicIRQAffinityChecker(nic network.Nic, mode irq.Mode, mask string) Checker
@@ -96,26 +96,26 @@ func (f *netCheckersFactory) DedicatedMaskForComputations(interfaces []string) s
 	return mask
 }
 
-func (f *netCheckersFactory) NewNicRxQueueCountChecker(
+func (f *netCheckersFactory) NewNicRxTxQueueCountChecker(
 	nic network.Nic, mode irq.Mode, cpuMask string,
 ) Checker {
 	return NewEqualityChecker(
-		NicRxQueueCountChecker,
-		fmt.Sprintf("NIC %s RX queue count set", nic.Name()),
+		NicRxTxQueueCountChecker,
+		fmt.Sprintf("NIC %s RX/TX queue count set", nic.Name()),
 		Warning,
 		true,
 		func() (interface{}, error) {
-			if !f.t.GetAllowRxQueueTuner() {
-				zap.L().Sugar().Debugf("Skipping RxQueue Tuner as it's disabled by configuration")
+			if !f.t.GetAllowRxTxQueueTuner() {
+				zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as it's disabled by configuration")
 				return true, nil
 			}
 
-			supportsIrqLowering, err := nic.SupportsRxQueueLowering()
+			supportsIrqLowering, err := nic.SupportsRxTxQueueLowering()
 			if err != nil {
 				return false, err
 			}
 			if !supportsIrqLowering {
-				zap.L().Sugar().Debugf("Skipping RxQueue Tuner as using an unknown driver")
+				zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as using an unknown driver")
 				return true, nil
 			}
 
@@ -134,12 +134,12 @@ func (f *netCheckersFactory) NewNicRxQueueCountChecker(
 	)
 }
 
-func (f *netCheckersFactory) NewNicRxQueueCountCheckers(
+func (f *netCheckersFactory) NewNicRxTxQueueCountCheckers(
 	interfaces []string, mode irq.Mode, cpuMask string,
 ) []Checker {
 	return f.forNonVirtualInterfaces(interfaces,
 		func(nic network.Nic) Checker {
-			return f.NewNicRxQueueCountChecker(nic, mode, cpuMask)
+			return f.NewNicRxTxQueueCountChecker(nic, mode, cpuMask)
 		})
 }
 

--- a/src/go/rpk/pkg/tuners/net_checkers.go
+++ b/src/go/rpk/pkg/tuners/net_checkers.go
@@ -125,10 +125,11 @@ func (f *netCheckersFactory) NewNicRxQueueCountChecker(
 			}
 
 			rxCheck := currentChannels.RxCount == targetChannels.RxCount
+			txCheck := currentChannels.TxCount == targetChannels.TxCount
 			combinedCheck := currentChannels.CombinedCount == targetChannels.CombinedCount
 
-			// We need both to be true because for the not in use one the check will always be true (0 == 0)
-			return rxCheck && combinedCheck, nil
+			// We need all to be true because for the not in use one the check will always be true (0 == 0)
+			return rxCheck && txCheck && combinedCheck, nil
 		},
 	)
 }

--- a/src/go/rpk/pkg/tuners/net_tuners.go
+++ b/src/go/rpk/pkg/tuners/net_tuners.go
@@ -41,8 +41,8 @@ func NewNetTuner(
 		fs, t, irqProcFile, irqDeviceInfo, ethtool, irqBalanceService, cpuMasks, executor)
 	return NewAggregatedTunable(
 		[]Tunable{
-			// RX queue count tuner should always be first in order as others will re-read queue counts
-			factory.NewRxQueueCountTuner(interfaces, mode, cpuMask),
+			// RX/TX queue count tuner should always be first in order as others will re-read queue counts
+			factory.NewRxTxQueueCountTuner(interfaces, mode, cpuMask),
 			factory.NewNICsBalanceServiceTuner(interfaces),
 			factory.NewNICsIRQsAffinityTuner(interfaces, mode, cpuMask),
 			factory.NewNICsRpsTuner(interfaces, mode, cpuMask),
@@ -56,7 +56,7 @@ func NewNetTuner(
 }
 
 type NetTunersFactory interface {
-	NewRxQueueCountTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
+	NewRxTxQueueCountTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
 	NewNICsBalanceServiceTuner(interfaces []string) Tunable
 	NewNICsIRQsAffinityTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
 	NewNICsRpsTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable
@@ -104,24 +104,24 @@ func NewNetTunersFactory(
 	}
 }
 
-func (f *netTunersFactory) NewRxQueueCountTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
+func (f *netTunersFactory) NewRxTxQueueCountTuner(interfaces []string, mode irq.Mode, cpuMask string) Tunable {
 	return f.tuneNonVirtualInterfaces(
 		interfaces,
 		func(nic network.Nic) Checker {
-			return f.checkersFactory.NewNicRxQueueCountChecker(nic, mode, cpuMask)
+			return f.checkersFactory.NewNicRxTxQueueCountChecker(nic, mode, cpuMask)
 		},
 		func(nic network.Nic) TuneResult {
-			if !f.t.GetAllowRxQueueTuner() {
-				zap.L().Sugar().Debugf("Skipping RxQueue Tuner as it's disabled by configuration")
+			if !f.t.GetAllowRxTxQueueTuner() {
+				zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as it's disabled by configuration")
 				return NewTuneResult(false)
 			}
 
-			supportsIrqLowering, err := nic.SupportsRxQueueLowering()
+			supportsIrqLowering, err := nic.SupportsRxTxQueueLowering()
 			if err != nil {
 				return NewTuneError(err)
 			}
 			if !supportsIrqLowering {
-				zap.L().Sugar().Debugf("Skipping RxQueue Tuner as using an unknown driver")
+				zap.L().Sugar().Debugf("Skipping RX/TX Queue Tuner as using an unknown driver")
 				return NewTuneResult(false)
 			}
 

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -154,6 +154,7 @@ type driverSupport struct {
 
 var supportedDrivers = []driverSupport{
 	{"ena", func() func(IrqInfo) int { return intelIrqToQueueIdx }},
+	{"virtio", func() func(IrqInfo) int { return virtioIrqToQueueIdx }},
 }
 
 func getQueueIndexFunc(driverName string) func(IrqInfo) int {
@@ -199,7 +200,7 @@ func (n *nic) GetIRQs() ([]IrqInfo, error) {
 		return nil, err
 	}
 
-	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|-Tx-Rx-|mlx\d+-\d+@`)
+	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|-Tx-Rx-|mlx\d+-\d+@`)
 	var fastPathIRQNums []int
 	for _, irq := range IRQNums {
 		if fastPathIRQsPattern.MatchString(procFileLines[irq]) {
@@ -240,6 +241,17 @@ func intelIrqToQueueIdx(irq IrqInfo) int {
 
 	if len(intelFastPathMatch) > 0 && len(fdirPatternMatch) == 0 {
 		idx, _ := strconv.Atoi(intelFastPathMatch[1])
+		return idx
+	}
+	return MaxInt
+}
+
+func virtioIrqToQueueIdx(irq IrqInfo) int {
+	virtioFastPathIrqPattern := regexp.MustCompile(`virtio\d+-(input|output)\.(\d+)$`)
+
+	virtioMatch := virtioFastPathIrqPattern.FindStringSubmatch(irq.ProcLine)
+	if len(virtioMatch) == 3 {
+		idx, _ := strconv.Atoi(virtioMatch[2])
 		return idx
 	}
 	return MaxInt

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -149,18 +149,21 @@ func (n *nic) IsHwInterface() bool {
 
 type driverSupport struct {
 	name           string
-	indexFuncMaker func() func(IrqInfo) int
+	indexFuncMaker func(numIRQs int) func(IrqInfo) int
 }
 
 var supportedDrivers = []driverSupport{
-	{"ena", func() func(IrqInfo) int { return intelIrqToQueueIdx }},
-	{"virtio", func() func(IrqInfo) int { return virtioIrqToQueueIdx }},
+	{"ena", func(_ int) func(IrqInfo) int { return intelIrqToQueueIdx }},
+	{"virtio", func(_ int) func(IrqInfo) int { return virtioIrqToQueueIdx }},
+	{"gve", func(numIRQs int) func(IrqInfo) int {
+		return func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, numIRQs) }
+	}},
 }
 
-func getQueueIndexFunc(driverName string) func(IrqInfo) int {
+func getQueueIndexFunc(driverName string, numIRQs int) func(IrqInfo) int {
 	for _, driver := range supportedDrivers {
 		if strings.HasPrefix(driverName, driver.name) {
-			return driver.indexFuncMaker()
+			return driver.indexFuncMaker(numIRQs)
 		}
 	}
 
@@ -200,7 +203,7 @@ func (n *nic) GetIRQs() ([]IrqInfo, error) {
 		return nil, err
 	}
 
-	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|-Tx-Rx-|mlx\d+-\d+@`)
+	fastPathIRQsPattern := regexp.MustCompile(`-TxRx-|-fp-|virtio\d+-(input|output)|ntfy-block|gve-ntfy-blk|-Tx-Rx-|mlx\d+-\d+@`)
 	var fastPathIRQNums []int
 	for _, irq := range IRQNums {
 		if fastPathIRQsPattern.MatchString(procFileLines[irq]) {
@@ -209,7 +212,7 @@ func (n *nic) GetIRQs() ([]IrqInfo, error) {
 	}
 
 	var fastPathIRQs []IrqInfo
-	fastPathIndexFunc := getQueueIndexFunc(driverName)
+	fastPathIndexFunc := getQueueIndexFunc(driverName, len(fastPathIRQNums))
 	for _, irq := range fastPathIRQNums {
 		fastPathIRQs = append(fastPathIRQs, IrqInfo{Num: irq, ProcLine: procFileLines[irq], indexFunc: fastPathIndexFunc})
 	}
@@ -225,7 +228,7 @@ func (n *nic) GetIRQs() ([]IrqInfo, error) {
 	}
 
 	var IRQs []IrqInfo
-	indexFunc := getQueueIndexFunc(driverName)
+	indexFunc := getQueueIndexFunc(driverName, len(IRQNums))
 	for _, irq := range IRQNums {
 		IRQs = append(IRQs, IrqInfo{Num: irq, ProcLine: procFileLines[irq], indexFunc: indexFunc})
 	}
@@ -253,6 +256,26 @@ func virtioIrqToQueueIdx(irq IrqInfo) int {
 	if len(virtioMatch) == 3 {
 		idx, _ := strconv.Atoi(virtioMatch[2])
 		return idx
+	}
+	return MaxInt
+}
+
+func gvnicIrqToQueueIdx(irq IrqInfo, numIRQs int) int {
+	// legacy pattern: eth%d-ntfy-block.30
+	// New pattern: gve-ntfy-blk30@pci:0000:00:08.0
+	newPattern := regexp.MustCompile(`gve-ntfy-blk(\d+)`)
+
+	virtioMatch := newPattern.FindStringSubmatch(irq.ProcLine)
+	if len(virtioMatch) == 0 {
+		// try the legacy pattern
+		legacyPattern := regexp.MustCompile(`ntfy-block\.(\d+)$`)
+		virtioMatch = legacyPattern.FindStringSubmatch(irq.ProcLine)
+	}
+	if len(virtioMatch) == 2 {
+		idx, _ := strconv.Atoi(virtioMatch[1])
+		// https://github.com/torvalds/linux/blob/v6.17/drivers/net/ethernet/google/gve/gve.h#L1082-L1094
+		// TX is the lower half, RX the upper half of the IRQs
+		return idx % (numIRQs / 2)
 	}
 	return MaxInt
 }

--- a/src/go/rpk/pkg/tuners/network/nic.go
+++ b/src/go/rpk/pkg/tuners/network/nic.go
@@ -73,7 +73,7 @@ type Nic interface {
 	GetNTupleStatus() (NTupleStatus, error)
 	// Do we support lowering RX queues
 	// Mostly returns false when driver is unknown
-	SupportsRxQueueLowering() (bool, error)
+	SupportsRxTxQueueLowering() (bool, error)
 	Name() string
 }
 
@@ -171,7 +171,7 @@ func getQueueIndexFunc(driverName string, numIRQs int) func(IrqInfo) int {
 	return intelIrqToQueueIdx
 }
 
-func (n *nic) SupportsRxQueueLowering() (bool, error) {
+func (n *nic) SupportsRxTxQueueLowering() (bool, error) {
 	driverName, err := n.ethtool.DriverName(n.name)
 	if err != nil {
 		return false, err

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -269,6 +269,66 @@ func Test_nic_GetIRQs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "gvnic legacy",
+			driverName: "gve",
+			irqProcFile: &procFileMock{
+				getIRQProcFileLinesMap: func() (map[int]string, error) {
+					return map[int]string{
+						26: "26:        134          0   ITS-MSI   0 Edge      eth%d-ntfy-block.0",
+						27: "27:          0        201   ITS-MSI   1 Edge      eth%d-ntfy-block.1",
+						58: "58:          0          0   ITS-MSI  32 Edge      eth%d-mgmnt",
+					}, nil
+				},
+			},
+			irqDeviceInfo: &deviceInfoMock{
+				getIRQs: func(string, string) ([]int, error) {
+					return []int{26, 27, 58}, nil
+				},
+			},
+			want: []IrqInfoRes{
+				{
+					Num:        26,
+					ProcLine:   "26:        134          0   ITS-MSI   0 Edge      eth%d-ntfy-block.0",
+					QueueIndex: 0,
+				},
+				{
+					Num:        27,
+					ProcLine:   "27:          0        201   ITS-MSI   1 Edge      eth%d-ntfy-block.1",
+					QueueIndex: 0,
+				},
+			},
+		},
+		{
+			name:       "gvnic",
+			driverName: "gve",
+			irqProcFile: &procFileMock{
+				getIRQProcFileLinesMap: func() (map[int]string, error) {
+					return map[int]string{
+						168: "168:          0          0 PCI-MSIX-0000:00:08.0  30-edge      gve-ntfy-blk0@pci:0000:00:08.0",
+						169: "169:          0          0 PCI-MSIX-0000:00:08.0  31-edge      gve-ntfy-blk1@pci:0000:00:08.0",
+						170: "170:          0          0 PCI-MSIX-0000:00:08.0  32-edge      gve-mgmnt@pci:0000:00:08.0",
+					}, nil
+				},
+			},
+			irqDeviceInfo: &deviceInfoMock{
+				getIRQs: func(string, string) ([]int, error) {
+					return []int{168, 169, 170}, nil
+				},
+			},
+			want: []IrqInfoRes{
+				{
+					Num:        168,
+					ProcLine:   "168:          0          0 PCI-MSIX-0000:00:08.0  30-edge      gve-ntfy-blk0@pci:0000:00:08.0",
+					QueueIndex: 0,
+				},
+				{
+					Num:        169,
+					ProcLine:   "169:          0          0 PCI-MSIX-0000:00:08.0  31-edge      gve-ntfy-blk1@pci:0000:00:08.0",
+					QueueIndex: 0,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -512,6 +572,54 @@ func Test_virtioIrqToQueueIdx(t *testing.T) {
 			Num:       27,
 			ProcLine:  "27:          0         68   PCI-MSI 65539-edge      virtio1-config",
 			indexFunc: virtioIrqToQueueIdx,
+		}
+		require.Equal(t, math.MaxInt64, irq.QueueIndex())
+	}
+}
+
+func Test_gvnicIrqToQueueIdx(t *testing.T) {
+	{
+		irq := IrqInfo{
+			Num:       26,
+			ProcLine:  "26:        134          0   ITS-MSI   0 Edge      eth%d-ntfy-block.1",
+			indexFunc: func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, 4) },
+		}
+		require.Equal(t, 1, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       26,
+			ProcLine:  "26:        134          0   ITS-MSI   0 Edge      eth%d-ntfy-block.18",
+			indexFunc: func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, 16) },
+		}
+		require.Equal(t, 2, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       26,
+			ProcLine:  "26:        134          0   ITS-MSI   0 Edge      gve-ntfy-blk1@pci:0000:00:08.0",
+			indexFunc: func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, 4) },
+		}
+		require.Equal(t, 1, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       26,
+			ProcLine:  "26:        134          0   ITS-MSI   0 Edge      gve-ntfy-blk18@pci:0000:00:08.0",
+			indexFunc: func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, 16) },
+		}
+		require.Equal(t, 2, irq.QueueIndex())
+	}
+
+	{
+
+		irq := IrqInfo{
+			Num:       26,
+			ProcLine:  "26:        134          0   ITS-MSI   0 Edge      eth%d-mgmnt",
+			indexFunc: func(irq IrqInfo) int { return gvnicIrqToQueueIdx(irq, 4) },
 		}
 		require.Equal(t, math.MaxInt64, irq.QueueIndex())
 	}

--- a/src/go/rpk/pkg/tuners/network/nic_test.go
+++ b/src/go/rpk/pkg/tuners/network/nic_test.go
@@ -115,6 +115,7 @@ func Test_nic_GetIRQs(t *testing.T) {
 		ethtool       ethtool.EthtoolWrapper
 		nicName       string
 		want          []IrqInfoRes
+		driverName    string
 	}{
 		{
 			name: "Shall return all device IRQs when there are not fast paths",
@@ -238,14 +239,45 @@ func Test_nic_GetIRQs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "virtio",
+			driverName: "virtio",
+			irqProcFile: &procFileMock{
+				getIRQProcFileLinesMap: func() (map[int]string, error) {
+					return map[int]string{
+						24: "24:          0          0   PCI-MSI 65536-edge      virtio1-config",
+						25: "25:        135          0   PCI-MSI 65537-edge      virtio1-input.2",
+						26: "26:        221          0   PCI-MSI 65538-edge      virtio1-output.2",
+					}, nil
+				},
+			},
+			irqDeviceInfo: &deviceInfoMock{
+				getIRQs: func(string, string) ([]int, error) {
+					return []int{24, 25, 26}, nil
+				},
+			},
+			want: []IrqInfoRes{
+				{
+					Num:        25,
+					ProcLine:   "25:        135          0   PCI-MSI 65537-edge      virtio1-input.2",
+					QueueIndex: 2,
+				},
+				{
+					Num:        26,
+					ProcLine:   "26:        221          0   PCI-MSI 65538-edge      virtio1-output.2",
+					QueueIndex: 2,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			drivernameFunc := func(string) (string, error) { return tt.driverName, nil }
 			n := &nic{
 				fs:            afero.NewMemMapFs(),
 				irqProcFile:   tt.irqProcFile,
 				irqDeviceInfo: tt.irqDeviceInfo,
-				ethtool:       &ethtoolMock{},
+				ethtool:       &ethtoolMock{driverName: drivernameFunc},
 				name:          "test0",
 			}
 			got, err := n.GetIRQs()
@@ -444,5 +476,43 @@ func Test_nic_GetNTupleStatus(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func Test_intelIrqToQueueIdx(t *testing.T) {
+	irq := IrqInfo{
+		Num:       92,
+		ProcLine:  "92:      79079          0          0          0   PCI-MSI 1572865-edge      eth0-TxRx-3",
+		indexFunc: intelIrqToQueueIdx,
+	}
+	require.Equal(t, 3, irq.QueueIndex())
+}
+
+func Test_virtioIrqToQueueIdx(t *testing.T) {
+	{
+		irq := IrqInfo{
+			Num:       27,
+			ProcLine:  "27:          0         68   PCI-MSI 65539-edge      virtio8-input.1",
+			indexFunc: virtioIrqToQueueIdx,
+		}
+		require.Equal(t, 1, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       27,
+			ProcLine:  "27:          0         68   PCI-MSI 65539-edge      virtio77-output.18",
+			indexFunc: virtioIrqToQueueIdx,
+		}
+		require.Equal(t, 18, irq.QueueIndex())
+	}
+
+	{
+		irq := IrqInfo{
+			Num:       27,
+			ProcLine:  "27:          0         68   PCI-MSI 65539-edge      virtio1-config",
+			indexFunc: virtioIrqToQueueIdx,
+		}
+		require.Equal(t, math.MaxInt64, irq.QueueIndex())
 	}
 }

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -148,7 +148,7 @@ func GetHwInterfaceIRQsDistribution(
 		return nil, err
 	}
 
-	supportsIrqLowering, err := nic.SupportsRxQueueLowering()
+	supportsIrqLowering, err := nic.SupportsRxTxQueueLowering()
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -299,6 +299,7 @@ func GetCurrentAndTargetChannels(
 
 	targetChannels = currentChannels
 	targetChannels.RxCount = min(currentChannels.MaxRx, uint32(puCount))
+	targetChannels.TxCount = min(currentChannels.MaxTx, uint32(puCount))
 	targetChannels.CombinedCount = min(currentChannels.MaxCombined, uint32(puCount))
 
 	zap.L().Sugar().Debugf("Got current channels for '%s': %+v, target channels: %+v", nic.Name(), currentChannels, targetChannels)

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -232,13 +232,15 @@ func GetHwInterfaceIRQsDistribution(
 	// Find the cut off for live IRQs
 	irqCutOffIndex := getIrqCutOffIndex(allIRQs, rxQueues)
 
-	fmt.Printf("Distributing '%s' IRQs handling Rx queues\n", nic.Name())
+	zap.L().Sugar().Debugf("Cut-off-index: %d, sorted irq list: %v", irqCutOffIndex, IrqInfosToIDs(allIRQs))
+
+	zap.L().Sugar().Debugf("Distributing '%s' IRQs handling Rx/Tx queues", nic.Name())
 	IRQsDistribution, err := cpuMasks.GetIRQsDistributionMasks(
 		IrqInfosToIDs(allIRQs[0:irqCutOffIndex]), irqCPUMask)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("Distributing rest of '%s' IRQs\n", nic.Name())
+	zap.L().Sugar().Debugf("Distributing rest of '%s' IRQs\n", nic.Name())
 	restIRQsDistribution, err := cpuMasks.GetIRQsDistributionMasks(
 		IrqInfosToIDs(allIRQs[irqCutOffIndex:]), irqCPUMask)
 	if err != nil {

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -49,7 +49,7 @@ const (
 	DiskIRQsAffinityStaticChecker
 	DiskIRQsAffinityChecker
 	FstrimChecker
-	NicRxQueueCountChecker
+	NicRxTxQueueCountChecker
 	NicIRQsAffinitChecker
 	NicIRQsAffinitStaticChecker
 	NicRfsChecker
@@ -251,7 +251,7 @@ func RedpandaCheckers(
 		SynBacklogChecker:             {netCheckersFactory.NewSynBacklogChecker()},
 		ListenBacklogChecker:          {netCheckersFactory.NewListenBacklogChecker()},
 		RfsTableEntriesChecker:        {netCheckersFactory.NewRfsTableSizeChecker()},
-		NicRxQueueCountChecker:        netCheckersFactory.NewNicRxQueueCountCheckers(interfaces, irq.Default, "all"),
+		NicRxTxQueueCountChecker:      netCheckersFactory.NewNicRxTxQueueCountCheckers(interfaces, irq.Default, "all"),
 		NicIRQsAffinitStaticChecker:   {netCheckersFactory.NewNicIRQAffinityStaticChecker(interfaces)},
 		NicIRQsAffinitChecker:         netCheckersFactory.NewNicIRQAffinityCheckers(interfaces, irq.Default, "all"),
 		NicRpsChecker:                 netCheckersFactory.NewNicRpsSetCheckers(interfaces, irq.Default, "all"),


### PR DESCRIPTION
Adds support for RX/TX queue lowering on GCP for both virtio and gvnic.

As part of that we also make the RX queue lowering tuner lower TX queues (and rename everything accordingly).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
