### PR TITLE
rpk: minor fixes to rpk group describe format json

### DIFF
--- a/src/go/rpk/pkg/cli/group/describe.go
+++ b/src/go/rpk/pkg/cli/group/describe.go
@@ -92,13 +92,9 @@ Describe any one-character group:
 			}
 
 			groupDescriptions := buildDescribed(lags, partitionCount)
-			formatOutput, isText, err := formatDescribedJSON(groupDescriptions, f)
-			if err != nil {
-				out.Die("Error formatting group descriptions: %v", err)
-			}
-			if !isText {
-				fmt.Print(formatOutput)
-				return
+			if isText, _, s, err := f.Format(groupDescriptions); !isText {
+				out.MaybeDie(err, "unable to format described group: %v", err)
+				out.Exit(s)
 			}
 			if lagPerTopic {
 				printLagPerTopic(lags, partitionCount)
@@ -186,10 +182,11 @@ func buildDescribed(lags kadm.DescribedGroupLags, partitionCount int) []groupDes
 			// Apache Kafka does use a different algorithm, https://github.com/apache/kafka/blob/4.0.0/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala#L192
 			hash := xxhash.Sum64String(group.Group)
 			partitionID = jump.Hash(hash, int32(partitionCount))
-			groupDescription.CoordinatorPartition = fmt.Sprintf("__consumer_offsets/%d\n", partitionID)
+			groupDescription.CoordinatorPartition = fmt.Sprintf("__consumer_offsets/%d", partitionID)
 		}
 
-		var partitionsInfo []partitionInfo
+		// Initialize partition info so that it is not null in the JSON output.
+		partitionsInfo := []partitionInfo{}
 		for _, l := range group.Lag.Sorted() {
 			pi := partitionInfo{
 				Topic:          l.Topic,
@@ -215,7 +212,7 @@ func buildDescribed(lags kadm.DescribedGroupLags, partitionCount int) []groupDes
 			partitionsInfo = append(partitionsInfo, pi)
 		}
 		groupDescription.Partitions = partitionsInfo
-		var membersInfo []memberInfo
+		membersInfo := []memberInfo{}
 		for _, m := range group.Members {
 			mi := memberInfo{
 				MemberID: m.MemberID,
@@ -232,23 +229,6 @@ func buildDescribed(lags kadm.DescribedGroupLags, partitionCount int) []groupDes
 		groupDescriptions = append(groupDescriptions, groupDescription)
 	}
 	return groupDescriptions
-}
-
-// formatDescribedJSON is used to verify the type of format that
-// should be outputted. If it is suppose to be text, then return true
-// so that main run function can continue with printing in text.
-// if it returns false, then print in requested format (json or yaml)
-// and then return after.
-func formatDescribedJSON(groupDescriptions []groupDescription, f config.OutFormatter) (string, bool, error) {
-	isText, _, s, err := f.Format(groupDescriptions)
-	if err != nil {
-		return "", false, fmt.Errorf("unable to print in the required format %q: %v", f.Kind, err)
-	}
-	// handle text printing else where
-	if isText {
-		return "", true, nil
-	}
-	return s, false, nil
 }
 
 // Below here lies printing the output of everything we have done.


### PR DESCRIPTION
Specifically:
- Avoiding printing \n in the coordinator-partition JSON output.
- Initializing members_details and partitions so the JSON output displays [] instead of null

Before:
```
$ rpk group describe g1 --format json
[{"group_name":"g1","coordinator_partition":"__consumer_offsets/1\n","state":"Dead","balancer":"","members":0,"coordinator_node":0,"total_lag":0,"partitions":null,"members_details":null}]
```

Now:
```
$ rpk group describe g1 --format json
[{"group_name":"g1","coordinator_partition":"__consumer_offsets/1","state":"Dead","balancer":"","members":0,"coordinator_node":0,"total_lag":0,"partitions":[],"members_details":[]}]
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
