### PR TITLE
CORE-13356 Client Monitoring: track and capture more connection attributes

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -455,6 +455,7 @@ ss::future<> connection_context::process_one_request() {
     _server.handler_probe(h->key).add_bytes_received(sz.value());
     _attributes.last_client_id.update(h->client_id);
     _attributes.record_api_version(h->key, h->version);
+    _attributes.in_flight_requests.record_begin_request(h->key);
     /**
      * An entry point for the MPX serverless extensions. If the first request
      * for a given connection has a special client_id then MPX extensions are
@@ -921,8 +922,10 @@ proto::admin::kafka_connection connection_context::to_proto() const {
       chunked_hash_map<int32_t, int32_t>{
         _attributes.api_versions.cbegin(), _attributes.api_versions.cend()});
 
-    using tracker_t = connection_attributes::request_state::tracker_t;
-    auto now = tracker_t::clock::now();
+    auto now = ss::lowres_clock::now();
+    res.set_in_flight_requests(_attributes.in_flight_requests.to_proto(now));
+    res.set_idle_duration(
+      absl::FromChrono(_attributes.in_flight_requests.get_idle_duration(now)));
 
     auto make_stats = [this](auto&& get_value) {
         auto stats = proto::admin::request_statistics{};
@@ -938,8 +941,6 @@ proto::admin::kafka_connection connection_context::to_proto() const {
       [now](auto& attr) { return attr.recent_stat.window_total(now); }));
     res.set_total_request_statistics(
       make_stats([](auto& attr) { return attr.total_stat; }));
-
-    // TODO: fill out the response with the remaining fields
 
     return res;
 }
@@ -1118,6 +1119,8 @@ connection_context::client_protocol_state::do_process_responses(
 
     _responses.erase(it);
 
+    connection_ctx->attributes().in_flight_requests.record_end_request();
+
     if (resp_and_res.response->is_noop()) {
         co_return ss::stop_iteration::no;
     }
@@ -1193,6 +1196,50 @@ void connection_attributes::record_api_version(
     if (!inserted) {
         it->second = std::max(it->second, version);
     }
+}
+
+void connection_attributes::in_flight_request_tracker::record_begin_request(
+  api_key key) {
+    while (_in_flight_request_samples.size() >= max_count) {
+        _in_flight_request_samples.pop_front();
+    }
+    ++_total_in_flight_count;
+    _in_flight_request_samples.emplace_back(key, clock::now());
+    _idle_since.reset();
+}
+void connection_attributes::in_flight_request_tracker::record_end_request() {
+    --_total_in_flight_count;
+
+    // We can rely on the assumption here that responses are sent in
+    // request-order to always pop_front instead of having to search for the
+    // request corresponding to the response
+
+    if (!_in_flight_request_samples.empty()) {
+        _in_flight_request_samples.pop_front();
+    }
+
+    if (_total_in_flight_count == 0) {
+        _idle_since = clock::now();
+    }
+}
+
+proto::admin::in_flight_requests
+connection_attributes::in_flight_request_tracker::to_proto(
+  clock::time_point now) const {
+    proto::admin::in_flight_requests res;
+
+    chunked_vector<proto::admin::in_flight_requests_request> reqs;
+    for (auto& req : _in_flight_request_samples) {
+        auto& proto_req = reqs.emplace_back();
+        proto_req.set_api_key(req.key);
+        proto_req.set_in_flight_duration(absl::FromChrono(now - req.recv_time));
+    }
+    res.set_sampled_in_flight_requests(std::move(reqs));
+
+    res.set_has_more_requests(
+      _in_flight_request_samples.size() < _total_in_flight_count);
+
+    return res;
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -910,6 +910,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
       get_last_str(_attributes.last_client_software_name));
     res.set_client_software_version(
       get_last_str(_attributes.last_client_software_version));
+    res.set_transactional_id(get_last_str(_attributes.last_transactional_id));
 
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -906,6 +906,10 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     };
 
     res.set_client_id(get_last_str(_attributes.last_client_id));
+    res.set_client_software_name(
+      get_last_str(_attributes.last_client_software_name));
+    res.set_client_software_version(
+      get_last_str(_attributes.last_client_software_version));
 
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -823,6 +823,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_shard_id(ss::this_shard_id());
     res.set_node_id(
       config::node().node_id.value().value_or(model::unassigned_node_id));
+    res.set_uid(ssx::sformat("{}", _attributes.connection_id));
     res.set_listener_name(ss::sstring{listener()});
     res.set_state(
       _as.abort_requested() ? kafka_connection_state::aborting

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -19,6 +19,7 @@
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
+#include "container/chunked_hash_map.h"
 #include "kafka/protocol/sasl_authenticate.h"
 #include "kafka/server/datalake_throttle_manager.h"
 #include "kafka/server/handlers/fetch.h"
@@ -453,6 +454,7 @@ ss::future<> connection_context::process_one_request() {
     }
     _server.handler_probe(h->key).add_bytes_received(sz.value());
     _attributes.last_client_id.update(h->client_id);
+    _attributes.record_api_version(h->key, h->version);
     /**
      * An entry point for the MPX serverless extensions. If the first request
      * for a given connection has a special client_id then MPX extensions are
@@ -915,6 +917,10 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_group_instance_id(get_last_str(_attributes.last_group_instance_id));
     res.set_group_member_id(get_last_str(_attributes.last_group_member_id));
 
+    res.set_api_versions(
+      chunked_hash_map<int32_t, int32_t>{
+        _attributes.api_versions.cbegin(), _attributes.api_versions.cend()});
+
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();
 
@@ -1178,6 +1184,14 @@ std::ostream& operator<<(std::ostream& o, const virtual_connection_id& id) {
 void last_value::update(std::optional<std::string_view> new_value) {
     if (new_value && value != *new_value) {
         value = ss::sstring{*new_value};
+    }
+}
+
+void connection_attributes::record_api_version(
+  api_key key, api_version version) {
+    auto [it, inserted] = api_versions.try_emplace(key, version);
+    if (!inserted) {
+        it->second = std::max(it->second, version);
     }
 }
 

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -913,6 +913,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_transactional_id(get_last_str(_attributes.last_transactional_id));
     res.set_group_id(get_last_str(_attributes.last_group_id));
     res.set_group_instance_id(get_last_str(_attributes.last_group_instance_id));
+    res.set_group_member_id(get_last_str(_attributes.last_group_member_id));
 
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -911,6 +911,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_client_software_version(
       get_last_str(_attributes.last_client_software_version));
     res.set_transactional_id(get_last_str(_attributes.last_transactional_id));
+    res.set_group_id(get_last_str(_attributes.last_group_id));
 
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -816,6 +816,14 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
       shared_from_this(), std::move(rctx), rres);
 }
 
+namespace {
+absl::Time
+ss_sys_clock_to_absl(const ss::lowres_system_clock::time_point& lowres_tp) {
+    return absl::FromChrono(
+      std::chrono::system_clock::time_point{lowres_tp.time_since_epoch()});
+}
+} // namespace
+
 proto::admin::kafka_connection connection_context::to_proto() const {
     using proto::admin::kafka_connection_state;
 
@@ -828,6 +836,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_state(
       _as.abort_requested() ? kafka_connection_state::aborting
                             : kafka_connection_state::open);
+    res.set_open_time(ss_sys_clock_to_absl(_attributes.open_time));
 
     auto src = proto::admin::source{};
     src.set_ip_address(fmt::format("{}", client_host()));

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -847,7 +847,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     res.set_open_time(ss_sys_clock_to_absl(_attributes.open_time));
 
     auto src = proto::admin::source{};
-    src.set_ip_address(fmt::format("{}", client_host()));
+    src.set_ip_address(ssx::sformat("{}", client_host()));
     src.set_port(client_port());
     res.set_source(std::move(src));
 

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -36,6 +36,10 @@
 #include "net/exceptions.h"
 #include "security/authorizer.h"
 #include "security/exceptions.h"
+#include "security/gssapi_authenticator.h"
+#include "security/oidc_authenticator.h"
+#include "security/plain_authenticator.h"
+#include "security/scram_authenticator.h"
 #include "utils/windowed_sum_tracker.h"
 
 #include <seastar/core/coroutine.hh>
@@ -847,8 +851,53 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     tls_info.set_enabled(conn->tls_enabled());
     res.set_tls_info(std::move(tls_info));
 
+    auto auth_state = [this]() {
+        if (_mtls_state) {
+            return proto::admin::authentication_state::success;
+        } else if (_sasl) {
+            switch (_sasl->state()) {
+            case security::sasl_server::sasl_state::initial:
+            case security::sasl_server::sasl_state::handshake:
+            case security::sasl_server::sasl_state::authenticate:
+                return proto::admin::authentication_state::unauthenticated;
+            case security::sasl_server::sasl_state::complete:
+                return proto::admin::authentication_state::success;
+            case security::sasl_server::sasl_state::failed:
+                return proto::admin::authentication_state::failure;
+            }
+        }
+        return proto::admin::authentication_state::unauthenticated;
+    }();
+    auto auth_mechanism = [this]() -> proto::admin::authentication_mechanism {
+        if (_mtls_state) {
+            return proto::admin::authentication_mechanism::mtls;
+        } else if (_sasl && _sasl->has_mechanism()) {
+            return string_switch<proto::admin::authentication_mechanism>(
+                     _sasl->mechanism().mechanism_name())
+              .match(
+                security::scram_sha256_authenticator::name,
+                proto::admin::authentication_mechanism::sasl_scram)
+              .match(
+                security::scram_sha512_authenticator::name,
+                proto::admin::authentication_mechanism::sasl_scram)
+              .match(
+                security::gssapi_authenticator::name,
+                proto::admin::authentication_mechanism::sasl_gssapi)
+              .match(
+                security::oidc::sasl_authenticator::name,
+                proto::admin::authentication_mechanism::sasl_oauthbearer)
+              .match(
+                security::plain_authenticator::name,
+                proto::admin::authentication_mechanism::sasl_plain)
+              .default_match(
+                proto::admin::authentication_mechanism::unspecified);
+        }
+        return proto::admin::authentication_mechanism::unspecified;
+    }();
     auto auth_info = proto::admin::authentication_info{};
     auth_info.set_user_principal(ss::sstring{get_principal().name()});
+    auth_info.set_state(auth_state);
+    auth_info.set_mechanism(auth_mechanism);
     res.set_authentication_info(std::move(auth_info));
 
     using tracker_t = connection_attributes::request_state::tracker_t;

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -912,6 +912,7 @@ proto::admin::kafka_connection connection_context::to_proto() const {
       get_last_str(_attributes.last_client_software_version));
     res.set_transactional_id(get_last_str(_attributes.last_transactional_id));
     res.set_group_id(get_last_str(_attributes.last_group_id));
+    res.set_group_instance_id(get_last_str(_attributes.last_group_instance_id));
 
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -452,6 +452,7 @@ ss::future<> connection_context::process_one_request() {
         co_return;
     }
     _server.handler_probe(h->key).add_bytes_received(sz.value());
+    _attributes.last_client_id.update(h->client_id);
     /**
      * An entry point for the MPX serverless extensions. If the first request
      * for a given connection has a special client_id then MPX extensions are
@@ -900,6 +901,12 @@ proto::admin::kafka_connection connection_context::to_proto() const {
     auth_info.set_mechanism(auth_mechanism);
     res.set_authentication_info(std::move(auth_info));
 
+    constexpr auto get_last_str = [](const last_value& val) {
+        return val.get().value_or("");
+    };
+
+    res.set_client_id(get_last_str(_attributes.last_client_id));
+
     using tracker_t = connection_attributes::request_state::tracker_t;
     auto now = tracker_t::clock::now();
 
@@ -1158,6 +1165,12 @@ std::ostream& operator<<(std::ostream& o, const virtual_connection_id& id) {
       id.virtual_cluster_id,
       id.connection_id);
     return o;
+}
+
+void last_value::update(std::optional<std::string_view> new_value) {
+    if (new_value && value != *new_value) {
+        value = ss::sstring{*new_value};
+    }
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -148,6 +148,16 @@ struct virtual_connection_id {
 class last_value {
 public:
     void update(std::optional<std::string_view> new_value);
+    template<typename Tag>
+    void update(const named_type<ss::sstring, Tag>& new_value) {
+        update(new_value());
+    }
+    template<typename Tag>
+    void update(const std::optional<named_type<ss::sstring, Tag>>& new_value) {
+        if (new_value) {
+            update((*new_value)());
+        }
+    }
     const std::optional<ss::sstring>& get() const { return value; }
 
 private:
@@ -180,6 +190,7 @@ struct connection_attributes {
     last_value last_client_id{};
     last_value last_client_software_name{};
     last_value last_client_software_version{};
+    last_value last_transactional_id{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "config/property.h"
 #include "container/chunked_hash_map.h"
+#include "kafka/protocol/types.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/handlers/details/security.h"
 #include "kafka/server/handlers/handler_probe.h"
@@ -180,6 +181,8 @@ struct connection_attributes {
         }
     };
 
+    void record_api_version(api_key key, api_version);
+
     request_state request_count;
     request_state produce_bytes;
     request_state produce_batch_count;
@@ -194,6 +197,8 @@ struct connection_attributes {
     last_value last_group_id{};
     last_value last_group_instance_id{};
     last_value last_group_member_id{};
+
+    chunked_hash_map<api_key, api_version> api_versions{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -181,6 +181,35 @@ struct connection_attributes {
         }
     };
 
+    class in_flight_request_tracker {
+    public:
+        using clock = ss::lowres_clock;
+        constexpr static auto max_count = size_t{5};
+
+        explicit in_flight_request_tracker(
+          std::optional<clock::time_point> idle_since = clock::now())
+          : _idle_since(idle_since) {}
+
+        void record_begin_request(api_key key);
+        void record_end_request();
+
+        proto::admin::in_flight_requests to_proto(clock::time_point now) const;
+        clock::duration get_idle_duration(clock::time_point now) const {
+            return _idle_since ? (now - *_idle_since) : clock::duration::zero();
+        }
+
+    private:
+        struct in_flight_request {
+            api_key key;
+            clock::time_point recv_time;
+        };
+        using queue_t = std::deque<in_flight_request>;
+
+        queue_t _in_flight_request_samples{};
+        size_t _total_in_flight_count{0};
+        std::optional<clock::time_point> _idle_since;
+    };
+
     void record_api_version(api_key key, api_version);
 
     request_state request_count;
@@ -199,6 +228,7 @@ struct connection_attributes {
     last_value last_group_member_id{};
 
     chunked_hash_map<api_key, api_version> api_versions{};
+    in_flight_request_tracker in_flight_requests;
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -178,6 +178,8 @@ struct connection_attributes {
     uuid_t connection_id{uuid_t::create()};
     sys_clock::time_point open_time{sys_clock::now()};
     last_value last_client_id{};
+    last_value last_client_software_name{};
+    last_value last_client_software_version{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -164,6 +164,8 @@ struct connection_attributes {
     request_state produce_bytes;
     request_state produce_batch_count;
     request_state fetch_bytes;
+
+    uuid_t connection_id{uuid_t::create()};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -241,7 +241,7 @@ private:
     security::acl_principal get_principal() const {
         if (_mtls_state) {
             return _mtls_state->principal();
-        } else if (_sasl) {
+        } else if (_sasl && _sasl->complete()) {
             return _sasl->principal();
         }
         // anonymous user

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -193,6 +193,7 @@ struct connection_attributes {
     last_value last_transactional_id{};
     last_value last_group_id{};
     last_value last_group_instance_id{};
+    last_value last_group_member_id{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -146,6 +146,7 @@ struct virtual_connection_id {
 };
 
 struct connection_attributes {
+    using sys_clock = ss::lowres_system_clock;
     struct request_state {
         constexpr static auto bucket_count = size_t{4};
         constexpr static auto window_ns = std::chrono::minutes(1)
@@ -166,6 +167,7 @@ struct connection_attributes {
     request_state fetch_bytes;
 
     uuid_t connection_id{uuid_t::create()};
+    sys_clock::time_point open_time{sys_clock::now()};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -145,6 +145,15 @@ struct virtual_connection_id {
     operator<<(std::ostream& o, const virtual_connection_id& id);
 };
 
+class last_value {
+public:
+    void update(std::optional<std::string_view> new_value);
+    const std::optional<ss::sstring>& get() const { return value; }
+
+private:
+    std::optional<ss::sstring> value{std::nullopt};
+};
+
 struct connection_attributes {
     using sys_clock = ss::lowres_system_clock;
     struct request_state {
@@ -168,6 +177,7 @@ struct connection_attributes {
 
     uuid_t connection_id{uuid_t::create()};
     sys_clock::time_point open_time{sys_clock::now()};
+    last_value last_client_id{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -192,6 +192,7 @@ struct connection_attributes {
     last_value last_client_software_version{};
     last_value last_transactional_id{};
     last_value last_group_id{};
+    last_value last_group_instance_id{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -191,6 +191,7 @@ struct connection_attributes {
     last_value last_client_software_name{};
     last_value last_client_software_version{};
     last_value last_transactional_id{};
+    last_value last_group_id{};
 };
 
 class connection_context final

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -123,6 +123,13 @@ api_versions_response api_versions_handler::handle_raw(request_context& ctx) {
         api_versions_request request;
         request.decode(ctx.reader(), ctx.header().version);
         r.data.error_code = error_code::none;
+
+        if (ctx.header().version >= api_version(3)) {
+            ctx.connection()->attributes().last_client_software_name.update(
+              request.data.client_software_name);
+            ctx.connection()->attributes().last_client_software_version.update(
+              request.data.client_software_version);
+        }
     }
 
     if (

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -634,6 +634,9 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    ctx.connection()->attributes().last_transactional_id.update(
+      request.data.transactional_id);
+
     if (unlikely(ctx.recovery_mode_enabled())) {
         return process_result_stages::single_stage(ctx.respond(
           request.make_error_response(error_code::policy_violation)));

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -102,6 +102,8 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
     ctx.connection()->attributes().last_group_instance_id.update(
       request.data.group_instance_id);
+    ctx.connection()->attributes().last_group_member_id.update(
+      request.data.member_id);
 
     if (unlikely(ctx.recovery_mode_enabled())) {
         return ctx.respond(

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -100,6 +100,8 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
     log_request(ctx.header(), request);
 
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+    ctx.connection()->attributes().last_group_instance_id.update(
+      request.data.group_instance_id);
 
     if (unlikely(ctx.recovery_mode_enabled())) {
         return ctx.respond(

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -99,6 +99,8 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+
     if (unlikely(ctx.recovery_mode_enabled())) {
         return ctx.respond(
           txn_offset_commit_response{request, error_code::policy_violation});

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -932,6 +932,10 @@ ss::future<response_ptr> end_txn_handler::handle(
         end_txn_request request;
         request.decode(ctx.reader(), ctx.header().version);
         log_request(ctx.header(), request);
+
+        ctx.connection()->attributes().last_transactional_id.update(
+          request.data.transactional_id);
+
         if (ctx.recovery_mode_enabled()) {
             end_txn_response response;
             response.data.error_code = error_code::policy_violation;
@@ -975,6 +979,9 @@ add_offsets_to_txn_handler::handle(request_context ctx, ss::smp_service_group) {
         add_offsets_to_txn_request request;
         request.decode(ctx.reader(), ctx.header().version);
         log_request(ctx.header(), request);
+
+        ctx.connection()->attributes().last_transactional_id.update(
+          request.data.transactional_id);
 
         if (unlikely(ctx.recovery_mode_enabled())) {
             add_offsets_to_txn_response response;
@@ -1028,6 +1035,9 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
         add_partitions_to_txn_request request;
         request.decode(ctx.reader(), ctx.header().version);
         log_request(ctx.header(), request);
+
+        ctx.connection()->attributes().last_transactional_id.update(
+          request.data.transactional_id);
 
         if (ctx.recovery_mode_enabled()) {
             add_partitions_to_txn_response response{
@@ -1759,6 +1769,9 @@ ss::future<response_ptr> init_producer_id_handler::handle(
         init_producer_id_request request;
         request.decode(ctx.reader(), ctx.header().version);
         log_request(ctx.header(), request);
+
+        ctx.connection()->attributes().last_transactional_id.update(
+          request.data.transactional_id);
 
         if (unlikely(ctx.recovery_mode_enabled())) {
             init_producer_id_response reply;

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -500,6 +500,8 @@ ss::future<response_ptr> heartbeat_handler::handle(
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
     ctx.connection()->attributes().last_group_instance_id.update(
       request.data.group_instance_id);
+    ctx.connection()->attributes().last_group_member_id.update(
+      request.data.member_id);
 
     if (unlikely(ctx.recovery_mode_enabled())) {
         co_return co_await ctx.respond(
@@ -616,6 +618,8 @@ process_result_stages sync_group_handler::handle(
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
     ctx.connection()->attributes().last_group_instance_id.update(
       request.data.group_instance_id);
+    ctx.connection()->attributes().last_group_member_id.update(
+      request.data.member_id);
 
     if (ctx.recovery_mode_enabled()) {
         return process_result_stages::single_stage(
@@ -853,6 +857,8 @@ process_result_stages join_group_handler::handle(
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
     ctx.connection()->attributes().last_group_instance_id.update(
       request.data.group_instance_id);
+    ctx.connection()->attributes().last_group_member_id.update(
+      request.data.member_id);
 
     if (ctx.recovery_mode_enabled()) {
         return process_result_stages::single_stage(
@@ -877,6 +883,8 @@ process_result_stages join_group_handler::handle(
       std::move(ctx),
       [f = std::move(stages.result)](request_context& ctx) mutable {
           return f.then([&ctx](join_group_response response) {
+              ctx.connection()->attributes().last_group_member_id.update(
+                response.data.member_id);
               return ctx.respond(std::move(response));
           });
       });
@@ -2024,6 +2032,8 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
     ctx.connection()->attributes().last_group_instance_id.update(
       request.data.group_instance_id);
+    ctx.connection()->attributes().last_group_member_id.update(
+      request.data.member_id);
 
     // check authorization for this group
     const auto group_authorized = ctx.authorized(

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -497,6 +497,8 @@ ss::future<response_ptr> heartbeat_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+
     if (unlikely(ctx.recovery_mode_enabled())) {
         co_return co_await ctx.respond(
           heartbeat_response(error_code::policy_violation));
@@ -608,6 +610,8 @@ process_result_stages sync_group_handler::handle(
     sync_group_request request;
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
+
+    ctx.connection()->attributes().last_group_id.update(request.data.group_id);
 
     if (ctx.recovery_mode_enabled()) {
         return process_result_stages::single_stage(
@@ -842,6 +846,8 @@ process_result_stages join_group_handler::handle(
       fmt::format("{}", ctx.connection()->client_host()));
     log_request(ctx.header(), request);
 
+    ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+
     if (ctx.recovery_mode_enabled()) {
         return process_result_stages::single_stage(
           ctx.respond(join_group_response(error_code::policy_violation)));
@@ -982,6 +988,8 @@ add_offsets_to_txn_handler::handle(request_context ctx, ss::smp_service_group) {
 
         ctx.connection()->attributes().last_transactional_id.update(
           request.data.transactional_id);
+        ctx.connection()->attributes().last_group_id.update(
+          request.data.group_id);
 
         if (unlikely(ctx.recovery_mode_enabled())) {
             add_offsets_to_txn_response response;
@@ -1207,6 +1215,11 @@ offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
     convert_to_latest(request, ctx.header().version);
+
+    if (request.data.groups.size() == 1) {
+        ctx.connection()->attributes().last_group_id.update(
+          request.data.groups[0].group_id);
+    }
 
     constexpr auto has_topics = [](const auto& g) {
         return g.topics.has_value();
@@ -2001,6 +2014,8 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     offset_commit_request request;
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
+
+    ctx.connection()->attributes().last_group_id.update(request.data.group_id);
 
     // check authorization for this group
     const auto group_authorized = ctx.authorized(

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -498,6 +498,8 @@ ss::future<response_ptr> heartbeat_handler::handle(
     log_request(ctx.header(), request);
 
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+    ctx.connection()->attributes().last_group_instance_id.update(
+      request.data.group_instance_id);
 
     if (unlikely(ctx.recovery_mode_enabled())) {
         co_return co_await ctx.respond(
@@ -612,6 +614,8 @@ process_result_stages sync_group_handler::handle(
     log_request(ctx.header(), request);
 
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+    ctx.connection()->attributes().last_group_instance_id.update(
+      request.data.group_instance_id);
 
     if (ctx.recovery_mode_enabled()) {
         return process_result_stages::single_stage(
@@ -847,6 +851,8 @@ process_result_stages join_group_handler::handle(
     log_request(ctx.header(), request);
 
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+    ctx.connection()->attributes().last_group_instance_id.update(
+      request.data.group_instance_id);
 
     if (ctx.recovery_mode_enabled()) {
         return process_result_stages::single_stage(
@@ -2016,6 +2022,8 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     log_request(ctx.header(), request);
 
     ctx.connection()->attributes().last_group_id.update(request.data.group_id);
+    ctx.connection()->attributes().last_group_instance_id.update(
+      request.data.group_instance_id);
 
     // check authorization for this group
     const auto group_authorized = ctx.authorized(

--- a/src/v/kafka/server/tests/BUILD
+++ b/src/v/kafka/server/tests/BUILD
@@ -996,3 +996,18 @@ redpanda_cc_btest(
         "@seastar//:testing",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "in_flight_requests_test",
+    timeout = "short",
+    srcs = [
+        "in_flight_requests_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/kafka/server",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)

--- a/src/v/kafka/server/tests/in_flight_requests_test.cc
+++ b/src/v/kafka/server/tests/in_flight_requests_test.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/connection_context.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+TEST_CORO(in_flight_requests_tests, test_usage) {
+    using tracker_t = kafka::connection_attributes::in_flight_request_tracker;
+
+    auto now = tracker_t::clock::now();
+    auto tracker = tracker_t{now};
+    EXPECT_LE(tracker.get_idle_duration(now), std::chrono::seconds(1));
+
+    auto test_req_count = 10;
+
+    for (int i = 0; i < test_req_count; ++i) {
+        tracker.record_begin_request(kafka::api_key(1));
+    }
+    auto res = tracker.to_proto(now);
+    EXPECT_TRUE(res.get_has_more_requests());
+    EXPECT_EQ(
+      res.get_sampled_in_flight_requests().size(), tracker_t::max_count);
+
+    for (int i = 0; i < test_req_count; ++i) {
+        tracker.record_end_request();
+    }
+    now = tracker_t::clock::now();
+
+    res = tracker.to_proto(now);
+    EXPECT_FALSE(res.get_has_more_requests());
+    EXPECT_EQ(res.get_sampled_in_flight_requests().size(), 0);
+
+    constexpr auto sleep_time = 50ms;
+    co_await ss::sleep(sleep_time);
+    now += sleep_time;
+
+    EXPECT_GE(tracker.get_idle_duration(now), 0s);
+}

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -67,6 +67,7 @@
 #include "security/gssapi_authenticator.h"
 #include "security/mtls.h"
 #include "security/oidc_authenticator.h"
+#include "security/plain_authenticator.h"
 #include "security/request_auth.h"
 #include "security/scram_authenticator.h"
 #include "utils/unresolved_address.h"
@@ -219,18 +220,15 @@ mechanism_string_to_auth_protocol(std::string_view mech) {
         return authentication::auth_protocol_id::unknown;
     }
     return string_switch<authentication::auth_protocol_variant>(mech)
-      .match(
-        security::scram_sha256_authenticator::name,
-        security::scram_sha256_authenticator::name)
-      .match(
-        security::scram_sha512_authenticator::name,
-        security::scram_sha512_authenticator::name)
+      .match(security::scram_sha256_authenticator::name, "SASL-SCRAM")
+      .match(security::scram_sha512_authenticator::name, "SASL-SCRAM")
       .match(
         security::gssapi_authenticator::name,
         authentication::auth_protocol_id::kerberos)
       .match(
         security::oidc::sasl_authenticator::name,
         authentication::auth_protocol_id::oauth_2_0)
+      .match(security::plain_authenticator::name, "SASL-PLAIN")
       .default_match(ss::sstring{mech});
 }
 

--- a/src/v/security/plain_authenticator.h
+++ b/src/v/security/plain_authenticator.h
@@ -44,7 +44,7 @@ public:
 
     const audit::user& audit_user() const override { return _audit_user; }
 
-    const char* mechanism_name() const override { return "SASL-PLAIN"; }
+    const char* mechanism_name() const override { return name; }
 
 private:
     enum class state {

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -85,6 +85,7 @@ public:
     }
 
     bool has_mechanism() const { return bool(_mechanism); }
+    const sasl_mechanism& mechanism() const { return *_mechanism; }
     sasl_mechanism& mechanism() { return *_mechanism; }
 
     ss::future<result<bytes>> authenticate(bytes data) {

--- a/src/v/security/scram_authenticator.h
+++ b/src/v/security/scram_authenticator.h
@@ -18,6 +18,9 @@
 namespace security {
 
 template<typename ScramMechanism>
+struct scram_mechanism_traits;
+
+template<typename ScramMechanism>
 class scram_authenticator final : public sasl_mechanism {
     static constexpr int nonce_size = 130;
 
@@ -43,7 +46,9 @@ public:
 
     const audit::user& audit_user() const override { return _audit_user; }
 
-    const char* mechanism_name() const override { return "SASL-SCRAM"; }
+    const char* mechanism_name() const override {
+        return scram_mechanism_traits<scram>::name;
+    }
 
 private:
     enum class state {
@@ -71,14 +76,26 @@ private:
     std::unique_ptr<server_first_message> _server_first;
 };
 
+template<>
+struct scram_mechanism_traits<scram_sha256> {
+    static constexpr const char* name = "SCRAM-SHA-256";
+};
+
+template<>
+struct scram_mechanism_traits<scram_sha512> {
+    static constexpr const char* name = "SCRAM-SHA-512";
+};
+
 struct scram_sha256_authenticator {
     using auth = scram_authenticator<scram_sha256>;
-    static constexpr const char* name = "SCRAM-SHA-256";
+    static constexpr const char* name
+      = scram_mechanism_traits<scram_sha256>::name;
 };
 
 struct scram_sha512_authenticator {
     using auth = scram_authenticator<scram_sha512>;
-    static constexpr const char* name = "SCRAM-SHA-512";
+    static constexpr const char* name
+      = scram_mechanism_traits<scram_sha512>::name;
 };
 
 std::optional<std::string_view> validate_scram_credential(

--- a/tests/rptest/tests/list_kafka_connections_test.py
+++ b/tests/rptest/tests/list_kafka_connections_test.py
@@ -6,15 +6,17 @@
 #
 # https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
 
+from datetime import datetime
 from typing import Any
 
 from ducktape.tests.test import TestContext
 
 from rptest.clients.admin.v2 import Admin as AdminV2
-from rptest.clients.admin.v2 import broker_pb
+from rptest.clients.admin.v2 import broker_pb, kafka_connections_pb
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import SecurityConfig
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import wait_until
@@ -26,21 +28,37 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
     """
 
     test_topic: str = "test-list-connections"
+    test_group: str = "test-cg-group"
 
     def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
-        super().__init__(test_ctx, *args, **kwargs)
+        security = SecurityConfig()
+        security.enable_sasl = True
+
+        super().__init__(test_ctx, *args, security=security, **kwargs)
         self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
         self.superuser_admin = Admin(
             self.redpanda, auth=(self.superuser.username, self.superuser.password)
         )
-        self.consumer = RpkConsumer(test_ctx, self.redpanda, self.test_topic)
+        self.consumer = RpkConsumer(
+            test_ctx,
+            self.redpanda,
+            self.test_topic,
+            group=self.test_group,
+            username=self.superuser.username,
+            password=self.superuser.password,
+            mechanism=self.superuser.mechanism,
+        )
+        self.super_rpk = RpkTool(
+            self.redpanda,
+            username=self.superuser.username,
+            password=self.superuser.password,
+            sasl_mechanism=self.superuser.algorithm,
+        )
 
     def setUp(self):
         super().setUp()
-        self.redpanda.set_cluster_config({"admin_api_require_auth": True})
 
-        rpk = RpkTool(self.redpanda)
-        rpk.create_topic(self.test_topic)
+        self.super_rpk.create_topic(self.test_topic)
 
     @cluster(num_nodes=2)
     def test_list_kafka_connections(self):
@@ -71,12 +89,33 @@ class AdminV2ListKafkaConnectionsTest(RedpandaTest):
 
             # Sanity check the response
             assert len(resp.connections) > 0
-            conn = resp.connections[0]
+
+            # Find the connection used for consumer group requests
+            # Note: this is different from the connection used for fetch requests
+            conn: kafka_connections_pb.KafkaConnection = next(
+                filter(lambda conn: conn.group_id == self.test_group, resp.connections)
+            )
 
             assert conn.node_id == node_id
+            assert conn.state == kafka_connections_pb.KAFKA_CONNECTION_STATE_OPEN
+            assert conn.open_time.ToDatetime() > datetime(year=2025, month=1, day=1)
             assert len(conn.source.ip_address) > 0
             assert conn.source.port != 0
+            assert (
+                conn.authentication_info.state
+                == kafka_connections_pb.AUTHENTICATION_STATE_SUCCESS
+            )
+            assert (
+                conn.authentication_info.mechanism
+                == kafka_connections_pb.AUTHENTICATION_MECHANISM_SASL_SCRAM
+            )
+            assert conn.authentication_info.user_principal == self.superuser.username
             assert not conn.tls_info.enabled
+            assert conn.client_id == "rpk"
+            assert conn.client_software_name == "kgo"
+            assert len(conn.client_software_version) > 0
+            assert len(conn.group_member_id) > 0
+            assert len(conn.api_versions) > 0
             assert conn.total_request_statistics.request_count > 0
 
             return True


### PR DESCRIPTION
This PR introduces tracking a wide set of information about kafka connections that will be surfaced in the `ListKafkaConnections` API. This information will be useful to show information about the behaviour of kafka clients.

You can see here an example output of the API while a producer and a consumer is active: https://gist.githubusercontent.com/pgellert/5705959693f5c8443c54c9f0737d7b8a/raw/62a746362fc8177ac398d590d3af246cb8ffd7e0/gistfile0.txt

See the commit messages for implementation details.

Fixes https://redpandadata.atlassian.net/browse/CORE-13356

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
