### PR TITLE
storage/log: calculate cleanly compacted prefix for coordinated compaction

### DIFF
--- a/src/v/raft/tests/failure_injectable_log.cc
+++ b/src/v/raft/tests/failure_injectable_log.cc
@@ -284,6 +284,10 @@ failure_injectable_log::max_removed_offset() const {
     return _underlying_log->max_removed_offset();
 }
 
+model::offset failure_injectable_log::cleanly_compacted_prefix_offset() const {
+    return _underlying_log->cleanly_compacted_prefix_offset();
+}
+
 bool failure_injectable_log::needs_compaction() const {
     return _underlying_log->needs_compaction();
 }

--- a/src/v/raft/tests/failure_injectable_log.h
+++ b/src/v/raft/tests/failure_injectable_log.h
@@ -152,6 +152,8 @@ public:
 
     virtual std::optional<model::offset> max_removed_offset() const final;
 
+    virtual model::offset cleanly_compacted_prefix_offset() const final;
+
     bool needs_compaction() const final;
 
 private:

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2474,6 +2474,29 @@ auto disk_log_impl::get_file_offset(
     };
 }
 
+model::offset disk_log_impl::cleanly_compacted_prefix_offset() const {
+    _cleanly_compacted_offset = std::max(
+      _cleanly_compacted_offset, _start_offset);
+    if (!_segs.empty()) {
+        auto first_seg_to_check_it = _segs.lower_bound(
+          _cleanly_compacted_offset);
+        auto first_non_clean_seg_it = std::find_if(
+          first_seg_to_check_it, _segs.end(), [](const segment_set::type& seg) {
+              return !seg->index().has_clean_compact_timestamp();
+          });
+        if (first_non_clean_seg_it == _segs.end()) [[unlikely]] {
+            // This should not happen, as we never compact the last segment.
+            // If it does for any reason, underreport cleanly compacted offset
+            // by the length of the last segment rather than use its max_offset
+            // which may be uninitialized.
+            --first_non_clean_seg_it;
+        }
+        _cleanly_compacted_offset
+          = (*first_non_clean_seg_it)->index().base_offset();
+    }
+    return _cleanly_compacted_offset;
+}
+
 bool disk_log_impl::log_contains_offset(model::offset o) const noexcept {
     auto log_offsets = offsets();
     auto log_interval = model::bounded_offset_interval::optional(

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -330,6 +330,10 @@ public:
       model::offset target,
       boundary_type boundary);
 
+    // Exclusive: returns the first offset that is not within the cleanly
+    // compacted prefix
+    model::offset cleanly_compacted_prefix_offset() const final;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -561,6 +565,10 @@ private:
     void reset_dirty_and_closed_bytes() const;
 
     bool _compaction_enabled;
+
+    // Exclusive: the offset that marks the first offset beyond the cleanly
+    // compacted prefix.
+    mutable model::offset _cleanly_compacted_offset{0};
 };
 
 } // namespace storage

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -273,6 +273,8 @@ public:
       earliest_removable_timestamp(model::offset) const = 0;
 
     virtual std::optional<model::offset> max_removed_offset() const = 0;
+    virtual model::offset cleanly_compacted_prefix_offset() const = 0;
+
     virtual bool needs_compaction() const = 0;
 
 private:

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -472,6 +472,10 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
     ASSERT_TRUE(segs[2]->finished_windowed_compaction());
     ASSERT_TRUE(segs[2]->has_clean_compact_timestamp());
 
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs[0]->offsets().get_base_offset());
+
     ASSERT_TRUE(disk_log.get_last_compaction_window_start_offset().has_value());
     ASSERT_EQ(
       disk_log.get_last_compaction_window_start_offset().value(),
@@ -492,6 +496,10 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
     // Now the first two segments should be marked as clean.
     ASSERT_TRUE(segs[0]->has_clean_compact_timestamp());
     ASSERT_TRUE(segs[1]->has_clean_compact_timestamp());
+    ASSERT_TRUE(segs[2]->has_clean_compact_timestamp());
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs.back()->offsets().get_base_offset());
 
     ASSERT_FALSE(
       disk_log.get_last_compaction_window_start_offset().has_value());
