### PR TITLE
[CORE-13844] ct: Reconciliation backlog size estimate

### DIFF
--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -58,6 +58,34 @@ private:
 };
 } // namespace
 
+namespace detail {
+
+simple_ewma::simple_ewma(double alpha)
+  : _alpha(alpha)
+  // We should collect enough samples to reliably estimate the size
+  // of offset ranges. This formula (2 / alpha) is quite optimistic
+  // and will allow us to use the estimate early (after 10 records
+  // if the default alpha is used). In practice, the estimate will
+  // be more reliable after 50-100 samples. But this is OK given that
+  // the estimate is only a hint and is not used for correctness.
+  , _min_samples(alpha > 0 ? static_cast<size_t>(2 / alpha) : 1) {}
+
+void simple_ewma::update(double avg_rec_size, size_t num_records) { // NOLINT
+    if (num_records == 0) {
+        return;
+    }
+    _value = _alpha * avg_rec_size + (1 - _alpha) * _value;
+    _num_samples += num_records;
+}
+
+uint64_t simple_ewma::size_estimate(int64_t num_records) const {
+    if (_num_samples < _min_samples) {
+        return 0;
+    }
+    return std::ceil(static_cast<double>(num_records) * _value);
+}
+} // namespace detail
+
 ctp_stm::ctp_stm(ss::logger& logger, raft::consensus* raft)
   : raft::persisted_stm<>(name, logger, raft) {}
 
@@ -377,6 +405,20 @@ void ctp_stm::apply_placeholder(const model::record_batch& batch) {
       _last_seen_epoch);
     _last_seen_epoch = id.epoch;
     _state.advance_epoch(id.epoch, batch.header().base_offset);
+    _size_estimator.update(
+      static_cast<double>(batch.size_bytes()) / batch.record_count(),
+      batch.record_count());
+}
+
+uint64_t ctp_stm::estimate_backlog_size() const noexcept {
+    auto lro = _state.get_last_reconciled_log_offset().value_or(
+      model::offset{0});
+    auto committed_offset = _raft->committed_offset();
+    if (committed_offset <= lro) {
+        return 0;
+    }
+    auto num_records = committed_offset - lro;
+    return _size_estimator.size_estimate(num_records);
 }
 
 ss::future<raft::local_snapshot_applied>

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -17,6 +17,31 @@
 #include <seastar/core/rwlock.hh>
 
 namespace cloud_topics {
+namespace detail {
+
+constexpr double default_simple_ewma_alpha = 0.2;
+/// Simple Exponentially Weighted Moving Average
+/// which is supposed to be used to estimate the sizes of offset ranges.
+class simple_ewma {
+public:
+    explicit simple_ewma(double alpha = default_simple_ewma_alpha);
+
+    void update(double avg_rec_size, size_t num_records); // NOLINT
+
+    uint64_t size_estimate(int64_t num_records) const;
+
+    auto serde_fields() {
+        return std::tie(_alpha, _value, _num_samples, _min_samples);
+    }
+
+private:
+    double _alpha{0};
+    double _value{0};
+    size_t _num_samples{0};
+    size_t _min_samples{1};
+};
+
+} // namespace detail
 
 class ctp_stm_api;
 
@@ -78,6 +103,17 @@ public:
     ss::future<bool> sync_in_term(
       model::timeout_clock::time_point deadline, ss::abort_source& as);
 
+    /// Estimate the size of data between the LRO and the end of the log.
+    ///
+    /// The returned value is initially zero and then it converges
+    /// to something close to the real value (with some error).
+    /// The value is updated when new placeholders are applied.
+    /// It shouldn't be used for exact accounting because it's an estimate.
+    /// However, it should be good enough for metrics and logging.
+    /// The estimate could diverge on different replicas and after restarts.
+    /// Currently, it's not snapshotted.
+    uint64_t estimate_backlog_size() const noexcept;
+
 private:
     ss::future<> do_apply(const model::record_batch&) override;
     void apply_placeholder(const model::record_batch&);
@@ -118,6 +154,9 @@ private:
     // The last point that we truncated to, so we can skip writing a raft
     // snapshot if needed. This is volatile state (which is fine).
     model::offset _last_truncation_point;
+
+    // Simple EWMA to estimate the size of offset ranges in bytes.
+    detail::simple_ewma _size_estimator;
 };
 
 } // namespace cloud_topics

--- a/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
+++ b/src/v/cloud_topics/level_zero/stm/tests/ctp_stm_test.cc
@@ -408,3 +408,20 @@ TEST_F_CORO(ctp_stm_fixture, can_replay_truncated_log) {
     co_await follower_stm->wait(dirty_offset, model::no_timeout);
     vlog(ct::cd_log.info, "recovery done: {}", follower_id);
 }
