### PR TITLE
iobuf: optimize equality

### DIFF
--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -106,18 +106,34 @@ bool iobuf::operator==(const iobuf& o) const {
     if (_size != o._size) {
         return false;
     }
-    auto lhs_begin = byte_iterator(cbegin(), cend());
-    auto lhs_end = byte_iterator(cend(), cend());
-    auto rhs = byte_iterator(o.cbegin(), o.cend());
-    auto rhs_end = byte_iterator(o.cend(), o.cend());
-    while (lhs_begin != lhs_end && rhs != rhs_end) {
-        char l = *lhs_begin;
-        char r = *rhs;
-        if (l != r) {
-            return false;
+    // We know these have the same amount of bytes in them, but they might be
+    // chunked differently.
+    auto o_it = o.cbegin();
+    auto other_next_view = [&o, &o_it] -> std::string_view {
+        while (o_it != o.cend() && o_it->is_empty()) {
+            ++o_it;
         }
-        ++lhs_begin;
-        ++rhs;
+        if (o_it == o.cend()) {
+            return {};
+        }
+        std::string_view s{o_it->get(), o_it->size()};
+        ++o_it;
+        return s;
+    };
+    std::string_view rhs = other_next_view();
+    for (const auto& frag : *this) {
+        std::string_view lhs{frag.get(), frag.size()};
+        while (!lhs.empty()) {
+            auto n = std::min(lhs.size(), rhs.size());
+            if (lhs.substr(0, n) != rhs.substr(0, n)) {
+                return false;
+            }
+            lhs.remove_prefix(n);
+            rhs.remove_prefix(n);
+            if (rhs.empty()) {
+                rhs = other_next_view();
+            }
+        }
     }
     return true;
 }

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -143,29 +143,38 @@ bool iobuf::operator<(const iobuf& o) const {
 }
 
 std::strong_ordering iobuf::operator<=>(const iobuf& o) const {
-    auto lhs = byte_iterator(cbegin(), cend());
-    auto lhs_end = byte_iterator(cend(), cend());
-    auto rhs = byte_iterator(o.cbegin(), o.cend());
-    auto rhs_end = byte_iterator(o.cend(), o.cend());
-    while (lhs != lhs_end && rhs != rhs_end) {
-        char l = *lhs;
-        char r = *rhs;
-        auto cmp = l <=> r;
-        if (cmp != std::strong_ordering::equal) {
-            return cmp;
+    auto o_it = o.cbegin();
+    auto other_next_view = [&o, &o_it] -> std::string_view {
+        while (o_it != o.cend() && o_it->is_empty()) {
+            ++o_it;
         }
-        ++lhs;
-        ++rhs;
+        if (o_it == o.cend()) {
+            return {};
+        }
+        std::string_view s{o_it->get(), o_it->size()};
+        ++o_it;
+        return s;
+    };
+    std::string_view rhs = other_next_view();
+    for (const auto& frag : *this) {
+        std::string_view lhs{frag.get(), frag.size()};
+        while (!lhs.empty()) {
+            auto n = std::min(lhs.size(), rhs.size());
+            auto cmp = lhs.substr(0, n) <=> rhs.substr(0, n);
+            if (cmp != std::strong_ordering::equal) {
+                return cmp;
+            }
+            lhs.remove_prefix(n);
+            rhs.remove_prefix(n);
+            if (rhs.empty()) {
+                rhs = other_next_view();
+                if (o_it == o.cend()) {
+                    break;
+                }
+            }
+        }
     }
-    if (rhs != rhs_end) {
-        // lhs is a prefix of rhs.
-        return std::strong_ordering::less;
-    }
-    if (lhs != lhs_end) {
-        // rhs is a prefix of lhs.
-        return std::strong_ordering::greater;
-    }
-    return std::strong_ordering::equal;
+    return _size <=> o._size;
 }
 
 bool iobuf::operator==(std::string_view o) const {

--- a/src/v/bytes/tests/iobuf_bench.cc
+++ b/src/v/bytes/tests/iobuf_bench.cc
@@ -31,6 +31,30 @@ size_t move_bench() {
     return inner_iters * 2;
 }
 
+template<size_t Size>
+size_t eq_bench() {
+    iobuf a = iobuf::from(random_generators::gen_alphanum_string(Size));
+    iobuf a_shared = a.share();
+    iobuf a_copy = a.copy();
+    iobuf b = iobuf::from(random_generators::gen_alphanum_string(Size));
+    iobuf b_copy;
+    for (const auto& frag : b) {
+        for (char c : std::string_view(frag.get(), frag.size())) {
+            b_copy.append(&c, 1);
+        }
+    }
+    perf_tests::start_measuring_time();
+    for (auto i = inner_iters; i--;) {
+        perf_tests::do_not_optimize(a == a_shared);
+        perf_tests::do_not_optimize(a == a_copy);
+        perf_tests::do_not_optimize(a == b);
+        perf_tests::do_not_optimize(a_copy == b_copy);
+        perf_tests::do_not_optimize(b_copy == b);
+    }
+    perf_tests::stop_measuring_time();
+    return inner_iters * 5;
+}
+
 // This microbench mocks common pattern in Redpanda where smaller iobufs will be
 // parsed out of a larger iobuf then appendded together. This pattern is heavily
 // used in the datalake impl.
@@ -59,6 +83,10 @@ size_t append_bench() {
 PERF_TEST(iobuf, move_bench_small) { return move_bench<71>(); }
 PERF_TEST(iobuf, move_bench_medium) { return move_bench<300_KiB>(); }
 PERF_TEST(iobuf, move_bench_large) { return move_bench<965_KiB>(); }
+
+PERF_TEST(iobuf, eq_bench_small) { return eq_bench<71>(); }
+PERF_TEST(iobuf, eq_bench_medium) { return eq_bench<300_KiB>(); }
+PERF_TEST(iobuf, eq_bench_large) { return eq_bench<965_KiB>(); }
 
 PERF_TEST(iobuf, append_bench_small) { return append_bench<1'000, 4>(); }
 PERF_TEST(iobuf, append_bench_medium) { return append_bench<1'000, 40_KiB>(); }

--- a/src/v/bytes/tests/iobuf_bench.cc
+++ b/src/v/bytes/tests/iobuf_bench.cc
@@ -49,8 +49,8 @@ size_t move_bench() {
     return inner_iters * 2;
 }
 
-template<size_t Size>
-size_t eq_bench() {
+template<size_t Size, typename cmp_fn>
+size_t cmp_bench() {
     iobuf a = make_iobuf(Size);
     iobuf a_shared = a.share();
     iobuf a_copy = a.copy();
@@ -63,11 +63,11 @@ size_t eq_bench() {
     }
     perf_tests::start_measuring_time();
     for (auto i = inner_iters; i--;) {
-        perf_tests::do_not_optimize(a == a_shared);
-        perf_tests::do_not_optimize(a == a_copy);
-        perf_tests::do_not_optimize(a == b);
-        perf_tests::do_not_optimize(a_copy == b_copy);
-        perf_tests::do_not_optimize(b_copy == b);
+        perf_tests::do_not_optimize(cmp_fn{}(a, a_shared));
+        perf_tests::do_not_optimize(cmp_fn{}(a, a_copy));
+        perf_tests::do_not_optimize(cmp_fn{}(a, b));
+        perf_tests::do_not_optimize(cmp_fn{}(a_copy, b_copy));
+        perf_tests::do_not_optimize(cmp_fn{}(b_copy, b));
     }
     perf_tests::stop_measuring_time();
     return inner_iters * 5;
@@ -102,9 +102,17 @@ PERF_TEST(iobuf, move_bench_small) { return move_bench<71>(); }
 PERF_TEST(iobuf, move_bench_medium) { return move_bench<300_KiB>(); }
 PERF_TEST(iobuf, move_bench_large) { return move_bench<965_KiB>(); }
 
-PERF_TEST(iobuf, eq_bench_small) { return eq_bench<71>(); }
-PERF_TEST(iobuf, eq_bench_medium) { return eq_bench<300_KiB>(); }
-PERF_TEST(iobuf, eq_bench_large) { return eq_bench<965_KiB>(); }
+PERF_TEST(iobuf, eq_bench_small) { return cmp_bench<71, std::equal_to<>>(); }
+PERF_TEST(iobuf, eq_bench_medium) {
+    return cmp_bench<300_KiB, std::equal_to<>>();
+}
+PERF_TEST(iobuf, eq_bench_large) {
+    return cmp_bench<965_KiB, std::equal_to<>>();
+}
+
+PERF_TEST(iobuf, cmp_bench_small) { return cmp_bench<71, std::less<>>(); }
+PERF_TEST(iobuf, cmp_bench_medium) { return cmp_bench<300_KiB, std::less<>>(); }
+PERF_TEST(iobuf, cmp_bench_large) { return cmp_bench<965_KiB, std::less<>>(); }
 
 PERF_TEST(iobuf, append_bench_small) { return append_bench<1'000, 4>(); }
 PERF_TEST(iobuf, append_bench_medium) { return append_bench<1'000, 40_KiB>(); }

--- a/src/v/bytes/tests/iobuf_bench.cc
+++ b/src/v/bytes/tests/iobuf_bench.cc
@@ -10,17 +10,35 @@
 #include "base/units.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
-#include "random/generators.h"
-#include "test_utils/random_bytes.h"
 
 #include <seastar/testing/perf_tests.hh>
 
 namespace {
 static constexpr size_t inner_iters = 1000;
 
+// Make a deterministic iobuf for consistent benchmarks instead of randomized
+// data.
+iobuf make_iobuf(size_t size, bool reverse = false) {
+    auto gen = std::views::iota('a', 'z');
+    std::string generated;
+    generated.reserve(size);
+    while (generated.size() < size) {
+        for (char c : gen) {
+            generated.push_back(c);
+            if (generated.size() == size) {
+                break;
+            }
+        }
+    }
+    if (reverse) {
+        std::ranges::reverse(generated);
+    }
+    return iobuf::from(generated);
+}
+
 template<size_t Size>
 size_t move_bench() {
-    iobuf buffer = iobuf::from(random_generators::gen_alphanum_string(Size));
+    iobuf buffer = make_iobuf(Size);
     perf_tests::start_measuring_time();
     for (auto i = inner_iters; i--;) {
         iobuf moved = std::move(buffer);
@@ -33,10 +51,10 @@ size_t move_bench() {
 
 template<size_t Size>
 size_t eq_bench() {
-    iobuf a = iobuf::from(random_generators::gen_alphanum_string(Size));
+    iobuf a = make_iobuf(Size);
     iobuf a_shared = a.share();
     iobuf a_copy = a.copy();
-    iobuf b = iobuf::from(random_generators::gen_alphanum_string(Size));
+    iobuf b = make_iobuf(Size, /*reverse=*/true);
     iobuf b_copy;
     for (const auto& frag : b) {
         for (char c : std::string_view(frag.get(), frag.size())) {
@@ -60,7 +78,7 @@ size_t eq_bench() {
 // used in the datalake impl.
 template<int Bufs, size_t BufSize>
 size_t append_bench() {
-    iobuf_parser parser(tests::random_iobuf(Bufs * BufSize));
+    iobuf_parser parser(make_iobuf(Bufs * BufSize));
 
     std::vector<iobuf> buffers;
     buffers.reserve(Bufs);


### PR DESCRIPTION
I was running benchmark/fuzzer that did a lot of verification of data
and I noticed iobuf equality showing up in the benchmark profiles. This
commit optimizes that away.

Before:

```
test                       iterations      median         mad         min         max      allocs       tasks        inst      cycles
iobuf.eq_bench_small         28380000    35.508ns     0.192ns    35.316ns    35.955ns       0.000       0.000       635.4       144.9
iobuf.eq_bench_medium           10000   180.590us    21.070ns   180.560us   180.706us       0.000       0.000   2580562.3    737934.3
iobuf.eq_bench_large             5000   365.385us   143.483ns   365.241us   366.229us       0.000       0.000   8300680.4   1487054.6
iobuf.cmp_bench_small        25260000    39.563ns     0.129ns    39.251ns    39.787ns       0.000       0.000       594.3       161.0
iobuf.cmp_bench_medium          10000   135.743us    17.305ns   135.711us   135.779us       0.000       0.000   2396246.6    553506.3
iobuf.cmp_bench_large            5000   436.648us    57.891ns   436.434us   504.353us       0.000       0.000   7707794.9   1836157.7
```

After:

```
test                       iterations      median         mad         min         max      allocs       tasks        inst      cycles
iobuf.eq_bench_small        149070000     6.447ns     0.001ns     6.446ns     6.448ns       0.000       0.000        87.9        25.7
iobuf.eq_bench_medium          285000     3.062us     0.546ns     3.062us     3.064us       0.000       0.000     24756.9     12404.8
iobuf.eq_bench_large            90000     9.881us     1.125ns     9.877us     9.882us       0.000       0.000     79231.9     40052.9
iobuf.cmp_bench_small       149765000     6.436ns     0.001ns     6.423ns     6.438ns       0.000       0.000        83.5        25.7
iobuf.cmp_bench_medium         305000     2.844us     0.419ns     2.843us     2.845us       0.000       0.000     23203.5     11544.5
iobuf.cmp_bench_large           95000     9.596us     1.370ns     9.594us     9.603us       0.000       0.000     77184.9     38924.3
```

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
