### PR TITLE
Add cluster property to limit `max.message.bytes`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1796,6 +1796,14 @@ configuration::configuration()
       "then no limit is enforced.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , kafka_max_message_size_upper_limit_bytes(
+      *this,
+      "kafka_max_message_size_upper_limit_bytes",
+      "Maximum allowed value for the `max.message.size` topic "
+      "property. When set to `null`, then no limit is enforced.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100_MiB,
+      {.min = 1})
   , compaction_ctrl_update_interval_ms(
       *this,
       "compaction_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -367,6 +367,8 @@ struct configuration final : public config_store {
     property<std::vector<ss::sstring>> kafka_nodelete_topics;
     property<std::vector<ss::sstring>> kafka_noproduce_topics;
     property<std::optional<uint32_t>> kafka_topics_max;
+    bounded_property<std::optional<int32_t>>
+      kafka_max_message_size_upper_limit_bytes;
 
     // Compaction controller
     property<std::chrono::milliseconds> compaction_ctrl_update_interval_ms;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -258,7 +258,8 @@ create_topic_properties_update(
                 parse_and_set_optional(
                   update.properties.batch_max_bytes,
                   cfg.value,
-                  kafka::config_resource_operation::set);
+                  kafka::config_resource_operation::set,
+                  batch_max_bytes_limits_validator{});
                 continue;
             }
             if (cfg.name == topic_property_retention_local_target_ms) {

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -326,6 +326,29 @@ struct min_cleanable_dirty_ratio_validator {
     }
 };
 
+struct batch_max_bytes_limits_validator {
+    std::optional<ss::sstring>
+    operator()(const ss::sstring&, const std::optional<uint32_t>& value) {
+        if (!value) {
+            return {};
+        }
+
+        const auto v = value.value();
+        const uint32_t upper_limit
+          = config::shard_local_cfg()
+              .kafka_max_message_size_upper_limit_bytes()
+              .value_or(std::numeric_limits<int32_t>::max());
+        if (v == 0 || v > upper_limit) {
+            return fmt::format(
+              "max.message.bytes {} is outside of the allowed range [1, {}]",
+              v,
+              upper_limit);
+        }
+
+        return {};
+    }
+};
+
 template<typename T, typename... ValidatorTypes>
 requires requires(
   model::topic_namespace_view tns,

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -273,7 +273,10 @@ create_topic_properties_update(
             }
             if (cfg.name == topic_property_max_message_bytes) {
                 parse_and_set_optional(
-                  update.properties.batch_max_bytes, cfg.value, op);
+                  update.properties.batch_max_bytes,
+                  cfg.value,
+                  op,
+                  batch_max_bytes_limits_validator{});
                 continue;
             }
             if (cfg.name == topic_property_replication_factor) {

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -183,7 +183,9 @@ struct remote_read_and_write_are_not_supported_for_read_replica {
 struct batch_max_bytes_limits {
     static constexpr error_code ec = error_code::invalid_config;
     static constexpr const char* error_message
-      = "Property max.message.bytes value must be positive";
+      = "Property max.message.bytes value must be positive and less than or "
+        "equal to the `kafka_max_message_size_upper_limit` broker "
+        "configuration";
 
     static bool is_valid(const creatable_topic& c) {
         auto it = std::find_if(
@@ -193,7 +195,11 @@ struct batch_max_bytes_limits {
               return cfg.name == topic_property_max_message_bytes;
           });
         if (it != c.configs.end() && it->value.has_value()) {
-            return boost::lexical_cast<int32_t>(it->value.value()) > 0;
+            auto val = boost::lexical_cast<int32_t>(it->value.value());
+            auto upper_limit = config::shard_local_cfg()
+                                 .kafka_max_message_size_upper_limit_bytes()
+                                 .value_or(std::numeric_limits<int32_t>::max());
+            return val > 0 && val <= upper_limit;
         }
 
         return true;

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -45,6 +45,7 @@ class TopicSpec:
     PROPERTY_MIN_CLEANABLE_DIRTY_RATIO = "min.cleanable.dirty.ratio"
     PROPERTY_MIN_COMPACTION_LAG_MS = "min.compaction.lag.ms"
     PROPERTY_MAX_COMPACTION_LAG_MS = "max.compaction.lag.ms"
+    PROPERTY_MAX_MESSAGE_BYTES = "max.message.bytes"
 
     # requires dev features enabled. only valid at topic create time
     PROPERTY_CLOUD_TOPIC_ENABLE = "redpanda.cloud_topic.enabled"

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -307,6 +307,43 @@ class AlterTopicConfiguration(RedpandaTest):
         )
 
     @cluster(num_nodes=3)
+    def test_batch_max_bytes_validation(self):
+        self.redpanda.set_cluster_config(
+            {"kafka_max_message_size_upper_limit_bytes": 10}
+        )
+
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        initial_spec = kafka_tools.describe_topic(topic)
+
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_MAX_MESSAGE_BYTES: 100}
+            )
+        except subprocess.CalledProcessError as e:
+            assert "is outside of the allowed range" in e.output
+
+        try:
+            self.client().alter_topic_configs(
+                topic, {TopicSpec.PROPERTY_MAX_MESSAGE_BYTES: 0}
+            )
+        except subprocess.CalledProcessError as e:
+            assert "is outside of the allowed range" in e.output
+
+        not_updated = kafka_tools.describe_topic(topic)
+        assert initial_spec.max_message_bytes == not_updated.max_message_bytes, (
+            "max.message.bytes should not have changed"
+        )
+
+        self.client().alter_topic_configs(
+            topic, {TopicSpec.PROPERTY_MAX_MESSAGE_BYTES: 1}
+        )
+        updated = kafka_tools.describe_topic(topic)
+        assert updated.max_message_bytes and int(updated.max_message_bytes) == 1, (
+            "max.message.bytes should have changed"
+        )
+
+    @cluster(num_nodes=3)
     def test_min_and_max_compaction_lag_ms_validation(self):
         topic = self.topics[0].name
         kafka_tools = KafkaCliTools(self.redpanda)

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -408,6 +408,36 @@ class CreateTopicsTest(RedpandaTest):
         rpk.create_topic("should-succeed", replicas=None)
 
     @cluster(num_nodes=3)
+    def test_batch_max_bytes_validation(self):
+        """
+        Validates that a `max.message.bytes` value outside of the allowed range
+        results in an invalid configuration response.
+        """
+        self.redpanda.set_cluster_config(
+            {"kafka_max_message_size_upper_limit_bytes": 10}
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        with expect_exception(
+            RpkException,
+            lambda e: "value must be positive and less than or equal to the" in str(e),
+        ):
+            rpk.create_topic(
+                "topic-1", config={TopicSpec.PROPERTY_MAX_MESSAGE_BYTES: 100}
+            )
+
+        with expect_exception(
+            RpkException,
+            lambda e: "value must be positive and less than or equal to the" in str(e),
+        ):
+            rpk.create_topic(
+                "topic-1", config={TopicSpec.PROPERTY_MAX_MESSAGE_BYTES: 0}
+            )
+
+        rpk.create_topic("topic-1", config={TopicSpec.PROPERTY_MAX_MESSAGE_BYTES: 10})
+
+    @cluster(num_nodes=3)
     def test_min_rf_log(self):
         """
         Validates that a log message appears when minimum_topic_replications


### PR DESCRIPTION
This PR adds the `kafka_max_message_size_upper_limit` cluster property. This property can be used to limit the max value of the `max.message.bytes` topic property.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
### Features
* Add the `kafka_max_message_size_upper_limit` cluster property. This property can be used to limit the max value of the `max.message.bytes` topic property.  
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
