### PR TITLE
cluster: re-enable partition balacer sim test

### DIFF
--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -451,9 +451,10 @@ private:
                                / (node_count * (node_count - 1));
 
         // Generous boundaries to allow for fluctuations. But they will catch
-        // pathological cases.
+        // pathological cases. Set empirically to avoid flakes (i.e., if the
+        // upper bound is * 3, we get ~1% flakes in the pair test).
         double expected_min = expected_freq - sqrt(expected_freq) * 3;
-        double expected_max = expected_freq + sqrt(expected_freq) * 3;
+        double expected_max = expected_freq + sqrt(expected_freq) * 4;
 
         logger.info(
           "validating replica pair frequencies, topic filter: {}, "
@@ -899,9 +900,6 @@ FIXTURE_TEST(test_many_topics, partition_balancer_sim_fixture) {
 }
 
 FIXTURE_TEST(test_replica_pair_frequency, partition_balancer_sim_fixture) {
-    // TODO: This is really flaky! Fix me!
-    return;
-
     for (model::node_id::type i = 0; i < 3; ++i) {
         add_node(model::node_id{i}, 300_GiB);
     }


### PR DESCRIPTION
Increase the upper bound threshold to 4x from 3x, which in my testing causes no failures in ~5,000 runs.

The old threshold failed in about 1% of runs.

Stack thread with background: https://redpandadata.slack.com/archives/C07HD9U0EHL/p1759528124177919

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

