### PR TITLE
iceberg: disable throttling by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4278,7 +4278,7 @@ configuration::configuration()
   , iceberg_throttle_backlog_size_ratio(
       *this,
       "iceberg_throttle_backlog_size_ratio",
-      "Ration of the total backlog size to the disk space at which the "
+      "Ratio of the total backlog size to the disk space at which the "
       "throttle to iceberg producers is applied. If set `null`, then "
       "throttling is disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4278,9 +4278,9 @@ configuration::configuration()
   , iceberg_throttle_backlog_size_ratio(
       *this,
       "iceberg_throttle_backlog_size_ratio",
-      "Ratio of the total backlog size to the disk space at which the "
-      "throttle to iceberg producers is applied. If set `null`, then "
-      "throttling is disabled.",
+      "Ratio of total backlog size to disk space "
+      "that triggers throttling for Iceberg producers. "
+      "Set to `null` to disable throttling.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , iceberg_delete(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4279,9 +4279,10 @@ configuration::configuration()
       *this,
       "iceberg_throttle_backlog_size_ratio",
       "Ration of the total backlog size to the disk space at which the "
-      "throttle to iceberg producers is applied",
+      "throttle to iceberg producers is applied. If set `null`, then "
+      "throttling is disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      0.3)
+      std::nullopt)
   , iceberg_delete(
       *this,
       "iceberg_delete",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -771,7 +771,7 @@ struct configuration final : public config_store {
     property<double> iceberg_backlog_controller_p_coeff;
     property<double> iceberg_backlog_controller_i_coeff;
     bounded_property<uint32_t> iceberg_target_backlog_size;
-    property<double> iceberg_throttle_backlog_size_ratio;
+    property<std::optional<double>> iceberg_throttle_backlog_size_ratio;
 
     property<bool> iceberg_delete;
     property<ss::sstring> iceberg_default_partition_spec;

--- a/src/v/kafka/server/datalake_throttle_manager.cc
+++ b/src/v/kafka/server/datalake_throttle_manager.cc
@@ -56,9 +56,13 @@ bool datalake_throttle_manager::needs_throttling() const {
     if (!_disk_space_info) [[unlikely]] {
         return false;
     }
+    auto ratio = _backlog_size_throttling_ratio();
+    if (!ratio.has_value()) {
+        return false;
+    }
     return _translation_status.max_shares_assigned
            && _translation_status.total_translation_backlog
-                > _backlog_size_throttling_ratio() * _disk_space_info->total;
+                > ratio.value() * _disk_space_info->total;
 }
 
 std::ostream&
@@ -76,7 +80,7 @@ datalake_throttle_manager::datalake_throttle_manager(
   ss::sharded<storage::node>& storage_node,
   config::binding<std::chrono::milliseconds> producer_gc_threshold,
   config::binding<std::chrono::milliseconds> max_kafka_throttle,
-  config::binding<double> backlog_size_throttling_ratio)
+  config::binding<std::optional<double>> backlog_size_throttling_ratio)
   : _shard_status_provider(std::move(status_provider))
   , _storage_node(storage_node)
   , _producer_gc_threshold(std::move(producer_gc_threshold))
@@ -198,7 +202,7 @@ datalake_throttle_manager::maybe_throttle_producer(
                 shard_0_manager._translation_status,
                 human::bytes(shard_0_manager._disk_space_info->total),
                 human::bytes(
-                  shard_0_manager._backlog_size_throttling_ratio()
+                  shard_0_manager._backlog_size_throttling_ratio().value_or(0)
                   * shard_0_manager._disk_space_info->total));
           }
           return throttle_ms;

--- a/src/v/kafka/server/datalake_throttle_manager.h
+++ b/src/v/kafka/server/datalake_throttle_manager.h
@@ -56,7 +56,7 @@ public:
       ss::sharded<storage::node>&,
       config::binding<std::chrono::milliseconds>,
       config::binding<std::chrono::milliseconds>,
-      config::binding<double>);
+      config::binding<std::optional<double>>);
 
     void start();
     ss::future<> stop();
@@ -96,7 +96,7 @@ private:
     ss::sharded<storage::node>& _storage_node;
     config::binding<std::chrono::milliseconds> _producer_gc_threshold;
     config::binding<std::chrono::milliseconds> _max_kafka_throttle;
-    config::binding<double> _backlog_size_throttling_ratio;
+    config::binding<std::optional<double>> _backlog_size_throttling_ratio;
 
     // Timestamp marking a last time when the Iceberg translation reported no
     // issues. This timestamp is used to calculate the throttle, the longer the

--- a/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
+++ b/src/v/kafka/server/tests/datalake_throttle_manager_test.cc
@@ -31,7 +31,7 @@ struct IcebergThrottlingManagerTest : ::testing::Test {
                 return shard_state.local().producer_gc_threshold.bind();
             }),
             ss::sharded_parameter(
-              [] { return config::mock_binding<double>(0.01); }))
+              [] { return config::mock_binding<std::optional<double>>(0.01); }))
           .get();
         manager.invoke_on_all(&kafka::datalake_throttle_manager::start).get();
         storage_node.local().set_disk_metrics(

--- a/tests/rptest/tests/datalake/throttling_test.py
+++ b/tests/rptest/tests/datalake/throttling_test.py
@@ -39,6 +39,7 @@ class DatalakeThrottlingTest(RedpandaTest):
             extra_rp_conf={
                 "iceberg_enabled": "true",
                 "iceberg_catalog_commit_interval_ms": 5000,
+                "iceberg_throttle_backlog_size_ratio": 0.3,
             },
             schema_registry_config=SchemaRegistryConfig(),
             pandaproxy_config=PandaproxyConfig(),


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Iceberg throttling is now opt-in and disabled by default.
