### PR TITLE
ct: followups from previous PRs

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -393,7 +393,7 @@ frontend::l0_timequery(storage::timequery_config cfg) {
       /*as=*/cfg.abort_source,
       /*client_addr=*/cfg.client_address,
     });
-    auto type_filter = std::to_array({
+    static constexpr auto type_filter = std::to_array({
       model::record_batch_type::raft_data,
       model::record_batch_type::ctp_placeholder,
     });

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -207,8 +207,8 @@ public:
     get_first_ge(const model::topic_id_partition&, kafka::offset) = 0;
 
     // Finds the first object of a given partition with data greater than or
-    // equal to the given timestamp, that starts after the provided offset. If
-    // no such timestamp exists, returns `out_of_range`.
+    // equal to the given timestamp, that starts at or after the provided
+    // offset. If no such timestamp exists, returns `out_of_range`.
     virtual ss::future<std::expected<object_response, errc>> get_first_ge(
       const model::topic_id_partition&, kafka::offset, model::timestamp)
       = 0;

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.cc
@@ -103,34 +103,13 @@ ss::future<> ctp_stm::prefix_truncate_below_lro() {
         }
         auto lro = _state.get_max_collectible_offset();
         auto snapshot_index = _raft->last_snapshot_index();
-        if (snapshot_index >= lro) {
-            vlog(
-              _log.trace,
-              "Last snapshot index {} past LRO {}",
-              _raft->last_snapshot_index(),
-              _state.get_max_collectible_offset());
-            continue;
-        }
-        auto truncate_point = _raft->log()->index_lower_bound(lro);
-        if (!truncate_point) {
-            vlog(
-              _log.warn,
-              "unable to find index lower bound for {}",
-              truncate_point);
-            continue;
-        }
-        vassert(
-          truncate_point <= lro,
-          "Calculated boundary {} must be <= LRO {}",
-          truncate_point,
-          lro);
         vlog(
-          _log.debug,
-          "Calulcated truncation point {} for LRO {}",
-          *truncate_point,
-          _state.get_last_reconciled_log_offset());
+          _log.trace,
+          "Attempting to snapshot ctp at {}, last snapshot at {}",
+          _state.get_max_collectible_offset(),
+          _raft->last_snapshot_index());
         try {
-            co_await do_write_raft_snapshot(*truncate_point);
+            co_await _raft->snapshot_and_truncate_log(lro);
         } catch (...) {
             auto ex = std::current_exception();
             vlogl(
@@ -148,63 +127,6 @@ ss::future<> ctp_stm::prefix_truncate_below_lro() {
             co_await ss::sleep_abortable(min_truncate_period, _as);
         }
     }
-}
-
-ss::future<> ctp_stm::do_write_raft_snapshot(model::offset truncation_point) {
-    vlog(
-      _log.trace,
-      "requested to write raft snapshot (prefix_truncate) at {}",
-      truncation_point);
-    co_await _raft->visible_offset_monitor().wait(
-      truncation_point, model::no_timeout, _as);
-    co_await _raft->refresh_commit_index();
-    co_await _raft->log()->stm_manager()->ensure_snapshot_exists(
-      truncation_point);
-    const auto max_removable_local_log_offset
-      = _raft->log()->stm_manager()->max_removable_local_log_offset();
-    if (truncation_point > max_removable_local_log_offset) {
-        truncation_point = max_removable_local_log_offset;
-        if (truncation_point <= _raft->last_snapshot_index()) {
-            /// Cannot truncate, have already reached maximum allowable
-            co_return;
-        }
-        vlog(
-          _log.trace,
-          "Can only evict up to offset: {}, asked to evict to: {} ",
-          max_removable_local_log_offset,
-          truncation_point);
-    }
-    if (truncation_point <= _raft->last_snapshot_index()) {
-        vlog(
-          _log.trace,
-          "Skipping writing snapshot as Raft already progressed with the new "
-          "snapshot. Current raft snapshot index: {}, requested truncation "
-          "point: {}",
-          _raft->last_snapshot_index(),
-          truncation_point);
-        co_return;
-    }
-    vlog(
-      _log.debug,
-      "Requesting raft snapshot with final offset: {}",
-      truncation_point);
-    auto snapshot_result = co_await _raft->stm_manager()->take_snapshot(
-      truncation_point);
-    // we need to check snapshot index again as it may already progressed after
-    // snapshot is taken by stm_manager
-    if (truncation_point <= _raft->last_snapshot_index()) {
-        vlog(
-          _log.trace,
-          "Skipping writing snapshot as Raft already progressed with the new "
-          "snapshot. Current raft snapshot index: {}, requested truncation "
-          "point: {}",
-          _raft->last_snapshot_index(),
-          truncation_point);
-        co_return;
-    }
-    co_await _raft->write_snapshot(
-      raft::write_snapshot_cfg(
-        snapshot_result.last_included_offset, std::move(snapshot_result.data)));
 }
 
 const model::ntp& ctp_stm::ntp() const noexcept { return _raft->ntp(); }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm.h
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm.h
@@ -97,7 +97,6 @@ private:
     // A function invoked in a background loop that attempts to truncate the log
     // below the current start offset.
     ss::future<> prefix_truncate_below_lro();
-    ss::future<> do_write_raft_snapshot(model::offset truncation_point);
 
 private:
     /// Lock to protect the state from concurrent access.

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_io/tests/s3_imposter.h"
 #include "cloud_topics/level_zero/stm/ctp_stm.h"
+#include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/batch_builder.h"
 #include "model/fundamental.h"
@@ -72,6 +73,15 @@ public:
         auto* c = consumer.get();
         cleanup.emplace_back([c = std::move(consumer)] { c->stop().get(); });
         return c;
+    }
+
+    tests::kafka_list_offsets_transport* make_list_offsets_client() {
+        auto transport = std::make_unique<tests::kafka_list_offsets_transport>(
+          make_kafka_client().get());
+        transport->start().get();
+        auto* t = transport.get();
+        cleanup.emplace_back([t = std::move(transport)] { t->stop().get(); });
+        return t;
     }
 
     std::vector<ss::noncopyable_function<void()>> cleanup;
