### PR TITLE
update shfmt version

### DIFF
--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install shfmt
         env:
-          SHFMT_VER: 3.6.0
+          SHFMT_VER: 3.12.0
         run: |
           mkdir -v -p "$HOME/.local/bin"
           wget -O "$HOME/.local/bin/shfmt" "https://github.com/mvdan/sh/releases/download/v${SHFMT_VER}/shfmt_v${SHFMT_VER}_linux_amd64"


### PR DESCRIPTION
To the newest 3.12.0.

This is needed to align with coming pre-commit configuration which needs a newer shfmt version.

All existing Redpanda scripts are unchanged under the new version.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
