### PR TITLE
ct/l1: Add retry helper for the metastore

### DIFF
--- a/src/v/cloud_topics/level_one/frontend_reader/BUILD
+++ b/src/v/cloud_topics/level_one/frontend_reader/BUILD
@@ -17,9 +17,11 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/common:object",
         "//src/v/cloud_topics/level_one/common:object_id",
         "//src/v/cloud_topics/level_one/metastore",
+        "//src/v/cloud_topics/level_one/metastore:retry",
         "//src/v/config",
         "//src/v/model",
         "//src/v/model:timeout_clock",
+        "//src/v/utils:retry_chain_node",
         "@seastar",
     ],
 )

--- a/src/v/cloud_topics/level_one/frontend_reader/reader.cc
+++ b/src/v/cloud_topics/level_one/frontend_reader/reader.cc
@@ -10,10 +10,12 @@
 #include "cloud_topics/level_one/frontend_reader/reader.h"
 
 #include "bytes/iostream.h"
+#include "cloud_topics/level_one/metastore/retry.h"
 #include "cloud_topics/logger.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
+#include "utils/retry_chain_node.h"
 
 #include <seastar/coroutine/as_future.hh>
 
@@ -122,21 +124,18 @@ ss::future<> level_one_log_reader_impl::fetch_metadata(
         co_return;
     }
 
