### PR TITLE
tuner: Add flag to disable RPS & RFS

### DIFF
--- a/src/go/rpk/pkg/config/redpanda_yaml.go
+++ b/src/go/rpk/pkg/config/redpanda_yaml.go
@@ -174,6 +174,8 @@ type (
 		BallastFilePath          string `yaml:"ballast_file_path,omitempty" json:"ballast_file_path"`
 		BallastFileSize          string `yaml:"ballast_file_size,omitempty" json:"ballast_file_size"`
 		WellKnownIo              string `yaml:"well_known_io,omitempty" json:"well_known_io"`
+		// Use GetAllowRpsRfsTuner to read
+		AllowRpsRfsTuner *bool `yaml:"allow_rps_rfs_tuner,omitempty" json:"allow_rps_rfs_tuner"`
 		// Use GetCoresPerDedicatedInterruptCore to read
 		CoresPerDedicatedInterruptCore *int `yaml:"cores_per_dedicated_interrupt_core,omitempty" json:"cores_per_dedicated_interrupt_core"`
 		// Use GetAllowDedicatedInterruptMode to read
@@ -222,6 +224,13 @@ func (t *RpkNodeTuners) GetAllowDedicatedInterruptMode() bool {
 func (t *RpkNodeTuners) GetAllowRxQueueTuner() bool {
 	if t.AllowRxQueueTuner != nil {
 		return *t.AllowRxQueueTuner
+	}
+	return true
+}
+
+func (t *RpkNodeTuners) GetAllowRpsRfsTuner() bool {
+	if t.AllowRpsRfsTuner != nil {
+		return *t.AllowRpsRfsTuner
 	}
 	return true
 }

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -435,6 +435,7 @@ func (rpkc *RpkNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		WellKnownIo                    weakString           `yaml:"well_known_io"`
 		Overprovisioned                weakBool             `yaml:"overprovisioned"`
 		SMP                            *weakInt             `yaml:"smp"`
+		AllowRpsRfsTuner               *weakBool            `yaml:"allow_rps_rfs_tuner"`
 		CoresPerDedicatedInterruptCore *weakInt             `yaml:"cores_per_dedicated_interrupt_core"`
 		AllowDedicatedInterruptMode    *weakBool            `yaml:"allow_dedicated_interrupt_mode"`
 		AllowRxQueueTuner              *weakBool            `yaml:"allow_rx_queue_tuner"`
@@ -480,6 +481,7 @@ func (rpkc *RpkNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	rpkc.Tuners.BallastFilePath = string(internal.BallastFilePath)
 	rpkc.Tuners.BallastFileSize = string(internal.BallastFileSize)
 	rpkc.Tuners.WellKnownIo = string(internal.WellKnownIo)
+	rpkc.Tuners.AllowRpsRfsTuner = (*bool)(internal.AllowRpsRfsTuner)
 	if internal.CoresPerDedicatedInterruptCore != nil && *internal.CoresPerDedicatedInterruptCore <= 1 {
 		return errors.New("cores_per_dedicated_interrupt_core must be greater than 1")
 	}

--- a/src/go/rpk/pkg/tuners/network/nics.go
+++ b/src/go/rpk/pkg/tuners/network/nics.go
@@ -83,6 +83,10 @@ func getEffectiveMode(mode irq.Mode, nic Nic, effectiveCPUMask string, cpuMasks 
 func GetRpsCPUMask(
 	nic Nic, mode irq.Mode, cpuMask string, cpuMasks irq.CPUMasks, t config.RpkNodeTuners,
 ) (string, error) {
+	if !t.GetAllowRpsRfsTuner() {
+		return "0x0", nil
+	}
+
 	effectiveCPUMask, err := cpuMasks.BaseCPUMask(cpuMask)
 	if err != nil {
 		return "", err
@@ -354,6 +358,9 @@ func OneRPSQueueLimit(limits []string, nic Nic, mode irq.Mode, cpuMask string, c
 
 	// In MQ mode, with at least one hardware RX queue per core just disable RFS as it adds no benefit.
 	if queueCount >= int(puCount) && effectiveMode == irq.Mq {
+		return 0, nil
+	}
+	if !t.GetAllowRpsRfsTuner() {
 		return 0, nil
 	}
 	return RfsTableSize / len(limits), nil

--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -192,6 +192,26 @@ class NetTunerTest(RedpandaTest):
         self._test_interrupt_config(self.node, self.rpk, expected_interrupt_setup)
 
     @cluster(num_nodes=1)
+    def test_tune_net_dedicated_1_core_no_rps_rfs(self):
+        self.rpk.config_set("rpk.cores_per_dedicated_interrupt_core", "4")
+        self.rpk.config_set("rpk.allow_dedicated_interrupt_mode", "true")
+        self.rpk.config_set("rpk.allow_rps_rfs_tuner", "false")
+
+        self.rpk.tune("net")
+
+        self.start_rp()
+
+        expected_interrupt_setup = self.ExpectedInterruptSetup(
+            interrupts_masks=["8"],
+            redpanda_cores={0, 1, 2},
+            rps_cpu_mask="0",
+            rps_cpu_flow_count=0,
+            rfs_table_size=self.TARGET_RFS_TABLE_SIZE,
+        )
+
+        self._test_interrupt_config(self.node, self.rpk, expected_interrupt_setup)
+
+    @cluster(num_nodes=1)
     def test_tune_net_dedicated_2_cores(self):
         self.rpk.config_set("rpk.cores_per_dedicated_interrupt_core", "2")
         self.rpk.config_set("rpk.allow_dedicated_interrupt_mode", "true")


### PR DESCRIPTION
This allows us to easily test with and without.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

