### PR TITLE
`tree-wide`: more test UB fixes

### DIFF
--- a/src/v/cluster/archival/tests/service_fixture.h
+++ b/src/v/cluster/archival/tests/service_fixture.h
@@ -182,6 +182,7 @@ public:
     ss::future<> upload_until_term_change(archival::ntp_archiver& archiver) {
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
+        archiver.initialize_probe();
         return archiver._parent.archival_meta_stm()
           ->sync(sync_timeout)
           .then([&](const auto& sync_result) {

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -476,10 +476,14 @@ private:
                 }
             }
         }
-        BOOST_REQUIRE_MESSAGE(
-          !offending_pair,
-          "validation failed, offending pair: " << offending_pair->first << ", "
-                                                << offending_pair->second);
+
+        auto failure_msg = offending_pair.has_value()
+                             ? fmt::format(
+                                 "validation failed, offending pair: {}, {}",
+                                 offending_pair->first,
+                                 offending_pair->second)
+                             : "";
+        BOOST_REQUIRE_MESSAGE(!offending_pair, failure_msg);
     }
 
     cluster::cluster_health_report create_health_report() const {


### PR DESCRIPTION
Some test fixes missed in https://github.com/redpanda-data/redpanda/pull/27954.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
