### PR TITLE
chunked_vector: Support random_access concept

### DIFF
--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -342,12 +342,17 @@ public:
     class iter {
     public:
         using iterator_category = std::random_access_iterator_tag;
-        using value_type = typename std::conditional_t<C, const T, T>;
+        using iterator_concept = std::random_access_iterator_tag;
+        using value_type = T;
         using difference_type = std::ptrdiff_t;
-        using pointer
-          = std::conditional_t<std::is_same_v<T, bool>, bool, value_type*>;
-        using reference
-          = std::conditional_t<std::is_same_v<T, bool>, bool, value_type&>;
+        using pointer = std::conditional_t<
+          std::is_same_v<T, bool>,
+          bool,
+          std::conditional_t<C, const T*, T*>>;
+        using reference = std::conditional_t<
+          std::is_same_v<T, bool>,
+          bool,
+          std::conditional_t<C, const T&, T&>>;
 
         iter() = default;
 

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -33,8 +33,10 @@ using testing::AssertionResult;
 using testing::AssertionSuccess;
 using vec = chunked_vector<int>;
 
-static_assert(std::forward_iterator<vec::iterator>);
-static_assert(std::forward_iterator<vec::const_iterator>);
+static_assert(std::random_access_iterator<vec::iterator>);
+static_assert(std::random_access_iterator<vec::const_iterator>);
+static_assert(std::ranges::random_access_range<vec>);
+static_assert(std::ranges::random_access_range<const vec>);
 
 class chunked_vector_validator {
 public:
@@ -358,6 +360,12 @@ TEST(Vector, Sort) {
     std::sort(v.begin(), v.end());
 
     EXPECT_THAT(v, ElementsAre(1, 2, 3));
+}
+
+TEST(Vector, Heap) {
+    vec v{1, 2, 3};
+    std::ranges::make_heap(v);
+    EXPECT_TRUE(std::ranges::is_heap(v));
 }
 
 TEST(Vector, Clear) {


### PR DESCRIPTION
The iterators are already random_access, but don't meet the requirements for the concepts.

* Add an alias for `iterator_concept`
* Remove cv_ref from `value_type`
* Fix `pointer` and `reference` to add back cv_ref

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


