### PR TITLE
[v25.2.x] `tree-wide`: UB fixes (MANUAL BACKPORT)

### DIFF
--- a/src/v/datalake/translation/deps.cc
+++ b/src/v/datalake/translation/deps.cc
@@ -821,7 +821,9 @@ public:
           _partition->ntp(),
           translated_offset,
           _translation_target);
-        if (translated_offset >= _translation_target->offset) {
+        if (
+          _translation_target.has_value()
+          && translated_offset >= _translation_target->offset) {
             _translation_target.reset();
         }
         // Reset inflight translation lto. The lag tracker is notified about

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2937,14 +2937,16 @@ disk_log_impl::make_reader(timequery_config config) {
               // timestamps on the batches are monotonically increasing.
               if (segment->index().batch_timestamps_are_monotonic()) {
                   index_entry = segment->index().find_nearest(cfg.time);
-                  vlog(
-                    stlog.debug,
-                    "Batch timestamps have monotonically increasing "
-                    "timestamps; used segment index to find first batch before "
-                    "timestamp {}: offset={} with ts={}",
-                    cfg.time,
-                    index_entry->offset,
-                    index_entry->timestamp);
+                  if (index_entry) {
+                      vlog(
+                        stlog.debug,
+                        "Batch timestamps have monotonically increasing "
+                        "timestamps; used segment index to find first batch "
+                        "before timestamp {}: offset={} with ts={}",
+                        cfg.time,
+                        index_entry->offset,
+                        index_entry->timestamp);
+                  }
               }
 
               auto offset_within_segment


### PR DESCRIPTION
Fixes for two potential UBs `cherry-pick`ed from https://github.com/redpanda-data/redpanda/pull/27954/.

Fixes https://github.com/redpanda-data/redpanda/issues/27957.

## Backports Required

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
