### PR TITLE
[CORE-13840] ct/l1: cloud topics purging

### DIFF
--- a/src/v/cloud_topics/BUILD
+++ b/src/v/cloud_topics/BUILD
@@ -81,6 +81,7 @@ redpanda_cc_library(
         ":cluster_services_interface",
         ":data_plane_impl",
         "//src/v/cloud_topics/housekeeper:manager",
+        "//src/v/cloud_topics/level_one/metastore:topic_purger",
         "//src/v/cloud_topics/level_zero/gc:level_zero_gc",
         "//src/v/cloud_topics/manager",
     ],

--- a/src/v/cloud_topics/app.cc
+++ b/src/v/cloud_topics/app.cc
@@ -14,6 +14,7 @@
 #include "cloud_topics/data_plane_api.h"
 #include "cloud_topics/data_plane_impl.h"
 #include "cloud_topics/housekeeper/manager.h"
+#include "cloud_topics/level_one/metastore/topic_purger.h"
 #include "cloud_topics/level_zero/gc/level_zero_gc.h"
 #include "cloud_topics/manager/manager.h"
 #include "cloud_topics/reconciler/reconciler.h"
@@ -90,6 +91,12 @@ ss::future<> app::construct(
         [&metadata_cache] { return &metadata_cache->local(); }));
 
     co_await construct_service(
+      topic_purge_manager,
+      ss::sharded_parameter([this] { return &replicated_metastore.local(); }),
+      &controller->get_topics_state(),
+      &controller->get_topics_frontend());
+
+    co_await construct_service(
       reconciler,
       ss::sharded_parameter([this] { return &l1_io.local(); }),
       ss::sharded_parameter([this] { return &replicated_metastore.local(); }));
@@ -144,6 +151,19 @@ ss::future<> app::wire_up_notifications() {
             } else {
                 gc.pause();
             }