@@ -198,15 +208,11 @@ TEST_F(e2e_fixture, timequery) {
       {.relative_timestamp = 23, .expected_offset = 28},
       {.relative_timestamp = 28, .expected_offset = -1},
     };
-    auto* consumer = make_consumer();
+    auto* client = make_list_offsets_client();
     for (const auto& testcase : timequery_tests) {
-        auto offset = consumer
-                        ->timequery(
-                          ntp.tp,
-                          model::timestamp{
-                            now()
-                            + (testcase.relative_timestamp * hour_in_milli)})
-                        .get();
+        model::timestamp ts{
+          now() + (testcase.relative_timestamp * hour_in_milli)};
+        auto offset = client->timequery(ntp.tp, ts).get();
         EXPECT_EQ(offset, testcase.expected_offset)
           << "for timequery at relative timestamp: "
           << testcase.relative_timestamp;
@@ -225,7 +231,7 @@ TEST_F(e2e_fixture, timequery) {
     });
     // Retry now that the data is in L1
     for (const auto& testcase : timequery_tests) {
-        auto offset = consumer
+        auto offset = client
                         ->timequery(
                           ntp.tp,
                           model::timestamp{

--- a/src/v/cloud_topics/tests/end_to_end_test.cc
+++ b/src/v/cloud_topics/tests/end_to_end_test.cc
@@ -146,6 +146,8 @@ TEST_F(e2e_fixture, timequery) {
       // For broker time, we should be ignoring the timestamp deltas
       {.relative_timestamps = {0, 1, 2, 3, 5}, .broker_time = true},
       {.relative_timestamps = {16, 17, 17, 18, 16, 20}},
+      {.relative_timestamps = {22, 23, 24}},
+      {.relative_timestamps = {25, 26, 27}},
     };
     model::timestamp now = model::timestamp::now();
     auto* producer = make_producer();
@@ -191,7 +193,10 @@ TEST_F(e2e_fixture, timequery) {
       {.relative_timestamp = 18, .expected_offset = 24},
       {.relative_timestamp = 19, .expected_offset = 26},
       {.relative_timestamp = 20, .expected_offset = 26},
-      {.relative_timestamp = 21, .expected_offset = -1},
+      {.relative_timestamp = 21, .expected_offset = 27},
+      {.relative_timestamp = 22, .expected_offset = 27},
+      {.relative_timestamp = 23, .expected_offset = 28},
+      {.relative_timestamp = 28, .expected_offset = -1},
     };
     auto* consumer = make_consumer();
     for (const auto& testcase : timequery_tests) {

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -73,8 +73,9 @@ ss::future<> log_eviction_stm::handle_log_eviction_events() {
                 // to try again soon even if no other notifications come in.
                 co_await _has_pending_truncation.wait(retry_backoff_time);
             }
-        } catch (const ss::condition_variable_timed_out&) {
+        } catch (const ss::condition_variable_timed_out& ex) {
             /// There is still more data to truncate
+            std::ignore = ex;
         } catch (const ss::abort_requested_exception&) {
             break;
         } catch (const ss::broken_condition_variable&) {
@@ -87,40 +88,17 @@ ss::future<> log_eviction_stm::handle_log_eviction_events() {
 
         auto evict_until = std::max(
           _delete_records_eviction_offset, _storage_eviction_offset);
-        if (_raft->last_snapshot_index() >= evict_until) {
-            previous_iter_truncated_everything = true;
-            continue;
-        }
-        auto truncation_point = _raft->log()->index_lower_bound(evict_until);
-        if (!truncation_point) {
-            vlog(
-              _log.warn,
-              "unable to find index lower bound for {}",
-              evict_until);
-            previous_iter_truncated_everything = false;
-            continue;
-        }
-
-        vassert(
-          truncation_point <= evict_until,
-          "Calculated boundary {} must be <= eviction offset {} ",
-          truncation_point,
-          evict_until);
         try {
-            co_await do_write_raft_snapshot(*truncation_point);
-            if (_raft->last_snapshot_index() < truncation_point) {
-                previous_iter_truncated_everything = false;
-                continue;
-            }
-            // NOTE: the offsets changed such that the truncation point may
-            // have changed, it will be caught in the next iteration, since we
-            // would have been signaled.
-            previous_iter_truncated_everything = true;
-        } catch (const ss::abort_requested_exception&) {
+            previous_iter_truncated_everything
+              = co_await _raft->snapshot_and_truncate_log(evict_until);
+        } catch (const ss::abort_requested_exception& ex) {
             // ignore abort requested exception, shutting down
-        } catch (const ss::gate_closed_exception&) {
+            std::ignore = ex;
+        } catch (const ss::gate_closed_exception& ex) {
             // ignore gate closed exception, shutting down
-        } catch (const ss::broken_semaphore&) {
+            std::ignore = ex;
+        } catch (const ss::broken_semaphore& ex) {
+            std::ignore = ex;
         } catch (const std::exception& e) {
             vlog(
               _log.error,
@@ -154,67 +132,6 @@ ss::future<> log_eviction_stm::monitor_log_eviction() {
             vlog(_log.info, "Error handling log eviction - {}", e);
         }
     }
-}
-
-ss::future<>
-log_eviction_stm::do_write_raft_snapshot(model::offset truncation_point) {
-    vlog(
-      _log.trace,
-      "requested to write raft snapshot (prefix_truncate) at {}",
-      truncation_point);
-    if (truncation_point <= _raft->last_snapshot_index()) {
-        co_return;
-    }
-    co_await _raft->visible_offset_monitor().wait(
-      truncation_point, model::no_timeout, _as);
-    co_await _raft->refresh_commit_index();
-    co_await _raft->log()->stm_manager()->ensure_snapshot_exists(
-      truncation_point);
-    const auto max_removable_local_log_offset
-      = _raft->log()->stm_manager()->max_removable_local_log_offset();
-    if (truncation_point > max_removable_local_log_offset) {
-        truncation_point = max_removable_local_log_offset;
-        if (truncation_point <= _raft->last_snapshot_index()) {
-            /// Cannot truncate, have already reached maximum allowable
-            co_return;
-        }
-        vlog(
-          _log.trace,
-          "Can only evict up to offset: {}, asked to evict to: {} ",
-          max_removable_local_log_offset,
-          truncation_point);
-    }
-    if (truncation_point <= _raft->last_snapshot_index()) {
-        vlog(
-          _log.trace,
-          "Skipping writing snapshot as Raft already progressed with the new "
-          "snapshot. Current raft snapshot index: {}, requested truncation "
-          "point: {}",
-          _raft->last_snapshot_index(),
-          truncation_point);
-        co_return;
-    }
-    vlog(
-      _log.debug,
-      "Requesting raft snapshot with final offset: {}",
-      truncation_point);
-    auto snapshot_result = co_await _raft->stm_manager()->take_snapshot(
-      truncation_point);
-    // we need to check snapshot index again as it may already progressed after
-    // snapshot is taken by stm_manager
-    if (truncation_point <= _raft->last_snapshot_index()) {
-        vlog(
-          _log.trace,
-          "Skipping writing snapshot as Raft already progressed with the new "
-          "snapshot. Current raft snapshot index: {}, requested truncation "
-          "point: {}",
-          _raft->last_snapshot_index(),
-          truncation_point);
-        co_return;
-    }
-    co_await _raft->write_snapshot(
-      raft::write_snapshot_cfg(
-        snapshot_result.last_included_offset, std::move(snapshot_result.data)));
 }
 
 kafka::offset log_eviction_stm::kafka_start_offset_override() {

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -130,7 +130,6 @@ private:
     bool should_process_evict(model::offset);
 
     ss::future<> monitor_log_eviction();
-    ss::future<> do_write_raft_snapshot(model::offset);
     ss::future<> handle_log_eviction_events();
     ss::future<> do_apply(const model::record_batch&) final;
     ss::future<> apply_raft_snapshot(const iobuf&) final;

--- a/src/v/kafka/server/tests/list_offsets_utils.cc
+++ b/src/v/kafka/server/tests/list_offsets_utils.cc
@@ -69,4 +69,34 @@ kafka_list_offsets_transport::high_watermark_for_partition(
       kafka::list_offsets_request::latest_timestamp);
 }
 
+ss::future<kafka::offset> kafka_list_offsets_transport::timequery(
+  model::topic_partition tp, model::timestamp time) {
+    kafka::list_offsets_request req;
+    req.data.isolation_level = std::to_underlying(
+      model::isolation_level::read_uncommitted);
+    req.data.topics.push_back(
+      kafka::list_offset_topic{
+        .name = tp.topic,
+        .partitions = {{
+          .partition_index = tp.partition,
+          .current_leader_epoch = kafka::invalid_leader_epoch,
+          .timestamp = time,
+        }},
+      });
+    auto api_resp = co_await _transport.dispatch(
+      std::move(req), kafka::api_version(5));
+    for (const auto& topic : api_resp.data.topics) {
+        if (topic.name != tp.topic) {
+            continue;
+        }
+        for (const auto& partition : topic.partitions) {
+            if (partition.partition_index != tp.partition) {
+                continue;
+            }
+            co_return model::offset_cast(partition.offset);
+        }
+    }
+    throw std::runtime_error(fmt::format("list offsets result missing {}", tp));
+}
+
 } // namespace tests

--- a/src/v/kafka/server/tests/list_offsets_utils.h
+++ b/src/v/kafka/server/tests/list_offsets_utils.h
@@ -52,6 +52,9 @@ public:
         co_return out_map[pid];
     }
 
+    ss::future<kafka::offset>
+    timequery(model::topic_partition tp, model::timestamp time);
+
 private:
     kafka::client::transport _transport;
 };

--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -368,34 +368,4 @@ ss::future<kafka::offset> kafka_produce_transport::produce_to_partition(
       ntp.tp.topic, ntp.tp.partition, std::move(batch));
 }
 
-ss::future<kafka::offset> kafka_consume_transport::timequery(
-  model::topic_partition tp, model::timestamp time) {
-    kafka::list_offsets_request req;
-    req.data.isolation_level = std::to_underlying(
-      model::isolation_level::read_uncommitted);
-    req.data.topics.push_back(
-      kafka::list_offset_topic{
-        .name = tp.topic,
-        .partitions = {{
-          .partition_index = tp.partition,
-          .current_leader_epoch = kafka::invalid_leader_epoch,
-          .timestamp = time,
-        }},
-      });
-    auto api_resp = co_await _transport.dispatch(
-      std::move(req), kafka::api_version(5));
-    for (const auto& topic : api_resp.data.topics) {
-        if (topic.name != tp.topic) {
-            continue;
-        }
-        for (const auto& partition : topic.partitions) {
-            if (partition.partition_index != tp.partition) {
-                continue;
-            }
-            co_return model::offset_cast(partition.offset);
-        }
-    }
-    throw std::runtime_error(fmt::format("list offsets result missing {}", tp));
-}
-
 } // namespace tests

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -144,9 +144,6 @@ public:
       model::partition_id pid,
       model::offset kafka_offset_inclusive);
 
