### PR TITLE
k/server: fix internal topics fetch usage tracking

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1580,7 +1580,6 @@ bool update_fetch_partition(
 
 ss::future<response_ptr> op_context::send_response() && {
     auto fetched_data_size = uint64_t{0};
-    auto internal_topic_bytes = size_t{0};
     for (const auto& topic : response.data.responses) {
         const bool bytes_to_exclude = std::find(
                                         usage_excluded_topics.cbegin(),
@@ -1595,7 +1594,7 @@ ss::future<response_ptr> op_context::send_response() && {
 
                 /// Account for special internal topic bytes for usage
                 if (bytes_to_exclude) {
-                    internal_topic_bytes += part_size;
+                    response.internal_topic_bytes += part_size;
                 }
             }
         }
@@ -1617,7 +1616,7 @@ ss::future<response_ptr> op_context::send_response() && {
     fetch_response final_response;
     final_response.data.error_code = response.data.error_code;
     final_response.data.session_id = response.data.session_id;
-    final_response.internal_topic_bytes = internal_topic_bytes;
+    final_response.internal_topic_bytes = response.internal_topic_bytes;
 
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {


### PR DESCRIPTION
Fetches from internal topics should not be included in usage tracking.

However, they have not be correctly excluded for sessionless fetches, only for fetches that use fetch sessions.

From the original commit, it looks like this was an oversight rather than intentional behaviour: https://github.com/redpanda-data/redpanda/commit/3339ab0c1d2938093e2ddfb7f333dcb16535641c

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v25.2.x
- [x] v25.1.x
- [x] v24.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