+        });
+    });
+    co_await topic_purge_manager.invoke_on_all([this](auto& purge_mgr) {
+        manager.local().on_l1_domain_leader([&purge_mgr](
+                                              const model::ntp& ntp,
+                                              const auto&,
+                                              const auto& partition) noexcept {
+            if (ntp.tp.partition != model::partition_id{0}) {
+                return;
+            }
+            auto needs_loop = l1::topic_purger_manager::needs_loop{
+              bool(partition)};
+            purge_mgr.enqueue_loop_reset(needs_loop);
         });
     });
     co_await housekeeper_manager.invoke_on_all([this](auto& hm) {

--- a/src/v/cloud_topics/app.h
+++ b/src/v/cloud_topics/app.h
@@ -38,6 +38,10 @@ class cloud_topics_manager;
 class level_zero_gc;
 class housekeeper_manager;
 
+namespace l1 {
+class topic_purger_manager;
+} // namespace l1
+
 class app : public ssx::sharded_service_container {
 public:
     explicit app(ss::sstring logger_name = "cloud_topics::app");
@@ -82,6 +86,7 @@ private:
     ss::sharded<reconciler::reconciler> reconciler;
     ss::sharded<l1::domain_supervisor> domain_supervisor;
     ss::sharded<l1::frontend> l1_metastore_fe;
+    ss::sharded<l1::topic_purger_manager> topic_purge_manager;
     ss::sharded<cloud_topics_manager> manager;
     ss::sharded<level_zero_gc> l0_gc;
     ss::sharded<housekeeper_manager> housekeeper_manager;

--- a/src/v/cloud_topics/level_one/domain/BUILD
+++ b/src/v/cloud_topics/level_one/domain/BUILD
@@ -38,6 +38,7 @@ redpanda_cc_library(
     implementation_deps = [
         "//src/v/cloud_topics:logger",
         "//src/v/cloud_topics/level_one/metastore:garbage_collector",
+        "//src/v/model:batch_builder",
         "//src/v/ssx:future_util",
         "//src/v/ssx:sleep_abortable",
     ],

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -13,6 +13,7 @@
 #include "cloud_topics/level_one/metastore/rpc_types.h"
 #include "cloud_topics/level_one/metastore/simple_metastore.h"
 #include "cloud_topics/logger.h"
+#include "model/batch_builder.h"
 #include "ssx/future-util.h"
 #include "ssx/sleep_abortable.h"
 
@@ -460,9 +461,64 @@ domain_manager::set_start_offset(rpc::set_start_offset_request req) {
 }
 
 ss::future<rpc::remove_topics_reply>
-domain_manager::remove_topics(rpc::remove_topics_request) {
-    // XXX: implemented in later commit!
-    co_return rpc::remove_topics_reply{};
+domain_manager::remove_topics(rpc::remove_topics_request req) {
+    auto gate = maybe_gate();
+    if (!gate.has_value()) {
+        co_return rpc::remove_topics_reply{
+          .ec = rpc::errc::not_leader, .not_removed = {}};
+    }
+
+    auto sync_res = co_await stm_->sync(10s);
+    if (!sync_res.has_value()) {
+        co_return rpc::remove_topics_reply{
+          .ec = convert_stm_errc(sync_res.error()), .not_removed = {}};
+    }
+    chunked_vector<model::topic_id> topics_to_remove;
+    for (const auto& t : req.topics) {
+        if (stm_->state().topic_to_state.contains(t)) {
+            topics_to_remove.emplace_back(t);
+        }
+    }
+    // NOTE: even if topics_to_remove is empty, replicate it so we're
+    // guaranteed to have been a caught up leader when we build not_removed
+    // below. It's possible the sync() call above finished but our state was
+    // still stale, e.g. because of a cross-shard movement.
+    auto update_res = remove_topics_update::build(
+      stm_->state(), std::move(topics_to_remove));
+    if (!update_res.has_value()) {
+        vlog(
+          cd_log.debug,
+          "Rejecting request to remove topics: {}",
+          update_res.error());
+        co_return rpc::remove_topics_reply{
+          .ec = rpc::errc::concurrent_requests,
+          .not_removed = {},
+        };
+    }
+    model::batch_builder builder;
+    builder.set_batch_type(model::record_batch_type::l1_stm);
+    builder.add_record(
+      {.key = serde::to_iobuf(remove_topics_update::key),
+       .value = serde::to_iobuf(std::move(update_res.value()))});
+    auto batch = co_await builder.build();
+    auto repl_res = co_await stm_->replicate_and_wait(
+      sync_res.value(), std::move(batch), as_);
+    if (!repl_res.has_value()) {
+        co_return rpc::remove_topics_reply{
+          .ec = convert_stm_errc(repl_res.error()),
+          .not_removed = {},
+        };
+    }
+    chunked_vector<model::topic_id> not_removed;
+    for (const auto& t : req.topics) {
+        if (stm_->state().topic_to_state.contains(t)) {
+            not_removed.emplace_back(t);
+        }
+    }
+    co_return rpc::remove_topics_reply{
+      .ec = rpc::errc::ok,
+      .not_removed = std::move(not_removed),
+    };
 }
 
 ss::future<> domain_manager::gc_loop() {

--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -459,6 +459,12 @@ domain_manager::set_start_offset(rpc::set_start_offset_request req) {
     co_return rpc::set_start_offset_reply{.ec = rpc::errc::ok};
 }
 
+ss::future<rpc::remove_topics_reply>
+domain_manager::remove_topics(rpc::remove_topics_request) {
+    // XXX: implemented in later commit!
+    co_return rpc::remove_topics_reply{};
+}
+
 ss::future<> domain_manager::gc_loop() {
     auto gate = maybe_gate();
     if (!gate.has_value()) {

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -58,6 +58,9 @@ public:
     ss::future<rpc::set_start_offset_reply>
       set_start_offset(rpc::set_start_offset_request);
 
+    ss::future<rpc::remove_topics_reply>
+      remove_topics(rpc::remove_topics_request);
+
 private:
     std::optional<ss::gate::holder> maybe_gate();
     ss::future<> gc_loop();

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -224,3 +224,28 @@ redpanda_cc_library(
         "//src/v/serde:map",
     ],
 )
+
+redpanda_cc_library(
+    name = "topic_purger",
+    srcs = [
+        "topic_purger.cc",
+    ],
+    hdrs = [
+        "topic_purger.h",
+    ],
+    implementation_deps = [
+        ":metastore",
+        "//src/v/base",
+        "//src/v/cloud_topics:logger",
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/model:batch_builder",
+        "//src/v/ssx:future_util",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/utils:named_type",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -240,11 +240,12 @@ redpanda_cc_library(
         "//src/v/cluster",
         "//src/v/model",
         "//src/v/model:batch_builder",
-        "//src/v/ssx:future_util",
+        "//src/v/ssx:sleep_abortable",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/v/base",
+        "//src/v/ssx:work_queue",
         "//src/v/utils:named_type",
         "@seastar",
     ],

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -330,6 +330,15 @@ frontend::metastore_partition(const model::topic_id_partition& tp) const {
     return model::partition_id{static_cast<int32_t>(partition)};
 }
 
+std::optional<int> frontend::num_metastore_partitions() const {
+    const auto md = _metadata->local().get_topic_metadata_ref(
+      model::l1_metastore_nt);
+    if (!md) {
+        return std::nullopt;
+    }
+    return md->get().get_configuration().partition_count;
+}
+
 ss::future<rpc::add_objects_reply> frontend::add_objects_locally(
   rpc::add_objects_request request,
   const model::ntp& metastore_ntp,

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -138,6 +138,18 @@ ss::future<rpc::set_start_offset_reply> do_set_start_offset(
     co_return co_await domain_mgr->set_start_offset(std::move(req));
 }
 
+ss::future<rpc::remove_topics_reply> do_remove_topics(
+  domain_supervisor& domain_supervisor,
+  const model::ntp& ntp,
+  rpc::remove_topics_request req) {
+    auto domain_mgr = domain_supervisor.get(ntp);
+    if (!domain_mgr) {
+        co_return rpc::remove_topics_reply{
+          .ec = rpc::errc::not_leader, .not_removed = {}};
+    }
+    co_return co_await domain_mgr->remove_topics(std::move(req));
+}
+
 } // namespace
 
 template<auto Func, typename req_t>
@@ -518,6 +530,25 @@ ss::future<rpc::set_start_offset_reply> frontend::set_start_offset(
     co_return co_await process<
       &frontend::set_start_offset_locally,
       &client::set_start_offset>(std::move(request), bool(local_only_exec));
+}
+
+ss::future<rpc::remove_topics_reply> frontend::remove_topics_locally(
+  rpc::remove_topics_request request,
+  const model::ntp& metastore_ntp,
+  ss::shard_id shard) {
+    co_return co_await container().invoke_on(
+      shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
+          return do_remove_topics(
+            *(fe._domain_supervisor), metastore_ntp, std::move(req));
+      });
+}
+
+ss::future<rpc::remove_topics_reply> frontend::remove_topics(
+  rpc::remove_topics_request request, local_only local_only_exec) {
+    auto holder = _gate.hold();
+    co_return co_await process<
+      &frontend::remove_topics_locally,
+      &client::remove_topics>(std::move(request), bool(local_only_exec));
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -92,6 +92,8 @@ public:
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
+    std::optional<int> num_metastore_partitions() const;
+
     ss::future<bool> ensure_topic_exists();
 
 private:

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -86,6 +86,9 @@ public:
     ss::future<rpc::set_start_offset_reply> set_start_offset(
       rpc::set_start_offset_request, local_only = local_only::no);
 
+    ss::future<rpc::remove_topics_reply>
+      remove_topics(rpc::remove_topics_request, local_only = local_only::no);
+
     std::optional<model::partition_id>
     metastore_partition(const model::topic_id_partition&) const;
 
@@ -162,6 +165,11 @@ private:
 
     ss::future<rpc::set_start_offset_reply> set_start_offset_locally(
       rpc::set_start_offset_request,
+      const model::ntp& metastore_ntp,
+      ss::shard_id);
+
+    ss::future<rpc::remove_topics_reply> remove_topics_locally(
+      rpc::remove_topics_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -189,6 +189,17 @@ public:
     virtual ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) = 0;
 
+    struct topic_removal_response {
+        // Topic IDs that were not removed from the metastore and still have
+        // state to be removed in a subsequent attempt.
+        chunked_hash_set<model::topic_id> not_removed;
+    };
+    // Removes the given topics from the metastore, returning any that need to
+    // be retried. If an error is returned, callers should assume that all
+    // topics need to be retried.
+    virtual ss::future<std::expected<topic_removal_response, errc>>
+    remove_topics(const chunked_vector<model::topic_id>&) = 0;
+
     // Finds the first object of a given partition with data greater than or
     // equal to the given offset. If no such offset exists, returns
     // `out_of_range`.

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -387,6 +387,12 @@ replicated_metastore::set_start_offset(
     co_return std::expected<void, metastore::errc>{};
 }
 
+ss::future<std::expected<metastore::topic_removal_response, metastore::errc>>
+replicated_metastore::remove_topics(const chunked_vector<model::topic_id>&) {
+    // XXX: implemented in the next commit!
+    co_return std::unexpected(metastore::errc::invalid_request);
+}
+
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 replicated_metastore::get_first_ge(
   const model::topic_id_partition& tidp, kafka::offset offset) {

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -388,9 +388,48 @@ replicated_metastore::set_start_offset(
 }
 
 ss::future<std::expected<metastore::topic_removal_response, metastore::errc>>
-replicated_metastore::remove_topics(const chunked_vector<model::topic_id>&) {
-    // XXX: implemented in the next commit!
-    co_return std::unexpected(metastore::errc::invalid_request);
+replicated_metastore::remove_topics(
+  const chunked_vector<model::topic_id>& topics) {
+    auto num_metastore_partitions = fe_.num_metastore_partitions();
+    if (!num_metastore_partitions.has_value()) {
+        vlog(cd_log.warn, "Unable to get num metastore partitions");
+        co_return std::unexpected(errc::transport_error);
+    }
+    static constexpr auto max_rpc_concurrency = 10;
+    chunked_hash_set<model::topic_id> not_removed;
+    auto fut = co_await ss::coroutine::as_future(
+      ss::max_concurrent_for_each(
+        std::views::iota(0, *num_metastore_partitions),
+        max_rpc_concurrency,
+        [this, &topics, &not_removed](int pid) {
+            return fe_
+              .remove_topics(
+                rpc::remove_topics_request{
+                  .metastore_partition = model::partition_id{pid},
+                  .topics = topics.copy(),
+                })
+              .then(
+                [&not_removed, &topics](const rpc::remove_topics_reply& repl) {
+                    if (topics.size() == not_removed.size()) {
+                        // Minor optimization: exit early if the set needing
+                        // retry is the complete set of topics to remove.
+                        return;
+                    }
+                    if (repl.ec != rpc::errc::ok) {
+                        not_removed.insert(topics.begin(), topics.end());
+                    }
+                    not_removed.insert(
+                      repl.not_removed.begin(), repl.not_removed.end());
+                });
+        }));
+    if (fut.failed()) {
+        auto ex = fut.get_exception();
+        vlog(cd_log.warn, "Error while sending topic removal requests: {}", ex);
+        co_return std::unexpected(metastore::errc::transport_error);
+    }
+    co_return topic_removal_response{
+      .not_removed = std::move(not_removed),
+    };
 }
 
 ss::future<std::expected<metastore::object_response, metastore::errc>>

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -37,6 +37,9 @@ public:
     ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) override;
 
+    ss::future<std::expected<topic_removal_response, errc>>
+    remove_topics(const chunked_vector<model::topic_id>&) override;
+
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;
 

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -54,6 +54,11 @@
             "name": "set_start_offset",
             "input_type": "set_start_offset_request",
             "output_type": "set_start_offset_reply"
+        },
+        {
+            "name": "remove_topics",
+            "input_type": "remove_topics_request",
+            "output_type": "remove_topics_reply"
         }
     ]
 }

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -285,6 +285,28 @@ struct set_start_offset_request
     kafka::offset start_offset;
 };
 
+struct remove_topics_reply
+  : serde::envelope<
+      remove_topics_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    auto serde_fields() { return std::tie(ec, not_removed); }
+
+    errc ec;
+    chunked_vector<model::topic_id> not_removed;
+};
+struct remove_topics_request
+  : serde::envelope<
+      remove_topics_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using resp_t = remove_topics_reply;
+    auto serde_fields() { return std::tie(metastore_partition, topics); }
+
+    model::partition_id metastore_partition;
+    chunked_vector<model::topic_id> topics;
+};
+
 } //  namespace cloud_topics::l1::rpc
 
 template<>

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -39,6 +39,12 @@ ss::future<set_start_offset_reply> service::set_start_offset(
       std::move(request), frontend::local_only::yes);
 }
 
+ss::future<remove_topics_reply> service::remove_topics(
+  remove_topics_request request, ::rpc::streaming_context&) {
+    return _frontend->local().remove_topics(
+      std::move(request), frontend::local_only::yes);
+}
+
 ss::future<get_first_offset_ge_reply> service::get_first_offset_ge(
   get_first_offset_ge_request request, ::rpc::streaming_context&) {
     return _frontend->local().get_first_offset_ge(

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -35,6 +35,9 @@ public:
     ss::future<set_start_offset_reply> set_start_offset(
       set_start_offset_request, ::rpc::streaming_context&) override;
 
+    ss::future<remove_topics_reply>
+    remove_topics(remove_topics_request, ::rpc::streaming_context&) override;
+
     ss::future<get_first_offset_ge_reply> get_first_offset_ge(
       get_first_offset_ge_request, ::rpc::streaming_context&) override;
 

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -240,6 +240,33 @@ simple_metastore::set_start_offset(
     co_return std::expected<void, metastore::errc>{};
 }
 
+ss::future<std::expected<metastore::topic_removal_response, metastore::errc>>
+simple_metastore::remove_topics(const chunked_vector<model::topic_id>& topics) {
+    auto update_res = remove_topics_update::build(state_, topics.copy());
+    if (!update_res.has_value()) {
+        vlog(cd_log.debug, "Topics removal failed: {}", update_res.error());
+        co_return std::unexpected(metastore::errc::invalid_request);
+    }
+    auto apply_res = update_res->apply(state_);
+    vassert(
+      apply_res.has_value(),
+      "Apply must succeed if can_apply() is true: {}",
+      apply_res.error());
+    topic_removal_response resp;
+    for (const auto& t : topics) {
+        if (state_.topic_to_state.contains(t)) {
+            vlog(cd_log.error, "Topics removal didn't remove topic {}", t);
+            resp.not_removed.insert(t);
+        }
+    }
+    vassert(
+      resp.not_removed.empty(),
+      "Topic removal in the simple_metastore is expected to always remove all "
+      "requested topics, {} not removed",
+      resp.not_removed.size());
+    co_return resp;
+}
+
 ss::future<std::expected<metastore::object_response, metastore::errc>>
 simple_metastore::get_first_ge(
   const model::topic_id_partition& tpr, kafka::offset o) {

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -70,6 +70,9 @@ public:
     ss::future<std::expected<void, errc>>
     set_start_offset(const model::topic_id_partition&, kafka::offset) override;
 
+    ss::future<std::expected<topic_removal_response, errc>>
+    remove_topics(const chunked_vector<model::topic_id>&) override;
+
     ss::future<std::expected<object_response, errc>>
     get_first_ge(const model::topic_id_partition&, kafka::offset) override;
 

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -140,6 +140,12 @@ ss::future<> simple_stm::do_apply(const model::record_batch& batch) {
             maybe_log_update_error(_log, key, o, result);
             break;
         }
+        case update_key::remove_topics: {
+            auto update = serde::read<remove_topics_update>(value_parser);
+            auto result = update.apply(state_);
+            maybe_log_update_error(_log, key, o, result);
+            break;
+        }
         }
     }
 

--- a/src/v/cloud_topics/level_one/metastore/state_update.cc
+++ b/src/v/cloud_topics/level_one/metastore/state_update.cc
@@ -707,4 +707,49 @@ remove_objects_update::apply(state& state) {
     return std::monostate{};
 }
 
+std::expected<remove_topics_update, stm_update_error>
+remove_topics_update::build(
+  const state& state, chunked_vector<model::topic_id> topics) {
+    remove_topics_update update{
+      .topics = std::move(topics),
+    };
+    auto allowed = update.can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    return update;
+}
+
+std::expected<std::monostate, stm_update_error>
+remove_topics_update::can_apply(const state&) {
+    return std::monostate{};
+}
+
+std::expected<std::monostate, stm_update_error>
+remove_topics_update::apply(state& state) {
+    auto allowed = can_apply(state);
+    if (!allowed.has_value()) {
+        return std::unexpected(allowed.error());
+    }
+    for (const auto tid : topics) {
+        auto t_it = state.topic_to_state.find(tid);
+        if (t_it == state.topic_to_state.end()) {
+            continue;
+        }
+        const auto& t_state = t_it->second;
+        for (const auto& [pid, p_state] : t_state.pid_to_state) {
+            for (const auto& e : p_state.extents) {
+                auto o_it = state.objects.find(e.oid);
+                if (o_it == state.objects.end()) {
+                    continue;
+                }
+                auto& [oid, obj_entry] = *o_it;
+                obj_entry.removed_data_size += e.len;
+            }
+        }
+        state.topic_to_state.erase(t_it);
+    }
+    return std::monostate{};
+}
+
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/state_update.h
+++ b/src/v/cloud_topics/level_one/metastore/state_update.h
@@ -25,6 +25,7 @@ enum class update_key : uint8_t {
     replace_objects = 1,
     set_start_offset = 2,
     remove_objects = 3,
+    remove_topics = 4,
 };
 
 using stm_update_error = named_type<ss::sstring, struct update_error_tag>;
@@ -208,6 +209,26 @@ struct remove_objects_update
     chunked_vector<object_id> objects;
 };
 
+struct remove_topics_update
+  : public serde::envelope<
+      remove_topics_update,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    friend bool
+    operator==(const remove_topics_update&, const remove_topics_update&)
+      = default;
+    auto serde_fields() { return std::tie(topics); }
+    static constexpr auto key{update_key::remove_topics};
+
+    static std::expected<remove_topics_update, stm_update_error>
+    build(const state&, chunked_vector<model::topic_id>);
+
+    std::expected<std::monostate, stm_update_error> can_apply(const state&);
+    std::expected<std::monostate, stm_update_error> apply(state&);
+
+    chunked_vector<model::topic_id> topics;
+};
+
 } // namespace cloud_topics::l1
 
 template<>
