### PR TITLE
Do not shadow topics with redpanda prefixes

### DIFF
--- a/proto/redpanda/core/admin/v2/shadow_link.proto
+++ b/proto/redpanda/core/admin/v2/shadow_link.proto
@@ -221,6 +221,13 @@ message TopicMetadataSyncOptions {
     // created as shadow topics on the shadow cluster.  This only controls
     // automatic creation of shadow topics and does not effect the state of the
     // mirror topic once it is created.
+    // Literal filters for __consumer_offsets and _redpanda.audit_log will be
+    // rejected as well as prefix filters to match topics prefixed with
+    // _redpanda or __redpanda.
+    // Wildcard `*` is permitted only for literal filters and will _not_ match
+    // any topics that start with _redpanda or __redpanda.  If users wish to
+    // shadow topics that start with _redpanda or __redpanda, they should
+    // provide a literal filter for those topics.
     repeated NameFilter auto_create_shadow_topic_filters = 2;
     // Additional topic properties to shadow
     // Partition count, `max.message.bytes`, `cleanup.policy` and

--- a/src/v/cluster/cluster_link/frontend.cc
+++ b/src/v/cluster/cluster_link/frontend.cc
@@ -1003,13 +1003,25 @@ errc frontend::validator::validate_metadata_mirroring_config(
                 "Filter pattern contains invalid characters");
               return true;
           }
+          // Do not permit specifying the consumer offsets or audit logging
+          // topic
           if (
-            p.pattern.starts_with("_redpanda")
-            || p.pattern.starts_with("__redpanda")
-            || p.pattern == ::model::kafka_consumer_offsets_topic()) {
+            p.pattern == ::model::kafka_consumer_offsets_topic()
+            || p.pattern == ::model::kafka_audit_logging_topic()) {
               vlog(
                 cluster::clusterlog.info,
                 "Filter pattern filtering on invalid topic name: {}",
+                p.pattern);
+              return true;
+          }
+          // Do not permit specifying "_redpanda" or "__redpanda" as a topic
+          // name prefix
+          if (
+            p.pattern_type == ::cluster_link::model::filter_pattern_type::prefix
+            && (p.pattern == "_redpanda" || p.pattern == "__redpanda")) {
+              vlog(
+                cluster::clusterlog.info,
+                "Filter pattern filtering on invalid topic name prefix: {}",
                 p.pattern);
               return true;
           }

--- a/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
+++ b/src/v/cluster/cluster_link/tests/frontend_validation_test.cc
@@ -814,19 +814,99 @@ TEST_F_CORO(
 
 TEST_F_CORO(
   frontend_validation_test, test_mirror_properties_invalid_topic_name) {
-    auto m1 = create_base_metadata();
-    m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
-      = ::cluster_link::model::topic_metadata_mirroring_config::properties_set{
-        "segment.ms"};
-    m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
-      .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
-      .filter = ::cluster_link::model::filter_type::include,
-      .pattern = "__redpanda.internal",
-    }};
+    {
+        auto m1 = create_base_metadata();
+        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+          = ::cluster_link::model::topic_metadata_mirroring_config::
+            properties_set{"segment.ms"};
+        m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
+          .pattern_type = ::cluster_link::model::filter_pattern_type::prefix,
+          .filter = ::cluster_link::model::filter_type::include,
+          .pattern = "__redpanda",
+        }};
 
