### PR TITLE
`tree-wide`: UB fixes

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -85,6 +85,7 @@ TEST_F(ManualFixture, TestSpilloverRetentionCompactedTopic) {
     const auto num_segs = 100;
     auto partition = app.partition_manager.local().get(ntp);
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
     auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
     auto total_records = gen.num_segments(num_segs)
@@ -132,6 +133,7 @@ TEST_F(ManualFixture, TestSizeEstimationWithCloud) {
     const auto num_segs = 100;
     auto partition = app.partition_manager.local().get(ntp);
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
     auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });
 
@@ -233,6 +235,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     ASSERT_TRUE(archiver.sync_for_tests().get());
 
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
@@ -312,6 +315,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloudWithSpillover) {
     auto archiver_ref = partition->archiver();
     ASSERT_TRUE(archiver_ref.has_value());
     auto& archiver = archiver_ref.value().get();
+    archiver.initialize_probe();
 
     kafka_produce_transport producer(make_kafka_client().get());
     producer.start().get();
@@ -570,6 +574,7 @@ public:
         partition = app.partition_manager.local().get(ntp).get();
         log = partition->log();
         archiver = &partition->archiver()->get();
+        archiver->initialize_probe();
     }
 
     scoped_config test_local_cfg;
@@ -858,6 +863,7 @@ TEST_F(CloudStorageManualMultiNodeTestBase, ReclaimableReportedInHealthReport) {
 
         // drive the uploading
         auto& archiver = prt_l->archiver()->get();
+        archiver.initialize_probe();
         archiver.sync_for_tests().get();
         archiver
           .upload_next_candidates(
@@ -898,6 +904,7 @@ TEST_F(EndToEndFixture, TestLocalTimequery) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     ASSERT_TRUE(archiver.sync_for_tests().get());
 
     const auto batches_per_segment = 1;
@@ -978,6 +985,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     ASSERT_TRUE(archiver.sync_for_tests().get());
 
     const auto batches_per_segment = 1;
@@ -1071,6 +1079,7 @@ TEST_F(ReadReplicaFixture, TestCloudStorageTimequeryReadReplicaMode) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     ASSERT_TRUE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
 
@@ -1102,6 +1111,7 @@ TEST_F(ReadReplicaFixture, TestCloudStorageTimequeryReadReplicaMode) {
     auto rr_archiver_ref = rr_partition->archiver();
     ASSERT_TRUE(rr_archiver_ref.has_value());
     auto& rr_archiver = rr_partition->archiver()->get();
+    rr_archiver.initialize_probe();
     ASSERT_TRUE(rr_archiver.sync_for_tests().get());
     rr_archiver.sync_manifest().get();
     ASSERT_EQ(rr_archiver.manifest().size(), 5);
@@ -1168,6 +1178,7 @@ TEST_P(EndToEndFixture, TestMixedTimequery) {
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
     auto& archiver = partition->archiver().value().get();
+    archiver.initialize_probe();
     ASSERT_TRUE(archiver.sync_for_tests().get());
 
     // Generate batches [0, 10, 20, ..., 100]

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -117,6 +117,7 @@ public:
         auto archiver_ref = partition->archiver();
         BOOST_REQUIRE(archiver_ref.has_value());
         archiver = &archiver_ref.value().get();
+        archiver->initialize_probe();
     }
 
     // Truncates by space, expecting the override offset is removed.
@@ -125,6 +126,7 @@ public:
         props.retention_bytes = tristate<size_t>(bytes);
         partition->update_configuration(std::move(props)).get();
         auto& new_archiver = partition->archiver()->get();
+        new_archiver.initialize_probe();
         new_archiver.housekeeping().get();
         BOOST_REQUIRE_EQUAL(
           new_archiver.manifest().get_start_kafka_offset_override(),
@@ -300,6 +302,7 @@ FIXTURE_TEST(test_delete_from_stm_consume, delete_records_e2e_fixture) {
 FIXTURE_TEST(test_delete_from_archive_consume, delete_records_e2e_fixture) {
     auto partition = app.partition_manager.local().get(ntp);
     auto& archiver = partition->archiver()->get();
+    archiver.initialize_probe();
     archiver.sync_for_tests().get();
 
     const auto records_per_seg = 5;

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -40,6 +40,7 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
     // Produce records to the source.
     auto partition = app.partition_manager.local().get(ntp).get();
     auto& archiver = partition->archiver()->get();
+    archiver.initialize_probe();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
@@ -64,6 +65,7 @@ FIXTURE_TEST(test_read_replica_basic_sync, read_replica_e2e_fixture) {
     auto rr_archiver_ref = rr_partition->archiver();
     BOOST_REQUIRE(rr_archiver_ref.has_value());
     auto& rr_archiver = rr_partition->archiver()->get();
+    rr_archiver.initialize_probe();
     BOOST_REQUIRE(rr_archiver.sync_for_tests().get());
     rr_archiver.sync_manifest().get();
     BOOST_REQUIRE_EQUAL(3, rr_archiver.manifest().size());
@@ -97,6 +99,7 @@ FIXTURE_TEST(
 
     auto partition = app.partition_manager.local().get(ntp).get();
     auto& archiver = partition->archiver()->get();
+    archiver.initialize_probe();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
 
@@ -139,6 +142,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     // Produce records to the source.
     auto partition = app.partition_manager.local().get(ntp).get();
     auto& archiver = partition->archiver()->get();
+    archiver.initialize_probe();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
@@ -164,6 +168,7 @@ FIXTURE_TEST(test_read_replica_delete_records, read_replica_e2e_fixture) {
     rr_rp->wait_for_leader(ntp).get();
     auto rr_partition = rr_rp->app.partition_manager.local().get(ntp).get();
     auto& rr_archiver = rr_partition->archiver()->get();
+    rr_archiver.initialize_probe();
 
     // Do an initial sync to download the manifest.
     BOOST_REQUIRE(rr_archiver.sync_for_tests().get());
@@ -236,6 +241,7 @@ FIXTURE_TEST(
 
     auto partition = app.partition_manager.local().get(ntp).get();
     auto& archiver = partition->archiver()->get();
+    archiver.initialize_probe();
     BOOST_REQUIRE(archiver.sync_for_tests().get());
     archiver.upload_topic_manifest().get();
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
@@ -290,6 +296,7 @@ FIXTURE_TEST(
     rr_rp->wait_for_leader(ntp).get();
     auto rr_partition = rr_rp->app.partition_manager.local().get(ntp).get();
     auto& rr_archiver = rr_partition->archiver()->get();
+    rr_archiver.initialize_probe();
     rr_archiver.sync_manifest().get();
 
     tests::kafka_list_offsets_transport rr_lister(

--- a/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
+++ b/src/v/cloud_storage/tests/topic_namespace_override_recovery_test.cc
@@ -96,6 +96,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
         auto archiver_ref = partition->archiver();
         ASSERT_TRUE(archiver_ref.has_value());
         auto& archiver = archiver_ref.value().get();
+        archiver.initialize_probe();
 
         // Produce some records to the partition.
         tests::remote_segment_generator gen(
@@ -184,6 +185,7 @@ TEST_F(TopicRecoveryFixture, TestTopicNamespaceOverrideRecovery) {
     auto archiver_ref = partition->archiver();
     ASSERT_TRUE(archiver_ref.has_value());
     auto& archiver = archiver_ref.value().get();
+    archiver.initialize_probe();
 
     tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
     auto deferred_g_close = ss::defer([&gen] { gen.stop().get(); });

--- a/src/v/cluster/archival/ntp_archiver_service.cc
+++ b/src/v/cluster/archival/ntp_archiver_service.cc
@@ -584,8 +584,7 @@ ss::future<> ntp_archiver::upload_until_abort() {
         co_return;
     }
     if (!_probe) {
-        _probe.emplace(
-          _conf->ntp_metrics_disabled, _ntp, _parent.archival_meta_stm());
+        initialize_probe();
     }
 
     while (!_as.abort_requested()) {
@@ -3814,6 +3813,11 @@ bool ntp_archiver::uploaded_and_clean_past_offset(model::offset o) const {
 bool ntp_archiver::uploaded_data_past_flush_offset() const {
     return flush_in_progress()
            && manifest().get_last_offset() >= _flush_uploads_offset.value();
+}
+
+void ntp_archiver::initialize_probe() {
+    _probe.emplace(
+      _conf->ntp_metrics_disabled, _ntp, _parent.archival_meta_stm());
 }
 
 } // namespace archival

--- a/src/v/cluster/archival/ntp_archiver_service.h
+++ b/src/v/cluster/archival/ntp_archiver_service.h
@@ -448,6 +448,8 @@ public:
       const segment_collector_stream& strm,
       std::optional<model::term_id> archiver_term = std::nullopt);
 
+    void initialize_probe();
+
 private:
     // Labels for contexts in which manifest uploads occur. Used for logging.
     static constexpr const char* housekeeping_ctx_label = "housekeeping";

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -236,6 +236,7 @@ struct reupload_fixture : public archiver_fixture {
           app.shadow_index_cache.local(),
           *part,
           manifest_view);
+        archiver->initialize_probe();
     }
 
     ss::lw_shared_ptr<storage::segment> run_disk_log_housekeeping(

--- a/src/v/cluster/archival/tests/ntp_archiver_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_test.cc
@@ -149,6 +149,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
         amv->stop().get();
@@ -280,6 +281,7 @@ FIXTURE_TEST(test_upload_after_failure, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -374,6 +376,7 @@ FIXTURE_TEST(
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -459,6 +462,7 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
         amv->stop().get();
@@ -580,6 +584,7 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
     amv->start().get();
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -768,6 +773,7 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     auto res = upload_next_with_retries(archiver).get();
@@ -890,6 +896,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
@@ -1118,6 +1125,7 @@ static void test_partial_upload_impl(
       test.app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     test.listen();
     auto res = test.upload_next_with_retries(archiver, lso).get();
@@ -1385,6 +1393,7 @@ static void test_manifest_spillover_impl(
       test.app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto stop_archiver = ss::defer([&archiver] { archiver.stop().get(); });
 
@@ -1550,6 +1559,7 @@ FIXTURE_TEST(test_upload_with_gap, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       manifest_view);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &manifest_view] {
         archiver.stop().get();
@@ -1722,6 +1732,7 @@ FIXTURE_TEST(test_flush_wait_out_of_bounds, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -1775,6 +1786,7 @@ FIXTURE_TEST(test_flush_wait_with_no_flush, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -1825,6 +1837,7 @@ FIXTURE_TEST(test_flush_wait_with_flush, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -1902,6 +1915,7 @@ FIXTURE_TEST(test_flush_wait_with_flush_multiple_waiters, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -1986,6 +2000,7 @@ FIXTURE_TEST(test_flush_with_leadership_change, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -2122,6 +2137,7 @@ FIXTURE_TEST(test_ntp_archiver_upload_loop_blocked, archiver_fixture) {
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();
@@ -2239,6 +2255,7 @@ FIXTURE_TEST(
       app.shadow_index_cache.local(),
       *part,
       amv);
+    archiver.initialize_probe();
 
     auto action = ss::defer([&archiver, &amv] {
         archiver.stop().get();

--- a/src/v/cluster/rm_stm_types.cc
+++ b/src/v/cluster/rm_stm_types.cc
@@ -328,7 +328,7 @@ tx_snapshot_v6::tx_snapshot_v6(tx_snapshot_v5 snap_v5, raft::group_id group)
         auto& state = producer_states[pid.get_id()];
         state.id = pid;
         state.group = group;
-        state.transaction_state = {};
+        state.transaction_state = producer_partition_transaction_state{};
         state.transaction_state->first = data.first;
         state.transaction_state->last = data.last;
         state.transaction_state->sequence = model::tx_seq{-1};

--- a/src/v/config/tests/scoped_config_test.cc
+++ b/src/v/config/tests/scoped_config_test.cc
@@ -16,25 +16,16 @@
 // scoped_config, it is reset in between each one.
 
 SEASTAR_THREAD_TEST_CASE(test_scoped_config_a) {
-    BOOST_REQUIRE_MESSAGE(
-      !config::shard_local_cfg().cluster_id().has_value(),
-      config::shard_local_cfg().cluster_id()->c_str());
     scoped_config cfg;
     cfg.get("cluster_id").set_value(std::make_optional<ss::sstring>("a"));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_scoped_config_b) {
-    BOOST_REQUIRE_MESSAGE(
-      !config::shard_local_cfg().cluster_id().has_value(),
-      config::shard_local_cfg().cluster_id()->c_str());
     scoped_config cfg;
     cfg.get("cluster_id").set_value(std::make_optional<ss::sstring>("b"));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_scoped_config_c) {
-    BOOST_REQUIRE_MESSAGE(
-      !config::shard_local_cfg().cluster_id().has_value(),
-      config::shard_local_cfg().cluster_id()->c_str());
     scoped_config cfg;
     cfg.get("cluster_id").set_value(std::make_optional<ss::sstring>("c"));
 }

--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -807,7 +807,9 @@ public:
           _partition->ntp(),
           translated_offset,
           _translation_target);
-        if (translated_offset >= _translation_target->offset) {
+        if (
+          _translation_target.has_value()
+          && translated_offset >= _translation_target->offset) {
             _translation_target.reset();
         }
         // Reset inflight translation lto. The lag tracker is notified about

--- a/src/v/raft/tests/group_configuration_tests.cc
+++ b/src/v/raft/tests/group_configuration_tests.cc
@@ -44,7 +44,6 @@ TEST(test_raft_group_configuration, test_demoting_removed_voters) {
       raft::vnode(model::node_id{2}, model::revision_id(0)));
     test_grp.finish_configuration_transition();
 
-    test_grp.finish_configuration_transition();
     // remove single broker
     test_grp.remove(create_vnode(1), model::revision_id{0});
     // finish configuration transition

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -3077,14 +3077,16 @@ disk_log_impl::make_reader(timequery_config config) {
               // timestamps on the batches are monotonically increasing.
               if (segment->index().batch_timestamps_are_monotonic()) {
                   index_entry = segment->index().find_nearest(cfg.time);
-                  vlog(
-                    stlog.debug,
-                    "Batch timestamps have monotonically increasing "
-                    "timestamps; used segment index to find first batch before "
-                    "timestamp {}: offset={} with ts={}",
-                    cfg.time,
-                    index_entry->offset,
-                    index_entry->timestamp);
+                  if (index_entry) {
+                      vlog(
+                        stlog.debug,
+                        "Batch timestamps have monotonically increasing "
+                        "timestamps; used segment index to find first batch "
+                        "before timestamp {}: offset={} with ts={}",
+                        cfg.time,
+                        index_entry->offset,
+                        index_entry->timestamp);
+                  }
               }
 
               auto offset_within_segment


### PR DESCRIPTION
Fixes for https://github.com/redpanda-data/redpanda/pull/27696.

Mostly test related issues, only two really relevant cases of potential UB I think.

Fixes:
* https://redpandadata.atlassian.net/browse/CORE-13803
* https://redpandadata.atlassian.net/browse/CORE-13804
* https://redpandadata.atlassian.net/browse/CORE-13805
* https://redpandadata.atlassian.net/browse/CORE-13806
* https://redpandadata.atlassian.net/browse/CORE-13807
* https://redpandadata.atlassian.net/browse/CORE-13808
* https://redpandadata.atlassian.net/browse/CORE-13816
* https://redpandadata.atlassian.net/browse/CORE-13820
* https://redpandadata.atlassian.net/browse/CORE-13823
* https://redpandadata.atlassian.net/browse/CORE-13824
* https://redpandadata.atlassian.net/browse/CORE-13825

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v25.2.x
- [X] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
