### PR TITLE
pbgen: zig instead of zagging

### DIFF
--- a/src/v/serde/protobuf/support.h
+++ b/src/v/serde/protobuf/support.h
@@ -279,13 +279,15 @@ public:
         while (parser.bytes_left() > 0) {
             auto tag = parser.read_tag();
             if (tag.field_number == 1) {
-                seconds
-                  = parser.template read_singular_varint<full_name, int64_t>(
-                    tag);
+                seconds = parser.template read_singular_varint<
+                  full_name,
+                  int64_t,
+                  zigzag::no>(tag);
             } else if (tag.field_number == 2) {
-                nanos
-                  = parser.template read_singular_varint<full_name, int32_t>(
-                    tag);
+                nanos = parser.template read_singular_varint<
+                  full_name,
+                  int32_t,
+                  zigzag::no>(tag);
             } else {
                 parser.skip_unknown(tag);
             }
@@ -345,11 +347,11 @@ inline iobuf duration_to_proto(absl::Duration d) {
     // seconds
     serde::pb::tag::write(
       {.wire_type = serde::pb::wire_type::varint, .field_number = 1}, &buf);
-    serde::pb::write_varint(d / absl::Seconds(1), &buf);
+    serde::pb::write_varint<int64_t, zigzag::no>(d / absl::Seconds(1), &buf);
     // nanos
     serde::pb::tag::write(
       {.wire_type = serde::pb::wire_type::varint, .field_number = 2}, &buf);
-    serde::pb::write_varint(
+    serde::pb::write_varint<int32_t, zigzag::no>(
       static_cast<int32_t>((d % absl::Seconds(1)) / absl::Nanoseconds(1)),
       &buf);
     return buf;

--- a/src/v/serde/protobuf/tests/round_trip_test.cc
+++ b/src/v/serde/protobuf/tests/round_trip_test.cc
@@ -259,6 +259,7 @@ TEST(ProtobufCompat, Wellknown) {
     proto::example::well_known_protos original;
     original.set_single_duration(
       absl::Seconds(123456) + absl::Nanoseconds(789012));
+    original.get_repeated_duration().emplace_back(absl::Seconds(1));
     original.get_repeated_duration().emplace_back(
       absl::Seconds(123) + absl::Nanoseconds(789));
     original.get_repeated_duration().emplace_back(
@@ -297,6 +298,8 @@ TEST(ProtobufCompat, Wellknown) {
       (deserialized = proto::example::well_known_protos::from_proto(
                         iobuf::from(libpb.SerializeAsString()))
                         .get()));
+    EXPECT_EQ(libpb.repeated_duration().at(0).nanos(), 0);
+    EXPECT_EQ(libpb.repeated_duration().at(0).seconds(), 1);
     EXPECT_EQ(original, deserialized);
 
     deserialized = {};
@@ -325,6 +328,8 @@ TEST(ProtobufCompat, Wellknown) {
                         iobuf::from(libpb_serialized))
                         .get()))
       << "JSON: " << libpb_serialized;
+    EXPECT_EQ(libpb.repeated_duration().at(0).nanos(), 0);
+    EXPECT_EQ(libpb.repeated_duration().at(0).seconds(), 1);
     EXPECT_EQ(original, deserialized)
       << "Proto: " << fmt::format("{}", original)
       << "Deserialized: " << fmt::format("{}", deserialized);


### PR DESCRIPTION
Durations/timestamps should not zigzag encode/decode. The default is
to zigzag encode/decode (maybe the default is bad). Explicitly specify
that we should no zigzag.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
