### PR TITLE
[CORE-13842] `ct/l1`: `get_compaction_info()` instead of `get_compaction_offsets()`

### DIFF
--- a/src/v/cloud_topics/level_one/domain/domain_manager.cc
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.cc
@@ -326,35 +326,35 @@ domain_manager::get_offsets(rpc::get_offsets_request req) {
     };
 }
 
-ss::future<rpc::get_compaction_offsets_reply>
-domain_manager::get_compaction_offsets(
-  rpc::get_compaction_offsets_request req) {
+ss::future<rpc::get_compaction_info_reply>
+domain_manager::get_compaction_info(rpc::get_compaction_info_request req) {
     auto gate = maybe_gate();
     if (!gate.has_value()) {
-        co_return rpc::get_compaction_offsets_reply{
+        co_return rpc::get_compaction_info_reply{
           .ec = rpc::errc::not_leader,
         };
     }
     auto sync_res = co_await stm_->sync(10s);
     if (!sync_res.has_value()) {
-        co_return rpc::get_compaction_offsets_reply{
+        co_return rpc::get_compaction_info_reply{
           .ec = convert_stm_errc(sync_res.error()),
         };
     }
     auto& stm_state = stm_->state();
-    auto get_res = simple_metastore::get_compaction_offsets(
+    auto get_res = simple_metastore::get_compaction_info(
       stm_state, req.tp, req.tombstone_removal_upper_bound_ts);
     if (!get_res.has_value()) {
-        co_return rpc::get_compaction_offsets_reply{
+        co_return rpc::get_compaction_info_reply{
           .ec = convert_metastore_errc(get_res.error()),
         };
     }
-    co_return rpc::get_compaction_offsets_reply{
+    co_return rpc::get_compaction_info_reply{
       .ec = rpc::errc::ok,
-      .dirty_ranges = std::move(get_res->dirty_ranges),
+      .dirty_ranges = std::move(get_res->offsets_response.dirty_ranges),
       .removable_tombstone_ranges = std::move(
-        get_res->removable_tombstone_ranges),
-    };
+        get_res->offsets_response.removable_tombstone_ranges),
+      .dirty_ratio = get_res->dirty_ratio,
+      .earliest_dirty_ts = get_res->earliest_dirty_ts};
 }
 
 ss::future<rpc::get_term_for_offset_reply>

--- a/src/v/cloud_topics/level_one/domain/domain_manager.h
+++ b/src/v/cloud_topics/level_one/domain/domain_manager.h
@@ -46,8 +46,8 @@ public:
 
     ss::future<rpc::get_offsets_reply> get_offsets(rpc::get_offsets_request);
 
-    ss::future<rpc::get_compaction_offsets_reply>
-      get_compaction_offsets(rpc::get_compaction_offsets_request);
+    ss::future<rpc::get_compaction_info_reply>
+      get_compaction_info(rpc::get_compaction_info_request);
 
     ss::future<rpc::get_term_for_offset_reply>
       get_term_for_offset(rpc::get_term_for_offset_request);

--- a/src/v/cloud_topics/level_one/metastore/frontend.cc
+++ b/src/v/cloud_topics/level_one/metastore/frontend.cc
@@ -92,16 +92,15 @@ ss::future<rpc::get_offsets_reply> do_get_offsets(
     co_return co_await domain_mgr->get_offsets(std::move(req));
 }
 
-ss::future<rpc::get_compaction_offsets_reply> do_get_compaction_offsets(
+ss::future<rpc::get_compaction_info_reply> do_get_compaction_info(
   domain_supervisor& domain_supervisor,
   const model::ntp& ntp,
-  rpc::get_compaction_offsets_request req) {
+  rpc::get_compaction_info_request req) {
     auto domain_mgr = domain_supervisor.get(ntp);
     if (!domain_mgr) {
-        co_return rpc::get_compaction_offsets_reply{
-          .ec = rpc::errc::not_leader};
+        co_return rpc::get_compaction_info_reply{.ec = rpc::errc::not_leader};
     }
-    co_return co_await domain_mgr->get_compaction_offsets(std::move(req));
+    co_return co_await domain_mgr->get_compaction_info(std::move(req));
 }
 
 ss::future<rpc::get_term_for_offset_reply> do_get_term_for_offset(
@@ -264,13 +263,13 @@ template ss::future<rpc::get_offsets_reply> frontend::process<
   &frontend::get_offsets_locally,
   &frontend::client::get_offsets>(rpc::get_offsets_request, bool);
 
-template ss::future<rpc::get_compaction_offsets_reply>
-  frontend::remote_dispatch<&frontend::client::get_compaction_offsets>(
-    rpc::get_compaction_offsets_request, model::node_id);
-template ss::future<rpc::get_compaction_offsets_reply> frontend::process<
-  &frontend::get_compaction_offsets_locally,
-  &frontend::client::get_compaction_offsets>(
-  rpc::get_compaction_offsets_request, bool);
+template ss::future<rpc::get_compaction_info_reply>
+  frontend::remote_dispatch<&frontend::client::get_compaction_info>(
+    rpc::get_compaction_info_request, model::node_id);
+template ss::future<rpc::get_compaction_info_reply> frontend::process<
+  &frontend::get_compaction_info_locally,
+  &frontend::client::get_compaction_info>(
+  rpc::get_compaction_info_request, bool);
 
 template ss::future<rpc::get_term_for_offset_reply>
   frontend::remote_dispatch<&frontend::client::get_term_for_offset>(
@@ -459,25 +458,24 @@ ss::future<rpc::get_offsets_reply> frontend::get_offsets(
       &client::get_offsets>(std::move(request), bool(local_only_exec));
 }
 
-ss::future<rpc::get_compaction_offsets_reply>
-frontend::get_compaction_offsets_locally(
-  rpc::get_compaction_offsets_request request,
+ss::future<rpc::get_compaction_info_reply>
+frontend::get_compaction_info_locally(
+  rpc::get_compaction_info_request request,
   const model::ntp& metastore_ntp,
   ss::shard_id shard) {
     co_return co_await container().invoke_on(
       shard, [metastore_ntp, req = std::move(request)](frontend& fe) mutable {
-          return do_get_compaction_offsets(
+          return do_get_compaction_info(
             *(fe._domain_supervisor), metastore_ntp, std::move(req));
       });
 }
 
-ss::future<rpc::get_compaction_offsets_reply> frontend::get_compaction_offsets(
-  rpc::get_compaction_offsets_request request, local_only local_only_exec) {
+ss::future<rpc::get_compaction_info_reply> frontend::get_compaction_info(
+  rpc::get_compaction_info_request request, local_only local_only_exec) {
     auto holder = _gate.hold();
     co_return co_await process<
-      &frontend::get_compaction_offsets_locally,
-      &client::get_compaction_offsets>(
-      std::move(request), bool(local_only_exec));
+      &frontend::get_compaction_info_locally,
+      &client::get_compaction_info>(std::move(request), bool(local_only_exec));
 }
 
 ss::future<rpc::get_term_for_offset_reply>

--- a/src/v/cloud_topics/level_one/metastore/frontend.h
+++ b/src/v/cloud_topics/level_one/metastore/frontend.h
@@ -74,8 +74,8 @@ public:
     ss::future<rpc::get_offsets_reply>
       get_offsets(rpc::get_offsets_request, local_only = local_only::no);
 
-    ss::future<rpc::get_compaction_offsets_reply> get_compaction_offsets(
-      rpc::get_compaction_offsets_request, local_only = local_only::no);
+    ss::future<rpc::get_compaction_info_reply> get_compaction_info(
+      rpc::get_compaction_info_request, local_only = local_only::no);
 
     ss::future<rpc::get_term_for_offset_reply> get_term_for_offset(
       rpc::get_term_for_offset_request, local_only = local_only::no);
@@ -148,9 +148,8 @@ private:
     ss::future<rpc::get_offsets_reply> get_offsets_locally(
       rpc::get_offsets_request, const model::ntp& metastore_ntp, ss::shard_id);
 
-    ss::future<rpc::get_compaction_offsets_reply>
-    get_compaction_offsets_locally(
-      rpc::get_compaction_offsets_request,
+    ss::future<rpc::get_compaction_info_reply> get_compaction_info_locally(
+      rpc::get_compaction_info_request,
       const model::ntp& metastore_ntp,
       ss::shard_id);
 

--- a/src/v/cloud_topics/level_one/metastore/metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/metastore.h
@@ -287,57 +287,14 @@ public:
         offset_interval_set removable_tombstone_ranges;
     };
     // Similar to replace_objects(), but with additional constraints based on
-    // compaction metadata. See get_compaction_offsets() for more details on
+    // compaction metadata. See get_compaction_info() for more details on
     // expected usage.
     virtual ss::future<std::expected<void, errc>>
     compact_objects(const object_metadata_builder&, const compaction_map_t&)
       = 0;
 
-    // Returns metadata required to determine what to compact for the given
-    // partition. Cleaned ranges with tombstones that were cleaned at or below
-    // tombstone_removal_upper_bound_ts are eligible to have tombstones
-    // entirely removed. These ranges will be returned in the response.
-    //
-    // Below is pseudocode for sample usage:
-    //
-    // offsets = co_await metastore.get_compaction_offsets( \
-    //   partition, tombstone_removal_upper_bound_ts);
-    //
-    // key_offset_map m;
-    // cleaned_ranges new_cleaned_ranges;
-    // offset_interval_set removed_tombstones_ranges;
-    //
-    // # Build an offset map based on the dirty ranges.
-    // for dirty_range in offsets.dirty_ranges:
-    //     reader = log.reader(dirty_range.base, dirty_range.last)
-    //     co_await m.add_latest_offset_per_key(reader)
-    //
-    //     cleaned_range r(...offset range that was actually read...);
-    //     if ...reader witnessed tombstones...:
-    //         cleaned_range.cleaned_with_tombstones_at = now()
-    //
-    //     new_cleaned_ranges.insert(cleaned_range)
-    //
-    // # Determine what ranges to remove tombstones from.
-    // removed_tombstones_ranges = \
-    //   ...offsets.removable_tombstone_ranges that fall below m.max_offset()...
-    //
-    // # This operation deduplicates based on the offset map and removes
-    // # tombstones in the given ranges, up to the max indexed by the map.
-    // objects = co_await log.compact( \
-    //   m.max_offset(), m, removed_tombstones_ranges)
-    //
-    // co_await metastore.compact_objects( \
-    //   objects, {{tp, {new_cleaned_ranges, removed_tombstones_ranges}}})
-    virtual ss::future<std::expected<compaction_offsets_response, errc>>
-    get_compaction_offsets(
-      const model::topic_id_partition&,
-      model::timestamp tombstone_removal_upper_bound_ts)
-      = 0;
-
     // All the information required to query a `compaction_info_response` from
-    // the metastore. Parameters are used for call to
-    // `get_compaction_offsets()`.
+    // the metastore. Parameters are used for call to `get_compaction_info()`.
     struct compaction_info_spec {
         model::topic_id_partition tidp;
         model::timestamp tombstone_removal_upper_bound_ts;
@@ -349,16 +306,49 @@ public:
         // The earliest dirty timestamp in the log. `std::nullopt` if there is
         // no such timestamp.
         std::optional<model::timestamp> earliest_dirty_ts;
-        // Compaction offsets returned by call to `get_compaction_offsets()`
-        // (see above).
+        // Dirty ranges & removable tombstone ranges.
         compaction_offsets_response offsets_response;
     };
 
-    // Obtains compaction state for a provided `compaction_info_spec` on the
-    // basis of a single partition. Provides information relevant to determining
-    // if a partition requires compaction - e.g dirty ratio and earliest dirty
-    // timestamp, as well as compaction offsets (see `get_compaction_offsets()`
-    // above).
+    // Returns metadata required to determine what to compact for the given
+    // partition - e.g dirty ratio and earliest dirty timestamp, as well as
+    // compaction offsets.
+    //
+    // Cleaned ranges with tombstones that were cleaned at or below
+    // tombstone_removal_upper_bound_ts are eligible to have tombstones
+    // entirely removed. These ranges will be returned in the response.
+    //
+    // Below is pseudocode for sample usage:
+    //
+    // info = co_await metastore.get_compaction_info( \
+    //   partition, tombstone_removal_upper_bound_ts);
+    //
+    // key_offset_map m;
+    // cleaned_ranges new_cleaned_ranges;
+    // offset_interval_set removed_tombstones_ranges;
+    //
+    // # Build an offset map based on the dirty ranges.
+    // for dirty_range in info.dirty_ranges:
+    //     reader = log.reader(dirty_range.base, dirty_range.last)
+    //     co_await m.add_latest_offset_per_key(reader)
+    //
+    //     cleaned_range r(...offset range that was actually read...);
+    //     if ...reader witnessed tombstones...:
+    //         cleaned_range.cleaned_with_tombstones_at = now()
+    //
+    //     new_cleaned_ranges.insert(cleaned_range)
+    //
+    // # Determine what ranges to remove tombstones from.
+    // removed_tombstones_ranges = \
+    //   ...info.removable_tombstone_ranges that fall below m.max_offset()...
+    //
+    // # This operation deduplicates based on the offset map and removes
+    // # tombstones in the given ranges, up to the max indexed by the map.
+    // objects = co_await log.compact( \
+    //   m.max_offset(), m, removed_tombstones_ranges)
+    //
+    // co_await metastore.compact_objects( \
+    //   objects, {{tp, {new_cleaned_ranges, removed_tombstones_ranges}}})
     virtual ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) = 0;
 

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.cc
@@ -627,12 +627,31 @@ ss::future<
   std::expected<metastore::compaction_offsets_response, metastore::errc>>
 replicated_metastore::get_compaction_offsets(
   const model::topic_id_partition& tidp, model::timestamp ts) {
-    rpc::get_compaction_offsets_request req;
-    req.tp = tidp;
-    req.tombstone_removal_upper_bound_ts = ts;
+    auto reply_res = co_await get_compaction_info(
+      compaction_info_spec{
+        .tidp = tidp, .tombstone_removal_upper_bound_ts = ts});
+
+    if (!reply_res.has_value()) {
+        co_return std::unexpected(reply_res.error());
+    }
+
+    auto reply = std::move(reply_res).value();
+
+    metastore::compaction_offsets_response resp;
+    resp.dirty_ranges = std::move(reply.offsets_response.dirty_ranges);
+    resp.removable_tombstone_ranges = std::move(
+      reply.offsets_response.removable_tombstone_ranges);
+    co_return resp;
+}
+
+ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
+replicated_metastore::get_compaction_info(const compaction_info_spec& log) {
+    rpc::get_compaction_info_request req;
+    req.tp = log.tidp;
+    req.tombstone_removal_upper_bound_ts = log.tombstone_removal_upper_bound_ts;
 
     auto reply_fut = co_await ss::coroutine::as_future(
-      fe_.get_compaction_offsets(std::move(req)));
+      fe_.get_compaction_info(std::move(req)));
     if (reply_fut.failed()) {
         auto ex = reply_fut.get_exception();
         vlog(cd_log.warn, "Error while sending request: {}", ex);
@@ -644,16 +663,14 @@ replicated_metastore::get_compaction_offsets(
         co_return std::unexpected(rpc_to_meta_errc(reply.ec));
     }
 
-    metastore::compaction_offsets_response resp;
-    resp.dirty_ranges = reply.dirty_ranges;
-    resp.removable_tombstone_ranges = reply.removable_tombstone_ranges;
-    co_return resp;
-}
+    metastore::compaction_info_response resp;
+    resp.dirty_ratio = reply.dirty_ratio;
+    resp.earliest_dirty_ts = reply.earliest_dirty_ts;
+    resp.offsets_response = {
+      .dirty_ranges = reply.dirty_ranges,
+      .removable_tombstone_ranges = reply.removable_tombstone_ranges};
 
-ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
-replicated_metastore::get_compaction_info(
-  [[maybe_unused]] const compaction_info_spec& log) {
-    co_return compaction_info_response{};
+    co_return resp;
 }
 
 } // namespace cloud_topics::l1

--- a/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/replicated_metastore.h
@@ -63,8 +63,7 @@ public:
       const chunked_vector<object_metadata>&, const compaction_map_t&);
 
     ss::future<std::expected<compaction_offsets_response, errc>>
-    get_compaction_offsets(
-      const model::topic_id_partition&, model::timestamp) override;
+    get_compaction_offsets(const model::topic_id_partition&, model::timestamp);
 
     ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) override;

--- a/src/v/cloud_topics/level_one/metastore/rpc.json
+++ b/src/v/cloud_topics/level_one/metastore/rpc.json
@@ -46,9 +46,9 @@
             "output_type": "get_end_offset_for_term_reply"
         },
         {
-            "name": "get_compaction_offsets",
-            "input_type": "get_compaction_offsets_request",
-            "output_type": "get_compaction_offsets_reply"
+            "name": "get_compaction_info",
+            "input_type": "get_compaction_info_request",
+            "output_type": "get_compaction_info_reply"
         },
         {
             "name": "set_start_offset",

--- a/src/v/cloud_topics/level_one/metastore/rpc_types.h
+++ b/src/v/cloud_topics/level_one/metastore/rpc_types.h
@@ -189,25 +189,32 @@ struct get_offsets_request
     model::topic_id_partition tp;
 };
 
-struct get_compaction_offsets_reply
+struct get_compaction_info_reply
   : serde::envelope<
-      get_compaction_offsets_reply,
+      get_compaction_info_reply,
       serde::version<0>,
       serde::compat_version<0>> {
     auto serde_fields() {
-        return std::tie(ec, dirty_ranges, removable_tombstone_ranges);
+        return std::tie(
+          ec,
+          dirty_ranges,
+          removable_tombstone_ranges,
+          dirty_ratio,
+          earliest_dirty_ts);
     }
 
     errc ec;
     offset_interval_set dirty_ranges;
     offset_interval_set removable_tombstone_ranges;
+    double dirty_ratio;
+    std::optional<model::timestamp> earliest_dirty_ts;
 };
-struct get_compaction_offsets_request
+struct get_compaction_info_request
   : serde::envelope<
-      get_compaction_offsets_request,
+      get_compaction_info_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    using resp_t = get_compaction_offsets_reply;
+    using resp_t = get_compaction_info_reply;
     auto serde_fields() {
         return std::tie(tp, tombstone_removal_upper_bound_ts);
     }

--- a/src/v/cloud_topics/level_one/metastore/service.cc
+++ b/src/v/cloud_topics/level_one/metastore/service.cc
@@ -82,9 +82,9 @@ ss::future<get_term_for_offset_reply> service::get_term_for_offset(
       std::move(request), frontend::local_only::yes);
 }
 
-ss::future<get_compaction_offsets_reply> service::get_compaction_offsets(
-  get_compaction_offsets_request request, ::rpc::streaming_context&) {
-    return _frontend->local().get_compaction_offsets(
+ss::future<get_compaction_info_reply> service::get_compaction_info(
+  get_compaction_info_request request, ::rpc::streaming_context&) {
+    return _frontend->local().get_compaction_info(
       std::move(request), frontend::local_only::yes);
 }
 

--- a/src/v/cloud_topics/level_one/metastore/service.h
+++ b/src/v/cloud_topics/level_one/metastore/service.h
@@ -56,8 +56,8 @@ public:
     ss::future<get_term_for_offset_reply> get_term_for_offset(
       get_term_for_offset_request, ::rpc::streaming_context&) override;
 
-    ss::future<get_compaction_offsets_reply> get_compaction_offsets(
-      get_compaction_offsets_request, ::rpc::streaming_context&) override;
+    ss::future<get_compaction_info_reply> get_compaction_info(
+      get_compaction_info_request, ::rpc::streaming_context&) override;
 
 private:
     ss::sharded<frontend>* _frontend;

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.cc
@@ -643,23 +643,31 @@ simple_metastore::get_earliest_dirty_ts(
 
 ss::future<std::expected<metastore::compaction_info_response, metastore::errc>>
 simple_metastore::get_compaction_info(const compaction_info_spec& log) {
-    auto dirty_ratio = get_dirty_ratio(state_, log.tidp);
-    if (!dirty_ratio.has_value()) {
-        co_return std::unexpected(dirty_ratio.error());
-    }
-
-    auto earliest_dirty_ts = get_earliest_dirty_ts(state_, log.tidp);
-    if (!earliest_dirty_ts.has_value()) {
-        co_return std::unexpected(earliest_dirty_ts.error());
-    }
-
-    auto offsets = get_compaction_offsets(
+    co_return get_compaction_info(
       state_, log.tidp, log.tombstone_removal_upper_bound_ts);
-    if (!offsets.has_value()) {
-        co_return std::unexpected(offsets.error());
+}
+
+std::expected<metastore::compaction_info_response, metastore::errc>
+simple_metastore::get_compaction_info(
+  const state& state,
+  const model::topic_id_partition& tidp,
+  model::timestamp ts) {
+    auto dirty_ratio = get_dirty_ratio(state, tidp);
+    if (!dirty_ratio.has_value()) {
+        return std::unexpected(dirty_ratio.error());
     }
 
-    co_return compaction_info_response{
+    auto earliest_dirty_ts = get_earliest_dirty_ts(state, tidp);
+    if (!earliest_dirty_ts.has_value()) {
+        return std::unexpected(earliest_dirty_ts.error());
+    }
+
+    auto offsets = get_compaction_offsets(state, tidp, ts);
+    if (!offsets.has_value()) {
+        return std::unexpected(offsets.error());
+    }
+
+    return compaction_info_response{
       .dirty_ratio = dirty_ratio.value(),
       .earliest_dirty_ts = earliest_dirty_ts.value(),
       .offsets_response = std::move(offsets).value()};

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -122,6 +122,8 @@ private:
     get_dirty_ratio(const state&, const model::topic_id_partition&);
     static std::expected<std::optional<model::timestamp>, errc>
     get_earliest_dirty_ts(const state&, const model::topic_id_partition&);
+    static std::expected<compaction_info_response, errc> get_compaction_info(
+      const state&, const model::topic_id_partition&, model::timestamp);
     static std::expected<kafka::offset, errc> get_end_offset_for_term(
       const state&, const model::topic_id_partition&, model::term_id);
     static std::expected<model::term_id, errc> get_term_for_offset(

--- a/src/v/cloud_topics/level_one/metastore/simple_metastore.h
+++ b/src/v/cloud_topics/level_one/metastore/simple_metastore.h
@@ -96,8 +96,7 @@ public:
       const chunked_vector<object_metadata>&, const compaction_map_t&);
 
     ss::future<std::expected<compaction_offsets_response, errc>>
-    get_compaction_offsets(
-      const model::topic_id_partition&, model::timestamp) override;
+    get_compaction_offsets(const model::topic_id_partition&, model::timestamp);
 
     ss::future<std::expected<compaction_info_response, errc>>
     get_compaction_info(const compaction_info_spec&) override;

--- a/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
+++ b/src/v/cloud_topics/level_one/metastore/tests/replicated_metastore_test.cc
@@ -315,13 +315,17 @@ TEST_F(ReplicatedMetastoreTest, TestBasicAdd) {
 
         // Sanity check the compaction offsets. Since no range is cleaned, the
         // entire log is dirty.
-        auto cmp_offsets
-          = meta.get_compaction_offsets(tp, model::timestamp::now()).get();
-        ASSERT_TRUE(cmp_offsets.has_value());
-        EXPECT_FALSE(cmp_offsets->dirty_ranges.empty());
+        auto spec = metastore::compaction_info_spec{
+          .tidp = tp,
+          .tombstone_removal_upper_bound_ts = model::timestamp::now()};
+        auto cmp_info = meta.get_compaction_info(spec).get();
+        ASSERT_TRUE(cmp_info.has_value());
+        EXPECT_FALSE(cmp_info->offsets_response.dirty_ranges.empty());
         EXPECT_THAT(
-          cmp_offsets->dirty_ranges.to_vec(),
+          cmp_info->offsets_response.dirty_ranges.to_vec(),
           testing::ElementsAre(MatchesRange(o{0}, o{999})));
+        EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 1.0);
+        EXPECT_TRUE(cmp_info->earliest_dirty_ts.has_value());
     }
 }
 
@@ -404,11 +408,15 @@ TEST_F(ReplicatedMetastoreTest, TestBasicCompact) {
 
         // Now check the compacted offsets. Since we've cleaned everything, we
         // should see the dirty ranges be empty.
-        auto cmp_offsets
-          = meta.get_compaction_offsets(tp, model::timestamp::now()).get();
-        ASSERT_TRUE(cmp_offsets.has_value());
-        EXPECT_TRUE(cmp_offsets->dirty_ranges.empty())
+        auto spec = metastore::compaction_info_spec{
+          .tidp = tp,
+          .tombstone_removal_upper_bound_ts = model::timestamp::now()};
+        auto cmp_info = meta.get_compaction_info(spec).get();
+        ASSERT_TRUE(cmp_info.has_value());
+        EXPECT_TRUE(cmp_info->offsets_response.dirty_ranges.empty())
           << fmt::format("{} is not cleaned", tp);
+        EXPECT_FLOAT_EQ(cmp_info->dirty_ratio, 0.0);
+        EXPECT_TRUE(!cmp_info->earliest_dirty_ts.has_value());
     }
 }
 


### PR DESCRIPTION
Alter the `replicated_metastore` to return all required compaction info instead of just compaction offsets- i.e., add the `dirty_ratio` and `earliest_dirty_timestamp` calculated from `stm_state` and `simple_metastore` function to the `compaction_info` response.

Leave the `get_compaction_offsets()` functions in the tree for testing.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
