### PR TITLE
[CORE-13363] container:priority_queue

### DIFF
--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -114,5 +114,6 @@ redpanda_cc_library(
     deps = [
         ":chunked_vector",
         "//src/v/base",
+        "//src/v/ssx:async_algorithm",
     ],
 )

--- a/src/v/container/BUILD
+++ b/src/v/container/BUILD
@@ -104,3 +104,15 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+redpanda_cc_library(
+    name = "priority_queue",
+    hdrs = [
+        "priority_queue.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":chunked_vector",
+        "//src/v/base",
+    ],
+)

--- a/src/v/container/chunked_vector.h
+++ b/src/v/container/chunked_vector.h
@@ -342,12 +342,17 @@ public:
     class iter {
     public:
         using iterator_category = std::random_access_iterator_tag;
-        using value_type = typename std::conditional_t<C, const T, T>;
+        using iterator_concept = std::random_access_iterator_tag;
+        using value_type = T;
         using difference_type = std::ptrdiff_t;
-        using pointer
-          = std::conditional_t<std::is_same_v<T, bool>, bool, value_type*>;
-        using reference
-          = std::conditional_t<std::is_same_v<T, bool>, bool, value_type&>;
+        using pointer = std::conditional_t<
+          std::is_same_v<T, bool>,
+          bool,
+          std::conditional_t<C, const T*, T*>>;
+        using reference = std::conditional_t<
+          std::is_same_v<T, bool>,
+          bool,
+          std::conditional_t<C, const T&, T&>>;
 
         iter() = default;
 

--- a/src/v/container/priority_queue.h
+++ b/src/v/container/priority_queue.h
@@ -12,6 +12,7 @@
 
 #include "base/vassert.h"
 #include "container/chunked_vector.h"
+#include "ssx/async_algorithm.h"
 
 #include <algorithm>
 #include <ranges>
@@ -76,6 +77,22 @@ public:
     [[nodiscard]] container_type extract_sorted() && noexcept {
         std::ranges::sort_heap(_cont, _comp);
         return std::move(_cont);
+    }
+
+    /// Returns the underlying container sorted.
+    /// \return The container sorted according to the comparison function.
+    ss::future<container_type> async_extract_sorted() && noexcept {
+        auto first = std::ranges::begin(_cont);
+        auto last = std::ranges::end(_cont);
+        auto distance = last - first;
+        co_await ssx::async_while(
+          [&distance]() { return distance > 1; },
+          [&]() mutable {
+              std::ranges::pop_heap(first, last, _comp);
+              --last;
+              --distance;
+          });
+        co_return std::move(_cont);
     }
 
 protected:
@@ -238,6 +255,21 @@ public:
         }
     }
 
+    /// \brief Inserts a range of elements..
+    /// \tparam Range The type of range to insert.
+    /// \param range The range of elements to insert.
+    template<std::ranges::sized_range Range>
+    requires std::is_nothrow_move_assignable_v<value_type>
+    ss::future<> async_push_range(Range&& range) {
+        if constexpr (base::has_reserve) {
+            reserve(base::size() + std::ranges::size(range));
+        }
+
+        co_await ssx::async_for_each(
+          base::template forward_view<Range>(range),
+          [this]<typename V>(V&& val) { this->push(std::forward<V>(val)); });
+    }
+
     /// \brief Swaps the contents of this queue with another.
     /// \param other The other priority_queue to swap with.
     using base::swap;
@@ -336,6 +368,22 @@ public:
         for (auto&& val : base::template forward_view<Range>(range)) {
             push(std::forward<decltype(val)>(val));
         }
+    }
+
+    /// \brief Inserts a range of elements. Worse elements may be evicted if the
+    /// container is full.
+    /// \param range The range of elements to insert.
+    /// \return ss::future<void>
+    template<std::ranges::sized_range Range>
+    requires std::is_nothrow_move_assignable_v<value_type>
+    ss::future<> async_push_range(Range&& range) {
+        if constexpr (base::has_reserve) {
+            reserve(base::size() + std::ranges::size(range));
+        }
+
+        co_await ssx::async_for_each(
+          base::template forward_view<Range>(range),
+          [this]<typename V>(V&& val) { this->push(std::forward<V>(val)); });
     }
 
     /// \brief Swaps the contents of this queue with another.

--- a/src/v/container/priority_queue.h
+++ b/src/v/container/priority_queue.h
@@ -18,6 +18,16 @@
 
 namespace detail {
 
+template<typename Comp>
+struct invert_comparator {
+    template<typename T, typename U>
+    constexpr bool operator()(T&& a, U&& b) const {
+        return _underlying(std::forward<U>(b), std::forward<T>(a));
+    }
+
+    [[no_unique_address]] Comp _underlying;
+};
+
 /// Base class for priority queue implementations containing common
 /// functionality.
 ///
@@ -233,5 +243,121 @@ public:
     using base::swap;
 };
 
