### PR TITLE
[CORE-13958] ct: make enablement property an enterprise property

### DIFF
--- a/src/v/cluster/topic_properties.cc
+++ b/src/v/cluster/topic_properties.cc
@@ -99,7 +99,7 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.message_timestamp_before_max_ms,
       properties.message_timestamp_after_max_ms);
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         fmt::print(
           o, ", cloud_topic_enabled: {}", properties.cloud_topic_enabled);
     }
@@ -153,7 +153,7 @@ bool topic_properties::has_overrides() const {
         || message_timestamp_before_max_ms.has_value()
         || message_timestamp_after_max_ms.has_value();
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         return overrides
                || (cloud_topic_enabled != storage::ntp_config::default_cloud_topic_enabled);
     }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -112,6 +112,11 @@ get_enterprise_features(const cluster::topic_configuration& cfg) {
             features.emplace_back("iceberg");
         }
     }
+    if (config::shard_local_cfg().cloud_topics_enabled.is_restricted()) {
+        if (cfg.properties.cloud_topic_enabled) {
+            features.emplace_back("cloud topics");
+        }
+    }
     return features;
 }
 
@@ -209,6 +214,11 @@ std::vector<std::string_view> get_enterprise_features(
     if (config::shard_local_cfg().iceberg_enabled.is_restricted()) {
         if (properties.iceberg_mode != model::iceberg_mode::disabled) {
             features.emplace_back("iceberg");
+        }
+    }
+    if (config::shard_local_cfg().cloud_topics_enabled.is_restricted()) {
+        if (properties.cloud_topic_enabled) {
+            features.emplace_back("cloud topics");
         }
     }
     return features;

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -636,7 +636,7 @@ topic_result topics_frontend::validate_topic_configuration(
 
     // the only way that cloud topics can be enabled on a topic is if the cloud
     // topics development feature is also enabled.
-    if (!config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (!config::shard_local_cfg().cloud_topics_enabled()) {
         if (assignable_config.cfg.properties.cloud_topic_enabled) {
             auto msg = ssx::sformat(
               "Cloud topic flag on {} is set but development feature is "

--- a/src/v/cluster_link/utils/topic_properties_utils.cc
+++ b/src/v/cluster_link/utils/topic_properties_utils.cc
@@ -248,7 +248,7 @@ bool maybe_append_update(
           kafka::noop_validator<config::leaders_preference>{});
     }
     if (config_name == kafka::topic_property_cloud_topic_enabled) {
-        if (config::shard_local_cfg().development_enable_cloud_topics()) {
+        if (config::shard_local_cfg().cloud_topics_enabled()) {
             throw kafka::validation_error(
               "Cloud topics property cannot be changed");
         }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4462,9 +4462,10 @@ configuration::configuration()
       false)
   , cloud_topics_enabled(
       *this,
+      true,
       "cloud_topics_enabled",
       "Enable cloud topics.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
   , cloud_topics_produce_batching_size_threshold(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -4460,9 +4460,9 @@ configuration::configuration()
       "cluster for data replication.",
       meta{.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
-  , development_enable_cloud_topics(
+  , cloud_topics_enabled(
       *this,
-      "development_enable_cloud_topics",
+      "cloud_topics_enabled",
       "Enable cloud topics.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -805,7 +805,7 @@ struct configuration final : public config_store {
     error_map_t load(const YAML::Node& root_node);
 
 public:
-    property<bool> development_enable_cloud_topics;
+    property<bool> cloud_topics_enabled;
     property<size_t> cloud_topics_produce_batching_size_threshold;
     property<std::chrono::milliseconds> cloud_topics_produce_upload_interval;
     property<size_t> cloud_topics_produce_cardinality_threshold;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -805,7 +805,7 @@ struct configuration final : public config_store {
     error_map_t load(const YAML::Node& root_node);
 
 public:
-    property<bool> cloud_topics_enabled;
+    enterprise<property<bool>> cloud_topics_enabled;
     property<size_t> cloud_topics_produce_batching_size_threshold;
     property<std::chrono::milliseconds> cloud_topics_produce_upload_interval;
     property<size_t> cloud_topics_produce_cardinality_threshold;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -805,7 +805,7 @@ struct configuration final : public config_store {
     error_map_t load(const YAML::Node& root_node);
 
 public:
-    development_feature_property<bool> development_enable_cloud_topics;
+    property<bool> development_enable_cloud_topics;
     property<size_t> cloud_topics_produce_batching_size_threshold;
     property<std::chrono::milliseconds> cloud_topics_produce_upload_interval;
     property<size_t> cloud_topics_produce_cardinality_threshold;

--- a/src/v/features/enterprise_features.h
+++ b/src/v/features/enterprise_features.h
@@ -68,6 +68,7 @@ public:
     // | Cluster     | `enable_schema_id_validation`   | `compat`      |
     // | Cluster     | `iceberg_enabled`               | `true`        |
     // | Cluster     | `enable_shadow_linking`         | `true`        |
+    // | Cluster     | `cloud_topics_enabled`          | `true`        |
     // | Node        | `fips_mode`                     | `enabled`     |
     // | Node        | `fips_mode`                     | `permissive`  |
     // +-------------+---------------------------------+---------------+

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -360,8 +360,7 @@ create_topic_properties_update(
                 continue;
             }
             if (cfg.name == topic_property_cloud_topic_enabled) {
-                if (config::shard_local_cfg()
-                      .development_enable_cloud_topics()) {
+                if (config::shard_local_cfg().cloud_topics_enabled()) {
                     throw validation_error(
                       "Cloud topics property cannot be changed");
                 }

--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -868,7 +868,7 @@ config_response_container_t make_topic_configs(
           });
     }
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         if (config_property_requested(
               config_keys, topic_property_cloud_topic_enabled)) {
             add_topic_config<bool>(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -102,7 +102,7 @@ bool is_supported(std::string_view name) {
      * enabled, the system should behave as if the feature does not exist.
      */
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         if (name == topic_property_cloud_topic_enabled) {
             return true;
         }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -364,8 +364,7 @@ create_topic_properties_update(
                 continue;
             }
             if (cfg.name == topic_property_cloud_topic_enabled) {
-                if (config::shard_local_cfg()
-                      .development_enable_cloud_topics()) {
+                if (config::shard_local_cfg().cloud_topics_enabled()) {
                     throw validation_error(
                       "Cloud topics property cannot be changed");
                 }

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -358,7 +358,7 @@ cluster::topic_configuration to_topic_config(
           name, value, kafka::config_resource_operation::set);
     }
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         cfg.properties.cloud_topic_enabled
           = get_bool_value(config_entries, topic_property_cloud_topic_enabled)
               .value_or(storage::ntp_config::default_cloud_topic_enabled);

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -380,7 +380,7 @@ struct cloud_topic_config_validator {
         if (it == c.configs.end()) {
             return true;
         }
-        if (!config::shard_local_cfg().development_enable_cloud_topics()) {
+        if (!config::shard_local_cfg().cloud_topics_enabled()) {
             return false;
         }
         try {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1766,7 +1766,7 @@ void application::wire_up_redpanda_services(
     producer_manager.invoke_on_all(&cluster::tx::producer_state_manager::start)
       .get();
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         vassert(
           archival_storage_enabled(),
           "cloud topics currently requires archival storage to be enabled");
@@ -3177,7 +3177,7 @@ void application::start_runtime_services(
           pm.register_factory<datalake::coordinator::stm_factory>();
           pm.register_factory<datalake::translation::stm_factory>(
             config::shard_local_cfg().iceberg_enabled());
-          if (config::shard_local_cfg().development_enable_cloud_topics()) {
+          if (config::shard_local_cfg().cloud_topics_enabled()) {
               pm.register_factory<cloud_topics::l0::ctp_stm_factory>();
               pm.register_factory<cloud_topics::l1::stm_factory>();
           }
@@ -3407,7 +3407,7 @@ void application::start_runtime_services(
               smp_service_groups.cluster_smp_sg(),
               std::ref(_consumer_group_lag_metrics_frontend)));
           if (
-            config::shard_local_cfg().development_enable_cloud_topics()
+            config::shard_local_cfg().cloud_topics_enabled()
             && cloud_topics_app) {
               runtime_services.push_back(
                 std::make_unique<cloud_topics::l1::rpc::service>(

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -92,7 +92,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
   bool enable_data_transforms,
   bool enable_legacy_upload_mode,
   bool iceberg_enabled,
-  bool development_enable_cloud_topics,
+  bool enable_cloud_topics,
   bool development_cluster_linking_enabled)
   : app(ssx::sformat("redpanda-{}", node_id()))
   , proxy_port(proxy_port)
@@ -114,7 +114,7 @@ redpanda_thread_fixture::redpanda_thread_fixture(
       enable_data_transforms,
       enable_legacy_upload_mode,
       iceberg_enabled,
-      development_enable_cloud_topics,
+      enable_cloud_topics,
       development_cluster_linking_enabled);
     app.initialize(
       proxy_config(proxy_port),
@@ -348,7 +348,7 @@ void redpanda_thread_fixture::configure(
   bool data_transforms_enabled,
   bool legacy_upload_mode_enabled,
   bool iceberg_enabled,
-  bool development_enable_cloud_topics,
+  bool cloud_topics_enabled,
   bool development_cluster_linking_enabled) {
     auto base_path = std::filesystem::path(data_dir);
     ss::smp::invoke_on_all([=]() {
@@ -442,8 +442,8 @@ void redpanda_thread_fixture::configure(
           .set_value(legacy_upload_mode_enabled);
         config.get("iceberg_enabled").set_value(iceberg_enabled);
 
-        if (development_enable_cloud_topics) {
-            config.get("development_enable_cloud_topics").set_value(true);
+        if (cloud_topics_enabled) {
+            config.get("cloud_topics_enabled").set_value(true);
         }
 
         config.get("enable_shadow_linking")

--- a/src/v/redpanda/tests/fixture.cc
+++ b/src/v/redpanda/tests/fixture.cc
@@ -443,14 +443,6 @@ void redpanda_thread_fixture::configure(
         config.get("iceberg_enabled").set_value(iceberg_enabled);
 
         if (development_enable_cloud_topics) {
-            const auto time_since_epoch
-              = std::chrono::system_clock::now().time_since_epoch();
-            config
-              .get(
-                "enable_developmental_unrecoverable_data_corrupting_"
-                "features")
-              .set_value(ssx::sformat("{}", time_since_epoch));
-
             config.get("development_enable_cloud_topics").set_value(true);
         }
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -86,7 +86,7 @@ public:
       bool enable_data_transforms = false,
       bool enable_legacy_upload_mode = true,
       bool iceberg_enabled = false,
-      bool development_enable_cloud_topics = false,
+      bool enable_cloud_topics = false,
       bool development_cluster_linking_enabled = false);
 
     // creates single node with default configuration
@@ -157,7 +157,7 @@ public:
       bool data_transforms_enabled = false,
       bool legacy_upload_mode_enabled = true,
       bool iceberg_enabled = false,
-      bool development_enable_cloud_topics = false,
+      bool enable_cloud_topics = false,
       bool development_cluster_linking_enabled = false);
 
     YAML::Node proxy_config(uint16_t proxy_port = 8082);

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -33,7 +33,7 @@ bool datalake_enabled() {
 }
 
 bool cloud_topics_enabled() {
-    return config::shard_local_cfg().development_enable_cloud_topics();
+    return config::shard_local_cfg().cloud_topics_enabled();
 }
 
 struct memory_shares {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -430,7 +430,7 @@ public:
     }
 
     bool cloud_topic_enabled() const {
-        if (!config::shard_local_cfg().development_enable_cloud_topics()) {
+        if (!config::shard_local_cfg().cloud_topics_enabled()) {
             return false;
         }
         return _overrides ? _overrides->cloud_topic_enabled

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -134,7 +134,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.min_compaction_lag_ms,
       v.max_compaction_lag_ms);
 
-    if (config::shard_local_cfg().development_enable_cloud_topics()) {
+    if (config::shard_local_cfg().cloud_topics_enabled()) {
         fmt::print(o, ", cloud_topic_enabled: {}", v.cloud_topic_enabled);
     }
 

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -48,7 +48,7 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         self.topic = self.s3_topic_name
 
         conf = dict(
-            development_enable_cloud_topics=True,
+            cloud_topics_enabled=True,
             enable_cluster_metadata_upload_loop=False,
         )
 

--- a/tests/rptest/tests/cloud_topics/e2e_test.py
+++ b/tests/rptest/tests/cloud_topics/e2e_test.py
@@ -48,9 +48,6 @@ class EndToEndCloudTopicsBase(EndToEndTest):
         self.topic = self.s3_topic_name
 
         conf = dict(
-            enable_developmental_unrecoverable_data_corrupting_features=int(
-                time.time()
-            ),
             development_enable_cloud_topics=True,
             enable_cluster_metadata_upload_loop=False,
         )

--- a/tests/rptest/tests/cloud_topics_test.py
+++ b/tests/rptest/tests/cloud_topics_test.py
@@ -33,7 +33,7 @@ class CloudTopicsTest(RedpandaTest):
         """
         self.redpanda.set_cluster_config(
             values={
-                "development_enable_cloud_topics": True,
+                "cloud_topics_enabled": True,
             }
         )
         self.redpanda.restart_nodes(self.redpanda.nodes)

--- a/tests/rptest/tests/cloud_topics_test.py
+++ b/tests/rptest/tests/cloud_topics_test.py
@@ -31,7 +31,6 @@ class CloudTopicsTest(RedpandaTest):
         to be done after development feature support has been enabled, and nodes
         have been restarted so that development services start at bootup.
         """
-        self.redpanda.enable_development_feature_support()
         self.redpanda.set_cluster_config(
             values={
                 "development_enable_cloud_topics": True,

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -655,9 +655,10 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 "iceberg_rest_catalog_crl_file",
             ]
         )
-        # Cloud storage and iceberg depend on properly configured cloud IO.
-        # Skip them to avoid breaking the test.
+        # Cloud storage, cloud topics, and iceberg depend on properly
+        # configured cloud IO. Skip them to avoid breaking the test.
         exclude_settings.add("cloud_storage_enabled")
+        exclude_settings.add("cloud_topics_enabled")
         exclude_settings.add("iceberg_enabled")
 
         # List of settings that must be odd

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -69,7 +69,7 @@ class FollowerFetchingTest(PreallocNodesTest):
                 "enable_rack_awareness": True,
                 # disable leader balancer to prevent leaders from moving and causing additional client retries
                 "enable_leader_balancer": False,
-                "development_enable_cloud_topics": True,
+                "cloud_topics_enabled": True,
             },
             si_settings=si_settings,
         )

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -69,10 +69,6 @@ class FollowerFetchingTest(PreallocNodesTest):
                 "enable_rack_awareness": True,
                 # disable leader balancer to prevent leaders from moving and causing additional client retries
                 "enable_leader_balancer": False,
-                # enable dev features to allow cloud topics to be created
-                "enable_developmental_unrecoverable_data_corrupting_features": int(
-                    time.time()
-                ),
                 "development_enable_cloud_topics": True,
             },
             si_settings=si_settings,

--- a/tests/rptest/tests/license_enforcement_test.py
+++ b/tests/rptest/tests/license_enforcement_test.py
@@ -345,6 +345,58 @@ class LicenseEnforcementPermittedTopicParams(RedpandaTest):
         cfgs = self.rpk.describe_topic_configs("test")
         assert cfgs["redpanda.iceberg.mode"][0] == "key_value", cfgs
 
+    @cluster(num_nodes=1)
+    def test_cloud_topics_enabled_cluster_property(self):
+        si_settings = SISettings(self.test_context)
+        self.redpanda.set_si_settings(si_settings)
+        super().setUp()
+        self.redpanda.set_environment(
+            {"__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE": True}
+        )
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.wait_until(
+            self.redpanda.healthy,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="The cluster hasn't stabilized",
+        )
+        # We shouldn't be able to set cloud_topics_enabled without a license.
+        try:
+            self.rpk.cluster_config_set("cloud_topics_enabled", "true")
+            assert False, "Enabling cloud_topics_enabled must fail without the license"
+        except RpkException as e:
+            pass
+
+    @cluster(num_nodes=1)
+    def test_cloud_topics_topic_property(self):
+        si_settings = SISettings(self.test_context)
+        self.redpanda.set_si_settings(si_settings)
+        super().setUp()
+
+        self.rpk.cluster_config_set("cloud_topics_enabled", "true")
+
+        self.redpanda.set_environment(
+            {"__REDPANDA_DISABLE_BUILTIN_TRIAL_LICENSE": True}
+        )
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.wait_until(
+            self.redpanda.healthy,
+            timeout_sec=60,
+            backoff_sec=1,
+            err_msg="The cluster hasn't stabilized",
+        )
+        # We shouldn't be able to set the topic property without a license,
+        # even with the cluster property set.
+        try:
+            self.rpk.create_topic(
+                "test", config={"redpanda.cloud_topic.enabled": "true"}
+            )
+            assert False, (
+                "Should have failed to create topic with redpanda.cloud_topic.enabled set"
+            )
+        except RpkException as e:
+            pass
+
     @cluster(num_nodes=3)
     def test_upgrade_with_topic_configs(self):
         """

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -287,7 +287,7 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         if with_cloud_topics:
             self.redpanda.set_cluster_config(
                 values={
-                    "development_enable_cloud_topics": True,
+                    "cloud_topics_enabled": True,
                     "cloud_topics_disable_reconciliation_loop": True,
                 }
             )

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -285,7 +285,6 @@ class RandomNodeOperationsBase(PreallocNodesTest):
         )
 
         if with_cloud_topics:
-            self.redpanda.enable_development_feature_support()
             self.redpanda.set_cluster_config(
                 values={
                     "development_enable_cloud_topics": True,


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Changes the property to enable cloud_topics:
- makes it not a development property
- renames it to cloud_topics_enabled
- makes it an enterprise property

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* None
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
