### PR TITLE
gha: trigger workflows when PR is added to merge queue

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -2,7 +2,7 @@
 # ---------------------------------------------------------------------------
 # Buf CI
 # ---------------------------------------------------------------------------
-# 1. validate -> lint + breaking checks (runs on both push & pull_request)
+# 1. validate -> lint + breaking checks (runs on push, merge_group, & pull_request)
 # 2. push-to-registry -> push to Buf registry only (runs after validation passes)
 # 3. archive-label -> archive label in registry when branch/tag deleted (with error handling)
 # ---------------------------------------------------------------------------
@@ -29,16 +29,18 @@ on:
       - '**/buf.lock'
       - '.github/workflows/buf.yml'
   delete:
+  merge_group:
+    types: [checks_requested]
 permissions:
   contents: read  # checkout + annotations
   pull-requests: write  # inline lint / breaking comments
   id-token: write  # OIDC to assume AWS role (push job)
 # ===========================================================================
-# Job: validate (both push and pull_request - comprehensive validation)
+# Job: validate (push, merge_group, and pull_request - comprehensive validation)
 # ===========================================================================
 jobs:
   validate:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +50,7 @@ jobs:
           paths: proto
           lint: true
           format: false  # We use clang-tidy
-          breaking: false # flip to true when we have a release
+          breaking: false  # flip to true when we have a release
           push: false  # Only validate, don't push to registry
   # ===========================================================================
   # Job: push-to-registry (push events only - registry operations only)

--- a/.github/workflows/dispatch-api-docs.yml
+++ b/.github/workflows/dispatch-api-docs.yml
@@ -1,3 +1,4 @@
+---
 name: Dispatch Admin API docs update on latest release
 
 on:

--- a/.github/workflows/lint-bazel-dependency-graph.yml
+++ b/.github/workflows/lint-bazel-dependency-graph.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'BUILD'
       - '.github/workflows/lint-bazel-dependency-graph.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   lint:
     name: Lint bazel dependency graph

--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - '.github/workflows/lint-bazel-pkg-tool.yml'
       - 'bazel/packaging/tool.go'
+  merge_group:
+    types: [checks_requested]
 jobs:
   golangci-lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint-bazel-pkg-tool.yml
+++ b/.github/workflows/lint-bazel-pkg-tool.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: stable
           cache: false
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout 10m --verbose tool.go

--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -20,6 +20,8 @@ on:
       - '**.proto'
       - '**.java'
       - '.github/workflows/lint-cpp.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   cpp:
     name: Lint files with clang-format

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'src/go/**'
       - '.github/workflows/lint-golang.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   go:
     name: Lint go files

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - '**.py'
       - '.github/workflows/lint-python.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   py:
     name: Lint python files

--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -20,6 +20,8 @@ on:
       - '.buildkite/hooks/*'
       - 'tests/docker/ducktape-deps/*'
       - 'tools/*'
+  merge_group:
+    types: [checks_requested]
 jobs:
   sh:
     name: Lint shell scripts

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - '.yamllint'
       - '.github/workflows/*.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   yamllint:
     runs-on: ubuntu-latest

--- a/.github/workflows/p.yml
+++ b/.github/workflows/p.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'tests/models/**'
       - '.github/workflows/p.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   cpp:
     name: Compile and check P models

--- a/.github/workflows/rp-storage-tool-checks.yml
+++ b/.github/workflows/rp-storage-tool-checks.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'tools/rp_storage_tool/**'
       - '.github/workflows/rp-storage-tool-checks.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   check:
     name: Compile check

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -20,6 +20,8 @@ on:
       - 'src/go/rpk/**'
       - 'src/v/pandaproxy/schema_registry/protobuf/**'
       - '.github/workflows/rpk-build.yml'
+  merge_group:
+    types: [checks_requested]
 jobs:
   build:
     strategy:

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -20,6 +20,8 @@ on:
     paths:
       - 'src/transform-sdk/**'
       - '.github/workflows/transform-sdk-build.yml'
