### PR TITLE
RNOT: Split into smoke and fuzz test suites

### DIFF
--- a/tests/rptest/fuzz/random_node_operations_fuzz.py
+++ b/tests/rptest/fuzz/random_node_operations_fuzz.py
@@ -1,0 +1,49 @@
+from typing import Any
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import get_cloud_storage_type
+from rptest.tests.random_node_operations_test import (
+    RNOT_ALLOW_LIST,
+    CompactionMode,
+    RandomNodeOperationsBase,
+)
+from rptest.utils.mode_checks import skip_debug_mode, skip_fips_mode
+
+from ducktape.mark import matrix
+
+# This is the "full fat" version of the Random Node Operations Test (RNOT).
+# It runs the test with a variety of parameters, including:
+# - with and without simulated failures
+# - mixed versions (rolling upgrade/downgrade)
+# - with and without iceberg
+# - different compaction modes
+# - different cloud storage types
+#
+# It is a fuzz test since it runs randomized inputs and failures.
+#
+# See also RandomNodeOperationsSmokeTest which is a much more limited version of
+# the test that is intended to be run more frequently (e.g. in PRs) to catch
+# obvious issues in the RNOT test itself.
+
+
+class RandomNodeOperationsTest(RandomNodeOperationsBase):
+    """
+    Main test for RNOT test with all the parameterization.
+    """
+
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @skip_fips_mode
+    @skip_debug_mode
+    @cluster(num_nodes=9, log_allow_list=RNOT_ALLOW_LIST)
+    @matrix(
+        enable_failures=[True, False],
+        mixed_versions=[True, False],
+        with_iceberg=[True, False],
+        compaction_mode=[
+            CompactionMode.SLIDING_WINDOW,
+            CompactionMode.CHUNKED_SLIDING_WINDOW,
+            CompactionMode.ADJACENT_MERGE,
+        ],
+        cloud_storage_type=get_cloud_storage_type(),
+    )
+    def test_node_operations(self, **kwargs: Any):
+        self._do_test_node_operations(**kwargs)

--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -4,6 +4,7 @@ ec2:
     - tests
     - transactions
     - scale_tests
+    - fuzz
     - tuner_integration_tests/net_tuner_test.py::AwsNetTunerTest
 
   excluded:

--- a/tests/rptest/test_suite_fuzz.yml
+++ b/tests/rptest/test_suite_fuzz.yml
@@ -1,0 +1,24 @@
+# Copyright 2025 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+# Fuzz tests have at least two key characteristics:
+#
+# 1. the use random inputs, i.e., different runs of the test
+# effectively explore different parts of the input domain
+#
+# 2. the longer you run them, the more coverage you get
+# https://redpandadata.atlassian.net/wiki/x/CoBvV
+#
+# We isolate these test in their own suite as the above means they
+# should get a special run and not run on per-change like other
+# ducktape tests.
+
+fuzz:
+  included:
+  - fuzz/

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -797,30 +797,6 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         return f"<RandomNodeOperationsBase {', '.join(fields)}>"
 
 
-class RandomNodeOperationsTest(RandomNodeOperationsBase):
-    """
-    Main test for RNOT test with all the parameterization.
-    """
-
-    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
-    @skip_fips_mode
-    @skip_debug_mode
-    @cluster(num_nodes=9, log_allow_list=RNOT_ALLOW_LIST)
-    @matrix(
-        enable_failures=[True, False],
-        mixed_versions=[True, False],
-        with_iceberg=[True, False],
-        compaction_mode=[
-            CompactionMode.SLIDING_WINDOW,
-            CompactionMode.CHUNKED_SLIDING_WINDOW,
-            CompactionMode.ADJACENT_MERGE,
-        ],
-        cloud_storage_type=get_cloud_storage_type(),
-    )
-    def test_node_operations(self, **kwargs: Any):
-        self._do_test_node_operations(**kwargs)
-
-
 class RedpandaNodeOperationsSmokeTest(RandomNodeOperationsBase):
     """
     Smoke test for RNOT.


### PR DESCRIPTION
This change actually moves the fuzz part of RNOT into the fuzz folder.

Fuzz folder doesn't run in "per-change" CI like PR and merge pipelines.

Details:

Separate the Random Node Operations Test (RNOT) into:

Smoke test (random_node_operations_test.py): fast, deterministic(ish) core coverage that still runs on every PR / merge. Fuzz test (random_node_operations_fuzz.py + test_suite_fuzz.yml): extended exploration with broader/randomized operation sequences, runs only in the fuzz / targeted pipelines. Motivation:

Reduce default CI runtime and flakiness surface. Keep quick signal for core node operation behaviors. Enable deeper, longer-running randomized scenarios without burdening every change. Create a clearer place to iterate on richer/random behaviors without destabilizing the smoke path. Key changes:

Added random_node_operations_fuzz.py containing the long-form randomized workload. Added test_suite_fuzz.yml to group / enable the fuzz execution outside the standard PR suites.

Fixes [CORE-13883].

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none


[CORE-13883]: https://redpandadata.atlassian.net/browse/CORE-13883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