@@ -225,6 +246,8 @@ struct fmt::formatter<cloud_topics::l1::update_key> final
             return formatter<string_view>::format("set_start_offset", ctx);
         case cloud_topics::l1::update_key::remove_objects:
             return formatter<string_view>::format("remove_objects", ctx);
+        case cloud_topics::l1::update_key::remove_topics:
+            return formatter<string_view>::format("remove_topics", ctx);
         }
     }
 };

--- a/src/v/cloud_topics/level_one/metastore/tests/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/tests/BUILD
@@ -93,6 +93,25 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
+    name = "topic_purger_test",
+    timeout = "short",
+    srcs = [
+        "topic_purger_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_topics/level_one/metastore:simple",
+        "//src/v/cloud_topics/level_one/metastore:topic_purger",
+        "//src/v/cluster",
+        "//src/v/cluster:nt_revision",
+        "//src/v/model",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "offset_interval_set_test",
     timeout = "short",
     srcs = [

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -41,6 +41,10 @@ public:
           fmt::format("deadbeef-aaaa-0000-0000-000000000000/{}", i));
     }
 
+    model::topic_id_partition make_topic_p0(int t) {
+        return model::topic_id_partition::from(
+          fmt::format("deadbeef-aaaa-0000-0000-{:012x}/0", t));
+    };
     // Create an object builder with objects for the given number of
     // partitions, one per partition.
     void create_initial_objects(
@@ -82,6 +86,36 @@ public:
                 .term = model::term_id{0}, .first_offset = o{0}});
         }
         auto add_res = meta.add_objects(*objs, terms).get();
