### PR TITLE
ct/tests: leader_epoch_test timeout to moderate

### DIFF
--- a/src/v/cloud_topics/tests/BUILD
+++ b/src/v/cloud_topics/tests/BUILD
@@ -60,7 +60,7 @@ redpanda_cc_gtest(
 
 redpanda_cc_gtest(
     name = "leader_epoch_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "leader_epoch_test.cc",
     ],


### PR DESCRIPTION
Increase the timeout from short (1min) to moderate (5min) because the test typically takes around 50s to run, and there have been some timeouts in CI with the test succeeding just above the 1 minutes limit.

Example timeout: https://buildkite.com/redpanda/redpanda/builds/74133/steps/canvas?jid=0199e19e-6240-45d8-85d7-b88e5ed9cf4c

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
