### PR TITLE
CORE-13357 Client Monitoring: track request stats on connections

### DIFF
--- a/src/v/kafka/server/BUILD
+++ b/src/v/kafka/server/BUILD
@@ -405,6 +405,7 @@ redpanda_cc_library(
         "//src/v/utils:to_string",
         "//src/v/utils:tristate",
         "//src/v/utils:truncating_logger",
+        "//src/v/utils:windowed_sum_tracker",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/container:node_hash_map",

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -835,6 +835,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
 
     auto auth_info = proto::admin::authentication_info{};
     auth_info.set_user_principal(ss::sstring{get_principal().name()});
+    res.set_authentication_info(std::move(auth_info));
 
     // TODO: fill out the response with the remaining fields
 

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -36,6 +36,7 @@
 #include "net/exceptions.h"
 #include "security/authorizer.h"
 #include "security/exceptions.h"
+#include "utils/windowed_sum_tracker.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -406,6 +407,8 @@ ss::future<> connection_context::process_one_request() {
     if (!sz.has_value()) {
         co_return;
     }
+
+    _attributes.request_count.record(1);
 
     if (sz.value() > _max_request_size()) {
         throw net::invalid_request_error(
@@ -836,6 +839,24 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     auto auth_info = proto::admin::authentication_info{};
     auth_info.set_user_principal(ss::sstring{get_principal().name()});
     res.set_authentication_info(std::move(auth_info));
+
+    using tracker_t = connection_attributes::request_state::tracker_t;
+    auto now = tracker_t::clock::now();
+
+    auto make_stats = [this](auto&& get_value) {
+        auto stats = proto::admin::request_statistics{};
+        stats.set_request_count(get_value(_attributes.request_count));
+        stats.set_produce_bytes(get_value(_attributes.produce_bytes));
+        stats.set_produce_batch_count(
+          get_value(_attributes.produce_batch_count));
+        stats.set_fetch_bytes(get_value(_attributes.fetch_bytes));
+        return stats;
+    };
+
+    res.set_recent_request_statistics(make_stats(
+      [now](auto& attr) { return attr.recent_stat.window_total(now); }));
+    res.set_total_request_statistics(
+      make_stats([](auto& attr) { return attr.total_stat; }));
 
     // TODO: fill out the response with the remaining fields
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -30,6 +30,7 @@
 #include "utils/log_hist.h"
 #include "utils/mutex.h"
 #include "utils/named_type.h"
+#include "utils/windowed_sum_tracker.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
@@ -39,6 +40,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/net/socket_defs.hh>
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -141,6 +143,28 @@ struct virtual_connection_id {
     friend std::ostream&
     operator<<(std::ostream& o, const virtual_connection_id& id);
 };
+
+struct connection_attributes {
+    struct request_state {
+        constexpr static auto bucket_count = size_t{4};
+        constexpr static auto window_ns = std::chrono::minutes(1)
+                                          / std::chrono::nanoseconds(1);
+        using tracker_t = windowed_sum_tracker<bucket_count, window_ns>;
+        tracker_t recent_stat{};
+        uint64_t total_stat{0};
+
+        void record(uint64_t val) {
+            total_stat += val;
+            recent_stat.record(val);
+        }
+    };
+
+    request_state request_count;
+    request_state produce_bytes;
+    request_state produce_batch_count;
+    request_state fetch_bytes;
+};
+
 class connection_context final
   : public ss::enable_lw_shared_from_this<connection_context>
   , public boost::intrusive::list_base_hook<> {
@@ -201,6 +225,8 @@ public:
     bool tls_enabled() const { return conn->tls_enabled(); }
 
     proto::admin::kafka_connection to_proto() const;
+
+    connection_attributes& attributes() { return _attributes; }
 
 private:
     template<typename T>
@@ -510,6 +536,8 @@ private:
     /// Used to enforce client quotas and ingress/egress quotas broker-side
     /// if the client does not obey the ThrottleTimeMs in the response
     throttling_state _throttling_state;
+
+    connection_attributes _attributes;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1705,6 +1705,23 @@ bool update_fetch_partition(
 }
 
 ss::future<response_ptr> op_context::send_response() && {
+    /// Account for special internal topic bytes for usage
+    auto internal_topic_bytes = size_t{0};
+    for (const auto& topic : response.data.responses) {
+        const bool bytes_to_exclude = std::find(
+                                        usage_excluded_topics.cbegin(),
+                                        usage_excluded_topics.cend(),
+                                        topic.topic)
+                                      != usage_excluded_topics.cend();
+        if (bytes_to_exclude) {
+            for (const auto& part : topic.partitions) {
+                if (part.records) {
+                    internal_topic_bytes += part.records->size_bytes();
+                }
+            }
+        }
+    }
+
     // Sessionless fetch
     if (session_ctx.is_sessionless()) {
         response.data.session_id = invalid_fetch_session_id;
@@ -1719,23 +1736,7 @@ ss::future<response_ptr> op_context::send_response() && {
     fetch_response final_response;
     final_response.data.error_code = response.data.error_code;
     final_response.data.session_id = response.data.session_id;
-
-    /// Account for special internal topic bytes for usage
-    for (const auto& topic : response.data.responses) {
-        const bool bytes_to_exclude = std::find(
-                                        usage_excluded_topics.cbegin(),
-                                        usage_excluded_topics.cend(),
-                                        topic.topic)
-                                      != usage_excluded_topics.cend();
-        if (bytes_to_exclude) {
-            for (const auto& part : topic.partitions) {
-                if (part.records) {
-                    final_response.internal_topic_bytes
-                      += part.records->size_bytes();
-                }
-            }
-        }
-    }
+    final_response.internal_topic_bytes = internal_topic_bytes;
 
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1705,7 +1705,7 @@ bool update_fetch_partition(
 }
 
 ss::future<response_ptr> op_context::send_response() && {
-    /// Account for special internal topic bytes for usage
+    auto fetched_data_size = uint64_t{0};
     auto internal_topic_bytes = size_t{0};
     for (const auto& topic : response.data.responses) {
         const bool bytes_to_exclude = std::find(
@@ -1713,14 +1713,21 @@ ss::future<response_ptr> op_context::send_response() && {
                                         usage_excluded_topics.cend(),
                                         topic.topic)
                                       != usage_excluded_topics.cend();
-        if (bytes_to_exclude) {
-            for (const auto& part : topic.partitions) {
-                if (part.records) {
-                    internal_topic_bytes += part.records->size_bytes();
+
+        for (const auto& part : topic.partitions) {
+            if (part.records) {
+                auto part_size = part.records->size_bytes();
+                fetched_data_size += part_size;
+
+                /// Account for special internal topic bytes for usage
+                if (bytes_to_exclude) {
+                    internal_topic_bytes += part_size;
                 }
             }
         }
     }
+
+    rctx.connection()->attributes().fetch_bytes.record(fetched_data_size);
 
     // Sessionless fetch
     if (session_ctx.is_sessionless()) {

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -273,6 +273,8 @@ partition_produce_stages produce_topic_partition(
     auto dispatch_f = dispatch->get_future();
     auto m = octx.rctx.probe().auto_produce_measurement();
     octx.rctx.probe().record_batch(batch_size, hdr.attrs.compression());
+    octx.rctx.connection()->attributes().produce_bytes.record(batch_size);
+    octx.rctx.connection()->attributes().produce_batch_count.record(1);
     auto timeout = octx.request.data.timeout_ms;
     if (timeout < 0ms) {
         static constexpr std::chrono::milliseconds max_timeout{

--- a/src/v/utils/BUILD
+++ b/src/v/utils/BUILD
@@ -673,3 +673,14 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "windowed_sum_tracker",
+    hdrs = [
+        "windowed_sum_tracker.h",
+    ],
+    deps = [
+        "//src/v/base",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/tests/BUILD
+++ b/src/v/utils/tests/BUILD
@@ -589,3 +589,16 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "windowed_sum_tracker_test",
+    timeout = "short",
+    srcs = ["windowed_sum_tracker_test.cc"],
+    deps = [
+        "//src/v/base",
+        "//src/v/test_utils:gtest",
+        "//src/v/utils:windowed_sum_tracker",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/utils/tests/windowed_sum_tracker_test.cc
+++ b/src/v/utils/tests/windowed_sum_tracker_test.cc
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "gtest/gtest.h"
+#include "utils/windowed_sum_tracker.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <chrono>
+
+namespace {
+
+using clock = ss::lowres_clock;
+using namespace std::chrono_literals;
+
+TEST(WindowedSumTrackerTests, EmptyTracker) {
+    auto now = clock::now();
+    auto tracker = windowed_sum_tracker<4, 4s / 1ns>(now);
+
+    EXPECT_EQ(tracker.window_total(now), 0);
+
+    // Advancing time without records should remain empty
+    now += std::chrono::seconds(10);
+    EXPECT_EQ(tracker.window_total(now), 0);
+
+    // Even if we call record
+    tracker.record(0, now);
+    EXPECT_EQ(tracker.window_total(now), 0);
+}
+
+TEST(WindowedSumTrackerTests, MinimalBucketCountLifecycle) {
+    auto now = clock::now();
+    auto tracker = windowed_sum_tracker<2, 1s / 1ns>(now);
+
+    // Record and verify immediate availability
+    tracker.record(100, now);
+    EXPECT_EQ(tracker.window_total(now), 100);
+
+    // Multiple records in same bucket accumulate
+    tracker.record(50, now);
+    EXPECT_EQ(tracker.window_total(now), 150);
+
+    // Just before expiry
+    now += std::chrono::milliseconds(999);
+    EXPECT_EQ(tracker.window_total(now), 150);
+
+    // At expiry boundary
+    now += std::chrono::milliseconds(1);
+    EXPECT_EQ(tracker.window_total(now), 150);
+
+    // Half-way through the next bucket, the previous bucket is 50% interpolated
+    now += std::chrono::milliseconds(500);
+    EXPECT_EQ(tracker.window_total(now), 75);
+
+    now += std::chrono::milliseconds(500);
+    EXPECT_EQ(tracker.window_total(now), 0);
+}
+
+TEST(WindowedSumTrackerTests, MultiBucketExpiration) {
+    auto now = clock::now();
+    auto tracker = windowed_sum_tracker<5, 4s / 1ns>(now);
+
+    // Fill a window worth of buckets with different values
+    for (int i = 1; i <= 4; ++i) {
+        tracker.record(i * 10, now);
+        now += std::chrono::seconds(1);
+    }
+
+    // All buckets active (total: 10+20+30+40 = 100)
+    now -= std::chrono::milliseconds(1);
+    EXPECT_EQ(tracker.window_total(now), 100);
+
+    // First bucket 50% expires (total: 10/2+20+30+40 = 95)
+    now += std::chrono::milliseconds(500);
+    EXPECT_EQ(tracker.window_total(now), 95);
+
+    // Advance to expire all buckets
+    now += std::chrono::seconds(4);
+    EXPECT_EQ(tracker.window_total(now), 0);
+}
+
+TEST(WindowedSumTrackerTests, NonExactBucketBoundaries) {
+    auto now = clock::now();
+    auto tracker = windowed_sum_tracker<3, 3s / 1ns>(now);
+
+    tracker.record(10, now);
+    now += std::chrono::milliseconds(800); // Still in first bucket
+    tracker.record(20, now);
+    EXPECT_EQ(tracker.window_total(now), 30);
+
+    now += std::chrono::milliseconds(300); // Cross to second bucket
+    tracker.record(40, now);
+    EXPECT_EQ(tracker.window_total(now), 70);
+}
+
+TEST(WindowedSumTrackerTests, MultiBucketJump) {
+    auto now = clock::now();
+    auto tracker = windowed_sum_tracker<5, 4s / 1ns>(now);
+
+    tracker.record(100, now);
+    EXPECT_EQ(tracker.window_total(now), 100);
+
+    // Jump 2 buckets worth
+    now += std::chrono::seconds(2);
+    EXPECT_EQ(tracker.window_total(now), 100);
+}
+
+TEST(WindowedSumTrackerTests, LargeTimeJumpClearsWindow) {
+    auto now = clock::now();
+    auto tracker = windowed_sum_tracker<5, 4s / 1ns>(now);
+
+    tracker.record(100, now);
+    EXPECT_EQ(tracker.window_total(now), 100);
+
+    // Jump well beyond window duration and the window sum should be 0
+    now += std::chrono::seconds(20);
+    EXPECT_EQ(tracker.window_total(now), 0);
+
+    // Check that calling record with 0 doesn't change this
+    tracker.record(0, now);
+    EXPECT_EQ(tracker.window_total(now), 0);
+}
+
+TEST(WindowedSumTrackerTests, MinimalJumpToClearWindow) {
+    constexpr auto window = 60s;
+    constexpr auto bucket_count = 4;
+    constexpr auto bucket_size = 20s;
+
+    auto now = clock::now();
+
+    using tracker_t = windowed_sum_tracker<bucket_count, window / 1ns>;
+    auto tracker = tracker_t(now);
+
+    // Sanity check the bucket_size
+    EXPECT_EQ(tracker_t::bucket_size, bucket_size);
+
+    tracker.record(100, now);
+    EXPECT_EQ(tracker.window_total(now), 100);
+
+    // Jump ahead by a single window + a bucket size to clear the value written
+    // at the beginning of the first window
+    now += window + bucket_size;
+    EXPECT_EQ(tracker.window_total(now), 0);
+}
+
+} // namespace

--- a/src/v/utils/windowed_sum_tracker.h
+++ b/src/v/utils/windowed_sum_tracker.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+/// Tracks the sum of recorded values over a sliding time window using
+/// fixed-size buckets.
+///
+/// The window size corresponds to (bucket_count - 1) buckets, and an additional
+/// bucket is used to track a bucket worth of data just before the start of the
+/// window. This additional bucket is included using partial-interpolation to
+/// account for the fact that the current bucket is also partial. This smooths
+/// the sum over bucket-rolls and avoid systematically undercounting the sum.
+template<size_t BucketCount, std::chrono::nanoseconds::rep WindowSizeNanos>
+class windowed_sum_tracker {
+public:
+    using clock = ss::lowres_clock;
+    using time_point = clock::time_point;
+    using duration = clock::duration;
+
+    /// The number of backing buckets to use
+    static constexpr size_t bucket_count = BucketCount;
+
+    /// The sliding window to aggregate over
+    static constexpr duration window_size = std::chrono::nanoseconds(
+      WindowSizeNanos);
+
+    /// The duration a single bucket covers
+    static constexpr duration bucket_size = window_size / (bucket_count - 1);
+
+    static_assert(bucket_count > 1, "bucket_count must be >1");
+    static_assert(bucket_size.count() > 0, "bucket_size must be >0");
+    static_assert(window_size.count() > 0, "window_size must be >0");
+
+    explicit windowed_sum_tracker(time_point now)
+      : _cur_bucket_zero(now) {}
+
+    windowed_sum_tracker()
+      : windowed_sum_tracker(clock::now()) {}
+
+    /// Record a value at the specified time.
+    void record(uint64_t value, time_point now = clock::now()) {
+        advance(now);
+        _buckets[_cur_bucket] += value;
+    }
+
+    /// Returns the sum of all values recorded within the sliding window
+    /// ending at `now`. The window spans [now - window_size, now].
+    /// Note: the first bucket corresponding to the beginning of the window may
+    /// be interpolated.
+    uint64_t window_total(time_point now = clock::now()) const {
+        // The _buckets[_cur_bucket] corresponds to the window
+        // [_cur_bucket_zero, _cur_bucket_zero + bucket_size], so use an
+        // open-ended window to ensure that the current bucket is not
+        // extrapolated, since it is already "partial".
+        const auto window_end = time_point::max();
+        const auto window_start = now - window_size;
+
+        uint64_t total = 0;
+        for (size_t i = 0; i < bucket_count; ++i) {
+            total += partial_bucket_sum(i, window_start, window_end);
+        }
+        return total;
+    }
+
+private:
+    // Advances the bucket ring to the correct position for `now`,
+    // clearing buckets that have expired.
+    void advance(time_point now) {
+        const auto elapsed = now - _cur_bucket_zero;
+        if (elapsed < bucket_size) {
+            return;
+        }
+
+        // Avoid a long loop for long time jumps
+        if (elapsed > window_size + bucket_size) {
+            std::ranges::fill(_buckets, 0);
+            _cur_bucket = 0;
+            _cur_bucket_zero = now;
+            return;
+        }
+
+        // Advance buckets incrementally, clearing expired ones
+        const auto buckets_to_advance = static_cast<size_t>(
+          elapsed / bucket_size);
+        for (size_t i = 0; i < buckets_to_advance; ++i) {
+            _cur_bucket = (_cur_bucket + 1) % bucket_count;
+            _buckets[_cur_bucket] = 0;
+        }
+        _cur_bucket_zero += buckets_to_advance * bucket_size;
+    }
+
+    constexpr static size_t circular_distance(size_t from, size_t to) {
+        return (to + bucket_count - from) % bucket_count;
+    }
+
+    // Calculate the contribution of a bucket that may be partially in the
+    // window
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+    uint64_t partial_bucket_sum(
+      size_t bucket_idx, time_point window_start, time_point window_end) const {
+        // NOLINTEND(bugprone-easily-swappable-parameters)
+        const auto buckets_ago = circular_distance(bucket_idx, _cur_bucket);
+        const auto bucket_start
+          = _cur_bucket_zero
+            - duration(static_cast<int64_t>(buckets_ago) * bucket_size.count());
+        const auto bucket_end = bucket_start + bucket_size;
+
+        const auto overlap_start = std::max(bucket_start, window_start);
+        const auto overlap_end = std::min(bucket_end, window_end);
+        const auto overlap = overlap_end - overlap_start;
+
+        if (overlap >= bucket_size) {
+            return _buckets[bucket_idx];
+        } else if (overlap <= overlap.zero()) {
+            return 0;
+        }
+
+        // Partial overlap: use lerp to estimate contribution
+        const double fraction = static_cast<double>(overlap.count())
+                                / static_cast<double>(bucket_size.count());
+        return std::llround(
+          std::lerp(0.0, static_cast<double>(_buckets[bucket_idx]), fraction));
+    }
+
+    std::array<uint64_t, bucket_count> _buckets{};
+
+    // The index of the bucket that we are currently filling
+    size_t _cur_bucket{0};
+
+    // The start time of _buckets[_cur_bucket]
+    time_point _cur_bucket_zero;
+};

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -6,7 +6,7 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
-from typing import Any, Literal, Tuple
+from typing import Any
 
 from ducktape.tests.test import TestContext
 
@@ -17,7 +17,7 @@ from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import wait_until_result
+from rptest.util import wait_until
 
 
 class AdminV2ListKafkaConnectionsTest(RedpandaTest):
@@ -61,32 +61,31 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
             page_size=10,
         )
 
-        def non_empty_result() -> Tuple[
-            bool, broker_pb.ListKafkaConnectionsResponse | None
-        ]:
+        def valid_response() -> bool:
             resp = admin_v2.broker().list_kafka_connections(req)
-            if len(resp.connections) == 0:
-                return False, None
-            return True, resp
 
-        resp = wait_until_result(
-            non_empty_result,
+            self.logger.info(
+                f"ListKafkaConnectionsResponse: total_size={resp.total_size}, connections={len(resp.connections)}"
+            )
+            self.logger.debug(f"ListKafkaConnectionsResponse: {resp}")
+
+            # Sanity check the response
+            assert len(resp.connections) > 0
+            conn = resp.connections[0]
+
+            assert conn.node_id == node_id
+            assert len(conn.source.ip_address) > 0
+            assert conn.source.port != 0
+            assert not conn.tls_info.enabled
+            assert conn.total_request_statistics.request_count > 0
+
+            return True
+
+        wait_until(
+            valid_response,
             timeout_sec=15,
-            err_msg="Unable to observe a non-empty ListKafkaConnectionsResponse",
+            retry_on_exc=True,
+            err_msg="Did not observe a valid ListKafkaConnectionsResponse",
         )
-
-        self.logger.info(
-            f"ListKafkaConnectionsResponse: "
-            f"total_size={resp.total_size}, connections={len(resp.connections)}"
-        )
-        self.logger.debug(f"ListKafkaConnectionsResponse: {resp}")
-
-        # Sanity check response
-        assert len(resp.connections) > 0
-        conn = resp.connections[0]
-        assert conn.node_id == node_id
-        assert len(conn.source.ip_address) > 0
-        assert conn.source.port != 0
-        assert not conn.tls_info.enabled
 
         self.consumer.stop()


### PR DESCRIPTION
Track per-connection requests statistics for each kafka connection:
- request_count: count of requests
- produce_bytes: size of successfully produced records
- produce_batch_count: count of successfully produced batches
- fetch_bytes: size of records in the fetch response

All of the above statistics are aggregated at both a "total over the
lifetime of the connection" and "sum over the last 1 minute window"
aggregations.

Fixes https://redpandadata.atlassian.net/browse/CORE-13357

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