+  merge_group:
+    types: [checks_requested]
 env:
   RUST_VERSION: '1.80'
   GO_VERSION: '1.22'

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -194,14 +194,14 @@ func createPackageDir(cfg pkgConfig, output string) error {
 
 	dir := func(path string) error {
 		if err := os.Mkdir(filepath.Join(output, path), 0755); err != nil {
-			return fmt.Errorf("Error creating directory %s: %v", path, err)
+			return fmt.Errorf("error creating directory %s: %v", path, err)
 		}
 		return nil
 	}
 
 	file := func(fileConfig fileConfig) error {
 		if err := copyFile(fileConfig.SourcePath, filepath.Join(output, fileConfig.Path, fileConfig.Name)); err != nil {
-			return fmt.Errorf("Error copying file %s: %v", fileConfig.SourcePath, err)
+			return fmt.Errorf("error copying file %s: %v", fileConfig.SourcePath, err)
 		}
 		return nil
 	}

--- a/bazel/packaging/tool.go
+++ b/bazel/packaging/tool.go
@@ -113,12 +113,21 @@ func createPackage(cfg pkgConfig, createDir func(path string) error, createFile 
 
 func createTarball(cfg pkgConfig, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	defer tw.Close()
+	defer func() {
+		if err := tw.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "error closing tar writer: %v\n", err)
+		}
+	}()
 	writeFile := func(fileConfig fileConfig) error {
 		file, err := os.Open(fileConfig.SourcePath)
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err := file.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing file %s: %v\n", fileConfig.SourcePath, err)
+			}
+		}()
 		info, err := file.Stat()
 		if err != nil {
 			return err
@@ -156,12 +165,20 @@ func copyFile(src string, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
+	defer func() {
+		if err := srcFile.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "error closing source file %s: %v\n", src, err)
+		}
+	}()
 	dstFile, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer dstFile.Close()
+	defer func() {
+		if err := dstFile.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "error closing destination file %s: %v\n", dst, err)
+		}
+	}()
 	_, err = dstFile.ReadFrom(srcFile)
 	if err != nil {
 		return err
@@ -212,11 +229,23 @@ func runTool() error {
 		if err != nil {
 			return fmt.Errorf("unable to open output file: %w", err)
 		}
-		defer file.Close()
+		defer func() {
+			if err := file.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing output file %s: %v\n", *output, err)
+			}
+		}()
 		bw := bufio.NewWriter(file)
-		defer bw.Flush()
+		defer func() {
+			if err := bw.Flush(); err != nil {
+				fmt.Fprintf(os.Stderr, "error flushing buffered writer: %v\n", err)
+			}
+		}()
 		gw := gzip.NewWriter(bw)
-		defer gw.Close()
+		defer func() {
+			if err := gw.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing gzip writer: %v\n", err)
+			}
+		}()
 		if err := createTarball(cfg, gw); err != nil {
 			return fmt.Errorf("unable to create tarball: %w", err)
 		}


### PR DESCRIPTION
jira: [DEVPROD-3436]

This PR adds [merge_group event](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) to workflows to enable the workflow to trigger when a PR is added to the merge queue. The workflows modified in this PR are the same ones that trigger on `pull_request` event:

1. [buf.yml](https://github.com/redpanda-data/redpanda/actions/workflows/buf.yml)
2. [lint-bazel-dependency-graph.yml ](https://github.com/redpanda-data/redpanda/actions/workflows/lint-bazel-dependency-graph.yml)
3. [lint-bazel-pkg-tool.yml](https://github.com/redpanda-data/redpanda/actions/workflows/lint-bazel-pkg-tool.yml)
4. [lint-cpp.yml](https://github.com/redpanda-data/redpanda/actions/workflows/lint-cpp.yml)
5. [lint-golang.yml ](https://github.com/redpanda-data/redpanda/actions/workflows/lint-golang.yml)
6. [lint-python.yml](https://github.com/redpanda-data/redpanda/actions/workflows/lint-python.yml)
7. [lint-sh.yml](https://github.com/redpanda-data/redpanda/actions/workflows/lint-sh.yml)
8. [lint-yaml.yml](https://github.com/redpanda-data/redpanda/actions/workflows/lint-yaml.yml)
9. [p.yml](https://github.com/redpanda-data/redpanda/actions/workflows/p.yml)
10. [rp-storage-tool-checks.yml](https://github.com/redpanda-data/redpanda/actions/workflows/rp-storage-tool-checks.yml)
11. [rpk-build.yml](https://github.com/redpanda-data/redpanda/actions/workflows/rpk-build.yml)
12. [transform-sdk-build.yml](https://github.com/redpanda-data/redpanda/actions/workflows/transform-sdk-build.yml)

While making these changes, encountered unrelated [error](https://github.com/redpanda-data/redpanda/actions/runs/18538329043/job/52839167669#step:4:31) in golangci-lint checks on `tool.go`, so fixed those as well.

After this PR merges, the merge queue will be enabled manually by creating a branch rule in the repo settings.

And after the merge queue is enabled and verified to run as intended in gha and buildkite jobs, a follow-up PR will be created to delete the `push` events in the workflow files that aren't need them anymore. Separating this step will allow easy turn off of merge queue by updating repo settings in case we need to.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none

[DEVPROD-3436]: https://redpandadata.atlassian.net/browse/DEVPROD-3436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