### PR TITLE
bench_wrapper: disable ASLR by default

### DIFF
--- a/bazel/bench_wrapper.py
+++ b/bazel/bench_wrapper.py
@@ -20,15 +20,21 @@ def main():
         )
         sys.exit(1)
 
+    def getenv_default(var: str, default: int = 0):
+        return int(os.getenv(var, os.getenv(var + "_DEFAULT", str(default))))
+
+    redirect_stderr = getenv_default("MB_REDIRECT_STDERR")
+    verbose = getenv_default("MB_VERBOSE")
+    disable_aslr = getenv_default("MB_DISABLE_ASLR", 1)
+    exec_in_shm = getenv_default("MB_EXEC_IN_SHM", 1)
+
     exe = Path(sys.argv[1]).resolve()
-    exec_in_shm = os.getenv("MB_EXEC_IN_SHM", "1") == "1"
+
+    exe_prefix = ["setarch", "--addr-no-randomize"] if disable_aslr else []
+
     rundir = Path(
-        os.getenv("MB_RUNDIR", "/dev/shm/vectorized_io" if exec_in_shm == 1 else ".")
+        os.getenv("MB_RUNDIR", "/dev/shm/vectorized_io" if exec_in_shm else ".")
     )
-    redirect_stderr = int(
-        os.getenv("MB_REDIRECT_STDERR", os.getenv("MB_REDIRECT_STDERR_DEFAULT", "0"))
-    )
-    verbose = int(os.getenv("MB_VERBOSE", "0"))
 
     # Resolve environment variables we pass to our benchmarks to absolute paths
     # this way we don't have errors
@@ -59,7 +65,7 @@ def main():
 
     print(f"[bench-wrapper] running benchmark : {exe.name}", file=sys.stderr)
     print(
-        f"[bench-wrapper] verbose={verbose}, exec_in_shm={exec_in_shm}, redirect_stderr={redirect_stderr}",
+        f"[bench-wrapper] verbose={verbose}, exec_in_shm={exec_in_shm}, redirect_stderr={redirect_stderr}, disable_aslr={disable_aslr}",
         file=sys.stderr,
     )
     print(f"[bench-wrapper] rundir            : {rundir}", file=sys.stderr)
@@ -85,7 +91,7 @@ def main():
 
     rundir.mkdir(parents=True, exist_ok=True)
     proc = subprocess.run(
-        [exe] + sys.argv[2:],
+        exe_prefix + [exe] + sys.argv[2:],
         stderr=subprocess.PIPE if redirect_stderr else None,
         text=True,
         cwd=rundir,


### PR DESCRIPTION
Bazel introduces random seeds both in its hashing framework and in containers like flat/node_hash_map (the latter to randomize iteration order).

This introduces considerable randomn variation in some benchmarks.

These random seeds rely on ASLR (they use an address of a global/thread local variable as the seed), so we can effectively disable them by disabling ASLR.

We do this with `setarch` rather than
/proc/sys/kernel/randomize_va_space because it doesn't require root, and affects only the current process, and doesn't need undoing after the test.

Here are 10 runs of 1 role_store test before and after, it looks like the variation in instruction count is roughly +/- 200 before, and mostly +/- 3 after (one run was +9: that run had quite a bit fewer iterations, showing that a lot of the remaining variance is due to iteration count, also confirmed by running with fixed iterations which further lowers the variance).

**before:**
```
test                               iterations      median         mad         min         max      allocs       tasks        inst      cycles
role_store_bench.user_range_query       54165    17.726us    52.755ns    17.437us    18.150us       9.470       0.000    152476.1     65386.3
role_store_bench.user_range_query       53704    17.855us   192.636ns    17.566us    18.073us       9.470       0.000    152540.3     65757.5
role_store_bench.user_range_query       54059    17.864us    25.363ns    17.791us    18.488us       9.470       0.000    152544.4     66081.3
role_store_bench.user_range_query       53085    17.553us    50.880ns    17.502us    19.176us       9.470       0.000    152389.5     65608.4
role_store_bench.user_range_query       52976    17.775us    59.748ns    17.492us    18.026us       9.470       0.000    152356.6     65719.6
role_store_bench.user_range_query       55547    17.411us    62.371ns    17.348us    17.848us       9.469       0.000    152366.9     65886.3
role_store_bench.user_range_query       55391    17.130us    56.106ns    16.949us    17.376us       9.469       0.000    152552.4     65031.5
role_store_bench.user_range_query       52675    17.798us    62.153ns    17.069us    17.969us       9.470       0.000    152401.5     65829.8
role_store_bench.user_range_query       54013    17.715us   112.098ns    17.187us    17.827us       9.470       0.000    152455.5     65605.7
role_store_bench.user_range_query       54653    17.415us    57.385ns    17.343us    17.488us       9.470       0.000    152388.8     65176.6
```

**after:**
```
test                               iterations      median         mad         min         max      allocs       tasks        inst      cycles
role_store_bench.user_range_query       53321    17.780us   138.281ns    17.562us    17.918us       9.470       0.000    152439.2     65595.0
role_store_bench.user_range_query       53708    17.958us    44.831ns    17.763us    18.178us       9.470       0.000    152439.5     66189.8
role_store_bench.user_range_query       53601    17.674us    73.138ns    17.560us    17.811us       9.470       0.000    152439.5     65551.0
role_store_bench.user_range_query       54064    17.752us    98.645ns    17.596us    17.908us       9.470       0.000    152440.5     65923.9
role_store_bench.user_range_query       52608    17.956us    31.021ns    17.830us    18.347us       9.470       0.000    152441.1     66049.1
role_store_bench.user_range_query       53802    17.697us   133.066ns    17.552us    18.591us       9.470       0.000    152439.4     65534.7
role_store_bench.user_range_query       54032    17.516us    61.490ns    17.434us    17.591us       9.470       0.000    152440.6     65430.7
role_store_bench.user_range_query       54246    17.618us   118.313ns    17.355us    18.090us       9.470       0.000    152440.4     65985.5
role_store_bench.user_range_query       46962    17.496us   196.218ns    17.297us    17.791us       9.470       0.000    152448.8     65667.1
role_store_bench.user_range_query       54615    17.767us    72.998ns    17.426us    17.966us       9.470       0.000    152441.3     66104.0
````

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none
