### PR TITLE
Enhancements to the LargeMessageTest

### DIFF
--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -266,11 +266,10 @@ class LargeMessagesTest(RedpandaTest):
 
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(
-        message_size_mib=[8, 16],
+        message_size_mib=[8, 16, 32],
         apply_throughput_limits=[False, True],
         mode=[Mode.MANY_PARTS, Mode.TEN_TOPICS],
     )
-    # @parametrize(message_size_mib=16, apply_throughput_limits=True)
     def test_large_messages_throughput(
         self, message_size_mib: float, apply_throughput_limits: bool, mode: Mode
     ):

--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -54,6 +54,9 @@ class LargeMessagesTest(RedpandaTest):
     # actually accept a message payload of 1 MIB.
     MAX_DEFAULT_MSG_SIZE_MIB = 0.9
 
+    # The maximum response size a client will tell RP its willing to receive.
+    FETCH_MAX_BYTES_MIB = 90
+
     def __init__(self, *args, **kwargs):
         # Topics
         # Prepare RP
@@ -81,6 +84,11 @@ class LargeMessagesTest(RedpandaTest):
                 # job. We should figure out how to make it faster for this
                 # use-case.
                 "cloud_storage_enable_scrubbing": False,
+                # Raise the broker-imposed fetch max bytes to allow for fetches
+                # to return more than just the obligatory read.
+                "fetch_max_bytes": self.FETCH_MAX_BYTES_MIB * 2**20,
+                # Similar to above, is deprecated in later versions of RP.
+                "kafka_max_bytes_per_fetch": self.FETCH_MAX_BYTES_MIB * 2**20,
             },
             # Reduce per-partition log spam
             log_config=LoggingConfig(
@@ -196,6 +204,12 @@ class LargeMessagesTest(RedpandaTest):
     def _run_consumers(self, group):
         swarm_node_consumers: list[ConsumerSwarm] = []
         node_message_count = int(0.95 * (self.message_count * self.n_clients))
+        max_fetch_bytes = min(self.FETCH_MAX_BYTES_MIB * 2**20, 4 * self.message_size)
+        # Set properties to allow for more than just the obligatory read to be returned.
+        properties = {
+            "fetch.max.bytes": max_fetch_bytes,
+            "max.partition.fetch.bytes": min(2 * self.message_size, max_fetch_bytes),
+        }
 
         for topic in self.topic_prefixes:
             swarm_node_consumers.append(
@@ -208,6 +222,7 @@ class LargeMessagesTest(RedpandaTest):
                     node_message_count,
                     unique_topics=self.unique,
                     unique_groups=self.unique,
+                    properties=properties if not self.default_consumer_config else {},
                 )
             )
 
@@ -269,9 +284,14 @@ class LargeMessagesTest(RedpandaTest):
         message_size_mib=[8, 16, 32],
         apply_throughput_limits=[False, True],
         mode=[Mode.MANY_PARTS, Mode.TEN_TOPICS],
+        default_consumer_config=[False, True],
     )
     def test_large_messages_throughput(
-        self, message_size_mib: float, apply_throughput_limits: bool, mode: Mode
+        self,
+        message_size_mib: float,
+        apply_throughput_limits: bool,
+        mode: Mode,
+        default_consumer_config: bool,
     ):
         """Test creates 10 topics, and uses client-swarm to
         generate 100 messages with parametrized size and sends this count
@@ -285,6 +305,7 @@ class LargeMessagesTest(RedpandaTest):
         self.message_size = int(message_size_mib * 2**20)
         self.replication_factor = 3
         self.swarm_nodes = 2
+        self.default_consumer_config = default_consumer_config
 
         # Scale tests are not run on debug builds
         assert not self.debug_mode

--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -346,10 +346,10 @@ class LargeMessagesTest(RedpandaTest):
         else:
             self.topic_names = self.topic_prefixes
 
-        # we size everything to this target runtime, 5 minutes, this will result in very
+        # we size everything to this target runtime, 3 minutes, this will result in very
         # different amounts of total message volume in different environments with different
         # scale parameters.
-        target_runtime_sec = 300
+        target_runtime_sec = 180
 
         # every increase of 1 in message_count increases total bytes written by this amount
         bytes_per_message_count = self.n_clients * self.message_size * self.swarm_nodes

--- a/tests/rptest/scale_tests/large_messages_test.py
+++ b/tests/rptest/scale_tests/large_messages_test.py
@@ -281,7 +281,7 @@ class LargeMessagesTest(RedpandaTest):
 
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(
-        message_size_mib=[8, 16, 32],
+        message_size_mib=[8, 32],
         apply_throughput_limits=[False, True],
         mode=[Mode.MANY_PARTS, Mode.TEN_TOPICS],
         default_consumer_config=[False, True],


### PR DESCRIPTION
This PR makes the following changes to the LargeMessageTest:
- Adds a test case for 32MiB
- Adds a test case for a non-default consumer config the allows for more than the obligatory batch read to be returned by Redpanda.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
