### PR TITLE
ct: Add L0 object size histogram to the metrics

### DIFF
--- a/src/v/cloud_topics/level_zero/common/BUILD
+++ b/src/v/cloud_topics/level_zero/common/BUILD
@@ -41,6 +41,7 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/metrics",
+        "//src/v/utils:hdr_hist",
         "//src/v/utils:log_hist",
         "@fmt",
         "@seastar",

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.cc
@@ -250,6 +250,11 @@ void batcher_probe::setup_internal_metrics(bool disable) {
           sm::description("Number of epoch errors encountered by the batcher."),
           labels),
 
+        sm::make_histogram(
+          "level_zero_object_size_bytes",
+          [this] { return _upload_size_hist.seastar_histogram_logform(); },
+          sm::description("Level zero object size histogram in bytes."),
+          labels),
       });
 }
 

--- a/src/v/cloud_topics/level_zero/common/level_zero_probe.h
+++ b/src/v/cloud_topics/level_zero/common/level_zero_probe.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "metrics/metrics.h"
+#include "utils/hdr_hist.h"
 #include "utils/log_hist.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -138,6 +139,7 @@ public:
     void register_upload(uint64_t size_bytes) {
         _objects_uploaded += 1;
         _bytes_uploaded += size_bytes;
+        _upload_size_hist.record(size_bytes);
     }
 
     void register_error() { ++_upload_errors; }
@@ -151,6 +153,7 @@ private:
     uint64_t _bytes_uploaded{0};
     uint64_t _upload_errors{0};
     uint64_t _epoch_errors{0};
+    hdr_hist _upload_size_hist;
 
     metrics::internal_metric_groups _metrics;
 };


### PR DESCRIPTION
Add L0 object size histogram to L0 metrics

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none