### PR TITLE
`cluster/cloud_metadata`: just one more UB fix :100: 

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -184,6 +184,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
             continue;
         }
         auto& archiver = p->archiver().value().get();
+        archiver.initialize_probe();
         archiver.sync_for_tests().get();
         auto res = archiver
                      .upload_next_candidates(


### PR DESCRIPTION
What it says

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
