### PR TITLE
[CORE-13316] kafka/handlers: log alter-config details

### DIFF
--- a/src/v/kafka/server/handlers/details/alter_config_utils.h
+++ b/src/v/kafka/server/handlers/details/alter_config_utils.h
@@ -183,6 +183,23 @@ ss::future<chunked_vector<R>> do_alter_topics_configuration(
             error_code::invalid_config,
             "duplicated topic {} alter config request"));
     }
+
+    // Constructing a map of requested changes for logging
+    chunked_hash_map<model::topic, chunked_vector<ss::sstring>>
+      requested_kv_map;
+    requested_kv_map.reserve(std::distance(resources.begin(), valid_end));
+    for (auto& r : boost::make_iterator_range(resources.begin(), valid_end)) {
+        chunked_vector<ss::sstring> kvs;
+        kvs.reserve(r.configs.size());
+        for (auto& c : r.configs) {
+            const auto& key = c.name;
+            kvs.emplace_back(
+              ssx::sformat(
+                "{}={}", key, c.value.value_or(ss::sstring("<null>"))));
+        }
+        requested_kv_map.emplace(model::topic(r.resource_name), std::move(kvs));
+    }
+
     cluster::topic_properties_update_vector updates;
     for (auto& r : boost::make_iterator_range(resources.begin(), valid_end)) {
         auto res = f(r);
@@ -236,10 +253,22 @@ ss::future<chunked_vector<R>> do_alter_topics_configuration(
     // Log success case
     auto found = err_map.find(cluster::errc::success);
     if (found != err_map.end()) {
-        vlog(
-          klog.info,
-          "Altered topic properties of topic(s) {{{}}} successfully",
-          fmt::join(found->second, ", "));
+        for (const auto& tpv : found->second) {
+            const auto& topic = tpv.tp;
+            if (auto it = requested_kv_map.find(topic);
+                it != requested_kv_map.end()) {
+                vlog(
+                  klog.info,
+                  "Successfully altered topic properties for {}: [{}]",
+                  topic,
+                  fmt::join(it->second, ", "));
+            } else {
+                vlog(
+                  klog.info,
+                  "Successfully altered topic properties for {}",
+                  topic);
+            }
+        }
         err_map.erase(found);
     }
 


### PR DESCRIPTION
Add altered topic properties to the existing logging.

Command: `$ rpk topic alter-config bar foo -s retention.ms=1000 -s segment.ms=1`

New broker log:
```
INFO  2025-10-09 21:25:45,559 [shard 0:kafk] kafka - alter_config_utils.h:264 - Successfully altered topic properties for bar: [retention.ms=1000, segment.ms=1]
INFO  2025-10-09 21:25:45,559 [shard 0:kafk] kafka - alter_config_utils.h:264 - Successfully altered topic properties for foo: [retention.ms=1000, segment.ms=1]
```

Fixes https://redpandadata.atlassian.net/browse/CORE-13316

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Log updated topic properties via alter-config