+
+TEST(test_ewma, smoke_test) {
+    cloud_topics::detail::simple_ewma ewma;
+
+    ewma.update(10, 1);
+    ASSERT_EQ(ewma.size_estimate(1), 0);
+
+    for (int i = 0; i < 20; i++) {
+        ewma.update(10, 1);
+    }
+
+    // The estimate is expected to be slightly
+    // below 10 but the 'size_estimate()' rounds up.
+    ASSERT_EQ(ewma.size_estimate(1), 10);
+    ASSERT_LT(ewma.size_estimate(100), 1000);
+    ASSERT_GT(ewma.size_estimate(100), 990);
+}

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -199,9 +199,13 @@ ss::future<> reconciler::reconcile() {
 
     chunked_vector<ss::shared_ptr<source>> sources;
     // Make a copy of the sources to not worry about concurrent modification.
+    uint64_t total_backlog_size = 0;
     for (auto& [_, src] : _sources) {
+        total_backlog_size += src->get_backlog_size_estimate();
         sources.push_back(src);
     }
+    _probe.record_backlog_size(total_backlog_size);
+
     if (sources.empty()) {
         vlog(lg.trace, "No leader partitions to reconcile");
         co_return;

--- a/src/v/cloud_topics/reconciler/reconciler_probe.cc
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.cc
@@ -76,6 +76,13 @@ void reconciler_probe::setup_metrics() {
           sm::description(
             "Total times the metastore returned a corrected offset")),
 
+        // Gauges.
+        sm::make_gauge(
+          "backlog_size",
+          [this] { return _backlog_size; },
+          sm::description(
+            "Current size of the reconciliation backlog in bytes")),
+
         // Histograms.
         sm::make_histogram(
           "object_upload_duration_seconds",

--- a/src/v/cloud_topics/reconciler/reconciler_probe.h
+++ b/src/v/cloud_topics/reconciler/reconciler_probe.h
@@ -54,6 +54,7 @@ public:
     void record_sources_per_object(uint64_t count) {
         _sources_per_object.record(count);
     }
+    void record_backlog_size(uint64_t size) { _backlog_size = size; }
 
     std::unique_ptr<hist_t::measurement> measure_object_upload_duration() {
         return _object_upload_duration.auto_measure();
@@ -91,6 +92,7 @@ private:
     uint64_t _empty_objects_skipped{0};
     uint64_t _metastore_retries{0};
     uint64_t _offset_corrections{0};
+    uint64_t _backlog_size{0};
 
     // Histograms.
     hist_t _object_upload_duration;

--- a/src/v/cloud_topics/reconciler/reconciliation_source.cc
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.cc
@@ -64,6 +64,13 @@ public:
         return api.get_last_reconciled_offset();
     }
 
+    uint64_t get_backlog_size_estimate() const override {
+        return _partition->raft()
+          ->stm_manager()
+          ->get<ctp_stm>()
+          ->estimate_backlog_size();
+    }
+
     ss::future<std::expected<void, errc>> set_last_reconciled_offset(
       kafka::offset offset, ss::abort_source& as) override {
         ctp_stm_api api(_partition->raft()->stm_manager()->get<ctp_stm>());

--- a/src/v/cloud_topics/reconciler/reconciliation_source.h
+++ b/src/v/cloud_topics/reconciler/reconciliation_source.h
@@ -56,6 +56,9 @@ public:
     // if none.
     virtual kafka::offset last_reconciled_offset() = 0;
 
+    // Estimate the size of the backlog to be reconciled, in bytes.
+    virtual uint64_t get_backlog_size_estimate() const = 0;
+
     // Set the last reconciled offset for this source.
     //
     // This operation is idempotent, the last reconciled offset never moves

--- a/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
+++ b/src/v/cloud_topics/reconciler/tests/reconciler_metrics_test.cc
@@ -115,6 +115,11 @@ std::optional<uint64_t> get_rounds_failed() {
       "cloud_topics_reconciler_rounds_failed");
 }
 
+std::optional<uint64_t> get_backlog_size() {
+    return test_utils::find_metric_value<uint64_t>(
+      "cloud_topics_reconciler_backlog_size");
+}
+
 } // namespace
 
 TEST_F(ReconcilerMetricsTest, ThroughputCounters) {
@@ -217,6 +222,9 @@ TEST_F(ReconcilerMetricsTest, ObjectMetrics) {
     auto src1 = add_source();
     auto src2 = add_source();
 
+    // Set to 0 initially
+    EXPECT_TRUE(get_backlog_size().value() == 0);
+
     src1->add_batch({.count = 10});
     src2->add_batch({.count = 5});
 
@@ -236,6 +244,7 @@ TEST_F(ReconcilerMetricsTest, ObjectMetrics) {
 
     object_size = probe.get_object_size_bytes_for_tests();
     EXPECT_EQ(object_size.sample_count, 2);
+    EXPECT_TRUE(get_backlog_size().value() > 0);
 
     sources_per_object = probe.get_sources_per_object_for_tests();
     EXPECT_EQ(sources_per_object.sample_count, 2);

--- a/src/v/cloud_topics/reconciler/tests/test_utils.h
+++ b/src/v/cloud_topics/reconciler/tests/test_utils.h
@@ -44,6 +44,17 @@ public:
         _source_log.push_back(std::move(batch));
     }
 
+    uint64_t get_backlog_size_estimate() const override {
+        uint64_t size = 0;
+        for (const auto& batch : _source_log) {
+            if (model::offset_cast(batch.base_offset()) < _lro) {
+                continue;
+            }
+            size += batch.size_bytes();
+        }
+        return size;
+    }
+
     kafka::offset last_reconciled_offset() override { return _lro; }
 
     ss::future<std::expected<void, errc>>


### PR DESCRIPTION
This PR adds simple backlog size estimation to the `ctp_stm`. The estimation is done using exponentially weighted moving average. The goal is to put emphasis on newest batches because in CT we will keep mostly recent batches at any moment so EWMA looks like a good fit. The sliding window is used to compute the average offset size and then the code uses this value to estimate the size of the offset range (LRO to committed offset).

The state of the estimator is not stored in the snapshot so it can undershoot after restarts or when the replica is bootstrapped. But eventually it will be OK (after log replay during bootstrap for instance).

The estimate is used to produce a single reconciler metric. The implementation is very minimal and uses reconciler's main loop to update the metric (which means that the metric is not updated if the reconciler is not running).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none