### PR TITLE
tuner: Just restart redpanda-tuner to reset state

### DIFF
--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -52,31 +52,10 @@ class NetTunerTest(RedpandaTest):
     def teardown(self):
         super().teardown()
 
-        # Reset the important bits to MQ like
-
-        # just assume CORE_COUNT for now, otherwise would have to parse
-        try:
-            self.node.account.ssh(
-                f"sudo ethtool -L {self.interface_name} rx {CORE_COUNT} tx {CORE_COUNT}"
-            )
-        except Exception:
-            self.node.account.ssh(
-                f"sudo ethtool -L {self.interface_name} combined {CORE_COUNT}"
-            )
-
-        interrupt_ids = self._get_interrupt_ids()
-        for interrupt_id in interrupt_ids:
-            self.node.account.ssh(
-                f"cat /proc/irq/default_smp_affinity | sudo tee /proc/irq/{interrupt_id}/smp_affinity"
-            )
-
-        self.node.account.ssh(
-            f"echo 0 | sudo tee /sys/class/net/{self.interface_name}/queues/rx-*/rps_flow_cnt"
-        )
-
-        self.node.account.ssh(
-            f"echo 0 | sudo tee /sys/class/net/{self.interface_name}/queues/rx-*/rps_cpus"
-        )
+        # Reset to what ansible gives you out of the box
+        self.node.account.ssh("rm -rf /etc/redpanda/redpanda.yaml")
+        self.node.account.ssh("sudo rpk redpanda mode prod")
+        self.node.account.ssh("sudo systemctl restart redpanda-tuner")
 
     def start_rp(self):
         # Need to explicitly pass listener config otherwise RP will complain about 0.0.0.0 listeners


### PR DESCRIPTION
Will give you effectively the same state but maybe more conventional like this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

