### PR TITLE
Single-fiber executor

### DIFF
--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -269,6 +269,7 @@ redpanda_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":future_util",
+        "//src/v/utils:retry_chain_node",
         "@seastar",
     ],
 )

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -260,3 +260,15 @@ redpanda_cc_library(
         "@seastar",
     ],
 )
+
+redpanda_cc_library(
+    name = "single_fiber_executor",
+    hdrs = [
+        "single_fiber_executor.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":future_util",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/single_fiber_executor.h
+++ b/src/v/ssx/single_fiber_executor.h
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/vassert.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/weak_ptr.hh>
+
+#include <expected>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace ssx {
+
+// a function that accepts an ss::abort_source& and returns any ss::future
+template<typename Func>
+concept abortable_async_fn = requires(Func&& f, ss::abort_source& as) {
+    { f(as) } -> ss::Future;
+};
+
+/**
+ * Single-fiber executor for abortable async functions.
+ * - It runs at most one function at a time.
+ * - When a new function is submitted all previously submitted functions are
+ * interrupted using an ss::abort_source.
+ * - Regardless how much progress a previously submitted function has made by
+ * then, if its callers did not receive a result yet it will receive
+ * errc::interrupted.
+ * - An interrupted function may remain running when its caller has received
+ * errc::interrupted. The new submitted function only starts working when the
+ * old one has finished.
+ *
+ * For memory safety users should:
+ * - either call submit() with rvalue callables holding gate(s) for
+ * component(s) used in said callables
+ * - or call `co_await executor_instance.drain()` before destructing
+ * `executor_instance` to wait for the currently running function to finish.
+ *
+ * The executor is only compile-time polymorphic: all submitted functions must
+ * have the same type. In particular they should either all be lvalue references
+ * or all objects. It would be convenient to accept any lambdas of the same
+ * signature, but since the implementation stores the function while waiting for
+ * the result, it needs to know the exact type. Options to work around it:
+ * - use `ss::noncopyable_function` or another type-erased wrapper;
+ * - use a custom callable class;
+ * - create lambdas with a constexpr function to get their type in compile time.
+ *
+ * It may seem that there is a lot of excessive moves, and the logic is
+ * overcomplicated. It's not exactly the case as there are some hidden race
+ * conditions:
+ * 1) every time we fulfill a promise its continuation may call submit(),
+ * drain(), request_abort() or ~single_fiber_executor();
+ * 2) launch() may result in a synchronouse call to complete_running();
+ * 3) user-submitted functions may call submit(), drain(), request_abort() or
+ * ~single_fiber_executor() as well.
+ * Each call to launch() and fulfilling each promise should be treated as a
+ * scheduling point.
+ */
+namespace single_fiber_executor_detail {
+enum class errc { interrupted };
+}
+
+template<abortable_async_fn Func>
+class single_fiber_executor
+  : public ss::weakly_referencable<single_fiber_executor<Func>> {
+public:
+    using errc = single_fiber_executor_detail::errc;
+
+private:
+    using self_t = single_fiber_executor<Func>;
+    using orig_future_t = decltype(std::declval<Func>()(
+      std::declval<ss::abort_source&>()));
+    using stored_t = orig_future_t::value_type;
+    using ret_value_t = std::conditional_t<
+      std::is_same_v<stored_t, ss::internal::monostate>,
+      void,
+      stored_t>;
+    using wrapped_ret_value_t = std::expected<ret_value_t, errc>;
+    using promise_t = ss::promise<wrapped_ret_value_t>;
+    using future_t = ss::future<wrapped_ret_value_t>;
+    using ss::weakly_referencable<single_fiber_executor<Func>>::weak_from_this;
+
+private:
+    struct handle_t {
+        // invariant: we never store a handle with a fulfilled promise or with a
+        // triggered abort source
+        promise_t promise;
+        const ss::lw_shared_ptr<ss::abort_source> as;
+
+        explicit handle_t(promise_t&& p)
+          : promise(std::move(p))
+          , as(ss::make_lw_shared<ss::abort_source>()) {}
+    };
+
+    struct running_t {
+        std::optional<handle_t> handle;
+
+        explicit running_t(promise_t&& promise)
+          : handle(std::move(promise)) {}
+        void run(Func&& func, ss::weak_ptr<self_t>&& executor) {
+            try {
+                ssx::background
+                  = func(*handle->as)
+                      .then_wrapped(
+                        [executor = std::move(executor),
+                         as = handle->as](orig_future_t&& f) mutable {
+                            if (executor) {
+                                executor->complete_running(std::move(f));
+                            } else {
+                                // caller received errc::interrupted, no-one is
+                                // interested in the result
+                                f.ignore_ready_future();
+                            }
+                            return ss::now();
+                        });
+            } catch (...) {
+                vassert(executor, "executor is nullptr");
+                executor->complete_running(
+                  ss::make_exception_future<ret_value_t>(
+                    std::current_exception()));
+            }
+        }
+        running_t(const running_t&) = delete;
+        running_t& operator=(const running_t&) = delete;
+        running_t(running_t&&) = default;
+        running_t& operator=(running_t&&) = default;
+        ~running_t() { vassert(!handle, "promise not fulfilled"); };
+    };
+
+    struct requested_t {
+        Func func;
+        promise_t promise;
+
+        explicit requested_t(Func&& func)
+          : func(std::forward<Func>(func)) {}
+    };
+
+    // _running is set iff the background fiber is running
+    std::optional<running_t> _running;
+    std::optional<requested_t> _pending;
+
+    enum class status { operating, draining, drained };
+    status _status{status::operating};
+
+    void launch(promise_t&& promise, Func&& func) {
+        vassert(!_running, "launch() called while already running");
+        _running.emplace(std::move(promise));
+        _running->run(std::forward<Func>(func), weak_from_this());
+    }
+
+    void mark_interrupted(std::optional<promise_t>&& p) {
+        if (p) {
+            p->set_value(wrapped_ret_value_t{std::unexpect, errc::interrupted});
+        }
+    }
+
+    // returns a promise to mark as interrupted
+    std::optional<promise_t> abort_unfulfilled() {
+        if (_pending) {
+            // if there is a pending function, then _running is already aborted
+            // and its promise has been fulfilled
+            auto promise = std::move(_pending->promise);
+            _pending = std::nullopt;
+            return promise;
+        }
+        if (_running && _running->handle) {
+            auto promise = std::move(_running->handle->promise);
+            auto as = std::move(_running->handle->as);
+            _running->handle = std::nullopt;
+            as->request_abort();
+            return promise;
+        }
+        return std::nullopt;
+        // if _running is present keep it to indicate the fiber is still running
+    }
+
+    void complete_running(orig_future_t&& f) {
+        vassert(_running, "no info about the background fiber completed");
+        if (_running->handle) {
+            auto p = std::move(_running->handle->promise);
+            _running->handle = std::nullopt;
+            _running = std::nullopt;
+            if (f.failed()) [[unlikely]] {
+                p.set_exception(std::move(f).get_exception());
+            } else {
+                if constexpr (std::is_same_v<ret_value_t, void>) {
+                    std::move(f).get();
+                    p.set_value();
+                } else {
+                    p.set_value(std::move(f).get());
+                }
+            }
+        } else {
+            // caller received errc::interrupted, no-one is
+            // interested in the result
+            f.ignore_ready_future();
+            _running = std::nullopt;
+        }
+
+        // _running CAN have a value here, as fulfilling the promise may trigger
+        // some continuation which submits a new function
+        if (!_running && _pending) {
+            auto pending = std::move(*_pending);
+            _pending = std::nullopt;
+            launch(
+              std::move(pending.promise), std::forward<Func>(pending.func));
+        }
+    }
+
+public:
+    ss::future<wrapped_ret_value_t> submit(Func&& func) {
+        if (_status != status::operating) {
+            return ssx::now(
+              wrapped_ret_value_t{std::unexpect, errc::interrupted});
+        }
+        auto interrupted_promise = abort_unfulfilled();
+        std::optional<future_t> f;
+        if (_running) {
+            vassert(
+              _running->handle == std::nullopt,
+              "abort_running() should have aborted it");
+            _pending.emplace(std::forward<Func>(func));
+            f.emplace(_pending->promise.get_future());
+        } else {
+            promise_t promise;
+            f.emplace(promise.get_future());
+            launch(std::move(promise), std::forward<Func>(func));
+        }
+        mark_interrupted(std::move(interrupted_promise));
+        return std::move(*f);
+    }
+
+    void request_abort() { mark_interrupted(abort_unfulfilled()); }
+
+    ss::future<> drain() {
+        vassert(_status == status::operating, "drain() called repeatedly");
+        _status = status::draining;
+        request_abort();
+        if (_running) {
+            promise_t promise;
+            auto future = promise.get_future();
+            _running->handle.emplace(std::move(promise));
+            co_await future.then_wrapped(
+              std::mem_fn(
+                &ss::future<wrapped_ret_value_t>::ignore_ready_future));
+        }
+        _status = status::drained;
+    }
+
+    single_fiber_executor() = default;
+    single_fiber_executor(const self_t&) = delete;
+    single_fiber_executor(self_t&&) = delete;
+    self_t& operator=(self_t&&) = delete;
+    self_t& operator=(const self_t&) = delete;
+    ~single_fiber_executor() {
+        vassert(_status != status::draining, "cannot destroy while draining");
+        request_abort();
+    };
+};
+
+} // namespace ssx

--- a/src/v/ssx/single_fiber_executor.h
+++ b/src/v/ssx/single_fiber_executor.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "base/vassert.h"
 #include "ssx/future-util.h"
+#include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future-util.hh>
@@ -272,5 +273,82 @@ public:
         request_abort();
     };
 };