-    ss::future<kafka::offset>
-    timequery(model::topic_partition tp, model::timestamp time);
-
 private:
     ss::future<kafka::fetch_response> raw_consume(
       model::topic topic_name,

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -4382,4 +4382,86 @@ consensus::do_remake_learner_state(remake_learner_state_request req) {
     co_return reply;
 }
 
+ss::future<bool>
+consensus::snapshot_and_truncate_log(model::offset eviction_point) {
+    if (_last_snapshot_index >= eviction_point) {
+        co_return true;
+    }
+    auto truncation_point = _log->index_lower_bound(eviction_point);
+    if (!truncation_point) {
+        vlog(
+          _ctxlog.warn,
+          "unable to find index lower bound for {}",
+          eviction_point);
+        co_return false;
+    }
+    vassert(
+      truncation_point <= eviction_point,
+      "Calculated boundary {} must be <= eviction offset {} ",
+      truncation_point,
+      eviction_point);
+    co_await do_snapshot_and_truncate_log(*truncation_point);
+    co_return _last_snapshot_index >= truncation_point;
+}
+
+ss::future<>
+consensus::do_snapshot_and_truncate_log(model::offset truncation_point) {
+    vlog(
+      _ctxlog.trace,
+      "requested to write raft snapshot (prefix_truncate) at {}",
+      truncation_point);
+    if (truncation_point <= _last_snapshot_index) {
+        co_return;
+    }
+    co_await _consumable_offset_monitor.wait(
+      truncation_point, model::no_timeout, _as);
+    co_await refresh_commit_index();
+    co_await _log->stm_manager()->ensure_snapshot_exists(truncation_point);
+    const auto max_removable_local_log_offset
+      = _log->stm_manager()->max_removable_local_log_offset();
+    if (truncation_point > max_removable_local_log_offset) {
+        truncation_point = max_removable_local_log_offset;
+        if (truncation_point <= _last_snapshot_index) {
+            /// Cannot truncate, have already reached maximum allowable
+            co_return;
+        }
+        vlog(
+          _ctxlog.trace,
+          "Can only evict up to offset: {}, asked to evict to: {} ",
+          max_removable_local_log_offset,
+          truncation_point);
+    }
+    if (truncation_point <= _last_snapshot_index) {
+        vlog(
+          _ctxlog.trace,
+          "Skipping writing snapshot as Raft already progressed with the new "
+          "snapshot. Current raft snapshot index: {}, requested truncation "
+          "point: {}",
+          _last_snapshot_index,
+          truncation_point);
+        co_return;
+    }
+    vlog(
+      _ctxlog.debug,
+      "Requesting raft snapshot with final offset: {}",
+      truncation_point);
+    auto snapshot_result = co_await _stm_manager->take_snapshot(
+      truncation_point);
+    // we need to check snapshot index again as it may already progressed after
+    // snapshot is taken by stm_manager
+    if (truncation_point <= _last_snapshot_index) {
+        vlog(
+          _ctxlog.trace,
+          "Skipping writing snapshot as Raft already progressed with the new "
+          "snapshot. Current raft snapshot index: {}, requested truncation "
+          "point: {}",
+          _last_snapshot_index,
+          truncation_point);
+        co_return;
+    }
+    co_await write_snapshot(
+      raft::write_snapshot_cfg(
+        snapshot_result.last_included_offset, std::move(snapshot_result.data)));
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -225,7 +225,7 @@ public:
     /**
      * \brief Persist snapshot with given data and start offset
      *
-     * The write snaphot API is called by the state machine implementation
+     * The write snapshot API is called by the state machine implementation
      * whenever it decides to take a snapshot. Write snapshot is executed under
      * consensus operations lock.
      */
@@ -245,6 +245,14 @@ public:
     std::filesystem::path get_snapshot_path() const {
         return _snapshot_mgr.snapshot_path();
     }
+
+    // This method will snapshot the log at somepoint <= `eviction_point` and
+    // then truncate the log. This should be used by retention mechansims to
+    // truncate the log safely.
+    //
+    // Returns true if the log was evicted fully up to some possible truncation
+    // point (which is the last segment boundary <= `eviction_point`).
+    ss::future<bool> snapshot_and_truncate_log(model::offset eviction_point);
 
     /// Increment and returns next append_entries order tracking sequence for
     /// follower with given node id
@@ -621,6 +629,7 @@ private:
     ss::future<install_snapshot_reply>
       finish_snapshot(install_snapshot_request, install_snapshot_reply);
 
+    ss::future<> do_snapshot_and_truncate_log(model::offset);
     ss::future<> do_write_snapshot(model::offset, iobuf&&);
     append_entries_reply
       make_append_entries_reply(vnode, storage::append_result);


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
