### PR TITLE
rptest: add e2e datalake test for field names compat

### DIFF
--- a/tests/rptest/tests/datalake/datalake_e2e_test.py
+++ b/tests/rptest/tests/datalake/datalake_e2e_test.py
@@ -606,16 +606,24 @@ class DatalakeE2ETests(RedpandaTest):
                 spark_describe_out = spark.run_query_fetch_all(f"describe {table_name}")
                 assert spark_describe_out == spark_expected_out, str(spark_describe_out)
 
-    # Run json unicode tests with all combinations of query engine and catalog type
-    # because it is the only format that supports unicode characters in field names
-    # and we want to ensure that everyone interoperates correctly with unicode.
+    # We use json because it is the only format that supports unicode
+    # characters in field names and we want to ensure that everyone
+    # interoperates correctly with unicode.
     @cluster(num_nodes=3)
     @matrix(
         cloud_storage_type=supported_storage_types(),
         query_engine=[QueryEngineType.SPARK, QueryEngineType.TRINO],
         catalog_type=supported_catalog_types(),
     )
-    def test_json_schema_unicode(self, cloud_storage_type, query_engine, catalog_type):
+    def test_field_names_compat(self, cloud_storage_type, query_engine, catalog_type):
+        """
+        Test that field names with dots, mixed case, and unicode characters are
+        handled correctly. We are mainly interested in the catalog preserving
+        the original field names so that schema evolution (field name matching)
+        works.
+        Known offender is AWS Glue which forces field names to be lowercase thus
+        breaking schema evolution. Not yet tested here but should be in future.
+        """
         count = 100
 
         schema_str = """{
@@ -623,19 +631,22 @@ class DatalakeE2ETests(RedpandaTest):
             "type": "object",
             "properties": {
                 "my_🍀_number": {"type": "integer"},
-                "col.with.dots": {"type": "integer"}
+                "col.with.dots": {"type": "integer"},
+                "MixedCase": {"type": "integer"}
             },
-            "required": ["my_🍀_number", "col.with.dots"]
+            "required": ["my_🍀_number", "col.with.dots", "MixedCase"]
         }"""
 
         def record_generator(t):
             return {
                 "my_🍀_number": int(t),
                 "col.with.dots": int(t),
+                "MixedCase": int(t),
             }
 
         expected_spark = [
             SPARK_RP_FIELD_TYPE,
+            ("MixedCase", "bigint", None),
             ("col.with.dots", "bigint", None),
             ("my_🍀_number", "bigint", None),
             ("", "", ""),
@@ -645,6 +656,11 @@ class DatalakeE2ETests(RedpandaTest):
 
         expected_trino = [
             TRINO_RP_FIELD_TYPE,
+            # Trino forces lowercase column names. Since this is just a query
+            # engine it does not affect the schema evolution in the catalog.
+            # However, if the table contains both `MixedCase` and `mixedcase`
+            # columns then Trino fails to query the table.
+            ("mixedcase", "bigint", "", ""),
             ("col.with.dots", "bigint", "", ""),
             ("my_🍀_number", "bigint", "", ""),
         ]
@@ -686,11 +702,12 @@ class DatalakeE2ETests(RedpandaTest):
                 assert spark_describe_out == expected_spark, str(spark_describe_out)
 
                 with spark.run_query(
-                    f"SELECT `my_🍀_number`, `col.with.dots` FROM {table_name} LIMIT 1"
+                    f"SELECT `my_🍀_number`, `col.with.dots`, `MixedCase` FROM {table_name} LIMIT 1"
                 ) as cursor:
                     assert cursor.description == [
                         ("my_🍀_number", "BIGINT_TYPE", None, None, None, None, True),
                         ("col.with.dots", "BIGINT_TYPE", None, None, None, None, True),
+                        ("MixedCase", "BIGINT_TYPE", None, None, None, None, True),
                     ]
                     row = cursor.fetchone()
                     assert row is not None
@@ -703,11 +720,12 @@ class DatalakeE2ETests(RedpandaTest):
                 assert trino_describe_out == expected_trino, str(trino_describe_out)
 
                 with trino.run_query(
-                    f"""SELECT "my_🍀_number", "col.with.dots" FROM {table_name} LIMIT 1"""
+                    f"""SELECT "my_🍀_number", "col.with.dots", "MixedCase" FROM {table_name} LIMIT 1"""
                 ) as cursor:
                     assert cursor.description == [
                         ("my_🍀_number", "bigint", None, None, None, None, True),
                         ("col.with.dots", "bigint", None, None, None, None, True),
+                        ("MixedCase", "bigint", None, None, None, None, True),
                     ]
                     row = cursor.fetchone()
                     assert row is not None


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
