### PR TITLE
rpk shadow: add --force-delete to delete command

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,7 +9,7 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250806153840-184e270a51f5.1
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-184e270a51f5.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251007130208-16fea41f579f.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20250813192242-efcc93bcd794.1

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -10,8 +10,8 @@ buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-0
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1/go.mod h1:pUNfu5CqCYitRtXrJ69rHyB7SXdTkDuqqnNwQYI2H1Q=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1 h1:+bBkTuaJtXW9irz6gDCCFHK17BNxjUPB0qIvNOiXSXE=
 buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1/go.mod h1:vJABXSPxk+Oeds+LifrwLGPUkbl7ftBHqNpLAfPcTRA=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1 h1:GoNb2M1NqJA97n6Joml7RitfzDJQbLEJKXingogSP/o=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251003220015-a1e818380921.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251007130208-16fea41f579f.1 h1:j01H0tQztIy/1GV6/ZdwGT2OJp105ymmmP1SZNMryEA=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251007130208-16fea41f579f.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1 h1:CiTv2Rme+0H/2IQpyZFK8SQYRWgRWEvFNxZIfDMYOQQ=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1/go.mod h1:HJnvbiwx2qZN8HcD30Dijm5Aamjcrk/8/ffTOFrF5Go=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1 h1:31r1Sv/BoVyGzzBfBHcUcyQJz/+4i/fr8wc7gQVihEM=

--- a/src/go/rpk/pkg/cli/shadow/delete.go
+++ b/src/go/rpk/pkg/cli/shadow/delete.go
@@ -22,7 +22,10 @@ import (
 )
 
 func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	var noConfirm bool
+	var (
+		noConfirm   bool
+		forceDelete bool
+	)
 	cmd := &cobra.Command{
 		Use:   "delete [LINK_NAME]",
 		Args:  cobra.ExactArgs(1),
@@ -35,6 +38,10 @@ deletion.
 
 The command prompts for confirmation by default. Use the --no-confirm flag to
 skip the confirmation prompt.
+
+Use the -f/--force flag to delete a Shadow Link even if it has active Shadow
+topics. Effectively has the same result as Failing Over all topics + deleting
+the Shadow Link. This flag also disables the confirmation prompt.
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			p, err := p.LoadVirtualProfile(fs)
@@ -51,7 +58,7 @@ skip the confirmation prompt.
 			out.MaybeDie(err, "unable to get Redpanda Shadow Link information: %v", err)
 
 			printShadowLinkInfo(link.Msg.GetShadowLink())
-			if !noConfirm {
+			if !noConfirm && !forceDelete {
 				ok, err := out.Confirm("Are you sure you want to delete this Shadow Link?")
 				out.MaybeDie(err, "unable to confirm Shadow Link deletion: %v", err)
 				if !ok {
@@ -60,7 +67,8 @@ skip the confirmation prompt.
 			}
 
 			_, err = cl.ShadowLinkService().DeleteShadowLink(cmd.Context(), connect.NewRequest(&adminv2.DeleteShadowLinkRequest{
-				Name: linkName,
+				Name:  linkName,
+				Force: forceDelete,
 			}))
 			out.MaybeDie(err, "unable to delete Redpanda Shadow Link %q: %v", linkName, err)
 
@@ -68,6 +76,7 @@ skip the confirmation prompt.
 		},
 	}
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	cmd.Flags().BoolVarP(&forceDelete, "force", "f", false, "If set, forces a delete while there are active shadow topics; disables confirmation prompt as well")
 	return cmd
 }
 


### PR DESCRIPTION
Support the Force option of Shadow Delete, that effectively FailOver all topics + delete the Shadowlink.

**Usage:**
```
rpk shadow delete my-link --force
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