@@ -503,6 +511,61 @@ TEST_F(CompactionFixtureTest, TestChunkedCompaction) {
     for (const auto& seg : disk_log.segments()) {
         ASSERT_EQ(seg->offsets().get_base_offset(), seg->index().base_offset());
     }
+}
+
+TEST_F(CompactionFixtureTest, TestCleanCompactionAndTruncation) {
+    constexpr auto num_segments = 5;
+    constexpr auto cardinality = 100;
+    size_t batches_per_segment = 5;
+    size_t records_per_batch = 10;
+    map_t latest_kv_map;
+
+    ASSERT_EQ(log->cleanly_compacted_prefix_offset(), model::offset{0});
+    generate_data(
+      num_segments,
+      cardinality,
+      batches_per_segment,
+      records_per_batch,
+      0,
+      false,
+      &latest_kv_map)
+      .get();
+
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    const auto& segs = disk_log.segments();
+
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs[0]->offsets().get_base_offset());
+
+    // Compact segments 0 and 1
+    bool did_compact = do_sliding_window_compact(
+                         segs[2]->offsets().get_base_offset(), std::nullopt)
+                         .get();
+    ASSERT_TRUE(did_compact);
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs[2]->offsets().get_base_offset());
+
+    // Truncate segments 0, 1 and 2
+    log->truncate_prefix({segs[3]->offsets().get_base_offset()}).get();
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs.front()->offsets().get_base_offset());
+
+    // Compact the rest
+    did_compact = do_sliding_window_compact(
+                    segs.back()->offsets().get_base_offset(), std::nullopt)
+                    .get();
+    ASSERT_TRUE(did_compact);
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs.back()->offsets().get_base_offset());
+
+    // Truncate everything
+    log->truncate_prefix({segs.back()->offsets().get_base_offset()}).get();
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(), log->offsets().start_offset);
 }
 
 TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
@@ -556,6 +619,9 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
     ASSERT_FALSE(segs[segs.size() - 2]->finished_windowed_compaction());
     ASSERT_FALSE(segs[segs.size() - 2]->has_self_compact_timestamp());
     ASSERT_FALSE(segs[segs.size() - 2]->has_clean_compact_timestamp());
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs[segs.size() - 2]->offsets().get_base_offset());
 
     // We should have compacted all the way down to the start of the log, and
     // reset the start offset.
@@ -569,6 +635,9 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
     ASSERT_TRUE(segs[segs.size() - 2]->finished_windowed_compaction());
     ASSERT_TRUE(segs[segs.size() - 2]->has_self_compact_timestamp());
     ASSERT_TRUE(segs[segs.size() - 2]->has_clean_compact_timestamp());
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      segs[segs.size() - 1]->offsets().get_base_offset());
 
     auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
     ASSERT_LT(segments_compacted_2, segments_compacted_3);
@@ -1019,6 +1088,10 @@ TEST_P(CompactionFixtureTombstonesParamTest, TestTombstonesCompletelyEmptyLog) {
     for (size_t i = 0; i < num_segments; ++i) {
         ASSERT_TRUE(log->segments()[i]->has_clean_compact_timestamp());
     }
+    ASSERT_EQ(
+      log->cleanly_compacted_prefix_offset(),
+      model::next_offset(
+        log->segments()[num_segments - 1]->offsets().get_dirty_offset()));
 
     {
         tests::kafka_consume_transport consumer(make_kafka_client().get());

--- a/src/v/storage/tests/compaction_fuzz_test.cc
+++ b/src/v/storage/tests/compaction_fuzz_test.cc
@@ -97,8 +97,7 @@ struct ot_state {
     std::deque<int64_t> gap_length;
 };
 
-/// Consumer that builds the map of all non-data
-/// batches!
+/// Consumer that builds the map of all non-data batches!
 struct ot_state_consumer {
     ss::future<ss::stop_iteration> operator()(model::record_batch rb) {
         static const auto translation_batches


### PR DESCRIPTION
This PR is part of coordinated tombstone removal project, see [RFC](https://docs.google.com/document/d/1xonretiC9XjoLmudixVIe_PdRalil4SJSNhG_Z0lHyM/edit?tab=t.0#heading=h.ojw25rni4gzp)).

This change is to collect the offset that binds the longest known cleanly compacted log prefix, i.e. the log prefix where each key is present there no more than once. This offset is called MCCO in the RFC.

We cache MCCO known from previous queries, bump it to log start in case it was prefix-truncated and check further segments one by one until we find one that is not cleanly compacted or get to the end of the log. The beginning of such segment or the end of the log will be the new MCCO.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