-    auto response_fut = co_await ss::coroutine::as_future(
-      _metastore->get_first_ge(_tidp, _next_offset));
-    if (response_fut.failed()) {
-        auto ex = response_fut.get_exception();
-        vlog(
-          cd_log.error,
-          "Exception fetching metadata from metastore for {} ({}): {}",
-          _ntp,
-          _tidp,
-          ex);
-        _state = state::end_of_stream;
-        std::rethrow_exception(ex);
-    }
-
-    auto response = response_fut.get();
+    ss::abort_source default_abort_source;
+    auto* abort_source = _config.abort_source
+                           ? &_config.abort_source.value().get()
+                           : &default_abort_source;
+    retry_chain_node rtc = l1::make_default_metastore_rtc(*abort_source);
+    auto response = co_await l1::retry_metastore_op(
+      [this]()
+        -> ss::future<
+          std::expected<l1::metastore::object_response, l1::metastore::errc>> {
+          return _metastore->get_first_ge(_tidp, _next_offset);
+      },
+      rtc);
     if (!response.has_value()) {
         switch (response.error()) {
         case l1::metastore::errc::out_of_range:

--- a/src/v/cloud_topics/level_one/metastore/BUILD
+++ b/src/v/cloud_topics/level_one/metastore/BUILD
@@ -77,6 +77,19 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "retry",
+    hdrs = [
+        "retry.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":metastore",
+        "//src/v/utils:retry_chain_node",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "replicated_metastore",
     srcs = [
         "replicated_metastore.cc",

--- a/src/v/cloud_topics/level_one/metastore/retry.h
+++ b/src/v/cloud_topics/level_one/metastore/retry.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "cloud_topics/level_one/metastore/metastore.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+
+#include <chrono>
+#include <concepts>
+#include <expected>
+
+namespace cloud_topics::l1 {
+
+using namespace std::chrono_literals;
+
+static constexpr auto default_metastore_retry_timeout = 5s;
+static constexpr auto default_metastore_retry_backoff = 100ms;
+
+inline retry_chain_node make_default_metastore_rtc(ss::abort_source& as) {
+    return {
+      as,
+      ss::lowres_clock::now() + default_metastore_retry_timeout,
+      default_metastore_retry_backoff};
+}
+
+template<typename Func>
+concept metastore_operation = requires(Func f) {
+    typename std::invoke_result_t<Func>::value_type;
+    requires std::same_as<
+      typename std::invoke_result_t<Func>::value_type::error_type,
+      metastore::errc>;
+};
+
+/// Retry a metastore operation with exponential backoff on transport errors.
+template<typename Func>
+requires metastore_operation<Func>
+auto retry_metastore_op(Func&& func, retry_chain_node& rtc)
+  -> ss::future<typename std::invoke_result_t<Func>::value_type> {
+    for (auto permit = rtc.retry(); permit.is_allowed; permit = rtc.retry()) {
+        auto result = co_await func();
+
+        if (result.has_value()) {
+            co_return result;
+        }
+
+        if (result.error() != metastore::errc::transport_error) {
+            co_return result;
+        }
+
+        co_await ss::sleep_abortable(permit.delay, rtc.root_abort_source());
+    }
+
+    co_return typename std::invoke_result_t<Func>::value_type{
+      std::unexpected(metastore::errc::transport_error)};
+}
+
+} // namespace cloud_topics::l1

--- a/src/v/cloud_topics/reconciler/BUILD
+++ b/src/v/cloud_topics/reconciler/BUILD
@@ -68,6 +68,7 @@ redpanda_cc_library(
         "//src/v/cloud_topics/level_one/common:object_utils",
         "//src/v/cloud_topics/level_one/metastore",
         "//src/v/cloud_topics/level_one/metastore:replicated_metastore",
+        "//src/v/cloud_topics/level_one/metastore:retry",
         "//src/v/cluster",
         "//src/v/container:chunked_hash_map",
         "//src/v/container:chunked_vector",

--- a/src/v/cloud_topics/reconciler/reconciler.cc
+++ b/src/v/cloud_topics/reconciler/reconciler.cc
@@ -18,6 +18,7 @@
 #include "cloud_topics/level_one/common/object.h"
 #include "cloud_topics/level_one/common/object_id.h"
 #include "cloud_topics/level_one/metastore/metastore.h"
+#include "cloud_topics/level_one/metastore/retry.h"
 #include "cloud_topics/log_reader_config.h"
 #include "cloud_topics/reconciler/reconciliation_consumer.h"
 #include "cloud_topics/reconciler/reconciliation_source.h"
@@ -208,7 +209,23 @@ ss::future<> reconciler::reconcile() {
     }
 
     // Begin by creating the set of objects to be built.
-    auto metadata_builder_res = co_await _metastore->object_builder();
+    retry_chain_node rtc = l1::make_default_metastore_rtc(_as);
+    auto metadata_builder_res = co_await l1::retry_metastore_op(
+      [this]() {
+          return _metastore->object_builder().then(
+            [this](
+              std::expected<
+                std::unique_ptr<l1::metastore::object_metadata_builder>,
+                l1::metastore::errc> result) {
+                if (
+                  !result.has_value()
+                  && result.error() == l1::metastore::errc::transport_error) {
+                    _probe.increment_metastore_retries();
+                }
+                return result;
+            });
+      },
+      rtc);
     if (!metadata_builder_res.has_value()) {
         vlog(
           lg.warn,
@@ -571,40 +588,6 @@ std::expected<void, reconcile_error> reconciler::add_object_metadata(
     return {};
 }
 
-ss::future<std::expected<l1::metastore::add_response, reconcile_error>>
-reconciler::add_objects_with_retry(
-  std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
-  l1::metastore::term_offset_map_t terms) {
-    static constexpr auto timeout = 5s;
-    static constexpr auto backoff = 100ms;
-
-    retry_chain_node rtc(_as, ss::lowres_clock::now() + timeout, backoff);
-    retry_chain_logger ctxlog(lg, rtc, "add_objects");
-    for (auto permit = rtc.retry(); permit.is_allowed; permit = rtc.retry()) {
-        auto metrics_duration_add_objects
-          = _probe.measure_metastore_add_objects_duration();
-        auto add_result = co_await _metastore->add_objects(
-          *meta_builder, terms);
-        metrics_duration_add_objects.reset();
-
-        if (add_result.has_value()) {
-            co_return std::move(add_result).value();
-        }
-
-        if (add_result.error() != l1::metastore::errc::transport_error) {
-            co_return std::unexpected(reconcile_error(
-              "Non-retryable error adding objects to the L1 metastore: {}",
-              add_result.error()));
-        }
-
-        _probe.increment_metastore_retries();
-        co_await ss::sleep_abortable(permit.delay, rtc.root_abort_source());
-    }
-
-    co_return std::unexpected(reconcile_error(
-      "ran out of retries attempt to add objects to L1 metastore"));
-}
-
 ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
   const chunked_vector<built_object_metadata>& objects,
   std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder) {
@@ -623,13 +606,37 @@ ss::future<std::expected<void, reconcile_error>> reconciler::commit_objects(
         }
     }
 
-    auto add_objects_result = co_await add_objects_with_retry(
-      std::move(meta_builder), std::move(terms));
+    retry_chain_node rtc = l1::make_default_metastore_rtc(_as);
+    auto add_objects_result = co_await l1::retry_metastore_op(
+      [this, &meta_builder, &terms]() {
+          auto metrics_duration_add_objects
+            = _probe.measure_metastore_add_objects_duration();
+          return _metastore->add_objects(*meta_builder, terms)
+            .then(
+              [this,
+               metrics_duration_add_objects = std::move(
+                 metrics_duration_add_objects)](
+                std::expected<l1::metastore::add_response, l1::metastore::errc>
+                  result) mutable {
+                  metrics_duration_add_objects.reset();
+
+                  if (
+                    !result.has_value()
+                    && result.error() == l1::metastore::errc::transport_error) {
+                      _probe.increment_metastore_retries();
+                  }
+
+                  return result;
+              });
+      },
+      rtc);
+
     if (!add_objects_result.has_value()) {
         // TODO: The objects have been uploaded. The reconciler could
         //       attempt cleanup (or notify a cleanup subsystem).
-        co_return std::unexpected(add_objects_result.error().with_context(
-          "Failed to add objects to the L1 metastore"));
+        co_return std::unexpected(reconcile_error(
+          "Failed to add objects to the L1 metastore: {}",
+          add_objects_result.error()));
     }
 
     // Now update the LRO, taking into account any corrections from

--- a/src/v/cloud_topics/reconciler/reconciler.h
+++ b/src/v/cloud_topics/reconciler/reconciler.h
@@ -247,15 +247,6 @@ private:
       const chunked_vector<built_object_metadata>& objects,
       std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder);
 
-    /*
-     * Retry metastore add_objects calls on transport errors.
-     * Other metastore errors are not retried.
-     */
-    ss::future<std::expected<l1::metastore::add_response, reconcile_error>>
-    add_objects_with_retry(
-      std::unique_ptr<l1::metastore::object_metadata_builder> meta_builder,
-      l1::metastore::term_offset_map_t terms);
-
     l1::io* _l1_io;
     l1::metastore* _metastore;
     ss::gate _gate;


### PR DESCRIPTION
This adds a templated retry helper for metastore operations and replaces the existing retry logic in add_objects_with_retry with the helper. It also uses the helper to add retries to metastore builder creation and metastore operations in the L1 reader.

There are existing reconciler tests that retries work for add objects and which serve as a test of the retry helper.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
