### PR TITLE
tuner: Fix clocksource checker on arm

### DIFF
--- a/src/go/rpk/pkg/tuners/clocksource.go
+++ b/src/go/rpk/pkg/tuners/clocksource.go
@@ -21,14 +21,24 @@ import (
 	"github.com/spf13/afero"
 )
 
-const preferredClkSource = "tsc"
+func preferredClockSource() string {
+	switch runtime.GOARCH {
+	case "amd64", "386":
+		return "tsc"
+	case "arm64":
+		return "arch_sys_counter"
+	default:
+		return ""
+	}
+}
 
 func NewClockSourceChecker(fs afero.Fs) Checker {
+	pref := preferredClockSource()
 	return NewEqualityChecker(
 		ClockSource,
 		"Clock Source",
 		Warning,
-		preferredClkSource,
+		pref,
 		func() (interface{}, error) {
 			content, err := afero.ReadFile(fs,
 				"/sys/devices/system/clocksource/clocksource0/current_clocksource")
@@ -44,19 +54,24 @@ func NewClockSourceTuner(fs afero.Fs, executor executors.Executor) Tunable {
 	return NewCheckedTunable(
 		NewClockSourceChecker(fs),
 		func() TuneResult {
+			pref := preferredClockSource()
+			if pref == "" {
+				return NewTuneError(fmt.Errorf("clocksource setting not available for this architecture"))
+			}
 			err := executor.Execute(commands.NewWriteFileCmd(fs,
 				"/sys/devices/system/clocksource/clocksource0/current_clocksource",
-				preferredClkSource))
+				pref))
 			if err != nil {
 				return NewTuneError(err)
 			}
 			return NewTuneResult(false)
 		},
 		func() (bool, string) {
-			// tsc clocksource is only available in x86 architectures.
-			if runtime.GOARCH != "amd64" && runtime.GOARCH != "386" {
+			pref := preferredClockSource()
+			if pref == "" {
 				return false, "Clocksource setting not available for this architecture"
 			}
+
 			content, err := afero.ReadFile(fs,
 				"/sys/devices/system/clocksource/clocksource0/available_clocksource")
 			if err != nil {
@@ -65,12 +80,12 @@ func NewClockSourceTuner(fs afero.Fs, executor executors.Executor) Tunable {
 			availableSrcs := strings.Fields(string(content))
 
 			for _, src := range availableSrcs {
-				if src == preferredClkSource {
+				if src == pref {
 					return true, ""
 				}
 			}
 			return false, fmt.Sprintf(
-				"Preferred clocksource '%s' not available", preferredClkSource)
+				"Preferred clocksource '%s' not available", pref)
 		},
 		executor.IsLazy(),
 	)

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -63,8 +63,13 @@ class RpkRemoteTool:
     def cluster_config_lint(self):
         return self._execute([self._rpk_binary(), "cluster", "config", "lint"])
 
-    def tune(self, tuner: str) -> str:
-        return self._execute([self._rpk_binary(), "redpanda", "tune", tuner, "-v"])
+    def tune(self, tuner: str, verbose: bool = True) -> str:
+        verbose_args: list[str] = []
+        if verbose:
+            verbose_args = ["-v"]
+        return self._execute(
+            [self._rpk_binary(), "redpanda", "tune", tuner] + verbose_args
+        )
 
     def check(self) -> str:
         return self._execute([self._rpk_binary(), "redpanda", "check", "-v"])

--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -92,16 +92,6 @@ transparent_hugepages  true     true
         r = str(node.account.ssh_output("dmidecode -s system-product-name"))
         isGCP = "Google Compute Engine" in r
 
-        # Clocksource is only available for x86 architectures.
-        expected = (
-            expected.replace(
-                "clocksource            true     true       ",
-                "clocksource            true     false      Clocksource setting not available for this architecture",
-            )
-            if is_not_x86
-            else expected
-        )
-
         expected = (
             expected.replace(
                 "disk_write_cache       true     false      Disk write cache tuner is only supported in GCP",

--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -101,8 +101,6 @@ transparent_hugepages  true     true
             else expected
         )
 
-        output = rpk.tune("list")
-        if output != expected:
-            self.logger.debug(f"expected:\n{expected}\ngot:\n{output}")
+        output = rpk.tune("list", verbose=False)
 
-        assert output == expected
+        assert output == expected, f"expected:\n{expected}\ngot:\n{output}"


### PR DESCRIPTION
Fix clock_source checker support on arm

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