+        ASSERT_TRUE_CORO(add_res.has_value());
+    }
+
+    ss::future<> add_objects_for_topics(
+      replicated_metastore& meta, int topics_count, int last_offset) {
+        auto obj_builder = meta.object_builder().get().value();
+        metastore::term_offset_map_t terms;
+        for (int i = 0; i < topics_count; ++i) {
+            auto tp = make_topic_p0(i);
+            auto oid = obj_builder->get_or_create_object_for(tp).value();
+            auto add_res = obj_builder->add(
+              oid,
+              metastore::object_metadata::ntp_metadata{
+                .tidp = tp,
+                .base_offset = o{0},
+                .last_offset = o{last_offset},
+                .max_timestamp = ts{10000},
+                .pos = 0,
+                .size = 500,
+              });
+            ASSERT_TRUE_CORO(add_res.has_value()) << add_res.error();
+            auto fin_res = obj_builder->finish(oid, 500, 1000);
+            ASSERT_TRUE_CORO(fin_res.has_value()) << fin_res.error();
+
+            terms[tp].emplace_back(
+              metastore::term_offset{
+                .term = model::term_id{0}, .first_offset = o{0}});
+        }
+
+        auto add_res = co_await meta.add_objects(*obj_builder, terms);
         ASSERT_TRUE_CORO(add_res.has_value());
     }
 };
@@ -671,4 +705,114 @@ TEST_F(ReplicatedMetastoreTest, TestSetStartOffset) {
     auto term_res = meta.get_term_for_offset(tp, o{100}).get();
     ASSERT_TRUE(term_res.has_value());
     ASSERT_EQ(term_res.value(), model::term_id{0});
+}
+
+TEST_F(ReplicatedMetastoreTest, TestBasicRemoveTopics) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+
+    static constexpr auto topics_count = 10000;
+    add_objects_for_topics(meta, topics_count, 99).get();
+
+    // Sanity check that all topics exist.
+    for (int i = 0; i < topics_count; ++i) {
+        auto tp = make_topic_p0(i);
+        auto offsets = meta.get_offsets(tp).get();
+        ASSERT_TRUE(offsets.has_value());
+        ASSERT_EQ(offsets->next_offset, o{100});
+    }
+
+    // Collect all topic IDs to remove.
+    chunked_vector<model::topic_id> topic_ids_to_remove;
+    for (int i = 0; i < topics_count; ++i) {
+        auto tp = make_topic_p0(i);
+        topic_ids_to_remove.push_back(tp.topic_id);
+    }
+
+    // Remove all topics.
+    auto remove_res = meta.remove_topics(topic_ids_to_remove).get();
+    ASSERT_TRUE(remove_res.has_value());
+    EXPECT_TRUE(remove_res->not_removed.empty())
+      << remove_res->not_removed.size() << " topics remain";
+
+    // Verify all topics are gone.
+    for (int i = 0; i < topics_count; ++i) {
+        auto tp = make_topic_p0(i);
+        auto offsets = meta.get_offsets(tp).get();
+        ASSERT_FALSE(offsets.has_value());
+        ASSERT_EQ(offsets.error(), metastore::errc::missing_ntp);
+    }
+    for (int i = 0; i < 3; ++i) {
+        auto l1_stm = get_l1_stm(model::partition_id{i});
+        ASSERT_TRUE(l1_stm != nullptr);
+        auto& l1_state = l1_stm->state();
+        EXPECT_TRUE(l1_state.topic_to_state.empty());
+    }
+}
+
+TEST_F(ReplicatedMetastoreTest, TestRemoveTopicsWithShuffleLoop) {
+    auto& app = get_ct_app(model::node_id{0});
+    replicated_metastore meta(app.get_sharded_l1_metastore_fe()->local());
+
+    static constexpr auto topics_count = 1000;
+    add_objects_for_topics(meta, topics_count, 99).get();
+
+    chunked_vector<model::topic_id> topics_to_remove;
+    for (int i = 0; i < topics_count; ++i) {
+        auto tp = make_topic_p0(i);
+        topics_to_remove.push_back(tp.topic_id);
+    }
+    // Pick a metastore partition to shuffle leadership on.
+    auto meta_ntp = model::ntp{
+      model::kafka_internal_namespace,
+      model::l1_metastore_topic,
+      model::partition_id{0},
+    };
+    // Start shuffle loop in the background.
+    ss::gate gate;
+    auto shuffle_loop = ssx::spawn_with_gate_then(gate, [this, meta_ntp] {
+        return shuffle_leadership(meta_ntp).then(
+          [] { return ss::sleep(300ms); });
+    });
+
+    // Retry until removal succeeds.
+    auto deadline = ss::lowres_clock::now() + 30s;
+    bool timed_out = false;
+    bool succeeded = false;
+    while (!succeeded) {
+        if (ss::lowres_clock::now() > deadline) {
+            timed_out = true;
+            break;
+        }
+        auto remove_res = meta.remove_topics(topics_to_remove).get();
+        if (
+          !remove_res.has_value() || !remove_res.value().not_removed.empty()) {
+            ss::sleep(100ms).get();
+            continue;
+        }
+        succeeded = true;
+    }
+
+    gate.close().get();
+    shuffle_loop.get();
+
+    ASSERT_FALSE(timed_out) << "Timed out waiting for remove_topics to succeed";
+    ASSERT_TRUE(succeeded);
+
+    // Verify all topics are gone.
+    for (int i = 0; i < topics_count; ++i) {
+        auto tp = make_topic_p0(i);
+        auto offsets = meta.get_offsets(tp).get();
+        ASSERT_FALSE(offsets.has_value());
+        ASSERT_EQ(offsets.error(), metastore::errc::missing_ntp);
+    }
+
+    // Verify metastore state is clean across all partitions.
+    for (int i = 0; i < 3; ++i) {
+        auto l1_stm = get_l1_stm(model::partition_id{i});
+        ASSERT_TRUE(l1_stm != nullptr);
+        auto& l1_state = l1_stm->state();
+        EXPECT_TRUE(l1_state.topic_to_state.empty())
+          << "Partition " << i << " still has topics";
+    }
 }

--- a/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/state_update_test.cc
@@ -1365,3 +1365,143 @@ TEST(StateUpdateTest, TestRemoveMissingObjects) {
     // The operation should have succeeded.
     EXPECT_EQ(0, s.objects.size());
 }