+
+/**
+ * A helper to create a repeater async callable that uses a retry chain node to
+ * determine when to stop repeating.
+ *
+ * @tparam Func: an `ssx::abortable_async_fn`, i.e. a callable type that
+ * accepts `ss::abort_source&` and returns `ss::future<R>` for some type `R`.
+ * May be a reference.
+ * @tparam StopCondition: a callable type that accepts `R` and returns
+ * `ss::stop_iteration`. It determines whether to stop repeating based on the
+ * result of the last invocation of `Func`. May be a reference.
+ * @tparam RcnArgs: arguments to construct a `ss::retry_chain_node`.
+ * Usually it's either a `retry_chain_node *` to use an existing instance,
+ * or some other arguments like timeouts to construct a new instance.
+ * @returns: an `ssx::abortable_async_fn` that repeats calling `Func` until
+ * `StopCondition` returns `ss::stop_iteration::yes` or the retry chain node
+ * stops allowing retries.
+ *
+ * RCN's abort source triggers the abort source passed to func, but not the
+ * other way round. Callers can always capture parent RCN's abort source if
+ * they want the whole chain to stop if the function is aborted by its local
+ * abort source.
+ */
+template<abortable_async_fn Func, typename StopCondition>
+class repeater_with_rcn {
+public:
+    template<typename... RcnArgs>
+    constexpr repeater_with_rcn(
+      Func&& func, StopCondition&& stop, RcnArgs&&... rcn_args)
+      : _func(std::forward<Func>(func))
+      , _stop(std::forward<StopCondition>(stop))
+      , _rcn(std::forward<RcnArgs>(rcn_args)...) {}
+    using future_t = decltype(std::declval<Func>()(
+      std::declval<ss::abort_source&>()));
+
+    future_t operator()(ss::abort_source& as) {
+        auto permit = _rcn.retry();
+        if (!permit.is_allowed) {
+            co_return typename future_t::value_type{};
+        }
+        auto subscription = _rcn.root_abort_source().subscribe(
+          [&as] noexcept { as.request_abort(); });
+        while (true) {
+            auto r = co_await _func(as);
+            if (_stop(r) == ss::stop_iteration::yes) {
+                co_return r;
+            }
+            auto permit = _rcn.retry();
+            if (!permit.is_allowed) {
+                co_return r;
+            }
+            // Using local abort source. If RCN's abort source is triggered,
+            // it will trigger the local one too.
+            co_await ss::sleep_abortable(permit.delay, as);
+        }
+    }
+
+private:
+    Func _func;
+    StopCondition _stop;
+    retry_chain_node _rcn;
+};
+
+namespace detail {
+template<typename T>
+using remove_rvalue_reference = std::
+  conditional_t<std::is_rvalue_reference_v<T>, std::remove_reference_t<T>, T>;
+}
+
+// Deduction guide to preserve value categories for functions.
+// If `repeater_with_rcn` was a function and `_func` and `_stop` were local
+// variables it would happen automatically. But it would be 5 nested lambdas
+// this way.
+template<abortable_async_fn Func, typename StopCondition, typename... RcnArgs>
+repeater_with_rcn(Func&&, StopCondition&&, RcnArgs&&...) -> repeater_with_rcn<
+  detail::remove_rvalue_reference<Func&&>,
+  detail::remove_rvalue_reference<StopCondition&&>>;
 
 } // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -301,3 +301,18 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "single_fiber_executor_test",
