### PR TITLE
ct: Replicate with term

### DIFF
--- a/src/v/cloud_topics/frontend/frontend.cc
+++ b/src/v/cloud_topics/frontend/frontend.cc
@@ -461,7 +461,8 @@ frontend::refine_timequery_result(
 
 namespace {
 
-raft::replicate_options update_replicate_options(raft::replicate_options opts) {
+raft::replicate_options update_replicate_options(
+  raft::replicate_options opts, model::term_id expected_term) {
     // We overwrite the consistency level in cloud topics. Since you're already
     // willing to wait for object storage uploads, it's much safer to make sure
     // metadata is written to a majority before acking the write as well. This
@@ -473,6 +474,7 @@ raft::replicate_options update_replicate_options(raft::replicate_options opts) {
     // consumers - and to prevent situations where we have to suffix truncate
     // the log, we just force a majority to persist the write before responding.
     opts.consistency = raft::consistency_level::quorum_ack;
+    opts.expected_term = expected_term;
     return opts;
 }
 
@@ -496,7 +498,7 @@ struct upload_and_replicate_stages {
       , ctp_stm_api(make_ctp_stm_api(this->partition))
       , batches(std::move(batches))
       , batch_id(batch_id)
-      , opts(update_replicate_options(opts))
+      , opts(opts)
       , timeout(timeout) {}
 
     ss::promise<> request_enqueued;
@@ -575,6 +577,7 @@ ss::future<> bg_upload_and_replicate(
       placeholders.batches.size());
 
     // Replicate
+    op->opts = update_replicate_options(op->opts, fence.term);
     auto replicate_stages = partition->replicate_in_stages(
       op->batch_id, std::move(placeholders.batches.front()), op->opts);
 
@@ -639,7 +642,6 @@ ss::future<> bg_upload_and_replicate(
 
 ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
   chunked_vector<model::record_batch> batches, raft::replicate_options opts) {
-    opts = update_replicate_options(opts);
     chunked_vector<model::record_batch_header> headers;
     headers.reserve(batches.size());
     for (const auto& batch : batches) {
@@ -695,6 +697,7 @@ ss::future<std::expected<kafka::offset, std::error_code>> frontend::replicate(
         placeholder_batches.push_back(std::move(batch));
     }
 
+    opts = update_replicate_options(opts, fence.term);
     auto result = co_await _partition->replicate(
       std::move(placeholder_batches), opts);
 

--- a/src/v/cloud_topics/level_one/metastore/simple_stm.cc
+++ b/src/v/cloud_topics/level_one/metastore/simple_stm.cc
@@ -21,6 +21,8 @@
 
 #include <seastar/coroutine/as_future.hh>
 
+#include <optional>
+
 namespace cloud_topics::l1 {
 
 namespace {
@@ -83,9 +85,12 @@ ss::future<std::expected<void, simple_stm::errc>>
 simple_stm::replicate_and_wait(
   model::term_id term, model::record_batch batch, ss::abort_source& as) {
     auto opts = raft::replicate_options(
-      raft::consistency_level::quorum_ack, std::ref(as));
+      raft::consistency_level::quorum_ack,
+      /*expected_term=*/term,
+      /*timeout=*/std::nullopt,
+      std::ref(as));
     opts.set_force_flush();
-    auto res = co_await _raft->replicate(term, std::move(batch), opts);
+    auto res = co_await _raft->replicate(std::move(batch), opts);
     if (res.has_error()) {
         co_return std::unexpected(errc::raft_error);
     }

--- a/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
+++ b/src/v/cloud_topics/level_zero/stm/ctp_stm_api.cc
@@ -52,9 +52,12 @@ ctp_stm_api::replicated_apply(
     vlog(cd_log.debug, "Replicating batch {} in term {}", batch.header(), term);
 
     auto opts = raft::replicate_options(
-      raft::consistency_level::quorum_ack, as);
+      raft::consistency_level::quorum_ack,
+      /*expected_term=*/term,
+      /*timeout=*/std::nullopt,
+      as);
     opts.set_force_flush();
-    auto res = co_await _stm->_raft->replicate(term, std::move(batch), opts);
+    auto res = co_await _stm->_raft->replicate(std::move(batch), opts);
 
     if (res.has_error()) {
         vlog(cd_log.debug, "Failed to replicate batch: {}", res.error());

--- a/src/v/cluster/archival/archival_metadata_stm.cc
+++ b/src/v/cluster/archival/archival_metadata_stm.cc
@@ -898,11 +898,11 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
                           .handle_exception_type(broken_promise_to_shutdown);
     auto op_state_reset = ss::defer([&] { _active_operation_res.reset(); });
 
-    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, current_term);
     opts.set_force_flush();
 
-    auto result = co_await _raft->replicate(
-      current_term, std::move(batch), opts);
+    auto result = co_await _raft->replicate(std::move(batch), opts);
     if (!result) {
         vlog(
           _logger.warn,

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -408,9 +408,9 @@ private:
 
     ss::future<errc> replicate_and_wait(simple_batch_builder builder) {
         auto r = co_await _raft->replicate(
-          _insync_term,
           std::move(builder).build(),
-          raft::replicate_options(raft::consistency_level::quorum_ack));
+          raft::replicate_options(
+            raft::consistency_level::quorum_ack, _insync_term));
 
         if (!r) {
             co_return errc::replication_error;

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -105,9 +105,9 @@ ss::future<bool> id_allocator_stm::set_state(
     auto batch = serialize_cmd(
       state_cmd{.next_state = value}, model::record_batch_type::id_allocator);
     auto r = co_await _raft->replicate(
-      _insync_term,
       std::move(batch),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(
+        raft::consistency_level::quorum_ack, _insync_term));
     if (!r) {
         co_return false;
     }

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -327,9 +327,10 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::replicate_command(
   model::record_batch batch,
   ss::lowres_clock::time_point deadline,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
-    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, _raft->term());
     opts.set_force_flush();
-    auto fut = _raft->replicate(_raft->term(), std::move(batch), opts);
+    auto fut = _raft->replicate(std::move(batch), opts);
 
     /// Execute the replicate command bound by timeout and cancellable via
     /// abort_source mechanism

--- a/src/v/cluster/partition_properties_stm.cc
+++ b/src/v/cluster/partition_properties_stm.cc
@@ -215,9 +215,10 @@ partition_properties_stm::replicate_properties_update(
       _log.debug, "replicating update partition properties command: {}", cmd);
     raft::replicate_options r_opts(
       raft::consistency_level::quorum_ack,
+      _insync_term,
       std::chrono::milliseconds(timeout / 1ms));
     r_opts.set_force_flush();
-    auto r = co_await _raft->replicate(_insync_term, std::move(b), r_opts);
+    auto r = co_await _raft->replicate(std::move(b), r_opts);
 
     if (r.has_error()) {
         vlog(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/rm_stm.h"
 
+#include "base/vassert.h"
 #include "bytes/iostream.h"
 #include "cluster/logger.h"
 #include "cluster/producer_state_manager.h"
@@ -25,6 +26,7 @@
 #include "model/record.h"
 #include "model/timestamp.h"
 #include "raft/persisted_stm.h"
+#include "raft/replicate.h"
 #include "raft/state_machine_base.h"
 #include "ssx/future-util.h"
 
@@ -61,8 +63,9 @@ ss::sstring abort_idx_name(model::offset first, model::offset last) {
     return fmt::format("abort.idx.{}.{}", first, last);
 }
 
-raft::replicate_options make_replicate_options() {
-    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+raft::replicate_options make_replicate_options(model::term_id synced_term) {
+    auto opts = raft::replicate_options(
+      raft::consistency_level::quorum_ack, synced_term);
     opts.set_force_flush();
     return opts;
 }
@@ -441,7 +444,7 @@ ss::future<checked<model::term_id, tx::errc>> rm_stm::do_begin_tx(
       pid, tx_seq, transaction_timeout_ms, tm);
 
     auto r = co_await _raft->replicate(
-      synced_term, std::move(batch), make_replicate_options());
+      std::move(batch), make_replicate_options(synced_term));
 
     if (!r) {
         vlog(
@@ -605,7 +608,7 @@ ss::future<tx::errc> rm_stm::do_commit_tx(
       pid, model::control_record_type::tx_commit);
 
     auto r = co_await _raft->replicate(
-      synced_term, std::move(batch), make_replicate_options());
+      std::move(batch), make_replicate_options(synced_term));
 
     if (!r) {
         vlog(
@@ -774,7 +777,7 @@ ss::future<tx::errc> rm_stm::do_abort_tx(
     auto batch = make_tx_control_batch(
       pid, model::control_record_type::tx_abort);
     auto r = co_await _raft->replicate(
-      synced_term, std::move(batch), make_replicate_options());
+      std::move(batch), make_replicate_options(synced_term));
 
     if (!r) {
         vlog(
@@ -853,7 +856,10 @@ ss::future<result<kafka_result>> rm_stm::do_replicate(
     auto holder = _gate.hold();
     auto unit = co_await _state_lock.hold_read_lock();
     if (bid.is_transactional) {
-        co_return co_await transactional_replicate(bid, std::move(batch));
+        // NOTE: transactional replicate doesn't respect the timeout value from
+        // the replicate_options. Only the expected term is taken into account.
+        co_return co_await transactional_replicate(
+          bid, std::move(batch), opts.expected_term);
     } else if (bid.is_idempotent()) {
         co_return co_await idempotent_replicate(
           bid, std::move(batch), opts, enqueued);
@@ -928,12 +934,12 @@ ss::future<tx::errc> rm_stm::mark_expired(model::producer_identity pid) {
 }
 
 ss::future<result<kafka_result>> rm_stm::transactional_replicate(
-  model::term_id synced_term,
+  model::term_id expected_term,
   producer_ptr producer,
   model::batch_identity bid,
   model::record_batch batch) {
     auto result = co_await do_transactional_replicate(
-      synced_term, producer, bid, std::move(batch));
+      expected_term, producer, bid, std::move(batch));
     if (!result) {
         vlog(
           _ctx_log.trace,
@@ -947,7 +953,7 @@ ss::future<result<kafka_result>> rm_stm::transactional_replicate(
             if (!barrier) {
                 co_return cluster::errc::not_leader;
             }
-        } else if (_raft->is_leader() && _raft->term() == synced_term) {
+        } else if (_raft->is_leader() && _raft->term() == expected_term) {
             co_await _raft->step_down(
               "Failed replication during transactional replicate.");
         }
@@ -1004,7 +1010,7 @@ ss::future<result<kafka_result>> rm_stm::do_transactional_replicate(
     req_ptr->mark_request_in_progress();
 
     auto r = co_await _raft->replicate(
-      synced_term, std::move(batch), make_replicate_options());
+      std::move(batch), make_replicate_options(synced_term));
     if (!r) {
         vlog(
           _ctx_log.warn,
@@ -1037,7 +1043,9 @@ ss::future<result<kafka_result>> rm_stm::do_transactional_replicate(
 }
 
 ss::future<result<kafka_result>> rm_stm::transactional_replicate(
-  model::batch_identity bid, model::record_batch batch) {
+  model::batch_identity bid,
+  model::record_batch batch,
+  std::optional<model::term_id> expected_term) {
     if (!check_tx_permitted()) {
         co_return cluster::errc::generic_tx_error;
     }
@@ -1048,22 +1056,23 @@ ss::future<result<kafka_result>> rm_stm::transactional_replicate(
           bid.pid);
         co_return cluster::errc::not_leader;
     }
-    auto synced_term = _insync_term;
+    if (!expected_term.has_value()) {
+        expected_term = _insync_term;
+    }
     auto result = maybe_create_producer(bid.pid);
     if (result.has_error()) {
         co_return result.error();
     }
     auto producer = result.value().first;
     co_return co_await producer->run_with_lock(
-      [&, synced_term](ssx::semaphore_units units) {
+      [&, expected_term](ssx::semaphore_units units) {
           return do_transactional_replicate(
-                   synced_term, producer, bid, std::move(batch))
+                   expected_term.value(), producer, bid, std::move(batch))
             .finally([units = std::move(units)] {});
       });
 }
 
 ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
-  model::term_id synced_term,
   producer_ptr producer,
   model::batch_identity bid,
   model::record_batch batch,
@@ -1071,8 +1080,8 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
   ss::lw_shared_ptr<available_promise<>> enqueued,
   ssx::semaphore_units units,
   producer_previously_known producer_known) {
+    vassert(opts.expected_term.has_value(), "expected term must be set");
     auto result = co_await do_idempotent_replicate(
-      synced_term,
       producer,
       bid,
       std::move(batch),
@@ -1105,7 +1114,9 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
             // if the request enqueue failed, its important to step down
             // under units scope so that the next request in the pipeline
             // fails on sync.
-            if (_raft->is_leader() && _raft->term() == synced_term) {
+            if (
+              _raft->is_leader()
+              && _raft->term() == opts.expected_term.value()) {
                 co_await _raft->step_down(
                   "Failed replication during idempotent replicate.");
             }
@@ -1116,7 +1127,6 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
 }
 
 ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
-  model::term_id synced_term,
   producer_ptr producer,
   model::batch_identity bid,
   model::record_batch batch,
@@ -1124,6 +1134,7 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
   ss::lw_shared_ptr<available_promise<>> enqueued,
   ssx::semaphore_units& units,
   producer_previously_known known_producer) {
+    vassert(opts.expected_term.has_value(), "expected term must be set");
     // Check if the producer bumped the epoch and reset accordingly.
     if (bid.pid.epoch > producer->id().epoch()) {
         producer->reset_with_new_epoch(bid.pid.epoch);
@@ -1143,10 +1154,10 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
           "Accepting batch from unknown producer that likely got evicted: {}, "
           "term: {}",
           bid,
-          synced_term);
+          opts.expected_term.value());
     }
     auto request = producer->try_emplace_request(
-      bid, synced_term, skip_sequence_checks);
+      bid, opts.expected_term.value(), skip_sequence_checks);
     if (!request) {
         co_return request.error();
     }
@@ -1157,8 +1168,7 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
     }
 
     req_ptr->mark_request_in_progress();
-    auto stages = _raft->replicate_in_stages(
-      synced_term, std::move(batch), opts);
+    auto stages = _raft->replicate_in_stages(std::move(batch), opts);
     auto req_enqueued = co_await ss::coroutine::as_future(
       std::move(stages.request_enqueued));
     if (req_enqueued.failed()) {
@@ -1204,7 +1214,9 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
         // the safety check in replicate_in_stages sets it automatically
         co_return cluster::errc::not_leader;
     }
-    auto synced_term = _insync_term;
+    if (!opts.expected_term.has_value()) {
+        opts.expected_term = _insync_term;
+    }
     auto result = maybe_create_producer(bid.pid);
     if (result.has_error()) {
         co_return result.error();
@@ -1213,7 +1225,6 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
     co_return co_await producer->run_with_lock(
       [&, known_producer](ssx::semaphore_units units) {
           return idempotent_replicate(
-            synced_term,
             producer,
             bid,
             std::move(batch),
@@ -1234,7 +1245,11 @@ ss::future<result<kafka_result>> rm_stm::replicate_msg(
         co_return cluster::errc::not_leader;
     }
 
-    auto ss = _raft->replicate_in_stages(_insync_term, std::move(batch), opts);
+    if (!opts.expected_term.has_value()) {
+        opts.expected_term = _insync_term;
+    }
+
+    auto ss = _raft->replicate_in_stages(std::move(batch), opts);
     co_await std::move(ss.request_enqueued);
     enqueued->set_value();
     auto r = co_await std::move(ss.replicate_finished);
@@ -1499,7 +1514,7 @@ ss::future<tx::errc> rm_stm::do_try_abort_old_tx(producer_ptr producer) {
                 auto batch = make_tx_control_batch(
                   pid, model::control_record_type::tx_commit);
                 auto cr = co_await _raft->replicate(
-                  synced_term, std::move(batch), make_replicate_options());
+                  std::move(batch), make_replicate_options(synced_term));
                 if (!cr) {
                     vlog(
                       _ctx_log.warn,
@@ -1538,7 +1553,7 @@ ss::future<tx::errc> rm_stm::do_try_abort_old_tx(producer_ptr producer) {
                 auto batch = make_tx_control_batch(
                   pid, model::control_record_type::tx_abort);
                 auto cr = co_await _raft->replicate(
-                  synced_term, std::move(batch), make_replicate_options());
+                  std::move(batch), make_replicate_options(synced_term));
                 if (!cr) {
                     vlog(
                       _ctx_log.warn,
@@ -1591,7 +1606,7 @@ ss::future<tx::errc> rm_stm::do_try_abort_old_tx(producer_ptr producer) {
           pid, model::control_record_type::tx_abort);
 
         auto cr = co_await _raft->replicate(
-          _insync_term, std::move(batch), make_replicate_options());
+          std::move(batch), make_replicate_options(_insync_term));
 
         if (!cr) {
             vlog(

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "raft/persisted_stm.h"
+#include "raft/replicate.h"
 #include "raft/state_machine.h"
 #include "storage/snapshot.h"
 #include "utils/available_promise.h"
@@ -278,8 +279,10 @@ private:
       raft::replicate_options,
       ss::lw_shared_ptr<available_promise<>>);
 
-    ss::future<result<kafka_result>>
-      transactional_replicate(model::batch_identity, model::record_batch);
+    ss::future<result<kafka_result>> transactional_replicate(
+      model::batch_identity,
+      model::record_batch,
+      std::optional<model::term_id>);
 
     ss::future<result<kafka_result>> transactional_replicate(
       model::term_id,
@@ -300,7 +303,6 @@ private:
       ss::lw_shared_ptr<available_promise<>>);
 
     ss::future<result<kafka_result>> do_idempotent_replicate(
-      model::term_id,
       tx::producer_ptr,
       model::batch_identity,
       model::record_batch,
@@ -310,7 +312,6 @@ private:
       producer_previously_known);
 
     ss::future<result<kafka_result>> idempotent_replicate(
-      model::term_id,
       tx::producer_ptr,
       model::batch_identity,
       model::record_batch,

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -30,9 +30,10 @@ namespace cluster {
 
 ss::future<result<raft::replicate_result>>
 tm_stm::replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
-    auto opts = raft::replicate_options{raft::consistency_level::quorum_ack};
+    auto opts = raft::replicate_options{
+      raft::consistency_level::quorum_ack, term};
     opts.set_force_flush();
-    return _raft->replicate(term, std::move(batch), opts);
+    return _raft->replicate(std::move(batch), opts);
 }
 
 model::record_batch tm_stm::serialize_tx(tx_metadata tx) {
@@ -143,9 +144,9 @@ tm_stm::quorum_write_empty_batch(model::timeout_clock::time_point timeout) {
     // replicate checkpoint batch
     return _raft
       ->replicate(
-        _insync_term,
         make_checkpoint(),
-        raft::replicate_options(raft::consistency_level::quorum_ack))
+        raft::replicate_options(
+          raft::consistency_level::quorum_ack, _insync_term))
       .then([this, timeout](ret_t r) {
           if (!r) {
               return ss::make_ready_future<ret_t>(r);

--- a/src/v/datalake/coordinator/state_machine.cc
+++ b/src/v/datalake/coordinator/state_machine.cc
@@ -82,9 +82,12 @@ ss::future<checked<std::nullopt_t, coordinator_stm::errc>>
 coordinator_stm::replicate_and_wait(
   model::term_id term, model::record_batch batch, ss::abort_source& as) {
     auto opts = raft::replicate_options(
-      raft::consistency_level::quorum_ack, std::ref(as));
+      raft::consistency_level::quorum_ack,
+      /*expected_term=*/term,
+      /*timeout=*/std::nullopt,
+      std::ref(as));
     opts.set_force_flush();
-    auto res = co_await _raft->replicate(term, std::move(batch), opts);
+    auto res = co_await _raft->replicate(std::move(batch), opts);
     if (res.has_error()) {
         co_return errc::raft_error;
     }

--- a/src/v/datalake/translation/state_machine.cc
+++ b/src/v/datalake/translation/state_machine.cc
@@ -20,10 +20,12 @@
 #include <seastar/core/future.hh>
 
 namespace {
-raft::replicate_options make_replicate_options(ss::abort_source& as) {
+raft::replicate_options
+make_replicate_options(model::term_id expected_term, ss::abort_source& as) {
     auto opts = raft::replicate_options(
       raft::consistency_level::quorum_ack, std::ref(as));
     opts.set_force_flush();
+    opts.expected_term = expected_term;
 
     return opts;
 }
@@ -148,9 +150,8 @@ ss::future<std::error_code> translation_stm::reset_highest_translated_offset(
         co_return raft::errc::success;
     }
     auto result = co_await _raft->replicate(
-      current_term,
       make_translation_state_batch(new_translated_offset, new_translated_ts),
-      make_replicate_options(as));
+      make_replicate_options(current_term, as));
     auto deadline = model::timeout_clock::now() + timeout;
     if (
       result

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1940,9 +1940,8 @@ group::begin_tx(cluster::begin_group_tx_request r) {
       r.pid, std::move(fence), use_dedicated_batch_type_for_fence());
 
     auto result = co_await _partition->raft()->replicate(
-      _term,
       std::move(batch),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 
     if (!result) {
         vlog(
@@ -2087,9 +2086,8 @@ group::store_txn_offsets(txn_offset_commit_request r) {
       std::move(tx_entry));
 
     auto result = co_await _partition->raft()->replicate(
-      _term,
       std::move(batch),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 
     if (!result) {
         if (
@@ -2287,9 +2285,8 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
     }
 
     auto replicate_stages = _partition->raft()->replicate_in_stages(
-      _term,
       chunked_vector<model::record_batch>::single(std::move(builder).build()),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 
     auto f = replicate_stages.replicate_finished.then(
       [this, req = std::move(r), commits = std::move(offset_commits)](
@@ -2670,9 +2667,8 @@ ss::future<error_code> group::remove() {
 
     try {
         auto result = co_await _partition->raft()->replicate(
-          _term,
           std::move(batch),
-          raft::replicate_options(raft::consistency_level::quorum_ack));
+          raft::replicate_options(raft::consistency_level::quorum_ack, _term));
         if (result) {
             vlog(
               cg_klog.trace,
@@ -2759,9 +2755,8 @@ ss::future<> group::remove_topic_partitions(
 
     try {
         auto result = co_await _partition->raft()->replicate(
-          _term,
           std::move(batch),
-          raft::replicate_options(raft::consistency_level::quorum_ack));
+          raft::replicate_options(raft::consistency_level::quorum_ack, _term));
         if (result) {
             vlog(
               cg_klog.trace,
@@ -2794,9 +2789,8 @@ ss::future<> group::remove_topic_partitions(
 ss::future<result<raft::replicate_result>>
 group::store_group(model::record_batch batch) {
     return _partition->raft()->replicate(
-      _term,
       std::move(batch),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 }
 
 error_code group::validate_existing_member(
@@ -3027,9 +3021,8 @@ ss::future<cluster::abort_group_tx_reply> group::do_abort(
       std::move(tx));
 
     auto result = co_await _partition->raft()->replicate(
-      _term,
       std::move(batch),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 
     if (!result) {
         vlog(
@@ -3180,9 +3173,8 @@ ss::future<cluster::commit_group_tx_reply> group::do_commit(
     batches.push_back(std::move(batch));
 
     auto result = co_await _partition->raft()->replicate(
-      _term,
       std::move(batches),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, _term));
 
     if (!result) {
         vlog(

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -384,9 +384,9 @@ ss::future<size_t> group_manager::delete_offsets(
 
     try {
         auto result = co_await group->partition()->raft()->replicate(
-          group->term(),
           std::move(batch),
-          raft::replicate_options(raft::consistency_level::leader_ack));
+          raft::replicate_options(
+            raft::consistency_level::leader_ack, group->term()));
 
         if (result) {
             vlog(
@@ -762,9 +762,8 @@ ss::future<result<model::offset>> group_manager::set_blocked_for_groups(
     }
 
     auto result = co_await p->partition->raft()->replicate(
-      p->term,
       std::move(builder).build(),
-      raft::replicate_options(raft::consistency_level::quorum_ack));
+      raft::replicate_options(raft::consistency_level::quorum_ack, p->term));
 
     if (!result) {
         co_return result.error();
@@ -1271,9 +1270,9 @@ ss::future<> group_manager::write_version_fence(
 
         try {
             auto result = co_await p->partition->raft()->replicate(
-              term,
               std::move(batch),
-              raft::replicate_options(raft::consistency_level::quorum_ack));
+              raft::replicate_options(
+                raft::consistency_level::quorum_ack, term));
 
             if (result) {
                 vlog(

--- a/src/v/kafka/server/write_at_offset_stm.cc
+++ b/src/v/kafka/server/write_at_offset_stm.cc
@@ -280,9 +280,12 @@ raft::replicate_stages write_at_offset_stm::try_replicate_in_stages(
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
     try {
         return _raft->replicate_in_stages(
-          _insync_term,
           std::move(batches),
-          raft::replicate_options(raft::consistency_level::quorum_ack, as));
+          raft::replicate_options(
+            raft::consistency_level::quorum_ack,
+            /*expected_term=*/_insync_term,
+            /*timeout=*/std::nullopt,
+            as));
     } catch (...) {
         vlog(
           _log.warn,

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -824,57 +824,23 @@ consensus::chain_stages(replicate_stages stages) {
 
 ss::future<result<replicate_result>> consensus::replicate(
   chunked_vector<model::record_batch> batches, replicate_options opts) {
-    return chain_stages(do_replicate({}, std::move(batches), opts));
+    return chain_stages(do_replicate(std::move(batches), opts));
 }
 ss::future<result<replicate_result>>
 consensus::replicate(model::record_batch batch, replicate_options opts) {
     return chain_stages(do_replicate(
-      {}, chunked_vector<model::record_batch>::single(std::move(batch)), opts));
-}
-
-ss::future<result<replicate_result>> consensus::replicate(
-  model::term_id expected_term,
-  model::record_batch batch,
-  replicate_options opts) {
-    return chain_stages(do_replicate(
-      expected_term,
-      chunked_vector<model::record_batch>::single(std::move(batch)),
-      opts));
-}
-
-ss::future<result<replicate_result>> consensus::replicate(
-  model::term_id expected_term,
-  chunked_vector<model::record_batch> batches,
-  replicate_options opts) {
-    return chain_stages(do_replicate(expected_term, std::move(batches), opts));
+      chunked_vector<model::record_batch>::single(std::move(batch)), opts));
 }
 
 replicate_stages consensus::replicate_in_stages(
   chunked_vector<model::record_batch> batches, replicate_options opts) {
-    return do_replicate({}, std::move(batches), opts);
+    return do_replicate(std::move(batches), opts);
 }
 
 replicate_stages consensus::replicate_in_stages(
   model::record_batch batch, replicate_options opts) {
     return do_replicate(
-      {}, chunked_vector<model::record_batch>::single(std::move(batch)), opts);
-}
-
-replicate_stages consensus::replicate_in_stages(
-  model::term_id expected_term,
-  chunked_vector<model::record_batch> batches,
-  replicate_options opts) {
-    return do_replicate(expected_term, std::move(batches), opts);
-}
-
-replicate_stages consensus::replicate_in_stages(
-  model::term_id expected_term,
-  model::record_batch batch,
-  replicate_options opts) {
-    return do_replicate(
-      expected_term,
-      chunked_vector<model::record_batch>::single(std::move(batch)),
-      opts);
+      chunked_vector<model::record_batch>::single(std::move(batch)), opts);
 }
 
 replicate_stages
@@ -890,9 +856,7 @@ wrap_stages_with_gate(ss::gate& gate, replicate_stages stages) {
       }));
 }
 replicate_stages consensus::do_replicate(
-  std::optional<model::term_id> expected_term,
-  chunked_vector<model::record_batch> batches,
-  replicate_options opts) {
+  chunked_vector<model::record_batch> batches, replicate_options opts) {
     // if gate is closed return fast, after this check we are certain that
     // `ss::with_gate` will succeed
     if (unlikely(_bg.is_closed())) {
@@ -921,7 +885,7 @@ replicate_stages consensus::do_replicate(
     }
 
     return wrap_stages_with_gate(
-      _bg, _batcher.replicate(expected_term, std::move(batches), opts));
+      _bg, _batcher.replicate(std::move(batches), opts));
 }
 
 ss::future<model::record_batch_reader>

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -256,25 +256,14 @@ public:
       follower_req_seq,
       model::offset);
 
-    ss::future<result<replicate_result>>
-      replicate(chunked_vector<model::record_batch>, replicate_options);
-    ss::future<result<replicate_result>>
-      replicate(model::record_batch, replicate_options);
-    replicate_stages replicate_in_stages(
-      chunked_vector<model::record_batch>, replicate_options);
-    replicate_stages
-      replicate_in_stages(model::record_batch, replicate_options);
-    uint64_t get_snapshot_size() const { return _snapshot_size; }
-
-    std::optional<state_machine_manager>& stm_manager() { return _stm_manager; }
-
     /**
-     * Replication happens only when expected_term matches the current _term
-     * otherwise consensus returns not_leader. This feature is needed to keep
-     * ingestion-time state machine in sync with the log. The conventional
-     * state machines running on top on the log are optimistic: to execute a
-     * command a user should add a command to a log (replicate) then continue
-     * reading the commands from the log and executing them one after another.
+     * Replication happens only when replicated_options::expected_term matches
+     * the current _term otherwise consensus returns not_leader.
+     * This feature is needed to keep ingestion-time state machine in sync
+     * with the log. The conventional state machines running on top on the log
+     * are optimistic: to execute a command a user should add a command to a
+     * log (replicate) then continue reading the commands from the log and
+     * executing them one after another.
      * When the commands are conditional the conventional approach is wasteful
      * because we even when a condition resolves to false we still pay the
      * replication costs. An alternative approach is to check the conditions
@@ -291,14 +280,19 @@ public:
      *      d. cache the term
      *      e. continue with step #1
      */
-    ss::future<result<replicate_result>> replicate(
-      model::term_id, chunked_vector<model::record_batch>, replicate_options);
     ss::future<result<replicate_result>>
-      replicate(model::term_id, model::record_batch, replicate_options);
+      replicate(chunked_vector<model::record_batch>, replicate_options);
+    ss::future<result<replicate_result>>
+      replicate(model::record_batch, replicate_options);
     replicate_stages replicate_in_stages(
-      model::term_id, chunked_vector<model::record_batch>, replicate_options);
-    replicate_stages replicate_in_stages(
-      model::term_id, model::record_batch, replicate_options);
+      chunked_vector<model::record_batch>, replicate_options);
+    replicate_stages
+      replicate_in_stages(model::record_batch, replicate_options);
+
+    uint64_t get_snapshot_size() const { return _snapshot_size; }
+
+    std::optional<state_machine_manager>& stm_manager() { return _stm_manager; }
+
     ss::future<model::record_batch_reader> make_reader(
       storage::local_log_reader_config,
       std::optional<clock_type::time_point> = std::nullopt);
@@ -625,10 +619,8 @@ private:
     append_entries_reply
       make_append_entries_reply(vnode, storage::append_result);
 
-    replicate_stages do_replicate(
-      std::optional<model::term_id>,
-      chunked_vector<model::record_batch>,
-      replicate_options);
+    replicate_stages
+      do_replicate(chunked_vector<model::record_batch>, replicate_options);
 
     ss::future<result<replicate_result>> chain_stages(replicate_stages);
 

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -252,9 +252,9 @@ ss::future<result<raft::replicate_result>> mux_state_machine<T...>::replicate(
       _gate, [this, batch = std::move(batch), term]() mutable {
           if (term) {
               return _c->replicate(
-                term.value(),
                 std::move(batch),
-                raft::replicate_options{raft::consistency_level::quorum_ack});
+                raft::replicate_options{
+                  raft::consistency_level::quorum_ack, term.value()});
           }
 
           return _c->replicate(

--- a/src/v/raft/replicate.h
+++ b/src/v/raft/replicate.h
@@ -40,6 +40,17 @@ struct replicate_options {
       , _force_flush(false)
       , as(as) {}
 
+    replicate_options(
+      consistency_level l,
+      std::optional<model::term_id> expected_term,
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt,
+      std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt)
+      : consistency(l)
+      , timeout(timeout)
+      , _force_flush(false)
+      , as(as)
+      , expected_term(expected_term) {}
+
     // Callers may choose to force flush on an individual replicate request
     // basis. This is useful if certain callers intend to override any
     // default behavior at global/topic scope.
@@ -53,6 +64,10 @@ struct replicate_options {
     std::optional<std::chrono::milliseconds> timeout;
     bool _force_flush;
     std::optional<std::reference_wrapper<ss::abort_source>> as;
+
+    /// If set, the replicate request will only be processed if the current
+    /// term matches the expected term.
+    std::optional<model::term_id> expected_term{std::nullopt};
 };
 
 struct replicate_result {

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -28,12 +28,10 @@ replicate_batcher::item::item(
   size_t record_count,
   chunked_vector<model::record_batch> batches,
   ssx::semaphore_units u,
-  std::optional<model::term_id> expected_term,
   replicate_options opts)
   : _record_count(record_count)
   , _data(std::move(batches))
   , _units(std::move(u))
-  , _expected_term(expected_term)
   , _replicate_opts(opts) {
     _timeout_timer.set_callback([this] { expire_with_timeout(); });
     if (_replicate_opts.timeout) {
@@ -89,9 +87,7 @@ replicate_batcher::replicate_batcher(consensus* ptr, size_t cache_size)
   , _max_batch_size(cache_size) {}
 
 replicate_stages replicate_batcher::replicate(
-  std::optional<model::term_id> expected_term,
-  chunked_vector<model::record_batch> batches,
-  replicate_options opts) {
+  chunked_vector<model::record_batch> batches, replicate_options opts) {
     if (opts.as) [[unlikely]] {
         if (opts.as->get().abort_requested()) {
             return replicate_stages{
@@ -104,20 +100,19 @@ replicate_stages replicate_batcher::replicate(
     auto enqueued_f = enqueued.get_future();
 
     auto f = cache_and_wait_for_result(
-      std::move(enqueued), expected_term, std::move(batches), opts);
+      std::move(enqueued), std::move(batches), opts);
     return {std::move(enqueued_f), std::move(f)};
 }
 
 ss::future<result<replicate_result>>
 replicate_batcher::cache_and_wait_for_result(
   ss::promise<> enqueued,
-  std::optional<model::term_id> expected_term,
   chunked_vector<model::record_batch> r,
   replicate_options opts) {
     item_ptr item;
     try {
         auto holder = _bg.hold();
-        item = co_await do_cache(expected_term, std::move(r), opts);
+        item = co_await do_cache(std::move(r), opts);
 
         // now request is already enqueued, we can release first
         // stage future
@@ -175,9 +170,7 @@ ss::future<> replicate_batcher::stop() {
 }
 
 ss::future<replicate_batcher::item_ptr> replicate_batcher::do_cache(
-  std::optional<model::term_id> expected_term,
-  chunked_vector<model::record_batch> batches,
-  replicate_options opts) {
+  chunked_vector<model::record_batch> batches, replicate_options opts) {
     size_t bytes = std::accumulate(
       batches.cbegin(),
       batches.cend(),
@@ -186,12 +179,11 @@ ss::future<replicate_batcher::item_ptr> replicate_batcher::do_cache(
           return sum + b.size_bytes();
       });
     co_return co_await do_cache_with_backpressure(
-      expected_term, std::move(batches), bytes, opts);
+      std::move(batches), bytes, opts);
 }
 
 ss::future<replicate_batcher::item_ptr>
 replicate_batcher::do_cache_with_backpressure(
-  std::optional<model::term_id> expected_term,
   chunked_vector<model::record_batch> batches,
   size_t bytes,
   replicate_options opts) {
@@ -223,7 +215,7 @@ replicate_batcher::do_cache_with_backpressure(
         record_count += b.record_count();
     }
     auto i = ss::make_lw_shared<item>(
-      record_count, std::move(batches), std::move(u), expected_term, opts);
+      record_count, std::move(batches), std::move(u), opts);
 
     _item_cache.emplace_back(i);
     co_return i;

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -30,7 +30,6 @@ public:
           size_t record_count,
           chunked_vector<model::record_batch> batches,
           ssx::semaphore_units u,
-          std::optional<model::term_id> expected_term,
           replicate_options opts);
 
         item(item&&) noexcept = default;
@@ -42,7 +41,7 @@ public:
         ~item() = default;
 
         std::optional<model::term_id> get_expected_term() const {
-            return _expected_term;
+            return _replicate_opts.expected_term;
         }
 
         size_t get_record_count() const { return _record_count; }
@@ -72,7 +71,6 @@ public:
         size_t _record_count;
         chunked_vector<model::record_batch> _data;
         ssx::semaphore_units _units;
-        std::optional<model::term_id> _expected_term;
         replicate_options _replicate_opts;
         /**
          * Item keeps semaphore units until replicate batcher is done with
@@ -93,10 +91,8 @@ public:
     replicate_batcher& operator=(const replicate_batcher&) = delete;
     ~replicate_batcher() noexcept = default;
 
-    replicate_stages replicate(
-      std::optional<model::term_id>,
-      chunked_vector<model::record_batch>,
-      replicate_options);
+    replicate_stages
+      replicate(chunked_vector<model::record_batch>, replicate_options);
 
     ss::future<> flush(ssx::semaphore_units u, const bool transfer_flush);
 
@@ -109,20 +105,14 @@ private:
       std::vector<ssx::semaphore_units>,
       absl::flat_hash_map<vnode, follower_req_seq>);
 
-    ss::future<item_ptr> do_cache(
-      std::optional<model::term_id>,
-      chunked_vector<model::record_batch>,
-      replicate_options);
+    ss::future<item_ptr>
+      do_cache(chunked_vector<model::record_batch>, replicate_options);
 
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
-      std::optional<model::term_id>,
-      chunked_vector<model::record_batch>,
-      size_t,
-      replicate_options);
+      chunked_vector<model::record_batch>, size_t, replicate_options);
 
     ss::future<result<replicate_result>> cache_and_wait_for_result(
       ss::promise<> enqueued,
-      std::optional<model::term_id> expected_term,
       chunked_vector<model::record_batch> r,
       replicate_options);
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -1045,9 +1045,8 @@ TEST_F_CORO(raft_fixture, test_term_conditional_replication) {
     auto term = leader_node.raft()->term();
     // this should succeed as there were no leadership changes
     auto result = co_await leader_node.raft()->replicate(
-      term,
       make_batches(10, 10, 128),
-      replicate_options(consistency_level::quorum_ack, 10s));
+      replicate_options(consistency_level::quorum_ack, term, 10s));
 
     ASSERT_TRUE_CORO(result.has_value());
     /**
@@ -1063,9 +1062,8 @@ TEST_F_CORO(raft_fixture, test_term_conditional_replication) {
     auto new_leader_id = co_await wait_for_leader(10s);
     ASSERT_EQ_CORO(new_leader_id, leader_id);
     auto result_with_term = co_await leader_node.raft()->replicate(
-      term,
       make_batches(10, 10, 128),
-      replicate_options(consistency_level::quorum_ack, 10s));
+      replicate_options(consistency_level::quorum_ack, term, 10s));
 
     // Replication must fail as the term was increased in leader election
     ASSERT_TRUE_CORO(result_with_term.has_error());

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -153,9 +153,8 @@ public:
         }
 
         auto r_result = co_await _raft->replicate(
-          _insync_term,
           build_batch({std::move(op)}),
-          replicate_options(consistency_level::quorum_ack));
+          replicate_options(consistency_level::quorum_ack, _insync_term));
         if (!r_result) {
             co_return r_result.error();
         }


### PR DESCRIPTION
This PR adds plumbing required to pass expected term using the `raft::replicate_options` struct instead of using a dedicated `replicate` or `replicate_in_stages` overload. It uses this field to replicate placeholder batches with specified term.

The alternative is to keep `replicate` and `repicate_in_stages` overloads. I don't like this because the same parameter can now be passed using two different means (vial parameter or via the `replicate_options` struct).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none