### PR TITLE
ct: Optimize base_pipeline::subscribe

### DIFF
--- a/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/base_pipeline.h
@@ -119,14 +119,9 @@ public:
     ss::future<event> subscribe(event_filter<Clock>& flt) noexcept {
         // If the pipeline already has some requests we need to set the future
         // eagerly
-        bool found = false;
-        for (auto& wr : _pending) {
-            if (wr.stage == flt.get_stage()) {
-                found = true;
-                break;
-            }
-        }
-        if (found) {
+        auto bytes_acc = static_cast<Derived*>(this)->total_size_at_stage(
+          flt.get_stage());
+        if (bytes_acc > flt.get_size_threshold()) {
             // Trigger event immediately without waiting for the future
             co_return static_cast<Derived*>(this)->trigger_event(
               flt.get_stage());
@@ -259,8 +254,12 @@ protected:
             ev.pending_write_bytes = pending_bytes;
             ev.total_write_bytes = total_bytes;
         }
+        auto stage_bytes = static_cast<Derived*>(this)->total_size_at_stage(
+          stage);
         for (auto& f : _filters) {
-            if (f.get_type() == ev_type && f.get_stage() == stage) {
+            if (
+              f.get_type() == ev_type && f.get_stage() == stage
+              && f.get_size_threshold() < stage_bytes) {
                 vlog(
                   _logger.debug,
                   "{}.signal, pending_write_bytes: {}, "

--- a/src/v/cloud_topics/level_zero/pipeline/event_filter.h
+++ b/src/v/cloud_topics/level_zero/pipeline/event_filter.h
@@ -94,6 +94,10 @@ public:
 
     pipeline_stage get_stage() const noexcept { return _stage; }
 
+    void set_size_threshold(uint64_t size) { _size_threshold = size; }
+
+    uint64_t get_size_threshold() const { return _size_threshold; }
+
     void trigger(const event& e) {
         if (e.type != _type) {
             return;
@@ -115,6 +119,7 @@ private:
     pipeline_stage _stage;
     std::optional<ss::promise<event>> _promise;
     std::optional<ss::timer<Clock>> _expiry;
+    uint64_t _size_threshold{0};
 
 public:
     template<class TT, class... Options>

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.cc
@@ -222,6 +222,18 @@ void read_pipeline<Clock>::signal(pipeline_stage stage) {
 }
 
 template<class Clock>
+uint64_t
+read_pipeline<Clock>::total_size_at_stage(pipeline_stage stage) const noexcept {
+    uint64_t total = 0;
+    for (auto& r : this->get_pending()) {
+        if (r.stage == stage) {
+            total += r.query.output_size_estimate;
+        }
+    }
+    return total;
+}
+
+template<class Clock>
 event read_pipeline<Clock>::trigger_event(pipeline_stage stage) {
     return event{
       .stage = stage,

--- a/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/read_pipeline.h
@@ -110,6 +110,8 @@ public:
 
     event trigger_event(pipeline_stage stage);
 
+    uint64_t total_size_at_stage(pipeline_stage stage) const noexcept;
+
 private:
     ss::abort_source& get_abort_source() {
         return this->get_root_rtc().root_abort_source();

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.cc
@@ -208,6 +208,18 @@ void write_pipeline<Clock>::signal(pipeline_stage stage) {
 }
 
 template<class Clock>
+uint64_t write_pipeline<Clock>::total_size_at_stage(
+  pipeline_stage stage) const noexcept {
+    uint64_t total = 0;
+    for (auto& r : this->get_pending()) {
+        if (r.stage == stage) {
+            total += r.size_bytes();
+        }
+    }
+    return total;
+}
+
+template<class Clock>
 event write_pipeline<Clock>::trigger_event(pipeline_stage stage) {
     return event{
       .stage = stage,
@@ -243,6 +255,7 @@ ss::future<checked<event, errc>> write_pipeline<Clock>::stage::wait_until(
     while (true) {
         l0::event_filter<Clock> filter(
           l0::event_type::new_write_request, _ps, deadline);
+        filter.set_size_threshold(max_bytes);
         auto event_fut = co_await ss::coroutine::as_future(
           _parent->subscribe(filter, *as));
         if (event_fut.failed()) {

--- a/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
+++ b/src/v/cloud_topics/level_zero/pipeline/write_pipeline.h
@@ -164,6 +164,9 @@ public:
 
     event trigger_event(pipeline_stage stage);
 
+    /// Get total size of all write requests at certain stage
+    uint64_t total_size_at_stage(pipeline_stage stage) const noexcept;
+
 private:
     /// Get write requests atomically.
     /// The total size of returned write requests and the stage to which they


### PR DESCRIPTION
Add 'szie_threshold' paramter to the event filter and trigger the event only if enough bytes are available.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none