+
+TEST(StateUpdateTest, TestRemoveTopicsBasic) {
+    state s;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 200, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(add.apply(s).has_value());
+    EXPECT_EQ(2, s.topic_to_state.size());
+    EXPECT_EQ(1, s.objects.size());
+
+    auto& obj = s.objects.at(oid1);
+    EXPECT_EQ(198, obj.total_data_size);
+    EXPECT_EQ(0, obj.removed_data_size);
+
+    // Remove just one topic.
+    auto tp_a = model::topic_id_partition::from(tidp_a);
+    auto remove_topics_res = remove_topics_update::build(s, {tp_a.topic_id});
+    ASSERT_TRUE(remove_topics_res.has_value());
+    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+
+    // Just the other topic should remain in the state.
+    EXPECT_EQ(1, s.topic_to_state.size());
+    EXPECT_FALSE(s.topic_to_state.contains(tp_a.topic_id));
+    auto tp_b = model::topic_id_partition::from(tidp_b);
+    EXPECT_TRUE(s.topic_to_state.contains(tp_b.topic_id));
+
+    // Validate object accounting.
+    EXPECT_EQ(1, s.objects.size());
+    EXPECT_EQ(198, obj.total_data_size);
+    EXPECT_EQ(99, obj.removed_data_size);
+
+    // We should be unable to remove object until the other topic is removed.
+    auto remove_obj_res = remove_objects_update::build(s, {oid1});
+    EXPECT_FALSE(remove_obj_res.has_value());
+    EXPECT_THAT(
+      remove_obj_res.error()(), testing::ContainsRegex("is still referenced"));
+    EXPECT_EQ(1, s.objects.size());
+
+    // Now remove the other topic and try again.
+    remove_topics_res = remove_topics_update::build(s, {tp_b.topic_id});
+    ASSERT_TRUE(remove_topics_res.has_value());
+    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+
+    remove_obj_res = remove_objects_update::build(s, {oid1});
+    EXPECT_TRUE(remove_obj_res.has_value());
+    ASSERT_TRUE(remove_obj_res->apply(s).has_value());
+    EXPECT_EQ(0, s.objects.size());
+}
+
+TEST(StateUpdateTest, TestRemoveMultipleTopics) {
+    state s;
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 200, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .add(tidp_b, 0_o, 10_o, 1999_t, 100, 199)
+                        .build())
+                 .add(new_obj_builder(oid2, 200, 1100)
+                        .add(tidp_b, 11_o, 20_o, 1999_t, 0, 99)
+                        .add(tidp_c, 0_o, 10_o, 1999_t, 100, 199)
+                        .build())
+                 .add(new_obj_builder(oid3, 100, 1100)
+                        .add(tidp_a, 11_o, 20_o, 1999_t, 0, 99)
+                        .build())
+                 .add(new_obj_builder(oid4, 100, 1100)
+                        .add(tidp_c, 11_o, 20_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .add_term_start(tidp_b, 0_tm, 0_o)
+                 .add_term_start(tidp_c, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(add.apply(s).has_value());
+    EXPECT_EQ(3, s.topic_to_state.size());
+    EXPECT_EQ(4, s.objects.size());
+
+    // Remove all the topics in a single update.
+    auto tp_a = model::topic_id_partition::from(tidp_a);
+    auto tp_b = model::topic_id_partition::from(tidp_b);
+    auto tp_c = model::topic_id_partition::from(tidp_c);
+    auto remove_topics_res = remove_topics_update::build(
+      s, {tp_a.topic_id, tp_b.topic_id, tp_c.topic_id});
+    ASSERT_TRUE(remove_topics_res.has_value());
+    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+    EXPECT_EQ(0, s.topic_to_state.size());
+
+    // Sanity check, the objects should still be there -- only the topics are
+    // removed.
+    EXPECT_EQ(4, s.objects.size());
+
+    // All the objects should be removable now.
+    auto remove_obj_res = remove_objects_update::build(
+      s, {oid1, oid2, oid3, oid4});
+    ASSERT_TRUE(remove_obj_res.has_value());
+    ASSERT_TRUE(remove_obj_res->apply(s).has_value());
+    EXPECT_EQ(0, s.objects.size());
+}
+
+TEST(StateUpdateTest, TestRemoveMissingTopic) {
+    state s;
+    // Add just one topic.
+    auto add = add_objects_builder()
+                 .add(new_obj_builder(oid1, 100, 1100)
+                        .add(tidp_a, 0_o, 10_o, 1999_t, 0, 99)
+                        .build())
+                 .add_term_start(tidp_a, 0_tm, 0_o)
+                 .build();
+    ASSERT_TRUE(add.apply(s).has_value());
+    EXPECT_EQ(1, s.topic_to_state.size());
+    EXPECT_EQ(1, s.objects.size());
+
+    // Remove topics that don't exist (and one that does).
+    auto tp_a = model::topic_id_partition::from(tidp_a);
+    auto tp_b = model::topic_id_partition::from(tidp_b);
+    auto tp_c = model::topic_id_partition::from(tidp_c);
+    auto remove_topics_res = remove_topics_update::build(
+      s, {tp_a.topic_id, tp_b.topic_id, tp_c.topic_id});
+    ASSERT_TRUE(remove_topics_res.has_value());
+    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+
+    // Should succeed gracefully despite having other topics.
+    EXPECT_EQ(0, s.topic_to_state.size());
+    EXPECT_EQ(1, s.objects.size());
+
+    // Object accounting should only reflect the removed topic A.
+    auto& obj = s.objects.at(oid1);
+    EXPECT_EQ(99, obj.total_data_size);
+    EXPECT_EQ(99, obj.removed_data_size);
+
+    // Do the same with only non-existent topics. This is a no-op.
+    remove_topics_res = remove_topics_update::build(
+      s, {tp_b.topic_id, tp_c.topic_id});
+    ASSERT_TRUE(remove_topics_res.has_value());
+    ASSERT_TRUE(remove_topics_res->apply(s).has_value());
+    EXPECT_EQ(0, s.topic_to_state.size());
+    EXPECT_EQ(1, s.objects.size());
+}

--- a/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/topic_purger_test.cc
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/metastore/simple_metastore.h"
+#include "cloud_topics/level_one/metastore/topic_purger.h"
+#include "cluster/data_migrated_resources.h"
+#include "cluster/nt_revision.h"
+#include "cluster/topic_table.h"
+#include "cluster/types.h"
+#include "gtest/gtest.h"
+#include "model/fundamental.h"
+#include "test_utils/test.h"
+
+using namespace cloud_topics::l1;
+
+namespace {
+using o = kafka::offset;
+using ts = model::timestamp;
+ss::abort_source never_abort;
+model::topic_id make_tid(int i) {
+    return model::topic_id(
+      uuid_t::from_string(fmt::format("deadbeef-aaaa-0000-0000-{:012d}", i)));
+}
+model::topic make_topic(int i) {
+    return model::topic{fmt::format("test_topic_{}", i)};
+}
+
+class unreliable_metastore : public simple_metastore {
+public:
+    ss::future<std::expected<topic_removal_response, metastore::errc>>
+    remove_topics(const chunked_vector<model::topic_id>& topic_ids) override {
+        if (fail_topics_removal_) {
+            co_return std::unexpected(metastore::errc::invalid_request);
+        }
+        co_return co_await simple_metastore::remove_topics(topic_ids);
+    }
+
+    void fail_remove_topics(bool fail) { fail_topics_removal_ = fail; }
+
+private:
+    bool fail_topics_removal_{false};
+};
+
+} // namespace
+
+class TopicPurgerTest : public testing::Test {
+public:
+    TopicPurgerTest()
+      : topic_table(mr) {}
+    model::offset next_topic_table_offset() const {
+        return model::offset(topic_table.last_applied_revision()() + 1);
+    }
+    ss::future<std::error_code> register_topic(
+      const model::topic& topic,
+      model::revision_id rev,
+      model::topic_id tp_id) {
+        auto topic_cfg = cluster::topic_configuration(
+          model::kafka_namespace, topic, 1, 1, tp_id);
+        topic_cfg.properties.cloud_topic_enabled = true;
+        topic_cfg.properties.remote_delete = true;
+        co_return co_await topic_table.apply(
+          cluster::create_topic_cmd{
+            model::topic_namespace{model::kafka_namespace, topic},
+            {topic_cfg, {}}},
+          model::offset{rev()});
+    }
+    ss::future<std::error_code>
+    register_tombstone(const model::topic& topic, model::revision_id rev) {
+        co_return co_await topic_table.apply(
+          cluster::topic_lifecycle_transition{
+            .topic = cluster::
+              nt_revision{.nt = model::topic_namespace(model::kafka_namespace, topic), .initial_revision_id = model::initial_revision_id{rev()}},
+            .mode = cluster::topic_lifecycle_transition_mode::pending_gc,
+            .domain = cluster::topic_purge_domain::cloud_topic,
+          },
+          next_topic_table_offset());
+    }
+    ss::future<std::error_code>
+    remove_tombstone(const model::topic& topic, model::revision_id rev) {
+        co_return co_await topic_table.apply(
+          cluster::topic_lifecycle_transition{
+            .topic = cluster::
+              nt_revision{.nt = model::topic_namespace(model::kafka_namespace, topic), .initial_revision_id = model::initial_revision_id{rev()}},
+            .mode = cluster::topic_lifecycle_transition_mode::purged,
+            .domain = cluster::topic_purge_domain::cloud_topic,
+          },
+          next_topic_table_offset());
+    }
+    ss::future<topic_purger::remove_tombstone_ret_t>
+    remove_tombstone_fn(const cluster::nt_revision& ntr) {
+        co_await remove_tombstone(
+          ntr.nt.tp, model::revision_id{ntr.initial_revision_id()});
+        co_return std::nullopt;
+    }
+    ss::future<> register_topics(int topics_count) {
+        for (int i = 0; i < topics_count; ++i) {
+            auto e = co_await register_topic(
+              make_topic(i), model::revision_id{i}, make_tid(i));
+            EXPECT_EQ(e, cluster::errc::success);
+        }
+    }
+    ss::future<> register_tombstones(int tombstones_count) {
+        for (int i = 0; i < tombstones_count; ++i) {
+            auto e = co_await register_tombstone(
+              make_topic(i), model::revision_id{i});
+            EXPECT_EQ(e, cluster::errc::success);
+        }
+    }
+
+    ss::future<> add_objects(int topics_count, int last_offset) {
+        auto builder_res = co_await metastore.object_builder();
+        ASSERT_TRUE_CORO(builder_res.has_value());
+        auto& builder = builder_res.value();
+
+        metastore::term_offset_map_t term_offsets;
+        for (int i = 0; i < topics_count; ++i) {
+            auto tp = model::topic_id_partition(
+              make_tid(i), model::partition_id{0});
+
+            auto oid_res = builder->get_or_create_object_for(tp);
+            ASSERT_TRUE_CORO(oid_res.has_value());
+
+            auto add_res = builder->add(
+              oid_res.value(),
+              metastore::object_metadata::ntp_metadata{
+                .tidp = tp,
+                .base_offset = o{0},
+                .last_offset = o{last_offset},
+                .max_timestamp = ts{10000},
+                .pos = 0,
+                .size = 500,
+              });
+            ASSERT_TRUE_CORO(add_res.has_value());
+
+            auto finish_res = builder->finish(oid_res.value(), 1000, 1500);
+            ASSERT_TRUE_CORO(finish_res.has_value());
+
+            term_offsets[tp].push_back(
+              metastore::term_offset{
+                .term = model::term_id{0}, .first_offset = o{0}});
+        }
+
+        auto add_res = co_await metastore.add_objects(*builder, term_offsets);
+        ASSERT_TRUE_CORO(add_res.has_value());
+    }
+
+protected:
+    unreliable_metastore metastore;
+    cluster::data_migrations::migrated_resources mr;
+    cluster::topic_table topic_table;
+};
+
+TEST_F(TopicPurgerTest, TestPurgeRemovesTombstones) {
+    register_topics(3).get();
+    ASSERT_EQ(3, topic_table.all_topics().size());
+    add_objects(3, 100).get();
+
+    // Verify the metastore has offsets for all topics.
+    auto tp0 = model::topic_id_partition(make_tid(0), model::partition_id{0});
+    auto tp1 = model::topic_id_partition(make_tid(1), model::partition_id{0});
+    auto tp2 = model::topic_id_partition(make_tid(2), model::partition_id{0});
+
+    auto offsets0 = metastore.get_offsets(tp0).get();
+    auto offsets1 = metastore.get_offsets(tp1).get();
+    auto offsets2 = metastore.get_offsets(tp2).get();
+    ASSERT_TRUE(offsets0.has_value());
+    ASSERT_TRUE(offsets1.has_value());
+    ASSERT_TRUE(offsets2.has_value());
+
+    // Tombstone some of the cloud topics in the topic table.
+    register_tombstones(2).get();
+    ASSERT_EQ(2, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(1, topic_table.all_topics().size());
+
+    auto remove_tombstones = topic_purger::remove_tombstone_fn_t{
+      [this](const cluster::nt_revision& ntr) {
+          return remove_tombstone_fn(ntr);
+      }};
+
+    // Reconcile the tombstones by removing state from the metastore.
+    topic_purger purger(&metastore, &topic_table, std::move(remove_tombstones));
+    auto result = purger.purge_tombstoned_topics(&never_abort).get();
+    ASSERT_TRUE(result.has_value());
+
+    // The tombstones should be removed, as should the state in the metastore.
+    ASSERT_EQ(0, topic_table.get_cloud_topic_tombstones().size());
+
+    // Verify the metastore no longer has offsets for the tombstoned topics.
+    offsets0 = metastore.get_offsets(tp0).get();
+    offsets1 = metastore.get_offsets(tp1).get();
+    offsets2 = metastore.get_offsets(tp2).get();
+    ASSERT_FALSE(offsets0.has_value());
+    ASSERT_FALSE(offsets1.has_value());
+    ASSERT_TRUE(offsets2.has_value());
+
+    ASSERT_EQ(1, topic_table.all_topics().size());
+}
+
+TEST_F(TopicPurgerTest, TestPurgeManyTopics) {
+    static constexpr auto many_topics_count = 10000;
+    register_topics(many_topics_count).get();
+    ASSERT_EQ(many_topics_count, topic_table.all_topics().size());
+    add_objects(many_topics_count, 100).get();
+
+    register_tombstones(many_topics_count).get();
+    ASSERT_EQ(
+      many_topics_count, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(0, topic_table.all_topics().size());
+
+    auto remove_tombstones = topic_purger::remove_tombstone_fn_t{
+      [this](const cluster::nt_revision& ntr) {
+          return remove_tombstone_fn(ntr);
+      }};
+
+    // Reconcile the tombstones by removing state from the metastore.
+    topic_purger purger(&metastore, &topic_table, std::move(remove_tombstones));
+    auto result = purger.purge_tombstoned_topics(&never_abort).get();
+    ASSERT_TRUE(result.has_value());
+
+    for (int i = 0; i < many_topics_count; ++i) {
+        auto tp = model::topic_id_partition(
+          make_tid(i), model::partition_id{0});
+        auto offsets = metastore.get_offsets(tp).get();
+        ASSERT_FALSE(offsets.has_value());
+    }
+    ASSERT_EQ(0, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(0, topic_table.all_topics().size());
+}
+
+TEST_F(TopicPurgerTest, TestPurgeWithUnreliableMetastore) {
+    register_topics(3).get();
+    ASSERT_EQ(3, topic_table.all_topics().size());
+    add_objects(3, 100).get();
+
+    register_tombstones(3).get();
+    ASSERT_EQ(3, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(0, topic_table.all_topics().size());
+
+    metastore.fail_remove_topics(true);
+
+    auto remove_tombstones = topic_purger::remove_tombstone_fn_t{
+      [this](const cluster::nt_revision& ntr) {
+          return remove_tombstone_fn(ntr);
+      }};
+    topic_purger purger(&metastore, &topic_table, std::move(remove_tombstones));
+
+    // Purge should fail due to metastore failure.
+    auto result = purger.purge_tombstoned_topics(&never_abort).get();
+    ASSERT_FALSE(result.has_value());
+
+    // Tombstones should still be present since we failed to update the
+    // metastore.
+    ASSERT_EQ(3, topic_table.get_cloud_topic_tombstones().size());
+
+    // Fix the metastore and retry purge.
+    metastore.fail_remove_topics(false);
+
+    result = purger.purge_tombstoned_topics(&never_abort).get();
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(0, topic_table.get_cloud_topic_tombstones().size());
+}
+
+TEST_F(TopicPurgerTest, TestPurgeWithUnreliableController) {
+    register_topics(3).get();
+    ASSERT_EQ(3, topic_table.all_topics().size());
+    add_objects(3, 100).get();
+
+    register_tombstones(3).get();
+    ASSERT_EQ(3, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(0, topic_table.all_topics().size());
+
+    auto bad_remove_tombstones = topic_purger::remove_tombstone_fn_t{
+      [](const cluster::nt_revision&) {
+          throw std::runtime_error("Oh no!");
+          return ss::make_ready_future<topic_purger::remove_tombstone_ret_t>(
+            std::nullopt);
+      }};
+    topic_purger purger(
+      &metastore, &topic_table, std::move(bad_remove_tombstones));
+
+    // Purge should fail due to tombstone removal failure.
+    auto result = purger.purge_tombstoned_topics(&never_abort).get();
+    ASSERT_FALSE(result.has_value());
+    ASSERT_EQ(3, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(0, topic_table.all_topics().size());
+
+    // The metastore removal should have succeeded though.
+    for (int i = 0; i < 3; ++i) {
+        auto tp = model::topic_id_partition(
+          make_tid(i), model::partition_id{0});
+        auto offsets = metastore.get_offsets(tp).get();
+        ASSERT_FALSE(offsets.has_value());
+    }
+
+    // Now try again with a healthy removal function.
+    auto remove_tombstones = topic_purger::remove_tombstone_fn_t{
+      [this](const cluster::nt_revision& ntr) {
+          return remove_tombstone_fn(ntr);
+      }};
+    topic_purger purger_retry(
+      &metastore, &topic_table, std::move(remove_tombstones));
+    result = purger_retry.purge_tombstoned_topics(&never_abort).get();
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(0, topic_table.get_cloud_topic_tombstones().size());
+    ASSERT_EQ(0, topic_table.all_topics().size());
+}

--- a/src/v/cloud_topics/level_one/metastore/topic_purger.cc
+++ b/src/v/cloud_topics/level_one/metastore/topic_purger.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_topics/level_one/metastore/topic_purger.h"
+
+#include "base/vlog.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/logger.h"
+#include "cluster/topic_table.h"
+
+namespace cloud_topics::l1 {
+
+topic_purger::topic_purger(
+  metastore* metastore,
+  cluster::topic_table* topics,
+  remove_tombstone_fn_t remove_fn)
+  : metastore_(metastore)
+  , topics_(topics)
+  , remove_tombstone_(std::move(remove_fn)) {}
+
+ss::future<std::expected<void, topic_purger::error>>
+topic_purger::purge_tombstoned_topics(ss::abort_source* as) {
+    static constexpr auto max_topics_per_req = 100;
+    static constexpr auto max_failed_metastore_attempts = 5;
+    static constexpr auto max_concurrent_purges = 10;
+    while (true) {
+        const auto& tombstones = topics_->get_cloud_topic_tombstones();
+        chunked_vector<model::topic_id> topics_to_remove;
+        chunked_vector<cluster::nt_revision> ntrs_to_purge;
+        for (const auto& [ntr, tombstone] : tombstones) {
+            if (topics_to_remove.size() == max_topics_per_req) {
+                break;
+            }
+            auto tid = tombstone.topic_id;
+            topics_to_remove.emplace_back(tid);
+            ntrs_to_purge.emplace_back(ntr);
+        }
+        if (topics_to_remove.empty()) {
+            // No tombstones to remove! We're done!
+            co_return std::expected<void, error>{};
+        }
+
+        size_t failed_attempts = 0;
+        while (true) {
+            // TODO: ensure all reconcilers for the given topics are stopped,
+            // otherwise we may end up with orphaned topics in the metastore.
+            auto remove_res = co_await metastore_->remove_topics(
+              topics_to_remove);
+            if (!remove_res.has_value()) {
+                co_return std::unexpected(
+                  error{fmt::format(
+                    "Error removing topics from metastore: {}",
+                    remove_res.error())});
+            }
+            const auto& resp = remove_res.value();
+            if (resp.not_removed.empty()) {
+                break;
+            }
+            ++failed_attempts;
+            if (failed_attempts == max_failed_metastore_attempts) {
+                co_return std::unexpected(
+                  error{"Metastore requests failed too many times"});
+            }
+            if (as->abort_requested()) {
+                co_return std::unexpected(error{"Shutting down topic purger"});
+            }
+            chunked_vector<model::topic_id> topics_to_retry;
+            for (const auto& t : resp.not_removed) {
+                topics_to_retry.push_back(t);
+            }
+            vlog(
+              cd_log.debug,
+              "Retrying removal of {} topics",
+              topics_to_retry.size());
+            topics_to_remove = std::move(topics_to_retry);
+        }
+        if (as->abort_requested()) {
+            co_return std::unexpected(error{"Shutting down topic purger"});
+        }
+        // The metastore update has succeeded, go ahead and purge all the
+        // topics we just removed.
+        std::optional<topic_purger::error> first_error;
+        auto purge_fut = co_await ss::coroutine::as_future(
+          ss::max_concurrent_for_each(
+            ntrs_to_purge,
+            max_concurrent_purges,
+            [this, &first_error](const cluster::nt_revision& ntr) {
+                return remove_tombstone_(ntr).then(
+                  [&first_error](
+                    const topic_purger::remove_tombstone_ret_t& ret) {
+                      if (!ret.has_value() && !first_error.has_value()) {
+                          first_error = ret.error();
+                      }
+                  });
+            }));
+        if (purge_fut.failed()) {
+            auto ex = purge_fut.get_exception();
+            co_return std::unexpected(
+              error{fmt::format("Exception purging tombstones: {}", ex)});
+        }
+        if (first_error.has_value()) {
+            co_return std::unexpected(
+              error{fmt::format("Error purging tombstones: {}", *first_error)});
+        }
+    }
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/topic_purger.cc
+++ b/src/v/cloud_topics/level_one/metastore/topic_purger.cc
@@ -13,6 +13,10 @@
 #include "cloud_topics/level_one/metastore/metastore.h"
 #include "cloud_topics/logger.h"
 #include "cluster/topic_table.h"
+#include "cluster/topics_frontend.h"
+#include "ssx/sleep_abortable.h"
+
+using namespace std::chrono_literals;
 
 namespace cloud_topics::l1 {
 
@@ -107,6 +111,131 @@ topic_purger::purge_tombstoned_topics(ss::abort_source* as) {
         if (first_error.has_value()) {
             co_return std::unexpected(
               error{fmt::format("Error purging tombstones: {}", *first_error)});
+        }
+    }
+}
+
+// Simple loop that purges topics periodically until stopped.
+class topic_purge_loop {
+public:
+    topic_purge_loop(
+      metastore* metastore,
+      cluster::topic_table* topics,
+      cluster::topics_frontend* topics_fe)
+      : metastore_(metastore)
+      , purger_(
+          metastore_, topics, [topics_fe](const cluster::nt_revision& ntr) {
+              return topics_fe
+                ->purged_topic(
+                  ntr, cluster::topic_purge_domain::cloud_topic, 5s)
+                .then(
+                  [&ntr](const cluster::topic_result& res)
+                    -> topic_purger::remove_tombstone_ret_t {
+                      if (res.ec != cluster::errc::success) {
+                          return std::unexpected(
+                            topic_purger::error{fmt::format(
+                              "Error purging topic {}: {}", ntr, res)});
+                      }
+                      return std::nullopt;
+                  });
+          }) {}
+
+    void start() {
+        ssx::spawn_with_gate(gate_, [this] { return run_loop(); });
+    }
+
+    ss::future<> stop_and_wait() {
+        vlog(cd_log.debug, "Topic purge loop stopping...");
+        as_.request_abort();
+        co_await gate_.close();
+        vlog(cd_log.debug, "Topic purge loop stopped...");
+    }
+
+private:
+    ss::future<> run_loop() {
+        while (!as_.abort_requested()) {
+            static const auto purge_interval = 30s;
+            auto res = co_await purger_.purge_tombstoned_topics(&as_);
+            if (!res.has_value()) {
+                vlog(
+                  cd_log.warn,
+                  "Failed to purge tombstoned cloud topics: {}",
+                  res.error());
+            }
+            auto sleep_res = co_await ss::coroutine::as_future(
+              ssx::sleep_abortable(purge_interval, as_));
+            if (sleep_res.failed()) {
+                auto eptr = sleep_res.get_exception();
+                auto log_lvl = ssx::is_shutdown_exception(eptr)
+                                 ? ss::log_level::debug
+                                 : ss::log_level::warn;
+                vlogl(
+                  cd_log,
+                  log_lvl,
+                  "Topic purge loop hit exception while sleeping: {}",
+                  eptr);
+            }
+        }
+    }
+
+    ss::gate gate_;
+    ss::abort_source as_;
+    metastore* metastore_;
+    topic_purger purger_;
+};
+
+topic_purger_manager::topic_purger_manager(
+  metastore* metastore,
+  ss::sharded<cluster::topic_table>* topics,
+  ss::sharded<cluster::topics_frontend>* topics_fe)
+  : metastore_(metastore)
+  , topics_(topics)
+  , topics_fe_(topics_fe)
+  , queue_([](const std::exception_ptr& ex) {
+      vlog(cd_log.error, "Unexpected topic purger manager error: {}", ex);
+  }) {}
+
+topic_purger_manager::~topic_purger_manager() = default;
+
+ss::future<> topic_purger_manager::reset_purge_loop(
+  topic_purger_manager::needs_loop needs_loop) {
+    if (!needs_loop) {
+        // We should not have a running loop.
+        if (topic_purge_loop_) {
+            auto purge_loop = std::exchange(topic_purge_loop_, nullptr);
+            auto stop_fut = co_await ss::coroutine::as_future(
+              purge_loop->stop_and_wait());
+            if (stop_fut.failed()) {
+                auto ex = stop_fut.get_exception();
+                vlog(cd_log.error, "Stopping purge loop failed: {}", ex);
+            }
+        }
+        co_return;
+    }
+    // We need a running loop.
+    if (topic_purge_loop_) {
+        co_return;
+    }
+    auto loop = std::make_unique<topic_purge_loop>(
+      metastore_, &topics_->local(), &topics_fe_->local());
+    loop->start();
+    topic_purge_loop_ = std::move(loop);
+}
+
+void topic_purger_manager::enqueue_loop_reset(
+  topic_purger_manager::needs_loop needs_loop) {
+    queue_.submit(
+      [this, needs_loop]() mutable { return reset_purge_loop(needs_loop); });
+}
+
+ss::future<> topic_purger_manager::stop() {
+    co_await queue_.shutdown();
+    if (topic_purge_loop_) {
+        auto fut = co_await ss::coroutine::as_future(
+          topic_purge_loop_->stop_and_wait());
+        if (fut.failed()) {
+            auto ex = fut.get_exception();
+            vlog(cd_log.error, "Error stopping topic purger manager: {}", ex);
         }
     }
 }

--- a/src/v/cloud_topics/level_one/metastore/topic_purger.h
+++ b/src/v/cloud_topics/level_one/metastore/topic_purger.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+
+#include <expected>
+
+namespace cluster {
+class topic_table;
+struct nt_revision;
+} // namespace cluster
+
+namespace cloud_topics::l1 {
+
+class metastore;
+
+// Removes topic state from the metastore based on cloud topic tombstones that
+// are in the topic table, removing the tombstone once successful.
+class topic_purger {
+public:
+    using error = named_type<ss::sstring, struct purger_error_tag>;
+    using remove_tombstone_ret_t = std::expected<std::nullopt_t, error>;
+    using remove_tombstone_fn_t = ss::noncopyable_function<
+      ss::future<remove_tombstone_ret_t>(const cluster::nt_revision&)>;
+    topic_purger(
+      metastore* metastore,
+      cluster::topic_table* topics,
+      remove_tombstone_fn_t remove_fn);
+
+    ss::future<std::expected<void, error>>
+    purge_tombstoned_topics(ss::abort_source*);
+
+private:
+    // Callers are expected to ensure this object outlives the stm and cluster
+    // state.
+    metastore* metastore_;
+    cluster::topic_table* topics_;
+    remove_tombstone_fn_t remove_tombstone_;
+};
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/topic_purger.h
+++ b/src/v/cloud_topics/level_one/metastore/topic_purger.h
@@ -10,15 +10,18 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "ssx/work_queue.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
 
 #include <expected>
 
 namespace cluster {
 class topic_table;
+class topics_frontend;
 struct nt_revision;
 } // namespace cluster
 
@@ -48,6 +51,35 @@ private:
     metastore* metastore_;
     cluster::topic_table* topics_;
     remove_tombstone_fn_t remove_tombstone_;
+};
+
+// Manages a loop to purge topics that runs only on leadership of a partition
+// (expected that the partition is partition 0 of the metastore topic).
+class topic_purge_loop;
+class topic_purger_manager {
+public:
+    using needs_loop = ss::bool_class<struct needs_loop_tag>;
+    topic_purger_manager(
+      metastore* metastore,
+      ss::sharded<cluster::topic_table>* topics,
+      ss::sharded<cluster::topics_frontend>* topics_fe);
+    ~topic_purger_manager();
+
+    // Enqueues a reset of the loop such that eventually a topic_purge_loop
+    // will be running if needs_loop is true, or not running if false.
+    void enqueue_loop_reset(needs_loop needs);
+
+    ss::future<> stop();
+
+private:
+    ss::future<> reset_purge_loop(needs_loop needs);
+
+    metastore* metastore_;
+    ss::sharded<cluster::topic_table>* topics_;
+    ss::sharded<cluster::topics_frontend>* topics_fe_;
+
+    ssx::work_queue queue_;
+    std::unique_ptr<topic_purge_loop> topic_purge_loop_;
 };
 
 } // namespace cloud_topics::l1


### PR DESCRIPTION
Based on https://github.com/redpanda-data/redpanda/pull/27939
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Adds a new component to the cloud_topics::app to reconcile the deletion of cloud topics with the L1 metastore. This PR is structured as:
1. (split off into https://github.com/redpanda-data/redpanda/pull/27939 for a review from the replication team) Introduction of cloud topic tombstones to the controller, following the pattern we have for tiered storage and Iceberg topics, where we leave behind a marker that indicates the need to remove additional state asynchronously after a topic is deleted synchronously
2. New state updates for the metastore STM, where the removal of a given topic removes the topic from the state and drops the reference counts of all associated extents
3. Addition of topic removal to the metastore. Notably, for the replicated metastore, since any domain may contain metadata for a given topic, requests to remove topics are sent to every domain.
4. A loop that examines the controller and uses the metastore interface to periodically remove topics from the metastore if cloud topics tombstones exist. This loop is run on the leader of the partition-0 L1 domain.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
