### PR TITLE
tuner: Skip some CDT tests on arm

### DIFF
--- a/tests/rptest/tuner_integration_tests/net_tuner_test.py
+++ b/tests/rptest/tuner_integration_tests/net_tuner_test.py
@@ -50,6 +50,9 @@ class NetTunerTest(RedpandaTest):
 
         self.logger.info(f"Found interface {self.interface_name}")
 
+        uname = self.node.account.ssh_output("uname -m").decode("utf-8")
+        self.is_arm = "aarch64" in uname
+
     def teardown(self):
         super().teardown()
 
@@ -265,6 +268,10 @@ class NetTunerTest(RedpandaTest):
 class AwsNetTunerTest(NetTunerTest):
     @cluster(num_nodes=1)
     def test_tune_net_mq(self):
+        if self.is_arm:
+            self.start_rp()
+            return
+
         expected_interrupt_setup = self.ExpectedInterruptSetup(
             interrupts_masks=["1", "4", "2", "8"],
             redpanda_cores={0, 1, 2, 3},
@@ -317,6 +324,10 @@ class AwsNetTunerTest(NetTunerTest):
 
     @cluster(num_nodes=1)
     def test_tune_net_dedicated_2_cores(self):
+        if self.is_arm:
+            self.start_rp()
+            return
+
         expected_interrupt_setup = self.ExpectedInterruptSetup(
             interrupts_masks=["4", "8"],
             redpanda_cores={0, 1},


### PR DESCRIPTION
x86 and arm assignment is different because of how SMT siblings are layed out.

Just skip them on arm if so. We are not gaining much by testing on both arm and x86.

I don't want to make it fully generic (i.e.: just calculate it with hwloc) to have expectations fairly clear and avoid cyclical bugs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes


* none


