### PR TITLE
Default to 2 CPUs in bazel unit tests, remove exclusive tag

### DIFF
--- a/bazel/test.bzl
+++ b/bazel/test.bzl
@@ -225,7 +225,7 @@ def _redpanda_cc_unit_test(cpu, memory, **kwargs):
     # TODO(bazel): What are the right defaults here?
     _redpanda_cc_test(
         memory = memory or "1GiB",
-        cpu = cpu or 4,
+        cpu = cpu or 2,
         extra_args = extra_args,
         **kwargs
     )

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -908,7 +908,6 @@ redpanda_cc_btest(
         "describe_user_scram_credentials_test.cc",
     ],
     env = {"RP_FIXTURE_ENV": "1"},
-    tags = ["exclusive"],
     deps = [
         "//src/v/cluster",
         "//src/v/kafka/protocol",
@@ -931,7 +930,6 @@ redpanda_cc_btest(
         "alter_user_scram_credentials_test.cc",
     ],
     env = {"RP_FIXTURE_ENV": "1"},
-    tags = ["exclusive"],
     deps = [
         "//src/v/cluster",
         "//src/v/kafka/protocol",
@@ -954,7 +952,6 @@ redpanda_cc_btest(
         "describe_acls_test.cc",
     ],
     env = {"RP_FIXTURE_ENV": "1"},
-    tags = ["exclusive"],
     deps = [
         "//src/v/cluster",
         "//src/v/kafka/protocol",

--- a/src/v/net/tests/BUILD
+++ b/src/v/net/tests/BUILD
@@ -22,6 +22,7 @@ redpanda_cc_btest(
     srcs = [
         "conn_quota_test.cc",
     ],
+    cpu = 4,
     deps = [
         "//src/v/base",
         "//src/v/config",


### PR DESCRIPTION
This pull request makes minor adjustments to test resource allocation and test tagging in the Bazel build configuration. The main changes are lowering the default CPU allocation for a test macro, explicitly setting CPU resources for a specific test, and removing the "exclusive" tag from several tests.

Resource allocation changes:

* The default CPU allocation in the `_redpanda_cc_unit_test` macro in `test.bzl` was reduced from 4 to 2, which will affect all tests using this macro unless overridden.
* The `redpanda_cc_btest` for `conn_quota_test.cc` in `net/tests/BUILD` now explicitly requests 4 CPUs, ensuring this test still runs with the higher allocation.

Test tagging changes:

* The "exclusive" tag was removed from three `redpanda_cc_btest` targets in `kafka/server/tests/BUILD`, which may allow these tests to run in parallel with others and improve test throughput:
  - `describe_user_scram_credentials_test.cc`
  - `alter_user_scram_credentials_test.cc`
  - `describe_acls_test.cc`
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

