### PR TITLE
ct: optimize waiting in write_pipeline

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -131,8 +131,11 @@ public:
         }
         if (found) {
             // Trigger event immediately without waiting for the future
-            co_return static_cast<Derived*>(this)->trigger_event(
+            auto event = static_cast<Derived*>(this)->trigger_event(
               flt.get_stage());
+            if (flt.trigger(event)) {
+                co_return event;
+            }
         }
         _filters.push_back(flt);
         auto ev = co_await ss::coroutine::as_future(flt.get_future());

--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -114,6 +114,9 @@ public:
               // improved by transferring exception to the subscriber.
               flt.cancel();
           });
+        if (!sub) {
+            co_return event{.type = event_type::shutting_down};
+        }
         co_return co_await subscribe(flt);
     }
     ss::future<event> subscribe(event_filter<Clock>& flt) noexcept {

--- a/src/v/cloud_topics/level_zero/pipeline/event_filter.h
+++ b/src/v/cloud_topics/level_zero/pipeline/event_filter.h
@@ -50,6 +50,9 @@ struct event {
 template<class Clock = ss::lowres_clock>
 class event_filter {
 public:
+    struct predicate {
+        size_t min_pending_write_bytes = 0;
+    };
     event_filter() = delete;
     ~event_filter() = default;
     event_filter(const event_filter&) = delete;
@@ -58,7 +61,7 @@ public:
     event_filter& operator=(event_filter&&) noexcept = default;
 
     /// Filter without timeout
-    explicit event_filter(event_type type, pipeline_stage stage)
+    event_filter(event_type type, pipeline_stage stage)
       : _type(type)
       , _stage(stage) {
         _promise.emplace();
@@ -68,9 +71,11 @@ public:
     event_filter(
       event_type type,
       pipeline_stage stage,
-      typename Clock::time_point deadline)
+      typename Clock::time_point deadline,
+      predicate pred)
       : _type(type)
-      , _stage(stage) {
+      , _stage(stage)
+      , _pred(pred) {
         _promise.emplace();
         _expiry.emplace();
         _expiry->set_callback([this] {
@@ -94,17 +99,21 @@ public:
 
     pipeline_stage get_stage() const noexcept { return _stage; }
 
-    void trigger(const event& e) {
+    bool trigger(const event& e) {
         if (e.type != _type) {
-            return;
+            return false;
         }
         if (e.stage != _stage) {
-            return;
+            return false;
+        }
+        if (e.pending_write_bytes < _pred.min_pending_write_bytes) {
+            return false;
         }
         if (_promise.has_value()) {
             _promise->set_value(e);
             _promise = std::nullopt;
         }
+        return true;
     }
 
     ss::future<event> get_future() noexcept { return _promise->get_future(); }
@@ -113,6 +122,7 @@ private:
     intrusive_list_hook _hook;
     event_type _type{event_type::none};
     pipeline_stage _stage;
+    predicate _pred;
     std::optional<ss::promise<event>> _promise;
     std::optional<ss::timer<Clock>> _expiry;
 

--- a/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/tests/event_filter_test.cc
@@ -15,6 +15,7 @@
 #include "model/namespace.h"
 #include "model/record.h"
 #include "model/tests/random_batch.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/abort_source.hh>
@@ -111,7 +112,6 @@ TEST_CORO(EventFilterTest, filter_triggered_once) {
         req.set_value(chunked_vector<extent_meta>());
     }
     std::ignore = co_await std::move(write);
-    co_return;
 }
 
 TEST_CORO(EventFilterTest, filter_has_memory) {
@@ -178,10 +178,57 @@ TEST_CORO(EventFilterTest, filter_timedout) {
     l0::event_filter<ss::lowres_clock> flt(
       l0::event_type::new_write_request,
       stage.id(),
-      ss::lowres_clock::now() + 1ms);
+      ss::lowres_clock::now() + 1ms,
+      {});
     auto sub = pipeline.subscribe(flt);
     co_await ss::sleep(10ms);
     auto res = co_await std::move(sub);
     ASSERT_TRUE_CORO(res.type == l0::event_type::err_timedout);
     co_return;
+}
+
+TEST_CORO(EventFilterTest, filter_min_write_bytes) {
+    auto batch1 = model::test::make_random_batch({
+      .offset = model::offset{0},
+      .allow_compression = false,
+      .count = 100,
+      .records = 10,
+    });
+    auto batch2 = model::test::make_random_batch({
+      .offset = model::offset{0},
+      .allow_compression = false,
+      .count = 100,
+      .records = 10,
+    });
+    l0::write_pipeline<ss::lowres_clock> pipeline;
+    auto stage = pipeline.register_write_pipeline_stage();
+    // The subscription mechanism can be aborted by timeout
+    l0::event_filter<ss::lowres_clock> flt(
+      l0::event_type::new_write_request,
+      stage.id(),
+      ss::lowres_clock::now() + 10000s,
+      {.min_pending_write_bytes = get_serialized_size(batch1)
+                                  + get_serialized_size(batch2)});
+    auto sub = pipeline.subscribe(flt);
+    EXPECT_FALSE(sub.available());
+    auto write1 = pipeline.write_and_debounce(
+      model::controller_ntp,
+      chunked_vector<model::record_batch>::single(batch1.copy()),
+      ss::lowres_clock::now() + 1s);
+    co_await tests::drain_task_queue();
+    EXPECT_FALSE(sub.available());
+    auto write2 = pipeline.write_and_debounce(
+      model::controller_ntp,
+      chunked_vector<model::record_batch>::single(batch2.copy()),
+      ss::lowres_clock::now() + 1s);
+    co_await tests::drain_task_queue();
+    auto res = co_await std::move(sub);
+    ASSERT_TRUE_CORO(res.type == l0::event_type::new_write_request);
+    auto pending = stage.pull_write_requests(
+      std::numeric_limits<size_t>::max());
+    for (auto& req : pending.requests) {
+        req.set_value(chunked_vector<extent_meta>());
+    }
+    std::ignore = co_await std::move(write1);
+    std::ignore = co_await std::move(write2);
 }

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -240,39 +240,32 @@ ss::future<checked<event, errc>> write_pipeline<Clock>::stage::wait_until(
   typename Clock::time_point deadline,
   ss::abort_source* maybe_as) noexcept {
     auto [sub, as] = choose_abort_source(maybe_as);
-    while (true) {
-        l0::event_filter<Clock> filter(
-          l0::event_type::new_write_request, _ps, deadline);
-        auto event_fut = co_await ss::coroutine::as_future(
-          _parent->subscribe(filter, *as));
-        if (event_fut.failed()) {
-            auto err = event_fut.get_exception();
-            if (ssx::is_shutdown_exception(err)) {
-                co_return errc::shutting_down;
-            }
-            co_return errc::unexpected_failure;
-        }
-        auto event = event_fut.get();
-        switch (event.type) {
-        case l0::event_type::shutting_down:
+    l0::event_filter<Clock> filter(
+      l0::event_type::new_write_request,
+      _ps,
+      deadline,
+      {.min_pending_write_bytes = max_bytes});
+    auto event_fut = co_await ss::coroutine::as_future(
+      _parent->subscribe(filter, *as));
+    if (event_fut.failed()) {
+        auto err = event_fut.get_exception();
+        if (ssx::is_shutdown_exception(err)) {
             co_return errc::shutting_down;
-        case l0::event_type::new_write_request:
-            if (
-              event.pending_write_bytes < max_bytes
-              && Clock::now() < deadline) {
-                // Ignore all write requests until timed
-                // out or enough data.
-                continue;
-            }
-            [[fallthrough]];
-        case l0::event_type::err_timedout:
-            break;
-        case l0::event_type::new_read_request:
-        case l0::event_type::none:
-            vassert(false, "Read request added to the write pipeline");
         }
-        co_return event;
+        co_return errc::unexpected_failure;
     }
+    auto event = event_fut.get();
+    switch (event.type) {
+    case l0::event_type::shutting_down:
+        co_return errc::shutting_down;
+    case l0::event_type::new_write_request:
+    case l0::event_type::err_timedout:
+        break;
+    case l0::event_type::new_read_request:
+    case l0::event_type::none:
+        vassert(false, "Read request added to the write pipeline");
+    }
+    co_return event;
 }
 
 template<class Clock>

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -309,6 +309,9 @@ write_pipeline<Clock>::stage::choose_abort_source(ss::abort_source* maybe_as) {
           [as](const std::optional<std::exception_ptr>&) noexcept {
               as->request_abort();
           });
+        if (!sub) {
+            as->request_abort();
+        }
     }
     return std::make_pair(std::move(sub), as);
 }


### PR DESCRIPTION
Push the
predicate into the filter instead of this loop.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
