### PR TITLE
{storage,compaction}/types: add max tombstone removal offset to config

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -252,6 +252,7 @@ TEST_P(EndToEndFixture, TestProduceConsumeFromCloud) {
       model::timestamp::min(),
       1,
       log->stm_manager()->max_removable_local_log_offset(),
+      log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -698,6 +699,7 @@ TEST_P(CloudStorageEndToEndManualTest, TestTimequeryAfterArchivalGC) {
       model::timestamp::min(),
       1, // max_bytes_in_log
       log->stm_manager()->max_removable_local_log_offset(),
+      log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -1009,6 +1011,7 @@ TEST_P(EndToEndFixture, TestCloudStorageTimequery) {
     storage::housekeeping_config housekeeping_conf(
       model::timestamp::max(),
       0,
+      log->stm_manager()->max_removable_local_log_offset(),
       log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,

--- a/src/v/cluster/archival/tests/async_data_uploader_fixture.h
+++ b/src/v/cluster/archival/tests/async_data_uploader_fixture.h
@@ -169,6 +169,7 @@ public:
           model::timestamp::min(),
           std::nullopt,
           max_collect_offset,
+          max_collect_offset,
           std::nullopt,
           std::nullopt,
           std::chrono::milliseconds{0},

--- a/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/cluster/archival/tests/ntp_archiver_reupload_test.cc
@@ -254,6 +254,7 @@ struct reupload_fixture : public archiver_fixture {
               model::timestamp::max(),
               std::nullopt,
               max_removable,
+              max_removable,
               std::nullopt,
               std::nullopt,
               std::chrono::milliseconds{0},

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -97,6 +97,7 @@ struct manual_deletion_fixture : public raft::raft_fixture {
                 retention_timestamp,
                 100_MiB,
                 model::offset::max(),
+                model::offset::max(),
                 std::nullopt,
                 std::nullopt,
                 std::chrono::milliseconds{0},

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -102,12 +102,16 @@ public:
                 return ss::make_ready_future<>();
             }
             return log->apply_segment_ms().then([&] {
+                // TODO: for now max_tombstone_remove_offset is set to
+                // max_removable_local_log_offset, change when coordinated
+                // compaction is implemented
                 return log
                   ->housekeeping(
                     storage::housekeeping_config{
                       model::timestamp(
                         model::timestamp::now().value() - ret_duration.count()),
                       std::nullopt,
+                      log->stm_manager()->max_removable_local_log_offset(),
                       log->stm_manager()->max_removable_local_log_offset(),
                       std::nullopt,
                       std::nullopt,
@@ -237,6 +241,7 @@ public:
         storage::housekeeping_config ccfg(
           model::timestamp::min(),
           std::nullopt,
+          model::offset::max(),
           model::offset::max(),
           std::nullopt,
           std::nullopt,

--- a/src/v/compaction/types.cc
+++ b/src/v/compaction/types.cc
@@ -22,10 +22,12 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
     fmt::print(
       o,
       "{{max_removable_local_log_offset:{}, "
+      "max_tombstone_remove_offset:{}, "
       "should_sanitize:{}, "
       "tombstone_retention_ms:{}, "
       "tx_retention_ms:{}}}",
       c.max_removable_local_log_offset,
+      c.max_tombstone_remove_offset,
       c.sanitizer_config,
       c.tombstone_retention_ms,
       c.tx_retention_ms);

--- a/src/v/compaction/types.h
+++ b/src/v/compaction/types.h
@@ -24,6 +24,7 @@ namespace compaction {
 struct compaction_config {
     compaction_config(
       model::offset max_collect_offset,
+      model::offset max_tombstone_remove_offset,
       std::optional<std::chrono::milliseconds> tombstone_ret_ms,
       std::optional<std::chrono::milliseconds> tx_ret_ms,
       ss::abort_source& as,
@@ -33,6 +34,7 @@ struct compaction_config {
       hash_key_offset_map* key_map = nullptr,
       storage::scoped_file_tracker::set_t* to_clean = nullptr)
       : max_removable_local_log_offset(max_collect_offset)
+      , max_tombstone_remove_offset(max_tombstone_remove_offset)
       , tombstone_retention_ms(tombstone_ret_ms)
       , tx_retention_ms(tx_ret_ms)
       , sanitizer_config(std::move(san_cfg))
@@ -45,6 +47,9 @@ struct compaction_config {
     // Cannot delete or compact past this offset (i.e. for unresolved txn
     // records): that is, only offsets <= this may be compacted.
     model::offset max_removable_local_log_offset;
+
+    // Cannot remove tombstones past this offset
+    model::offset max_tombstone_remove_offset;
 
     // The retention time for tombstones. Tombstone removal occurs only for
     // "clean" compacted segments past the tombstone deletion horizon timestamp,

--- a/src/v/kafka/server/tests/group_tx_compaction_test.cc
+++ b/src/v/kafka/server/tests/group_tx_compaction_test.cc
@@ -351,6 +351,7 @@ ss::future<> run_workload(
                   model::timestamp::max(),
                   std::nullopt,
                   log->stm_manager()->max_removable_local_log_offset(),
+                  log->stm_manager()->max_removable_local_log_offset(),
                   std::nullopt,
                   std::nullopt,
                   std::chrono::milliseconds{0},

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -429,6 +429,11 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         }
         model::offset max_compactible_offset
           = current_log.handle->stm_manager()->max_removable_local_log_offset();
+        // TODO: for now max_tombstone_remove_offset is set to
+        // max_removable_local_log_offset, change when coordinated compaction is
+        // implemented
+        model::offset max_tombstone_remove_offset
+          = current_log.handle->stm_manager()->max_removable_local_log_offset();
         if (
           max_unpinned_offset
           && *max_unpinned_offset < max_compactible_offset) {
@@ -446,6 +451,7 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
           collection_threshold,
           _config.retention_bytes(),
           max_compactible_offset,
+          max_tombstone_remove_offset,
           current_log.handle->config().tombstone_retention_ms(),
           current_log.handle->config().tx_retention_ms(),
           current_log.handle->config().min_compaction_lag_ms(),

--- a/src/v/storage/opfuzz/opfuzz.cc
+++ b/src/v/storage/opfuzz/opfuzz.cc
@@ -501,6 +501,7 @@ struct compact_op final : opfuzz::op {
           model::timestamp::max(),
           std::nullopt,
           model::offset::max(),
+          model::offset::max(),
           std::nullopt,
           std::nullopt,
           std::chrono::milliseconds{0},

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -1383,7 +1383,9 @@ bool is_past_tombstone_delete_horizon(
   ss::lw_shared_ptr<segment> seg, const compaction::compaction_config& cfg) {
     if (
       seg->has_clean_compact_timestamp()
-      && cfg.tombstone_retention_ms.has_value()) {
+      && cfg.tombstone_retention_ms.has_value()
+      && seg->offsets().get_stable_offset()
+           <= cfg.max_tombstone_remove_offset) {
         const auto now = model::to_time_point(model::timestamp::now());
         return (now
                 - model::to_time_point(

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -76,6 +76,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       first_log->stm_manager()->max_removable_local_log_offset(),
+      first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -127,6 +128,7 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     storage::housekeeping_config conf2(
       model::timestamp::min(),
       std::nullopt,
+      new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,
@@ -202,6 +204,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
       model::timestamp::min(),
       std::nullopt,
       first_log->stm_manager()->max_removable_local_log_offset(),
+      first_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -231,6 +234,7 @@ FIXTURE_TEST(compact_transactions_and_replicate, compaction_multinode_test) {
     storage::housekeeping_config conf2(
       model::timestamp::min(),
       std::nullopt,
+      new_log->stm_manager()->max_removable_local_log_offset(),
       new_log->stm_manager()->max_removable_local_log_offset(),
       std::nullopt,
       std::nullopt,

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -246,6 +246,7 @@ public:
         ss::abort_source never_abort;
         compaction::compaction_config cfg(
           max_collect_offset,
+          max_collect_offset,
           tombstone_ret_ms,
           std::nullopt,
           never_abort,
@@ -267,6 +268,7 @@ public:
       std::optional<size_t> max_keys = std::nullopt) {
         ss::abort_source never_abort;
         compaction::compaction_config cfg(
+          max_collect_offset,
           max_collect_offset,
           tombstone_ret_ms,
           std::nullopt,
@@ -311,6 +313,7 @@ TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
     ss::abort_source never_abort;
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     compaction::compaction_config cfg(
+      disk_log.segments().back()->offsets().get_base_offset(),
       disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
@@ -383,6 +386,7 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPass) {
     ss::abort_source never_abort;
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     compaction::compaction_config cfg(
+      disk_log.segments().back()->offsets().get_base_offset(),
       disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
@@ -519,6 +523,7 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPassAddedSegment) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     compaction::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
       never_abort,
@@ -616,6 +621,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     compaction::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
       never_abort,
@@ -635,6 +641,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     // But once we add more data, we become eligible for compaction again.
     generate_data(1, cardinality, records_per_segment).get();
     compaction::compaction_config new_cfg(
+      disk_log.segments().back()->offsets().get_base_offset(),
       disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
@@ -679,6 +686,7 @@ TEST_F(CompactionFixtureTest, TestCompactWithNonDataBatches) {
     auto before_compaction_count
       = disk_log.get_probe().get_segments_compacted();
     compaction::compaction_config new_cfg(
+      disk_log.segments().back()->offsets().get_base_offset(),
       disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
@@ -764,6 +772,7 @@ TEST_P(CompactionFilledReaderTest, ReadFilledGaps) {
     // when reading.
     compaction::compaction_config cfg(
       disk_log.segments().back()->offsets().get_base_offset(),
+      disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
       never_abort,
@@ -818,6 +827,7 @@ TEST_F(CompactionFixtureTest, TestReadFilledGapsWithTerms) {
     }
 
     compaction::compaction_config cfg(
+      disk_log.segments().back()->offsets().get_base_offset(),
       disk_log.segments().back()->offsets().get_base_offset(),
       std::nullopt,
       std::nullopt,
@@ -1576,7 +1586,11 @@ TEST_F(CompactionFixtureTest, TestSlidingWindowNoUnecessaryRewrites) {
     auto& segments = disk_log.segments();
 
     compaction::compaction_config cfg(
-      model::offset::max(), std::nullopt, std::nullopt, never_abort);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      never_abort);
 
     for (auto& seg : segments) {
         if (!seg->has_appender()) {
@@ -1683,6 +1697,7 @@ TEST_F(CompactionFixtureParamTest, TestSegmentConcatenation) {
     ss::abort_source never_abort;
     compaction::compaction_config cfg(
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       never_abort,
@@ -1723,6 +1738,7 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompaction) {
     ss::abort_source never_abort;
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     compaction::compaction_config cfg(
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -1813,6 +1829,7 @@ TEST_F(CompactionFixtureTest, TestAdjacentCompactionMultipleRanges) {
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     compaction::compaction_config cfg(
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       never_abort,
@@ -1880,7 +1897,11 @@ TEST_F(
     auto do_adjacent_compact = [](const auto& l) {
         ss::abort_source never_abort;
         compaction::compaction_config cfg(
-          model::offset::max(), std::nullopt, std::nullopt, never_abort);
+          model::offset::max(),
+          model::offset::max(),
+          std::nullopt,
+          std::nullopt,
+          never_abort);
 
         const auto closed_segment_filter = [](const auto& s) -> bool {
             return !s->has_appender();
@@ -2100,7 +2121,11 @@ TEST_F(CompactionFixtureTest, TestBatchCacheResetAfterAdjacentMerge) {
 
     ss::abort_source never_abort;
     compaction::compaction_config cfg(
-      model::offset::max(), std::nullopt, std::nullopt, never_abort);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      never_abort);
 
     // self compact everything up front so that it doesn't happen inline with
     // adjacent merge compaction. this would cause batch caches to be reset

--- a/src/v/storage/tests/compaction_fuzz_test.cc
+++ b/src/v/storage/tests/compaction_fuzz_test.cc
@@ -159,7 +159,11 @@ ss::future<ot_state> arrange_and_compact(
             }
         }
         auto compact_cfg = compaction::compaction_config(
-          batches.back().last_offset(), std::nullopt, std::nullopt, as);
+          batches.back().last_offset(),
+          batches.back().last_offset(),
+          std::nullopt,
+          std::nullopt,
+          as);
         std::ignore = co_await b1.apply_sliding_window_compaction(compact_cfg);
         co_await b1.apply_adjacent_merge_compaction(compact_cfg);
     } catch (...) {

--- a/src/v/storage/tests/compaction_reducer_fixture_test.cc
+++ b/src/v/storage/tests/compaction_reducer_fixture_test.cc
@@ -60,7 +60,11 @@ TEST_F(MapBuildingReducerFixtureTest, TestMapIndexing) {
     static constexpr int64_t max_keys = 4;
     compaction::simple_key_offset_map map(max_keys);
     compaction::compaction_config compact_cfg(
-      model::offset::max(), std::nullopt, std::nullopt, as);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      as);
     auto pb = storage::probe{};
 
     auto last_indexed_offset = model::offset{-1};

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -256,6 +256,7 @@ TEST_F(log_builder_fixture, test_skipping_compaction_below_start_offset) {
       model::timestamp::max(),
       1,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -341,6 +341,7 @@ TEST_F(
         ts,
         std::nullopt,
         model::offset::max(),
+        model::offset::max(),
         std::nullopt,
         std::nullopt,
         std::chrono::milliseconds{0},
@@ -514,6 +515,7 @@ TEST_F(storage_test_fixture, test_concurrent_prefix_truncate_and_gc) {
       ts,
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       std::chrono::milliseconds{0},
@@ -564,7 +566,11 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
     // leaving room for further windowed compaction.
     ss::abort_source as;
     compaction::compaction_config compaction_cfg(
-      model::offset::max(), std::nullopt, std::nullopt, as);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      as);
     auto& disk_log = *dynamic_cast<disk_log_impl*>(log.get());
     disk_log.adjacent_merge_compact(disk_log.segments().copy(), compaction_cfg)
       .get();
@@ -584,6 +590,7 @@ TEST_F(storage_test_fixture, test_concurrent_truncate_and_compaction) {
     housekeeping_config housekeeping_cfg(
       ts,
       std::nullopt,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,

--- a/src/v/storage/tests/segment_concatenation_test.cc
+++ b/src/v/storage/tests/segment_concatenation_test.cc
@@ -126,7 +126,11 @@ void concatenate_segments_from_log(
   storage::kvstore& kvs,
   bool maybe_compress) {
     compaction::compaction_config cfg(
-      model::offset::max(), std::nullopt, std::nullopt, never_abort);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      never_abort);
 
     const auto closed_segment_filter = [](const auto& s) -> bool {
         return !s->has_appender();

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -114,7 +114,11 @@ TEST(FindSlidingRangeTest, TestCollectSegments) {
     for (int start = 0; start < 30; start += 5) {
         for (int end = start; end < 30; end += 5) {
             compaction::compaction_config cfg(
-              model::offset{end}, std::nullopt, std::nullopt, never_abort);
+              model::offset{end},
+              model::offset{end},
+              std::nullopt,
+              std::nullopt,
+              never_abort);
             auto segs = disk_log.find_sliding_range(cfg, model::offset{start});
             if (end - start < 10) {
                 // If the compactible range isn't a full segment, we can't
@@ -136,7 +140,11 @@ TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(3, segs.size());
     ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
@@ -165,7 +173,11 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(5, segs.size());
 
@@ -206,7 +218,11 @@ TEST(FindSlidingRangeTest, TestPlaceholderBatchesNoCompactibleRecords) {
     auto& disk_log = b.get_disk_log_impl();
     auto cleanup = ss::defer([&] { b.stop().get(); });
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
 
     ASSERT_EQ(disk_log.segment_count(), num_placeholder_batches);
 
@@ -226,7 +242,11 @@ TEST(FindSlidingRangeTest, TestEmptySegmentNoCompactibleRecords) {
     auto& disk_log = b.get_disk_log_impl();
     auto cleanup = ss::defer([&] { b.stop().get(); });
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
 
     ASSERT_EQ(disk_log.segment_count(), 1);
 
@@ -249,7 +269,7 @@ TEST(FindSlidingRangeTest, TestAllCleanlyCompactedSegments) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction::compaction_config cfg(
-      model::offset{30}, 1ms, std::nullopt, never_abort);
+      model::offset{30}, model::offset{30}, 1ms, std::nullopt, never_abort);
     auto segs = disk_log.find_sliding_range(cfg, model::offset{0});
     // All cleanly compacted segments are still considered in the range.
     ASSERT_EQ(segs.size(), num_segs);
@@ -263,7 +283,11 @@ TEST(FindSlidingRangeTest, TestCompactionLastSegmentNotCompacted) {
     auto cleanup = ss::defer([&] { b.stop().get(); });
     auto& disk_log = b.get_disk_log_impl();
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(3, segs.size());
     ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
@@ -296,7 +320,7 @@ TEST(FindSlidingRangeTest, TestWindowWithRemovedSegments) {
     disk_log.segments().pop_front();
 
     compaction::compaction_config cfg(
-      model::offset{30}, 1ms, std::nullopt, never_abort);
+      model::offset{30}, model::offset{30}, 1ms, std::nullopt, never_abort);
     auto segs = disk_log.find_sliding_range(cfg, model::offset{0});
 
     // We should have reset the compaction window start offset, and had the
@@ -321,7 +345,7 @@ TEST(FindSlidingRangeTest, TestWindowWithTruncatedSegments) {
     disk_log.truncate_prefix(trunc_cfg).get();
 
     compaction::compaction_config cfg(
-      model::offset{30}, 1ms, std::nullopt, never_abort);
+      model::offset{30}, model::offset{30}, 1ms, std::nullopt, never_abort);
     auto segs = disk_log.find_sliding_range(cfg, model::offset{0});
 
     // We should have reset the compaction window start offset, and had the
@@ -349,7 +373,11 @@ TEST(BuildOffsetMap, TestBuildSimpleMap) {
     auto& disk_log = b.get_disk_log_impl();
     auto& segs = disk_log.segments();
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     probe pb;
 
     feature_table.start().get();
@@ -406,7 +434,11 @@ TEST(BuildOffsetMap, TestBuildMapWithMissingCompactedIndex) {
     auto& disk_log = b.get_disk_log_impl();
     auto& segs = disk_log.segments();
     compaction::compaction_config cfg(
-      model::offset{30}, std::nullopt, std::nullopt, never_abort);
+      model::offset{30},
+      model::offset{30},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     for (const auto& s : segs) {
         auto idx_path = s->path().to_compacted_index();
         ASSERT_FALSE(ss::file_exists(idx_path.string()).get());
@@ -448,7 +480,11 @@ TEST(DeduplicateSegmentsTest, TestBadReader) {
 
     // Build an offset map for our log.
     compaction::compaction_config cfg(
-      model::offset{0}, std::nullopt, std::nullopt, never_abort);
+      model::offset{0},
+      model::offset{0},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     compaction::simple_key_offset_map all_segs_map(50);
     auto map_start_offset = build_offset_map(
                               cfg,
@@ -510,7 +546,11 @@ TEST(DeduplicateSegmentsTest, SegmentNeedsRewriteNoCompactedIndex) {
     auto& segs = disk_log.segments();
     auto& seg = segs[0];
     compaction::compaction_config cfg(
-      model::offset{0}, std::nullopt, std::nullopt, never_abort);
+      model::offset{0},
+      model::offset{0},
+      std::nullopt,
+      std::nullopt,
+      never_abort);
     compaction::simple_key_offset_map map(50);
 
     // When the .compaction_index file doesn't exist, the segment should assume

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -98,6 +98,7 @@ FIXTURE_TEST(test_concurrent_log_eviction_and_append, storage_e2e_fixture) {
       /*gc_upper=*/model::timestamp::max(),
       /*max_bytes_in_log=*/1,
       /*max_collect_offset=*/model::offset::min(),
+      /*max_tombstone_remove_offset=*/model::offset::min(),
       /*tombstone_retention_ms=*/std::nullopt,
       /*tx_retention_ms=*/std::nullopt,
       /*min_lag_ms=*/std::chrono::milliseconds{0},

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -678,6 +678,7 @@ TEST_F(storage_test_fixture, test_time_based_eviction) {
       model::to_timestamp(broker_t0 - (2 * broker_ts_sep)),
       std::nullopt,
       model::offset::min(), // should prevent compaction
+      model::offset::min(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -693,6 +694,7 @@ TEST_F(storage_test_fixture, test_time_based_eviction) {
           return storage::housekeeping_config(
             model::to_timestamp(timestamp),
             std::nullopt,
+            model::offset::max(),
             model::offset::max(),
             std::nullopt,
             std::nullopt,
@@ -748,6 +750,7 @@ TEST_F(storage_test_fixture, test_size_based_eviction) {
       model::timestamp::min(),
       total_size + first_size,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -778,6 +781,7 @@ TEST_F(storage_test_fixture, test_size_based_eviction) {
     storage::housekeeping_config ccfg(
       model::timestamp::min(),
       max_size,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -851,6 +855,7 @@ TEST_F(storage_test_fixture, test_eviction_notification) {
     storage::housekeeping_config ccfg(
       gc_ts,
       std::nullopt,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -953,6 +958,7 @@ TEST_F(storage_test_fixture, write_concurrently_with_gc) {
         storage::housekeeping_config ccfg(
           model::timestamp::min(),
           1000,
+          model::offset::max(),
           model::offset::max(),
           std::nullopt,
           std::nullopt,
@@ -1247,6 +1253,7 @@ TEST_F(storage_test_fixture, test_compaction_preserve_state) {
       model::timestamp::min(),
       1,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -1411,6 +1418,7 @@ TEST_F(storage_test_fixture, compacted_log_truncation) {
           model::timestamp::min(),
           std::nullopt,
           model::offset::max(),
+          model::offset::max(),
           std::nullopt,
           std::nullopt,
           0ms,
@@ -1478,6 +1486,7 @@ TEST_F(storage_test_fixture, check_segment_roll_after_compacted_log_truncate) {
     storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -1667,6 +1676,7 @@ TEST_F(storage_test_fixture, partition_size_while_cleanup) {
       model::timestamp::min(),
       50_KiB,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -1790,6 +1800,7 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -1856,6 +1867,7 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction_terms) {
     storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -1930,6 +1942,7 @@ TEST_F(storage_test_fixture, max_adjacent_segment_compaction) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -1991,7 +2004,11 @@ TEST_F(storage_test_fixture, adjacent_segment_compaction_range_u32_bounds) {
 
     ss::abort_source as;
     compaction::compaction_config cfg(
-      model::offset::max(), std::nullopt, std::nullopt, as);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      as);
     auto ranges = disk_log->find_adjacent_compaction_ranges(cfg);
     ASSERT_TRUE(!ranges.has_value());
 
@@ -2188,6 +2205,7 @@ TEST_F(storage_test_fixture, compaction_backlog_calculation) {
     storage::housekeeping_config c_cfg(
       model::timestamp::min(),
       std::nullopt,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -2533,6 +2551,7 @@ TEST_F(storage_test_fixture, changing_cleanup_policy_back_and_forth) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -2775,6 +2794,7 @@ TEST_F(storage_test_fixture, test_compacting_batches_of_different_types) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -3014,6 +3034,7 @@ TEST_F(storage_test_fixture, write_truncate_compact) {
                                model::timestamp::min(),
                                std::nullopt,
                                model::offset::max(),
+                               model::offset::max(),
                                std::nullopt,
                                std::nullopt,
                                0ms,
@@ -3180,6 +3201,7 @@ TEST_F(storage_test_fixture, compaction_non_raft_batches_regression_test) {
       model::timestamp::min(),
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -3267,6 +3289,7 @@ TEST_F(storage_test_fixture, compaction_truncation_corner_cases) {
               storage::housekeeping_config(
                 model::timestamp::min(),
                 std::nullopt,
+                model::offset::max(),
                 model::offset::max(),
                 std::nullopt,
                 std::nullopt,
@@ -3397,6 +3420,7 @@ TEST_F(storage_test_fixture, test_max_compact_offset) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       max_compact_offset,
+      max_compact_offset,
       std::nullopt,
       std::nullopt,
       0ms,
@@ -3465,6 +3489,7 @@ TEST_F(storage_test_fixture, test_self_compaction_while_reader_is_open) {
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
       model::offset::max(),
+      model::offset::max(),
       std::nullopt,
       std::nullopt,
       0ms,
@@ -3518,6 +3543,7 @@ TEST_F(storage_test_fixture, test_simple_compaction_rebuild_index) {
     storage::housekeeping_config ccfg(
       model::timestamp::min(),
       std::nullopt,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -3614,6 +3640,7 @@ do_compact_test(const compact_test_args args, storage_test_fixture& f) {
     storage::housekeeping_config ccfg(
       model::timestamp::max(), // no time-based deletion
       std::nullopt,
+      model::offset(args.max_compact_offs),
       model::offset(args.max_compact_offs),
       std::nullopt,
       std::nullopt,
@@ -3899,6 +3926,7 @@ TEST_F(storage_test_fixture, test_bytes_eviction_overrides) {
           storage::housekeeping_config(
             model::timestamp::min(),
             cfg.retention_bytes(),
+            model::offset::max(),
             model::offset::max(),
             std::nullopt,
             std::nullopt,
@@ -4638,6 +4666,7 @@ TEST_F(storage_test_fixture, test_offset_range_size_compacted) {
       model::timestamp::min(),
       std::nullopt,
       log->offsets().committed_offset,
+      log->offsets().committed_offset,
       std::nullopt,
       std::nullopt,
       0ms,
@@ -4834,6 +4863,7 @@ TEST_F(storage_test_fixture, test_offset_range_size2_compacted) {
     storage::housekeeping_config h_cfg(
       model::timestamp::min(),
       std::nullopt,
+      log->offsets().committed_offset,
       log->offsets().committed_offset,
       std::nullopt,
       std::nullopt,
@@ -5260,7 +5290,11 @@ TEST_F(storage_test_fixture, dirty_ratio) {
         // Perform sliding window compaction, which will fully cleanly compact
         // the log.
         static const compaction::compaction_config compact_cfg(
-          model::offset::max(), std::nullopt, std::nullopt, as);
+          model::offset::max(),
+          model::offset::max(),
+          std::nullopt,
+          std::nullopt,
+          as);
         disk_log->sliding_window_compact(compact_cfg).get();
 
         dirty_segments_size_bytes = 0;
@@ -5376,6 +5410,7 @@ TEST_F(storage_test_fixture, dirty_and_closed_bytes_bookkeeping) {
     housekeeping_config cfg{
       model::timestamp::max(),
       1,
+      model::offset::max(),
       model::offset::max(),
       std::nullopt,
       std::nullopt,
@@ -6322,7 +6357,11 @@ TEST_F(storage_test_fixture, find_sliding_ranges) {
         }
 
         compaction::compaction_config cfg(
-          model::offset::max(), std::nullopt, std::nullopt, as);
+          model::offset::max(),
+          model::offset::max(),
+          std::nullopt,
+          std::nullopt,
+          as);
 
         for (size_t i = 0; i < segment_fields.size(); ++i) {
             auto& seg = disk_log->segments()[i];
@@ -6409,7 +6448,11 @@ TEST_F(storage_test_fixture, segment_cached_disk_usage_set_after_compaction) {
 
     ss::abort_source as;
     compaction::compaction_config cfg(
-      model::offset::max(), std::nullopt, std::nullopt, as);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      as);
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
 
     auto check_cached_sizes = [](auto& seg) {
@@ -6854,6 +6897,7 @@ TEST_F(storage_test_fixture, test_max_eligible_for_compacted_reupload_offset) {
           model::timestamp::min(),
           std::nullopt,
           first->offsets().get_committed_offset(),
+          first->offsets().get_committed_offset(),
           std::nullopt,
           std::nullopt,
           0ms,
@@ -6877,6 +6921,7 @@ TEST_F(storage_test_fixture, test_max_eligible_for_compacted_reupload_offset) {
         storage::housekeeping_config h_cfg(
           model::timestamp::min(),
           std::nullopt,
+          log->offsets().committed_offset,
           log->offsets().committed_offset,
           std::nullopt,
           std::nullopt,
@@ -7076,7 +7121,11 @@ TEST_F(storage_test_fixture, adjacent_merge_compaction_advances_generation_id) {
 
     ss::abort_source as;
     compaction::compaction_config cfg(
-      model::offset::max(), std::nullopt, std::nullopt, as);
+      model::offset::max(),
+      model::offset::max(),
+      std::nullopt,
+      std::nullopt,
+      as);
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
 
     auto& segs = log->segments();

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -130,6 +130,7 @@ ss::future<> disk_log_builder::gc(
         collection_upper_bound,
         max_partition_retention_size,
         model::offset::max(),
+        model::offset::max(),
         tombstone_retention_ms,
         std::nullopt,
         std::chrono::milliseconds{0},

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -448,6 +448,7 @@ struct housekeeping_config {
       model::timestamp upper,
       std::optional<size_t> max_bytes_in_log,
       model::offset max_collect_offset,
+      model::offset max_tombstone_remove_offset,
       std::optional<std::chrono::milliseconds> tombstone_retention_ms,
       std::optional<std::chrono::milliseconds> tx_retention_ms,
       std::chrono::milliseconds min_lag_ms,
@@ -456,6 +457,7 @@ struct housekeeping_config {
       compaction::hash_key_offset_map* key_map = nullptr)
       : compact(
           max_collect_offset,
+          max_tombstone_remove_offset,
           tombstone_retention_ms,
           tx_retention_ms,
           as,


### PR DESCRIPTION
For now init it as max compaction offset, it'll be overridden later using storage::stm_manager.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
