### PR TITLE
bazel: fix module dependency declarations

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,9 +37,11 @@ single_version_override(
 )
 
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.2.0")
 bazel_dep(name = "rules_foreign_cc", version = "0.12.0")
 bazel_dep(name = "rules_go", version = "0.56.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_python", version = "1.5.1")
 bazel_dep(name = "rules_rust", version = "0.60.0")
 bazel_dep(name = "snappy", version = "1.2.1")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
@@ -50,8 +52,6 @@ bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")
 bazel_dep(name = "googleapis", version = "0.0.0-20250703-f9d6fe4a")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
-bazel_dep(name = "rules_python", version = "1.5.1", dev_dependency = True)
-bazel_dep(name = "rules_cc", version = "0.2.0", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.4.1", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
@@ -97,7 +97,7 @@ use_repo(non_module_dependencies, "xxhash")
 use_repo(non_module_dependencies, "x86_64_sysroot")
 use_repo(non_module_dependencies, "aarch64_sysroot")
 
-bazel_dep(name = "toolchains_llvm", version = "1.3.0")
+bazel_dep(name = "toolchains_llvm", version = "1.3.0", dev_dependency = True)
 archive_override(
     module_name = "toolchains_llvm",
     integrity = "sha256-uX1B8p+idMPln1PCR+Glr+5iXZnvDx6h1h0miiPzWQA=",
@@ -110,7 +110,7 @@ archive_override(
 # ====================================
 
 # NOTE: We build our toolchains on ubuntu:jammy so you're going to need a distro at least that old.
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 
 CXX_STANDARD = "c++23"
 
@@ -204,7 +204,10 @@ COMPILERS = {
         ),
         use_repo(llvm, "{version}_llvm_toolchain".format(version = major_version)),
         use_repo(llvm, "{version}_llvm_toolchain_llvm".format(version = major_version)),
-        register_toolchains("@{version}_llvm_toolchain//:all".format(version = major_version)),
+        register_toolchains(
+            "@{version}_llvm_toolchain//:all".format(version = major_version),
+            dev_dependency = True,
+        ),
     )
     for (major_version, compiler) in COMPILERS.items()
 ]
@@ -212,7 +215,7 @@ COMPILERS = {
 # ====================================
 # Go Toolchain
 # ====================================
-go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
 go_sdk.download(version = "1.24.3")
 
 # The microsoft compiler versions can be listed at their github release under the `asset.json` file
@@ -330,7 +333,7 @@ use_repo(
 # ====================================
 # Rust Toolchain
 # ====================================
-rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust", dev_dependency = True)
 rust.toolchain(
     edition = "2021",
     extra_target_triples = [
@@ -341,7 +344,10 @@ rust.toolchain(
 )
 use_repo(rust, "rust_toolchains")
 
-register_toolchains("@rust_toolchains//:all")
+register_toolchains(
+    "@rust_toolchains//:all",
+    dev_dependency = True,
+)
 
 crate = use_extension(
     "@rules_rust//crate_universe:extension.bzl",
@@ -358,21 +364,20 @@ crate.from_cargo(
         "x86_64-unknown-linux-gnu",
     ],
 )
-use_repo(crate, "crates")
-
 crate.annotation(
     additive_build_file = "//bazel/thirdparty:wasmtime.BUILD",
     crate = "wasmtime-c-api-impl",
     extra_aliased_targets = {"wasmtime_c": "wasmtime_c"},
     gen_build_script = "off",
 )
+use_repo(crate, "crates")
 
 # ====================================
 # OCI Base Images
 # ====================================
 bazel_dep(name = "rules_oci", version = "2.0.1", dev_dependency = True)
 
-oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci", dev_dependency = True)
 
 # Use a distroless docker image that only comes with the following:
 #

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -925,7 +925,7 @@
     },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "vyKH4VZgvJxNRuv2Dn3yUi/i7TcjLFk2up5SgTbIUY8=",
+        "bzlTransitiveDigest": "G7xCmtNWXRuBtChRgB5OK5+gmM8Uoy8Mec/B7j3fhqs=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedFileInputs": {
           "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
@@ -955,7 +955,7 @@
     },
     "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
       "general": {
-        "bzlTransitiveDigest": "HtMqmKFmq6Ihw8Q8yEljwD3GjGyiEOPe/RWC2cmGaFs=",
+        "bzlTransitiveDigest": "l8RKpoHR7zGm/jAf9MjCgnfCV0G4HzOsM8aQwFTjH/w=",
         "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1037,7 +1037,7 @@
     },
     "@@rules_apple+//apple:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "CwnxZSval4booBn3AH4F4AU4C9LwBCZuIK9TxDRaO0k=",
+        "bzlTransitiveDigest": "hZq9NZQ3DfMM3SejWMrPlGSZAv38GRVt6iSG5FbwbhQ=",
         "usagesDigest": "M3VqFpeTCo4qmrNKGZw0dxBHvTYDrfV3cscGzlSAhQ4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1540,7 +1540,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "7mvYd9qW/BecPot3UiD0yQKzBwuHv+sleAQcgADZfdo=",
-        "usagesDigest": "6XQ+kkV7cOS1tn+f5/hXrLIo6BVp5Fv4jfvZiXETGpk=",
+        "usagesDigest": "D8Vc31kJbvSZtGmk/s82uAuo4Kg6P7b5rd/7tw+gknI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1932,12 +1932,12 @@
           }
         },
         "moduleExtensionMetadata": {
-          "explicitRootModuleDirectDeps": [
+          "explicitRootModuleDirectDeps": [],
+          "explicitRootModuleDirectDevDeps": [
             "distroless_cc_debian12",
             "distroless_cc_debian12_linux_amd64",
             "distroless_cc_debian12_linux_arm64_v8"
           ],
-          "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
           "reproducible": false
         },
@@ -4070,7 +4070,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "4Hg06TIbbW6HzUFXlr9tqEaVr9KFUAupgIjNBr3c+8s=",
+        "bzlTransitiveDigest": "3/ZcDheTqdpGTf2nu7nmRi8zX0y6v2/3d06nLDO0gMI=",
         "usagesDigest": "WcrwUq7tMYKrrQoXBAJOrk0OAZY0JyWHpnidg71TX10=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -4213,7 +4213,7 @@
     },
     "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "188HAR1B7/zgGCexknNy/LA9sxfIShSv1ttw1bk62XM=",
+        "bzlTransitiveDigest": "7HCu9g5L/A6rnapg3vth7ZT5JAXGhHB5cfk39qhGYuM=",
         "usagesDigest": "mhACFnrdMv9Wi0Mt67bxocJqviRkDSV+Ee5Mqdj5akA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -4373,7 +4373,7 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "c1HwgmsVfl3HQfJp5j/lYNFyGkE5EiG6RookiyKG0oM=",
-        "usagesDigest": "rwpkkTnNHzR5ruvmlEIhcIOwvqU55SHssS+CA2XsDnU=",
+        "usagesDigest": "8I9gdsRBinaMjJ5TZWklU2azuuh3ZY0YGTCfpacsflQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
When redpanda is used as a non-root Bazel module, several dependency declaration issues become visible. The rules rules_cc and rules_python were incorrectly marked as dev dependencies, causing them to be unavailable when redpanda is a submodule. Additionally, toolchain declarations (LLVM, Go, Rust, OCI) were not marked as dev dependencies. rules_rust in particular requires that only the root module register a toolchain.

This patch corrects the dependencies by:

1. Moving rules_cc and rules_python from dev_dependency=True to regular dependencies, as they are required by the actual public build targets
2. Marking toolchain-related dependencies (toolchains_llvm and its extensions, go_sdk, rust toolchains, and oci) with dev_dependency=True since they are only needed when building redpanda itself
3. Reordering crate.annotation() to occur before use_repo() to unambiguously ensure the annotation exists when the module extension is evaluated

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Fix bazel MODULE misconfig around deps and toolchain registration 
