### PR TITLE
gh: add codeowners for proto changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@ licenses           @emaxerrno
 /src/v/redpanda/admin/api-doc                       @redpanda-data/documentation
 
 #
-# automatically tag docs team for any changes to our public proto files
+# automatically tag docs team and API reviewers for any changes to our public proto files
 #
-/proto/redpanda/core/admin/v2/*.proto    @redpanda-data/documentation
-/proto/redpanda/core/common/*.proto      @redpanda-data/documentation
+/proto/redpanda/core/admin/v2/*.proto    @redpanda-data/documentation @rockwotj @michael-redpanda
+/proto/redpanda/core/common/*.proto      @redpanda-data/documentation @rockwotj @michael-redpanda


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