+/// \brief The bounded priority queue is a container that maintains the top-k of
+/// inserted elements.
+///
+/// It provides logarithmic insertion.
+/// top() and pop() are not provided, since it would require O(n) time, instead,
+/// use extract_heap(), or extract_sorted().
+template<
+  typename T,
+  typename Container = std::vector<T>,
+  typename Comp = std::ranges::less>
+requires std::same_as<typename Container::value_type, T>
+         && std::is_nothrow_move_constructible_v<T>
+         && std::is_nothrow_move_assignable_v<T>
+class bounded_priority_queue
+  : public detail::
+      priority_queue_base<T, Container, detail::invert_comparator<Comp>> {
+private:
+    using base = detail::
+      priority_queue_base<T, Container, detail::invert_comparator<Comp>>;
+
+public:
+    using typename base::const_reference;
+    using typename base::container_type;
+    using typename base::reference;
+    using typename base::size_type;
+    using typename base::value_compare;
+    using typename base::value_type;
+
+    /// \brief Constructs a bounded priority queue with the specified capacity
+    /// and comparison function.
+    /// \param capacity The maximum number of elements the queue can hold.
+    /// \param comp The comparison function to use for ordering elements.
+    /// Note: Internally uses a min-heap (inverted comparator) for efficient
+    /// top-K operations.
+    explicit bounded_priority_queue(size_type capacity, Comp comp = {})
+      : base{detail::invert_comparator<Comp>{std::move(comp)}}
+      , _cap{capacity} {}
+
+    /// \brief Checks whether the container adaptor is full
+    bool full() const noexcept { return base::size() == _cap; }
+
+    /// \brief Reserves storage for at least the specified number of elements
+    /// (only available if the underlying container supports reserve).
+    /// \param cap The new capacity to reserve (bounded to capacity on
+    /// construction).
+    void reserve(size_type new_cap)
+    requires base::has_reserve
+    {
+        return base::reserve(std::min(_cap, new_cap));
+    }
+
+    /// \brief Inserts an element. The worst element may be evicted if the
+    /// container is full.
+    /// \param val The element to insert.
+    /// \return whether the element was inserted.
+    template<typename U>
+    requires std::same_as<std::remove_cvref_t<U>, value_type>
+    bool push(U&& val) {
+        if (!full()) {
+            base::_cont.push_back(std::forward<U>(val));
+            base::push_heap();
+            return true;
+        }
+
+        // Min-heap: front contains the worst of the K best elements
+        if (!comp()(base::_cont.front(), val)) {
+            return false; // New element is not better than worst
+        }
+
+        // Move worst (front) to back: O(log K)
+        base::pop_heap();
+        // Replace worst with new element
+        base::_cont.back() = std::forward<U>(val);
+        // Restore heap
+        base::push_heap();
+
+        return true;
+    }
+
+    /// \brief Inserts a range of elements. Worse elements may be evicted if the
+    /// container is full.
+    /// \param range The range of elements to insert.
+    /// \return void
+    template<std::ranges::sized_range Range>
+    requires std::is_nothrow_move_assignable_v<value_type>
+    void push_range(Range&& range) {
+        if constexpr (base::has_reserve) {
+            reserve(base::size() + std::ranges::size(range));
+        }
+
+        for (auto&& val : base::template forward_view<Range>(range)) {
+            push(std::forward<decltype(val)>(val));
+        }
+    }
+
+    /// \brief Swaps the contents of this queue with another.
+    /// \param other The other bounded_priority_queue to swap with.
+    void swap(bounded_priority_queue& other) noexcept(
+      std::is_nothrow_swappable_v<container_type>
+      && std::is_nothrow_swappable_v<value_compare>
+      && std::is_nothrow_swappable_v<Comp>) {
+        using std::swap;
+        base::swap(other);
+        swap(_cap, other._cap);
+    }
+
+private:
+    auto comp() const noexcept { return base::_comp._underlying; }
+
+    size_type _cap;
+};
+
 template<typename T, typename Comp = std::ranges::less>
 using chunked_priority_queue = priority_queue<T, chunked_vector<T>, Comp>;
+
+template<typename T, typename Comp = std::ranges::less>
+using chunked_bounded_priority_queue
+  = bounded_priority_queue<T, chunked_vector<T>, Comp>;

--- a/src/v/container/priority_queue.h
+++ b/src/v/container/priority_queue.h
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/vassert.h"
+#include "container/chunked_vector.h"
+
+#include <algorithm>
+#include <ranges>
+
+namespace detail {
+
+/// Base class for priority queue implementations containing common
+/// functionality.
+///
+/// \tparam T The type of elements stored in the priority queue
+/// \tparam Container The underlying container type (default: std::vector<T>)
+/// \tparam Comp The comparison function type (default: std::ranges::less)
+template<
+  typename T,
+  typename Container = std::vector<T>,
+  typename Comp = std::ranges::less>
+requires std::same_as<typename Container::value_type, T>
+         && std::is_nothrow_move_constructible_v<T>
+         && std::is_nothrow_move_assignable_v<T>
+class priority_queue_base {
+public:
+    using container_type = Container;
+    using value_compare = Comp;
+    using value_type = typename container_type::value_type;
+    using reference = typename container_type::reference;
+    using const_reference = typename container_type::const_reference;
+    using size_type = typename container_type::size_type;
+
+protected:
+    /// Protected constructor for derived classes.
+    /// \param comp The comparison function to use for ordering elements
+    explicit priority_queue_base(Comp comp = {})
+      : _comp{std::move(comp)} {}
+
+public:
+    /// \brief Checks whether the container adaptor is empty.
+    /// \return true if the container adaptor is empty, false otherwise
+    bool empty() const noexcept { return _cont.empty(); }
+
+    /// \brief Returns the number of elements.
+    /// \return The number of elements in the container
+    size_type size() const noexcept { return _cont.size(); }
+
+    /// Returns the underlying container as a heap.
+    /// \return The container with heap ordering.
+    [[nodiscard]] container_type extract_heap() && noexcept {
+        return std::move(_cont);
+    }
+
+    /// Returns the underlying container sorted.
+    /// \return The container sorted according to the comparison function.
+    [[nodiscard]] container_type extract_sorted() && noexcept {
+        std::ranges::sort_heap(_cont, _comp);
+        return std::move(_cont);
+    }
+
+protected:
+    static constexpr bool has_reserve = requires(Container& c, size_type n) {
+        c.reserve(n);
+    };
+
+    /// \brief Reserves storage for at least the specified number of elements
+    /// (only available if the underlying container supports reserve).
+    /// \param new_cap The new capacity to reserve
+    void reserve(size_type new_cap)
+    requires has_reserve
+    {
+        _cont.reserve(new_cap);
+    }
+
+    /// \brief Swaps the contents of this queue with another.
+    /// \param other The other bounded_priority_queue to swap with.
+    void swap(priority_queue_base& other) noexcept(
+      std::is_nothrow_swappable_v<container_type>
+      && std::is_nothrow_swappable_v<value_compare>) {
+        using std::swap;
+        swap(_cont, other._cont);
+        swap(_comp, other._comp);
+    }
+
+    /// \brief Move elements from a range, when safe to do so.
+    /// \tparam Range The type of the range to forward.
+    /// \param range The range to forward.
+    template<std::ranges::sized_range Range>
+    decltype(auto) forward_view(auto&& range) noexcept {
+        if constexpr (std::ranges::borrowed_range<Range>) {
+            return std::forward<Range>(range);
+        } else {
+            return std::views::as_rvalue(range);
+        }
+    };
+
+    /// \brief Restores heap property after adding an element to the back.
+    /// Should be called after inserting elements into the underlying container.
+    void push_heap() { std::ranges::push_heap(_cont, _comp); }
+
+    /// \brief Restores heap property before removing the top element.
+    /// Should be called before removing elements from the underlying container.
+    void pop_heap() { std::ranges::pop_heap(_cont, _comp); }
+
+    /// \brief Restores heap property after inserting a range.
+    /// Should be called after inserting several elements into the underlying
+    /// container.
+    void make_heap() { std::ranges::make_heap(_cont, _comp); }
+
+    Container _cont;
+    Comp _comp;
+};
+
+} // namespace detail
+
+/// Unbounded priority queue - drop-in replacement for std::priority_queue with
+/// move-semantics.
+///
+/// This class provides a compatible interface with std::priority_queue while
+/// allowing for future extensions and optimizations. It maintains a max-heap
+/// by default (largest element at top).
+///
+/// \tparam T The type of elements stored in the priority queue
+/// \tparam Container The underlying container type (default: std::vector<T>)
+/// \tparam Comp The comparison function type (default: std::ranges::less)
+template<
+  typename T,
+  typename Container = std::vector<T>,
+  typename Comp = std::ranges::less>
+requires std::same_as<typename Container::value_type, T>
+         && std::is_nothrow_move_constructible_v<T>
+         && std::is_nothrow_move_assignable_v<T>
+class priority_queue : public detail::priority_queue_base<T, Container, Comp> {
+private:
+    using base = detail::priority_queue_base<T, Container, Comp>;
+
+public:
+    using typename base::const_reference;
+    using typename base::container_type;
+    using typename base::reference;
+    using typename base::size_type;
+    using typename base::value_compare;
+    using typename base::value_type;
+
+    /// Default constructor - creates an empty priority queue.
+    priority_queue() = default;
+
+    /// Constructor with comparison function.
+    /// \param comp The comparison function to use for ordering elements
+    explicit priority_queue(Comp comp)
+      : base{std::move(comp)} {}
+
+    /// \brief Reserves storage for at least the specified number of elements
+    /// (only available if the underlying container supports reserve).
+    /// \param new_cap The new capacity to reserve
+    void reserve(size_type new_cap)
+    requires base::has_reserve
+    {
+        return base::reserve(new_cap);
+    }
+
+    /// \brief Accesses the top element.
+    /// \pre !empty()
+    /// \return Reference to the top element
+    const_reference top() const noexcept {
+        vassert(!base::empty(), "top() called on empty priority queue");
+        return base::_cont.front();
+    }
+
+    /// \brief Removes and returns the top element
+    /// \pre !empty()
+    /// \return The top element.
+    [[nodiscard]] value_type pop() noexcept {
+        vassert(!base::empty(), "pop() called on empty priority queue");
+        base::pop_heap();
+        value_type val = std::move(base::_cont.back());
+        base::_cont.pop_back();
+        return val;
+    }
+
+    /// \brief Insert an element.
+    /// \param val The element to insert
+    template<typename U>
+    requires std::same_as<std::remove_cvref_t<U>, value_type>
+    void push(U&& val) {
+        base::_cont.emplace_back(std::forward<U>(val));
+        base::push_heap();
+    }
+
+    /// \brief Inserts a range of elements.
+    /// \tparam Range The type of range to insert.
+    /// \param range The range of elements to insert.
+    template<std::ranges::sized_range Range>
+    requires std::is_nothrow_move_constructible_v<value_type>
+    void push_range(Range&& range) {
+        auto&& forwarded = base::template forward_view<Range>(range);
+
+        const size_type input_size = std::ranges::size(forwarded);
+
+        if constexpr (base::has_reserve) {
+            reserve(base::size() + input_size);
+        }
+
+        if (base::empty()) {
+            for (auto&& val : forwarded) {
+                base::_cont.emplace_back(std::forward<decltype(val)>(val));
+            }
+
+            if (input_size == 1) {
+                base::push_heap();
+            } else if (input_size > 1) {
+                base::make_heap();
+            }
+        } else {
+            for (auto&& val : forwarded) {
+                push(std::forward<decltype(val)>(val));
+            }
+        }
+    }
+
+    /// \brief Swaps the contents of this queue with another.
+    /// \param other The other priority_queue to swap with.
+    using base::swap;
+};
+
+template<typename T, typename Comp = std::ranges::less>
+using chunked_priority_queue = priority_queue<T, chunked_vector<T>, Comp>;