-    EXPECT_EQ(
-      co_await upsert_cluster_link(std::move(m1)),
-      cluster::cluster_link::errc::topic_filter_invalid);
+        EXPECT_EQ(
+          co_await upsert_cluster_link(std::move(m1)),
+          cluster::cluster_link::errc::topic_filter_invalid);
+    }
+    {
+        auto m1 = create_base_metadata();
+        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+          = ::cluster_link::model::topic_metadata_mirroring_config::
+            properties_set{"segment.ms"};
+        m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
+          .pattern_type = ::cluster_link::model::filter_pattern_type::prefix,
+          .filter = ::cluster_link::model::filter_type::include,
+          .pattern = "_redpanda",
+        }};
+
+        EXPECT_EQ(
+          co_await upsert_cluster_link(std::move(m1)),
+          cluster::cluster_link::errc::topic_filter_invalid);
+    }
+    {
+        auto m1 = create_base_metadata();
+        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+          = ::cluster_link::model::topic_metadata_mirroring_config::
+            properties_set{"segment.ms"};
+        m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
+          .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
+          .filter = ::cluster_link::model::filter_type::include,
+          .pattern = "__consumer_offsets",
+        }};
+
+        EXPECT_EQ(
+          co_await upsert_cluster_link(std::move(m1)),
+          cluster::cluster_link::errc::topic_filter_invalid);
+    }
+    {
+        auto m1 = create_base_metadata();
+        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+          = ::cluster_link::model::topic_metadata_mirroring_config::
+            properties_set{"segment.ms"};
+        m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
+          .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
+          .filter = ::cluster_link::model::filter_type::include,
+          .pattern = "_redpanda.audit_log",
+        }};
+
+        EXPECT_EQ(
+          co_await upsert_cluster_link(std::move(m1)),
+          cluster::cluster_link::errc::topic_filter_invalid);
+    }
+    {
+        auto m1 = create_base_metadata();
+        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+          = ::cluster_link::model::topic_metadata_mirroring_config::
+            properties_set{"segment.ms"};
+        m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
+          .pattern_type = ::cluster_link::model::filter_pattern_type::literal,
+          .filter = ::cluster_link::model::filter_type::include,
+          .pattern = "_redpanda.mine",
+        }};
+
+        EXPECT_EQ(
+          co_await upsert_cluster_link(std::move(m1)),
+          cluster::cluster_link::errc::success);
+
+        ASSERT_EQ_CORO(
+          co_await delete_cluster_link(name_t("link1"), true), errc::success);
+    }
+    {
+        auto m1 = create_base_metadata();
+        m1.configuration.topic_metadata_mirroring_cfg.topic_properties_to_mirror
+          = ::cluster_link::model::topic_metadata_mirroring_config::
+            properties_set{"segment.ms"};
+        m1.configuration.topic_metadata_mirroring_cfg.topic_name_filters = {{
+          .pattern_type = ::cluster_link::model::filter_pattern_type::prefix,
+          .filter = ::cluster_link::model::filter_type::include,
+          .pattern = "_redpanda.mine",
+        }};
+
+        EXPECT_EQ(
+          co_await upsert_cluster_link(std::move(m1)),
+          cluster::cluster_link::errc::success);
+    }
 }
 
 TEST_F_CORO(

--- a/src/v/cluster_link/BUILD
+++ b/src/v/cluster_link/BUILD
@@ -119,6 +119,7 @@ redpanda_cc_library(
         ":logger",
         "//src/v/cluster_link/model",
         "//src/v/kafka/server:topic_config_utils",
+        "//src/v/model",
         "@fmt",
     ],
     visibility = ["//src/v/cluster_link:__subpackages__"],

--- a/src/v/cluster_link/source_topic_syncer.cc
+++ b/src/v/cluster_link/source_topic_syncer.cc
@@ -15,6 +15,7 @@
 #include "cluster_link/model/filter_utils.h"
 #include "cluster_link/model/types.h"
 #include "kafka/server/handlers/topics/types.h"
+#include "model/namespace.h"
 
 #include <fmt/ranges.h>
 
@@ -37,9 +38,8 @@ const absl::flat_hash_map<ss::sstring, ss::sstring>
   topic_configuration_overrides{
     {{ss::sstring(kafka::topic_property_remote_allow_gaps), "true"}}};
 
-const absl::flat_hash_set<::model::topic> topic_denylist{
-  ::model::kafka_consumer_offsets_topic,
-};
+const chunked_vector<ss::sstring> topic_prefix_denylist{
+  ss::sstring("__redpanda"), ss::sstring("_redpanda")};
 
 bool has_required_permissions(
   kafka::topic_authorized_operations permissions_to_check,
@@ -164,6 +164,35 @@ validate_topic_cache_entry(
       replication_factor,
       it->second.authorized_operations,
       topic_id);
+}
+
+std::optional<ss::sstring> is_valid_topic(
+  ::model::topic_view topic,
+  const chunked_vector<model::resource_name_filter_pattern>& patterns) {
+    if (!::model::is_shadow_link_enabled({::model::kafka_namespace, topic})) {
+        return ssx::sformat(
+          "Topic {} is not a valid topic for Shadow Linking", topic);
+    }
+    for (const auto& prefix : topic_prefix_denylist) {
+        if (topic().starts_with(prefix)) {
+            // Need to check the list of include filters and see if it matches
+            // any specifically included topics
+            for (const auto& p : patterns) {
+                if (
+                  p.filter == model::filter_type::include
+                  && p.pattern_type == model::filter_pattern_type::literal
+                  && p.pattern == topic) {
+                    // Even though the topic is prefixed with either "_redpanda"
+                    // or "__redpanda", if it's specifically included, then we
+                    // will permit shadowing of this topic
+                    return std::nullopt;
+                }
+            }
+            return ssx::sformat(
+              "Topic {} starts with a denied prefix: {}", topic, prefix);
+        }
+    }
+    return std::nullopt;
 }
 } // namespace
 
