### PR TITLE
rpk shadow config: allow tls_enabled only

### DIFF
--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -289,6 +289,29 @@ const (
 	ACLPermissionTypeDeny  ACLPermissionType = "DENY"
 )
 
+// checkRawTLSConfig checks the raw map for TLS config and determines if it's
+// file-based or PEM-based. It also performs validation to ensure that the
+// config is valid.
+func checkRawTLSConfig(raw map[string]any) (hasCA, hasCAPath bool, err error) {
+	var isEnabled bool
+	if val, hasEnabled := raw["enabled"]; hasEnabled {
+		if enabledVal, ok := val.(bool); ok {
+			isEnabled = enabledVal
+		}
+	}
+	// Determine type based on presence of fields; ca_path is mandatory for
+	// file-based and ca is mandatory for PEM-based.
+	_, hasCa := raw["ca"]
+	_, hasCaPath := raw["ca_path"]
+	if hasCaPath && hasCa {
+		return false, false, errors.New("both ca_path and ca are set; only one of these can be set")
+	}
+	if !hasCaPath && !hasCa && !isEnabled {
+		return false, false, errors.New("unrecognized 'tls_settings' neither ca_path nor ca are set; one of these must be set")
+	}
+	return hasCa, hasCaPath, nil
+}
+
 // tlsSettingsWrapper is used for YAML unmarshaling of TLSSettings interface.
 type tlsSettingsWrapper struct {
 	TLSSettings
@@ -301,18 +324,12 @@ func (w *tlsSettingsWrapper) UnmarshalYAML(unmarshal func(interface{}) error) er
 		return err
 	}
 
-	// Determine type based on presence of fields; ca_path is mandatory for
-	// file-based and ca is mandatory for PEM-based.
-	_, hasCaPath := raw["ca_path"]
-	_, hasCa := raw["ca"]
-	if hasCaPath && hasCa {
-		return errors.New("both ca_path and ca are set; only one of these can be set")
-	}
-	if !hasCaPath && !hasCa {
-		return errors.New("unrecognized 'tls_settings' neither ca_path nor ca are set; one of these must be set")
+	_, hasCAPath, err := checkRawTLSConfig(raw)
+	if err != nil {
+		return err
 	}
 
-	if hasCaPath {
+	if hasCAPath {
 		var fileSettings TLSFileSettings
 		if err := unmarshal(&fileSettings); err != nil {
 			return err
@@ -394,18 +411,11 @@ func (w *tlsSettingsWrapper) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Determine type based on presence of fields; ca_path is mandatory for
-	// file-based and ca is mandatory for PEM-based.
-	_, hasCaPath := raw["ca_path"]
-	_, hasCa := raw["ca"]
-	if hasCaPath && hasCa {
-		return errors.New("both ca_path and ca are set; only one of these can be set")
+	_, hasCAPath, err := checkRawTLSConfig(raw)
+	if err != nil {
+		return err
 	}
-	if !hasCaPath && !hasCa {
-		return errors.New("unrecognized 'tls_settings' neither ca_path nor ca are set; one of these must be set")
-	}
-
-	if hasCaPath {
+	if hasCAPath {
 		var fileSettings TLSFileSettings
 		if err := json.Unmarshal(data, &fileSettings); err != nil {
 			return err

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -227,6 +227,13 @@ func TestTLSSettingsUnmarshalYAML(t *testing.T) {
 		wantErr  bool
 	}{
 		{
+			name:     "just enabled TLS",
+			yamlData: "enabled: true",
+			want: &TLSPEMSettings{
+				Enabled: true,
+			},
+		},
+		{
 			name: "file-based TLS settings",
 			yamlData: `
 ca_path: "/path/to/ca.crt"
@@ -261,8 +268,9 @@ ca: "ca-content"
 			wantErr: true,
 		},
 		{
-			name: "error - neither ca_path nor ca",
+			name: "error - neither ca_path nor ca (enabled is false)",
 			yamlData: `
+enabled: false
 key_path: "/path/to/key.pem"
 `,
 			wantErr: true,
@@ -537,6 +545,13 @@ func TestTLSSettingsUnmarshalJSON(t *testing.T) {
 		wantErr  bool
 	}{
 		{
+			name:     "just enabled TLS",
+			jsonData: `{"enabled": true}`,
+			want: &TLSPEMSettings{
+				Enabled: true,
+			},
+		},
+		{
 			name: "file-based TLS settings",
 			jsonData: `{
 				"enabled": true,
@@ -575,8 +590,9 @@ func TestTLSSettingsUnmarshalJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error - neither ca_path nor ca",
+			name: "error - neither ca_path nor ca and enabled is false",
 			jsonData: `{
+				"enabled": false,
 				"key_path": "/path/to/key.pem"
 			}`,
 			wantErr: true,


### PR DESCRIPTION
We were asking for either ca or ca_path, now with
the tls_enabled, if it's true, we can accept it
as a valid TLS configuration.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
