### PR TITLE
Client Monitoring: require license + integrate filter

### DIFF
--- a/proto/redpanda/core/admin/v2/kafka_connections.proto
+++ b/proto/redpanda/core/admin/v2/kafka_connections.proto
@@ -172,7 +172,7 @@ message RequestStatistics {
     uint64 fetch_bytes = 2;
     // Number of requests the client has made.
     uint64 request_count = 3;
-    // Number of produced batches
+    // Number of produced batches.
     // Average batch size = produce_bytes / produce_batch_count
     uint64 produce_batch_count = 4;
 }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -524,7 +524,10 @@ ss::future<> admin_server::start() {
       });
     add_service(
       std::make_unique<admin::broker_service_impl>(
-        std::move(client), &_services, _kafka_server));
+        std::move(client),
+        &_services,
+        _kafka_server,
+        _controller->get_feature_table()));
 
     co_await _debug_bundle_file_handler.start();
 

--- a/src/v/redpanda/admin/services/BUILD
+++ b/src/v/redpanda/admin/services/BUILD
@@ -8,9 +8,11 @@ redpanda_cc_library(
     hdrs = ["broker.h"],
     deps = [
         "//proto/redpanda/core/admin/v2:broker_redpanda_proto",
+        "//src/v/features",
         "//src/v/kafka/server",
         "//src/v/redpanda/admin:aip_filter",
         "//src/v/redpanda/admin/proxy:client",
+        "//src/v/serde/protobuf:rpc",
         "//src/v/ssx:async_algorithm",
         "//src/v/version",
         "@seastar",

--- a/src/v/redpanda/admin/services/BUILD
+++ b/src/v/redpanda/admin/services/BUILD
@@ -9,6 +9,7 @@ redpanda_cc_library(
     deps = [
         "//proto/redpanda/core/admin/v2:broker_redpanda_proto",
         "//src/v/kafka/server",
+        "//src/v/redpanda/admin:aip_filter",
         "//src/v/redpanda/admin/proxy:client",
         "//src/v/ssx:async_algorithm",
         "//src/v/version",

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -14,6 +14,7 @@
 #include "kafka/server/connection_context.h"
 #include "kafka/server/server.h"
 #include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
+#include "redpanda/admin/aip_filter.h"
 #include "ssx/async_algorithm.h"
 #include "version/version.h"
 
@@ -93,19 +94,18 @@ struct connection_gather_result {
     size_t total_matching_count;
 };
 
-ss::future<connection_gather_result>
-gather_connections(const kafka::server& server, size_t limit) {
+ss::future<connection_gather_result> gather_connections(
+  const kafka::server& server, size_t limit, const filter_predicate& filter) {
     auto result = connection_gather_result{};
 
     auto conn_ptrs = server.list_connections();
     co_await ss::maybe_yield();
 
     co_await ssx::async_for_each(
-      conn_ptrs, [&result, limit](const auto& conn_ptr) {
+      conn_ptrs, [&result, limit, &filter](const auto& conn_ptr) {
           auto conn_proto = conn_ptr->to_proto();
 
-          // TODO: Apply filtering here when implemented
-          bool matches_filter = true;
+          bool matches_filter = filter(conn_proto);
 
           if (matches_filter) {
               result.total_matching_count++;
@@ -142,6 +142,10 @@ broker_service_impl::list_kafka_connections(
     auto limit = (req.get_page_size() == 0) ? default_limit
                                             : req.get_page_size();
 
+    auto filter_cfg = make_aip_filter_config<proto::kafka_connection>(
+      req.get_filter());
+    auto filter = aip_filter_parser::create_aip_filter(std::move(filter_cfg));
+
     // Iterate across shards sequentially to bound memory usage while
     // calculating total size
     auto result_connections = chunked_vector<proto::kafka_connection>{};
@@ -152,9 +156,9 @@ broker_service_impl::list_kafka_connections(
         auto remaining_limit = limit - result_connections.size();
         auto shard_result = co_await _kafka_server.invoke_on(
           shard,
-          [remaining_limit](
+          [remaining_limit, &filter](
             kafka::server& server) -> ss::future<connection_gather_result> {
-              return gather_connections(server, remaining_limit);
+              return gather_connections(server, remaining_limit, filter);
           });
 
         total_matching_connections += shard_result.total_matching_count;

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -11,10 +11,12 @@
 
 #include "redpanda/admin/services/broker.h"
 
+#include "features/feature_table.h"
 #include "kafka/server/connection_context.h"
 #include "kafka/server/server.h"
 #include "proto/redpanda/core/admin/v2/kafka_connections.proto.h"
 #include "redpanda/admin/aip_filter.h"
+#include "serde/protobuf/rpc.h"
 #include "ssx/async_algorithm.h"
 #include "version/version.h"
 
@@ -35,10 +37,12 @@ ss::logger brlog{"admin_api_server/broker_service"};
 broker_service_impl::broker_service_impl(
   admin::proxy::client client,
   std::vector<std::unique_ptr<serde::pb::rpc::base_service>>* services,
-  ss::sharded<kafka::server>& kafka_server)
+  ss::sharded<kafka::server>& kafka_server,
+  ss::sharded<features::feature_table>& feature_table)
   : _proxy_client(std::move(client))
   , _services(services)
-  , _kafka_server(kafka_server) {}
+  , _kafka_server(kafka_server)
+  , _feature_table(feature_table) {}
 
 ss::future<proto::admin::get_broker_response> broker_service_impl::get_broker(
   serde::pb::rpc::context ctx, proto::admin::get_broker_request req) {
@@ -119,6 +123,19 @@ ss::future<connection_gather_result> gather_connections(
     co_return result;
 }
 
+void check_license(const features::feature_table& ft) {
+    if (ft.should_sanction()) {
+        const auto& license = ft.get_license();
+        auto status = [&license]() {
+            return !license.has_value()    ? "not present"
+                   : license->is_expired() ? "expired"
+                                           : "unknown error";
+        };
+        throw serde::pb::rpc::failed_precondition_exception(
+          fmt::format("Invalid license: {}", status()));
+    }
+}
+
 } // namespace
 
 ss::future<proto::admin::list_kafka_connections_response>
@@ -126,6 +143,8 @@ broker_service_impl::list_kafka_connections(
   serde::pb::rpc::context ctx,
   proto::admin::list_kafka_connections_request req) {
     vlog(brlog.trace, "list_kafka_connections: {}", req);
+
+    check_license(_feature_table.local());
 
     // Proxy to the target node id specified in the request
     auto target = model::node_id{req.get_node_id()};

--- a/src/v/redpanda/admin/services/broker.cc
+++ b/src/v/redpanda/admin/services/broker.cc
@@ -103,7 +103,7 @@ ss::future<connection_gather_result> gather_connections(
     auto result = connection_gather_result{};
 
     auto conn_ptrs = server.list_connections();
-    co_await ss::maybe_yield();
+    co_await ss::coroutine::maybe_yield();
 
     co_await ssx::async_for_each(
       conn_ptrs, [&result, limit, &filter](const auto& conn_ptr) {
@@ -184,7 +184,7 @@ broker_service_impl::list_kafka_connections(
         std::ranges::move(
           shard_result.connections, std::back_inserter(result_connections));
 
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
     }
 
     resp.set_total_size(total_matching_connections);

--- a/src/v/redpanda/admin/services/broker.h
+++ b/src/v/redpanda/admin/services/broker.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "features/fwd.h"
 #include "kafka/server/fwd.h"
 #include "proto/redpanda/core/admin/v2/broker.proto.h"
 #include "redpanda/admin/proxy/client.h"
@@ -25,7 +26,8 @@ public:
     broker_service_impl(
       admin::proxy::client,
       std::vector<std::unique_ptr<serde::pb::rpc::base_service>>* services,
-      ss::sharded<kafka::server>& kafka_server);
+      ss::sharded<kafka::server>& kafka_server,
+      ss::sharded<features::feature_table>& _feature_table);
 
     ss::future<proto::admin::get_broker_response> get_broker(
       serde::pb::rpc::context, proto::admin::get_broker_request) override;
@@ -43,6 +45,7 @@ private:
     admin::proxy::client _proxy_client;
     std::vector<std::unique_ptr<serde::pb::rpc::base_service>>* _services;
     ss::sharded<kafka::server>& _kafka_server;
+    ss::sharded<features::feature_table>& _feature_table;
 };
 
 } // namespace admin

--- a/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/kafka_connections_pb2.pyi
+++ b/tests/rptest/clients/admin/proto/redpanda/core/admin/v2/kafka_connections_pb2.pyi
@@ -348,7 +348,7 @@ class RequestStatistics(google.protobuf.message.Message):
     request_count: builtins.int
     'Number of requests the client has made.'
     produce_batch_count: builtins.int
-    'Number of produced batches\n    Average batch size = produce_bytes / produce_batch_count\n    '
+    'Number of produced batches.\n    Average batch size = produce_bytes / produce_batch_count\n    '
 
     def __init__(self, *, produce_bytes: builtins.int=..., fetch_bytes: builtins.int=..., request_count: builtins.int=..., produce_batch_count: builtins.int=...) -> None:
         ...

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -102,3 +102,30 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
         assert filtered_resp.total_size == 0
 
         self.consumer.stop()
+
+
+class AdminV2ListKafkaConnectionsLicenseTest(RedpandaTest):
+    """
+    Tests that list_kafka_connections requires a valid license.
+    """
+
+    def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(test_ctx, *args, **kwargs)
+
+    def setUp(self):
+        self.redpanda.set_environment(
+            {"__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE": "true"}
+        )
+        super().setUp()
+
+    @cluster(num_nodes=1)
+    def test_without_license(self):
+        admin = AdminV2(self.redpanda)
+        resp = admin.broker().call_list_kafka_connections(
+            broker_pb.ListKafkaConnectionsRequest(node_id=-1)
+        )
+        err = resp.error()
+        assert err is not None, f"expected error response without license, got {err}"
+        assert "license" in err.message, (
+            f"expected license in error message, got {err.message}"
+        )

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -88,4 +88,17 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
             err_msg="Did not observe a valid ListKafkaConnectionsResponse",
         )
 
+        self.logger.info(
+            "Test the filtering integration by filtering for an unknown UUID, expect an empty response"
+        )
+        filtered_resp = admin_v2.broker().list_kafka_connections(
+            broker_pb.ListKafkaConnectionsRequest(
+                node_id=-1,
+                filter='uid = "ba26cadd-90f6-4999-b2c9-a89b5f033507"',
+            )
+        )
+        self.logger.debug(f"Filtered response: {filtered_resp}")
+        assert len(filtered_resp.connections) == 0
+        assert filtered_resp.total_size == 0
+
         self.consumer.stop()


### PR DESCRIPTION
1. Integrate the filter parser and predicate into the ListKafkaConnections admin API endpoint.
2. Require an enterprise license for the ListKafkaConnections endpoint

Fixes https://redpandadata.atlassian.net/browse/CORE-13361
Fixes https://redpandadata.atlassian.net/browse/CORE-13573

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