--- a/src/v/container/tests/BUILD
+++ b/src/v/container/tests/BUILD
@@ -127,3 +127,16 @@ redpanda_cc_bench(
         "@seastar//:benchmark",
     ],
 )
+
+redpanda_cc_gtest(
+    name = "priority_queue_test",
+    timeout = "short",
+    srcs = [
+        "priority_queue_test.cc",
+    ],
+    deps = [
+        "//src/v/container:priority_queue",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+    ],
+)

--- a/src/v/container/tests/BUILD
+++ b/src/v/container/tests/BUILD
@@ -140,3 +140,21 @@ redpanda_cc_gtest(
         "@googletest//:gtest",
     ],
 )
+
+redpanda_cc_bench(
+    name = "priority_queue_rpbench",
+    srcs = [
+        "priority_queue_bench.cc",
+    ],
+    deps = [
+        ":bench_utils",
+        "//src/v/container:chunked_vector",
+        "//src/v/container:priority_queue",
+        "//src/v/random:generators",
+        "//src/v/ssx:async_algorithm",
+        "//src/v/ssx:async_clear",
+        "//src/v/ssx:async_merge_top_k",
+        "@seastar",
+        "@seastar//:benchmark",
+    ],
+)

--- a/src/v/container/tests/chunked_vector_test.cc
+++ b/src/v/container/tests/chunked_vector_test.cc
@@ -33,8 +33,10 @@ using testing::AssertionResult;
 using testing::AssertionSuccess;
 using vec = chunked_vector<int>;
 