+    timeout = "short",
+    srcs = [
+        "single_fiber_executor_test.cc",
+    ],
+    deps = [
+        "//src/v/base",
+        "//src/v/ssx:single_fiber_executor",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/ssx/tests/single_fiber_executor_test.cc
+++ b/src/v/ssx/tests/single_fiber_executor_test.cc
@@ -1,0 +1,267 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "ssx/single_fiber_executor.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/semaphore.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+using fn_t = ss::noncopyable_function<ss::future<ss::sstring>(
+  ss::abort_source&) noexcept(false)>;
+
+fn_t make_ready_coro(ss::sstring retval) {
+    return {[retval](ss::abort_source&) { return ssx::now(retval); }};
+}
+
+fn_t make_slow_coro(ss::semaphore& sem, ss::sstring retval) {
+    return {[&sem, retval](ss::abort_source& as) {
+        return sem.wait(as).then([retval] { return retval; });
+    }};
+}
+
+fn_t make_uncooperative_coro(ss::semaphore& sem, ss::sstring retval) {
+    return {[&sem, retval](ss::abort_source& as) {
+        return sem.wait().then([&as, retval] {
+            return as.abort_requested() ? ss::sstring("tripped-on-abort-source")
+                                        : retval;
+        });
+    }};
+}
+
+fn_t make_side_effect_coro(
+  ss::semaphore& sem, ss::sstring retval, int& counter) {
+    return {[&sem, retval, &counter](ss::abort_source& as) {
+        return sem.wait().then([&as, retval, &counter] {
+            ++counter;
+            return as.abort_requested() ? ss::sstring("tripped-on-abort-source")
+                                        : retval;
+        });
+    }};
+}
+
+using sfe = ssx::single_fiber_executor<fn_t>;
+
+// depending on Seastar scheduling, the coro may or may not complete
+MATCHER_P(InterruptedOr, expected_value, "") {
+    return arg ? arg.value() == expected_value
+               : arg.error() == sfe::errc::interrupted;
+}
+
+MATCHER_P(CompletedAnd, expected_value, "") {
+    return arg && arg.value() == expected_value;
+}
+
+constexpr std::expected<ss::sstring, sfe::errc> interrupted{
+  std::unexpect, sfe::errc::interrupted};
+
+void assure_new_tasks_are_bounced(ssx::single_fiber_executor<fn_t>& executor) {
+    auto f = executor.submit(make_ready_coro("na"));
+    ASSERT_EQ(f.get(), interrupted);
+}
+
+} // namespace
+
+TEST(SingleFiberExecutor, no_destruction_test) {
+    ssx::single_fiber_executor<fn_t> executor;
+
+    { // superseded ones may or may not complete
+        auto f1 = executor.submit(make_ready_coro("ret1"));
+        auto f2 = executor.submit(make_ready_coro("ret2"));
+        auto f3 = executor.submit(make_ready_coro("ret3"));
+        ASSERT_THAT(f1.get(), InterruptedOr("ret1"));
+        ASSERT_THAT(f2.get(), InterruptedOr("ret2"));
+        ASSERT_THAT(f3.get(), CompletedAnd("ret3"));
+    }
+
+    { // running, superseded and queued -- all get aborted
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        auto f2 = executor.submit(make_slow_coro(sem, "ret2"));
+        auto f3 = executor.submit(make_slow_coro(sem, "ret3"));
+        executor.request_abort();
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_EQ(f2.get(), interrupted);
+        ASSERT_EQ(f3.get(), interrupted);
+    }
+
+    { // the second is scheduled before the first one completes
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        auto f2 = executor.submit(make_ready_coro("ret2"));
+        sem.signal();
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_THAT(f2.get(), CompletedAnd("ret2"));
+    }
+
+    { // the result of the interrupted one is discarded
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_uncooperative_coro(sem, "ret1"));
+        auto f2 = executor.submit(make_ready_coro("ret2"));
+        sem.signal();
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_THAT(f2.get(), CompletedAnd("ret2"));
+    }
+
+    { // aborted yields to next scheduled
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        executor.request_abort();
+        auto f2 = executor.submit(make_ready_coro("ret2"));
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_THAT(f2.get(), CompletedAnd("ret2"));
+    }
+
+    { // latest scheduled runs to completion
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        auto f2 = executor.submit(make_slow_coro(sem, "ret2"));
+        auto f3 = executor.submit(make_slow_coro(sem, "ret3"));
+        sem.signal(3);
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_EQ(f2.get(), interrupted);
+        ASSERT_THAT(f3.get(), CompletedAnd("ret3"));
+    }
+
+    { // exception gets propagated
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        sem.broken();
+        ASSERT_THROW(f1.get(), ss::broken_semaphore);
+    }
+
+    { // exception gets propagated for the pending one as well
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        auto f2 = executor.submit(make_slow_coro(sem, "ret2"));
+        sem.broken();
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_THROW(f2.get(), ss::broken_semaphore);
+    }
+
+    { // superseding wins over exception
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        auto f2 = executor.submit(make_ready_coro("ret2"));
+        sem.broken();
+        ASSERT_EQ(f1.get(), interrupted);
+        ASSERT_THAT(f2.get(), CompletedAnd("ret2"));
+    }
+}
+
+TEST(SingleFiberExecutor, drain_test) {
+    { // drain while idle
+        ssx::single_fiber_executor<fn_t> executor;
+        auto drain_f = executor.drain();
+        assure_new_tasks_are_bounced(executor);
+        drain_f.get();
+        assure_new_tasks_are_bounced(executor);
+    }
+
+    { // drain while running
+        ssx::single_fiber_executor<fn_t> executor;
+        ss::semaphore sem{0};
+        auto f1 = executor.submit(make_slow_coro(sem, "ret1"));
+        auto drain_f = executor.drain();
+        ASSERT_EQ(f1.get(), interrupted); // it got canceled by drain
+        assure_new_tasks_are_bounced(executor);
+        drain_f.get();
+        assure_new_tasks_are_bounced(executor);
+    }
+
+    { // drain while running and queued
+        ssx::single_fiber_executor<fn_t> executor;
+        ss::semaphore sem{0};
+        int cnt_f1_completed = 0;
+        auto f1 = executor.submit(
+          make_side_effect_coro(sem, "ret1", cnt_f1_completed));
+        auto f2 = executor.submit(make_ready_coro("ret2"));
+        auto drain_f = executor.drain();
+        ASSERT_EQ(f1.get(), interrupted); // it got canceled by drain
+        ASSERT_EQ(f2.get(), interrupted); // and this one never even got run
+        ASSERT_EQ(cnt_f1_completed, 0);   // however, f1 hasn't completed
+        assure_new_tasks_are_bounced(executor);
+        ASSERT_FALSE(drain_f.available()); // can't complete because f1 is stuck
+        sem.signal();                      // let f1 complete
+        drain_f.get();
+        ASSERT_EQ(cnt_f1_completed, 1); // it has completed now
+        assure_new_tasks_are_bounced(executor);
+    }
+    return;
+}
+
+TEST(SingleFiberExecutor, empty_return_test) {
+    using fn_t = ss::noncopyable_function<ss::future<>(
+      ss::abort_source&) noexcept(false)>;
+    using sfe = ssx::single_fiber_executor<fn_t>;
+    auto make_ready_coro = [] -> fn_t {
+        return {[](ss::abort_source&) -> ss::future<> { return ss::now(); }};
+    };
+    constexpr std::expected<void, sfe::errc> completed{};
+
+    ssx::single_fiber_executor<fn_t> executor;
+    { // superseded ones may or may not complete
+        auto f1 = executor.submit(make_ready_coro());
+        auto f2 = executor.submit(make_ready_coro());
+        auto f3 = executor.submit(make_ready_coro());
+        f1.get();
+        f2.get();
+        ASSERT_EQ(f3.get(), completed);
+    }
+    auto drain_f = executor.drain();
+    drain_f.get();
+}
+
+TEST(SingleFiberExecutor, lvalue_test) {
+    using sfe = ssx::single_fiber_executor<fn_t&>;
+    constexpr std::expected<ss::sstring, sfe::errc> interrupted{
+      std::unexpect, sfe::errc::interrupted};
+
+    ssx::single_fiber_executor<fn_t&> executor;
+    fn_t f = make_ready_coro("ret1");
+    { // superseded ones may or may not complete
+        auto f1 = executor.submit(f);
+        auto f2 = executor.submit(f);
+        auto f3 = executor.submit(f);
+        ASSERT_THAT(f1.get(), InterruptedOr("ret1"));
+        ASSERT_THAT(f2.get(), InterruptedOr("ret1"));
+        ASSERT_THAT(f3.get(), CompletedAnd("ret1"));
+    }
+    auto drain_f = executor.drain();
+    drain_f.get();
+}
+
+namespace {
+constexpr auto make_fn(int retval) {
+    return [retval](ss::abort_source&) { return ssx::now(retval); };
+}
+} // namespace
+
+TEST(SingleFiberExecutor, constexpr_test) {
+    // this test demonstrates how to use it with a lambda factory without a
+    // type-erasing wrapper
+
+    // rvalue
+    ssx::single_fiber_executor<decltype(make_fn(0))> executor_r;
+    auto f1 = executor_r.submit(make_fn(1));
+    ASSERT_EQ(f1.get(), 1);
+
+    // lvalue
+    ssx::single_fiber_executor<decltype(make_fn(0))&> executor_l;
+    auto fn = make_fn(5);
+    auto f2 = executor_l.submit(fn);
+    ASSERT_EQ(f2.get(), 5);
+}

