### PR TITLE
rpk: Remove deprecated cmd from help text

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/config.go
@@ -80,8 +80,8 @@ func printCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 func set(fs afero.Fs, p *config.Params) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "set [KEY] [VALUE]",
-		Short: "Set configuration values, such as the redpanda node ID or the list of seed servers",
-		Long: `Set configuration values, such as the redpanda node ID or the list of seed servers
+		Short: "Set node configuration values",
+		Long: `Set node configuration values, such as the list of seed servers or the ports that various APIs listen on
 
 This command modifies the redpanda.yaml you have locally on disk. The first
 argument is the key within the yaml representing a property / field that you


### PR DESCRIPTION
We don't recommend setting Node IDs, it causes all manner of painful edge cases, so we shouldn't use this as an example.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [ ] v24.3.x

## Release Notes


* none