-static_assert(std::forward_iterator<vec::iterator>);
-static_assert(std::forward_iterator<vec::const_iterator>);
+static_assert(std::random_access_iterator<vec::iterator>);
+static_assert(std::random_access_iterator<vec::const_iterator>);
+static_assert(std::ranges::random_access_range<vec>);
+static_assert(std::ranges::random_access_range<const vec>);
 
 class chunked_vector_validator {
 public:
@@ -358,6 +360,12 @@ TEST(Vector, Sort) {
     std::sort(v.begin(), v.end());
 
     EXPECT_THAT(v, ElementsAre(1, 2, 3));
+}
+
+TEST(Vector, Heap) {
+    vec v{1, 2, 3};
+    std::ranges::make_heap(v);
+    EXPECT_TRUE(std::ranges::is_heap(v));
 }
 
 TEST(Vector, Clear) {

--- a/src/v/container/tests/priority_queue_bench.cc
+++ b/src/v/container/tests/priority_queue_bench.cc
@@ -1,0 +1,194 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "container/chunked_vector.h"
+#include "container/priority_queue.h"
+#include "container/tests/bench_utils.h"
+#include "random/generators.h"
+
+#include <seastar/core/map_reduce.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <queue>
+#include <type_traits>
+
+template<typename PriorityQueue, size_t Size>
+struct PriorityQueueBenchTest {
+    using value_type = typename PriorityQueue::value_type;
+
+    static auto make_random_value() {
+        if constexpr (std::is_integral_v<value_type>) {
+            return random_generators::get_int<value_type>();
+        } else if constexpr (std::same_as<value_type, ss::sstring>) {
+            return random_generators::gen_alphanum_string(32);
+        } else if constexpr (std::same_as<value_type, large_struct>) {
+            constexpr size_t max_str_len = 64;
+            constexpr size_t max_num_cardinality = 16;
+            return large_struct{
+              .foo = max_num_cardinality / 3,
+              .bar = max_num_cardinality - 2,
+              .qux = std::string(max_str_len / 8, 'x'),
+              .baz = random_generators::gen_alphanum_string(max_str_len / 4),
+              .more = random_generators::gen_alphanum_string(max_str_len / 2),
+              .data = random_generators::gen_alphanum_string(max_str_len / 1),
+              .okdone = 4242,
+            };
+        }
+    }
+
+    static auto make_test_data() {
+        chunked_vector<value_type> vec;
+        vec.reserve(Size);
+        for (size_t j = 0; j < Size; ++j) {
+            vec.emplace_back(make_random_value());
+        }
+        return vec;
+    }
+
+    chunked_vector<value_type> test_data = make_test_data();
+
+    PriorityQueue make_filled() {
+        PriorityQueue pq;
+        for (auto val : test_data) {
+            pq.push(val);
+        }
+        return pq;
+    }
+
+    PriorityQueue make_range_filled() {
+        PriorityQueue pq;
+        pq.push_range(test_data);
+        return pq;
+    }
+
+    [[gnu::noinline]]
+    void run_push_test() {
+        PriorityQueue pq = make_filled();
+        perf_tests::do_not_optimize(pq);
+    }
+
+    [[gnu::noinline]]
+    void run_push_range_test() {
+        PriorityQueue pq = make_range_filled();
+        perf_tests::do_not_optimize(pq);
+    }
+
+    PriorityQueue filled_pop = make_range_filled();
+
+    [[gnu::noinline]]
+    void run_pop_test() {
+        while (!filled_pop.empty()) {
+            if constexpr (!std::is_void_v<decltype(filled_pop.pop())>) {
+                // bounded_priority_queue::pop() returns a value
+                auto x = filled_pop.pop();
+                perf_tests::do_not_optimize(x);
+            } else {
+                // std::priority_queue::pop() returns void
+                auto x = filled_pop.top();
+                filled_pop.pop();
+                perf_tests::do_not_optimize(x);
+            }
+        }
+    }
+
+    PriorityQueue filled_extract_sorted = make_range_filled();
+
+    [[gnu::noinline]]
+    void run_extract_sorted_test() {
+        auto x = std::move(filled_extract_sorted).extract_sorted();
+        perf_tests::do_not_optimize(x);
+    }
+
+    PriorityQueue filled_async_extract_sorted = make_range_filled();
+
+    [[gnu::noinline]]
+    ss::future<> run_async_extract_sorted_test() {
+        auto x = co_await std::move(filled_async_extract_sorted)
+                   .async_extract_sorted()
+                   .get();
+        perf_tests::do_not_optimize(x);
+    }
+
+    PriorityQueue filled_sort_extract_sorted = make_range_filled();
+
+    [[gnu::noinline]]
+    void run_sort_extract_heap_test() {
+        auto x = std::move(filled_sort_extract_sorted).extract_heap();
+        std::ranges::sort(x);
+        perf_tests::do_not_optimize(x);
+    }
+};
+
+// NOLINTBEGIN(*-macro-*)
+#define PRIORITY_QUEUE_PERF_TEST(container, element, size)                     \
+    class PriorityQueueBenchTest_##container##_##element##_##size              \
+      : public PriorityQueueBenchTest<container<element>, size> {};            \
+    PERF_TEST_F(                                                               \
+      PriorityQueueBenchTest_##container##_##element##_##size, Push) {         \
+        run_push_test();                                                       \
+    }                                                                          \
+    PERF_TEST_F(                                                               \
+      PriorityQueueBenchTest_##container##_##element##_##size, PushRange) {    \
+        run_push_range_test();                                                 \
+    }                                                                          \
+    PERF_TEST_F(                                                               \
+      PriorityQueueBenchTest_##container##_##element##_##size, Pop) {          \
+        run_pop_test();                                                        \
+    }
+
+#define BOUNDED_PRIORITY_QUEUE_PERF_TEST(container, element, size)             \
+    class BoundedPriorityQueueBenchTest_##container##_##element##_##size       \
+      : public PriorityQueueBenchTest<container<element>, size> {};            \
+    PERF_TEST_F(                                                               \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##size, Push) {  \
+        run_push_test();                                                       \
+    }                                                                          \
+    PERF_TEST_F(                                                               \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##size,          \
+      PushRange) {                                                             \
+        run_push_range_test();                                                 \
+    }                                                                          \
+    PERF_TEST_F(                                                               \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##size,          \
+      ExtractSorted) {                                                         \
+        run_extract_sorted_test();                                             \
+    }                                                                          \
+    PERF_TEST_F(                                                               \
+      BoundedPriorityQueueBenchTest_##container##_##element##_##size,          \
+      SortExtractHeap) {                                                       \
+        run_sort_extract_heap_test();                                          \
+    }
+// NOLINTEND(*-macro-*)
+
+template<typename T>
+using std_priority_queue = std::priority_queue<T>;
+
+PRIORITY_QUEUE_PERF_TEST(std_priority_queue, int64_t, 64)
+PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 64)
+
+PRIORITY_QUEUE_PERF_TEST(std_priority_queue, int64_t, 1024)
+PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1024)
+
+PRIORITY_QUEUE_PERF_TEST(std_priority_queue, sstring, 1024)
+PRIORITY_QUEUE_PERF_TEST(priority_queue, sstring, 1024)
+
+PRIORITY_QUEUE_PERF_TEST(std_priority_queue, large_struct, 1024)
+PRIORITY_QUEUE_PERF_TEST(priority_queue, large_struct, 1024)
+
+PRIORITY_QUEUE_PERF_TEST(std_priority_queue, int64_t, 1048576)
+PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1048576)
+
+// BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 64)
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1024)
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, sstring, 1024)
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, large_struct, 1024)
+BOUNDED_PRIORITY_QUEUE_PERF_TEST(priority_queue, int64_t, 1048576)