--- a/src/v/ssx/tests/single_fiber_executor_test.cc
+++ b/src/v/ssx/tests/single_fiber_executor_test.cc
@@ -16,6 +16,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 using namespace std::chrono_literals;
 
 namespace {
@@ -264,4 +266,146 @@ TEST(SingleFiberExecutor, constexpr_test) {
     auto fn = make_fn(5);
     auto f2 = executor_l.submit(fn);
     ASSERT_EQ(f2.get(), 5);
+}
+
+TEST(RepeaterWithRcn, basic_test) {
+    ss::abort_source as;
+    retry_chain_node parent_rcn{as, 1min, 1ms};
+
+    int counter = 0;
+    auto func = [&counter](ss::abort_source&) -> ss::future<int> {
+        return ssx::now(++counter);
+    };
+    auto stop = [](int v) {
+        return v == 3 ? ss::stop_iteration::yes : ss::stop_iteration::no;
+    };
+    auto repeater = ssx::repeater_with_rcn(func, stop, &parent_rcn);
+
+    auto f = repeater(as);
+    ASSERT_EQ(f.get(), 3);
+}
+
+TEST(RepeaterWithRcn, slow_retry_test) {
+    ss::abort_source as;
+    int counter = 0;
+    auto func = [&counter](ss::abort_source&) -> ss::future<int> {
+        return ssx::now(++counter);
+    };
+    auto stop = [](int) { return ss::stop_iteration::no; };
+    auto repeater = ssx::repeater_with_rcn(
+      std::move(func), // rvalues supported too
+      std::move(stop), // rvalues supported too
+      as,
+      1000ms,
+      100ms,
+      retry_strategy::polling);
+
+    auto f = repeater(as);
+    auto cnt_called = f.get();
+
+    // in reality, each delay was between 100 and 200ms due to jitter
+    ASSERT_GE(cnt_called, 5);
+    ASSERT_LE(cnt_called, 10);
+}
+
+TEST(RepeaterWithRcn, slow_execution_test) {
+    ss::abort_source as;
+    retry_chain_node parent_rcn{as, 350ms, 1ms};
+    int counter = 0;
+    auto func = [&counter](ss::abort_source& as) -> ss::future<int> {
+        return ss::sleep_abortable(100ms, as).then_wrapped(
+          [&counter](auto&& f) {
+              if (f.failed()) {
+                  // will not happen: RCN won't trigger abort source
+                  counter += 100;
+              } else {
+                  ++counter;
+              }
+              f.ignore_ready_future();
+              return ssx::now(counter);
+          });
+    };
+    auto stop = [](int) { return ss::stop_iteration::no; };
+    auto repeater = ssx::repeater_with_rcn(func, stop, &parent_rcn);
+
+    auto f = repeater(as);
+    ASSERT_EQ(f.get(), 4);
+}
+
+TEST(RepeaterWithRcn, aborted_during_delay_test) {
+    ss::abort_source as;
+    auto repeater = ssx::repeater_with_rcn(
+      [](ss::abort_source&) { return ssx::now(0); },
+      [](int) { return ss::stop_iteration::no; },
+      as,
+      1000ms,
+      100ms,
+      retry_strategy::polling);
+
+    auto f = repeater(as);
+    ss::sleep(50ms).get();
+    as.request_abort();
+    ASSERT_THROW(f.get(), ss::sleep_aborted);
+}
+
+TEST(RepeaterWithRcn, aborted_during_execution_test) {
+    ss::abort_source as;
+    retry_chain_node parent_rcn{as, 350ms, 1ms};
+    int counter = 0;
+    auto func = [&counter](ss::abort_source& as) -> ss::future<int> {
+        return ss::sleep_abortable(100ms, as).then_wrapped(
+          [&counter](auto&& f) {
+              if (f.failed()) {
+                  counter += 100;
+              } else {
+                  ++counter;
+              }
+              f.ignore_ready_future();
+              return ssx::now(counter);
+          });
+    };
+    auto stop = [](int r) {
+        // stopping if execution aborted, as otherwise RCN retry check throws
+        return r >= 100 ? ss::stop_iteration::yes : ss::stop_iteration::no;
+    };
+    auto repeater = ssx::repeater_with_rcn(func, stop, &parent_rcn);
+
+    auto f = repeater(as);
+    ss::sleep(350ms).get();
+    as.request_abort();
+    ASSERT_EQ(f.get(), 103);
+}
+
+TEST(RepeaterWithRcn, disallowed_retries_test) {
+    ss::abort_source as;
+    int counter = 0;
+    auto repeater = ssx::repeater_with_rcn(
+      [&counter](ss::abort_source&) { return ssx::now(++counter); },
+      [](int) { return ss::stop_iteration::no; },
+      as,
+      1min,
+      1s,
+      retry_strategy::disallow);
+
+    auto f = repeater(as);
+    ASSERT_EQ(f.get(), 1); // run once, then no retries allowed
+}
+
+TEST(RepeaterWithRcn, originally_expired_rcn_test) {
+    ss::abort_source as;
+    auto repeater = ssx::repeater_with_rcn(
+      [](ss::abort_source&) -> ss::future<int> {
+          throw std::runtime_error("should not be called");
+      },
+      [](int) -> ss::stop_iteration {
+          throw std::runtime_error("should not be called");
+      },
+      as,
+      ss::lowres_clock::now() - 1min, // deadline in the past
+      65s);
+
+    auto start = ss::lowres_clock::now();
+    auto f = repeater(as);
+    ASSERT_EQ(f.get(), 0); // run once, then no retries allowed
+    ASSERT_LT(ss::lowres_clock::now() - start, 10s); // and it was quick
 }


### PR DESCRIPTION
Single-fiber executor for abortable coroutines.

It's purpose is to run at most one coroutine at a time. If there is one running and a new coroutine is scheduled, the old coroutine will be interrupted and the new one is will run once the old one finishes.
 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required
<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
