### PR TITLE
[CORE-13211] iceberg/conversion: Map PB enum values to string, not int

### DIFF
--- a/src/v/iceberg/conversion/schema_protobuf.cc
+++ b/src/v/iceberg/conversion/schema_protobuf.cc
@@ -181,7 +181,7 @@ field_outcome from_protobuf(
     case pb::FieldDescriptor::TYPE_BYTES:
         return success(fd, iceberg::binary_type{});
     case pb::FieldDescriptor::TYPE_ENUM:
-        [[fallthrough]];
+        return success(fd, iceberg::string_type{});
     case pb::FieldDescriptor::TYPE_SFIXED32:
         return success(fd, iceberg::int_type{});
     case pb::FieldDescriptor::TYPE_SFIXED64:

--- a/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
@@ -147,8 +147,8 @@ TEST(SchemaProtobuf, TestComplexSchema) {
     auto& replica_list_type = std::get<list_type>(
       partition_type.fields[1]->type);
 
-    // enum is mapped to signed integer
-    EXPECT_THAT(partition_type.fields[2], IsField(3, "state", int_type{}));
+    // Enum is mapped to string.
+    EXPECT_THAT(partition_type.fields[2], IsField(3, "state", string_type{}));
 
     auto& broker_shard_type = std::get<struct_type>(
       replica_list_type.element_field->type);
@@ -337,7 +337,7 @@ TEST_CORO(values_protobuf, TestComplexValueConversion) {
                     IcebergStruct(
                       OptionalIcebergPrimitive<iceberg::long_value>(11),
                       OptionalIcebergPrimitive<iceberg::int_value>(0)))),
-                  OptionalIcebergPrimitive<int_value>(0)))))),
+                  OptionalIcebergPrimitive<string_value>("ACTIVE")))))),
           IcebergKeyValue(
             IcebergPrimitive<string_value>("topic_1"),
             // topic
@@ -450,8 +450,8 @@ TEST_CORO(values_protobuf, TestEmptyMessage) {
                 case google::protobuf::FieldDescriptor::TYPE_ENUM:
                     EXPECT_THAT(
                       field_value,
-                      OptionalIcebergPrimitive<int_value>(
-                        field_descriptor->default_value_enum()->number()));
+                      OptionalIcebergPrimitive<string_value>(
+                        field_descriptor->default_value_enum()->name()));
                     break;
                 }
             }

--- a/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
+++ b/src/v/iceberg/conversion/tests/iceberg_protobuf_tests.cc
@@ -890,3 +890,32 @@ TEST(values_protobuf, TestStructDepthLimit) {
         fmt::format(
           "Maximum recursion depth {} exceeded", max_recursion_depth)));
 }
+
+TEST_CORO(values_protobuf, TestInvalidEnumValue) {
+    Partition partition;
+    partition.set_id(123);
+
+    // Use reflection to set an invalid enum value.
+    auto descriptor = partition.GetDescriptor();
+    auto reflection = partition.GetReflection();
+    auto state_field = descriptor->FindFieldByName("state");
+    reflection->SetEnumValue(&partition, state_field, 99);
+
+    auto result = co_await serialize_and_convert(partition);
+    ASSERT_TRUE_CORO(result.has_value());
+    auto r_opt = std::move(result.value());
+    ASSERT_TRUE_CORO(r_opt.has_value());
+    auto struct_v = std::get<std::unique_ptr<iceberg::struct_value>>(
+      std::move(r_opt.value()));
+
+    // The partition should have:
+    // - id field with value 123
+    // - replicas field (empty list)
+    // - state field with "ACTIVE" (the default enum value, not 99)
+    EXPECT_THAT(
+      struct_v->fields,
+      ElementsAre(
+        OptionalIcebergPrimitive<int_value>(123),
+        IcebergList(ElementsAre()),
+        OptionalIcebergPrimitive<string_value>("ACTIVE")));
+}

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -459,11 +459,22 @@ ss::future<optional_value_outcome> single_field_to_value(
             if (field_descriptor.has_presence()) {
                 co_return std::nullopt;
             }
-            co_return iceberg::int_value(
-              field_descriptor.default_value_enum()->number());
+            co_return iceberg::string_value(
+              iobuf::from(field_descriptor.default_value_enum()->name()));
+        } else {
+            auto enum_number = std::get<int32_t>(std::move(field.value()));
+            auto enum_value_desc
+              = field_descriptor.enum_type()->FindValueByNumber(enum_number);
+            if (!enum_value_desc) {
+                co_return value_conversion_exception(
+                  fmt::format(
+                    "Invalid enum value {} for field {}",
+                    enum_number,
+                    field_descriptor.DebugString()));
+            }
+            co_return iceberg::string_value(
+              iobuf::from(enum_value_desc->name()));
         }
-        co_return iceberg::int_value(
-          std::get<int32_t>(std::move(field.value())));
     case pb::FieldDescriptor::TYPE_BOOL:
         co_return convert<bool, iceberg::boolean_value>(
           std::move(field),

--- a/src/v/iceberg/conversion/values_protobuf.cc
+++ b/src/v/iceberg/conversion/values_protobuf.cc
@@ -466,11 +466,9 @@ ss::future<optional_value_outcome> single_field_to_value(
             auto enum_value_desc
               = field_descriptor.enum_type()->FindValueByNumber(enum_number);
             if (!enum_value_desc) {
-                co_return value_conversion_exception(
-                  fmt::format(
-                    "Invalid enum value {} for field {}",
-                    enum_number,
-                    field_descriptor.DebugString()));
+                // Use the default for invalid enum values (closed enums).
+                co_return iceberg::string_value(
+                  iobuf::from(field_descriptor.default_value_enum()->name()));
             }
             co_return iceberg::string_value(
               iobuf::from(enum_value_desc->name()));


### PR DESCRIPTION
Map protobuf enum values to their string name instead of int value. For example, the enum

    enum state {
        Active = 0;
        Inactive = 1;
    }

previously would translate `Active = 0` to `0` and `Inactive = 1` to `1`, but now will translate `Active = 0` to `"ACTIVE"` and `Inactive = 1` to `"INACTIVE"` (note the capitalization, which comes from the PB descriptor).

This is a breaking change. The type of columns translated from enums will change from signed integer to string.

Values that are not valid for the enum are translated to the default value's name. For example, a value of 100 for `state`
will be translated into `"ACTIVE"`.

Fixes CORE-13211

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Iceberg now translates protobuf enum values to their name, instead of integer value. This is a backwards-incompatible change. Additionally, it is now an error to provide an enum value outside the range of the enum definition, as it has no name it can be converted into.