--- a/src/v/container/tests/priority_queue_test.cc
+++ b/src/v/container/tests/priority_queue_test.cc
@@ -231,6 +231,25 @@ TYPED_TEST(PriorityQueueCommonTest, ExtractSorted) {
     EXPECT_EQ(sorted[4], this->make_value(5));
 }
 
+TYPED_TEST(PriorityQueueCommonTest, AsyncExtractSorted) {
+    auto pq = this->make_queue();
+
+    std::vector<typename TestFixture::value_type> values;
+    for (int val : {3, 1, 4, 1, 5}) {
+        values.push_back(this->make_value(val));
+    }
+    pq.async_push_range(std::move(values)).get();
+
+    auto sorted = std::move(pq).async_extract_sorted().get();
+
+    EXPECT_EQ(sorted.size(), 5);
+    EXPECT_EQ(sorted[0], this->make_value(1));
+    EXPECT_EQ(sorted[1], this->make_value(1));
+    EXPECT_EQ(sorted[2], this->make_value(3));
+    EXPECT_EQ(sorted[3], this->make_value(4));
+    EXPECT_EQ(sorted[4], this->make_value(5));
+}
+
 TYPED_TEST(PriorityQueueCommonTest, CustomComparator) {
     auto pq = this->make_queue_with_comp(std::ranges::greater{});
 
@@ -376,6 +395,22 @@ TYPED_TEST(BoundedPriorityQueueTest, TopKBehavior) {
     EXPECT_EQ(bpq.size(), 3);
 
     auto results = std::move(bpq).extract_sorted();
+
+    // Should be the top 3 elements in descending order
+    auto expected = this->make_values({20, 15, 12});
+    EXPECT_EQ(results, expected);
+}
+
+TYPED_TEST(BoundedPriorityQueueTest, AsyncExtractSorted) {
+    auto bpq = this->make_bounded_queue(3); // Keep top 3 elements
+
+    // Insert elements in random order
+    bpq.async_push_range(this->make_values({5, 10, 2, 15, 8, 20, 1, 12})).get();
+
+    // Should contain the 3 largest elements: 20, 15, 12
+    EXPECT_EQ(bpq.size(), 3);
+
+    auto results = std::move(bpq).async_extract_sorted().get();
 
     // Should be the top 3 elements in descending order
     auto expected = this->make_values({20, 15, 12});

--- a/src/v/container/tests/priority_queue_test.cc
+++ b/src/v/container/tests/priority_queue_test.cc
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "container/priority_queue.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <queue>
+#include <vector>
+
+struct value {
+    explicit value(int data)
+      : _data(data) {}
+
+    auto operator<=>(const value&) const = default;
+    bool operator==(const value&) const = default;
+
+    int _data;
+};
+
+struct move_only {
+    explicit move_only(int data)
+      : _data{data} {}
+
+    move_only(move_only&&) = default;
+    move_only& operator=(move_only&&) = default;
+
+    move_only(const move_only&) = delete;
+    move_only& operator=(const move_only&) = delete;
+
+    ~move_only() = default;
+
+    auto operator<=>(const move_only&) const = default;
+    bool operator==(const move_only&) const = default;
+
+    int _data;
+};
+
+template<template<typename...> class Queue, typename ValueType>
+struct QueueFactory {
+    // Use large capacity for bounded queues so they behave like unbounded for
+    // small test data
+    static constexpr size_t large_capacity = 1000;
+    using value_type = ValueType;
+
+    static auto make_queue() { return Queue<ValueType>{}; }
+
+    template<typename Comp>
+    static auto make_queue_with_comp(Comp comp) {
+        return Queue<ValueType, Comp>{comp};
+    }
+
+    static value_type make_value(int val) { return value_type{val}; }
+};
+
+// Specific factory types using the generic template
+template<typename T>
+using UnboundedQueueFactory = QueueFactory<chunked_priority_queue, T>;
+
+// Types to test - both value types and move-only types
+using QueueTypes = ::testing::
+  Types<UnboundedQueueFactory<int>, UnboundedQueueFactory<move_only>>;
+
+// Copyable types only (for tests that require copying)
+using CopyableQueueTypes = ::testing::Types<UnboundedQueueFactory<int>>;
+
+// Types for std compatibility testing (unbounded only, copyable types)
+using StdCompatibilityTypes
+  = ::testing::Types<UnboundedQueueFactory<int>, UnboundedQueueFactory<value>>;
+
+// Typed test suite for std::priority_queue compatibility - inherits common
+// functionality
+template<typename QueueFactory>
+class StdCompatibilityTest
+  : public QueueFactory
+  , public ::testing::Test {};
+
+TYPED_TEST_SUITE(StdCompatibilityTest, StdCompatibilityTypes);
+
+// Test drop-in replacement compatibility with std::priority_queue
+TYPED_TEST(StdCompatibilityTest, StdCompatibility) {
+    std::priority_queue<typename TestFixture::value_type> std_pq;
+    priority_queue<typename TestFixture::value_type> our_pq;
+
+    for (int i : {3, 1, 4, 1, 5}) {
+        std_pq.push(this->make_value(i));
+        our_pq.push(this->make_value(i));
+    }
+
+    // Test size and empty
+    EXPECT_EQ(std_pq.size(), our_pq.size());
+    EXPECT_EQ(std_pq.empty(), our_pq.empty());
+
+    // Test top and pop equivalence
+    while (!std_pq.empty() && !our_pq.empty()) {
+        EXPECT_EQ(std_pq.top(), our_pq.top());
+        std_pq.pop();
+        std::ignore = our_pq.pop();
+    }
+
+    EXPECT_EQ(std_pq.empty(), our_pq.empty());
+}
+
+// Typed test suite for common functionality
+template<typename QueueFactory>
+class PriorityQueueCommonTest
+  : public QueueFactory
+  , public ::testing::Test {};
+
+TYPED_TEST_SUITE(PriorityQueueCommonTest, QueueTypes);
+
+TYPED_TEST(PriorityQueueCommonTest, BasicOperations) {
+    auto pq = this->make_queue();
+
+    EXPECT_TRUE(pq.empty());
+    EXPECT_EQ(pq.size(), 0);
+
+    auto test_value = this->make_value(42);
+    pq.push(std::move(test_value));
+    EXPECT_FALSE(pq.empty());
+    EXPECT_EQ(pq.size(), 1);
+
+    auto expected_value = this->make_value(42);
+    EXPECT_EQ(pq.top(), expected_value);
+
+    std::ignore = pq.pop();
+    EXPECT_TRUE(pq.empty());
+}
+
+TYPED_TEST(PriorityQueueCommonTest, PushRange) {
+    auto pq = this->make_queue();
+
+    // Create a vector of values of the appropriate type
+    {
+        std::vector<typename TestFixture::value_type> values;
+        values.push_back(this->make_value(3));
+        pq.push_range(std::move(values));
+    }
+
+    {
+        std::vector<typename TestFixture::value_type> values;
+        for (int val : {1, 4, 1, 5}) {
+            values.push_back(this->make_value(val));
+        }
+        pq.push_range(std::move(values));
+    }
+    EXPECT_EQ(pq.size(), 5);
+
+    std::vector<typename TestFixture::value_type> results;
+    while (!pq.empty()) {
+        results.push_back(pq.pop());
+    }
+
+    EXPECT_TRUE(std::ranges::is_sorted(results, std::ranges::greater{}));
+}
+
+TYPED_TEST(PriorityQueueCommonTest, ExtractHeap) {
+    auto pq = this->make_queue();
+
+    std::vector<typename TestFixture::value_type> values;
+    for (int val : {3, 1, 4, 1, 5}) {
+        values.push_back(this->make_value(val));
+    }
+    pq.push_range(std::move(values));
+
+    auto heap = std::move(pq).extract_heap();
+    EXPECT_TRUE(std::ranges::is_heap(heap));
+
+    constexpr auto pop = [](auto& heap) {
+        std::ranges::pop_heap(heap);
+        auto val = std::move(heap.back());
+        heap.pop_back();
+        return val;
+    };
+
+    EXPECT_EQ(pop(heap), this->make_value(5));
+    EXPECT_EQ(pop(heap), this->make_value(4));
+    EXPECT_EQ(pop(heap), this->make_value(3));
+    EXPECT_EQ(pop(heap), this->make_value(1));
+    EXPECT_EQ(pop(heap), this->make_value(1));
+}
+
+TYPED_TEST(PriorityQueueCommonTest, ExtractSorted) {
+    auto pq = this->make_queue();
+
+    std::vector<typename TestFixture::value_type> values;
+    for (int val : {3, 1, 4, 1, 5}) {
+        values.push_back(this->make_value(val));
+    }
+    pq.push_range(std::move(values));
+
+    auto sorted = std::move(pq).extract_sorted();
+
+    EXPECT_EQ(sorted.size(), 5);
+    EXPECT_EQ(sorted[0], this->make_value(1));
+    EXPECT_EQ(sorted[1], this->make_value(1));
+    EXPECT_EQ(sorted[2], this->make_value(3));
+    EXPECT_EQ(sorted[3], this->make_value(4));
+    EXPECT_EQ(sorted[4], this->make_value(5));
+}
+
+TYPED_TEST(PriorityQueueCommonTest, CustomComparator) {
+    auto pq = this->make_queue_with_comp(std::ranges::greater{});
+
+    // Create a vector of values with custom comparator (min-heap behavior)
+    std::vector<typename TestFixture::value_type> values;
+    for (int val : {3, 1, 4, 1, 5}) {
+        values.push_back(this->make_value(val));
+    }
+
+    pq.push_range(std::move(values));
+    EXPECT_EQ(pq.size(), 5);
+
+    std::vector<typename TestFixture::value_type> sorted;
+    while (!pq.empty()) {
+        sorted.push_back(pq.pop());
+    }
+
+    EXPECT_EQ(sorted.size(), 5);
+    EXPECT_EQ(sorted[0], this->make_value(1));
+    EXPECT_EQ(sorted[1], this->make_value(1));
+    EXPECT_EQ(sorted[2], this->make_value(3));
+    EXPECT_EQ(sorted[3], this->make_value(4));
+    EXPECT_EQ(sorted[4], this->make_value(5));
+}

--- a/src/v/container/tests/priority_queue_test.cc
+++ b/src/v/container/tests/priority_queue_test.cc
@@ -54,24 +54,47 @@ struct QueueFactory {
 
     static auto make_queue() { return Queue<ValueType>{}; }
 
+    static auto make_bounded_queue(size_t cap) { return Queue<ValueType>{cap}; }
+
     template<typename Comp>
     static auto make_queue_with_comp(Comp comp) {
         return Queue<ValueType, Comp>{comp};
     }
 
+    template<typename Comp>
+    static auto make_bounded_queue_with_comp(size_t cap, Comp comp) {
+        return Queue<ValueType, Comp>{cap, comp};
+    }
+
     static value_type make_value(int val) { return value_type{val}; }
+
+    static chunked_vector<value_type>
+    make_values(std::initializer_list<size_t> vals) {
+        chunked_vector<value_type> result;
+        result.reserve(vals.size());
+        for (auto v : vals)
+            result.push_back(make_value(v));
+        return result;
+    }
 };
 
 // Specific factory types using the generic template
 template<typename T>
 using UnboundedQueueFactory = QueueFactory<chunked_priority_queue, T>;
 
+template<typename T>
+using BoundedQueueFactory = QueueFactory<chunked_bounded_priority_queue, T>;
+
 // Types to test - both value types and move-only types
 using QueueTypes = ::testing::
   Types<UnboundedQueueFactory<int>, UnboundedQueueFactory<move_only>>;
 
+using BoundedQueueTypes
+  = ::testing::Types<BoundedQueueFactory<int>, BoundedQueueFactory<move_only>>;
+
 // Copyable types only (for tests that require copying)
-using CopyableQueueTypes = ::testing::Types<UnboundedQueueFactory<int>>;
+using CopyableQueueTypes
+  = ::testing::Types<UnboundedQueueFactory<int>, BoundedQueueFactory<int>>;
 
 // Types for std compatibility testing (unbounded only, copyable types)
 using StdCompatibilityTypes
@@ -231,4 +254,130 @@ TYPED_TEST(PriorityQueueCommonTest, CustomComparator) {
     EXPECT_EQ(sorted[2], this->make_value(3));
     EXPECT_EQ(sorted[3], this->make_value(4));
     EXPECT_EQ(sorted[4], this->make_value(5));
+}
+
+template<typename QueueFactory>
+class BoundedPriorityQueueTest
+  : public QueueFactory
+  , public ::testing::Test {};
+
+TYPED_TEST_SUITE(BoundedPriorityQueueTest, BoundedQueueTypes);
+
+TYPED_TEST(BoundedPriorityQueueTest, CapacityConstraints) {
+    auto bpq = this->make_bounded_queue(2);
+
+    // Fill to capacity
+    EXPECT_TRUE(bpq.push(this->make_value(10)));
+    EXPECT_TRUE(bpq.push(this->make_value(20)));
+    EXPECT_TRUE(bpq.full());
+
+    // Try to push a worse element (smaller value) - should be rejected
+    EXPECT_FALSE(bpq.push(this->make_value(5)));
+    EXPECT_EQ(bpq.size(), 2);
+
+    // Try to push a better element (larger value) - should evict worst element
+    // This maintains the top-K elements by comparing with the worst (minimum)
+    // and replacing it if the new element is better
+    EXPECT_TRUE(bpq.push(this->make_value(25)));
+    EXPECT_EQ(bpq.size(), 2);
+
+    // Verify the final contents - should have the 2 best elements
+    auto results = std::move(bpq).extract_sorted();
+    EXPECT_TRUE(std::ranges::is_sorted(results, std::ranges::greater{}));
+    EXPECT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0], this->make_value(25));
+    EXPECT_EQ(results[1], this->make_value(20));
+}
+
+TYPED_TEST(BoundedPriorityQueueTest, PushRange) {
+    auto bpq = this->make_bounded_queue(3); // Keep top 3 elements
+
+    auto elements = this->make_values({5, 10, 2, 15, 8, 20, 1, 12});
+
+    bpq.push_range(elements | std::views::as_rvalue);
+
+    // Should contain the 3 largest elements: 20, 15, 12
+    EXPECT_EQ(bpq.size(), 3);
+
+    auto results = std::move(bpq).extract_sorted();
+
+    // Should be the top 3 elements in descending order
+    auto expected = this->make_values({20, 15, 12});
+    EXPECT_EQ(results, expected);
+}
+
+TYPED_TEST(BoundedPriorityQueueTest, Swap) {
+    auto bpq1 = this->make_bounded_queue(2);
+    auto bpq2 = this->make_bounded_queue(3);
+
+    bpq1.push(this->make_value(10));
+    bpq1.push(this->make_value(20));
+
+    bpq2.push(this->make_value(30));
+    bpq2.push(this->make_value(40));
+    bpq2.push(this->make_value(50));
+
+    bpq1.swap(bpq2);
+
+    EXPECT_EQ(bpq1.size(), 3);
+    EXPECT_EQ(bpq2.size(), 2);
+
+    EXPECT_EQ(std::move(bpq1).extract_sorted()[0], this->make_value(50));
+    EXPECT_EQ(std::move(bpq2).extract_sorted()[0], this->make_value(20));
+}
+
+TYPED_TEST(BoundedPriorityQueueTest, MoveSemantics) {
+    auto bpq1 = this->make_bounded_queue(3);
+    bpq1.push(this->make_value(10));
+    bpq1.push(this->make_value(20));
+
+    // Test move constructor
+    auto bpq2 = std::move(bpq1);
+    EXPECT_EQ(bpq2.size(), 2);
+    EXPECT_EQ(std::move(bpq2).extract_sorted()[0], this->make_value(20));
+
+    // Test move assignment
+    auto bpq3 = this->make_bounded_queue(5);
+    bpq3.push(this->make_value(5));
+    auto bpq4 = this->make_bounded_queue(3);
+    bpq4.push(this->make_value(15));
+    bpq4.push(this->make_value(25));
+
+    bpq3 = std::move(bpq4);
+    EXPECT_EQ(bpq3.size(), 2);
+    EXPECT_EQ(std::move(bpq3).extract_sorted()[0], this->make_value(25));
+}
+
+TYPED_TEST(BoundedPriorityQueueTest, LargeCapacity) {
+    constexpr size_t large_cap = 1000;
+    auto bpq = this->make_bounded_queue(large_cap);
+    bpq.reserve(500);
+
+    // Fill partially
+    for (int i = 0; i < 500; ++i) {
+        EXPECT_TRUE(bpq.push(this->make_value(i)));
+    }
+
+    EXPECT_EQ(bpq.size(), 500);
+    EXPECT_FALSE(bpq.full());
+    EXPECT_EQ(
+      std::move(bpq).extract_sorted()[0],
+      this->make_value(499)); // Largest element
+}
+
+TYPED_TEST(BoundedPriorityQueueTest, TopKBehavior) {
+    // Demonstrate proper top-K behavior with a small capacity
+    auto bpq = this->make_bounded_queue(3); // Keep top 3 elements
+
+    // Insert elements in random order
+    bpq.push_range(this->make_values({5, 10, 2, 15, 8, 20, 1, 12}));
+
+    // Should contain the 3 largest elements: 20, 15, 12
+    EXPECT_EQ(bpq.size(), 3);
+
+    auto results = std::move(bpq).extract_sorted();
+
+    // Should be the top 3 elements in descending order
+    auto expected = this->make_values({20, 15, 12});
+    EXPECT_EQ(results, expected);
 }

