### PR TITLE
[CORE-13986] `storage`: expose `storage_log_segment_size` histogram internal metric

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1620,6 +1620,15 @@ configuration::configuration()
       "for the log reader.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , storage_segment_size_refresh_rate_ms(
+      *this,
+      "storage_segment_size_refresh_rate_ms",
+      "The interval, in milliseconds, for recalculating the "
+      "`storage_manager_segment_size` histogram metric. This metric provides "
+      "visibility into segment size distribution per shard. Set to `null` to "
+      "disable histogram recalculation.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::chrono::minutes(60))
   , tx_registry_log_capacity(*this, "tx_registry_log_capacity")
   , id_allocator_log_capacity(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -340,6 +340,8 @@ struct configuration final : public config_store {
     property<bool> storage_ignore_cstore_hints;
     bounded_property<int16_t> storage_reserve_min_segments;
     property<std::optional<uint32_t>> debug_load_slice_warning_depth;
+    property<std::optional<std::chrono::milliseconds>>
+      storage_segment_size_refresh_rate_ms;
 
     deprecated_property tx_registry_log_capacity;
     property<int16_t> id_allocator_log_capacity;

--- a/src/v/ssx/rate_limited_function.h
+++ b/src/v/ssx/rate_limited_function.h
@@ -15,19 +15,23 @@
 
 #include <functional>
 #include <optional>
+#include <type_traits>
 
 namespace ssx {
 
 /// A rate-limited function that caches the result of the function call
 /// for a specified duration.
-template<typename Signature, typename Clock = seastar::lowres_clock>
+template<
+  typename Signature,
+  typename Clock = seastar::lowres_clock,
+  typename Rate = Clock::duration>
 class rate_limited_function;
 
-template<typename Ret, bool Noexcept, typename Clock>
-class rate_limited_function<Ret() noexcept(Noexcept), Clock> {
+template<typename Ret, bool Noexcept, typename Clock, typename Rate>
+class rate_limited_function<Ret() noexcept(Noexcept), Clock, Rate> {
 public:
     template<class Fn>
-    rate_limited_function(Fn&& func, Clock::duration rate)
+    rate_limited_function(Fn&& func, Rate rate)
       : _func(std::forward<Fn>(func))
       , _result(std::nullopt)
       , _rate(rate)
@@ -47,12 +51,27 @@ public:
 private:
     // Returns true if the cached value is ready to be used.
     bool is_ready(Clock::time_point now = Clock::now()) const {
-        return _result.has_value() && now <= (_last_call + _rate);
+        auto rate = [](
+                      this auto&& self,
+                      auto&& rate) -> std::optional<typename Clock::duration> {
+            if constexpr (std::is_invocable_v<decltype(rate)>) {
+                return self(rate());
+            } else {
+                return rate;
+            }
+        }(_rate);
+
+        if (!rate.has_value()) {
+            // If rate is unset, use originally computed value.
+            return _result.has_value();
+        }
+
+        return _result.has_value() && now <= (_last_call + rate.value());
     }
 
     std::function<Ret() noexcept(Noexcept)> _func;
     mutable std::optional<Ret> _result;
-    Clock::duration _rate;
+    Rate _rate;
     mutable Clock::time_point _last_call;
 };
 

--- a/src/v/ssx/tests/BUILD
+++ b/src/v/ssx/tests/BUILD
@@ -265,6 +265,7 @@ redpanda_cc_gtest(
         "rate_limited_function_test.cc",
     ],
     deps = [
+        "//src/v/config",
         "//src/v/ssx:rate_limited_function",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",

--- a/src/v/ssx/tests/rate_limited_function_test.cc
+++ b/src/v/ssx/tests/rate_limited_function_test.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#include "config/property.h"
 #include "ssx/rate_limited_function.h"
 
 #include <seastar/core/manual_clock.hh>
@@ -32,6 +33,90 @@ TEST(Event, Expire) {
       seastar::manual_clock::time_point(),
       seastar::manual_clock>
       fn([] { return seastar::manual_clock::now(); }, 1s);
+
+    auto baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+
+    seastar::manual_clock::advance(100ms);
+    EXPECT_FALSE(seastar::manual_clock::now() == baseline);
+    EXPECT_TRUE(fn() == baseline);
+
+    // Should expire
+    seastar::manual_clock::advance(1s);
+    baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+}
+
+TEST(Event, MockBinding) {
+    auto interval = config::mock_binding(std::chrono::seconds(1));
+    rate_limited_function<
+      seastar::manual_clock::time_point(),
+      seastar::manual_clock,
+      decltype(interval)>
+      fn([] { return seastar::manual_clock::now(); }, interval);
+
+    auto baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+
+    seastar::manual_clock::advance(100ms);
+    EXPECT_FALSE(seastar::manual_clock::now() == baseline);
+    EXPECT_TRUE(fn() == baseline);
+
+    // Should expire
+    seastar::manual_clock::advance(1s);
+    baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+}
+
+TEST(Event, EmptyOptional) {
+    auto interval = std::optional<std::chrono::seconds>{std::nullopt};
+    rate_limited_function<
+      seastar::manual_clock::time_point(),
+      seastar::manual_clock,
+      decltype(interval)>
+      fn([] { return seastar::manual_clock::now(); }, interval);
+
+    auto baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+
+    seastar::manual_clock::advance(100ms);
+    EXPECT_FALSE(seastar::manual_clock::now() == baseline);
+    EXPECT_TRUE(fn() == baseline);
+
+    // Shouldn't expire
+    seastar::manual_clock::advance(1s);
+    EXPECT_TRUE(fn() == baseline);
+}
+
+TEST(Event, EngagedOptional) {
+    auto interval = std::optional<std::chrono::seconds>{1s};
+    rate_limited_function<
+      seastar::manual_clock::time_point(),
+      seastar::manual_clock,
+      decltype(interval)>
+      fn([] { return seastar::manual_clock::now(); }, interval);
+
+    auto baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+
+    seastar::manual_clock::advance(100ms);
+    EXPECT_FALSE(seastar::manual_clock::now() == baseline);
+    EXPECT_TRUE(fn() == baseline);
+
+    // Should expire
+    seastar::manual_clock::advance(1s);
+    baseline = seastar::manual_clock::now();
+    EXPECT_TRUE(fn() == baseline);
+}
+
+TEST(Event, MockBindingWithOptional) {
+    auto interval = config::mock_binding(
+      std::optional<std::chrono::seconds>(1s));
+    rate_limited_function<
+      seastar::manual_clock::time_point(),
+      seastar::manual_clock,
+      decltype(interval)>
+      fn([] { return seastar::manual_clock::now(); }, interval);
 
     auto baseline = seastar::manual_clock::now();
     EXPECT_TRUE(fn() == baseline);

--- a/src/v/storage/BUILD
+++ b/src/v/storage/BUILD
@@ -385,6 +385,7 @@ redpanda_cc_library(
         "//src/v/utils:file_io",
         "//src/v/utils:filtered_lower_bound",
         "//src/v/utils:functional",
+        "//src/v/utils:hdr_hist",
         "//src/v/utils:human",
         "//src/v/utils:moving_average",
         "//src/v/utils:mutex",
@@ -461,6 +462,8 @@ redpanda_cc_library(
     ],
     deps = [
         "//src/v/metrics",
+        "//src/v/ssx:rate_limited_function",
+        "//src/v/utils:hdr_hist",
     ],
 )
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -220,6 +220,15 @@ ss::future<> log_manager::stop() {
     }
 
     _probe->clear_metrics();
+
+    // Important to co_await and clear `_segment_size_hist_fut`.
+    if (_segment_size_hist_fut.has_value()) {
+        auto hist_fut
+          = std::exchange(_segment_size_hist_fut, std::nullopt).value();
+        auto hist_fut_res = co_await ss::coroutine::as_future(
+          std::move(hist_fut));
+        hist_fut_res.ignore_ready_future();
+    }
 }
 
 /**
@@ -1119,6 +1128,53 @@ void log_manager::update_log_count() {
 
     _resources.update_partition_count(count);
     _probe->set_log_count(count);
+}
+
+std::optional<hdr_hist> log_manager::try_get_segment_size_histogram() {
+    std::optional<hdr_hist> hist{std::nullopt};
+    if (
+      _segment_size_hist_fut.has_value()
+      && _segment_size_hist_fut->available()) {
+        auto hist_fut
+          = std::exchange(_segment_size_hist_fut, std::nullopt).value();
+        if (hist_fut.failed()) {
+            hist_fut.ignore_ready_future();
+        } else {
+            hist = hist_fut.get();
+        }
+    }
+
+    return hist;
+}
+
+bool log_manager::schedule_calc_segment_size_histogram() {
+    if (_segment_size_hist_fut.has_value()) {
+        return false;
+    }
+
+    // Schedule a new computation for the next segment size histogram.
+    _segment_size_hist_fut = ss::try_with_gate(
+      _gate, [this] { return compute_segment_size_histogram(); });
+
+    return true;
+}
+
+ss::future<hdr_hist> log_manager::compute_segment_size_histogram() const {
+    hdr_hist hist;
+    for (const auto& log : _logs_list) {
+        if (!log.link.is_linked()) {
+            continue;
+        }
+
+        for (const auto& segment : log.handle->segments()) {
+            _abort_source.check();
+            hist.record(segment->size_bytes());
+        }
+
+        co_await ss::maybe_yield();
+    }
+
+    co_return hist;
 }
 
 } // namespace storage

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -146,7 +146,10 @@ log_manager::log_manager(
   , _housekeeping_jitter(_config.compaction_interval())
   , _trigger_gc_jitter(0s, 5s)
   , _batch_cache(_config.reclaim_opts)
-  , _probe(std::make_unique<log_manager_probe>()) {
+  , _probe(
+      std::make_unique<log_manager_probe>(
+        [this] { return try_get_segment_size_histogram(); },
+        [this] { return schedule_calc_segment_size_histogram(); })) {
     _config.compaction_interval.watch([this]() {
         _housekeeping_jitter = simple_time_jitter<ss::lowres_clock>{
           _config.compaction_interval()};

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -32,6 +32,7 @@
 #include "storage/storage_resources.h"
 #include "storage/types.h"
 #include "storage/version.h"
+#include "utils/hdr_hist.h"
 #include "utils/mutex.h"
 
 #include <seastar/core/abort_source.hh>
@@ -259,6 +260,19 @@ public:
 
     std::optional<batch_cache_index> create_cache(with_cache);
 
+    // Attempts to retrieve a value from `_segment_size_hist_fut`, if it has
+    // one (set by an earlier call to `schedule_calc_segment_size_histogram()`).
+    // If it does not, or if it contains an exceptional future, `std::nullopt`
+    // is returned.
+    std::optional<hdr_hist> try_get_segment_size_histogram();
+
+    // Schedules computation for a new segment size histogram across all
+    // logs & their segments on this shard (via
+    // `compute_segment_size_histogram()`), if `_segment_size_hist_fut` does not
+    // currently have a backgrounded computation running.
+    // Returns `true` if a new computation was scheduled, otherwise `false`.
+    bool schedule_calc_segment_size_histogram();
+
 private:
     using logs_type
       = chunked_hash_map<model::ntp, std::unique_ptr<log_housekeeping_meta>>;
@@ -302,6 +316,15 @@ private:
 
     void update_log_count();
 
+    // Computes a histogram of segment sizes across all logs managed on this
+    // shard by iterating over segments. This is a potentially expensive
+    // operation- it should only be invoked periodically, and is made
+    // asynchronous to allow yielding to the reactor.
+    // TODO: Uniform random sampling of segments to reduce cost? Could
+    // potentially avoid any asychronicity if the calculation had a clear upper
+    // bound.
+    ss::future<hdr_hist> compute_segment_size_histogram() const;
+
     log_config _config;
     kvstore& _kvstore;
     storage_resources& _resources;
@@ -321,6 +344,12 @@ private:
 
     ss::gate _gate;
     ss::abort_source _abort_source;
+
+    // May contain a backgrounded future that returns a segment size histogram
+    // for use in the `log_manager_probe` (see
+    // `compute_segment_size_histogram()`). May contain an exception due to use
+    // of `_abort_source.check()` which must be handled.
+    std::optional<ss::future<hdr_hist>> _segment_size_hist_fut;
 
     friend std::ostream& operator<<(std::ostream&, const log_manager&);
 

--- a/src/v/storage/log_manager_probe.cc
+++ b/src/v/storage/log_manager_probe.cc
@@ -11,6 +11,7 @@
 
 #include "config/configuration.h"
 #include "metrics/prometheus_sanitize.h"
+#include "ssx/rate_limited_function.h"
 
 #include <seastar/core/metrics.hh>
 
@@ -43,6 +44,35 @@ void log_manager_probe::setup_metrics() {
       },
       {},
       {});
+
+    _metrics.add_group(
+      group_name,
+      {
+        sm::make_histogram(
+          "segment_size",
+          [this] {
+              auto segment_size_collection_enabled
+                = config::shard_local_cfg()
+                    .storage_segment_size_refresh_rate_ms()
+                    .has_value();
+
+              if (segment_size_collection_enabled) {
+                  auto new_segment_size_histogram
+                    = _try_get_segment_histogram_cb();
+                  if (new_segment_size_histogram.has_value()) {
+                      _segment_size_histogram
+                        = std::move(new_segment_size_histogram).value();
+                  }
+
+                  _rate_limited_calc_segment_histogram_cb();
+              }
+
+              return _segment_size_histogram.seastar_histogram_logform();
+          },
+          sm::description("Local segment size histogram in bytes.")),
+      },
+      {},
+      {sm::shard_label});
 }
 
 void log_manager_probe::clear_metrics() { _metrics.clear(); }

--- a/src/v/storage/log_manager_probe.h
+++ b/src/v/storage/log_manager_probe.h
@@ -9,7 +9,11 @@
 
 #pragma once
 
+#include "config/configuration.h"
+#include "config/property.h"
 #include "metrics/metrics.h"
+#include "ssx/rate_limited_function.h"
+#include "utils/hdr_hist.h"
 
 #include <cstdint>
 
@@ -18,7 +22,18 @@ namespace storage {
 /// Log manager per-shard storage probe.
 class log_manager_probe {
 public:
-    log_manager_probe() = default;
+    using try_get_segment_histogram_cb_t
+      = ss::noncopyable_function<std::optional<hdr_hist>()>;
+    using calc_segment_histogram_cb_t = std::function<bool()>;
+    log_manager_probe(
+      try_get_segment_histogram_cb_t try_get_segment_histogram_cb,
+      calc_segment_histogram_cb_t calc_segment_histogram_cb)
+      : _try_get_segment_histogram_cb(std::move(try_get_segment_histogram_cb))
+      , _rate_limited_calc_segment_histogram_cb(
+          std::move(calc_segment_histogram_cb),
+          config::shard_local_cfg()
+            .storage_segment_size_refresh_rate_ms.bind()) {}
+
     log_manager_probe(const log_manager_probe&) = delete;
     log_manager_probe& operator=(const log_manager_probe&) = delete;
     log_manager_probe(log_manager_probe&&) = delete;
@@ -38,6 +53,20 @@ private:
     uint32_t _log_count = 0;
     uint64_t _urgent_gc_runs = 0;
     uint64_t _housekeeping_log_processed = 0;
+
+    hdr_hist _segment_size_histogram{};
+
+    // A cheap function to fetch an update to `_segment_size_histogram` if one
+    // is available.
+    try_get_segment_histogram_cb_t _try_get_segment_histogram_cb;
+
+    // A function to schedule a new segment size histogram calculation, which is
+    // potentially expensive.
+    ssx::rate_limited_function<
+      bool(),
+      seastar::lowres_clock,
+      config::binding<std::optional<std::chrono::milliseconds>>>
+      _rate_limited_calc_segment_histogram_cb;
 
     metrics::internal_metric_groups _metrics;
 };

--- a/src/v/storage/tests/common.h
+++ b/src/v/storage/tests/common.h
@@ -30,6 +30,10 @@ public:
     logs_list(storage::log_manager& m) {
         return m._logs_list;
     }
+
+    static ss::abort_source& abort_source(storage::log_manager& m) {
+        return m._abort_source;
+    }
 };
 
 class offset_tracker_accessor {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -7147,3 +7147,77 @@ TEST_F(storage_test_fixture, adjacent_merge_compaction_advances_generation_id) {
 
     ASSERT_EQ(gen_id_after(), gen_id_before() + 1);
 }
+
+TEST_F(storage_test_fixture, log_manager_segment_size_histogram) {
+    storage::log_manager mgr = make_log_manager();
+    auto ntp = model::ntp("kafka", "tapioca", 0);
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+
+    auto log
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(0));
+        log->force_roll().get();
+    };
+
+    add_segment_func();
+
+    auto hist = mgr.try_get_segment_size_histogram();
+    // First time this is called, no histogram is available.
+    ASSERT_TRUE(!hist.has_value());
+
+    // Schedule a histogram calculation.
+    mgr.schedule_calc_segment_size_histogram();
+
+    // Eventually the future will become available and provide a histogram
+    // result.
+    RPTEST_REQUIRE_EVENTUALLY(60s, [&] {
+        auto hist = mgr.try_get_segment_size_histogram();
+        return hist.has_value();
+    });
+}
+
+TEST_F(
+  storage_test_fixture,
+  log_manager_segment_size_histogram_exception_during_shutdown) {
+    storage::log_manager mgr = make_log_manager();
+    auto ntp = model::ntp("kafka", "tapioca", 0);
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+
+    auto log
+      = mgr.manage(storage::ntp_config(ntp, mgr.config().base_dir)).get();
+
+    auto add_segment = [log](size_t size, model::term_id term) {
+        do {
+            append_single_record_batch(log, 1, term, 16_KiB, true);
+        } while (log->segments().back()->size_bytes() < size);
+    };
+
+    auto add_segment_func = [&]() {
+        auto size = random_generators::get_int(4_KiB, 10_MiB);
+        add_segment(size, model::term_id(0));
+        log->force_roll().get();
+    };
+
+    add_segment_func();
+
+    auto& mgr_as = storage::testing_details::log_manager_accessor::abort_source(
+      mgr);
+    mgr_as.request_abort();
+    mgr.schedule_calc_segment_size_histogram();
+    // Attempting to get this will return `std::nullopt` due to requested abort.
+    auto hist = mgr.try_get_segment_size_histogram();
+    ASSERT_TRUE(!hist.has_value());
+
+    // Check that scheduling and leaving `_segment_size_hist_fut` in an
+    // exceptional state during shutdown is properly handled.
+    mgr.schedule_calc_segment_size_histogram();
+}

--- a/tests/rptest/tests/log_segment_size_test.py
+++ b/tests/rptest/tests/log_segment_size_test.py
@@ -1,0 +1,149 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import bisect
+
+from rptest.util import wait_until_result
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from ducktape.tests.test import TestContext
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import MetricsEndpoint
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class LogSegmentSizeTest(RedpandaTest):
+    """
+    Validates that the `segment_size` histogram metric accurately captures segment size data.
+    """
+
+    def __init__(self, test_context: TestContext):
+        extra_rp_conf = {
+            "aggregate_metrics": True,
+            "storage_segment_size_refresh_rate_ms": "1000",
+        }
+        super().__init__(
+            test_context=test_context, num_brokers=1, extra_rp_conf=extra_rp_conf
+        )
+
+        self.segment_size = 1024 * 1024
+        self.topic_name = "tapioca"
+        self.topics = [
+            TopicSpec(
+                name=self.topic_name,
+                replication_factor=1,
+                segment_bytes=self.segment_size,
+            )
+        ]
+
+        self.segment_count = 10
+        self.record_size = 1024
+        self.record_count = self.segment_size * self.segment_count // self.record_size
+
+    def wait_for_non_empty_segment_size_hist(self):
+        def get_segment_size_hist() -> dict[int, int]:
+            metrics = self.redpanda.metrics(
+                self.redpanda.nodes[0], MetricsEndpoint.METRICS
+            )
+
+            segment_size_metric_name = "vectorized_storage_manager_segment_size"
+            segment_size_metric = next(
+                filter(lambda m: m.name == segment_size_metric_name, metrics), None
+            )
+            assert segment_size_metric is not None
+
+            cumulative_segment_size_hist = [
+                (s.value, s.labels["le"])
+                for s in segment_size_metric.samples
+                if s.name == f"{segment_size_metric_name}_bucket"
+            ]
+
+            prev = 0
+            segment_size_hist = {}
+            for v, le in cumulative_segment_size_hist:
+                try:
+                    segment_size_hist[int(float(le))] = int(v - prev)
+                    prev = v
+                except:
+                    continue
+
+            return segment_size_hist
+
+        def get_non_empty_segment_size_hist():
+            hist = get_segment_size_hist()
+            if all([v == 0 for v in hist.values()]):
+                return False
+            return True, hist
+
+        return wait_until_result(
+            get_non_empty_segment_size_hist,
+            timeout_sec=15,
+            backoff_sec=1,
+            err_msg="Didn't see non-empty segment size histogram",
+        )
+
+    @cluster(num_nodes=2)
+    def test_segment_size_metric(self):
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            self.topic_name,
+            self.record_size,
+            self.record_count,
+        )
+
+        segment_size_hist = self.wait_for_non_empty_segment_size_hist()
+
+        bucket_keys = list(segment_size_hist.keys())
+
+        # Get the bucket corresponding to `self.segment_size` (i.e first bucket GE than 1024_KiB)
+        bucket = bucket_keys[bisect.bisect_left(bucket_keys, self.segment_size)]
+
+        # Expect to see at least `self.segment_count` produced segments with that size.
+        assert segment_size_hist[bucket] >= self.segment_count
+
+        # Prefix truncate the partition up to HWM
+        rpk = RpkTool(self.redpanda)
+        max_offset = next(rpk.describe_topic(self.topic_name)).high_watermark
+        rpk.trim_prefix(self.topic_name, max_offset)
+
+        def prefix_truncated():
+            segs = self.redpanda.node_storage(self.redpanda.nodes[0]).segments(
+                "kafka", self.topic_name, 0
+            )
+            self.logger.debug(f"Segments: {segs}")
+            return len(segs) <= 1
+
+        self.redpanda.wait_until(prefix_truncated, timeout_sec=30, backoff_sec=1)
+
+        # Restart node to force a refresh of metrics
+        self.redpanda.restart_nodes(self.redpanda.nodes[0])
+
+        # Sample metric again post-restart
+        segment_size_hist = self.wait_for_non_empty_segment_size_hist()
+
+        # Build expected histogram from segment sizes on disk
+        expected_segment_hist = {bucket: 0 for bucket in bucket_keys}
+        storage = self.redpanda.node_storage(self.redpanda.nodes[0], sizes=True)
+        for ns in storage.ns.values():
+            for topic in ns.topics.values():
+                if topic.name == "kvstore":
+                    continue
+                for partition in topic.partitions.values():
+                    p = partition.num
+                    segs = storage.segments(ns.name, topic.name, p)
+                    for s in segs:
+                        expected_bucket = bucket_keys[
+                            bisect.bisect_left(bucket_keys, s.size)
+                        ]
+                        expected_segment_hist[expected_bucket] += 1
+
+        # Assert the constructed histogram is equivalent to the reported histogram
+        assert expected_segment_hist == segment_size_hist


### PR DESCRIPTION
This PR exposes a `storage_log_segment_size` histogram which is aggregated across shards/partitions to give visibility into the profile of `segment` sizes for a given topic. 

This histogram is calculated by iterating over all `segment`s in a partition every `storage_segment_size_refresh_rate_ms` and recording their sizes in a `hdr_hist`. This interval defaults to `60min`, since the profile of segment sizes is not expected to fluctuate wildly, nor often in most cases. The `O(n)` computation of the histogram can be disabled by setting this cluster config to `std::nullopt`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v25.2.x
- [ ] v25.1.x
- [ ] v24.3.x

## Release Notes

### Improvements

* Expose the `vectorized_storage_log_segment_size` internal metric for visibility into the distribution of `segment` sizes within a topic.

