### PR TITLE
[v24.3.x] `setup.py`: pin `pydantic` version to `2.11.0`

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -47,6 +47,7 @@ setup(
         "jsonschema==4.10.0",
         "polaris.management@git+https://github.com/apache/polaris.git@1a6b3eb3963355f78c5ca916cc1d66ecd1493092#&subdirectory=regtests/client/python",
         "pyiceberg==0.7.1",
+        "pydantic==2.11.0",
         "adlfs==2024.7.0",
         "pyarrow",
         "pandas",


### PR DESCRIPTION
`pydantic` version `2.12.0` has a breaking change [1] that results in many failed CI tests which use `pyiceberg` with an error like

```
AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'current_schema_id'
```

Pin the `pydantic` version to avoid this issue.

[1] https://github.com/apache/iceberg-python/issues/2590

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