--- a/src/v/ssx/BUILD
+++ b/src/v/ssx/BUILD
@@ -99,6 +99,20 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "async_merge_top_k",
+    hdrs = [
+        "async_merge_top_k.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":async_algorithm",
+        "//src/v/base",
+        "//src/v/container:priority_queue",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "async_clear",
     hdrs = [
         "async-clear.h",

--- a/src/v/ssx/async_algorithm.h
+++ b/src/v/ssx/async_algorithm.h
@@ -347,4 +347,72 @@ async_for_each_counter(async_counter& counter, Container&& container, Fn f) {
       counter, std::begin(container), std::end(container), std::move(f));
 }
 
+/**
+ * @brief Call f until cond is false, yielding occasionally and accepting
+ * an externally provided counter for yield control.
+ *
+ * This is equivalent to while (cond()) f(); except that the computational
+ * loop yields every Traits::interval (default 100) iterations in order
+ * to avoid reactor stalls. The returned future resolves when cond() is false.
+ *
+ * The counter is taken by reference and must live at least until the
+ * returned future resolves: this usually trivial when the caller is a
+ * coroutine but may require some care when continuation style is used.
+ *
+ * The functions are taken by value.
+ *
+ * @param counter the counter object to use, may be reused across invocations
+ * @param cond the synchronous nullary predicate to call to check the condition
+ * @param f the synchronous nullary function to call on each element
+ * @return ss::future<> a future which resolves when !cond()
+ */
+template<
+  typename Traits = async_algo_traits,
+  std::predicate Cond,
+  std::invocable Fn>
+requires std::same_as<std::invoke_result_t<Fn&>, void>
+ss::future<> async_while_counter(async_counter& counter, Cond cond, Fn f) {
+    bool stop{false};
+    while (!stop) {
+        int i = 0;
+        for (; i < Traits::interval; ++i) {
+            if (cond()) {
+                f();
+            } else {
+                stop = true;
+            }
+        }
+        counter.count += i;
+        if (!stop && counter.count >= Traits::interval) {
+            co_await ss::coroutine::maybe_yield();
+            counter.count = 0;
+            Traits::yield_called();
+        }
+    }
+}
+
+/**
+ * @brief Call f until cond is false, yielding occasionally.
+ *
+ * This is equivalent to while (cond()) f(); except that the computational
+ * loop yields every Traits::interval (default 100) iterations in order
+ * to avoid reactor stalls. The returned future resolves when cond() is false.
+ *
+ * The functions are taken by value.
+ *
+ * @param cond the synchronous nullary predicate to call to check the condition
+ * @param f the synchronous nullary function to call on each element
+ * @return ss::future<> a future which resolves when !cond()
+ */
+template<
+  typename Traits = async_algo_traits,
+  std::predicate Cond,
+  std::invocable Fn>
+requires std::same_as<std::invoke_result_t<Fn&>, void>
+ss::future<> async_while(Cond cond, Fn f) {
+    async_counter counter{0};
+    co_await async_while_counter<Traits>(
+      counter, std::move(cond), std::move(f));
+}
+
 } // namespace ssx

