### PR TITLE
rpk: update shadow config with new protos

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -9,13 +9,13 @@ require (
 	buf.build/gen/go/redpandadata/cloud/connectrpc/go v1.18.1-20250806153840-184e270a51f5.1
 	buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-184e270a51f5.1
 	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1
-	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251007130208-16fea41f579f.1
+	buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251014201443-fb6b4019204e.1
 	buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1
 	buf.build/gen/go/redpandadata/gatekeeper/connectrpc/go v1.18.1-20250813192242-efcc93bcd794.1
 	buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.7-20250813192242-efcc93bcd794.1
 	cloud.google.com/go/compute/metadata v0.7.0
-	connectrpc.com/connect v1.19.0
+	connectrpc.com/connect v1.19.1
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.55.6
@@ -85,7 +85,7 @@ require (
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.7-20250613105001-9f2d3c737feb.1 // indirect
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.7-20240617172850-a48fcebcf8f1.1 // indirect
-	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1 // indirect
+	buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251014201443-fb6b4019204e.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-18
 buf.build/gen/go/redpandadata/cloud/protocolbuffers/go v1.36.7-20250806153840-184e270a51f5.1/go.mod h1:J6+tKG3WghdUGXXD5lYp/G15vFpzMRvAsbF6+L+YZBQ=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1 h1:mE9lPhqy3ghMKY6fAot31NySa8aI22sUjKbJuMlmDGA=
 buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.36.7-20250718021421-04f2daa29ad9.1/go.mod h1:pUNfu5CqCYitRtXrJ69rHyB7SXdTkDuqqnNwQYI2H1Q=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1 h1:+bBkTuaJtXW9irz6gDCCFHK17BNxjUPB0qIvNOiXSXE=
-buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.0-20251003220015-a1e818380921.1/go.mod h1:vJABXSPxk+Oeds+LifrwLGPUkbl7ftBHqNpLAfPcTRA=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251007130208-16fea41f579f.1 h1:j01H0tQztIy/1GV6/ZdwGT2OJp105ymmmP1SZNMryEA=
-buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251007130208-16fea41f579f.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251014201443-fb6b4019204e.2 h1:Xa24Vx+bjlbCNoLWqZYoG/GmTl2wlNYdaTqYGWyjmeo=
+buf.build/gen/go/redpandadata/core/connectrpc/go v1.19.1-20251014201443-fb6b4019204e.2/go.mod h1:QLiZyAutqeut+igpx0oY139aKk2iITbxnguMlTBNNSg=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251014201443-fb6b4019204e.1 h1:WbEB6JEGDLcWkIEa9eZ10irey+NGZahhLYhaEh25K2U=
+buf.build/gen/go/redpandadata/core/protocolbuffers/go v1.36.10-20251014201443-fb6b4019204e.1/go.mod h1:QenSPzqxZpyo9hHIpRzTetvDchelVDzimnmaggHKenc=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1 h1:CiTv2Rme+0H/2IQpyZFK8SQYRWgRWEvFNxZIfDMYOQQ=
 buf.build/gen/go/redpandadata/dataplane/connectrpc/go v1.18.1-20250819145731-621dc775ffe4.1/go.mod h1:HJnvbiwx2qZN8HcD30Dijm5Aamjcrk/8/ffTOFrF5Go=
 buf.build/gen/go/redpandadata/dataplane/protocolbuffers/go v1.36.7-20250819145731-621dc775ffe4.1 h1:31r1Sv/BoVyGzzBfBHcUcyQJz/+4i/fr8wc7gQVihEM=
@@ -22,8 +22,8 @@ buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.7-202508131922
 buf.build/gen/go/redpandadata/gatekeeper/protocolbuffers/go v1.36.7-20250813192242-efcc93bcd794.1/go.mod h1:6dMZEth9vdnAuW0dV/OVjTJYnVLq5pzi7F6b0L+2uyg=
 cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
-connectrpc.com/connect v1.19.0 h1:LuqUbq01PqbtL0o7vn0WMRXzR2nNsiINe5zfcJ24pJM=
-connectrpc.com/connect v1.19.0/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
+connectrpc.com/connect v1.19.1 h1:R5M57z05+90EfEvCY1b7hBxDVOUl45PrtXtAV2fOC14=
+connectrpc.com/connect v1.19.1/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=

--- a/src/go/rpk/pkg/cli/shadow/BUILD
+++ b/src/go/rpk/pkg/cli/shadow/BUILD
@@ -33,11 +33,16 @@ go_library(
 
 go_test(
     name = "shadow_test",
-    srcs = ["types_test.go"],
+    srcs = [
+        "mapper_test.go",
+        "types_test.go",
+    ],
     embed = [":shadow"],
     deps = [
         "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/admin/v2:admin",
+        "@build_buf_gen_go_redpandadata_core_protocolbuffers_go//redpanda/core/common",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/src/go/rpk/pkg/cli/shadow/config.go
+++ b/src/go/rpk/pkg/cli/shadow/config.go
@@ -96,7 +96,8 @@ func generateSampleConfig() *ShadowLinkConfig {
 			FetchMaxBytes:       1048576,
 		},
 		TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
-			Interval: 30 * time.Second,
+			ExcludeDefault: true,
+			Interval:       30 * time.Second,
 			AutoCreateShadowTopicFilters: []*NameFilter{
 				{
 					PatternType: PatternTypeLiteral,
@@ -109,7 +110,7 @@ func generateSampleConfig() *ShadowLinkConfig {
 					Name:        "foo-",
 				},
 			},
-			ShadowedTopicProperties: []string{"retention.ms", "segment.ms"},
+			SyncedShadowTopicProperties: []string{"retention.ms", "segment.ms"},
 		},
 		ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
 			Interval: 30 * time.Second,
@@ -125,20 +126,6 @@ func generateSampleConfig() *ShadowLinkConfig {
 		SecuritySyncOptions: &SecuritySettingsSyncOptions{
 			Interval: 30 * time.Second,
 			Enabled:  false,
-			RoleFilters: []*NameFilter{
-				{
-					PatternType: PatternTypeLiteral,
-					FilterType:  FilterTypeInclude,
-					Name:        "*",
-				},
-			},
-			ScramCredFilters: []*NameFilter{
-				{
-					PatternType: PatternTypePrefix,
-					FilterType:  FilterTypeExclude,
-					Name:        "admin-",
-				},
-			},
 			ACLFilters: []*ACLFilter{
 				{
 					ResourceFilter: &ACLResourceFilter{

--- a/src/go/rpk/pkg/cli/shadow/describe.go
+++ b/src/go/rpk/pkg/cli/shadow/describe.go
@@ -223,9 +223,9 @@ func printTopicSync(opts *adminv2.TopicMetadataSyncOptions) {
 		}
 	}
 
-	if len(opts.GetShadowedTopicProperties()) > 0 {
+	if props := opts.GetSyncedShadowTopicProperties(); len(props) > 0 {
 		tw.Print("PROPERTIES:", "")
-		for _, prop := range opts.GetShadowedTopicProperties() {
+		for _, prop := range props {
 			tw.Print("", fmt.Sprintf("- %s", prop))
 		}
 	}
@@ -266,20 +266,6 @@ func printSecuritySync(opts *adminv2.SecuritySettingsSyncOptions) {
 		return
 	}
 	tw.Print("INTERVAL", opts.GetInterval().AsDuration().String())
-
-	if len(opts.GetRoleFilters()) > 0 {
-		tw.Print("ROLE FILTERS:", "")
-		for _, filter := range opts.GetRoleFilters() {
-			tw.Print("", fmt.Sprintf("- %s %s %q", formatFilterType(filter.GetFilterType()), formatPatternType(filter.GetPatternType()), filter.GetName()))
-		}
-	}
-
-	if len(opts.GetScramCredFilters()) > 0 {
-		tw.Print("SCRAM FILTERS:", "")
-		for _, filter := range opts.GetScramCredFilters() {
-			tw.Print("", fmt.Sprintf("- %s %s %q", formatFilterType(filter.GetFilterType()), formatPatternType(filter.GetPatternType()), filter.GetName()))
-		}
-	}
 
 	if len(opts.GetAclFilters()) > 0 {
 		tw.Print("ACL FILTERS:")

--- a/src/go/rpk/pkg/cli/shadow/mapper.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper.go
@@ -135,7 +135,8 @@ func mapTopicMetadataSyncOptions(opts *TopicMetadataSyncOptions) *adminv2.TopicM
 	}
 
 	pbOpts := &adminv2.TopicMetadataSyncOptions{
-		ShadowedTopicProperties: opts.ShadowedTopicProperties,
+		SyncedShadowTopicProperties: opts.SyncedShadowTopicProperties,
+		ExcludeDefault:              opts.ExcludeDefault,
 	}
 
 	if opts.Interval > 0 {
@@ -180,14 +181,6 @@ func mapSecuritySyncOptions(opts *SecuritySettingsSyncOptions) *adminv2.Security
 
 	if opts.Interval > 0 {
 		pbOpts.Interval = durationpb.New(opts.Interval)
-	}
-
-	for _, filter := range opts.RoleFilters {
-		pbOpts.RoleFilters = append(pbOpts.RoleFilters, mapNameFilter(filter))
-	}
-
-	for _, filter := range opts.ScramCredFilters {
-		pbOpts.ScramCredFilters = append(pbOpts.ScramCredFilters, mapNameFilter(filter))
 	}
 
 	for _, filter := range opts.ACLFilters {

--- a/src/go/rpk/pkg/cli/shadow/mapper_test.go
+++ b/src/go/rpk/pkg/cli/shadow/mapper_test.go
@@ -1,0 +1,884 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package shadow
+
+import (
+	"testing"
+	"time"
+
+	adminv2 "buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/admin/v2"
+	"buf.build/gen/go/redpandadata/core/protocolbuffers/go/redpanda/core/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestShadowLinkConfigToCreateReq(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *ShadowLinkConfig
+		want *adminv2.CreateShadowLinkRequest
+	}{
+		{
+			name: "nil config returns nil",
+			cfg:  nil,
+			want: nil,
+		},
+		{
+			name: "minimal config",
+			cfg: &ShadowLinkConfig{
+				Name: "test-link",
+			},
+			want: &adminv2.CreateShadowLinkRequest{
+				ShadowLink: &adminv2.ShadowLink{
+					Name:           "test-link",
+					Configurations: &adminv2.ShadowLinkConfigurations{},
+				},
+			},
+		},
+		{
+			name: "complete config with all options",
+			cfg: &ShadowLinkConfig{
+				Name: "complete-link",
+				ClientOptions: &ShadowLinkClientOptions{
+					BootstrapServers:    []string{"broker1:9092", "broker2:9092"},
+					SourceClusterID:     "cluster-123",
+					MetadataMaxAgeMs:    10000,
+					ConnectionTimeoutMs: 1000,
+					RetryBackoffMs:      100,
+					FetchWaitMaxMs:      500,
+					FetchMinBytes:       1,
+					FetchMaxBytes:       1048576,
+					TLSSettings: &TLSFileSettings{
+						Enabled:  true,
+						CAPath:   "/path/to/ca.crt",
+						KeyPath:  "/path/to/key.pem",
+						CertPath: "/path/to/cert.pem",
+					},
+					AuthenticationConfiguration: &ScramConfig{
+						Username:       "testuser",
+						Password:       "testpass",
+						ScramMechanism: ScramMechanismScramSha256,
+					},
+				},
+				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
+					Interval: 30 * time.Second,
+					AutoCreateShadowTopicFilters: []*NameFilter{
+						{
+							PatternType: PatternTypeLiteral,
+							FilterType:  FilterTypeInclude,
+							Name:        "test-topic",
+						},
+					},
+					SyncedShadowTopicProperties: []string{"retention.ms"},
+					ExcludeDefault:              true,
+				},
+				ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
+					Enabled:  true,
+					Interval: 30 * time.Second,
+					GroupFilters: []*NameFilter{
+						{
+							PatternType: PatternTypePrefix,
+							FilterType:  FilterTypeExclude,
+							Name:        "test-",
+						},
+					},
+				},
+				SecuritySyncOptions: &SecuritySettingsSyncOptions{
+					Enabled:  true,
+					Interval: 30 * time.Second,
+					ACLFilters: []*ACLFilter{
+						{
+							ResourceFilter: &ACLResourceFilter{
+								ResourceType: ACLResourceTopic,
+								PatternType:  ACLPatternLiteral,
+								Name:         "secure-topic",
+							},
+							AccessFilter: &ACLAccessFilter{
+								Principal:      "User:alice",
+								Operation:      ACLOperationRead,
+								PermissionType: ACLPermissionTypeAllow,
+								Host:           "*",
+							},
+						},
+					},
+				},
+			},
+			want: &adminv2.CreateShadowLinkRequest{
+				ShadowLink: &adminv2.ShadowLink{
+					Name: "complete-link",
+					Configurations: &adminv2.ShadowLinkConfigurations{
+						ClientOptions: &adminv2.ShadowLinkClientOptions{
+							BootstrapServers:    []string{"broker1:9092", "broker2:9092"},
+							SourceClusterId:     "cluster-123",
+							MetadataMaxAgeMs:    10000,
+							ConnectionTimeoutMs: 1000,
+							RetryBackoffMs:      100,
+							FetchWaitMaxMs:      500,
+							FetchMinBytes:       1,
+							FetchMaxBytes:       1048576,
+							TlsSettings: &adminv2.TLSSettings{
+								Enabled: true,
+								TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
+									TlsFileSettings: &adminv2.TLSFileSettings{
+										CaPath:   "/path/to/ca.crt",
+										KeyPath:  "/path/to/key.pem",
+										CertPath: "/path/to/cert.pem",
+									},
+								},
+							},
+							AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
+								Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+									ScramConfiguration: &adminv2.ScramConfig{
+										Username:       "testuser",
+										Password:       "testpass",
+										ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256,
+									},
+								},
+							},
+						},
+						TopicMetadataSyncOptions: &adminv2.TopicMetadataSyncOptions{
+							Interval: durationpb.New(30 * time.Second),
+							AutoCreateShadowTopicFilters: []*adminv2.NameFilter{
+								{
+									PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL,
+									FilterType:  adminv2.FilterType_FILTER_TYPE_INCLUDE,
+									Name:        "test-topic",
+								},
+							},
+							SyncedShadowTopicProperties: []string{"retention.ms"},
+							ExcludeDefault:              true,
+						},
+						ConsumerOffsetSyncOptions: &adminv2.ConsumerOffsetSyncOptions{
+							Enabled:  true,
+							Interval: durationpb.New(30 * time.Second),
+							GroupFilters: []*adminv2.NameFilter{
+								{
+									PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX,
+									FilterType:  adminv2.FilterType_FILTER_TYPE_EXCLUDE,
+									Name:        "test-",
+								},
+							},
+						},
+						SecuritySyncOptions: &adminv2.SecuritySettingsSyncOptions{
+							Enabled:  true,
+							Interval: durationpb.New(30 * time.Second),
+							AclFilters: []*adminv2.ACLFilter{
+								{
+									ResourceFilter: &adminv2.ACLResourceFilter{
+										ResourceType: common.ACLResource_ACL_RESOURCE_TOPIC,
+										PatternType:  common.ACLPattern_ACL_PATTERN_LITERAL,
+										Name:         "secure-topic",
+									},
+									AccessFilter: &adminv2.ACLAccessFilter{
+										Principal:      "User:alice",
+										Operation:      common.ACLOperation_ACL_OPERATION_READ,
+										PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+										Host:           "*",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shadowLinkConfigToCreateReq(tt.cfg)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapClientOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *ShadowLinkClientOptions
+		want *adminv2.ShadowLinkClientOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "basic options without TLS or auth",
+			opts: &ShadowLinkClientOptions{
+				BootstrapServers:    []string{"localhost:9092"},
+				SourceClusterID:     "test-cluster",
+				MetadataMaxAgeMs:    5000,
+				ConnectionTimeoutMs: 2000,
+				RetryBackoffMs:      200,
+				FetchWaitMaxMs:      1000,
+				FetchMinBytes:       10,
+				FetchMaxBytes:       2097152,
+			},
+			want: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers:    []string{"localhost:9092"},
+				SourceClusterId:     "test-cluster",
+				MetadataMaxAgeMs:    5000,
+				ConnectionTimeoutMs: 2000,
+				RetryBackoffMs:      200,
+				FetchWaitMaxMs:      1000,
+				FetchMinBytes:       10,
+				FetchMaxBytes:       2097152,
+			},
+		},
+		{
+			name: "with file-based TLS",
+			opts: &ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TLSSettings: &TLSFileSettings{
+					Enabled:  true,
+					CAPath:   "/ca.crt",
+					KeyPath:  "/key.pem",
+					CertPath: "/cert.pem",
+				},
+			},
+			want: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TlsSettings: &adminv2.TLSSettings{
+					Enabled: true,
+					TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
+						TlsFileSettings: &adminv2.TLSFileSettings{
+							CaPath:   "/ca.crt",
+							KeyPath:  "/key.pem",
+							CertPath: "/cert.pem",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with PEM-based TLS",
+			opts: &ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TLSSettings: &TLSPEMSettings{
+					Enabled: true,
+					CA:      "ca-content",
+					Key:     "key-content",
+					Cert:    "cert-content",
+				},
+			},
+			want: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				TlsSettings: &adminv2.TLSSettings{
+					Enabled: true,
+					TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
+						TlsPemSettings: &adminv2.TLSPEMSettings{
+							Ca:   "ca-content",
+							Key:  "key-content",
+							Cert: "cert-content",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with SCRAM authentication",
+			opts: &ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				AuthenticationConfiguration: &ScramConfig{
+					Username:       "user",
+					Password:       "pass",
+					ScramMechanism: ScramMechanismScramSha512,
+				},
+			},
+			want: &adminv2.ShadowLinkClientOptions{
+				BootstrapServers: []string{"localhost:9092"},
+				AuthenticationConfiguration: &adminv2.AuthenticationConfiguration{
+					Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+						ScramConfiguration: &adminv2.ScramConfig{
+							Username:       "user",
+							Password:       "pass",
+							ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapClientOptions(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapTLSSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  TLSSettings
+		want *adminv2.TLSSettings
+	}{
+		{
+			name: "nil TLS returns nil",
+			tls:  nil,
+			want: nil,
+		},
+		{
+			name: "file-based TLS settings",
+			tls: &TLSFileSettings{
+				Enabled:  true,
+				CAPath:   "/path/to/ca",
+				KeyPath:  "/path/to/key",
+				CertPath: "/path/to/cert",
+			},
+			want: &adminv2.TLSSettings{
+				Enabled: true,
+				TlsSettings: &adminv2.TLSSettings_TlsFileSettings{
+					TlsFileSettings: &adminv2.TLSFileSettings{
+						CaPath:   "/path/to/ca",
+						KeyPath:  "/path/to/key",
+						CertPath: "/path/to/cert",
+					},
+				},
+			},
+		},
+		{
+			name: "PEM-based TLS settings",
+			tls: &TLSPEMSettings{
+				Enabled: false,
+				CA:      "ca-pem",
+				Key:     "key-pem",
+				Cert:    "cert-pem",
+			},
+			want: &adminv2.TLSSettings{
+				Enabled: false,
+				TlsSettings: &adminv2.TLSSettings_TlsPemSettings{
+					TlsPemSettings: &adminv2.TLSPEMSettings{
+						Ca:   "ca-pem",
+						Key:  "key-pem",
+						Cert: "cert-pem",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapTLSSettings(tt.tls)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapAuthenticationConfiguration(t *testing.T) {
+	tests := []struct {
+		name string
+		auth AuthenticationConfiguration
+		want *adminv2.AuthenticationConfiguration
+	}{
+		{
+			name: "nil auth returns nil",
+			auth: nil,
+			want: nil,
+		},
+		{
+			name: "SCRAM-SHA-256 configuration",
+			auth: &ScramConfig{
+				Username:       "alice",
+				Password:       "secret",
+				ScramMechanism: ScramMechanismScramSha256,
+			},
+			want: &adminv2.AuthenticationConfiguration{
+				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+					ScramConfiguration: &adminv2.ScramConfig{
+						Username:       "alice",
+						Password:       "secret",
+						ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256,
+					},
+				},
+			},
+		},
+		{
+			name: "SCRAM-SHA-512 configuration",
+			auth: &ScramConfig{
+				Username:       "bob",
+				Password:       "password",
+				ScramMechanism: ScramMechanismScramSha512,
+			},
+			want: &adminv2.AuthenticationConfiguration{
+				Authentication: &adminv2.AuthenticationConfiguration_ScramConfiguration{
+					ScramConfiguration: &adminv2.ScramConfig{
+						Username:       "bob",
+						Password:       "password",
+						ScramMechanism: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapAuthenticationConfiguration(tt.auth)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapScramMechanism(t *testing.T) {
+	tests := []struct {
+		name string
+		mech ScramMechanism
+		want adminv2.ScramMechanism
+	}{
+		{
+			name: "SCRAM-SHA-256",
+			mech: ScramMechanismScramSha256,
+			want: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_256,
+		},
+		{
+			name: "SCRAM-SHA-512",
+			mech: ScramMechanismScramSha512,
+			want: adminv2.ScramMechanism_SCRAM_MECHANISM_SCRAM_SHA_512,
+		},
+		{
+			name: "unknown mechanism",
+			mech: ScramMechanism("unknown"),
+			want: adminv2.ScramMechanism_SCRAM_MECHANISM_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapScramMechanism(tt.mech)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapTopicMetadataSyncOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *TopicMetadataSyncOptions
+		want *adminv2.TopicMetadataSyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "options with zero interval",
+			opts: &TopicMetadataSyncOptions{
+				Interval: 0,
+			},
+			want: &adminv2.TopicMetadataSyncOptions{},
+		},
+		{
+			name: "complete options",
+			opts: &TopicMetadataSyncOptions{
+				Interval: 60 * time.Second,
+				AutoCreateShadowTopicFilters: []*NameFilter{
+					{PatternType: PatternTypeLiteral, FilterType: FilterTypeInclude, Name: "topic1"},
+					{PatternType: PatternTypePrefix, FilterType: FilterTypeExclude, Name: "test-"},
+				},
+				SyncedShadowTopicProperties: []string{"retention.ms", "compression.type"},
+				ExcludeDefault:              true,
+			},
+			want: &adminv2.TopicMetadataSyncOptions{
+				Interval: durationpb.New(60 * time.Second),
+				AutoCreateShadowTopicFilters: []*adminv2.NameFilter{
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL, FilterType: adminv2.FilterType_FILTER_TYPE_INCLUDE, Name: "topic1"},
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX, FilterType: adminv2.FilterType_FILTER_TYPE_EXCLUDE, Name: "test-"},
+				},
+				SyncedShadowTopicProperties: []string{"retention.ms", "compression.type"},
+				ExcludeDefault:              true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapTopicMetadataSyncOptions(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapConsumerOffsetSyncOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *ConsumerOffsetSyncOptions
+		want *adminv2.ConsumerOffsetSyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "disabled with zero interval",
+			opts: &ConsumerOffsetSyncOptions{
+				Enabled:  false,
+				Interval: 0,
+			},
+			want: &adminv2.ConsumerOffsetSyncOptions{
+				Enabled: false,
+			},
+		},
+		{
+			name: "enabled with filters",
+			opts: &ConsumerOffsetSyncOptions{
+				Enabled:  true,
+				Interval: 45 * time.Second,
+				GroupFilters: []*NameFilter{
+					{PatternType: PatternTypeLiteral, FilterType: FilterTypeInclude, Name: "*"},
+				},
+			},
+			want: &adminv2.ConsumerOffsetSyncOptions{
+				Enabled:  true,
+				Interval: durationpb.New(45 * time.Second),
+				GroupFilters: []*adminv2.NameFilter{
+					{PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL, FilterType: adminv2.FilterType_FILTER_TYPE_INCLUDE, Name: "*"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapConsumerOffsetSyncOptions(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapSecuritySyncOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *SecuritySettingsSyncOptions
+		want *adminv2.SecuritySettingsSyncOptions
+	}{
+		{
+			name: "nil options returns nil",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "disabled with no filters",
+			opts: &SecuritySettingsSyncOptions{
+				Enabled:  false,
+				Interval: 0,
+			},
+			want: &adminv2.SecuritySettingsSyncOptions{
+				Enabled: false,
+			},
+		},
+		{
+			name: "enabled with ACL filters",
+			opts: &SecuritySettingsSyncOptions{
+				Enabled:  true,
+				Interval: 120 * time.Second,
+				ACLFilters: []*ACLFilter{
+					{
+						ResourceFilter: &ACLResourceFilter{
+							ResourceType: ACLResourceTopic,
+							PatternType:  ACLPatternLiteral,
+							Name:         "sensitive-topic",
+						},
+						AccessFilter: &ACLAccessFilter{
+							Principal:      "User:admin",
+							Operation:      ACLOperationWrite,
+							PermissionType: ACLPermissionTypeAllow,
+							Host:           "192.168.1.1",
+						},
+					},
+				},
+			},
+			want: &adminv2.SecuritySettingsSyncOptions{
+				Enabled:  true,
+				Interval: durationpb.New(120 * time.Second),
+				AclFilters: []*adminv2.ACLFilter{
+					{
+						ResourceFilter: &adminv2.ACLResourceFilter{
+							ResourceType: common.ACLResource_ACL_RESOURCE_TOPIC,
+							PatternType:  common.ACLPattern_ACL_PATTERN_LITERAL,
+							Name:         "sensitive-topic",
+						},
+						AccessFilter: &adminv2.ACLAccessFilter{
+							Principal:      "User:admin",
+							Operation:      common.ACLOperation_ACL_OPERATION_WRITE,
+							PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+							Host:           "192.168.1.1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSecuritySyncOptions(tt.opts)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapNameFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *NameFilter
+		want   *adminv2.NameFilter
+	}{
+		{
+			name:   "nil filter returns nil",
+			filter: nil,
+			want:   nil,
+		},
+		{
+			name: "literal include filter",
+			filter: &NameFilter{
+				PatternType: PatternTypeLiteral,
+				FilterType:  FilterTypeInclude,
+				Name:        "my-topic",
+			},
+			want: &adminv2.NameFilter{
+				PatternType: adminv2.PatternType_PATTERN_TYPE_LITERAL,
+				FilterType:  adminv2.FilterType_FILTER_TYPE_INCLUDE,
+				Name:        "my-topic",
+			},
+		},
+		{
+			name: "prefix exclude filter",
+			filter: &NameFilter{
+				PatternType: PatternTypePrefix,
+				FilterType:  FilterTypeExclude,
+				Name:        "internal-",
+			},
+			want: &adminv2.NameFilter{
+				PatternType: adminv2.PatternType_PATTERN_TYPE_PREFIX,
+				FilterType:  adminv2.FilterType_FILTER_TYPE_EXCLUDE,
+				Name:        "internal-",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapNameFilter(tt.filter)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapACLFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *ACLFilter
+		want   *adminv2.ACLFilter
+	}{
+		{
+			name:   "nil filter returns nil",
+			filter: nil,
+			want:   nil,
+		},
+		{
+			name: "complete ACL filter",
+			filter: &ACLFilter{
+				ResourceFilter: &ACLResourceFilter{
+					ResourceType: ACLResourceGroup,
+					PatternType:  ACLPatternPrefixed,
+					Name:         "consumer-",
+				},
+				AccessFilter: &ACLAccessFilter{
+					Principal:      "User:consumer",
+					Operation:      ACLOperationRead,
+					PermissionType: ACLPermissionTypeAllow,
+					Host:           "*",
+				},
+			},
+			want: &adminv2.ACLFilter{
+				ResourceFilter: &adminv2.ACLResourceFilter{
+					ResourceType: common.ACLResource_ACL_RESOURCE_GROUP,
+					PatternType:  common.ACLPattern_ACL_PATTERN_PREFIXED,
+					Name:         "consumer-",
+				},
+				AccessFilter: &adminv2.ACLAccessFilter{
+					Principal:      "User:consumer",
+					Operation:      common.ACLOperation_ACL_OPERATION_READ,
+					PermissionType: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW,
+					Host:           "*",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapACLFilter(tt.filter)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapPatternType(t *testing.T) {
+	tests := []struct {
+		name string
+		pt   PatternType
+		want adminv2.PatternType
+	}{
+		{
+			name: "literal pattern",
+			pt:   PatternTypeLiteral,
+			want: adminv2.PatternType_PATTERN_TYPE_LITERAL,
+		},
+		{
+			name: "prefix pattern",
+			pt:   PatternTypePrefix,
+			want: adminv2.PatternType_PATTERN_TYPE_PREFIX,
+		},
+		{
+			name: "unknown pattern",
+			pt:   PatternType("unknown"),
+			want: adminv2.PatternType_PATTERN_TYPE_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapPatternType(tt.pt)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapFilterType(t *testing.T) {
+	tests := []struct {
+		name string
+		ft   FilterType
+		want adminv2.FilterType
+	}{
+		{
+			name: "include filter",
+			ft:   FilterTypeInclude,
+			want: adminv2.FilterType_FILTER_TYPE_INCLUDE,
+		},
+		{
+			name: "exclude filter",
+			ft:   FilterTypeExclude,
+			want: adminv2.FilterType_FILTER_TYPE_EXCLUDE,
+		},
+		{
+			name: "unknown filter",
+			ft:   FilterType("unknown"),
+			want: adminv2.FilterType_FILTER_TYPE_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapFilterType(tt.ft)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapACLResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource ACLResource
+		want     common.ACLResource
+	}{
+		{name: "any", resource: ACLResourceAny, want: common.ACLResource_ACL_RESOURCE_ANY},
+		{name: "cluster", resource: ACLResourceCluster, want: common.ACLResource_ACL_RESOURCE_CLUSTER},
+		{name: "group", resource: ACLResourceGroup, want: common.ACLResource_ACL_RESOURCE_GROUP},
+		{name: "topic", resource: ACLResourceTopic, want: common.ACLResource_ACL_RESOURCE_TOPIC},
+		{name: "txn_id", resource: ACLResourceTXNID, want: common.ACLResource_ACL_RESOURCE_TXN_ID},
+		{name: "sr_subject", resource: ACLResourceSRSubject, want: common.ACLResource_ACL_RESOURCE_SR_SUBJECT},
+		{name: "sr_registry", resource: ACLResourceSRRegistry, want: common.ACLResource_ACL_RESOURCE_SR_REGISTRY},
+		{name: "sr_any", resource: ACLResourceSRAny, want: common.ACLResource_ACL_RESOURCE_SR_ANY},
+		{name: "unknown", resource: ACLResource("unknown"), want: common.ACLResource_ACL_RESOURCE_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapACLResource(tt.resource)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapACLPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern ACLPattern
+		want    common.ACLPattern
+	}{
+		{name: "any", pattern: ACLPatternAny, want: common.ACLPattern_ACL_PATTERN_ANY},
+		{name: "literal", pattern: ACLPatternLiteral, want: common.ACLPattern_ACL_PATTERN_LITERAL},
+		{name: "prefixed", pattern: ACLPatternPrefixed, want: common.ACLPattern_ACL_PATTERN_PREFIXED},
+		{name: "match", pattern: ACLPatternMatch, want: common.ACLPattern_ACL_PATTERN_MATCH},
+		{name: "unknown", pattern: ACLPattern("unknown"), want: common.ACLPattern_ACL_PATTERN_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapACLPattern(tt.pattern)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapACLOperation(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation ACLOperation
+		want      common.ACLOperation
+	}{
+		{name: "any", operation: ACLOperationAny, want: common.ACLOperation_ACL_OPERATION_ANY},
+		{name: "read", operation: ACLOperationRead, want: common.ACLOperation_ACL_OPERATION_READ},
+		{name: "write", operation: ACLOperationWrite, want: common.ACLOperation_ACL_OPERATION_WRITE},
+		{name: "create", operation: ACLOperationCreate, want: common.ACLOperation_ACL_OPERATION_CREATE},
+		{name: "remove", operation: ACLOperationRemove, want: common.ACLOperation_ACL_OPERATION_REMOVE},
+		{name: "alter", operation: ACLOperationAlter, want: common.ACLOperation_ACL_OPERATION_ALTER},
+		{name: "describe", operation: ACLOperationDescribe, want: common.ACLOperation_ACL_OPERATION_DESCRIBE},
+		{name: "cluster_action", operation: ACLOperationClusterAction, want: common.ACLOperation_ACL_OPERATION_CLUSTER_ACTION},
+		{name: "describe_configs", operation: ACLOperationDescribeConfigs, want: common.ACLOperation_ACL_OPERATION_DESCRIBE_CONFIGS},
+		{name: "alter_configs", operation: ACLOperationAlterConfigs, want: common.ACLOperation_ACL_OPERATION_ALTER_CONFIGS},
+		{name: "idempotent_write", operation: ACLOperationIdempotentWrite, want: common.ACLOperation_ACL_OPERATION_IDEMPOTENT_WRITE},
+		{name: "unknown", operation: ACLOperation("unknown"), want: common.ACLOperation_ACL_OPERATION_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapACLOperation(tt.operation)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapACLPermissionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		permType ACLPermissionType
+		want     common.ACLPermissionType
+	}{
+		{name: "any", permType: ACLPermissionTypeAny, want: common.ACLPermissionType_ACL_PERMISSION_TYPE_ANY},
+		{name: "allow", permType: ACLPermissionTypeAllow, want: common.ACLPermissionType_ACL_PERMISSION_TYPE_ALLOW},
+		{name: "deny", permType: ACLPermissionTypeDeny, want: common.ACLPermissionType_ACL_PERMISSION_TYPE_DENY},
+		{name: "unknown", permType: ACLPermissionType("unknown"), want: common.ACLPermissionType_ACL_PERMISSION_TYPE_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapACLPermissionType(tt.permType)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/shadow/types.go
+++ b/src/go/rpk/pkg/cli/shadow/types.go
@@ -142,7 +142,19 @@ type TopicMetadataSyncOptions struct {
 	// Additional topic properties to shadow
 	// Partition count, `max.message.bytes`, `cleanup.policy` and
 	// `timestamp.type` will always be replicated
-	ShadowedTopicProperties []string `json:"shadowed_topic_properties,omitempty" yaml:"shadowed_topic_properties,omitempty"`
+	SyncedShadowTopicProperties []string `json:"synced_shadow_topic_properties,omitempty" yaml:"synced_shadow_topic_properties,omitempty"`
+	// If false, then the following topic properties will be synced by default:
+	// - compression.type
+	// - retention.bytes
+	// - retention.ms
+	// - delete.retention.ms
+	// - Replication Factor
+	// - min.compaction.lag.ms
+	// - max.compaction.lag.ms
+	//
+	// If this is true, then only the properties listed in
+	// `synced_shadow_topic_properties` will be synced.
+	ExcludeDefault bool `json:"exclude_default,omitempty" yaml:"exclude_default,omitempty"`
 }
 
 type ConsumerOffsetSyncOptions struct {
@@ -161,10 +173,6 @@ type SecuritySettingsSyncOptions struct {
 	Interval time.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
 	// Whether or not it's enabled
 	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	// Role filters
-	RoleFilters []*NameFilter `json:"role_filters,omitempty" yaml:"role_filters,omitempty"`
-	// SCRAM credential filters
-	ScramCredFilters []*NameFilter `json:"scram_cred_filters,omitempty" yaml:"scram_cred_filters,omitempty"`
 	// ACL filters
 	ACLFilters []*ACLFilter `json:"acl_filters,omitempty" yaml:"acl_filters,omitempty"`
 }

--- a/src/go/rpk/pkg/cli/shadow/types_test.go
+++ b/src/go/rpk/pkg/cli/shadow/types_test.go
@@ -57,7 +57,7 @@ topic_metadata_sync_options:
     - pattern_type: "LITERAL"
       filter_type: "INCLUDE"
       name: "test-topic"
-  shadowed_topic_properties:
+  synced_shadow_topic_properties:
     - "retention.ms"
 consumer_offset_sync_options:
   interval: "30s"
@@ -90,7 +90,8 @@ security_sync_options:
 					ConnectionTimeoutMs: 1000,
 				},
 				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
-					Interval: 30 * time.Second,
+					Interval:       30 * time.Second,
+					ExcludeDefault: false,
 					AutoCreateShadowTopicFilters: []*NameFilter{
 						{
 							PatternType: "LITERAL",
@@ -98,7 +99,7 @@ security_sync_options:
 							Name:        "test-topic",
 						},
 					},
-					ShadowedTopicProperties: []string{"retention.ms"},
+					SyncedShadowTopicProperties: []string{"retention.ms"},
 				},
 				ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
 					Interval: 30 * time.Second,
@@ -373,13 +374,14 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 					"connection_timeout_ms": 1000
 				},
 				"topic_metadata_sync_options": {
+					"exclude_default": true,
 					"interval": 30000000000,
 					"auto_create_shadow_topic_filters": [{
 						"pattern_type": "LITERAL",
 						"filter_type": "INCLUDE",
 						"name": "test-topic"
 					}],
-					"shadowed_topic_properties": ["retention.ms"]
+					"synced_shadow_topic_properties": ["retention.ms"]
 				},
 				"consumer_offset_sync_options": {
 					"interval": 30000000000,
@@ -415,7 +417,8 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 					ConnectionTimeoutMs: 1000,
 				},
 				TopicMetadataSyncOptions: &TopicMetadataSyncOptions{
-					Interval: 30 * time.Second,
+					ExcludeDefault: true,
+					Interval:       30 * time.Second,
 					AutoCreateShadowTopicFilters: []*NameFilter{
 						{
 							PatternType: "LITERAL",
@@ -423,7 +426,7 @@ func TestShadowLinkConfigUnmarshalJSON(t *testing.T) {
 							Name:        "test-topic",
 						},
 					},
-					ShadowedTopicProperties: []string{"retention.ms"},
+					SyncedShadowTopicProperties: []string{"retention.ms"},
 				},
 				ConsumerOffsetSyncOptions: &ConsumerOffsetSyncOptions{
 					Interval: 30 * time.Second,


### PR DESCRIPTION
This includes:
- Renaming `shadowed_topic_properties` to
  `synced_shadow_topic_properties`.
- Adding a new field
  `topic_metadata_sync_options.exclude_default`
- Removing RoleFilters and ScramCredFilters
  from the security sync options

and also the missing mapper tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

* none