@@ -552,14 +581,6 @@ source_topic_syncer::find_candidate_topics_for_update(
     candidate_topics.reserve(mirror_topics->size());
 
     for (auto& [topic, mirror_metadata] : *mirror_topics) {
-        if (topic_denylist.contains(topic)) {
-            vlog(
-              logger().trace,
-              "Skipping mirroring of {} topic, it is in the denylist",
-              topic);
-            continue;
-        }
-
         vlog(logger().trace, "Checking metadata cache for topic {}", topic);
         auto metadata_value = validate_topic_cache_entry(
           logger(), cluster.get_topics(), topic);
@@ -612,11 +633,9 @@ source_topic_syncer::find_candidate_topics_for_creation(
 
     for (const auto& topic : topics) {
         vlog(logger().trace, "Checking topic: {}", topic);
-        if (topic_denylist.contains(topic)) {
-            vlog(
-              logger().trace,
-              "Skipping mirroring of {} topic, it is in the denylist",
-              topic);
+        auto deny_msg = is_valid_topic(topic, _config.topic_name_filters);
+        if (deny_msg.has_value()) {
+            vlog(logger().trace, "{}", *deny_msg);
             continue;
         }
 

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -381,8 +381,7 @@ write_at_offset_stm_factory::write_at_offset_stm_factory(
 
 bool write_at_offset_stm_factory::is_applicable_for(
   const storage::ntp_config& cfg) const {
-    return model::is_user_topic(cfg.ntp())
-           || cfg.ntp().tp.topic == model::schema_registry_internal_tp.topic;
+    return model::is_shadow_link_enabled(cfg.ntp());
 }
 
 void write_at_offset_stm_factory::create(

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -111,4 +111,13 @@ inline bool is_consumer_offsets_topic(const ntp& ntp) {
     return topic_namespace_view{ntp} == kafka_consumer_offsets_nt;
 }
 
+inline bool is_shadow_link_enabled(topic_namespace_view tp_ns) {
+    return is_user_topic(tp_ns)
+           || tp_ns.tp == schema_registry_internal_tp.topic;
+}
+
+inline bool is_shadow_link_enabled(const ntp& ntp) {
+    return is_shadow_link_enabled(topic_namespace_view{ntp});
+}
+
 } // namespace model

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/shadow_link_pb2.pyi
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/shadow_link_pb2.pyi
@@ -566,6 +566,13 @@ class TopicMetadataSyncOptions(google.protobuf.message.Message):
         created as shadow topics on the shadow cluster.  This only controls
         automatic creation of shadow topics and does not effect the state of the
         mirror topic once it is created.
+        Literal filters for __consumer_offsets and _redpanda.audit_log will be
+        rejected as well as prefix filters to match topics prefixed with
+        _redpanda or __redpanda.
+        Wildcard `*` is permitted only for literal filters and will _not_ match
+        any topics that start with _redpanda or __redpanda.  If users wish to
+        shadow topics that start with _redpanda or __redpanda, they should
+        provide a literal filter for those topics.
         """
 
     @property

--- a/tests/rptest/tests/cluster_linking_e2e_test.py
+++ b/tests/rptest/tests/cluster_linking_e2e_test.py
@@ -679,6 +679,77 @@ class ShadowLinkBasicTests(ShadowLinkTestBase):
         ):
             self.create_link("test-link")
 
+    @cluster(num_nodes=6)
+    def test_deny_prefix(self):
+        topics = [
+            TopicSpec(name="__redpanda-topic", partition_count=3, replication_factor=3),
+            TopicSpec(name="_redpanda-topic", partition_count=3, replication_factor=3),
+            TopicSpec(name="normal-topic", partition_count=3, replication_factor=3),
+        ]
+
+        for topic in topics:
+            self.source_default_client().create_topic(topic)
+
+        shadow_link = self.create_link("test-link")
+
+        def _only_normal_topic_present_in_target_cluster():
+            topics_in_target = {t for t in self.target_cluster_rpk.list_topics()}
+            self.logger.info(f"Topics in target cluster: {topics_in_target}")
+            return len(topics_in_target) == 1 and "normal-topic" in topics_in_target
+
+        self.target_cluster_service.wait_until(
+            _only_normal_topic_present_in_target_cluster,
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg="Failed to find only normal-topic in the target cluster",
+        )
+
+        # Now attempt to add a filter to specifically include _redpanda.audit_log
+        update_mask = google.protobuf.field_mask_pb2.FieldMask(
+            paths=[
+                "configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters"
+            ]
+        )
+        shadow_link.configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters.extend(
+            [
+                shadow_link_pb2.NameFilter(
+                    pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                    filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                    name="_redpanda.audit_log",
+                )
+            ]
+        )
+
+        with expect_exception(
+            ConnectError, lambda e: e.code == ConnectErrorCode.INVALID_ARGUMENT
+        ):
+            self.update_link(shadow_link=shadow_link, update_mask=update_mask)
+
+        shadow_link = self.get_link("test-link")
+        # Now create a link adding the two above topics
+        shadow_link.configurations.topic_metadata_sync_options.auto_create_shadow_topic_filters.extend(
+            [
+                shadow_link_pb2.NameFilter(
+                    pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                    filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                    name="__redpanda-topic",
+                ),
+                shadow_link_pb2.NameFilter(
+                    pattern_type=shadow_link_pb2.PATTERN_TYPE_LITERAL,
+                    filter_type=shadow_link_pb2.FILTER_TYPE_INCLUDE,
+                    name="_redpanda-topic",
+                ),
+            ]
+        )
+        self.update_link(shadow_link=shadow_link, update_mask=update_mask)
+
+        self.target_cluster_service.wait_until(
+            lambda: self._topics_are_present_in_target_cluster(topics),
+            timeout_sec=20,
+            backoff_sec=1,
+            err_msg="Failed to find all topics in the target cluster",
+        )
+
 
 class ShadowLinkingReplicationTests(ShadowLinkPreAllocTestBase):
     def leadership_shuffler(self, redpanda, topic: str, enabled: bool):


### PR DESCRIPTION
This PR adjusts the auto topic creation strategy.

* Wildcard filter does _not_ select any topic starting with `_redpanda` or `__redpanda`
* Users may specify _literal_ topic names that start with those prefixes if they wish
* Filters will reject any attempt to add literal match to `__consumer_offsets` or `_redpanda.audit_log`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
