### PR TITLE
[CORE-13839 ] `ct/l1`: add `log_collector` and `log_sampler` [CT - Compaction #5]

### DIFF
--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -165,6 +165,31 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "log_info_collector",
+    srcs = [
+        "log_info_collector.cc",
+    ],
+    hdrs = [
+        "log_info_collector.h",
+    ],
+    implementation_deps = [
+        "//src/v/ssx:future_util",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":logger",
+        ":meta",
+        "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cluster",
+        "//src/v/compaction:utils",
+        "//src/v/config",
+        "//src/v/container:chunked_vector",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "committing_policy",
     srcs = [
         "committing_policy.cc",

--- a/src/v/cloud_topics/level_one/compaction/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/BUILD
@@ -145,6 +145,26 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "log_collector",
+    srcs = [
+        "log_collector.cc",
+    ],
+    hdrs = [
+        "log_collector.h",
+    ],
+    implementation_deps = [
+        "//src/v/ssx:future_util",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/v/base",
+        "//src/v/cluster",
+        "//src/v/model",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "committing_policy",
     srcs = [
         "committing_policy.cc",

--- a/src/v/cloud_topics/level_one/compaction/log_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/log_collector.h"
+
+#include "cluster/partition.h"
+#include "cluster/partition_manager.h"
+#include "cluster/topic_configuration.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cloud_topics::l1 {
+
+ss::future<> log_collector::start() { co_await start_collecting_logs(); }
+
+ss::future<> log_collector::stop() { co_await stop_collecting_logs(); }
+
+partition_leader_log_collector::partition_leader_log_collector(
+  manage_cb_t manage_cb,
+  unmanage_cb_t unmanage_cb,
+  is_managed_cb_t is_managed_cb,
+  model::node_id self,
+  ss::sharded<cluster::partition_leaders_table>* leaders,
+  ss::sharded<cluster::topic_table>* topic_table)
+  : _manage_cb(std::move(manage_cb))
+  , _unmanage_cb(std::move(unmanage_cb))
+  , _is_managed_cb(std::move(is_managed_cb))
+  , _self(self)
+  , _leaders(leaders)
+  , _topic_table(topic_table) {}
+
+ss::future<> partition_leader_log_collector::start_collecting_logs() {
+    _ntp_notify_handle = _topic_table->local().register_ntp_delta_notification(
+      [this](cluster::topic_table::ntp_delta_range_t deltas) {
+          for (const auto& delta : deltas) {
+              on_ntp_change(delta);
+          }
+      });
+    _leader_notify_handle
+      = _leaders->local().register_leadership_change_notification(
+        [this](const model::ntp& ntp, model::term_id, model::node_id leader) {
+            on_leadership_change(std::move(ntp), leader);
+        });
+    co_return;
+}
+
+ss::future<> partition_leader_log_collector::stop_collecting_logs() {
+    auto close_fut = _gate.close();
+    _topic_table->local().unregister_ntp_delta_notification(_ntp_notify_handle);
+    _leaders->local().unregister_leadership_change_notification(
+      _leader_notify_handle);
+    co_await std::move(close_fut);
+    co_return;
+}
+
+void partition_leader_log_collector::on_ntp_change(
+  cluster::topic_table::ntp_delta delta) {
+    auto& ntp = delta.ntp;
+    auto is_managed = _is_managed_cb(ntp);
+
+    using delta_type = cluster::topic_table_ntp_delta_type;
+    switch (delta.type) {
+    case delta_type::removed: {
+        // Partition/possibly topic was removed. Unmanage it if necessary.
+        if (is_managed) {
+            _unmanage_cb(std::move(ntp), "Partition removed");
+        }
+        return;
+    }
+    case delta_type::properties_updated: {
+        auto topic_cfg_opt = _topic_table->local().get_topic_cfg(
+          model::topic_namespace_view{ntp});
+        if (!topic_cfg_opt.has_value()) {
+            return;
+        }
+
+        auto& topic_cfg = topic_cfg_opt.value();
+
+        auto is_compacted_cloud_topic = topic_cfg.is_compacted()
+                                        && topic_cfg.is_cloud_topic();
+        if (is_compacted_cloud_topic && !is_managed) {
+            // This is likely an existing cloud topic which is now `compact`
+            // enabled.
+            auto tp_id = topic_cfg.tp_id;
+            vassert(tp_id.has_value(), "Expected tp_id to have value.");
+            auto tidp = model::topic_id_partition(
+              tp_id.value(), ntp.tp.partition);
+
+            _manage_cb(ntp, tidp, "Enabled compaction");
+        }
+
+        if (!is_compacted_cloud_topic && is_managed) {
+            // This is likely an existing cloud topic which is no longer
+            // `compact` enabled.
+            _unmanage_cb(std::move(ntp), "Disabled compaction");
+        }
+        return;
+    }
+    case delta_type::added:
+        [[fallthrough]];
+    case delta_type::replicas_updated:
+        [[fallthrough]];
+    case delta_type::disabled_flag_updated:
+        return;
+    }
+}
+
+void partition_leader_log_collector::on_leadership_change(
+  model::ntp ntp, model::node_id leader) {
+    auto topic_cfg_opt = _topic_table->local().get_topic_cfg(
+      model::topic_namespace_view{ntp});
+    if (!topic_cfg_opt.has_value()) {
+        return;
+    }
+
+    auto& topic_cfg = topic_cfg_opt.value();
+
+    auto is_compacted_cloud_topic = topic_cfg.is_compacted()
+                                    && topic_cfg.is_cloud_topic();
+
+    if (!is_compacted_cloud_topic) {
+        return;
+    }
+
+    auto is_managed = _is_managed_cb(ntp);
+    auto is_leader = leader == _self;
+
+    if (is_leader && !is_managed) {
+        auto tp_id = topic_cfg.tp_id;
+        vassert(tp_id.has_value(), "Expected tp_id to have value.");
+        auto tidp = model::topic_id_partition(tp_id.value(), ntp.tp.partition);
+
+        _manage_cb(ntp, tidp, "Became the leader");
+    }
+
+    if (!is_leader && is_managed) {
+        _unmanage_cb(std::move(ntp), "Stepped down as leader");
+    }
+}
+
+std::unique_ptr<log_collector> make_default_log_collector(
+  partition_leader_log_collector::manage_cb_t manage_cb,
+  partition_leader_log_collector::unmanage_cb_t unmanage_cb,
+  partition_leader_log_collector::is_managed_cb_t is_managed_cb,
+  compaction_cluster_state state) {
+    return std::make_unique<partition_leader_log_collector>(
+      std::move(manage_cb),
+      std::move(unmanage_cb),
+      std::move(is_managed_cb),
+      state.self,
+      state.leaders_table,
+      state.topic_table);
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_collector.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/notification.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/topic_table.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
+
+namespace cloud_topics::l1 {
+
+struct compaction_cluster_state {
+    model::node_id self;
+    ss::sharded<cluster::partition_leaders_table>* leaders_table;
+    ss::sharded<cluster::topic_table>* topic_table;
+    ss::sharded<cluster::metadata_cache>* metadata_cache;
+};
+
+// Responsible for pushing CTPs/logs that require compaction to the
+// `compaction_scheduler` for managing, as well as their removal. Provides a
+// very limited interface to the user- implementors require only adding
+// `start_collecting_logs()` and `stop_collecting_logs()` functions in their
+// concrete classes.
+class log_collector {
+public:
+    virtual ~log_collector() noexcept = default;
+
+    // Starts the `log_collector` by calling `manage_logs()`, allowing it to
+    // push CTPs that require compaction to the `compaction_scheduler`, or
+    // remove CTPs that no longer require compaction from the
+    // `compaction_scheduler`.
+    ss::future<> start();
+
+    // Stops the `log_collector` by calling `unmanage_logs()`. The
+    // `compaction_scheduler` will no longer receive updates on which CTPs
+    // require managing. This should only be invoked during application
+    // shutdown.
+    ss::future<> stop();
+
+protected:
+    // Called during start-up. Initiates log collection, allowing for
+    // registration/deregistration of logs with the `compaction_scheduler`. For
+    // example, setting up a callback with a cluster object that pushes newly
+    // managed CTPs to the `compaction_scheduler`.
+    virtual ss::future<> start_collecting_logs() = 0;
+
+    // Called during tear-down. Stops the `log_collector` from making further
+    // registrations/deregistrations of logs with the `compaction_scheduler`
+    // (stopping call-backs, destructing objects or closing background loops,
+    // etc.)
+    virtual ss::future<> stop_collecting_logs() = 0;
+};
+
+// An implementation of the `log_collector` that pushes CTPs which have leaders
+// on this broker (irrespective of shard) to the `compaction_scheduler`.
+class partition_leader_log_collector : public log_collector {
+public:
+    // Typedefs for necessary functions to call into the `compaction_scheduler`.
+    using manage_cb_t = ss::noncopyable_function<void(
+      const model::ntp&, const model::topic_id_partition&, std::string_view)>;
+    using unmanage_cb_t
+      = ss::noncopyable_function<void(const model::ntp&, std::string_view)>;
+    using is_managed_cb_t = ss::noncopyable_function<bool(const model::ntp&)>;
+
+    partition_leader_log_collector(
+      manage_cb_t,
+      unmanage_cb_t,
+      is_managed_cb_t,
+      model::node_id,
+      ss::sharded<cluster::partition_leaders_table>*,
+      ss::sharded<cluster::topic_table>*);
+
+protected:
+    // Sets up `*_notify_handles` using pointers to `cluster` utilities.
+    ss::future<> start_collecting_logs() final;
+
+    // Tears down `*_notify_handles` using pointers to `cluster` utilities.
+    ss::future<> stop_collecting_logs() final;
+
+private:
+    // Registers/unregisters `ntp`s with the `compaction_scheduler` using
+    // `ntp_delta` notifications from the `topic_table`. The following cases are
+    // handled:
+    // 1. A cloud-topic enabled `ntp` becomes `compact`-enabled (register)
+    // 2. A cloud-topic enabled `ntp` is no longer `compact`-enabled
+    // (unregister)
+    // 3. A currently managed `ntp` is removed (unregister)
+    //
+    // Register operations can be performed synchronously while unregister
+    // operations are performed in a backgrounded fiber (see
+    // `compaction_scheduler::unmanage_partition()`).
+    void on_ntp_change(cluster::topic_table::ntp_delta);
+
+    // Registers/unregisters `ntp`s with the `compaction_scheduler` using
+    // leadership notifications from the `partition_leaders_table`. The
+    // following cases are handled:
+    // 1. A cloud-topic, `compact`-enabled `ntp` becomes the leader on a shard
+    // on this node (register)
+    // 2. A cloud-topic, `compact`-enabled `ntp` steps down from being the
+    // leader on a shard on this node (unregister)
+    //
+    // Register operations can be performed synchronously while unregister
+    // operations are performed in a backgrounded fiber (see
+    // `compaction_scheduler::unmanage_partition()`).
+    void on_leadership_change(model::ntp, model::node_id);
+
+    // Callback to register a partition with the `compaction_scheduler`.
+    manage_cb_t _manage_cb;
+
+    // Callback to deregister a partition with the `compaction_scheduler`.
+    unmanage_cb_t _unmanage_cb;
+
+    // Callback to query whether a partition is registered with the
+    // `compaction_scheduler`.
+    is_managed_cb_t _is_managed_cb;
+
+    // The `node_id` of the current broker.
+    model::node_id _self;
+
+    ss::gate _gate;
+
+    // A notification handle that tracks `ntp_delta` notifications from the
+    // `topic_table` (notably property updates & removals).
+    cluster::notification_id_type _ntp_notify_handle;
+
+    // A notification handle that tracks leadership notifications from the
+    // `partition_leaders_table`.
+    cluster::notification_id_type _leader_notify_handle;
+
+    ss::sharded<cluster::partition_leaders_table>* _leaders;
+    ss::sharded<cluster::topic_table>* _topic_table;
+};
+
+std::unique_ptr<log_collector> make_default_log_collector(
+  partition_leader_log_collector::manage_cb_t,
+  partition_leader_log_collector::unmanage_cb_t,
+  partition_leader_log_collector::is_managed_cb_t,
+  compaction_cluster_state);
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.cc
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/log_info_collector.h"
+
+#include "cloud_topics/level_one/compaction/logger.h"
+#include "cloud_topics/level_one/compaction/meta.h"
+#include "compaction/utils.h"
+#include "config/configuration.h"
+#include "container/chunked_vector.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace cloud_topics::l1 {
+
+namespace {
+
+inline bool needs_compaction(
+  const log_compaction_meta& log,
+  const cluster::topic_configuration& topic_cfg) {
+    auto& topic_mcdr = topic_cfg.properties.min_cleanable_dirty_ratio;
+    auto min_cleanable_dirty_ratio
+      = topic_mcdr.has_optional_value()
+          ? topic_mcdr.value()
+          : config::shard_local_cfg().min_cleanable_dirty_ratio().value_or(0.0);
+    auto& topic_mcl = topic_cfg.properties.max_compaction_lag_ms;
+    auto max_compaction_lag_ms
+      = topic_mcl.has_value()
+          ? topic_mcl.value()
+          : config::shard_local_cfg().max_compaction_lag_ms();
+    return compaction::log_needs_compaction(
+      log.info_and_ts->info.dirty_ratio,
+      min_cleanable_dirty_ratio,
+      log.info_and_ts->info.earliest_dirty_ts,
+      max_compaction_lag_ms);
+}
+
+} // namespace
+
+topic_cfg_provider_impl::topic_cfg_provider_impl(
+  cluster::metadata_cache* metadata_cache)
+  : _metadata_cache(metadata_cache) {}
+
+std::optional<std::reference_wrapper<const cluster::topic_configuration>>
+topic_cfg_provider_impl::get_topic_cfg(model::topic_namespace_view tp) const {
+    auto topic_md_ref = _metadata_cache->get_topic_metadata_ref(tp);
+    if (!topic_md_ref.has_value()) {
+        return std::nullopt;
+    }
+
+    return topic_md_ref.value().get().get_configuration();
+}
+
+log_info_collector::log_info_collector(
+  metastore* metastore,
+  std::unique_ptr<topic_cfg_provider> tp_metadata_provider)
+  : _metastore(metastore)
+  , _topic_metadata_provider(std::move(tp_metadata_provider)) {}
+
+ss::future<> log_info_collector::collect_info_for_logs(
+  log_set_t& logs_set,
+  log_list_t& logs_list,
+  log_compaction_queue& compaction_queue) const {
+    auto now = model::timestamp::now();
+
+    auto to_collect = get_logs_to_collect(logs_list, logs_set.size(), now);
+
+    auto compaction_infos = co_await _metastore->get_compaction_infos(
+      to_collect);
+
+    populate_log_infos(
+      compaction_infos, logs_set, logs_list, compaction_queue, now);
+}
+
+chunked_vector<metastore::compaction_info_spec>
+log_info_collector::get_logs_to_collect(
+  log_list_t& logs_list,
+  size_t size,
+  model::timestamp collection_timestamp) const {
+    chunked_vector<metastore::compaction_info_spec> to_collect;
+
+    to_collect.reserve(size);
+
+    for (const auto& log : logs_list) {
+        if (!log.link.is_linked()) {
+            continue;
+        }
+
+        if (log.inflight) {
+            // No need to sample inflight logs
+            vlog(
+              compaction_log.debug,
+              "Skipping info collection for CTP {}, compaction is inflight",
+              log.ntp);
+            continue;
+        }
+
+        if (log.info_and_ts.has_value()) {
+            // TODO: maybe configure this some other way.
+            auto sample_interval
+              = config::shard_local_cfg().log_compaction_interval_ms();
+            auto delta = to_time_point(collection_timestamp)
+                         - to_time_point(log.info_and_ts->collected_at);
+            if (delta <= sample_interval) {
+                vlog(
+                  compaction_log.debug,
+                  "Skipping info collection for CTP {}, delta is less than "
+                  "sample interval.",
+                  log.ntp);
+
+                continue;
+            }
+        }
+
+        auto topic_cfg_opt = _topic_metadata_provider->get_topic_cfg(
+          model::topic_namespace_view(log.ntp));
+
+        if (!topic_cfg_opt.has_value()) {
+            continue;
+        }
+
+        const auto& topic_cfg = topic_cfg_opt.value().get();
+        auto tombstone_removal_ts =
+          [&topic_cfg, collection_timestamp]() -> model::timestamp {
+            // Cleaned ranges with tombstones that were cleaned at or below
+            // tombstone_removal_upper_bound_ts are eligible to have tombstones
+            // entirely removed.
+            auto delete_retention_ms
+              = config::shard_local_cfg().tombstone_retention_ms();
+            if (topic_cfg.properties.delete_retention_ms.has_optional_value()) {
+                delete_retention_ms
+                  = topic_cfg.properties.delete_retention_ms.value();
+            }
+
+            if (topic_cfg.properties.delete_retention_ms.is_disabled()) {
+                delete_retention_ms = std::nullopt;
+            }
+
+            return delete_retention_ms.has_value()
+                     ? collection_timestamp
+                         - model::timestamp(delete_retention_ms->count())
+                     : model::timestamp::max();
+        }();
+        vlog(compaction_log.debug, "Sampling CTP {}", log.ntp);
+
+        to_collect.emplace_back(log.tidp, tombstone_removal_ts);
+    }
+
+    to_collect.shrink_to_fit();
+    return to_collect;
+}
+
+void log_info_collector::populate_log_infos(
+  const metastore::compaction_info_map& compaction_infos,
+  log_set_t& logs_set,
+  log_list_t& logs_list,
+  log_compaction_queue& compaction_queue,
+  model::timestamp collection_timestamp) const {
+    for (auto& log : logs_list) {
+        if (!log.link.is_linked()) {
+            continue;
+        }
+
+        if (log.inflight) {
+            // Don't step on compaction info that is actively being used.
+            continue;
+        }
+
+        auto it = compaction_infos.find(log.tidp);
+        if (it == compaction_infos.end()) {
+            // Likely this log was not sampled because the log was previously
+            // sampled less than `gather_interval` time ago.
+            continue;
+        }
+
+        auto& compaction_info = it->second;
+
+        if (!compaction_info.has_value()) {
+            vlog(
+              compaction_log.warn,
+              "Failed to collect compaction info for CTP {} during compaction: "
+              "{}",
+              log.ntp,
+              compaction_info.error());
+            continue;
+        }
+
+        log.info_and_ts = compaction_info_and_timestamp{
+          .info = std::move(compaction_info).value(),
+          .collected_at = collection_timestamp};
+
+        vlog(
+          compaction_log.debug,
+          "Compaction info for CTP {} returned {}",
+          log.ntp,
+          log.info_and_ts->info.dirty_ratio);
+
+        auto topic_cfg_opt = _topic_metadata_provider->get_topic_cfg(
+          model::topic_namespace_view(log.ntp));
+
+        if (!topic_cfg_opt.has_value()) {
+            continue;
+        }
+
+        const auto& topic_cfg = topic_cfg_opt.value().get();
+
+        if (needs_compaction(log, topic_cfg)) {
+            auto ptr_it = logs_set.find(log.tidp);
+            if (ptr_it != logs_set.end()) {
+                compaction_queue.push(*ptr_it);
+            }
+        }
+    }
+}
+
+log_info_collector make_default_log_info_collector(
+  metastore* metastore, cluster::metadata_cache* metadata_cache) {
+    return log_info_collector(
+      metastore, std::make_unique<topic_cfg_provider_impl>(metadata_cache));
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/log_info_collector.h
+++ b/src/v/cloud_topics/level_one/compaction/log_info_collector.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/types.h"
+
+namespace cloud_topics::l1 {
+
+// A wrapper to provide easy mocking and break dependency on a multitude of
+// cluster objects within the `log_info_collector`.
+class topic_cfg_provider {
+public:
+    virtual ~topic_cfg_provider() noexcept = default;
+
+    virtual std::optional<
+      std::reference_wrapper<const cluster::topic_configuration>>
+      get_topic_cfg(model::topic_namespace_view) const = 0;
+};
+
+// Default topic_cfg_provider, which is the `cluster::metadata_cache`.
+class topic_cfg_provider_impl : public topic_cfg_provider {
+public:
+    topic_cfg_provider_impl(cluster::metadata_cache*);
+
+    std::optional<std::reference_wrapper<const cluster::topic_configuration>>
+      get_topic_cfg(model::topic_namespace_view) const final;
+
+private:
+    cluster::metadata_cache* _metadata_cache;
+};
+
+// Responsible for issuing `get_compaction_info()` requests to the `metastore`
+// when attempting to schedule a round of compactions.
+class log_info_collector {
+public:
+    log_info_collector(metastore*, std::unique_ptr<topic_cfg_provider>);
+
+    // Populates `info_and_ts` within `log_compaction_meta`s from the provided
+    // `log_list_t` by collecting each log's compaction info from the metastore.
+    // It is not guaranteed that every log present in `log_list_t` will have its
+    // `info_and_ts` set e.g. due to concurrent removal or metastore errors.
+    // If a log already has `info_and_ts` set, it will not be collected again
+    // until an interval has elapsed and the current `info_and_ts` is determined
+    // stale. Additionally, logs that have an inflight compaction in process do
+    // not need to be collected. Logs that have their information collected and
+    // deemed eligible for compaction will also have their `lw_shared_ptr`
+    // copied into the `log_compaction_queue` for future compaction.
+    ss::future<>
+    collect_info_for_logs(log_set_t&, log_list_t&, log_compaction_queue&) const;
+
+private:
+    // Returns a container of `compaction_info_spec` to sample the metastore
+    // with based on the input `log_list_t`.
+    chunked_vector<metastore::compaction_info_spec>
+    get_logs_to_collect(log_list_t&, size_t, model::timestamp) const;
+
+    // Sets compaction info state within the input logs per the
+    // `compaction_info_map` collected from the metastore and pushes logs
+    // eligible for compaction to the provided `log_compaction_queue`.
+    void populate_log_infos(
+      const metastore::compaction_info_map&,
+      log_set_t&,
+      log_list_t&,
+      log_compaction_queue&,
+      model::timestamp) const;
+
+    // Owned by `app`.
+    metastore* _metastore;
+
+    std::unique_ptr<topic_cfg_provider> _topic_metadata_provider;
+};
+
+log_info_collector
+make_default_log_info_collector(metastore*, cluster::metadata_cache*);
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -57,11 +57,11 @@ struct log_compaction_meta_hash {
 
     size_t
     operator()(const cloud_topics::l1::log_compaction_meta_ptr& m) const {
-        return std::hash<model::ntp>{}(m->ntp);
+        return absl::Hash<model::topic_id_partition>{}(m->tidp);
     }
 
-    size_t operator()(const model::ntp& ntp) const {
-        return std::hash<model::ntp>{}(ntp);
+    size_t operator()(const model::topic_id_partition& tidp) const {
+        return absl::Hash<model::topic_id_partition>{}(tidp);
     }
 };
 
@@ -71,19 +71,19 @@ struct log_compaction_meta_eq {
     bool operator()(
       const cloud_topics::l1::log_compaction_meta_ptr& lhs,
       const cloud_topics::l1::log_compaction_meta_ptr& rhs) const {
-        return lhs->ntp == rhs->ntp;
+        return lhs->tidp == rhs->tidp;
     }
 
     bool operator()(
       const cloud_topics::l1::log_compaction_meta_ptr& lhs,
-      const model::ntp& rhs) const noexcept {
-        return lhs->ntp == rhs;
+      const model::topic_id_partition& rhs) const noexcept {
+        return lhs->tidp == rhs;
     }
 
     bool operator()(
-      const model::ntp& lhs,
+      const model::topic_id_partition& lhs,
       const cloud_topics::l1::log_compaction_meta_ptr& rhs) const {
-        return lhs == rhs->ntp;
+        return lhs == rhs->tidp;
     }
 };
 

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -87,7 +87,7 @@ struct log_compaction_meta_eq {
     }
 };
 
-using logs_type_t = chunked_hash_set<
+using log_set_t = chunked_hash_set<
   log_compaction_meta_ptr,
   log_compaction_meta_hash,
   log_compaction_meta_eq>;

--- a/src/v/cloud_topics/level_one/compaction/meta.h
+++ b/src/v/cloud_topics/level_one/compaction/meta.h
@@ -25,11 +25,11 @@
 
 namespace cloud_topics::l1 {
 
-// Contains sampled information from the metastore and the time at which it was
-// sampled.
+// Contains compaction information collected from the metastore and the time at
+// which it was obtained.
 struct compaction_info_and_timestamp {
     metastore::compaction_info_response info;
-    model::timestamp sampled_at;
+    model::timestamp collected_at;
 };
 
 struct log_compaction_meta {
@@ -40,7 +40,7 @@ struct log_compaction_meta {
     model::topic_id_partition tidp;
     model::ntp ntp;
     // If set, this is cached compaction metadata obtained from the metastore at
-    // the `sampled_at` time.
+    // the `collected_at` time.
     std::optional<compaction_info_and_timestamp> info_and_ts{std::nullopt};
     // If set, this is the shard on which the log is currently undergoing an
     // inflight compaction.

--- a/src/v/cloud_topics/level_one/compaction/tests/BUILD
+++ b/src/v/cloud_topics/level_one/compaction/tests/BUILD
@@ -71,3 +71,22 @@ redpanda_cc_gtest(
         "@seastar",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "log_info_collector_test",
+    timeout = "short",
+    srcs = [
+        "log_info_collector_test.cc",
+    ],
+    deps = [
+        "//src/v/cloud_topics/level_one/compaction:log_info_collector",
+        "//src/v/cloud_topics/level_one/compaction:meta",
+        "//src/v/cloud_topics/level_one/frontend_reader/tests:l1_reader_fixture",
+        "//src/v/cluster",
+        "//src/v/model",
+        "//src/v/model/tests:random",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/cloud_topics/level_one/compaction/tests/log_info_collector_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/log_info_collector_test.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_topics/level_one/compaction/log_info_collector.h"
+#include "cloud_topics/level_one/compaction/meta.h"
+#include "cloud_topics/level_one/frontend_reader/tests/l1_reader_fixture.h"
+#include "cluster/topic_configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/tests/random_batch.h"
+
+#include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <variant>
+
+using namespace cloud_topics;
+
+class LogInfoCollectorTestFixture : public l1::l1_reader_fixture {};
+
+// A fake topic config provider which always returns a value.
+class fake_cfg_provider : public l1::topic_cfg_provider {
+public:
+    std::optional<std::reference_wrapper<const cluster::topic_configuration>>
+    get_topic_cfg(model::topic_namespace_view) const final {
+        return _cfg;
+    }
+
+private:
+    cluster::topic_configuration _cfg{};
+};
+
+TEST_F(LogInfoCollectorTestFixture, TestInfoCollector) {
+    auto cfg_provider = std::make_unique<fake_cfg_provider>();
+    l1::log_info_collector log_info_collector(
+      &_metastore, std::move(cfg_provider));
+    std::vector<std::pair<model::ntp, model::topic_id_partition>> ntidps;
+    const auto topic_names = {"topic_a", "topic_b", "topic_c"};
+    const auto num_topics = topic_names.size();
+    for (const auto& topic : topic_names) {
+        ntidps.push_back(make_ntidp(topic));
+    }
+
+    std::vector<tidp_batches_t> tidp_batches;
+    l1::log_set_t logs;
+    l1::log_compaction_queue cached_metadata(
+      [](
+        const l1::log_compaction_meta_ptr& a,
+        const l1::log_compaction_meta_ptr& b) { return a->ntp < b->ntp; });
+    l1::log_list_t logs_list;
+    for (const auto& [ntp, tidp] : ntidps) {
+        auto [it, success] = logs.emplace(
+          ss::make_lw_shared<l1::log_compaction_meta>(tidp, ntp));
+        logs_list.push_back(*it->get());
+        auto batches
+          = model::test::make_random_batches(model::offset{0}, 10).get();
+        tidp_batches.emplace_back(tidp, std::move(batches));
+    }
+
+    make_l1_objects(tidp_batches);
+    log_info_collector.collect_info_for_logs(logs, logs_list, cached_metadata)
+      .get();
+    ASSERT_EQ(cached_metadata.size(), num_topics);
+    while (!cached_metadata.empty()) {
+        auto sample = std::move(cached_metadata.top());
+        cached_metadata.pop();
+        ASSERT_TRUE(sample->info_and_ts.has_value());
+        ASSERT_FLOAT_EQ(sample->info_and_ts->info.dirty_ratio, 1.0);
+        ASSERT_TRUE(sample->info_and_ts->info.earliest_dirty_ts.has_value());
+    }
+}

--- a/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
+++ b/src/v/cloud_topics/level_one/compaction/tests/reducer_test.cc
@@ -125,10 +125,10 @@ TEST_F(ReducerTestFixture, Reducer) {
 
     auto state = l1::compaction_job_state::running;
     auto map = compaction::simple_key_offset_map();
-    auto sample_spec = l1::metastore::compaction_sample_spec{
+    auto info_spec = l1::metastore::compaction_info_spec{
       .tidp = tidp,
       .tombstone_removal_upper_bound_ts = model::timestamp::max()};
-    auto compaction_info = _metastore.get_compaction_info(sample_spec).get();
+    auto compaction_info = _metastore.get_compaction_info(info_spec).get();
 
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 1.0);

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -326,7 +326,7 @@ public:
     // All the information required to query a `compaction_info_response` from
     // the metastore. Parameters are used for call to
     // `get_compaction_offsets()`.
-    struct compaction_sample_spec {
+    struct compaction_info_spec {
         model::topic_id_partition tidp;
         model::timestamp tombstone_removal_upper_bound_ts;
     };
@@ -342,13 +342,13 @@ public:
         compaction_offsets_response offsets_response;
     };
 
-    // Obtains compaction state for a provided `sample_spec` on the basis of a
-    // single partition. Provides information relevant to determining if a
-    // partition requires compaction - e.g dirty ratio and earliest dirty
+    // Obtains compaction state for a provided `compaction_info_spec` on the
+    // basis of a single partition. Provides information relevant to determining
+    // if a partition requires compaction - e.g dirty ratio and earliest dirty
     // timestamp, as well as compaction offsets (see `get_compaction_offsets()`
     // above).
     virtual ss::future<std::expected<compaction_info_response, errc>>
-    get_compaction_info(const compaction_sample_spec&) = 0;
+    get_compaction_info(const compaction_info_spec&) = 0;
 
     using compaction_info_map = chunked_hash_map<
       model::topic_id_partition,
@@ -356,9 +356,9 @@ public:
 
     // Vectorized RPC for obtaining compaction state for a number of partitions.
     virtual ss::future<compaction_info_map> get_compaction_infos(
-      const chunked_vector<compaction_sample_spec>& to_sample) {
+      const chunked_vector<compaction_info_spec>& to_collect) {
         compaction_info_map ret;
-        for (const auto& log : to_sample) {
+        for (const auto& log : to_collect) {
             ret.emplace(log.tidp, co_await get_compaction_info(log));
         }
         co_return ret;

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -606,7 +606,7 @@ replicated_metastore::get_compaction_offsets(
 
 ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
 replicated_metastore::get_compaction_info(
-  [[maybe_unused]] const compaction_sample_spec& log) {
+  [[maybe_unused]] const compaction_info_spec& log) {
     co_return compaction_info_response{};
 }
 

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -62,7 +62,7 @@ public:
       const model::topic_id_partition&, model::timestamp) override;
 
     ss::future<std::expected<compaction_info_response, errc>>
-    get_compaction_info(const compaction_sample_spec&) override;
+    get_compaction_info(const compaction_info_spec&) override;
 
 private:
     frontend& fe_;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -611,7 +611,7 @@ simple_metastore::get_earliest_dirty_ts(
 }
 
 ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
-simple_metastore::get_compaction_info(const compaction_sample_spec& log) {
+simple_metastore::get_compaction_info(const compaction_info_spec& log) {
     auto dirty_ratio = get_dirty_ratio(state_, log.tidp);
     if (!dirty_ratio.has_value()) {
         co_return std::unexpected(dirty_ratio.error());

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -95,7 +95,7 @@ public:
       const model::topic_id_partition&, model::timestamp) override;
 
     ss::future<std::expected<compaction_info_response, errc>>
-    get_compaction_info(const compaction_sample_spec&) override;
+    get_compaction_info(const compaction_info_spec&) override;
 
 private:
     friend class domain_manager;

--- a/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/simple_metastore_test.cc
@@ -1533,9 +1533,9 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
         ASSERT_TRUE(compact_res.has_value());
     }
 
-    auto to_sample = metastore::compaction_sample_spec{
+    auto to_collect = metastore::compaction_info_spec{
       .tidp = tp, .tombstone_removal_upper_bound_ts = 3000_t};
-    auto compaction_info = m.get_compaction_info(to_sample).get();
+    auto compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 1.0);
 
@@ -1552,7 +1552,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
         ASSERT_TRUE(compact_res.has_value());
     }
 
-    compaction_info = m.get_compaction_info(to_sample).get();
+    compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.5);
 
@@ -1569,7 +1569,7 @@ TEST(SimpleMetastoreTest, TestDirtyRatio) {
         ASSERT_TRUE(compact_res.has_value());
     }
 
-    compaction_info = m.get_compaction_info(to_sample).get();
+    compaction_info = m.get_compaction_info(to_collect).get();
     ASSERT_TRUE(compaction_info.has_value());
     ASSERT_FLOAT_EQ(compaction_info->dirty_ratio, 0.0);
 }

--- a/src/v/cluster/topic_configuration.h
+++ b/src/v/cluster/topic_configuration.h
@@ -69,6 +69,8 @@ struct topic_configuration
                || properties.record_value_schema_id_validation_compat.value_or(
                  false);
     }
+    bool is_cloud_topic() const { return properties.cloud_topic_enabled; }
+    bool is_compacted() const { return properties.is_compacted(); }
 
     const model::topic_namespace& remote_tp_ns() const {
         if (has_remote_topic_namespace_override()) {

--- a/src/v/compaction/utils.cc
+++ b/src/v/compaction/utils.cc
@@ -83,4 +83,20 @@ ss::future<bool> is_latest_record_for_key(
     co_return o >= latest_offset_indexed.value();
 }
 
+bool log_needs_compaction(
+  double dirty_ratio,
+  double min_cleanable_dirty_ratio,
+  std::optional<model::timestamp> earliest_dirty_ts,
+  std::chrono::milliseconds max_lag) {
+    if (dirty_ratio >= min_cleanable_dirty_ratio) {
+        return true;
+    }
+
+    const auto exceed_compact_lag
+      = earliest_dirty_ts.has_value()
+        && (to_time_point(model::timestamp::now()) - to_time_point(earliest_dirty_ts.value()) > max_lag);
+
+    return exceed_compact_lag;
+}
+
 } // namespace compaction

--- a/src/v/compaction/utils.h
+++ b/src/v/compaction/utils.h
@@ -52,4 +52,17 @@ ss::future<bool> is_latest_record_for_key(
   const model::record_batch& b,
   const model::record& r);
 
+// A log is eligible for compaction if at least one of the following
+// is true:
+// 1. It's dirty enough: the dirty ratio is at least the minimum
+//    cleanable dirty ratio.
+// 2. It's gone long enough without compaction: the earliest first
+//    batch timestamp of a dirty segment is longer ago than
+//    the max compaction lag.
+bool log_needs_compaction(
+  double dirty_ratio,
+  double min_cleanable_dirty_ratio,
+  std::optional<model::timestamp> earliest_dirty_ts,
+  std::chrono::milliseconds max_lag);
+
 } // namespace compaction


### PR DESCRIPTION
Added here are the `log_collector` and `log_sampler`.

The `log_collector` is a barebones abstract class at this point with only two functions that need to be implemented (`start_collecting_logs()` and `stop_collecting_logs()`).  It is up to the implementer to make this class responsible for pushing CTPs/logs that require compaction to the `compaction_scheduler` (still not present in the tree, I promise this is coming next :smiley:) for managing, as well as their removal. To decouple the `log_collector` from the `compaction_scheduler` and avoid a circular dependency, instead of holding a `compaction_scheduler*` pointer, callback functions are used instead.

The `log_sampler` is responsible for issuing `get_compaction_info()` requests to the `metastore` periodically. `log_sampler::sample_logs()` populates `log_compaction_meta::info_and_ts`, and pushes logs eligible for compaction to the `log_compaction_queue` which `compaction_worker`s will eventually pull from.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
