### PR TITLE
`admin`: add strict weak ordering guarantees to `NaN` handling in `aip_ordering`

### DIFF
--- a/src/v/redpanda/admin/aip_ordering.cc
+++ b/src/v/redpanda/admin/aip_ordering.cc
@@ -93,6 +93,17 @@ auto compare_field_variant(
           } else if constexpr (std::is_same_v<A, serde::pb::raw_enum_value>) {
               // Compare enums by their variant number
               return a.number <=> b.number;
+          } else if constexpr (std::is_floating_point_v<A>) {
+              // Handle NaNs with strict weak ordering guarantees
+              auto a_isnan = std::isnan(a);
+              auto b_isnan = std::isnan(b);
+              if (a_isnan || b_isnan) {
+                  return a_isnan == b_isnan
+                           ? std::partial_ordering::equivalent
+                           : (a_isnan ? std::partial_ordering::less
+                                      : std::partial_ordering::greater);
+              }
+              return a <=> b;
           } else {
               return a <=> b;
           }


### PR DESCRIPTION
This would previously fail in hardened libc++ mode:

```
[ RUN      ] AIPOrderingTest.FloatFieldOrdering
external/toolchains_llvm++llvm+current_llvm_toolchain/bin/../../toolchains_llvm++llvm+current_llvm_toolchain_llvm/bin/../include/c++/v1/__algorithm/comp_ref_type.h:47: assertion !__comp_(__l, __r) failed: Comparator does not induce a strict weak ordering
```

due to the way NaN values were being handled within `aip_ordering.cc`.

Handle floating point NaN values with strict weak ordering guarantees by handling the appropriate cases:

1. `cmp(NaN, NaN)` -> `partial_ordering::equivalent`
2. `cmp(NaN, float)` -> `partial_ordering::less`
3. `cmp(float, NaN)` -> `partial_ordering::greater`

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