--- a/src/v/ssx/async_merge_top_k.h
+++ b/src/v/ssx/async_merge_top_k.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "container/priority_queue.h"
+#include "ssx/async_algorithm.h"
+
+namespace ssx {
+
+/// \brief Async merge top k elements from multiple sorted lists
+template<
+  std::ranges::random_access_range Rng,
+  std::weakly_incrementable OutIt,
+  typename Comp = std::ranges::less>
+requires std::ranges::forward_range<std::ranges::range_value_t<Rng>>
+ss::future<> async_merge_top_k(
+  Rng&& sorted_lists, OutIt result, std::size_t k, Comp comp = {}) {
+    using list_t = std::ranges::range_value_t<Rng>;
+    using iter_t = std::ranges::iterator_t<list_t>;
+    using value_t = std::ranges::range_value_t<list_t>;
+
+    // The heap element: (value, list index, iterator)
+    struct heap_elem {
+        heap_elem(iter_t it, size_t idx)
+          : value{&*it}
+          , list_idx{idx}
+          , it{std::move(it)} {}
+        const value_t* value;
+        std::size_t list_idx;
+        iter_t it;
+    };
+
+    auto heap_comp = [&comp](const heap_elem& a, const heap_elem& b) {
+        return comp(*a.value, *b.value);
+    };
+    chunked_priority_queue<heap_elem, decltype(heap_comp)> heap{heap_comp};
+    if constexpr (std::ranges::sized_range<Rng>) {
+        heap.reserve(std::ranges::size(sorted_lists));
+    }
+
+    size_t idx = 0;
+    for (auto&& list : sorted_lists) {
+        if (!std::ranges::empty(list)) {
+            heap.push(heap_elem{std::ranges::begin(list), idx});
+        }
+        ++idx;
+    }
+
+    size_t count{0};
+
+    co_await ssx::async_while(
+      [&]() { return !heap.empty() && count < k; },
+      [&]() {
+          auto top = heap.pop();
+          *result = std::move(*top.it);
+          ++result;
+          ++top.it;
+          ++count;
+          if (top.it != std::ranges::end(sorted_lists[top.list_idx])) {
+              top.value = &(*top.it);
+              heap.push(std::move(top));
+          }
+      });
+}
+
+} // namespace ssx

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -164,6 +164,23 @@ redpanda_cc_btest(
 )
 
 redpanda_cc_gtest(
+    name = "async_merge_top_k",
+    timeout = "short",
+    srcs = [
+        "async_merge_top_k_test.cc",
+    ],
+    cpu = 1,
+    deps = [
+        "//src/v/base",
+        "//src/v/container:chunked_vector",
+        "//src/v/ssx:async_merge_top_k",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "when_all_test",
     timeout = "short",
     srcs = [

--- a/src/v/ssx/tests/async_merge_top_k_test.cc
+++ b/src/v/ssx/tests/async_merge_top_k_test.cc
@@ -1,0 +1,65 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "base/seastarx.h"
+#include "ssx/async_merge_top_k.h"
+#include "test_utils/test.h"
+
+namespace {
+
+struct move_only {
+    explicit move_only(int val)
+      : val(val) {}
+    move_only(move_only&&) noexcept = default;
+    move_only& operator=(move_only&&) noexcept = default;
+    move_only(const move_only&) = delete;
+    move_only& operator=(const move_only&) = delete;
+    ~move_only() noexcept = default;
+
+    friend bool operator==(const move_only&, const move_only&) noexcept
+      = default;
+
+    friend auto operator<=>(const move_only&, const move_only&) noexcept
+      = default;
+
+    int val;
+};
+
+} // namespace
+
+template<typename T>
+ss::future<void> run_test() {
+    using value_type = T;
+
+    chunked_vector<chunked_vector<value_type>> input;
+    input.emplace_back();
+    input.back().emplace_back(12);
+    input.back().emplace_back(5);
+    input.back().emplace_back(5);
+    input.emplace_back();
+    input.back().emplace_back(2);
+    input.emplace_back();
+    input.back().emplace_back(14);
+    input.back().emplace_back(9);
+    input.back().emplace_back(1);
+    input.emplace_back();
+
+    chunked_vector<value_type> result;
+    result.reserve(5);
+    co_await ssx::async_merge_top_k(input, std::back_inserter(result), 5);
+
+    EXPECT_EQ(result.size(), 5);
+    EXPECT_EQ(result[0], value_type{14});
+    EXPECT_EQ(result[1], value_type{12});
+    EXPECT_EQ(result[2], value_type{9});
+    EXPECT_EQ(result[3], value_type{5});
+    EXPECT_EQ(result[4], value_type{5});
+}
+
+TEST_CORO(AsyncMergeTopK, copy_value) { co_await run_test<int>(); }
+TEST_CORO(AsyncMergeTopK, move_value) { co_await run_test<move_only>(); }


### PR DESCRIPTION
Add:
* `async_while` - an asynchronous while loop for large ranges.
* `priority_queue` - like `std::priority_queue` with move semantics.
* `bounded_priority_queue` - keeps the top-k elements.
* `async_merge_top_k` - efficiently merge a range of sorted range.

Both of the queues support:
* `async_push_range` - to avoid reactor stalls
* `async_extract_sorted() &&` - obtain a sorted container without reactor stalls.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
